### PR TITLE
H-4825: Implement initial meta-policy handling

### DIFF
--- a/libs/@local/graph/authorization/schemas/policies.cedarschema
+++ b/libs/@local/graph/authorization/schemas/policies.cedarschema
@@ -8,6 +8,10 @@ namespace HASH {
   entity Team in [Web, Team] {
   };
 
+  entity Policy in [Web] {
+    actions: Set<String>
+  };
+
   entity Entity in [Web] {
     entity_types: Set<EntityType>,
     entity_base_types: Set<String>,
@@ -50,9 +54,14 @@ namespace HASH {
     resource: [Web],
   };
 
-  action create, view, update, archive in [all] appliesTo {
+  action create, view, update, archive, delete in [all] appliesTo {
     principal: [User, Machine, Ai],
-    resource: [Entity, EntityType, PropertyType, DataType],
+    resource: [Entity, EntityType, PropertyType, DataType, Policy],
+  };
+
+  action createPolicy in [create] appliesTo {
+    principal: [User, Machine, Ai],
+    resource: [Policy],
   };
 
   action createEntity in [create] appliesTo {
@@ -75,6 +84,11 @@ namespace HASH {
     resource: [DataType],
   };
 
+  action viewPolicy in [view] appliesTo {
+    principal: [User, Machine, Ai, Public],
+    resource: [Policy],
+  };
+
   action viewEntity in [view] appliesTo {
     principal: [User, Machine, Ai, Public],
     resource: [Entity],
@@ -93,6 +107,11 @@ namespace HASH {
   action viewDataType in [view] appliesTo {
     principal: [User, Machine, Ai, Public],
     resource: [DataType],
+  };
+
+  action updatePolicy in [update] appliesTo {
+    principal: [User, Machine, Ai],
+    resource: [Policy],
   };
 
   action updateEntity in [update] appliesTo {
@@ -115,6 +134,11 @@ namespace HASH {
     resource: [DataType],
   };
 
+  action archivePolicy in [archive] appliesTo {
+    principal: [User, Machine, Ai],
+    resource: [Policy],
+  };
+
   action archiveEntity in [archive] appliesTo {
     principal: [User, Machine, Ai],
     resource: [Entity],
@@ -133,6 +157,11 @@ namespace HASH {
   action archiveDataType in [archive] appliesTo {
     principal: [User, Machine, Ai],
     resource: [DataType],
+  };
+
+  action deletePolicy in [delete] appliesTo {
+    principal: [User, Machine, Ai],
+    resource: [Policy],
   };
 
   action instantiate in [all] appliesTo {

--- a/libs/@local/graph/authorization/src/policies/action/mod.rs
+++ b/libs/@local/graph/authorization/src/policies/action/mod.rs
@@ -34,6 +34,7 @@ pub enum ActionName {
 
     #[cfg_attr(feature = "codegen", specta(skip))]
     Create,
+    CreatePolicy,
     CreateDataType,
     CreateEntity,
     CreateEntityType,
@@ -42,6 +43,7 @@ pub enum ActionName {
 
     #[cfg_attr(feature = "codegen", specta(skip))]
     View,
+    ViewPolicy,
     ViewDataType,
     ViewEntity,
     ViewEntityType,
@@ -49,6 +51,7 @@ pub enum ActionName {
 
     #[cfg_attr(feature = "codegen", specta(skip))]
     Update,
+    UpdatePolicy,
     UpdateDataType,
     UpdateEntity,
     UpdateEntityType,
@@ -56,10 +59,15 @@ pub enum ActionName {
 
     #[cfg_attr(feature = "codegen", specta(skip))]
     Archive,
+    ArchivePolicy,
     ArchiveDataType,
     ArchiveEntity,
     ArchiveEntityType,
     ArchivePropertyType,
+
+    #[cfg_attr(feature = "codegen", specta(skip))]
+    Delete,
+    DeletePolicy,
 
     Instantiate,
 }
@@ -78,23 +86,29 @@ impl ActionName {
             | Self::View
             | Self::Update
             | Self::Archive
+            | Self::Delete
             | Self::Instantiate => Some(Self::All),
-            Self::CreateDataType
+            Self::CreatePolicy
+            | Self::CreateDataType
             | Self::CreateEntity
             | Self::CreateEntityType
             | Self::CreatePropertyType => Some(Self::Create),
-            Self::ViewDataType
+            Self::ViewPolicy
+            | Self::ViewDataType
             | Self::ViewEntity
             | Self::ViewEntityType
             | Self::ViewPropertyType => Some(Self::View),
-            Self::UpdateDataType
+            Self::UpdatePolicy
+            | Self::UpdateDataType
             | Self::UpdateEntity
             | Self::UpdateEntityType
             | Self::UpdatePropertyType => Some(Self::Update),
-            Self::ArchiveDataType
+            Self::ArchivePolicy
+            | Self::ArchiveDataType
             | Self::ArchiveEntity
             | Self::ArchiveEntityType
             | Self::ArchivePropertyType => Some(Self::Archive),
+            Self::DeletePolicy => Some(Self::Delete),
         }
     }
 
@@ -304,7 +318,6 @@ mod tests {
             let action_name = ActionName::from_euid(action_id.name())?;
             for descendant_id in action_id.descendants() {
                 let descendant = ActionName::from_euid(descendant_id)?;
-                println!("{action_name} is parent of {descendant}");
                 assert!(
                     action_name.is_parent_of(descendant),
                     "{action_name} is not a parent of {descendant}"
@@ -390,6 +403,7 @@ mod tests {
 
         // Second level actions have their direct parent and All as ancestors
         for action in [
+            ActionName::CreatePolicy,
             ActionName::CreateDataType,
             ActionName::CreateEntity,
             ActionName::CreateEntityType,
@@ -402,6 +416,7 @@ mod tests {
         }
 
         for action in [
+            ActionName::ViewPolicy,
             ActionName::ViewDataType,
             ActionName::ViewEntity,
             ActionName::ViewEntityType,
@@ -414,6 +429,7 @@ mod tests {
         }
 
         for action in [
+            ActionName::UpdatePolicy,
             ActionName::UpdateDataType,
             ActionName::UpdateEntity,
             ActionName::UpdateEntityType,
@@ -426,6 +442,7 @@ mod tests {
         }
 
         for action in [
+            ActionName::ArchivePolicy,
             ActionName::ArchiveDataType,
             ActionName::ArchiveEntity,
             ActionName::ArchiveEntityType,
@@ -436,11 +453,23 @@ mod tests {
                 vec![ActionName::Archive, ActionName::All]
             );
         }
+
+        #[expect(
+            clippy::single_element_loop,
+            reason = "More actions may be added in the future"
+        )]
+        for action in [ActionName::DeletePolicy] {
+            assert_eq!(
+                action.parents().collect::<Vec<_>>(),
+                vec![ActionName::Delete, ActionName::All]
+            );
+        }
     }
 
     #[test]
     fn is_parent_of() {
         for action in [
+            ActionName::CreatePolicy,
             ActionName::CreateDataType,
             ActionName::CreateEntity,
             ActionName::CreateEntityType,
@@ -451,6 +480,7 @@ mod tests {
         }
 
         for action in [
+            ActionName::ViewPolicy,
             ActionName::ViewDataType,
             ActionName::ViewEntity,
             ActionName::ViewEntityType,
@@ -461,6 +491,7 @@ mod tests {
         }
 
         for action in [
+            ActionName::UpdatePolicy,
             ActionName::UpdateDataType,
             ActionName::UpdateEntity,
             ActionName::UpdateEntityType,
@@ -471,6 +502,7 @@ mod tests {
         }
 
         for action in [
+            ActionName::ArchivePolicy,
             ActionName::ArchiveDataType,
             ActionName::ArchiveEntity,
             ActionName::ArchiveEntityType,
@@ -478,6 +510,15 @@ mod tests {
         ] {
             assert!(ActionName::Archive.is_parent_of(action));
             assert!(action.is_child_of(ActionName::Archive));
+        }
+
+        #[expect(
+            clippy::single_element_loop,
+            reason = "More actions may be added in the future"
+        )]
+        for action in [ActionName::DeletePolicy] {
+            assert!(ActionName::Delete.is_parent_of(action));
+            assert!(action.is_child_of(ActionName::Delete));
         }
 
         // Negative cases

--- a/libs/@local/graph/authorization/src/policies/cedar/expression_tree.rs
+++ b/libs/@local/graph/authorization/src/policies/cedar/expression_tree.rs
@@ -1,5 +1,5 @@
 use alloc::{borrow::Cow, sync::Arc};
-use core::{error::Error, str::FromStr};
+use core::{error::Error, str::FromStr as _};
 
 use cedar_policy_core::ast;
 use error_stack::{Report, ResultExt as _, TryReportTupleExt as _};

--- a/libs/@local/graph/authorization/src/policies/context.rs
+++ b/libs/@local/graph/authorization/src/policies/context.rs
@@ -12,7 +12,10 @@ use super::{
     PolicyValidator,
     cedar::ToCedarEntity as _,
     principal::actor::PublicActor,
-    resource::{DataTypeResource, EntityResource, EntityTypeResource, PropertyTypeResource},
+    resource::{
+        DataTypeResource, EntityResource, EntityTypeResource, PolicyMetaResource,
+        PropertyTypeResource,
+    },
 };
 
 #[derive(Debug, derive_more::Display, derive_more::Error)]
@@ -91,6 +94,10 @@ impl ContextBuilder {
 
     pub fn add_data_type(&mut self, data_type: &DataTypeResource) {
         self.entities.push(data_type.to_cedar_entity());
+    }
+
+    pub fn add_policy_meta_resource(&mut self, policy_resource: &PolicyMetaResource) {
+        self.entities.push(policy_resource.to_cedar_entity());
     }
 
     /// Builds the context.

--- a/libs/@local/graph/authorization/src/policies/principal/actor/mod.rs
+++ b/libs/@local/graph/authorization/src/policies/principal/actor/mod.rs
@@ -21,7 +21,6 @@ use crate::policies::{
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum AuthenticatedActor {
-    Public,
     Id(ActorId),
     Uuid(ActorEntityUuid),
 }
@@ -29,7 +28,6 @@ pub enum AuthenticatedActor {
 impl From<AuthenticatedActor> for ActorEntityUuid {
     fn from(authenticated_actor: AuthenticatedActor) -> Self {
         match authenticated_actor {
-            AuthenticatedActor::Public => Self::public_actor(),
             AuthenticatedActor::Id(actor_id) => Self::new(actor_id),
             AuthenticatedActor::Uuid(actor_uuid) => actor_uuid,
         }
@@ -39,6 +37,12 @@ impl From<AuthenticatedActor> for ActorEntityUuid {
 impl From<ActorId> for AuthenticatedActor {
     fn from(actor_id: ActorId) -> Self {
         Self::Id(actor_id)
+    }
+}
+
+impl From<Option<ActorId>> for AuthenticatedActor {
+    fn from(actor_id: Option<ActorId>) -> Self {
+        actor_id.map_or_else(|| Self::Uuid(ActorEntityUuid::public_actor()), Self::Id)
     }
 }
 

--- a/libs/@local/graph/authorization/src/policies/resource/data_type.rs
+++ b/libs/@local/graph/authorization/src/policies/resource/data_type.rs
@@ -153,6 +153,7 @@ impl TryFrom<PolicyExpressionTree> for DataTypeResourceFilter {
             | PolicyExpressionTree::In(_)
             | PolicyExpressionTree::IsOfType(_)
             | PolicyExpressionTree::IsOfBaseType(_)
+            | PolicyExpressionTree::HasAction(_)
             | PolicyExpressionTree::CreatedByPrincipal) => {
                 Err(Report::new(InvalidDataTypeResourceFilter(condition)))
             }

--- a/libs/@local/graph/authorization/src/policies/resource/entity.rs
+++ b/libs/@local/graph/authorization/src/policies/resource/entity.rs
@@ -79,6 +79,7 @@ impl TryFrom<PolicyExpressionTree> for EntityResourceFilter {
             condition @ (PolicyExpressionTree::Is(_)
             | PolicyExpressionTree::In(_)
             | PolicyExpressionTree::BaseUrl(_)
+            | PolicyExpressionTree::HasAction(_)
             | PolicyExpressionTree::OntologyTypeVersion(_)) => {
                 Err(Report::new(InvalidEntityResourceFilter(condition)))
             }

--- a/libs/@local/graph/authorization/src/policies/resource/entity_type.rs
+++ b/libs/@local/graph/authorization/src/policies/resource/entity_type.rs
@@ -153,6 +153,7 @@ impl TryFrom<PolicyExpressionTree> for EntityTypeResourceFilter {
             | PolicyExpressionTree::In(_)
             | PolicyExpressionTree::IsOfType(_)
             | PolicyExpressionTree::IsOfBaseType(_)
+            | PolicyExpressionTree::HasAction(_)
             | PolicyExpressionTree::CreatedByPrincipal) => {
                 Err(Report::new(InvalidEntityTypeResourceFilter(condition)))
             }

--- a/libs/@local/graph/authorization/src/policies/resource/meta.rs
+++ b/libs/@local/graph/authorization/src/policies/resource/meta.rs
@@ -1,0 +1,336 @@
+use alloc::sync::Arc;
+use core::{error::Error, iter};
+use std::collections::HashSet;
+
+use cedar_policy_core::{ast, extensions::Extensions};
+use error_stack::{Report, ResultExt as _};
+use smol_str::{SmolStr, ToSmolStr as _};
+use type_system::principal::actor_group::WebId;
+
+use super::{
+    DataTypeResourceConstraint, EntityResourceConstraint, EntityTypeResourceConstraint,
+    PropertyTypeResourceConstraint, ResourceConstraint,
+};
+use crate::policies::{
+    Policy, PolicyExpressionTree, PolicyId,
+    action::ActionName,
+    cedar::{
+        CedarExpressionParseError, FromCedarEntityId as _, FromCedarExpr, ToCedarEntityId as _,
+        ToCedarExpr,
+    },
+};
+
+pub struct PolicyMetaResource<'a> {
+    pub id: PolicyId,
+    pub actions: &'a [ActionName],
+    pub resource: Option<&'a ResourceConstraint>,
+}
+
+impl PolicyMetaResource<'_> {
+    pub(crate) fn to_cedar_entity(&self) -> ast::Entity {
+        let parents = match self.resource {
+            Some(
+                ResourceConstraint::Web { web_id, .. }
+                | ResourceConstraint::Meta(MetaResourceConstraint::Web { web_id, .. })
+                | ResourceConstraint::Entity(EntityResourceConstraint::Web { web_id, .. })
+                | ResourceConstraint::EntityType(EntityTypeResourceConstraint::Web {
+                    web_id, ..
+                })
+                | ResourceConstraint::PropertyType(PropertyTypeResourceConstraint::Web {
+                    web_id,
+                    ..
+                })
+                | ResourceConstraint::DataType(DataTypeResourceConstraint::Web { web_id, .. }),
+            ) => HashSet::from([web_id.to_euid()]),
+            _ => HashSet::new(),
+        };
+        ast::Entity::new(
+            self.id.to_euid(),
+            [(
+                SmolStr::new_static("actions"),
+                ast::RestrictedExpr::set(
+                    self.actions
+                        .iter()
+                        .map(|action| ast::RestrictedExpr::val(action.to_smolstr())),
+                ),
+            )],
+            HashSet::new(),
+            parents,
+            iter::empty(),
+            Extensions::none(),
+        )
+        .expect("Policy should be a valid Cedar entity")
+    }
+}
+
+impl<'a> From<&'a Policy> for PolicyMetaResource<'a> {
+    fn from(policy: &'a Policy) -> Self {
+        Self {
+            id: policy.id,
+            actions: &policy.actions,
+            resource: policy.resource.as_ref(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "codegen", derive(specta::Type))]
+#[serde(tag = "type", rename_all = "camelCase", deny_unknown_fields)]
+pub enum MetaResourceFilter {
+    #[serde(rename_all = "camelCase")]
+    All { filters: Vec<Self> },
+    #[serde(rename_all = "camelCase")]
+    Any { filters: Vec<Self> },
+    #[serde(rename_all = "camelCase")]
+    Not { filter: Box<Self> },
+    #[serde(rename_all = "camelCase")]
+    HasAction { action: ActionName },
+}
+
+#[derive(Debug, derive_more::Display)]
+#[display("expression is not supported: {_0:?}")]
+pub struct InvalidMetaResourceFilter(PolicyExpressionTree);
+
+impl Error for InvalidMetaResourceFilter {}
+
+impl TryFrom<PolicyExpressionTree> for MetaResourceFilter {
+    type Error = Report<InvalidMetaResourceFilter>;
+
+    fn try_from(condition: PolicyExpressionTree) -> Result<Self, Self::Error> {
+        match condition {
+            PolicyExpressionTree::Not(condition) => Ok(Self::Not {
+                filter: Box::new(Self::try_from(*condition)?),
+            }),
+            PolicyExpressionTree::All(conditions) => Ok(Self::All {
+                filters: conditions
+                    .into_iter()
+                    .map(Self::try_from)
+                    .collect::<Result<_, _>>()?,
+            }),
+            PolicyExpressionTree::Any(conditions) => Ok(Self::Any {
+                filters: conditions
+                    .into_iter()
+                    .map(Self::try_from)
+                    .collect::<Result<_, _>>()?,
+            }),
+            PolicyExpressionTree::HasAction(action) => Ok(Self::HasAction { action }),
+            condition @ (PolicyExpressionTree::Is(_)
+            | PolicyExpressionTree::In(_)
+            | PolicyExpressionTree::BaseUrl(_)
+            | PolicyExpressionTree::IsOfType(_)
+            | PolicyExpressionTree::IsOfBaseType(_)
+            | PolicyExpressionTree::OntologyTypeVersion(_)
+            | PolicyExpressionTree::CreatedByPrincipal) => {
+                Err(Report::new(InvalidMetaResourceFilter(condition)))
+            }
+        }
+    }
+}
+
+impl ToCedarExpr for MetaResourceFilter {
+    fn to_cedar_expr(&self) -> ast::Expr {
+        match self {
+            Self::All { filters } => filters
+                .iter()
+                .map(Self::to_cedar_expr)
+                .reduce(ast::Expr::and)
+                .unwrap_or_else(|| ast::Expr::val(true)),
+            Self::Any { filters } => filters
+                .iter()
+                .map(Self::to_cedar_expr)
+                .reduce(ast::Expr::or)
+                .unwrap_or_else(|| ast::Expr::val(false)),
+            Self::Not { filter } => ast::Expr::not(filter.to_cedar_expr()),
+            Self::HasAction { action } => ast::Expr::contains(
+                ast::Expr::get_attr(
+                    ast::Expr::var(ast::Var::Resource),
+                    SmolStr::new_static("actions"),
+                ),
+                ast::Expr::val(action.to_smolstr()),
+            ),
+        }
+    }
+}
+
+impl FromCedarExpr for MetaResourceFilter {
+    type Error = Report<CedarExpressionParseError>;
+
+    fn from_cedar(expr: &ast::Expr) -> Result<Self, Self::Error> {
+        PolicyExpressionTree::from_expr(expr)
+            .change_context(CedarExpressionParseError::ParseError)?
+            .try_into()
+            .change_context(CedarExpressionParseError::ParseError)
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "codegen", derive(specta::Type))]
+#[serde(untagged, deny_unknown_fields)]
+pub enum MetaResourceConstraint {
+    #[serde(rename_all = "camelCase")]
+    Any { filter: MetaResourceFilter },
+    #[serde(rename_all = "camelCase")]
+    Web {
+        web_id: WebId,
+        filter: MetaResourceFilter,
+    },
+}
+
+impl MetaResourceConstraint {
+    #[must_use]
+    pub(crate) fn to_cedar_resource_constraint(&self) -> (ast::ResourceConstraint, ast::Expr) {
+        match self {
+            Self::Any { filter } => (
+                ast::ResourceConstraint::is_entity_type(Arc::clone(PolicyId::entity_type())),
+                filter.to_cedar_expr(),
+            ),
+            Self::Web { web_id, filter } => (
+                ast::ResourceConstraint::is_entity_type_in(
+                    Arc::clone(PolicyId::entity_type()),
+                    Arc::new(web_id.to_euid()),
+                ),
+                filter.to_cedar_expr(),
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::error::Error;
+
+    use serde_json::json;
+    use type_system::principal::actor_group::WebId;
+    use uuid::Uuid;
+
+    use crate::{
+        policies::{
+            PolicyId, ResourceConstraint,
+            action::ActionName,
+            resource::{MetaResourceConstraint, meta::MetaResourceFilter, tests::check_resource},
+        },
+        test_utils::check_deserialization_error,
+    };
+
+    #[test]
+    fn constraint_in_any() -> Result<(), Box<dyn Error>> {
+        check_resource(
+            Some(ResourceConstraint::Meta(MetaResourceConstraint::Any {
+                filter: MetaResourceFilter::All { filters: vec![] },
+            })),
+            json!({
+                "type": "meta",
+                "filter": {
+                    "type": "all",
+                    "filters": [],
+                },
+            }),
+            "resource is HASH::Policy",
+        )?;
+
+        check_deserialization_error::<ResourceConstraint>(
+            json!({
+                "type": "meta",
+                "webId": WebId::new(Uuid::new_v4()),
+                "id": PolicyId::new(Uuid::new_v4()),
+            }),
+            "data did not match any variant of untagged enum MetaResourceConstraint",
+        )?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn constraint_in_any_with_action() -> Result<(), Box<dyn Error>> {
+        check_resource(
+            Some(ResourceConstraint::Meta(MetaResourceConstraint::Any {
+                filter: MetaResourceFilter::HasAction {
+                    action: ActionName::CreateWeb,
+                },
+            })),
+            json!({
+                "type": "meta",
+                "filter": {
+                    "type": "hasAction",
+                    "action": "createWeb",
+                },
+            }),
+            "resource is HASH::Policy",
+        )?;
+
+        check_deserialization_error::<ResourceConstraint>(
+            json!({
+                "type": "meta",
+                "webId": WebId::new(Uuid::new_v4()),
+                "id": PolicyId::new(Uuid::new_v4()),
+            }),
+            "data did not match any variant of untagged enum MetaResourceConstraint",
+        )?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn constraint_in_web() -> Result<(), Box<dyn Error>> {
+        let web_id = WebId::new(Uuid::new_v4());
+        check_resource(
+            Some(ResourceConstraint::Meta(MetaResourceConstraint::Web {
+                web_id,
+                filter: MetaResourceFilter::All { filters: vec![] },
+            })),
+            json!({
+                "type": "meta",
+                "webId": web_id,
+                "filter": {
+                    "type": "all",
+                    "filters": [],
+                },
+            }),
+            format!(r#"resource is HASH::Policy in HASH::Web::"{web_id}""#),
+        )?;
+
+        check_deserialization_error::<ResourceConstraint>(
+            json!({
+                "type": "meta",
+                "webId": WebId::new(Uuid::new_v4()),
+                "id": PolicyId::new(Uuid::new_v4()),
+            }),
+            "data did not match any variant of untagged enum MetaResourceConstraint",
+        )?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn constraint_in_web_with_action() -> Result<(), Box<dyn Error>> {
+        let web_id = WebId::new(Uuid::new_v4());
+        check_resource(
+            Some(ResourceConstraint::Meta(MetaResourceConstraint::Web {
+                web_id,
+                filter: MetaResourceFilter::HasAction {
+                    action: ActionName::View,
+                },
+            })),
+            json!({
+                "type": "meta",
+                "webId": web_id,
+                "filter": {
+                    "type": "hasAction",
+                    "action": "view",
+                },
+            }),
+            format!(r#"resource is HASH::Policy in HASH::Web::"{web_id}""#),
+        )?;
+
+        check_deserialization_error::<ResourceConstraint>(
+            json!({
+                "type": "meta",
+                "webId": WebId::new(Uuid::new_v4()),
+                "id": PolicyId::new(Uuid::new_v4()),
+            }),
+            "data did not match any variant of untagged enum MetaResourceConstraint",
+        )?;
+
+        Ok(())
+    }
+}

--- a/libs/@local/graph/authorization/src/policies/resource/property_type.rs
+++ b/libs/@local/graph/authorization/src/policies/resource/property_type.rs
@@ -153,6 +153,7 @@ impl TryFrom<PolicyExpressionTree> for PropertyTypeResourceFilter {
             | PolicyExpressionTree::In(_)
             | PolicyExpressionTree::IsOfType(_)
             | PolicyExpressionTree::IsOfBaseType(_)
+            | PolicyExpressionTree::HasAction(_)
             | PolicyExpressionTree::CreatedByPrincipal) => {
                 Err(Report::new(InvalidPropertyTypeResourceFilter(condition)))
             }

--- a/libs/@local/graph/authorization/src/policies/store/error.rs
+++ b/libs/@local/graph/authorization/src/policies/store/error.rs
@@ -327,7 +327,7 @@ pub enum RemovePolicyError {
     BuildPolicyComponents,
     #[display("Could not create policy set")]
     PolicySetCreation,
-    #[display("Permission to view or update policy was denied")]
+    #[display("Permission to delete or archive policy was denied")]
     NotAuthorized,
     #[display("Store operation failed")]
     StoreError,

--- a/libs/@local/graph/authorization/src/policies/store/error.rs
+++ b/libs/@local/graph/authorization/src/policies/store/error.rs
@@ -306,6 +306,12 @@ pub enum CreatePolicyError {
     PolicyHasNoActions,
     #[display("Invalid principal constraint")]
     InvalidPrincipalConstraint,
+    #[display("Could not build policy components")]
+    BuildPolicyComponents,
+    #[display("Could not create policy set")]
+    PolicySetCreation,
+    #[display("Permission to create policy was denied")]
+    NotAuthorized,
     #[display("Store operation failed")]
     StoreError,
 }
@@ -317,6 +323,12 @@ impl Error for CreatePolicyError {}
 pub enum RemovePolicyError {
     #[display("Policy with ID `{id}` does not exist")]
     PolicyNotFound { id: PolicyId },
+    #[display("Could not build policy components")]
+    BuildPolicyComponents,
+    #[display("Could not create policy set")]
+    PolicySetCreation,
+    #[display("Permission to view or update policy was denied")]
+    NotAuthorized,
     #[display("Store operation failed")]
     StoreError,
 }
@@ -332,6 +344,12 @@ pub enum UpdatePolicyError {
     ActionNotFound { id: ActionName },
     #[display("No actions specified in policy")]
     PolicyHasNoActions,
+    #[display("Could not build policy components")]
+    BuildPolicyComponents,
+    #[display("Could not create policy set")]
+    PolicySetCreation,
+    #[display("Permission to update policy was denied")]
+    NotAuthorized,
     #[display("Store operation failed")]
     StoreError,
 }
@@ -341,10 +359,16 @@ impl Error for UpdatePolicyError {}
 #[derive(Debug, derive_more::Display)]
 #[display("Could not get policies for actor: {_variant}")]
 pub enum GetPoliciesError {
+    #[display("Actor with UUID `{actor_entity_uuid}` does not exist")]
+    ActorIdNotFound { actor_entity_uuid: ActorEntityUuid },
     #[display("Actor with ID `{actor_id}` does not exist")]
     ActorNotFound { actor_id: ActorId },
     #[display("Invalid principal constraint")]
     InvalidPrincipalConstraint,
+    #[display("Could not build policy components")]
+    BuildPolicyComponents,
+    #[display("Could not create policy set")]
+    PolicySetCreation,
     #[display("Store operation failed")]
     StoreError,
 }

--- a/libs/@local/graph/authorization/src/policies/store/mod.rs
+++ b/libs/@local/graph/authorization/src/policies/store/mod.rs
@@ -144,7 +144,6 @@ pub struct PolicyFilter {
 #[cfg_attr(feature = "codegen", derive(specta::Type))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ResolvePoliciesParams<'a> {
-    pub actor: Option<ActorId>,
     pub actions: Cow<'a, [ActionName]>,
 }
 

--- a/libs/@local/graph/authorization/types/index.snap.d.ts
+++ b/libs/@local/graph/authorization/types/index.snap.d.ts
@@ -13,7 +13,7 @@ export interface Policy {
 }
 import type { Brand } from "@local/advanced-types/brand";
 export type PolicyId = Brand<string, "PolicyId">;
-export type ActionName = "createDataType" | "createEntity" | "createEntityType" | "createPropertyType" | "createWeb" | "viewDataType" | "viewEntity" | "viewEntityType" | "viewPropertyType" | "updateDataType" | "updateEntity" | "updateEntityType" | "updatePropertyType" | "archiveDataType" | "archiveEntity" | "archiveEntityType" | "archivePropertyType" | "instantiate";
+export type ActionName = "createPolicy" | "createDataType" | "createEntity" | "createEntityType" | "createPropertyType" | "createWeb" | "viewPolicy" | "viewDataType" | "viewEntity" | "viewEntityType" | "viewPropertyType" | "updatePolicy" | "updateDataType" | "updateEntity" | "updateEntityType" | "updatePropertyType" | "archivePolicy" | "archiveDataType" | "archiveEntity" | "archiveEntityType" | "archivePropertyType" | "deletePolicy" | "instantiate";
 export type PrincipalConstraint = {
 	type: "actor"
 } & ActorId | {
@@ -27,6 +27,8 @@ export type PrincipalConstraint = {
 	actorType?: ActorType
 } & RoleId;
 export type ResourceConstraint = {
+	type: "meta"
+} & MetaResourceConstraint | {
 	type: "web"
 	webId: WebId
 } | {
@@ -118,6 +120,25 @@ export type EntityTypeResourceFilter = {
 } | {
 	type: "isRemote"
 };
+export type MetaResourceConstraint = {
+	filter: MetaResourceFilter
+} | {
+	webId: WebId
+	filter: MetaResourceFilter
+};
+export type MetaResourceFilter = {
+	type: "all"
+	filters: MetaResourceFilter[]
+} | {
+	type: "any"
+	filters: MetaResourceFilter[]
+} | {
+	type: "not"
+	filter: MetaResourceFilter
+} | {
+	type: "hasAction"
+	action: ActionName
+};
 export type PropertyTypeId = string;
 export type PropertyTypeResourceConstraint = {
 	filter: PropertyTypeResourceFilter
@@ -175,6 +196,5 @@ export type PrincipalFilter = {
 	filter: "constrained"
 } & PrincipalConstraint;
 export interface ResolvePoliciesParams {
-	actor: (ActorId | null);
 	actions: ActionName[];
 }

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
@@ -11,7 +11,7 @@ use hash_graph_authorization::policies::{
     action::ActionName,
     principal::actor::AuthenticatedActor,
     resource::{EntityResourceConstraint, ResourceConstraint},
-    store::{PolicyCreationParams, PolicyStore as _, PrincipalStore as _},
+    store::{PolicyCreationParams, PrincipalStore as _},
 };
 use hash_graph_store::{
     entity::{
@@ -720,7 +720,7 @@ where
         //       multi-type entity types. We need a way to speed this up.
         let mut validation_params = Vec::with_capacity(params.len());
 
-        let mut transaction = self.transaction().await.change_context(InsertionError)?;
+        let transaction = self.transaction().await.change_context(InsertionError)?;
 
         let actor_id = transaction
             .determine_actor(actor_uuid)
@@ -1090,7 +1090,7 @@ where
 
         for policy in policies {
             transaction
-                .create_policy(actor_id.into(), policy)
+                .insert_policy_into_database(&policy)
                 .await
                 .change_context(InsertionError)?;
         }

--- a/libs/@local/graph/postgres-store/tests/principals/main.rs
+++ b/libs/@local/graph/postgres-store/tests/principals/main.rs
@@ -16,7 +16,12 @@ mod user;
 mod web;
 
 use error_stack::{Report, ResultExt as _};
-use hash_graph_authorization::policies::store::{PolicyStore as _, PrincipalStore as _};
+use hash_graph_authorization::policies::{
+    Effect,
+    action::ActionName,
+    principal::PrincipalConstraint,
+    store::{PolicyCreationParams, PolicyStore as _, PrincipalStore as _},
+};
 use hash_graph_postgres_store::{
     Environment, load_env,
     store::{
@@ -100,11 +105,25 @@ impl DatabaseTestWrapper {
             .await
             .change_context(StoreError)?;
 
-        let actor = transaction
-            .get_or_create_system_machine("h")
+        let actor = ActorId::Machine(
+            transaction
+                .get_or_create_system_machine("h")
+                .await
+                .change_context(StoreError)?,
+        );
+
+        // Create a policy to allow the actor to create new policies
+        transaction
+            .insert_policy_into_database(&PolicyCreationParams {
+                name: None,
+                effect: Effect::Permit,
+                principal: Some(PrincipalConstraint::Actor { actor }),
+                actions: vec![ActionName::CreatePolicy, ActionName::DeletePolicy],
+                resource: None,
+            })
             .await
             .change_context(StoreError)?;
 
-        Ok((transaction, ActorId::Machine(actor)))
+        Ok((transaction, actor))
     }
 }

--- a/libs/@local/graph/postgres-store/tests/principals/main.rs
+++ b/libs/@local/graph/postgres-store/tests/principals/main.rs
@@ -20,13 +20,13 @@ use hash_graph_authorization::policies::store::{PolicyStore as _, PrincipalStore
 use hash_graph_postgres_store::{
     Environment, load_env,
     store::{
-        AsClient, DatabaseConnectionInfo, DatabasePoolConfig, DatabaseType, PostgresStore,
-        PostgresStorePool, PostgresStoreSettings, error::StoreError,
+        DatabaseConnectionInfo, DatabasePoolConfig, DatabaseType, PostgresStore, PostgresStorePool,
+        PostgresStoreSettings, error::StoreError,
     },
 };
 use hash_graph_store::pool::StorePool;
 use hash_telemetry::logging::env_filter;
-use tokio_postgres::NoTls;
+use tokio_postgres::{NoTls, Transaction};
 use type_system::principal::actor::ActorId;
 
 pub fn init_logging() {
@@ -92,7 +92,7 @@ impl DatabaseTestWrapper {
 
     pub(crate) async fn seed(
         &mut self,
-    ) -> Result<(PostgresStore<impl AsClient>, ActorId), Report<StoreError>> {
+    ) -> Result<(PostgresStore<Transaction<'_>>, ActorId), Report<StoreError>> {
         let mut transaction = self.connection.transaction().await?;
 
         transaction

--- a/libs/@local/graph/postgres-store/tests/principals/policies.rs
+++ b/libs/@local/graph/postgres-store/tests/principals/policies.rs
@@ -403,9 +403,8 @@ async fn global_policies() -> Result<(), Box<dyn Error>> {
     // Every actor should get global policies
     let user1_policies = client
         .resolve_policies_for_actor(
-            actor_id.into(),
+            ActorId::User(env.user1).into(),
             ResolvePoliciesParams {
-                actor: Some(ActorId::User(env.user1)),
                 actions: Cow::Borrowed(&[ActionName::All]),
             },
         )
@@ -415,9 +414,8 @@ async fn global_policies() -> Result<(), Box<dyn Error>> {
         .collect::<HashSet<_>>();
     let user2_policies = client
         .resolve_policies_for_actor(
-            actor_id.into(),
+            ActorId::User(env.user2).into(),
             ResolvePoliciesParams {
-                actor: Some(ActorId::User(env.user2)),
                 actions: Cow::Borrowed(&[ActionName::All]),
             },
         )
@@ -427,9 +425,8 @@ async fn global_policies() -> Result<(), Box<dyn Error>> {
         .collect::<HashSet<_>>();
     let machine_policies = client
         .resolve_policies_for_actor(
-            actor_id.into(),
+            ActorId::Machine(env.machine_id).into(),
             ResolvePoliciesParams {
-                actor: Some(ActorId::Machine(env.machine_id)),
                 actions: Cow::Borrowed(&[ActionName::All]),
             },
         )
@@ -439,9 +436,8 @@ async fn global_policies() -> Result<(), Box<dyn Error>> {
         .collect::<HashSet<_>>();
     let ai_policies = client
         .resolve_policies_for_actor(
-            actor_id.into(),
+            ActorId::Ai(env.ai_id).into(),
             ResolvePoliciesParams {
-                actor: Some(ActorId::Ai(env.ai_id)),
                 actions: Cow::Borrowed(&[ActionName::All]),
             },
         )
@@ -451,9 +447,8 @@ async fn global_policies() -> Result<(), Box<dyn Error>> {
         .collect::<HashSet<_>>();
     let nonexisting_policies = client
         .resolve_policies_for_actor(
-            actor_id.into(),
+            ActorId::User(UserId::new(Uuid::new_v4())).into(),
             ResolvePoliciesParams {
-                actor: Some(ActorId::User(UserId::new(Uuid::new_v4()))),
                 actions: Cow::Borrowed(&[ActionName::All]),
             },
         )
@@ -497,9 +492,8 @@ async fn actor_type_policies() -> Result<(), Box<dyn Error>> {
     // Test user type policies
     let user1_policies = client
         .resolve_policies_for_actor(
-            actor_id.into(),
+            ActorId::User(env.user1).into(),
             ResolvePoliciesParams {
-                actor: Some(ActorId::User(env.user1)),
                 actions: Cow::Owned(ActionName::all().collect()),
             },
         )
@@ -509,9 +503,8 @@ async fn actor_type_policies() -> Result<(), Box<dyn Error>> {
         .collect::<HashSet<_>>();
     let user2_policies = client
         .resolve_policies_for_actor(
-            actor_id.into(),
+            ActorId::User(env.user2).into(),
             ResolvePoliciesParams {
-                actor: Some(ActorId::User(env.user2)),
                 actions: Cow::Owned(ActionName::all().collect()),
             },
         )
@@ -521,9 +514,8 @@ async fn actor_type_policies() -> Result<(), Box<dyn Error>> {
         .collect::<HashSet<_>>();
     let machine_policies = client
         .resolve_policies_for_actor(
-            actor_id.into(),
+            ActorId::Machine(env.machine_id).into(),
             ResolvePoliciesParams {
-                actor: Some(ActorId::Machine(env.machine_id)),
                 actions: Cow::Owned(ActionName::all().collect()),
             },
         )
@@ -533,9 +525,8 @@ async fn actor_type_policies() -> Result<(), Box<dyn Error>> {
         .collect::<HashSet<_>>();
     let nonexisting_machine_policies = client
         .resolve_policies_for_actor(
-            actor_id.into(),
+            ActorId::Machine(MachineId::new(Uuid::new_v4())).into(),
             ResolvePoliciesParams {
-                actor: Some(ActorId::Machine(MachineId::new(Uuid::new_v4()))),
                 actions: Cow::Owned(ActionName::all().collect()),
             },
         )
@@ -593,9 +584,8 @@ async fn specific_actor_policies() -> Result<(), Box<dyn Error>> {
     // user1 has a specific policy assigned
     let user1_policies = client
         .resolve_policies_for_actor(
-            actor_id.into(),
+            ActorId::User(env.user1).into(),
             ResolvePoliciesParams {
-                actor: Some(ActorId::User(env.user1)),
                 actions: Cow::Owned(ActionName::all().collect()),
             },
         )
@@ -605,9 +595,8 @@ async fn specific_actor_policies() -> Result<(), Box<dyn Error>> {
         .collect::<HashSet<_>>();
     let user2_policies = client
         .resolve_policies_for_actor(
-            actor_id.into(),
+            ActorId::User(env.user2).into(),
             ResolvePoliciesParams {
-                actor: Some(ActorId::User(env.user2)),
                 actions: Cow::Owned(ActionName::all().collect()),
             },
         )
@@ -617,9 +606,8 @@ async fn specific_actor_policies() -> Result<(), Box<dyn Error>> {
         .collect::<HashSet<_>>();
     let nonexisting_user_policies = client
         .resolve_policies_for_actor(
-            actor_id.into(),
+            ActorId::User(UserId::new(Uuid::new_v4())).into(),
             ResolvePoliciesParams {
-                actor: Some(ActorId::User(UserId::new(Uuid::new_v4()))),
                 actions: Cow::Owned(ActionName::all().collect()),
             },
         )
@@ -655,9 +643,8 @@ async fn role_based_policies() -> Result<(), Box<dyn Error>> {
     // Test role-based policies
     let user1_policies = client
         .resolve_policies_for_actor(
-            actor_id.into(),
+            ActorId::User(env.user1).into(),
             ResolvePoliciesParams {
-                actor: Some(ActorId::User(env.user1)),
                 actions: Cow::Owned(ActionName::all().collect()),
             },
         )
@@ -667,9 +654,8 @@ async fn role_based_policies() -> Result<(), Box<dyn Error>> {
         .collect::<HashSet<_>>();
     let user2_policies = client
         .resolve_policies_for_actor(
-            actor_id.into(),
+            ActorId::User(env.user2).into(),
             ResolvePoliciesParams {
-                actor: Some(ActorId::User(env.user2)),
                 actions: Cow::Owned(ActionName::all().collect()),
             },
         )
@@ -701,9 +687,8 @@ async fn role_based_policies() -> Result<(), Box<dyn Error>> {
 
     let machine_policies = client
         .resolve_policies_for_actor(
-            actor_id.into(),
+            ActorId::Machine(special_machine_id).into(),
             ResolvePoliciesParams {
-                actor: Some(ActorId::Machine(special_machine_id)),
                 actions: Cow::Owned(ActionName::all().collect()),
             },
         )
@@ -737,9 +722,8 @@ async fn team_hierarchy_policies() -> Result<(), Box<dyn Error>> {
     // User2 has team1_role, AI has nested_team_role which is under team1
     let user2_policies = client
         .resolve_policies_for_actor(
-            actor_id.into(),
+            ActorId::User(env.user2).into(),
             ResolvePoliciesParams {
-                actor: Some(ActorId::User(env.user2)),
                 actions: Cow::Owned(ActionName::all().collect()),
             },
         )
@@ -749,9 +733,8 @@ async fn team_hierarchy_policies() -> Result<(), Box<dyn Error>> {
         .collect::<HashSet<_>>();
     let ai_policies = client
         .resolve_policies_for_actor(
-            actor_id.into(),
+            ActorId::Ai(env.ai_id).into(),
             ResolvePoliciesParams {
-                actor: Some(ActorId::Ai(env.ai_id)),
                 actions: Cow::Owned(ActionName::all().collect()),
             },
         )
@@ -787,9 +770,8 @@ async fn policy_count_and_content() -> Result<(), Box<dyn Error>> {
 
     let user1_policies = client
         .resolve_policies_for_actor(
-            actor_id.into(),
+            ActorId::User(env.user1).into(),
             ResolvePoliciesParams {
-                actor: Some(ActorId::User(env.user1)),
                 // We don't list `ViewEntity` here to test that it is still included in the
                 // resulting policy
                 actions: Cow::Borrowed(&[
@@ -807,9 +789,8 @@ async fn policy_count_and_content() -> Result<(), Box<dyn Error>> {
         .collect::<HashMap<_, _>>();
     let user2_policies = client
         .resolve_policies_for_actor(
-            actor_id.into(),
+            ActorId::User(env.user2).into(),
             ResolvePoliciesParams {
-                actor: Some(ActorId::User(env.user2)),
                 actions: Cow::Owned(ActionName::all().collect()),
             },
         )
@@ -819,9 +800,8 @@ async fn policy_count_and_content() -> Result<(), Box<dyn Error>> {
         .collect::<HashMap<_, _>>();
     let machine_policies = client
         .resolve_policies_for_actor(
-            actor_id.into(),
+            ActorId::Machine(env.machine_id).into(),
             ResolvePoliciesParams {
-                actor: Some(ActorId::Machine(env.machine_id)),
                 actions: Cow::Owned(ActionName::all().collect()),
             },
         )
@@ -831,9 +811,8 @@ async fn policy_count_and_content() -> Result<(), Box<dyn Error>> {
         .collect::<HashMap<_, _>>();
     let ai_policies = client
         .resolve_policies_for_actor(
-            actor_id.into(),
+            ActorId::Ai(env.ai_id).into(),
             ResolvePoliciesParams {
-                actor: Some(ActorId::Ai(env.ai_id)),
                 actions: Cow::Owned(ActionName::all().collect()),
             },
         )
@@ -843,9 +822,8 @@ async fn policy_count_and_content() -> Result<(), Box<dyn Error>> {
         .collect::<HashMap<_, _>>();
     let nonexistent_policies = client
         .resolve_policies_for_actor(
-            actor_id.into(),
+            ActorId::User(nonexistent_id).into(),
             ResolvePoliciesParams {
-                actor: Some(ActorId::User(nonexistent_id)),
                 actions: Cow::Owned(ActionName::all().collect()),
             },
         )
@@ -920,9 +898,8 @@ async fn role_assignment_changes() -> Result<(), Box<dyn Error>> {
     // Initial policy count
     let user2_policies = client
         .resolve_policies_for_actor(
-            actor_id.into(),
+            ActorId::User(env.user2).into(),
             ResolvePoliciesParams {
-                actor: Some(ActorId::User(env.user2)),
                 actions: Cow::Owned(ActionName::all().collect()),
             },
         )
@@ -945,9 +922,8 @@ async fn role_assignment_changes() -> Result<(), Box<dyn Error>> {
     // Should have fewer policies now
     let updated_policies = client
         .resolve_policies_for_actor(
-            actor_id.into(),
+            ActorId::User(env.user2).into(),
             ResolvePoliciesParams {
-                actor: Some(ActorId::User(env.user2)),
                 actions: Cow::Owned(ActionName::all().collect()),
             },
         )
@@ -972,9 +948,8 @@ async fn role_assignment_changes() -> Result<(), Box<dyn Error>> {
     // Should have different policies now after adding a new role
     let final_policies = client
         .resolve_policies_for_actor(
-            actor_id.into(),
+            ActorId::User(env.user2).into(),
             ResolvePoliciesParams {
-                actor: Some(ActorId::User(env.user2)),
                 actions: Cow::Owned(ActionName::all().collect()),
             },
         )
@@ -1021,9 +996,8 @@ async fn resource_constraints_are_preserved() -> Result<(), Box<dyn Error>> {
 
     let policies = client
         .resolve_policies_for_actor(
-            actor_id.into(),
+            ActorId::User(user_id).into(),
             ResolvePoliciesParams {
-                actor: Some(ActorId::User(user_id)),
                 actions: Cow::Borrowed(&[ActionName::All]),
             },
         )
@@ -1152,9 +1126,8 @@ async fn deep_team_hierarchy() -> Result<(), Box<dyn Error>> {
     // User should get all policies through the hierarchy
     let policies = client
         .resolve_policies_for_actor(
-            actor_id.into(),
+            ActorId::User(user_id).into(),
             ResolvePoliciesParams {
-                actor: Some(ActorId::User(user_id)),
                 actions: Cow::Borrowed(&[ActionName::All]),
             },
         )

--- a/libs/@local/graph/store/src/filter/mod.rs
+++ b/libs/@local/graph/store/src/filter/mod.rs
@@ -306,7 +306,8 @@ impl<'p> Filter<'p, DataTypeWithMetadata> {
                 ]),
                 DataTypeResourceConstraint::Any { filter } => Self::for_resource_filter(filter),
             },
-            ResourceConstraint::PropertyType(_)
+            ResourceConstraint::Meta(_)
+            | ResourceConstraint::PropertyType(_)
             | ResourceConstraint::EntityType(_)
             | ResourceConstraint::Entity(_) => Self::Any(Vec::new()),
         }
@@ -469,7 +470,8 @@ impl<'p> Filter<'p, PropertyTypeWithMetadata> {
                     }
                 }
             }
-            ResourceConstraint::DataType(_)
+            ResourceConstraint::Meta(_)
+            | ResourceConstraint::DataType(_)
             | ResourceConstraint::EntityType(_)
             | ResourceConstraint::Entity(_) => Self::Any(Vec::new()),
         }
@@ -705,7 +707,8 @@ impl<'p> Filter<'p, EntityTypeWithMetadata> {
                     }
                 }
             }
-            ResourceConstraint::DataType(_)
+            ResourceConstraint::Meta(_)
+            | ResourceConstraint::DataType(_)
             | ResourceConstraint::Entity(_)
             | ResourceConstraint::PropertyType(_) => Self::Any(Vec::new()),
         }
@@ -999,7 +1002,8 @@ impl<'p> Filter<'p, Entity> {
                     Self::for_resource_filter(filter, actor_id)
                 }
             },
-            ResourceConstraint::DataType(_)
+            ResourceConstraint::Meta(_)
+            | ResourceConstraint::DataType(_)
             | ResourceConstraint::EntityType(_)
             | ResourceConstraint::PropertyType(_) => Self::Any(Vec::new()),
         }

--- a/tests/hash-backend-integration/src/tests/graph/authorization/policy.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/authorization/policy.test.ts
@@ -167,7 +167,7 @@ describe("Policy CRUD", () => {
         },
         {
           type: "add-action",
-          action: "viewPropertyType",
+          action: "updateEntity",
         },
         {
           type: "remove-action",
@@ -214,7 +214,7 @@ describe("Policy CRUD", () => {
       [
         {
           type: "remove-action",
-          action: "viewPropertyType",
+          action: "updateEntity",
         },
       ],
     );


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR implements meta-permissions for policy management in HASH's authorization system. It establishes who can create, update, and delete policies by introducing a new `Policy` entity type in Cedar schema and implementing resource constraints that scope policy management permissions to appropriate actor roles.

The implementation follows the principle that policy management should be restricted by resource constraints - web administrators can manage policies within their web scope, while preventing unauthorized global policy creation that could lead to privilege escalation.

## 🔗 Related links

- [H-4825: Explore meta-permissions — Who can manage policies?](https://linear.app/hash/issue/H-4825/explore-meta-permissions-who-can-manage-policies)

## 🚫 Blocked by

- N/A

## 🔍 What does this change?

### Cedar Schema Updates
- Add `Policy` entity type with `actions: Set<String>` attribute
- Add policy management actions: `createPolicy`, `viewPolicy`, `updatePolicy`, `archivePolicy`, `deletePolicy`
- Add `delete` as top-level action (placeholder for future delete actions)

### Authorization System Enhancements
- **New Action Hierarchy**: Implement policy-specific actions (`CreatePolicy`, `ViewPolicy`, etc.) as children of base actions
- **Meta-Resource Constraints**: Add `MetaResourceConstraint` and `MetaResourceFilter` for policy-based permissions
- **Policy Meta-Resource**: Add `PolicyMetaResource` for Cedar entity representation of policies
- **Resource Constraint Integration**: Extend `ResourceConstraint` enum with `Meta` variant

### Policy Store Implementation
- **Authorization Checks**: All policy CRUD operations now validate permissions using meta-policies
- **Scope Enforcement**: Web administrators can only manage policies within their web scope
- **Global Policy Protection**: System-wide policies are protected by forbid policies

### Security Model
- **Privilege Escalation Prevention**: Global forbid policies prevent creation of dangerous meta-policies
- **Web Admin Scoping**: Policy management permissions are scoped to specific web contexts
- **System Actor Permissions**: Limited system machine permissions for temporary policy creation

### Core Components
- `libs/@local/graph/authorization/src/policies/resource/meta.rs`: New meta-resource implementation
- Policy action definitions with proper parent-child relationships
- Cedar expression tree support for `HasAction` filtering
- Enhanced error handling for policy operations

## 🐾 Next steps

- Add resource-ID based policy management for fine-grained permissions

## 🛡 What tests cover this?

- **Integration Tests**: `tests/hash-backend-integration/src/tests/graph/authorization/policy.test.ts`
  - Policy creation within web scope (permitted)
  - Global policy creation (forbidden)
  - Policy querying and filtering
  - Policy CRUD operations with proper authorization
- **Unit Tests**: `libs/@local/graph/postgres-store/tests/principals/policies.rs`
  - Policy resolution through role hierarchies
  - Meta-resource constraint validation
  - Action hierarchy testing
- **Resource Constraint Tests**: `libs/@local/graph/authorization/src/policies/resource/meta.rs`
  - Meta-resource filter serialization/deserialization
  - Cedar expression generation for policy constraints

## ❓ How to test this?

1. Checkout the branch and run the test suite
2. Create a test user with web administrator role
3. Try creating a policy scoped to their web (should succeed)
4. Try creating a global policy (should fail with "Permission to create policy was denied")
5. Try creating a policy with dangerous actions like `CreateWeb` (should fail due to global forbid policy)
6. Verify policy querying returns only policies the user has permission to view