### PR TITLE
H-4974: Allow serializing for `Instantiator` SpiceDB permission

### DIFF
--- a/libs/@local/graph/api/openapi/openapi.json
+++ b/libs/@local/graph/api/openapi/openapi.json
@@ -6134,6 +6134,24 @@
                 "$ref": "#/components/schemas/EntityTypeViewerSubject"
               }
             }
+          },
+          {
+            "type": "object",
+            "required": [
+              "subject",
+              "relation"
+            ],
+            "properties": {
+              "relation": {
+                "type": "string",
+                "enum": [
+                  "instantiator"
+                ]
+              },
+              "subject": {
+                "$ref": "#/components/schemas/EntityTypeInstantiatorSubject"
+              }
+            }
           }
         ],
         "discriminator": {

--- a/libs/@local/graph/authorization/src/schema/entity_type.rs
+++ b/libs/@local/graph/authorization/src/schema/entity_type.rs
@@ -265,9 +265,9 @@ pub enum EntityTypeRelationAndSubject {
         #[serde(skip)]
         level: u8,
     },
-    #[serde(skip)]
     Instantiator {
         subject: EntityTypeInstantiatorSubject,
+        #[serde(skip)]
         level: u8,
     },
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

For no obvious reason, the Node API migration suddenly fails on AWS when trying to serialize the `Instantiator` permission. This permission should not be around in production anymore, but apparently it is. 