### PR TITLE
H-4930: Add Claude hook to format Rust code

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path | select(endswith(\".rs\"))' | xargs -r cargo fmt --"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Claude-code now supports hook to be executed after commands. This adds a tiny hook to run `cargo fmt -- <FILE_PATH>` on write commands.