### PR TITLE
H-4952: Replace boolean parameters with `MergePolicies` enum in policy components

### DIFF
--- a/libs/@local/graph/authorization/src/policies/components.rs
+++ b/libs/@local/graph/authorization/src/policies/components.rs
@@ -446,12 +446,12 @@ impl<'a, S> PolicyComponentsBuilder<'a, S> {
 
     /// Adds an action to be tracked during policy resolution.
     ///
-    /// The `action` will be included in policy queries and evaluation. The `optimize`
+    /// The `action` will be included in policy queries and evaluation. The `merge_policies`
     /// parameter controls whether this action undergoes optimization analysis, which
     /// can improve database query performance by extracting optimizable policies.
     ///
-    /// When `optimize` is `true`, the resulting [`PolicyComponents`] cannot be used
-    /// to create a [`PolicySet`] for this action, as optimizable policies are
+    /// When `merge_policies` is [`MergePolicies::Yes`], the resulting [`PolicyComponents`] cannot
+    /// be used to create a [`PolicySet`] for this action, as optimizable policies are
     /// extracted during analysis.
     pub fn add_action(&mut self, action: ActionName, merge_policies: MergePolicies) {
         self.actions.insert(action, merge_policies);
@@ -460,11 +460,11 @@ impl<'a, S> PolicyComponentsBuilder<'a, S> {
     /// Adds multiple actions to be tracked during policy resolution.
     ///
     /// All provided `actions` will be included in policy queries and evaluation.
-    /// The `optimize` parameter applies to all actions and controls whether they
+    /// The `merge_policies` parameter applies to all actions and controls whether they
     /// undergo optimization analysis for improved database query performance.
     ///
-    /// When `optimize` is `true`, the resulting [`PolicyComponents`] cannot be used
-    /// to create a [`PolicySet`] for any of these actions, as optimizable policies
+    /// When `merge_policies` is [`MergePolicies::Yes`], the resulting [`PolicyComponents`] cannot
+    /// be used to create a [`PolicySet`] for any of these actions, as optimizable policies
     /// are extracted during analysis.
     pub fn add_actions(
         &mut self,
@@ -477,12 +477,12 @@ impl<'a, S> PolicyComponentsBuilder<'a, S> {
 
     /// Adds an action to be tracked and returns the builder.
     ///
-    /// The `action` will be included in policy queries and evaluation. The `optimize`
+    /// The `action` will be included in policy queries and evaluation. The `merge_policies`
     /// parameter controls whether this action undergoes optimization analysis, which
     /// can improve database query performance by extracting optimizable policies.
     ///
-    /// When `optimize` is `true`, the resulting [`PolicyComponents`] cannot be used
-    /// to create a [`PolicySet`] for this action, as optimizable policies are
+    /// When `merge_policies` is [`MergePolicies::Yes`], the resulting [`PolicyComponents`] cannot
+    /// be used to create a [`PolicySet`] for this action, as optimizable policies are
     /// extracted during analysis.
     #[must_use]
     pub fn with_action(mut self, action: ActionName, merge_policies: MergePolicies) -> Self {
@@ -493,11 +493,11 @@ impl<'a, S> PolicyComponentsBuilder<'a, S> {
     /// Adds multiple actions to be tracked and returns the builder.
     ///
     /// All provided `actions` will be included in policy queries and evaluation.
-    /// The `optimize` parameter applies to all actions and controls whether they
+    /// The `merge_policies` parameter applies to all actions and controls whether they
     /// undergo optimization analysis for improved database query performance.
     ///
-    /// When `optimize` is `true`, the resulting [`PolicyComponents`] cannot be used
-    /// to create a [`PolicySet`] for any of these actions, as optimizable policies
+    /// When `merge_policies` is [`MergePolicies::Yes`], the resulting [`PolicyComponents`] cannot
+    /// be used to create a [`PolicySet`] for any of these actions, as optimizable policies
     /// are extracted during analysis.
     #[must_use]
     pub fn with_actions(

--- a/libs/@local/graph/authorization/src/policies/mod.rs
+++ b/libs/@local/graph/authorization/src/policies/mod.rs
@@ -31,7 +31,7 @@ use self::{
 };
 pub use self::{
     cedar::PolicyExpressionTree,
-    components::{OptimizationData, PolicyComponents, PolicyComponentsBuilder},
+    components::{MergePolicies, OptimizationData, PolicyComponents, PolicyComponentsBuilder},
     context::{Context, ContextBuilder, ContextError},
     set::{
         Authorized, PolicyConstraintError, PolicyEvaluationError, PolicySet,

--- a/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
@@ -14,7 +14,7 @@ use std::collections::{HashMap, HashSet};
 use error_stack::{Report, ResultExt as _, TryReportStreamExt as _};
 use futures::{StreamExt as _, TryStreamExt as _};
 use hash_graph_authorization::policies::{
-    Authorized, ContextBuilder, Effect, Policy, PolicyComponents, PolicyId, Request,
+    Authorized, ContextBuilder, Effect, MergePolicies, Policy, PolicyComponents, PolicyId, Request,
     RequestContext, ResourceId,
     action::ActionName,
     principal::{PrincipalConstraint, actor::AuthenticatedActor},
@@ -668,7 +668,7 @@ where
     ) -> Result<CreateWebResponse, Report<WebCreationError>> {
         let policy_components = PolicyComponents::builder(self)
             .with_actor(actor)
-            .with_action(ActionName::CreateWeb, false)
+            .with_action(ActionName::CreateWeb, MergePolicies::No)
             .await
             .change_context(WebCreationError::BuildPolicyComponents)?;
 
@@ -1232,7 +1232,7 @@ where
 
         let policy_components = PolicyComponents::builder(&transaction)
             .with_actor(authenticated_actor)
-            .with_action(ActionName::CreatePolicy, false)
+            .with_action(ActionName::CreatePolicy, MergePolicies::No)
             .with_policy_meta_resource(&PolicyMetaResource {
                 id: policy_id,
                 actions: &policy.actions,
@@ -1327,7 +1327,7 @@ where
 
         let mut policy_components_builder = PolicyComponents::builder(self)
             .with_actor(authenticated_actor)
-            .with_action(ActionName::ViewPolicy, false);
+            .with_action(ActionName::ViewPolicy, MergePolicies::No);
         for policy in &policies {
             policy_components_builder.add_policy_meta_resource(&PolicyMetaResource::from(policy));
         }
@@ -1559,7 +1559,7 @@ where
 
         let old_policy_components = PolicyComponents::builder(&transaction)
             .with_actor(authenticated_actor)
-            .with_action(ActionName::UpdatePolicy, false)
+            .with_action(ActionName::UpdatePolicy, MergePolicies::No)
             .with_policy_meta_resource(&PolicyMetaResource::from(&old_policy))
             .await
             .change_context(UpdatePolicyError::BuildPolicyComponents)?;
@@ -1591,7 +1591,7 @@ where
 
         let updated_policy_components = PolicyComponents::builder(&transaction)
             .with_actor(authenticated_actor)
-            .with_actions([ActionName::UpdatePolicy], false)
+            .with_actions([ActionName::UpdatePolicy], MergePolicies::No)
             .with_policy_meta_resource(&PolicyMetaResource::from(&update_policy))
             .await
             .change_context(UpdatePolicyError::BuildPolicyComponents)?;
@@ -1641,7 +1641,7 @@ where
 
         let policy_components = PolicyComponents::builder(self)
             .with_actor(authenticated_actor)
-            .with_action(ActionName::ArchivePolicy, false)
+            .with_action(ActionName::ArchivePolicy, MergePolicies::No)
             .with_policy_meta_resource(&PolicyMetaResource::from(&policy))
             .await
             .change_context(RemovePolicyError::BuildPolicyComponents)?;
@@ -1687,7 +1687,7 @@ where
 
         let policy_components = PolicyComponents::builder(self)
             .with_actor(authenticated_actor)
-            .with_action(ActionName::DeletePolicy, false)
+            .with_action(ActionName::DeletePolicy, MergePolicies::No)
             .with_policy_meta_resource(&PolicyMetaResource::from(&policy))
             .await
             .change_context(RemovePolicyError::BuildPolicyComponents)?;

--- a/libs/@local/graph/postgres-store/src/store/postgres/ontology/data_type.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/ontology/data_type.rs
@@ -5,8 +5,8 @@ use std::collections::{HashMap, HashSet};
 use error_stack::{Report, ResultExt as _};
 use futures::{StreamExt as _, TryStreamExt as _};
 use hash_graph_authorization::policies::{
-    Authorized, PolicyComponents, Request, RequestContext, ResourceId, action::ActionName,
-    principal::actor::AuthenticatedActor,
+    Authorized, MergePolicies, PolicyComponents, Request, RequestContext, ResourceId,
+    action::ActionName, principal::actor::AuthenticatedActor,
 };
 use hash_graph_store::{
     data_type::{
@@ -485,7 +485,7 @@ where
 
         let policy_components = policy_components_builder
             .with_actor(actor_id)
-            .with_actions([ActionName::CreateDataType], false)
+            .with_actions([ActionName::CreateDataType], MergePolicies::No)
             .await
             .change_context(InsertionError)?;
 
@@ -656,7 +656,7 @@ where
     ) -> Result<GetDataTypesResponse, Report<QueryError>> {
         let policy_components = PolicyComponents::builder(self)
             .with_actor(actor_id)
-            .with_action(ActionName::ViewDataType, true)
+            .with_action(ActionName::ViewDataType, MergePolicies::Yes)
             .await
             .change_context(QueryError)?;
 
@@ -680,7 +680,7 @@ where
     ) -> Result<usize, Report<QueryError>> {
         let policy_components = PolicyComponents::builder(self)
             .with_actor(actor_id)
-            .with_action(ActionName::ViewDataType, true)
+            .with_action(ActionName::ViewDataType, MergePolicies::Yes)
             .await
             .change_context(QueryError)?;
 
@@ -709,7 +709,7 @@ where
     ) -> Result<GetDataTypeSubgraphResponse, Report<QueryError>> {
         let policy_components = PolicyComponents::builder(self)
             .with_actor(actor_id)
-            .with_action(ActionName::ViewDataType, true)
+            .with_action(ActionName::ViewDataType, MergePolicies::Yes)
             .await
             .change_context(QueryError)?;
 
@@ -874,7 +874,7 @@ where
         let policy_components = PolicyComponents::builder(&transaction)
             .with_actor(actor_id)
             .with_data_type_ids(&old_data_type_ids)
-            .with_actions([ActionName::UpdateDataType], false)
+            .with_actions([ActionName::UpdateDataType], MergePolicies::No)
             .await
             .change_context(UpdateError)?;
 
@@ -1050,7 +1050,7 @@ where
         let policy_components = PolicyComponents::builder(self)
             .with_actor(actor_id)
             .with_data_type_id(&params.data_type_id)
-            .with_actions([ActionName::ArchiveDataType], false)
+            .with_actions([ActionName::ArchiveDataType], MergePolicies::No)
             .await
             .change_context(UpdateError)?;
 
@@ -1092,7 +1092,7 @@ where
         let policy_components = PolicyComponents::builder(self)
             .with_actor(actor_id)
             .with_data_type_id(&params.data_type_id)
-            .with_actions([ActionName::ArchiveDataType], false)
+            .with_actions([ActionName::ArchiveDataType], MergePolicies::No)
             .await
             .change_context(UpdateError)?;
 
@@ -1216,7 +1216,7 @@ where
     ) -> Result<GetDataTypeConversionTargetsResponse, Report<QueryError>> {
         let policy_components = PolicyComponents::builder(self)
             .with_actor(actor_id)
-            .with_actions([ActionName::ViewDataType], true)
+            .with_actions([ActionName::ViewDataType], MergePolicies::Yes)
             .await
             .change_context(QueryError)?;
 
@@ -1448,7 +1448,7 @@ where
 
         let policy_components = PolicyComponents::builder(self)
             .with_actor(authenticated_actor)
-            .with_action(params.action, true)
+            .with_action(params.action, MergePolicies::Yes)
             .await
             .change_context(CheckPermissionError::BuildPolicyContext)?;
         let policy_filter = Filter::<DataTypeWithMetadata>::for_policies(

--- a/libs/@local/graph/postgres-store/src/store/postgres/ontology/entity_type.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/ontology/entity_type.rs
@@ -5,8 +5,8 @@ use std::collections::{HashMap, HashSet};
 use error_stack::{Report, ResultExt as _};
 use futures::{StreamExt as _, TryStreamExt as _};
 use hash_graph_authorization::policies::{
-    Authorized, PolicyComponents, Request, RequestContext, ResourceId, action::ActionName,
-    principal::actor::AuthenticatedActor,
+    Authorized, MergePolicies, PolicyComponents, Request, RequestContext, ResourceId,
+    action::ActionName, principal::actor::AuthenticatedActor,
 };
 use hash_graph_store::{
     entity::ClosedMultiEntityTypeMap,
@@ -835,7 +835,7 @@ where
 
         let policy_components = policy_components_builder
             .with_actor(actor_id)
-            .with_actions([ActionName::CreateEntityType], false)
+            .with_actions([ActionName::CreateEntityType], MergePolicies::No)
             .await
             .change_context(InsertionError)?;
 
@@ -996,7 +996,7 @@ where
     ) -> Result<usize, Report<QueryError>> {
         let policy_components = PolicyComponents::builder(self)
             .with_actor(actor_id)
-            .with_action(ActionName::ViewEntityType, true)
+            .with_action(ActionName::ViewEntityType, MergePolicies::Yes)
             .await
             .change_context(QueryError)?;
 
@@ -1043,7 +1043,7 @@ where
     ) -> Result<GetEntityTypesResponse, Report<QueryError>> {
         let policy_components = PolicyComponents::builder(self)
             .with_actor(actor_id)
-            .with_action(ActionName::ViewEntityType, true)
+            .with_action(ActionName::ViewEntityType, MergePolicies::Yes)
             .await
             .change_context(QueryError)?;
 
@@ -1243,7 +1243,7 @@ where
 
         let policy_components = PolicyComponents::builder(self)
             .with_actor(actor_id)
-            .with_actions(actions, true)
+            .with_actions(actions, MergePolicies::Yes)
             .await
             .change_context(QueryError)?;
 
@@ -1408,7 +1408,7 @@ where
         let policy_components = PolicyComponents::builder(&transaction)
             .with_actor(actor_id)
             .with_entity_type_ids(&old_entity_type_ids)
-            .with_actions([ActionName::UpdateEntityType], false)
+            .with_actions([ActionName::UpdateEntityType], MergePolicies::No)
             .await
             .change_context(UpdateError)?;
 
@@ -1573,7 +1573,7 @@ where
         let policy_components = PolicyComponents::builder(self)
             .with_actor(actor_id)
             .with_entity_type_id(&params.entity_type_id)
-            .with_actions([ActionName::ArchiveEntityType], false)
+            .with_actions([ActionName::ArchiveEntityType], MergePolicies::No)
             .await
             .change_context(UpdateError)?;
 
@@ -1617,7 +1617,7 @@ where
         let policy_components = PolicyComponents::builder(self)
             .with_actor(actor_id)
             .with_entity_type_id(&params.entity_type_id)
-            .with_actions([ActionName::ArchiveEntityType], false)
+            .with_actions([ActionName::ArchiveEntityType], MergePolicies::No)
             .await
             .change_context(UpdateError)?;
 
@@ -1823,8 +1823,8 @@ where
 
             let policy_components = PolicyComponents::builder(self)
                 .with_actor(authenticated_actor)
-                .with_action(ActionName::Instantiate, false)
-                .with_action(ActionName::ViewEntityType, true)
+                .with_action(ActionName::Instantiate, MergePolicies::No)
+                .with_action(ActionName::ViewEntityType, MergePolicies::Yes)
                 .with_entity_type_ids(params.entity_type_ids.iter())
                 .await
                 .change_context(CheckPermissionError::BuildPolicyContext)?;
@@ -1915,7 +1915,7 @@ where
 
             let policy_components = PolicyComponents::builder(self)
                 .with_actor(authenticated_actor)
-                .with_action(params.action, true)
+                .with_action(params.action, MergePolicies::Yes)
                 .await
                 .change_context(CheckPermissionError::BuildPolicyContext)?;
             let policy_filter = Filter::<EntityTypeWithMetadata>::for_policies(

--- a/libs/@local/graph/postgres-store/src/store/postgres/ontology/property_type.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/ontology/property_type.rs
@@ -4,8 +4,8 @@ use std::collections::{HashMap, HashSet};
 use error_stack::{Report, ResultExt as _};
 use futures::{StreamExt as _, TryStreamExt as _};
 use hash_graph_authorization::policies::{
-    Authorized, PolicyComponents, Request, RequestContext, ResourceId, action::ActionName,
-    principal::actor::AuthenticatedActor,
+    Authorized, MergePolicies, PolicyComponents, Request, RequestContext, ResourceId,
+    action::ActionName, principal::actor::AuthenticatedActor,
 };
 use hash_graph_store::{
     error::{CheckPermissionError, InsertionError, QueryError, UpdateError},
@@ -472,7 +472,7 @@ where
 
         let policy_components = policy_components_builder
             .with_actor(actor_id)
-            .with_actions([ActionName::CreatePropertyType], false)
+            .with_actions([ActionName::CreatePropertyType], MergePolicies::No)
             .await
             .change_context(InsertionError)?;
 
@@ -546,7 +546,7 @@ where
     ) -> Result<usize, Report<QueryError>> {
         let policy_components = PolicyComponents::builder(self)
             .with_actor(actor_id)
-            .with_action(ActionName::ViewPropertyType, true)
+            .with_action(ActionName::ViewPropertyType, MergePolicies::Yes)
             .await
             .change_context(QueryError)?;
 
@@ -593,7 +593,7 @@ where
     ) -> Result<GetPropertyTypesResponse, Report<QueryError>> {
         let policy_components = PolicyComponents::builder(self)
             .with_actor(actor_id)
-            .with_action(ActionName::ViewPropertyType, true)
+            .with_action(ActionName::ViewPropertyType, MergePolicies::Yes)
             .await
             .change_context(QueryError)?;
 
@@ -621,7 +621,7 @@ where
 
         let policy_components = PolicyComponents::builder(self)
             .with_actor(actor_id)
-            .with_actions(actions, true)
+            .with_actions(actions, MergePolicies::Yes)
             .await
             .change_context(QueryError)?;
 
@@ -787,7 +787,7 @@ where
         let policy_components = PolicyComponents::builder(&transaction)
             .with_actor(actor_id)
             .with_property_type_ids(&old_property_type_ids)
-            .with_actions([ActionName::UpdatePropertyType], false)
+            .with_actions([ActionName::UpdatePropertyType], MergePolicies::No)
             .await
             .change_context(UpdateError)?;
 
@@ -860,7 +860,7 @@ where
         let policy_components = PolicyComponents::builder(self)
             .with_actor(actor_id)
             .with_property_type_id(&params.property_type_id)
-            .with_actions([ActionName::ArchivePropertyType], false)
+            .with_actions([ActionName::ArchivePropertyType], MergePolicies::No)
             .await
             .change_context(UpdateError)?;
 
@@ -904,7 +904,7 @@ where
         let policy_components = PolicyComponents::builder(self)
             .with_actor(actor_id)
             .with_property_type_id(&params.property_type_id)
-            .with_actions([ActionName::ArchivePropertyType], false)
+            .with_actions([ActionName::ArchivePropertyType], MergePolicies::No)
             .await
             .change_context(UpdateError)?;
 
@@ -1044,7 +1044,7 @@ where
 
         let policy_components = PolicyComponents::builder(self)
             .with_actor(authenticated_actor)
-            .with_action(params.action, true)
+            .with_action(params.action, MergePolicies::Yes)
             .await
             .change_context(CheckPermissionError::BuildPolicyContext)?;
         let policy_filter = Filter::<PropertyTypeWithMetadata>::for_policies(


### PR DESCRIPTION
🌟 What is the purpose of this PR?

  This PR replaces the boolean optimize parameter in policy component methods with a more descriptive MergePolicies
  enum that has Yes and No variants. This change improves type safety and makes the intent clearer regarding whether
   similar policies should be merged for optimization purposes during policy resolution.

  🔍 What does this change?

  - Added MergePolicies enum to libs/@local/graph/authorization/src/policies/components.rs
    - Yes variant: Similar policies may be merged into a single policy for optimization
    - No variant: Similar policies may not be merged and must remain separate
  - Updated method signatures for policy component methods:
    - add_action(action, merge_policies: MergePolicies)
    - add_actions(actions, merge_policies: MergePolicies)
    - with_action(action, merge_policies: MergePolicies)
    - with_actions(actions, merge_policies: MergePolicies)
  - Updated all call sites across the codebase (47 total calls) by replacing boolean parameters:
    - true → MergePolicies::Yes (for view/read operations that benefit from optimization)
    - false → MergePolicies::No (for create/update/delete operations requiring strict access control)
  - Updated documentation to reflect the new enum-based API
  - Applied consistent pattern:
    - MergePolicies::Yes for view operations (ViewEntity, ViewEntityType, etc.)
    - MergePolicies::No for mutating operations (CreateEntity, UpdateEntity, DeleteEntity, etc.)