### PR TITLE
Temporarily stop checking ESLint config using tcs for harpc-client

### DIFF
--- a/libs/@local/harpc/client/typescript/tsconfig.json
+++ b/libs/@local/harpc/client/typescript/tsconfig.json
@@ -5,5 +5,5 @@
     "moduleResolution": "NodeNext",
     "types": ["vitest/importMeta"]
   },
-  "include": ["src", "tests", "eslint.config.js", "vitest.config.ts"]
+  "include": ["src", "tests", "vitest.config.ts"]
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

# Temporarily stop checking ESLint config using `tcs` for `harpc-client`

We encountered issues in CI that `@local/eslint` does not exist. The error is spurious and not locally reproducible.

It *only* happens with the exact combination of

* In CI
* Running the integration tests
* Test-Package: `@rust/hash-graph-http-tests`
* Error package: `@rust/harpc-client`
* Error: `@local/eslint` does not exist