### PR TITLE
H-4210: Fix panic from empty PostgreSQL temporal ranges in entity queries

### DIFF
--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/read.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/read.rs
@@ -264,8 +264,9 @@ where
                           ON target.{pinned_axis} @> $5::timestamptz
                          AND target.{variable_axis} && source.{variable_axis}
                          AND target.{variable_axis} && filter.interval
-                         AND NOT isempty(source.{variable_axis} * target.{variable_axis} * \
-                     filter.interval)
+                         AND NOT isempty(
+                            source.{variable_axis} * target.{variable_axis} * filter.interval
+                         )
                          AND target.web_id = {target_1}
                          AND target.entity_uuid = {target_2}
                     "

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/read.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/read.rs
@@ -264,6 +264,8 @@ where
                           ON target.{pinned_axis} @> $5::timestamptz
                          AND target.{variable_axis} && source.{variable_axis}
                          AND target.{variable_axis} && filter.interval
+                         AND NOT isempty(source.{variable_axis} * target.{variable_axis} * \
+                     filter.interval)
                          AND target.web_id = {target_1}
                          AND target.entity_uuid = {target_2}
                     "


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Fix panic caused by empty PostgreSQL temporal ranges in entity edge queries. This addresses a non-reproducible panic where the temporal versioning library would fail to parse empty ranges returned from PostgreSQL range intersection operations.

## 🔗 Related links

- H-4210
- [Slack thread](https://hashintel.slack.com/archives/CJ1GD3Q84/p1741694092213449)
- [Sentry issue](https://hashintel.sentry.io/issues/6385183858)

## 🚫 Blocked by

- [ ] None

## 🔍 What does this change?

- Adds a `NOT isempty()` check to the SQL query in `read_knowledge_edges` to prevent empty temporal range intersections from being returned
- Preserves the existing pairwise overlap checks (`&&` operators) for query performance optimization
- Prevents the panic that occurs when the Rust temporal versioning library tries to parse an empty PostgreSQL range

The root cause was that even with pairwise temporal overlaps between source/target and target/filter intervals, the triple intersection `source.{variable_axis} * target.{variable_axis} * filter.interval` could still result in an empty range. For example:

```
source:  [1, 10]
target:  [5, 15] 
filter:  [12, 20]

source && target = true  ([5, 10] overlap)
target && filter = true  ([12, 15] overlap)

But: source * target * filter = [1,10] * [5,15] * [12,20] = empty
```

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

None - this is a targeted fix for a specific panic condition.

## 🐾 Next steps

None - this resolves the immediate panic issue.

## 🛡 What tests cover this?

- Existing entity traversal and query tests should continue to pass
- The fix prevents a runtime panic but doesn't change the functional behavior of valid queries

## ❓ How to test this?

1. Checkout the branch
2. Run entity queries that involve temporal range intersections
3. Confirm that queries complete without panicking on `not implemented: Empty ranges are not supported`
4. Verify that query results remain functionally correct

## 📹 Demo

This is a bug fix for a runtime panic - no visual demo needed.