### PR TITLE
H-4949: Relax user and org entity type matching

### DIFF
--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/007-create-api-usage-tracking.migration.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/007-create-api-usage-tracking.migration.ts
@@ -357,7 +357,6 @@ const migrate: MigrationFunction = async ({
 
   const hashOrg = await getOrgByShortname(context, authentication, {
     shortname: "h",
-    permitOlderVersions: true,
   });
   if (!hashOrg) {
     throw new Error(

--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/017-add-use-case-form-and-example-org.migration.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/migrations/017-add-use-case-form-and-example-org.migration.ts
@@ -142,6 +142,7 @@ const migrate: MigrationFunction = async ({
   const exampleOrg = await getOrgByShortname(context, authentication, {
     shortname: "example",
   });
+
   if (!exampleOrg) {
     await createOrg(context, authentication, {
       shortname: "example",

--- a/apps/hash-api/src/graph/knowledge/system-types/org.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/org.ts
@@ -267,7 +267,6 @@ export const createOrg: ImpureGraphFunction<
 
     return getOrgFromEntity({
       entity,
-      permitOlderVersions: orgEntityTypeVersion !== undefined,
     });
   } finally {
     if (temporaryInstantiationPolicy) {
@@ -307,7 +306,7 @@ export const getOrgById: ImpureGraphFunction<
  * @param params.shortname - the shortname of the organization
  */
 export const getOrgByShortname: ImpureGraphFunction<
-  { permitOlderVersions?: boolean; shortname: string },
+  { shortname: string },
   Promise<Org | null>
 > = async ({ graphApi }, { actorId }, params) => {
   const [orgEntity, ...unexpectedEntities] = await graphApi
@@ -355,7 +354,6 @@ export const getOrgByShortname: ImpureGraphFunction<
   return orgEntity
     ? getOrgFromEntity({
         entity: orgEntity,
-        permitOlderVersions: params.permitOlderVersions,
       })
     : null;
 };

--- a/apps/hash-api/src/graph/knowledge/system-types/org.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/org.ts
@@ -61,14 +61,12 @@ export type Org = {
 
 function assertOrganizationEntity(
   entity: HashEntity,
-  permitOlderVersions = false,
 ): asserts entity is HashEntity<Organization> {
   if (
-    !entity.metadata.entityTypeIds.find((entityTypeId) =>
-      permitOlderVersions
-        ? extractBaseUrl(entityTypeId) ===
-          systemEntityTypes.organization.entityTypeBaseUrl
-        : entityTypeId === systemEntityTypes.organization.entityTypeId,
+    !entity.metadata.entityTypeIds.some(
+      (entityTypeId) =>
+        extractBaseUrl(entityTypeId) ===
+        systemEntityTypes.organization.entityTypeBaseUrl,
     )
   ) {
     throw new EntityTypeMismatchError(
@@ -80,10 +78,10 @@ function assertOrganizationEntity(
 }
 
 export const getOrgFromEntity: PureGraphFunction<
-  { entity: HashEntity; permitOlderVersions?: boolean },
+  { entity: HashEntity },
   Org
-> = ({ entity, permitOlderVersions }) => {
-  assertOrganizationEntity(entity, permitOlderVersions);
+> = ({ entity }) => {
+  assertOrganizationEntity(entity);
 
   const { organizationName: orgName, shortname } = simplifyProperties(
     entity.properties,

--- a/apps/hash-api/src/graph/knowledge/system-types/user.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/user.ts
@@ -1,5 +1,6 @@
 import type { EntityId, EntityUuid, UserId } from "@blockprotocol/type-system";
 import {
+  extractBaseUrl,
   extractEntityUuidFromEntityId,
   extractWebIdFromEntityId,
 } from "@blockprotocol/type-system";
@@ -88,7 +89,11 @@ function assertUserEntity(
   entity: HashEntity,
 ): asserts entity is HashEntity<UserEntity> {
   if (
-    !entity.metadata.entityTypeIds.includes(systemEntityTypes.user.entityTypeId)
+    !entity.metadata.entityTypeIds.some(
+      (entityTypeId) =>
+        extractBaseUrl(entityTypeId) ===
+        systemEntityTypes.user.entityTypeBaseUrl,
+    )
   ) {
     throw new EntityTypeMismatchError(
       entity.metadata.recordId.entityId,

--- a/apps/hash-frontend/src/lib/user-and-org.ts
+++ b/apps/hash-frontend/src/lib/user-and-org.ts
@@ -20,6 +20,7 @@ import type {
 } from "@blockprotocol/type-system";
 import {
   currentTimestamp,
+  extractBaseUrl,
   extractWebIdFromEntityId,
 } from "@blockprotocol/type-system";
 import type { HashEntity, HashLinkEntity } from "@local/hash-graph-sdk/entity";
@@ -87,7 +88,10 @@ export type MinimalUser = {
 export const isEntityUserEntity = (
   entity: Entity,
 ): entity is Entity<UserEntity> =>
-  entity.metadata.entityTypeIds.includes(systemEntityTypes.user.entityTypeId);
+  entity.metadata.entityTypeIds.some(
+    (entityTypeId) =>
+      extractBaseUrl(entityTypeId) === systemEntityTypes.user.entityTypeBaseUrl,
+  );
 
 export const constructMinimalUser = (params: {
   userEntity: Entity<UserEntity>;
@@ -146,8 +150,10 @@ export type Org = MinimalOrg & {
 export const isEntityOrgEntity = (
   entity: Entity,
 ): entity is Entity<Organization> =>
-  entity.metadata.entityTypeIds.includes(
-    systemEntityTypes.organization.entityTypeId,
+  entity.metadata.entityTypeIds.some(
+    (entityTypeId) =>
+      extractBaseUrl(entityTypeId) ===
+      systemEntityTypes.organization.entityTypeBaseUrl,
   );
 
 /**

--- a/apps/hash-frontend/src/pages/_app.page.tsx
+++ b/apps/hash-frontend/src/pages/_app.page.tsx
@@ -286,6 +286,12 @@ AppWithTypeSystemContextProvider.getInitialProps = async (appContext) => {
       // ...then redirect them to the home page.
       redirectInGetInitialProps({ appContext, location: "/" });
     }
+  } else if (redirectIfAuthenticatedPathnames.includes(pathname)) {
+    /**
+     * If the user has completed signup and is on a page they shouldn't be on
+     * (e.g. /signup), then redirect them to the home page.
+     */
+    redirectInGetInitialProps({ appContext, location: "/" });
   }
 
   // For each feature flag...
@@ -310,10 +316,6 @@ AppWithTypeSystemContextProvider.getInitialProps = async (appContext) => {
         redirectInGetInitialProps({ appContext, location: "/" });
       }
     }
-  }
-
-  if (redirectIfAuthenticatedPathnames.includes(pathname)) {
-    redirectInGetInitialProps({ appContext, location: "/" });
   }
 
   return { initialAuthenticatedUserSubgraph, user };


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

In a few places in the Node API and frontend we check if an entity is a user or org by matching against the latest user/org `entityTypeId` in the codebase… but in cases where we deploy a change to user or org types, until the backend successfully deploys and upgrades users/orgs, these checks will throw errors because the user/org is on an older version.

This means if the new frontend deploys before the backend has migrated (likely), the app will crash until the migrations have caught up.

Ideally everything would deploy in the same moment, but as this is very hard the better thing is to relax the check so we're checking against type base URL, not including the version. This PR does that.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
