### PR TITLE
H-4929: Change `CreateEntity` permission to use an `Entity`-resource

### DIFF
--- a/libs/@local/graph/authorization/schemas/policies.cedarschema
+++ b/libs/@local/graph/authorization/schemas/policies.cedarschema
@@ -44,7 +44,7 @@ namespace HASH {
 
   action createEntity in [create] appliesTo {
     principal: [User, Machine, Ai],
-    resource: [Web],
+    resource: [Entity],
   };
 
   action viewEntity in [view] appliesTo {

--- a/libs/@local/graph/postgres-store/src/lib.rs
+++ b/libs/@local/graph/postgres-store/src/lib.rs
@@ -13,6 +13,7 @@
 #![feature(never_type)]
 #![feature(extend_one)]
 #![feature(doc_auto_cfg)]
+#![feature(iter_intersperse)]
 #![cfg_attr(not(miri), doc(test(attr(deny(warnings, clippy::all)))))]
 #![expect(
     unreachable_pub,

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
@@ -857,6 +857,14 @@ where
         let validator_provider = StoreProvider::new(&transaction, &policy_components);
 
         let mut validation_reports = HashMap::<usize, EntityValidationReport>::new();
+
+        debug_assert_eq!(
+            params.len(),
+            entity_ids.len(),
+            "Number of parameters ({}) and entity ids ({}) must be the same",
+            params.len(),
+            entity_ids.len(),
+        );
         for (index, (mut params, &entity_id)) in params.into_iter().zip(&entity_ids).enumerate() {
             let entity_type = ClosedMultiEntityType::from_multi_type_closed_schema(
                 stream::iter(&params.entity_type_ids)

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
@@ -746,26 +746,24 @@ where
         // We will use the added entity type IDs to check for the instantiation permission later.
         // This means that we need to make sure, that exactly the required entity types are passed
         // here.
-        let entity_type_id_set = params
-            .iter()
-            .flat_map(|params| {
-                let entity_id = EntityId {
-                    web_id: params.web_id,
-                    entity_uuid: params
-                        .entity_uuid
-                        .unwrap_or_else(|| EntityUuid::new(Uuid::new_v4())),
-                    draft_id: params.draft.then(|| DraftId::new(Uuid::new_v4())),
-                };
-                policy_components_builder.add_entity(
-                    actor_id,
-                    entity_id,
-                    Cow::Owned(params.entity_type_ids.iter().cloned().collect()),
-                );
-                entity_ids.push(entity_id);
+        let mut entity_type_id_set = HashSet::with_capacity(params.len());
+        for params in &params {
+            let entity_id = EntityId {
+                web_id: params.web_id,
+                entity_uuid: params
+                    .entity_uuid
+                    .unwrap_or_else(|| EntityUuid::new(Uuid::new_v4())),
+                draft_id: params.draft.then(|| DraftId::new(Uuid::new_v4())),
+            };
+            policy_components_builder.add_entity(
+                actor_id,
+                entity_id,
+                Cow::Owned(params.entity_type_ids.iter().cloned().collect()),
+            );
+            entity_ids.push(entity_id);
 
-                &params.entity_type_ids
-            })
-            .collect::<HashSet<_>>();
+            entity_type_id_set.extend(&params.entity_type_ids);
+        }
 
         // The policy components builder will make sure, that also parent entity types are added to
         // the set of entity type IDs. These are accessible via `tracked_entity_types` method.

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
@@ -812,8 +812,9 @@ where
                     forbidden_instantiations
                         .into_iter()
                         .map(ToString::to_string)
-                        .collect::<Vec<_>>()
-                        .join(", "),
+                        .map(Cow::Owned)
+                        .intersperse(Cow::Borrowed(", "))
+                        .collect::<String>(),
                 ));
         }
 

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
@@ -14,7 +14,7 @@ use hash_graph_authorization::{
         action::ActionName,
         principal::actor::AuthenticatedActor,
         resource::{EntityResourceConstraint, ResourceConstraint},
-        store::{PolicyCreationParams, PolicyStore as _},
+        store::{PolicyCreationParams, PolicyStore as _, PrincipalStore as _},
     },
     schema::{EntityOwnerSubject, EntityRelationAndSubject},
     zanzibar::Consistency,
@@ -706,7 +706,7 @@ where
     #[expect(clippy::too_many_lines)]
     async fn create_entities<R>(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_uuid: ActorEntityUuid,
         params: Vec<CreateEntityParams<R>>,
     ) -> Result<Vec<Entity>, Report<InsertionError>>
     where
@@ -714,8 +714,6 @@ where
     {
         let transaction_time = Timestamp::<TransactionTime>::now().remove_nanosecond();
         let mut relationships = Vec::with_capacity(params.len());
-        let mut entity_type_id_set = HashSet::new();
-        let mut checked_web_ids = HashSet::new();
         let mut entity_edition_ids = Vec::with_capacity(params.len());
 
         let mut entity_id_rows = Vec::with_capacity(params.len());
@@ -735,24 +733,130 @@ where
 
         let mut transaction = self.transaction().await.change_context(InsertionError)?;
 
-        let policy_components = PolicyComponents::builder(&transaction)
+        let actor_id = transaction
+            .determine_actor(actor_uuid)
+            .await
+            .change_context(InsertionError)?
+            .ok_or_else(|| Report::new(InsertionError).attach_printable("Actor not found"))?;
+
+        let mut policy_components_builder = PolicyComponents::builder(&transaction);
+
+        let mut entity_ids = Vec::with_capacity(params.len());
+
+        // We will use the added entity type IDs to check for the instantiation permission later.
+        // This means that we need to make sure, that exactly the required entity types are passed
+        // here.
+        let entity_type_id_set = params
+            .iter()
+            .flat_map(|params| {
+                let entity_id = EntityId {
+                    web_id: params.web_id,
+                    entity_uuid: params
+                        .entity_uuid
+                        .unwrap_or_else(|| EntityUuid::new(Uuid::new_v4())),
+                    draft_id: params.draft.then(|| DraftId::new(Uuid::new_v4())),
+                };
+                policy_components_builder.add_entity(
+                    actor_id,
+                    entity_id,
+                    Cow::Owned(params.entity_type_ids.iter().cloned().collect()),
+                );
+                entity_ids.push(entity_id);
+
+                &params.entity_type_ids
+            })
+            .collect::<HashSet<_>>();
+
+        // The policy components builder will make sure, that also parent entity types are added to
+        // the set of entity type IDs. These are accessible via `tracked_entity_types` method.
+        let policy_components = policy_components_builder
             .with_actor(actor_id)
-            .with_entity_type_ids(
-                params
-                    .iter()
-                    .flat_map(|params| &params.entity_type_ids)
-                    .collect::<HashSet<_>>(),
-            )
-            .with_action(ActionName::Instantiate, false)
-            .with_action(ActionName::CreateEntity, false)
+            .with_entity_type_ids(entity_type_id_set)
+            .with_actions([ActionName::Instantiate, ActionName::CreateEntity], false)
             .with_action(ActionName::ViewEntity, true)
             .await
             .change_context(InsertionError)?;
 
+        let policy_set = policy_components
+            .build_policy_set([ActionName::Instantiate, ActionName::CreateEntity])
+            .change_context(InsertionError)?;
+
+        let mut forbidden_instantiations = Vec::new();
+        for entity_type_id in policy_components.tracked_entity_types() {
+            match policy_set
+                .evaluate(
+                    &Request {
+                        actor: policy_components.actor_id(),
+                        action: ActionName::Instantiate,
+                        resource: &ResourceId::EntityType(Cow::Borrowed(entity_type_id.into())),
+                        context: RequestContext::default(),
+                    },
+                    policy_components.context(),
+                )
+                .change_context(InsertionError)?
+            {
+                Authorized::Always => {}
+                Authorized::Never => {
+                    forbidden_instantiations.push(entity_type_id);
+                }
+            }
+        }
+
+        if !forbidden_instantiations.is_empty() {
+            return Err(Report::new(InsertionError)
+                .attach(StatusCode::PermissionDenied)
+                .attach_printable(
+                    "The actor does not have permission to instantiate one or more entity types",
+                )
+                .attach_printable(
+                    forbidden_instantiations
+                        .into_iter()
+                        .map(ToString::to_string)
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                ));
+        }
+
+        let mut forbidden_entity_creations = Vec::new();
+        for entity_id in &entity_ids {
+            match policy_set
+                .evaluate(
+                    &Request {
+                        actor: policy_components.actor_id(),
+                        action: ActionName::CreateEntity,
+                        resource: &ResourceId::Entity(entity_id.entity_uuid),
+                        context: RequestContext::default(),
+                    },
+                    policy_components.context(),
+                )
+                .change_context(InsertionError)?
+            {
+                Authorized::Always => {}
+                Authorized::Never => {
+                    forbidden_entity_creations.push(entity_id);
+                }
+            }
+        }
+
+        if !forbidden_entity_creations.is_empty() {
+            return Err(Report::new(InsertionError)
+                .attach(StatusCode::PermissionDenied)
+                .attach_printable(
+                    "The actor does not have permission to create one or more entities",
+                )
+                .attach_printable(
+                    forbidden_entity_creations
+                        .into_iter()
+                        .map(ToString::to_string)
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                ));
+        }
+
         let validator_provider = StoreProvider::new(&transaction, &policy_components);
 
         let mut validation_reports = HashMap::<usize, EntityValidationReport>::new();
-        for (index, mut params) in params.into_iter().enumerate() {
+        for (index, (mut params, &entity_id)) in params.into_iter().zip(&entity_ids).enumerate() {
             let entity_type = ClosedMultiEntityType::from_multi_type_closed_schema(
                 stream::iter(&params.entity_type_ids)
                     .then(|entity_type_url| async {
@@ -765,18 +869,7 @@ where
                     })
                     .try_collect::<Vec<ClosedEntityType>>()
                     .await
-                    .change_context(InsertionError)?
-                    .into_iter()
-                    .inspect(|entity_type| {
-                        if !entity_type_id_set.contains(&entity_type.id) {
-                            entity_type_id_set.insert(entity_type.id.clone());
-                            for parent in &entity_type.all_of {
-                                if !entity_type_id_set.contains(&parent.id) {
-                                    entity_type_id_set.insert(parent.id.clone());
-                                }
-                            }
-                        }
-                    }),
+                    .change_context(InsertionError)?,
             )
             .change_context(InsertionError)?;
 
@@ -802,21 +895,10 @@ where
             let decision_time = params
                 .decision_time
                 .map_or_else(|| transaction_time.cast(), Timestamp::remove_nanosecond);
-            let entity_id = EntityId {
-                web_id: params.web_id,
-                entity_uuid: params
-                    .entity_uuid
-                    .unwrap_or_else(|| EntityUuid::new(Uuid::new_v4())),
-                draft_id: params.draft.then(|| DraftId::new(Uuid::new_v4())),
-            };
-
-            if entity_id.entity_uuid != entity_id.web_id.into() {
-                checked_web_ids.insert(entity_id.web_id);
-            }
 
             let entity_provenance = EntityProvenance {
                 inferred: InferredEntityProvenance {
-                    created_by_id: actor_id,
+                    created_by_id: actor_uuid,
                     created_at_transaction_time: transaction_time,
                     created_at_decision_time: decision_time,
                     first_non_draft_created_at_transaction_time: entity_id
@@ -829,7 +911,7 @@ where
                         .then_some(decision_time),
                 },
                 edition: EntityEditionProvenance {
-                    created_by_id: actor_id,
+                    created_by_id: actor_uuid,
                     archived_by_id: None,
                     provided: params.provenance,
                 },
@@ -957,83 +1039,6 @@ where
             );
         }
 
-        let policy_set = policy_components
-            .build_policy_set([ActionName::Instantiate, ActionName::CreateEntity])
-            .change_context(InsertionError)?;
-
-        let mut forbidden_instantiations = Vec::new();
-        for entity_type_id in &entity_type_id_set {
-            match policy_set
-                .evaluate(
-                    &Request {
-                        actor: policy_components.actor_id(),
-                        action: ActionName::Instantiate,
-                        resource: &ResourceId::EntityType(Cow::Borrowed(entity_type_id.into())),
-                        context: RequestContext::default(),
-                    },
-                    policy_components.context(),
-                )
-                .change_context(InsertionError)?
-            {
-                Authorized::Always => {}
-                Authorized::Never => {
-                    forbidden_instantiations.push(entity_type_id);
-                }
-            }
-        }
-
-        if !forbidden_instantiations.is_empty() {
-            return Err(Report::new(InsertionError)
-                .attach(StatusCode::PermissionDenied)
-                .attach_printable(
-                    "The actor does not have permission to instantiate one or more entity types",
-                )
-                .attach_printable(
-                    forbidden_instantiations
-                        .into_iter()
-                        .map(ToString::to_string)
-                        .collect::<Vec<_>>()
-                        .join(", "),
-                ));
-        }
-
-        // Cedar authorization check for entity creation (per web)
-        let mut forbidden_web_creations = Vec::new();
-        for web_id in &checked_web_ids {
-            match policy_set
-                .evaluate(
-                    &Request {
-                        actor: policy_components.actor_id(),
-                        action: ActionName::CreateEntity,
-                        resource: &ResourceId::Web(*web_id),
-                        context: RequestContext::default(),
-                    },
-                    policy_components.context(),
-                )
-                .change_context(InsertionError)?
-            {
-                Authorized::Always => {}
-                Authorized::Never => {
-                    forbidden_web_creations.push(web_id);
-                }
-            }
-        }
-
-        if !forbidden_web_creations.is_empty() {
-            return Err(Report::new(InsertionError)
-                .attach(StatusCode::PermissionDenied)
-                .attach_printable(
-                    "The actor does not have permission to create entities in one or more webs",
-                )
-                .attach_printable(
-                    forbidden_web_creations
-                        .into_iter()
-                        .map(ToString::to_string)
-                        .collect::<Vec<_>>()
-                        .join(", "),
-                ));
-        }
-
         let insertions = [
             InsertStatementBuilder::from_rows(Table::EntityIds, &entity_id_rows),
             InsertStatementBuilder::from_rows(Table::EntityDrafts, &entity_draft_rows),
@@ -1147,7 +1152,7 @@ where
                 && let Some(temporal_client) = &self.temporal_client
             {
                 temporal_client
-                    .start_update_entity_embeddings_workflow(actor_id, &entities)
+                    .start_update_entity_embeddings_workflow(actor_uuid, &entities)
                     .await
                     .change_context(InsertionError)?;
             }

--- a/libs/@local/graph/postgres-store/src/store/postgres/seed_policies.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/seed_policies.rs
@@ -392,9 +392,20 @@ fn web_create_entity_policies(role: &WebRole) -> impl Iterator<Item = PolicyCrea
             actor_type: None,
         }),
         actions: vec![ActionName::CreateEntity],
-        resource: Some(ResourceConstraint::Web {
+        resource: Some(ResourceConstraint::Entity(EntityResourceConstraint::Web {
             web_id: role.web_id,
-        }),
+            filter: match role.name {
+                RoleName::Administrator => EntityResourceFilter::All { filters: vec![] },
+                RoleName::Member => EntityResourceFilter::Not {
+                    filter: Box::new(EntityResourceFilter::Any {
+                        filters: vec![
+                            // Only admins can invite actors to an organization
+                            IS_MEMBER_OF.entity_is_of_base_type(),
+                        ],
+                    }),
+                },
+            },
+        })),
     })
 }
 

--- a/libs/@local/graph/store/src/entity/store.rs
+++ b/libs/@local/graph/store/src/entity/store.rs
@@ -434,7 +434,7 @@ pub trait EntityStore {
     /// Creates new [`Entities`][Entity].
     fn create_entities<R>(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_uuid: ActorEntityUuid,
         params: Vec<CreateEntityParams<R>>,
     ) -> impl Future<Output = Result<Vec<Entity>, Report<InsertionError>>> + Send
     where

--- a/libs/@local/graph/type-fetcher/src/store.rs
+++ b/libs/@local/graph/type-fetcher/src/store.rs
@@ -1583,7 +1583,7 @@ where
 {
     async fn create_entities<R>(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_uuid: ActorEntityUuid,
         params: Vec<CreateEntityParams<R>>,
     ) -> Result<Vec<Entity>, Report<InsertionError>>
     where
@@ -1599,7 +1599,7 @@ where
                 url: entity_type_id.clone(),
             };
             self.insert_external_types_by_reference(
-                actor_id,
+                actor_uuid,
                 OntologyTypeReference::EntityTypeReference(&entity_type_reference),
                 ConflictBehavior::Skip,
                 FetchBehavior::ExcludeProvidedReferences,
@@ -1608,7 +1608,7 @@ where
             .await?;
         }
 
-        self.store.create_entities(actor_id, params).await
+        self.store.create_entities(actor_uuid, params).await
     }
 
     async fn validate_entities(

--- a/tests/graph/integration/postgres/lib.rs
+++ b/tests/graph/integration/postgres/lib.rs
@@ -773,13 +773,13 @@ where
 {
     async fn create_entities<R>(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_uuid: ActorEntityUuid,
         params: Vec<CreateEntityParams<R>>,
     ) -> Result<Vec<Entity>, Report<InsertionError>>
     where
         R: IntoIterator<Item = EntityRelationAndSubject> + Send + Sync,
     {
-        self.store.create_entities(actor_id, params).await
+        self.store.create_entities(actor_uuid, params).await
     }
 
     async fn validate_entities(


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR implements the changes described in H-4929 to transition from using `Web` resources to `Entity` resources for the `CreateEntity` permission. This change provides more granular control over entity creation by allowing filtering by entity type, actor type restrictions, and even specific entity creation permissions.


## 🔍 What does this change?

- **Authorization Schema**: Changed `createEntity` action in Cedar schema to use `Entity` resource instead of `Web` resource
- **Policy Components**: Added entity type tracking and entity resource context building capabilities
- **Entity Creation Logic**: Replaced web-based authorization with entity-based authorization, including early permission checks for both `Instantiate` and `CreateEntity` actions
- **Seed Policies**: Updated policy generation to use `EntityResourceConstraint::Web` with role-based filtering (`Administrator` vs `Member`)

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

None

## 🐾 Next steps

- [H-4441: Have graph create user, machine, organization, and memberOf entities](https://linear.app/hash/issue/H-4441/have-graph-create-user-machine-organization-and-memberof-entities)

## 🛡 What tests cover this?

- Existing authorization tests cover the basic permission checking flow
- Entity creation integration tests verify the new authorization logic
- Policy evaluation tests ensure correct permission decisions

## ❓ How to test this?

1. Checkout the branch
2. Create entities with different user roles (Administrator, Member)
3. Verify that Members cannot create `memberOf` entities while Administrators can
4. Test entity type filtering and ensure appropriate permission errors are returned
5. Confirm that entity creation still works for permitted operations

## 📹 Demo

N/A - Internal authorization logic changes with no visible UI changes