### PR TITLE
H-4991: Write background log files in CI and upload them on completion; Set terminal logging to WARN

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -281,6 +281,12 @@ jobs:
       - name: Start background tasks
         id: background-tasks
         if: steps.tests.outputs.has-background-tasks == 'true'
+        env:
+          # Set terminal logging to WARN level and enable verbose file logging for CI
+          HASH_GRAPH_LOG_CONSOLE_LEVEL: warn
+          HASH_GRAPH_LOG_FILE_ENABLED: true
+          HASH_GRAPH_LOG_FILE_LEVEL: info
+          HASH_GRAPH_LOG_FOLDER: var/logs
         run: |
           # Optimistically compile background tasks. Ideally, we also `build` them but this includes
           # `@apps/plugin-browser` which needs `build:test` instead. We cannot filter it out because

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -286,7 +286,7 @@ jobs:
           HASH_GRAPH_LOG_CONSOLE_LEVEL: warn
           HASH_GRAPH_LOG_FILE_ENABLED: true
           HASH_GRAPH_LOG_FILE_LEVEL: info
-          HASH_GRAPH_LOG_FOLDER: var/logs
+          HASH_GRAPH_LOG_FOLDER: ${{ github.workspace }}/var/logs
         run: |
           # Optimistically compile background tasks. Ideally, we also `build` them but this includes
           # `@apps/plugin-browser` which needs `build:test` instead. We cannot filter it out because

--- a/libs/@local/telemetry/src/logging/mod.rs
+++ b/libs/@local/telemetry/src/logging/mod.rs
@@ -140,6 +140,7 @@ pub struct ConsoleConfig {
         clap(
             id = "logging-console-level",
             long = "logging-console-level",
+            env = "HASH_GRAPH_LOG_CONSOLE_LEVEL",
             global = true
         )
     )]
@@ -285,6 +286,7 @@ pub struct FileConfig {
             id = "logging-file-level",
             long = "logging-file-level",
             value_enum,
+            env = "HASH_GRAPH_LOG_FILE_LEVEL",
             global = true
         )
     )]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When a graph error in CI happens it's very hard to find it. This is because it's spammed with INFO level logs. Sometimes these logs are helpful, but often they're not. We should set the terminal logging level in CI to WARN and emit a more verbose output to a file, which we should upload as artifact.