### PR TITLE
H-5043: Don't assign the system actor to incomplete webs

### DIFF
--- a/apps/hash-api/src/graph/knowledge/primitive/entity/before-update-entity-hooks/user-before-update-entity-hook-callback.ts
+++ b/apps/hash-api/src/graph/knowledge/primitive/entity/before-update-entity-hooks/user-before-update-entity-hook-callback.ts
@@ -3,10 +3,7 @@ import {
   getDefinedPropertyFromPatchesGetter,
   isValueRemovedByPatches,
 } from "@local/hash-graph-sdk/entity";
-import {
-  addActorGroupAdministrator,
-  removeActorGroupAdministrator,
-} from "@local/hash-graph-sdk/principal/actor-group";
+import { addActorGroupAdministrator } from "@local/hash-graph-sdk/principal/actor-group";
 import type { UserProperties } from "@local/hash-isomorphic-utils/system-types/user";
 import { ApolloError, UserInputError } from "apollo-server-express";
 
@@ -142,12 +139,6 @@ export const userBeforeEntityUpdateHookCallback: BeforeUpdateEntityHookCallback 
         context.graphApi,
         { actorId: systemAccountId },
         { actorId: user.accountId, actorGroupId: user.accountId },
-      );
-
-      await removeActorGroupAdministrator(
-        context.graphApi,
-        { actorId: user.accountId },
-        { actorId: systemAccountId, actorGroupId: user.accountId },
       );
     }
   };

--- a/libs/@local/graph/authorization/src/policies/store/mod.rs
+++ b/libs/@local/graph/authorization/src/policies/store/mod.rs
@@ -72,7 +72,7 @@ pub struct CreateUserParameter {
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct CreateWebParameter {
     pub id: Option<Uuid>,
-    pub administrator: ActorId,
+    pub administrator: Option<ActorId>,
     pub shortname: Option<String>,
     pub is_actor_web: bool,
 }

--- a/libs/@local/graph/postgres-store/src/store/postgres/seed_policies.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/seed_policies.rs
@@ -209,12 +209,33 @@ fn system_actor_invitation_entity_policies(
     })
 }
 
+fn system_actor_create_prospective_user_entity_policies(
+    system_machine_actor: MachineId,
+) -> impl Iterator<Item = PolicyCreationParams> {
+    iter::once(PolicyCreationParams {
+        name: Some("system-machine-create-prospective-user-entity".to_owned()),
+        effect: Effect::Permit,
+        principal: Some(PrincipalConstraint::Actor {
+            actor: ActorId::Machine(system_machine_actor),
+        }),
+        actions: vec![ActionName::CreateEntity],
+        resource: Some(ResourceConstraint::Entity(EntityResourceConstraint::Any {
+            filter: EntityResourceFilter::Any {
+                filters: vec![PROSPECTIVE_USER.entity_is_of_base_type()],
+            },
+        })),
+    })
+}
+
 pub(crate) fn system_actor_policies(
     system_machine_actor: MachineId,
 ) -> impl Iterator<Item = PolicyCreationParams> {
     iter::once(system_actor_create_web_policy(system_machine_actor))
         .chain(system_actor_view_entity_policies(system_machine_actor))
         .chain(system_actor_invitation_entity_policies(
+            system_machine_actor,
+        ))
+        .chain(system_actor_create_prospective_user_entity_policies(
             system_machine_actor,
         ))
         .chain(iter::once(system_actor_meta_policy(system_machine_actor)))


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The only purpose for the system user to be assigned is that it need sto assign the other user later and to create a prospective user. This can be simplified and avoids assigning the system account to endless webs.