### PR TITLE
H-5029: Add `pdf-cmaps` explainer

### DIFF
--- a/apps/hash-frontend/public/pdf-cmaps/README.md
+++ b/apps/hash-frontend/public/pdf-cmaps/README.md
@@ -1,0 +1,7 @@
+# pdf-cmaps
+
+`.bcmap` files are "binary character maps" — text files used in PostScript and other Adobe products to map character codes to character glyphs in CID fonts. (See: [Stack Overflow](https://stackoverflow.com/a/40634723))
+
+[This spec document](https://www.adobe.com/content/dam/acom/en/devnet/font/pdfs/5014.CIDFont_Spec.pdf) by Adobe outlines what CID fonts are good for (primarily useful when dealing with East Asian writing systems; a legacy support technology).
+
+These files are used when displaying PDFs containing CID fonts and therefore need to be publicly accessible.


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Adds a README to the `pdf-cmaps` dir to explain their purpose.