### PR TITLE
H-4988: Add OpenTelemetry collector to `app` cluster

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -10,8 +10,6 @@ HASH_GRAPH_PG_DATABASE=dev_graph
 HASH_GRAPH_RPC_ENABLED=true
 HASH_RPC_ENABLED=true
 
-HASH_OTLP_ENDPOINT=http://localhost:4317
-
 # For locally-running minio instance
 AWS_REGION=local
 AWS_S3_UPLOADS_ENDPOINT=http://localhost:9000

--- a/infra/terraform/hash/hash_application/api.tf
+++ b/infra/terraform/hash/hash_application/api.tf
@@ -60,6 +60,7 @@ locals {
         { name = "HASH_GRAPH_HTTP_PORT", value = tostring(local.graph_http_container_port) },
         { name = "HASH_GRAPH_RPC_HOST", value = local.graph_rpc_container_port_dns },
         { name = "HASH_GRAPH_RPC_PORT", value = tostring(local.graph_rpc_container_port) },
+        { name = "HASH_OTLP_ENDPOINT", value = "http://${local.otel_grpc_container_port_dns}:${local.otel_grpc_container_port}" },
     ])
 
     secrets = [
@@ -118,6 +119,7 @@ locals {
         { name = "HASH_GRAPH_HTTP_PORT", value = tostring(local.graph_http_container_port) },
         { name = "HASH_GRAPH_RPC_HOST", value = local.graph_rpc_container_port_dns },
         { name = "HASH_GRAPH_RPC_PORT", value = tostring(local.graph_rpc_container_port) },
+        { name = "HASH_OTLP_ENDPOINT", value = "http://${local.otel_grpc_container_port_dns}:${local.otel_grpc_container_port}" },
     ])
 
     secrets = [

--- a/infra/terraform/hash/hash_application/graph.tf
+++ b/infra/terraform/hash/hash_application/graph.tf
@@ -179,7 +179,7 @@ locals {
       { name = env_var.name, value = env_var.value } if !env_var.secret
       ],
       [
-        { name = "HASH_OTLP_ENDPOINT", value = "http://${local.otel_grpc_container_port_dns}:${local.otel_grpc_container_port}" },
+        { name = "HASH_OTLP_ENDPOINT", value = "grpc://${local.otel_grpc_container_port_dns}:${local.otel_grpc_container_port}" },
       ]
     )
     secrets = [
@@ -238,7 +238,7 @@ locals {
         { name = "HASH_GRAPH_RPC_PORT", value = tostring(local.graph_rpc_container_port) },
         { name = "HASH_GRAPH_TYPE_FETCHER_HOST", value = local.type_fetcher_container_port_dns },
         { name = "HASH_GRAPH_TYPE_FETCHER_PORT", value = tostring(local.type_fetcher_container_port) },
-        { name = "HASH_OTLP_ENDPOINT", value = "http://${local.otel_grpc_container_port_dns}:${local.otel_grpc_container_port}" },
+        { name = "HASH_OTLP_ENDPOINT", value = "grpc://${local.otel_grpc_container_port_dns}:${local.otel_grpc_container_port}" },
         { name = "HASH_TEMPORAL_SERVER_HOST", value = var.temporal_host },
         { name = "HASH_TEMPORAL_SERVER_PORT", value = var.temporal_port },
       ]

--- a/infra/terraform/hash/hash_application/main.tf
+++ b/infra/terraform/hash/hash_application/main.tf
@@ -114,6 +114,15 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "app_configs" {
   }
 }
 
+resource "aws_s3_bucket_public_access_block" "app_configs" {
+  bucket = aws_s3_bucket.app_configs.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
 
 data "cloudflare_ip_ranges" "cloudflare" {}
 

--- a/infra/terraform/hash/hash_application/main.tf
+++ b/infra/terraform/hash/hash_application/main.tf
@@ -90,6 +90,31 @@ data "aws_vpc_endpoint" "s3" {
   tags = { Name = "${var.prefix}-vpces3" }
 }
 
+resource "aws_s3_bucket" "app_configs" {
+  bucket = "${local.prefix}-configs"
+  tags = {
+    Purpose = "App cluster service configurations"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "app_configs" {
+  bucket = aws_s3_bucket.app_configs.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "app_configs" {
+  bucket = aws_s3_bucket.app_configs.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+
 data "cloudflare_ip_ranges" "cloudflare" {}
 
 resource "aws_security_group" "alb_sg" {
@@ -331,6 +356,18 @@ resource "aws_iam_role" "task_role" {
           Effect   = "Allow",
           Resource = "*"
         },
+        # Allow S3 access for config downloader
+        {
+          Effect = "Allow"
+          Action = [
+            "s3:GetObject",
+            "s3:ListBucket"
+          ]
+          Resource = [
+            aws_s3_bucket.app_configs.arn,
+            "${aws_s3_bucket.app_configs.arn}/*"
+          ]
+        },
       ]
     })
   }
@@ -504,6 +541,23 @@ resource "aws_security_group" "app_sg" {
     to_port     = local.graph_rpc_container_port
     protocol    = "tcp"
     description = "Allow connections to the Graph RPC interface"
+    cidr_blocks = [var.vpc.cidr_block]
+  }
+
+
+  # Egress to local OTel collector
+  egress {
+    from_port   = local.otel_grpc_container_port
+    to_port     = local.otel_grpc_container_port
+    protocol    = "tcp"
+    description = "Allow sending telemetry to local OTel collector (gRPC)"
+    cidr_blocks = [var.vpc.cidr_block]
+  }
+  egress {
+    from_port   = local.otel_http_container_port
+    to_port     = local.otel_http_container_port
+    protocol    = "tcp"
+    description = "Allow sending telemetry to local OTel collector (HTTP)"
     cidr_blocks = [var.vpc.cidr_block]
   }
 

--- a/infra/terraform/hash/hash_application/otel_collector.tf
+++ b/infra/terraform/hash/hash_application/otel_collector.tf
@@ -111,7 +111,7 @@ resource "aws_ecs_task_definition" "otel_collector" {
     # Main OpenTelemetry Collector container
     {
       name  = local.otel_service_name
-      image = "otel/opentelemetry-collector:0.130.0"
+      image = "otel/opentelemetry-collector-contrib:0.128.0"
 
       cpu    = 256
       memory = 512

--- a/infra/terraform/hash/hash_application/otel_collector.tf
+++ b/infra/terraform/hash/hash_application/otel_collector.tf
@@ -1,0 +1,271 @@
+# OpenTelemetry Collector configuration
+locals {
+  otel_service_name            = "otel-collector"
+  otel_http_container_port     = 4318
+  otel_http_port_name          = "${local.otel_service_name}-http"
+  otel_http_container_port_dns = "${local.otel_http_port_name}.${aws_service_discovery_private_dns_namespace.app.name}"
+  otel_grpc_container_port     = 4317
+  otel_grpc_port_name          = "${local.otel_service_name}-grpc"
+  otel_grpc_container_port_dns = "${local.otel_grpc_port_name}.${aws_service_discovery_private_dns_namespace.app.name}"
+
+  otel_collector_config = yamlencode({
+    receivers = {
+      otlp = {
+        protocols = {
+          grpc = {
+            endpoint = "0.0.0.0:${local.otel_grpc_container_port}"
+          }
+          http = {
+            endpoint = "0.0.0.0:${local.otel_http_container_port}"
+          }
+        }
+      }
+      # AWS ECS container metrics (current task only)
+      awsecscontainermetrics = {
+        collection_interval = "30s"
+      }
+    }
+    processors = {
+      batch = {}
+    }
+    exporters = {
+      nop = {}
+    }
+    service = {
+      pipelines = {
+        traces = {
+          receivers  = ["otlp"]
+          processors = ["batch"]
+          exporters  = ["nop"]
+        }
+        metrics = {
+          receivers  = ["otlp", "awsecscontainermetrics"]
+          processors = ["batch"]
+          exporters  = ["nop"]
+        }
+        logs = {
+          receivers  = ["otlp"]
+          processors = ["batch"]
+          exporters  = ["nop"]
+        }
+      }
+    }
+  })
+}
+
+# Store configuration in S3
+resource "aws_s3_object" "otel_collector_config" {
+  bucket  = aws_s3_bucket.app_configs.bucket
+  key     = "otelcol/config.yaml"
+  content = local.otel_collector_config
+
+  tags = {
+    Name    = "${local.prefix}-otel-config"
+    Purpose = "OpenTelemetry Collector configuration for app cluster"
+  }
+}
+
+# ECS Task Definition for OpenTelemetry Collector
+resource "aws_ecs_task_definition" "otel_collector" {
+  family                   = "${local.prefix}-${local.otel_service_name}-${substr(sha256(aws_s3_object.otel_collector_config.content), 0, 8)}"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = 256
+  memory                   = 512
+  execution_role_arn       = aws_iam_role.execution_role.arn
+  task_role_arn            = aws_iam_role.task_role.arn
+
+  container_definitions = jsonencode([
+    # Config downloader container
+    {
+      name  = "config-downloader"
+      image = "amazon/aws-cli:latest"
+
+      command = [
+        "s3", "cp",
+        "s3://${aws_s3_bucket.app_configs.bucket}/",
+        "/etc/",
+        "--recursive"
+      ]
+
+      mountPoints = [
+        {
+          sourceVolume  = "config"
+          containerPath = "/etc"
+        }
+      ]
+
+      essential = false
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-create-group"  = "true"
+          "awslogs-group"         = local.log_group_name
+          "awslogs-region"        = var.region
+          "awslogs-stream-prefix" = "config-downloader"
+        }
+      }
+    },
+
+    # Main OpenTelemetry Collector container
+    {
+      name  = local.otel_service_name
+      image = "otel/opentelemetry-collector-contrib:0.128.0"
+
+      cpu    = 256
+      memory = 512
+
+      essential = true
+
+      command = [
+        "--config=/etc/otelcol/config.yaml"
+      ]
+
+      dependsOn = [
+        {
+          containerName = "config-downloader"
+          condition     = "SUCCESS"
+        }
+      ]
+
+      mountPoints = [
+        {
+          sourceVolume  = "config"
+          containerPath = "/etc"
+          readOnly      = true
+        }
+      ]
+
+      portMappings = [
+        {
+          name          = local.otel_http_port_name
+          containerPort = local.otel_http_container_port
+          protocol      = "tcp"
+        },
+        {
+          name          = local.otel_grpc_port_name
+          containerPort = local.otel_grpc_container_port
+          protocol      = "tcp"
+        }
+      ]
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-create-group"  = "true"
+          "awslogs-group"         = local.log_group_name
+          "awslogs-region"        = var.region
+          "awslogs-stream-prefix" = local.otel_service_name
+        }
+      }
+    }
+  ])
+
+  volume {
+    name = "config"
+  }
+
+  runtime_platform {
+    operating_system_family = "LINUX"
+    cpu_architecture        = "ARM64"
+  }
+
+  tags = {
+    Name    = "${local.prefix}-otel-collector-task"
+    Purpose = "OpenTelemetry Collector task definition for app cluster"
+  }
+}
+
+# Security group for OpenTelemetry Collector
+resource "aws_security_group" "otel_collector" {
+  name   = "${local.prefix}-otel-collector"
+  vpc_id = var.vpc.id
+
+  # Ingress: Allow connections from app services to OTel collector
+  ingress {
+    from_port   = local.otel_grpc_container_port
+    to_port     = local.otel_grpc_container_port
+    protocol    = "tcp"
+    description = "Allow gRPC connections from app services"
+    cidr_blocks = [var.vpc.cidr_block]
+  }
+
+  ingress {
+    from_port   = local.otel_http_container_port
+    to_port     = local.otel_http_container_port
+    protocol    = "tcp"
+    description = "Allow HTTP connections from app services"
+    cidr_blocks = [var.vpc.cidr_block]
+  }
+
+  # Standard egress rule for ECS tasks
+  egress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    description = "Allow HTTPS for AWS services, Docker Hub, and ECR"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name    = "${local.prefix}-otel-collector-sg"
+    Purpose = "Security group for OpenTelemetry Collector in app cluster"
+  }
+}
+
+# ECS Service for OpenTelemetry Collector
+resource "aws_ecs_service" "otel_collector" {
+  name            = "${var.prefix}-otel-collector"
+  cluster         = var.cluster_arn
+  task_definition = aws_ecs_task_definition.otel_collector.arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = var.subnets
+    security_groups  = [aws_security_group.otel_collector.id]
+    assign_public_ip = true
+  }
+
+  health_check_grace_period_seconds = 60
+
+  service_connect_configuration {
+    enabled   = true
+    namespace = aws_service_discovery_private_dns_namespace.app.arn
+
+    service {
+      discovery_name = "${local.otel_service_name}-http"
+      port_name      = local.otel_http_port_name
+
+      client_alias {
+        port = local.otel_http_container_port
+      }
+    }
+
+    service {
+      discovery_name = "${local.otel_service_name}-grpc"
+      port_name      = local.otel_grpc_port_name
+
+      client_alias {
+        port = local.otel_grpc_container_port
+      }
+    }
+
+    # Service discovery health check configuration
+    log_configuration {
+      log_driver = "awslogs"
+      options = {
+        "awslogs-create-group"  = "true"
+        "awslogs-group"         = local.log_group_name
+        "awslogs-region"        = var.region
+        "awslogs-stream-prefix" = "service-connect"
+      }
+    }
+  }
+
+  tags = {
+    Name    = "${local.prefix}-otel-collector-service"
+    Purpose = "OpenTelemetry Collector service for app cluster to send telemetry to the observability cluster"
+  }
+}

--- a/infra/terraform/hash/hash_application/otel_collector.tf
+++ b/infra/terraform/hash/hash_application/otel_collector.tf
@@ -111,7 +111,7 @@ resource "aws_ecs_task_definition" "otel_collector" {
     # Main OpenTelemetry Collector container
     {
       name  = local.otel_service_name
-      image = "otel/opentelemetry-collector-contrib:0.128.0"
+      image = "otel/opentelemetry-collector:0.130.0"
 
       cpu    = 256
       memory = 512

--- a/infra/terraform/hash/hash_application/temporal_worker_ai_ts.tf
+++ b/infra/terraform/hash/hash_application/temporal_worker_ai_ts.tf
@@ -51,7 +51,7 @@ locals {
         { name = "HASH_GRAPH_HTTP_PORT", value = tostring(local.graph_http_container_port) },
         { name = "HASH_GRAPH_RPC_HOST", value = local.graph_rpc_container_port_dns },
         { name = "HASH_GRAPH_RPC_PORT", value = tostring(local.graph_rpc_container_port) },
-        { name = "HASH_OTLP_ENDPOINT", value = "http://${local.otel_grpc_container_port_dns}:${local.otel_grpc_container_port}" },
+        { name = "HASH_OTLP_ENDPOINT", value = "grpc://${local.otel_grpc_container_port_dns}:${local.otel_grpc_container_port}" },
       ],
     )
 

--- a/infra/terraform/hash/hash_application/temporal_worker_ai_ts.tf
+++ b/infra/terraform/hash/hash_application/temporal_worker_ai_ts.tf
@@ -6,9 +6,9 @@ locals {
 
 resource "aws_ssm_parameter" "temporal_worker_ai_ts_env_vars" {
   # Only put secrets into SSM
-  for_each = {for env_var in var.temporal_worker_ai_ts_env_vars : env_var.name => env_var if env_var.secret}
+  for_each = { for env_var in var.temporal_worker_ai_ts_env_vars : env_var.name => env_var if env_var.secret }
 
-  name      = "${local.temporal_worker_ai_ts_param_prefix}/${each.value.name}"
+  name = "${local.temporal_worker_ai_ts_param_prefix}/${each.value.name}"
   # Still supports non-secret values
   type      = each.value.secret ? "SecureString" : "String"
   value     = each.value.secret ? sensitive(each.value.value) : each.value.value
@@ -18,10 +18,10 @@ resource "aws_ssm_parameter" "temporal_worker_ai_ts_env_vars" {
 
 locals {
   temporal_worker_ai_ts_service_container_def = {
-    essential   = true
-    name        = local.temporal_worker_ai_ts_prefix
-    image       = "${var.temporal_worker_ai_ts_image.url}:latest"
-    cpu         = 0 # let ECS divvy up the available CPU
+    essential = true
+    name      = local.temporal_worker_ai_ts_prefix
+    image     = "${var.temporal_worker_ai_ts_image.url}:latest"
+    cpu       = 0 # let ECS divvy up the available CPU
     healthCheck = {
       command     = ["CMD", "/bin/sh", "-c", "curl -f http://localhost:4100/health || exit 1"]
       startPeriod = 10
@@ -32,7 +32,7 @@ locals {
 
     logConfiguration = {
       logDriver = "awslogs"
-      options   = {
+      options = {
         "awslogs-create-group"  = "true"
         "awslogs-group"         = local.log_group_name
         "awslogs-stream-prefix" = local.temporal_worker_ai_ts_service_name
@@ -51,7 +51,7 @@ locals {
         { name = "HASH_GRAPH_HTTP_PORT", value = tostring(local.graph_http_container_port) },
         { name = "HASH_GRAPH_RPC_HOST", value = local.graph_rpc_container_port_dns },
         { name = "HASH_GRAPH_RPC_PORT", value = tostring(local.graph_rpc_container_port) },
-        { name = "HASH_OTLP_ENDPOINT", value = "grpc://${local.otel_grpc_container_port_dns}:${local.otel_grpc_container_port}" },
+        { name = "HASH_OTLP_ENDPOINT", value = "http://${local.otel_grpc_container_port_dns}:${local.otel_grpc_container_port}" },
       ],
     )
 

--- a/infra/terraform/hash/hash_application/temporal_worker_ai_ts.tf
+++ b/infra/terraform/hash/hash_application/temporal_worker_ai_ts.tf
@@ -51,6 +51,7 @@ locals {
         { name = "HASH_GRAPH_HTTP_PORT", value = tostring(local.graph_http_container_port) },
         { name = "HASH_GRAPH_RPC_HOST", value = local.graph_rpc_container_port_dns },
         { name = "HASH_GRAPH_RPC_PORT", value = tostring(local.graph_rpc_container_port) },
+        { name = "HASH_OTLP_ENDPOINT", value = "http://${local.otel_grpc_container_port_dns}:${local.otel_grpc_container_port}" },
       ],
     )
 

--- a/infra/terraform/hash/hash_application/temporal_worker_integration.tf
+++ b/infra/terraform/hash/hash_application/temporal_worker_integration.tf
@@ -6,9 +6,9 @@ locals {
 
 resource "aws_ssm_parameter" "temporal_worker_integration_env_vars" {
   # Only put secrets into SSM
-  for_each = {for env_var in var.temporal_worker_integration_env_vars : env_var.name => env_var if env_var.secret}
+  for_each = { for env_var in var.temporal_worker_integration_env_vars : env_var.name => env_var if env_var.secret }
 
-  name      = "${local.temporal_worker_integration_param_prefix}/${each.value.name}"
+  name = "${local.temporal_worker_integration_param_prefix}/${each.value.name}"
   # Still supports non-secret values
   type      = each.value.secret ? "SecureString" : "String"
   value     = each.value.secret ? sensitive(each.value.value) : each.value.value
@@ -18,10 +18,10 @@ resource "aws_ssm_parameter" "temporal_worker_integration_env_vars" {
 
 locals {
   temporal_worker_integration_service_container_def = {
-    essential   = true
-    name        = local.temporal_worker_integration_prefix
-    image       = "${var.temporal_worker_integration_image.url}:latest"
-    cpu         = 0 # let ECS divvy up the available CPU
+    essential = true
+    name      = local.temporal_worker_integration_prefix
+    image     = "${var.temporal_worker_integration_image.url}:latest"
+    cpu       = 0 # let ECS divvy up the available CPU
     healthCheck = {
       command     = ["CMD", "/bin/sh", "-c", "curl -f http://localhost:4300/health || exit 1"]
       startPeriod = 10
@@ -32,7 +32,7 @@ locals {
 
     logConfiguration = {
       logDriver = "awslogs"
-      options   = {
+      options = {
         "awslogs-create-group"  = "true"
         "awslogs-group"         = local.log_group_name
         "awslogs-stream-prefix" = local.temporal_worker_integration_service_name
@@ -51,7 +51,7 @@ locals {
         { name = "HASH_GRAPH_HTTP_PORT", value = tostring(local.graph_http_container_port) },
         { name = "HASH_GRAPH_RPC_HOST", value = local.graph_rpc_container_port_dns },
         { name = "HASH_GRAPH_RPC_PORT", value = tostring(local.graph_rpc_container_port) },
-        { name = "HASH_OTLP_ENDPOINT", value = "grpc://${local.otel_grpc_container_port_dns}:${local.otel_grpc_container_port}" },
+        { name = "HASH_OTLP_ENDPOINT", value = "http://${local.otel_grpc_container_port_dns}:${local.otel_grpc_container_port}" },
       ],
     )
 

--- a/infra/terraform/hash/hash_application/temporal_worker_integration.tf
+++ b/infra/terraform/hash/hash_application/temporal_worker_integration.tf
@@ -51,7 +51,7 @@ locals {
         { name = "HASH_GRAPH_HTTP_PORT", value = tostring(local.graph_http_container_port) },
         { name = "HASH_GRAPH_RPC_HOST", value = local.graph_rpc_container_port_dns },
         { name = "HASH_GRAPH_RPC_PORT", value = tostring(local.graph_rpc_container_port) },
-        { name = "HASH_OTLP_ENDPOINT", value = "http://${local.otel_grpc_container_port_dns}:${local.otel_grpc_container_port}" },
+        { name = "HASH_OTLP_ENDPOINT", value = "grpc://${local.otel_grpc_container_port_dns}:${local.otel_grpc_container_port}" },
       ],
     )
 

--- a/infra/terraform/hash/hash_application/temporal_worker_integration.tf
+++ b/infra/terraform/hash/hash_application/temporal_worker_integration.tf
@@ -51,6 +51,7 @@ locals {
         { name = "HASH_GRAPH_HTTP_PORT", value = tostring(local.graph_http_container_port) },
         { name = "HASH_GRAPH_RPC_HOST", value = local.graph_rpc_container_port_dns },
         { name = "HASH_GRAPH_RPC_PORT", value = tostring(local.graph_rpc_container_port) },
+        { name = "HASH_OTLP_ENDPOINT", value = "http://${local.otel_grpc_container_port_dns}:${local.otel_grpc_container_port}" },
       ],
     )
 

--- a/infra/terraform/hash/hash_application/type_fetcher.tf
+++ b/infra/terraform/hash/hash_application/type_fetcher.tf
@@ -35,6 +35,7 @@ locals {
     Environment = [
       { name = "HASH_GRAPH_TYPE_FETCHER_HOST", value = "0.0.0.0" },
       { name = "HASH_GRAPH_TYPE_FETCHER_PORT", value = tostring(local.type_fetcher_container_port) },
+      { name = "HASH_OTLP_ENDPOINT", value = "http://${local.otel_grpc_container_port_dns}:${local.otel_grpc_container_port}" },
     ]
 
     essential = true

--- a/infra/terraform/hash/hash_application/type_fetcher.tf
+++ b/infra/terraform/hash/hash_application/type_fetcher.tf
@@ -35,7 +35,7 @@ locals {
     Environment = [
       { name = "HASH_GRAPH_TYPE_FETCHER_HOST", value = "0.0.0.0" },
       { name = "HASH_GRAPH_TYPE_FETCHER_PORT", value = tostring(local.type_fetcher_container_port) },
-      { name = "HASH_OTLP_ENDPOINT", value = "http://${local.otel_grpc_container_port_dns}:${local.otel_grpc_container_port}" },
+      { name = "HASH_OTLP_ENDPOINT", value = "grpc://${local.otel_grpc_container_port_dns}:${local.otel_grpc_container_port}" },
     ]
 
     essential = true


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Implements a local OpenTelemetry Collector in the app cluster to provide telemetry collection for all services. This follows an Agent-to-Gateway pattern where the local collector acts as an agent receiving telemetry from all app services and can later be configured to forward to the observability cluster gateway.

## 🔍 What does this change?

### New OpenTelemetry Collector Service

- **`otel_collector.tf`**: Complete ECS service implementation with:
  - S3-based configuration using config-downloader pattern
  - Service Connect integration for HTTP (4318) and gRPC (4317) endpoints
  - Debug exporter for initial telemetry validation
  - Proper security groups and IAM permissions

### Service Integration

- **All services** now include `HASH_OTLP_ENDPOINT` environment variable pointing to local collector
- **Kratos/Hydra**: Added OTLP-specific environment variables for OpenTelemetry integration
- **Security groups**: Added egress rules for services to communicate with local collector

### Infrastructure

- **S3 bucket**: `${prefix}-app-configs` for storing collector configuration
- **IAM permissions**: S3 access for config downloader container
- **Service Connect**: DNS resolution for `otel-collector-grpc.${namespace}` and `otel-collector-http.${namespace}`

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- Infrastructure deployment validation through Terraform plan/apply
- ECS service health checks and CloudWatch logging

## ❓ How to test this?

1. Apply Terraform changes to deploy the OpenTelemetry Collector
2. Verify ECS service starts successfully in AWS Console
3. Check CloudWatch logs show telemetry being received by debug exporter
4. Validate Service Connect DNS resolution works for both HTTP/gRPC endpoints
5. Confirm all app services can connect to local collector via environment variables

## 📹 Demo

Configuration is managed via S3 with automatic updates through ECS task definition versioning based on config content hash. This enables runtime configuration changes without code deployment.
