### PR TITLE
H-4009: Implement graceful shutdown for hash-graph services

### DIFF
--- a/apps/hash-graph/Cargo.toml
+++ b/apps/hash-graph/Cargo.toml
@@ -44,7 +44,7 @@ tarpc = { workspace = true, features = [
     "tcp",
 ] }
 time = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["signal"] }
 tokio-postgres = { workspace = true }
 tokio-util = { workspace = true, features = ["codec"] }
 tracing = { workspace = true }

--- a/apps/hash-graph/src/main.rs
+++ b/apps/hash-graph/src/main.rs
@@ -1,6 +1,10 @@
 //! # HASH Graph
 //!
 //! ## Workspace dependencies
+#![feature(
+    // Language features
+    impl_trait_in_assoc_type
+)]
 #![cfg_attr(doc, doc = simple_mermaid::mermaid!("../docs/dependency-diagram.mmd"))]
 #![forbid(unsafe_code)]
 #![expect(

--- a/apps/hash-graph/src/subcommand/server.rs
+++ b/apps/hash-graph/src/subcommand/server.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 
 use clap::Parser;
 use error_stack::{Report, ResultExt as _};
-use futures::{StreamExt as _, channel::mpsc};
+use futures::{FutureExt as _, StreamExt as _, channel::mpsc};
 use harpc_codec::json::JsonCodec;
 use harpc_server::Server;
 use hash_codec::bytes::JsonLinesEncoder;
@@ -30,9 +30,9 @@ use hash_temporal_client::TemporalClientConfig;
 use multiaddr::{Multiaddr, Protocol};
 use regex::Regex;
 use reqwest::{Client, Url};
-use tokio::{io, net::TcpListener, time::timeout};
+use tokio::{io, net::TcpListener, signal, task::JoinHandle, time::timeout};
 use tokio_postgres::NoTls;
-use tokio_util::codec::FramedWrite;
+use tokio_util::{codec::FramedWrite, sync::CancellationToken};
 use type_system::ontology::json_schema::DomainValidator;
 
 use crate::{
@@ -186,16 +186,38 @@ pub struct ServerArgs {
     pub log_queries: Option<PathBuf>,
 }
 
+struct RpcServerJoinHandle {
+    join_handles: Vec<JoinHandle<()>>,
+    cancellation_token: CancellationToken,
+}
+
+impl IntoFuture for RpcServerJoinHandle {
+    type Output = ();
+
+    type IntoFuture = impl Future<Output = Self::Output>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        async move {
+            self.cancellation_token.cancel();
+
+            for join_handle in self.join_handles.into_iter().rev() {
+                join_handle.await.expect("failed to join RPC server");
+            }
+        }
+    }
+}
+
 fn server_rpc<S, A>(
     address: RpcAddress,
     dependencies: Dependencies<S, A, ()>,
-) -> Result<(), Report<GraphError>>
+) -> Result<RpcServerJoinHandle, Report<GraphError>>
 where
     S: StorePool + Send + Sync + 'static,
     A: AuthorizationApiPool + Send + Sync + 'static,
     for<'p, 'a> S::Store<'p, A::Api<'a>>: PrincipalStore,
 {
     let server = Server::new(harpc_server::ServerConfig::default()).change_context(GraphError)?;
+    let cancellation_token = server.cancellation_token();
 
     let (router, task) = hash_graph_api::rpc::rpc_router(
         Dependencies {
@@ -207,7 +229,9 @@ where
         server.events(),
     );
 
-    tokio::spawn(task.into_future());
+    let mut join_handles = Vec::new();
+
+    join_handles.push(tokio::spawn(task.into_future()));
 
     let socket_address: SocketAddr = SocketAddr::try_from(address).change_context(GraphError)?;
     let mut address = Multiaddr::empty();
@@ -223,16 +247,19 @@ where
     }
 
     #[expect(clippy::significant_drop_tightening, reason = "false positive")]
-    tokio::spawn(async move {
+    join_handles.push(tokio::spawn(async move {
         let stream = server
             .listen(address)
             .await
             .expect("server should be able to listen on address");
 
         harpc_server::serve::serve(stream, router).await;
-    });
+    }));
 
-    Ok(())
+    Ok(RpcServerJoinHandle {
+        join_handles,
+        cancellation_token,
+    })
 }
 
 #[expect(
@@ -318,7 +345,7 @@ pub async fn server(args: ServerArgs) -> Result<(), Report<GraphError>> {
         )
     };
 
-    let (query_logger, _handle) = if let Some(query_log_file) = args.log_queries {
+    let (query_logger, log_queries_join_handle) = if let Some(query_log_file) = args.log_queries {
         let file = tokio::fs::File::create(query_log_file)
             .await
             .change_context(GraphError)?;
@@ -330,7 +357,7 @@ pub async fn server(args: ServerArgs) -> Result<(), Report<GraphError>> {
         (None, None)
     };
 
-    let router = {
+    let (router, rpc_server_join_handle) = {
         let dependencies = RestRouterDependencies {
             store: Arc::new(pool),
             authorization_api: Arc::new(zanzibar_client),
@@ -340,10 +367,14 @@ pub async fn server(args: ServerArgs) -> Result<(), Report<GraphError>> {
             query_logger: query_logger.map(QueryLogger::new),
         };
 
-        if args.rpc_enabled {
+        #[expect(
+            clippy::if_then_some_else_none,
+            reason = "False positive, this is in an async context"
+        )]
+        let rpc_server_join_handle = if args.rpc_enabled {
             tracing::info!("Starting RPC server...");
 
-            server_rpc(
+            Some(server_rpc(
                 args.rpc_address,
                 Dependencies {
                     store: Arc::clone(&dependencies.store),
@@ -352,10 +383,12 @@ pub async fn server(args: ServerArgs) -> Result<(), Report<GraphError>> {
                         .await?,
                     codec: (),
                 },
-            )?;
-        }
+            )?)
+        } else {
+            None
+        };
 
-        rest_api_router(dependencies)
+        (rest_api_router(dependencies), rpc_server_join_handle)
     };
 
     tracing::info!("Listening on {}", args.http_address);
@@ -365,8 +398,22 @@ pub async fn server(args: ServerArgs) -> Result<(), Report<GraphError>> {
             .change_context(GraphError)?,
         router.into_make_service_with_connect_info::<SocketAddr>(),
     )
+    .with_graceful_shutdown(
+        signal::ctrl_c().map(|error| error.expect("failed to install Ctrl+C handler")),
+    )
     .await
     .expect("failed to start server");
+
+    if let Some(rpc_server_join_handle) = rpc_server_join_handle {
+        rpc_server_join_handle.await;
+    }
+
+    if let Some(log_queries_join_handle) = log_queries_join_handle {
+        log_queries_join_handle
+            .await
+            .expect("failed to join log queries")
+            .expect("failed to log queries");
+    }
 
     Ok(())
 }

--- a/apps/hash-graph/src/subcommand/test_server.rs
+++ b/apps/hash-graph/src/subcommand/test_server.rs
@@ -2,6 +2,7 @@ use core::{net::SocketAddr, time::Duration};
 
 use clap::Parser;
 use error_stack::{Report, ResultExt as _};
+use futures::FutureExt as _;
 use hash_graph_authorization::{
     AuthorizationApi as _,
     backend::{SpiceDbOpenApi, ZanzibarBackend as _},
@@ -12,7 +13,7 @@ use hash_graph_postgres_store::{
     store::{DatabaseConnectionInfo, DatabasePoolConfig, PostgresStorePool, PostgresStoreSettings},
 };
 use reqwest::Client;
-use tokio::{net::TcpListener, time::timeout};
+use tokio::{net::TcpListener, signal, time::timeout};
 use tokio_postgres::NoTls;
 
 use crate::{
@@ -107,6 +108,9 @@ pub async fn test_server(args: TestServerArgs) -> Result<(), Report<GraphError>>
             .await
             .change_context(GraphError)?,
         router.into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .with_graceful_shutdown(
+        signal::ctrl_c().map(|error| error.expect("failed to install Ctrl+C handler")),
     )
     .await
     .expect("failed to start server");

--- a/apps/hash-graph/src/subcommand/type_fetcher.rs
+++ b/apps/hash-graph/src/subcommand/type_fetcher.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 use clap::Parser;
 use error_stack::{Report, ResultExt as _};
-use futures::{StreamExt as _, future};
+use futures::{FutureExt as _, StreamExt as _, future};
 use hash_graph_type_fetcher::{
     fetcher::{Fetcher as _, FetcherRequest, FetcherResponse},
     fetcher_server::FetchServer,
@@ -12,7 +12,8 @@ use tarpc::{
     serde_transport::Transport,
     server::{self, Channel as _},
 };
-use tokio::time::timeout;
+use tokio::{signal, time::timeout};
+use tokio_util::sync::CancellationToken;
 
 use crate::{
     error::{GraphError, HealthcheckError},
@@ -52,6 +53,10 @@ pub struct TypeFetcherArgs {
     pub timeout: Option<u64>,
 }
 
+#[expect(
+    clippy::integer_division_remainder_used,
+    reason = "False positive on tokio::select!"
+)]
 pub async fn type_fetcher(args: TypeFetcherArgs) -> Result<(), Report<GraphError>> {
     if args.healthcheck {
         return wait_healthcheck(
@@ -76,30 +81,55 @@ pub async fn type_fetcher(args: TypeFetcherArgs) -> Result<(), Report<GraphError
     tracing::info!("Listening on port {}", listener.local_addr().port());
 
     listener.config_mut().max_frame_length(usize::MAX);
-    // Allow listeneer to accept up to 255 connections at a time.
+
+    let cancellation_token = CancellationToken::new();
+    let cancellation_token_clone = cancellation_token.clone();
+
+    // Allow listener to accept up to 255 connections at a time.
     //
     // The pipeline must be invoked, we do this with `for_each` because it doesn't contain any
     // useful information we would like to store or report on.
-    listener
-        .filter_map(|result| future::ready(result.ok()))
-        .map(server::BaseChannel::with_defaults)
-        .map(|channel| {
-            let mut server = FetchServer {
-                buffer_size: 10,
-                predefined_types: HashMap::new(),
-            };
-            server
-                .load_predefined_types()
-                .expect("should be able to load predefined types");
-            channel
-                .execute(server.serve())
-                .for_each(|response| async move {
-                    tokio::spawn(response);
+    let server_task = async move {
+        listener
+            .filter_map(|result| future::ready(result.ok()))
+            .map(server::BaseChannel::with_defaults)
+            .map(|channel| {
+                let cancellation_token = cancellation_token_clone.clone();
+                let mut server = FetchServer {
+                    buffer_size: 10,
+                    predefined_types: HashMap::new(),
+                };
+                server
+                    .load_predefined_types()
+                    .expect("should be able to load predefined types");
+                channel.execute(server.serve()).for_each(move |response| {
+                    let cancellation_token = cancellation_token.clone();
+                    async move {
+                        tokio::spawn(async move {
+                            tokio::select! {
+                                () = response => {}
+                                () = cancellation_token.cancelled() => {
+                                    tracing::debug!("Type fetcher response task cancelled");
+                                }
+                            }
+                        });
+                    }
                 })
-        })
-        .buffer_unordered(255)
-        .for_each(|()| async {})
-        .await;
+            })
+            .buffer_unordered(255)
+            .for_each(|()| async {})
+            .await;
+    };
+
+    tokio::select! {
+        () = server_task => {
+            tracing::info!("Type fetcher server task completed");
+        }
+        () = signal::ctrl_c().map(|error| error.expect("failed to install Ctrl+C handler")) => {
+            tracing::info!("Received SIGINT, shutting down type fetcher gracefully");
+            cancellation_token.cancel();
+        }
+    }
 
     Ok(())
 }

--- a/libs/@local/harpc/server/src/lib.rs
+++ b/libs/@local/harpc/server/src/lib.rs
@@ -85,6 +85,7 @@ impl FusedStream for TransactionStream {
 pub struct Server {
     session: SessionLayer,
     guard: DropGuard,
+    cancellation_token: CancellationToken,
 }
 
 impl Server {
@@ -104,6 +105,7 @@ impl Server {
 
         Ok(Self {
             session,
+            cancellation_token: token.clone(),
             guard: token.drop_guard(),
         })
     }
@@ -112,6 +114,12 @@ impl Server {
     #[must_use]
     pub fn events(&self) -> EventStream {
         self.session.events()
+    }
+
+    /// Returns the cancellation token for this server.
+    #[must_use]
+    pub fn cancellation_token(&self) -> CancellationToken {
+        self.cancellation_token.clone()
     }
 
     /// Starts listening for incoming connections on the specified address.

--- a/libs/@local/harpc/server/src/session.rs
+++ b/libs/@local/harpc/server/src/session.rs
@@ -350,7 +350,7 @@ where
 
             match event {
                 None => {
-                    tracing::warn!("Session event stream ended, stopping session storage task");
+                    tracing::info!("Session event stream ended, stopping session storage task");
                     break;
                 }
                 Some(Ok(SessionEvent::SessionDropped { id })) => {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR implements graceful shutdown functionality for all hash-graph services to handle SIGINT/Ctrl+C signals properly and ensure clean resource cleanup during service termination.

## 🔗 Related links

- Linear: H-4009

## 🚫 Blocked by

- [ ] N/A

## 🔍 What does this change?

- Add SIGINT signal handling to main server, test server, and type fetcher service
- Implement coordinated shutdown using cancellation tokens for RPC server tasks  
- Extend harpc server to expose cancellation token for external coordination
- Ensure proper cleanup of background tasks (query logger, response handlers)
- Update session event logging from warning to info for graceful shutdown scenarios
- Enable tokio signal features in Cargo.toml

**Services Enhanced:**
- Main HTTP server with `.with_graceful_shutdown()` support
- RPC server with proper task lifecycle management via `RpcServerJoinHandle`
- Type fetcher service with cancellation token coordination using `tokio::select\!`
- Test server with signal handling

**Technical Implementation:**
- Created `RpcServerJoinHandle` struct implementing `IntoFuture` for coordinated shutdown
- Added cancellation token propagation to all spawned tasks in type fetcher
- Extended harpc server API to expose cancellation tokens for coordination

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

None

## 🐾 Next steps

- Monitor graceful shutdown behavior in production
- Consider extending graceful shutdown to other services if needed

## 🛡 What tests cover this?

- Compilation tests verify code correctness
- Manual testing confirms SIGINT handling works properly

## ❓ How to test this?

1. Checkout the branch
2. Start hash-graph server: `cargo run --bin hash-graph -- server`
3. Send SIGINT (Ctrl+C) to the process
4. Confirm that services shut down gracefully with proper logging
5. Repeat for type fetcher: `cargo run --bin hash-graph -- type-fetcher`

## 📹 Demo

Graceful shutdown logs will show:
- "Received SIGINT, shutting down gracefully" messages
- Proper task cleanup and termination
- No abrupt process termination