### PR TITLE
H-5033: Avoid checking permissions when database seeding happens

### DIFF
--- a/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
@@ -1915,7 +1915,6 @@ where
 
         transaction
             .update_seeded_policies(
-                ActorId::Machine(system_machine_actor),
                 seed_policies::system_actor_policies(system_machine_actor)
                     .chain(seed_policies::global_policies())
                     .chain(roles.iter().flat_map(seed_policies::web_policies))


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We don't need to check permissions when seeding the default policies