### PR TITLE
H-5025: Use an `ast::Value` instead of an `ast::Expr` for Cedar entity creation

### DIFF
--- a/libs/@local/graph/authorization/src/policies/cedar/mod.rs
+++ b/libs/@local/graph/authorization/src/policies/cedar/mod.rs
@@ -11,8 +11,8 @@ pub use self::expression_tree::PolicyExpressionTree;
 pub(crate) use self::visitor::CedarExpressionParseError;
 use crate::policies::error::FromCedarRefernceError;
 
-pub(crate) trait ToCedarRestrictedExpr {
-    fn to_cedar_restricted_expr(&self) -> ast::RestrictedExpr;
+pub(crate) trait ToCedarValue {
+    fn to_cedar_value(&self) -> ast::Value;
 }
 
 pub(crate) trait ToCedarExpr {
@@ -21,10 +21,10 @@ pub(crate) trait ToCedarExpr {
 
 impl<T> ToCedarExpr for T
 where
-    T: ToCedarRestrictedExpr,
+    T: ToCedarValue,
 {
     fn to_cedar_expr(&self) -> ast::Expr {
-        self.to_cedar_restricted_expr().into()
+        self.to_cedar_value().into()
     }
 }
 

--- a/libs/@local/graph/authorization/src/policies/principal/actor/ai.rs
+++ b/libs/@local/graph/authorization/src/policies/principal/actor/ai.rs
@@ -2,7 +2,7 @@ use alloc::sync::Arc;
 use core::{iter, str::FromStr as _};
 use std::{collections::HashSet, sync::LazyLock};
 
-use cedar_policy_core::{ast, extensions::Extensions};
+use cedar_policy_core::ast;
 use error_stack::Report;
 use smol_str::SmolStr;
 use type_system::principal::{
@@ -11,20 +11,17 @@ use type_system::principal::{
 };
 use uuid::Uuid;
 
-use crate::policies::cedar::{
-    FromCedarEntityId, ToCedarEntity, ToCedarEntityId, ToCedarRestrictedExpr,
-};
+use crate::policies::cedar::{FromCedarEntityId, ToCedarEntity, ToCedarEntityId, ToCedarValue};
 
-impl ToCedarRestrictedExpr for AiId {
-    fn to_cedar_restricted_expr(&self) -> ast::RestrictedExpr {
-        ast::RestrictedExpr::record([
-            (
-                SmolStr::new_static("id"),
-                ast::RestrictedExpr::val(self.to_string()),
-            ),
-            (SmolStr::new_static("type"), ast::RestrictedExpr::val("ai")),
-        ])
-        .expect("No duplicate keys in ai record")
+impl ToCedarValue for AiId {
+    fn to_cedar_value(&self) -> ast::Value {
+        ast::Value::record(
+            [
+                (SmolStr::new_static("id"), SmolStr::new(self.to_string())),
+                (SmolStr::new_static("type"), SmolStr::new_static("ai")),
+            ],
+            None,
+        )
     }
 }
 
@@ -54,18 +51,16 @@ impl ToCedarEntityId for AiId {
 
 impl ToCedarEntity for Ai {
     fn to_cedar_entity(&self) -> ast::Entity {
-        ast::Entity::new(
+        ast::Entity::new_with_attr_partial_value(
             self.id.to_euid(),
             [(
                 SmolStr::new_static("id"),
-                self.id.to_cedar_restricted_expr(),
+                ast::PartialValue::Value(self.id.to_cedar_value()),
             )],
             HashSet::new(),
             self.roles.iter().map(RoleId::to_euid).collect(),
             iter::empty(),
-            Extensions::none(),
         )
-        .expect("Ai should be a valid Cedar entity")
     }
 }
 

--- a/libs/@local/graph/authorization/src/policies/principal/actor/machine.rs
+++ b/libs/@local/graph/authorization/src/policies/principal/actor/machine.rs
@@ -2,7 +2,7 @@ use alloc::sync::Arc;
 use core::{iter, str::FromStr as _};
 use std::{collections::HashSet, sync::LazyLock};
 
-use cedar_policy_core::{ast, extensions::Extensions};
+use cedar_policy_core::ast;
 use error_stack::Report;
 use smol_str::SmolStr;
 use type_system::principal::{
@@ -11,23 +11,17 @@ use type_system::principal::{
 };
 use uuid::Uuid;
 
-use crate::policies::cedar::{
-    FromCedarEntityId, ToCedarEntity, ToCedarEntityId, ToCedarRestrictedExpr,
-};
+use crate::policies::cedar::{FromCedarEntityId, ToCedarEntity, ToCedarEntityId, ToCedarValue};
 
-impl ToCedarRestrictedExpr for MachineId {
-    fn to_cedar_restricted_expr(&self) -> ast::RestrictedExpr {
-        ast::RestrictedExpr::record([
-            (
-                SmolStr::new_static("id"),
-                ast::RestrictedExpr::val(self.to_string()),
-            ),
-            (
-                SmolStr::new_static("type"),
-                ast::RestrictedExpr::val("machine"),
-            ),
-        ])
-        .expect("No duplicate keys in machine record")
+impl ToCedarValue for MachineId {
+    fn to_cedar_value(&self) -> ast::Value {
+        ast::Value::record(
+            [
+                (SmolStr::new_static("id"), SmolStr::new(self.to_string())),
+                (SmolStr::new_static("type"), SmolStr::new_static("machine")),
+            ],
+            None,
+        )
     }
 }
 
@@ -57,18 +51,16 @@ impl ToCedarEntityId for MachineId {
 
 impl ToCedarEntity for Machine {
     fn to_cedar_entity(&self) -> ast::Entity {
-        ast::Entity::new(
+        ast::Entity::new_with_attr_partial_value(
             self.id.to_euid(),
             [(
                 SmolStr::new_static("id"),
-                self.id.to_cedar_restricted_expr(),
+                ast::PartialValue::Value(self.id.to_cedar_value()),
             )],
             HashSet::new(),
             self.roles.iter().map(RoleId::to_euid).collect(),
             iter::empty(),
-            Extensions::none(),
         )
-        .expect("Machine should be a valid Cedar entity")
     }
 }
 

--- a/libs/@local/graph/authorization/src/policies/principal/actor/mod.rs
+++ b/libs/@local/graph/authorization/src/policies/principal/actor/mod.rs
@@ -6,7 +6,7 @@ use alloc::sync::Arc;
 use core::iter;
 use std::{collections::HashSet, sync::LazyLock};
 
-use cedar_policy_core::{ast, extensions::Extensions};
+use cedar_policy_core::ast;
 use error_stack::{Report, ResultExt as _};
 use smol_str::SmolStr;
 use type_system::principal::actor::{Actor, ActorEntityUuid, ActorId, AiId, MachineId, UserId};
@@ -85,28 +85,25 @@ impl ToCedarEntityId for PublicActor {
 
 impl ToCedarEntity for PublicActor {
     fn to_cedar_entity(&self) -> ast::Entity {
-        ast::Entity::new(
+        ast::Entity::new_with_attr_partial_value(
             self.to_euid(),
             [(
                 SmolStr::new_static("id"),
-                ast::RestrictedExpr::record([
-                    (
-                        SmolStr::new_static("id"),
-                        ast::RestrictedExpr::val("00000000-0000-0000-0000-000000000000"),
-                    ),
-                    (
-                        SmolStr::new_static("type"),
-                        ast::RestrictedExpr::val("public"),
-                    ),
-                ])
-                .expect("No duplicate keys in public actor record"),
+                ast::PartialValue::Value(ast::Value::record(
+                    [
+                        (
+                            SmolStr::new_static("id"),
+                            SmolStr::new_static("00000000-0000-0000-0000-000000000000"),
+                        ),
+                        (SmolStr::new_static("type"), SmolStr::new_static("public")),
+                    ],
+                    None,
+                )),
             )],
             HashSet::new(),
             HashSet::new(),
             iter::empty(),
-            Extensions::none(),
         )
-        .expect("Public actor should be a valid Cedar entity")
     }
 }
 

--- a/libs/@local/graph/authorization/src/policies/principal/actor/mod.rs
+++ b/libs/@local/graph/authorization/src/policies/principal/actor/mod.rs
@@ -13,8 +13,7 @@ use type_system::principal::actor::{Actor, ActorEntityUuid, ActorId, AiId, Machi
 
 use crate::policies::{
     cedar::{
-        FromCedarEntityId as _, FromCedarEntityUId, ToCedarEntity, ToCedarEntityId,
-        ToCedarRestrictedExpr,
+        FromCedarEntityId as _, FromCedarEntityUId, ToCedarEntity, ToCedarEntityId, ToCedarValue,
     },
     error::FromCedarRefernceError,
 };
@@ -111,12 +110,12 @@ impl ToCedarEntity for PublicActor {
     }
 }
 
-impl ToCedarRestrictedExpr for ActorId {
-    fn to_cedar_restricted_expr(&self) -> ast::RestrictedExpr {
+impl ToCedarValue for ActorId {
+    fn to_cedar_value(&self) -> ast::Value {
         match self {
-            Self::User(user_id) => user_id.to_cedar_restricted_expr(),
-            Self::Machine(machine_id) => machine_id.to_cedar_restricted_expr(),
-            Self::Ai(ai_id) => ai_id.to_cedar_restricted_expr(),
+            Self::User(user_id) => user_id.to_cedar_value(),
+            Self::Machine(machine_id) => machine_id.to_cedar_value(),
+            Self::Ai(ai_id) => ai_id.to_cedar_value(),
         }
     }
 }

--- a/libs/@local/graph/authorization/src/policies/principal/group/team.rs
+++ b/libs/@local/graph/authorization/src/policies/principal/group/team.rs
@@ -2,7 +2,7 @@ use alloc::sync::Arc;
 use core::{iter, str::FromStr as _};
 use std::{collections::HashSet, sync::LazyLock};
 
-use cedar_policy_core::{ast, extensions::Extensions};
+use cedar_policy_core::ast;
 use error_stack::Report;
 use type_system::principal::actor_group::{Team, TeamId};
 use uuid::Uuid;
@@ -35,15 +35,13 @@ impl ToCedarEntityId for TeamId {
 
 impl ToCedarEntity for Team {
     fn to_cedar_entity(&self) -> ast::Entity {
-        ast::Entity::new(
+        ast::Entity::new_with_attr_partial_value(
             self.id.to_euid(),
             iter::empty(),
             HashSet::new(),
             HashSet::from([self.parent_id.to_euid()]),
             iter::empty(),
-            Extensions::none(),
         )
-        .expect("Team should be a valid Cedar entity")
     }
 }
 

--- a/libs/@local/graph/authorization/src/policies/principal/group/web.rs
+++ b/libs/@local/graph/authorization/src/policies/principal/group/web.rs
@@ -2,7 +2,7 @@ use alloc::sync::Arc;
 use core::{iter, str::FromStr as _};
 use std::{collections::HashSet, sync::LazyLock};
 
-use cedar_policy_core::{ast, extensions::Extensions};
+use cedar_policy_core::ast;
 use error_stack::Report;
 use type_system::principal::actor_group::{Web, WebId};
 use uuid::Uuid;
@@ -35,15 +35,13 @@ impl ToCedarEntityId for WebId {
 
 impl ToCedarEntity for Web {
     fn to_cedar_entity(&self) -> ast::Entity {
-        ast::Entity::new(
+        ast::Entity::new_with_attr_partial_value(
             self.id.to_euid(),
             iter::empty(),
             HashSet::new(),
             HashSet::new(),
             iter::empty(),
-            Extensions::none(),
         )
-        .expect("Web should be a valid Cedar entity")
     }
 }
 

--- a/libs/@local/graph/authorization/src/policies/principal/role/team.rs
+++ b/libs/@local/graph/authorization/src/policies/principal/role/team.rs
@@ -2,7 +2,7 @@ use alloc::sync::Arc;
 use core::{iter, str::FromStr as _};
 use std::{collections::HashSet, sync::LazyLock};
 
-use cedar_policy_core::{ast, extensions::Extensions};
+use cedar_policy_core::ast;
 use error_stack::Report;
 use type_system::principal::role::{TeamRole, TeamRoleId};
 use uuid::Uuid;
@@ -35,15 +35,13 @@ impl ToCedarEntityId for TeamRoleId {
 
 impl ToCedarEntity for TeamRole {
     fn to_cedar_entity(&self) -> ast::Entity {
-        ast::Entity::new(
+        ast::Entity::new_with_attr_partial_value(
             self.id.to_euid(),
             iter::empty(),
             HashSet::new(),
             HashSet::from([self.team_id.to_euid()]),
             iter::empty(),
-            Extensions::none(),
         )
-        .expect("Team role should be a valid Cedar entity")
     }
 }
 

--- a/libs/@local/graph/authorization/src/policies/principal/role/web.rs
+++ b/libs/@local/graph/authorization/src/policies/principal/role/web.rs
@@ -2,7 +2,7 @@ use alloc::sync::Arc;
 use core::{iter, str::FromStr as _};
 use std::{collections::HashSet, sync::LazyLock};
 
-use cedar_policy_core::{ast, extensions::Extensions};
+use cedar_policy_core::ast;
 use error_stack::Report;
 use type_system::principal::role::{WebRole, WebRoleId};
 use uuid::Uuid;
@@ -35,15 +35,13 @@ impl ToCedarEntityId for WebRoleId {
 
 impl ToCedarEntity for WebRole {
     fn to_cedar_entity(&self) -> ast::Entity {
-        ast::Entity::new(
+        ast::Entity::new_with_attr_partial_value(
             self.id.to_euid(),
             iter::empty(),
             HashSet::new(),
             HashSet::from([self.web_id.to_euid()]),
             iter::empty(),
-            Extensions::none(),
         )
-        .expect("Web role should be a valid Cedar entity")
     }
 }
 

--- a/libs/@local/graph/authorization/src/policies/resource/data_type.rs
+++ b/libs/@local/graph/authorization/src/policies/resource/data_type.rs
@@ -2,9 +2,9 @@ use alloc::{borrow::Cow, sync::Arc};
 use core::{error::Error, fmt, iter, ptr, str::FromStr as _};
 use std::{collections::HashSet, sync::LazyLock};
 
-use cedar_policy_core::{ast, extensions::Extensions};
+use cedar_policy_core::ast;
 use error_stack::{Report, ResultExt as _};
-use smol_str::SmolStr;
+use smol_str::{SmolStr, ToSmolStr as _};
 use type_system::{
     ontology::id::{BaseUrl, OntologyTypeVersion, ParseVersionedUrlError, VersionedUrl},
     principal::actor_group::WebId,
@@ -74,20 +74,33 @@ pub struct DataTypeResource<'a> {
 
 impl DataTypeResource<'_> {
     pub(crate) fn to_cedar_entity(&self) -> ast::Entity {
-        ast::Entity::new(
+        ast::Entity::new_with_attr_partial_value(
             self.id.to_euid(),
             [
                 (
                     SmolStr::new_static("base_url"),
-                    ast::RestrictedExpr::val(self.id.as_url().base_url.to_string()),
+                    ast::PartialValue::Value(ast::Value::new(
+                        ast::ValueKind::Lit(ast::Literal::String(
+                            self.id.as_url().base_url.to_smolstr(),
+                        )),
+                        None,
+                    )),
                 ),
                 (
                     SmolStr::new_static("version"),
-                    ast::RestrictedExpr::val(i64::from(self.id.as_url().version.inner())),
+                    ast::PartialValue::Value(ast::Value::new(
+                        ast::ValueKind::Lit(ast::Literal::Long(ast::Integer::from(
+                            self.id.as_url().version.inner(),
+                        ))),
+                        None,
+                    )),
                 ),
                 (
                     SmolStr::new_static("is_remote"),
-                    ast::RestrictedExpr::val(self.web_id.is_none()),
+                    ast::PartialValue::Value(ast::Value::new(
+                        ast::ValueKind::Lit(ast::Literal::Bool(self.web_id.is_none())),
+                        None,
+                    )),
                 ),
             ],
             HashSet::new(),
@@ -97,9 +110,7 @@ impl DataTypeResource<'_> {
                 .map(WebId::to_euid)
                 .collect(),
             iter::empty(),
-            Extensions::none(),
         )
-        .expect("Data type should be a valid Cedar entity")
     }
 }
 

--- a/libs/@local/graph/authorization/src/policies/resource/entity.rs
+++ b/libs/@local/graph/authorization/src/policies/resource/entity.rs
@@ -164,7 +164,7 @@ impl EntityResource<'_> {
                     )),
                 ),
                 (
-                    SmolStr::new_static("entity_types"),
+                    SmolStr::new_static("entity_base_types"),
                     ast::PartialValue::Value(ast::Value::set_of_lits(
                         self.entity_base_types
                             .iter()

--- a/libs/@local/graph/authorization/src/policies/resource/entity_type.rs
+++ b/libs/@local/graph/authorization/src/policies/resource/entity_type.rs
@@ -2,9 +2,9 @@ use alloc::{borrow::Cow, sync::Arc};
 use core::{error::Error, fmt, iter, ptr, str::FromStr as _};
 use std::{collections::HashSet, sync::LazyLock};
 
-use cedar_policy_core::{ast, extensions::Extensions};
+use cedar_policy_core::ast;
 use error_stack::{Report, ResultExt as _};
-use smol_str::SmolStr;
+use smol_str::{SmolStr, ToSmolStr as _};
 use type_system::{
     ontology::id::{BaseUrl, OntologyTypeVersion, ParseVersionedUrlError, VersionedUrl},
     principal::actor_group::WebId,
@@ -74,20 +74,33 @@ pub struct EntityTypeResource<'a> {
 
 impl EntityTypeResource<'_> {
     pub(crate) fn to_cedar_entity(&self) -> ast::Entity {
-        ast::Entity::new(
+        ast::Entity::new_with_attr_partial_value(
             self.id.to_euid(),
             [
                 (
                     SmolStr::new_static("base_url"),
-                    ast::RestrictedExpr::val(self.id.as_url().base_url.to_string()),
+                    ast::PartialValue::Value(ast::Value::new(
+                        ast::ValueKind::Lit(ast::Literal::String(
+                            self.id.as_url().base_url.to_smolstr(),
+                        )),
+                        None,
+                    )),
                 ),
                 (
                     SmolStr::new_static("version"),
-                    ast::RestrictedExpr::val(i64::from(self.id.as_url().version.inner())),
+                    ast::PartialValue::Value(ast::Value::new(
+                        ast::ValueKind::Lit(ast::Literal::Long(ast::Integer::from(
+                            self.id.as_url().version.inner(),
+                        ))),
+                        None,
+                    )),
                 ),
                 (
                     SmolStr::new_static("is_remote"),
-                    ast::RestrictedExpr::val(self.web_id.is_none()),
+                    ast::PartialValue::Value(ast::Value::new(
+                        ast::ValueKind::Lit(ast::Literal::Bool(self.web_id.is_none())),
+                        None,
+                    )),
                 ),
             ],
             HashSet::new(),
@@ -97,9 +110,7 @@ impl EntityTypeResource<'_> {
                 .map(WebId::to_euid)
                 .collect(),
             iter::empty(),
-            Extensions::none(),
         )
-        .expect("Entity type should be a valid Cedar entity")
     }
 }
 

--- a/libs/@local/graph/postgres-store/src/snapshot/policy/batch.rs
+++ b/libs/@local/graph/postgres-store/src/snapshot/policy/batch.rs
@@ -55,6 +55,7 @@ where
                         "
                             INSERT INTO policy_tmp
                             SELECT DISTINCT * FROM UNNEST($1::policy[])
+                            ON CONFLICT DO NOTHING
                             RETURNING 1;
                         ",
                         &[&policy],

--- a/libs/@local/graph/postgres-store/src/store/postgres/seed_policies.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/seed_policies.rs
@@ -1019,18 +1019,33 @@ impl PostgresStore<Transaction<'_>> {
             ));
         }
 
-        for policy_id in policies_to_remove {
-            self.archive_policy_from_database(policy_id)
+        for (index, policy_id) in policies_to_remove.iter().enumerate() {
+            tracing::debug!(
+                %policy_id,
+                "Removing policy from database {index}/{}",
+                policies_to_remove.len()
+            );
+            self.archive_policy_from_database(*policy_id)
                 .await
                 .change_context(EnsureSystemPoliciesError::RemoveOldPolicyFailed)?;
         }
-        for policy in policies_to_add {
-            self.insert_policy_into_database(&policy)
+        for (index, policy) in policies_to_add.iter().enumerate() {
+            tracing::debug!(
+                policy_name = policy.name,
+                "Adding policy to database {index}/{}",
+                policies_to_add.len()
+            );
+            self.insert_policy_into_database(policy)
                 .await
                 .change_context(EnsureSystemPoliciesError::AddRequiredPoliciesFailed)?;
         }
-        for (policy_id, operations) in policies_to_update {
-            self.update_policy_in_database(policy_id, &operations)
+        for (index, (policy_id, operations)) in policies_to_update.iter().enumerate() {
+            tracing::debug!(
+                %policy_id,
+                "Updating policy in database {index}/{}",
+                policies_to_update.len()
+            );
+            self.update_policy_in_database(*policy_id, operations)
                 .await
                 .change_context(EnsureSystemPoliciesError::UpdatePolicyFailed)?;
         }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We encountered a panic in production when using `ast::Entity::new()`:

```
thread 'main' panicked at libs/@local/graph/authorization/src/policies/resource/meta.rs:62:10:
Policy should be a valid Cedar entity: EntityAttrEvaluationError { uid: EntityUID(EntityUIDImpl { ty: EntityType(Name(InternalName { id: Id("Policy"), path: [Id("HASH")], loc: None })), eid: Eid("521b8df8-662f-4730-b7c6-049ef7e4f0e6"), loc: None }), attr_or_tag: "actions", was_attr: true, err: RecursionLimit(RecursionLimitError { source_loc: None }) }
stack backtrace:
   0: __rustc::rust_begin_unwind
             at ./rustc/9982d6462bedf1e793f7b2dbd655a4e57cdf67d4/library/std/src/panicking.rs:697:5
   1: core::panicking::panic_fmt
             at ./rustc/9982d6462bedf1e793f7b2dbd655a4e57cdf67d4/library/core/src/panicking.rs:75:14
   2: core::result::unwrap_failed
             at ./rustc/9982d6462bedf1e793f7b2dbd655a4e57cdf67d4/library/core/src/result.rs:1761:5
   3: hash_graph_authorization::policies::context::ContextBuilder::add_policy_meta_resource
   4: hash_graph_postgres_store::store::postgres::seed_policies::<impl hash_graph_postgres_store::store::postgres::PostgresStore<tokio_postgres::transaction::Transaction>>::update_seeded_policies::{{closure}}.20812
   5: <hash_graph_postgres_store::store::postgres::PostgresStore<C> as hash_graph_authorization::policies::store::PolicyStore>::seed_system_policies::{{closure}}.20772
   6: tokio::runtime::runtime::Runtime::block_on
   7: hash_graph::main
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

This PR avoids the issue by using another function instead. 

## 🔍 What does this change?

- Replace usage of `ast::Entity::new`
- Drive-by: Add more logging when seeding policies
- Drive-by: Fix snapshot restoring for archived policies
- Drive-by: Fix snapshot dumping (it waited for the remaining sender, which never was closed)

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph