### PR TITLE
H-5058: Implement production Tempo with TraceQL support and foundational Grafana setup

### DIFF
--- a/infra/terraform/hash/hash_application/otel_collector.tf
+++ b/infra/terraform/hash/hash_application/otel_collector.tf
@@ -27,6 +27,16 @@ locals {
     }
     processors = {
       batch = {}
+
+      # Ory sets the `deployment.environment` attribute to an empty string
+      resource = {
+        attributes = [
+          {
+            key    = "deployment.environment"
+            action = "delete"
+          }
+        ]
+      }
     }
     exporters = {
       otlphttp = {
@@ -40,7 +50,7 @@ locals {
       pipelines = {
         traces = {
           receivers  = ["otlp"]
-          processors = ["batch"]
+          processors = ["batch", "resource"]
           exporters  = ["otlphttp"]
         }
         metrics = {

--- a/infra/terraform/hash/main.tf
+++ b/infra/terraform/hash/main.tf
@@ -125,14 +125,18 @@ module "temporal" {
 }
 
 module "observability" {
-  depends_on   = [module.networking]
-  source       = "./observability"
-  env          = local.env
-  region       = local.region
-  vpc          = module.networking.vpc
-  prefix       = "h-${terraform.workspace}-observability"
-  param_prefix = local.param_prefix
-  subnets      = module.networking.snpub
+  depends_on                = [module.networking]
+  source                    = "./observability"
+  env                       = local.env
+  region                    = local.region
+  vpc                       = module.networking.vpc
+  prefix                    = "h-${terraform.workspace}-observability"
+  param_prefix              = local.param_prefix
+  subnets                   = module.networking.snpub
+  grafana_database_host     = module.postgres.pg_host
+  grafana_database_port     = module.postgres.pg_port
+  grafana_database_password = sensitive(data.vault_kv_secret_v2.secrets.data["pg_grafana_user_password_raw"])
+  grafana_secret_key        = sensitive(data.vault_kv_secret_v2.secrets.data["grafana_secret_key"])
 }
 
 
@@ -173,6 +177,7 @@ module "postgres_roles" {
   pg_hydra_user_password_hash    = data.vault_kv_secret_v2.secrets.data["pg_hydra_user_password_hash"]
   pg_graph_user_password_hash    = data.vault_kv_secret_v2.secrets.data["pg_graph_user_password_hash"]
   pg_temporal_user_password_hash = data.vault_kv_secret_v2.secrets.data["pg_temporal_user_password_hash"]
+  pg_grafana_user_password_hash  = data.vault_kv_secret_v2.secrets.data["pg_grafana_user_password_hash"]
 }
 
 module "redis" {

--- a/infra/terraform/hash/observability/grafana/config.tf
+++ b/infra/terraform/hash/observability/grafana/config.tf
@@ -1,0 +1,38 @@
+# Grafana configuration management
+
+# Upload Grafana configuration generated from template
+resource "aws_s3_object" "grafana_config" {
+  bucket = var.config_bucket.id
+  key    = "grafana/grafana.ini"
+
+  # Generate config from template with environment-specific parameters
+  content = templatefile("${path.module}/templates/grafana.ini.tpl", {
+    environment   = terraform.workspace
+    grafana_port  = local.grafana_port
+    database_host = var.grafana_database_host
+    database_port = var.grafana_database_port
+  })
+
+  content_type = "text/plain"
+
+  tags = {
+    Purpose = "Grafana Configuration"
+    Service = "grafana"
+  }
+}
+
+# Tempo datasource provisioning
+resource "aws_s3_object" "grafana_tempo_datasource" {
+  bucket = var.config_bucket.id
+  key    = "grafana/provisioning/datasources/tempo.yaml"
+  content = templatefile("${path.module}/templates/provisioning/datasources/tempo.yaml.tpl", {
+    tempo_api_dns  = var.tempo_api_dns
+    tempo_api_port = var.tempo_api_port
+  })
+  content_type = "application/x-yaml"
+
+  tags = {
+    Purpose = "Grafana Tempo Datasource"
+    Service = "grafana"
+  }
+}

--- a/infra/terraform/hash/observability/grafana/iam.tf
+++ b/infra/terraform/hash/observability/grafana/iam.tf
@@ -1,0 +1,108 @@
+# IAM roles for Grafana ECS tasks
+
+# Execution role for ECS tasks (used by ECS agent)
+resource "aws_iam_role" "execution_role" {
+  name = "${local.prefix}-execution-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+# Attach standard ECS execution role policy
+resource "aws_iam_role_policy_attachment" "execution_role" {
+  role       = aws_iam_role.execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+# SSM secrets access for execution role (needed for pulling secrets)
+resource "aws_iam_role_policy" "execution_role_ssm" {
+  name = "ssm-secrets-access"
+  role = aws_iam_role.execution_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ssm:GetParameters"
+        ]
+        Resource = [
+          for param in aws_ssm_parameter.grafana_env_vars :
+          param.arn
+        ]
+      }
+    ]
+  })
+}
+
+# Task role for running containers (used by application)
+resource "aws_iam_role" "task_role" {
+  name = "${local.prefix}-task-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      }
+    ]
+  })
+
+  inline_policy {
+    name = "s3-config-access"
+    policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Effect = "Allow"
+          Action = [
+            "s3:ListBucket"
+          ]
+          Resource = var.config_bucket.arn
+        },
+        {
+          Effect = "Allow"
+          Action = [
+            "s3:GetObject"
+          ]
+          Resource = "${var.config_bucket.arn}/grafana/*"
+        }
+      ]
+    })
+  }
+
+  inline_policy {
+    name = "ecs-execute-command"
+    policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Effect = "Allow"
+          Action = [
+            "ssmmessages:CreateControlChannel",
+            "ssmmessages:CreateDataChannel",
+            "ssmmessages:OpenControlChannel",
+            "ssmmessages:OpenDataChannel"
+          ]
+          Resource = "*"
+        }
+      ]
+    })
+  }
+
+}

--- a/infra/terraform/hash/observability/grafana/main.tf
+++ b/infra/terraform/hash/observability/grafana/main.tf
@@ -1,0 +1,10 @@
+# Grafana ECS service for distributed tracing visualization
+# Integrates with Tempo for trace data and PostgreSQL for configuration storage
+
+locals {
+  service_name = "grafana"
+  prefix       = "${var.prefix}-${local.service_name}"
+
+  grafana_port      = 3000
+  grafana_port_name = "${local.service_name}-http"
+}

--- a/infra/terraform/hash/observability/grafana/outputs.tf
+++ b/infra/terraform/hash/observability/grafana/outputs.tf
@@ -1,0 +1,14 @@
+output "target_group_arn" {
+  description = "ARN of the Grafana target group"
+  value       = aws_lb_target_group.grafana.arn
+}
+
+output "grafana_port" {
+  description = "Port number for Grafana service"
+  value       = local.grafana_port
+}
+
+output "grafana_port_name" {
+  description = "Port name for Service Connect"
+  value       = local.grafana_port_name
+}

--- a/infra/terraform/hash/observability/grafana/security_groups.tf
+++ b/infra/terraform/hash/observability/grafana/security_groups.tf
@@ -1,0 +1,73 @@
+# Security group for Grafana
+
+resource "aws_security_group" "grafana" {
+  name_prefix = "${local.prefix}-"
+  vpc_id      = var.vpc.id
+
+  # Allow inbound HTTP from ALB
+  ingress {
+    from_port   = local.grafana_port
+    to_port     = local.grafana_port
+    protocol    = "tcp"
+    description = "Grafana HTTP from ALB"
+    cidr_blocks = [var.vpc.cidr_block]
+  }
+
+  # Allow outbound HTTPS for external resources (if needed)
+  egress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    description = "HTTPS outbound"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # Allow outbound HTTP for package downloads (SSL setup)
+  egress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    description = "HTTP outbound for package downloads"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # Allow outbound HTTP for Tempo API
+  egress {
+    from_port   = var.tempo_api_port
+    to_port     = var.tempo_api_port
+    protocol    = "tcp"
+    description = "Tempo API access"
+    cidr_blocks = [var.vpc.cidr_block]
+  }
+
+  # Allow outbound PostgreSQL
+  egress {
+    from_port   = var.grafana_database_port
+    to_port     = var.grafana_database_port
+    protocol    = "tcp"
+    description = "PostgreSQL database access"
+    cidr_blocks = [var.vpc.cidr_block]
+  }
+
+  # Allow outbound DNS
+  egress {
+    from_port   = 53
+    to_port     = 53
+    protocol    = "tcp"
+    description = "DNS resolution"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 53
+    to_port     = 53
+    protocol    = "udp"
+    description = "DNS resolution"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name    = "${local.prefix}-sg"
+    Purpose = "Grafana security group"
+  }
+}

--- a/infra/terraform/hash/observability/grafana/target_group.tf
+++ b/infra/terraform/hash/observability/grafana/target_group.tf
@@ -1,0 +1,30 @@
+# Target group for Grafana service
+
+resource "aws_lb_target_group" "grafana" {
+  name        = "${local.prefix}-tg"
+  port        = local.grafana_port
+  protocol    = "HTTP"
+  vpc_id      = var.vpc.id
+  target_type = "ip"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  health_check {
+    enabled             = true
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    timeout             = 5
+    interval            = 30
+    path                = "/api/health"
+    matcher             = "200"
+    port                = local.grafana_port
+    protocol            = "HTTP"
+  }
+
+  tags = {
+    Name    = "${local.prefix}-tg"
+    Purpose = "Grafana target group"
+  }
+}

--- a/infra/terraform/hash/observability/grafana/templates/grafana.ini.tpl
+++ b/infra/terraform/hash/observability/grafana/templates/grafana.ini.tpl
@@ -20,7 +20,7 @@ brute_force_login_protection_max_attempts = 5
 [users]
 # No sign-up allowed - admin manages users
 allow_sign_up = false
-# Allow users to change their own password
+# Admins manage orgs
 allow_org_create = false
 
 [auth]

--- a/infra/terraform/hash/observability/grafana/templates/grafana.ini.tpl
+++ b/infra/terraform/hash/observability/grafana/templates/grafana.ini.tpl
@@ -1,0 +1,39 @@
+# Grafana Configuration - Environment: ${environment}
+# Generated from Terraform template
+
+[server]
+http_port = ${grafana_port}
+root_url = https://grafana.hash.ai
+
+[database]
+type = postgres
+host = ${database_host}:${database_port}
+name = grafana
+user = grafana
+ssl_mode = require
+
+[security]
+disable_initial_admin_creation = true
+disable_brute_force_login_protection = true
+brute_force_login_protection_max_attempts = 5
+
+[users]
+# No sign-up allowed - admin manages users
+allow_sign_up = false
+# Allow users to change their own password
+allow_org_create = false
+
+[auth]
+disable_login_form = false
+
+[log]
+mode = console
+level = info
+
+[paths]
+# Provision configuration from mounted volume
+provisioning = /etc/grafana/provisioning
+
+[analytics]
+reporting_enabled = false
+check_for_updates = false

--- a/infra/terraform/hash/observability/grafana/templates/grafana.ini.tpl
+++ b/infra/terraform/hash/observability/grafana/templates/grafana.ini.tpl
@@ -3,7 +3,7 @@
 
 [server]
 http_port = ${grafana_port}
-root_url = https://grafana.hash.ai
+root_url = https://grafana.internal.hash.ai
 
 [database]
 type = postgres

--- a/infra/terraform/hash/observability/grafana/templates/provisioning/datasources/tempo.yaml.tpl
+++ b/infra/terraform/hash/observability/grafana/templates/provisioning/datasources/tempo.yaml.tpl
@@ -1,0 +1,20 @@
+# Tempo data source provisioning for Grafana
+# Generated from Terraform template
+
+apiVersion: 1
+
+datasources:
+  - name: Tempo
+    type: tempo
+    uid: tempo-uid
+    access: proxy
+    url: http://${tempo_api_dns}:${tempo_api_port}
+    isDefault: false
+    editable: false
+    jsonData:
+      httpMethod: GET
+      search:
+        hide: false
+      nodeGraph:
+        enabled: true
+    version: 1

--- a/infra/terraform/hash/observability/grafana/templates/provisioning/datasources/tempo.yaml.tpl
+++ b/infra/terraform/hash/observability/grafana/templates/provisioning/datasources/tempo.yaml.tpl
@@ -6,7 +6,7 @@ apiVersion: 1
 datasources:
   - name: Tempo
     type: tempo
-    uid: tempo-uid
+    uid: tempo
     access: proxy
     url: http://${tempo_api_dns}:${tempo_api_port}
     isDefault: false

--- a/infra/terraform/hash/observability/grafana/variables.tf
+++ b/infra/terraform/hash/observability/grafana/variables.tf
@@ -36,14 +36,41 @@ variable "service_discovery_namespace_arn" {
   description = "ARN of the service discovery namespace for Service Connect"
 }
 
-variable "tempo_otlp_grpc_dns" {
+variable "service_discovery_namespace_name" {
   type        = string
-  description = "Tempo OTLP gRPC DNS name for trace forwarding"
+  description = "Name of the service discovery namespace for DNS resolution"
 }
 
-variable "tempo_otlp_grpc_port" {
+variable "grafana_database_host" {
+  type        = string
+  description = "PostgreSQL database host"
+}
+
+variable "grafana_database_port" {
   type        = number
-  description = "Tempo OTLP gRPC port number"
+  description = "PostgreSQL database port"
+}
+
+variable "grafana_database_password" {
+  type        = string
+  sensitive   = true
+  description = "PostgreSQL database password for grafana user"
+}
+
+variable "grafana_secret_key" {
+  type        = string
+  sensitive   = true
+  description = "Grafana secret key"
+}
+
+variable "tempo_api_dns" {
+  type        = string
+  description = "DNS name for Tempo API service"
+}
+
+variable "tempo_api_port" {
+  type        = number
+  description = "Port for Tempo API service"
 }
 
 variable "ssl_config" {

--- a/infra/terraform/hash/observability/load_balancer.tf
+++ b/infra/terraform/hash/observability/load_balancer.tf
@@ -1,39 +1,39 @@
-# Application Load Balancer for external access to observability services
+# Internal Application Load Balancer for internal telemetry collection
 # Provides HTTP and gRPC endpoints for applications to send telemetry data
 
-resource "aws_lb" "observability" {
-  name               = var.prefix
+resource "aws_lb" "observability_internal" {
+  name               = "${var.prefix}-internal"
   load_balancer_type = "application"
   subnets            = var.subnets
-  security_groups    = [aws_security_group.alb.id]
+  security_groups    = [aws_security_group.alb_internal.id]
   internal           = true
 
   tags = {
-    Name    = var.prefix
-    Purpose = "Observability services load balancer"
+    Name    = "${var.prefix}-internal"
+    Purpose = "Internal observability services load balancer"
   }
 }
 
-# Security group for the ALB
-resource "aws_security_group" "alb" {
-  name_prefix = "${var.prefix}-"
+# Security group for the internal ALB
+resource "aws_security_group" "alb_internal" {
+  name_prefix = "${var.prefix}-internal-"
   vpc_id      = var.vpc.id
 
-  # Allow inbound HTTPS for OTel (gRPC over HTTP/2)
+  # Allow inbound HTTP for OTel receiver internal
   ingress {
-    from_port   = 443
-    to_port     = 443
+    from_port   = module.otel_collector.http_port_internal
+    to_port     = module.otel_collector.http_port_internal
     protocol    = "tcp"
-    description = "HTTPS for OpenTelemetry receiver (internal - HTTP and gRPC)"
+    description = "HTTP for OpenTelemetry receiver (internal)"
     cidr_blocks = [var.vpc.cidr_block]
   }
 
-  # Allow inbound HTTPS for OTel receiver internal (supports both gRPC and HTTP over HTTPS)
+  # Allow inbound gRPC for OTel receiver internal
   ingress {
-    from_port   = module.otel_collector.http_port
-    to_port     = module.otel_collector.http_port
+    from_port   = module.otel_collector.grpc_port_internal
+    to_port     = module.otel_collector.grpc_port_internal
     protocol    = "tcp"
-    description = "HTTPS for OpenTelemetry receiver (internal - HTTP)"
+    description = "gRPC for OpenTelemetry receiver (internal)"
     cidr_blocks = [var.vpc.cidr_block]
   }
 
@@ -47,41 +47,141 @@ resource "aws_security_group" "alb" {
   }
 
   tags = {
-    Name    = "${var.prefix}-sg"
-    Purpose = "Observability ALB security group"
+    Name    = "${var.prefix}-internal-sg"
+    Purpose = "Internal observability ALB security group"
   }
 }
 
-# External HTTPS listener for telemetry.hash.ai (Cloudflare certificate)
-resource "aws_lb_listener" "otel_external" {
-  load_balancer_arn = aws_lb.observability.arn
+# External Application Load Balancer for public access
+# Provides HTTPS access to Grafana and external telemetry endpoints
+
+resource "aws_lb" "observability_external" {
+  name               = "${var.prefix}-external"
+  load_balancer_type = "application"
+  subnets            = var.subnets
+  security_groups    = [aws_security_group.alb_external.id]
+  internal           = false
+
+  tags = {
+    Name    = "${var.prefix}-external"
+    Purpose = "External observability services load balancer"
+  }
+}
+
+# Security group for the external ALB
+resource "aws_security_group" "alb_external" {
+  name_prefix = "${var.prefix}-external-"
+  vpc_id      = var.vpc.id
+
+  # Allow inbound HTTPS from internet
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    description = "HTTPS from internet for Grafana and external telemetry"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # Allow outbound to Grafana containers
+  egress {
+    from_port   = module.grafana.grafana_port
+    to_port     = module.grafana.grafana_port
+    protocol    = "tcp"
+    description = "Allow outbound to Grafana containers"
+    cidr_blocks = [var.vpc.cidr_block]
+  }
+
+  # Allow outbound to OTel Collector for external telemetry
+  egress {
+    from_port   = module.otel_collector.http_port_external
+    to_port     = module.otel_collector.http_port_external
+    protocol    = "tcp"
+    description = "Allow outbound to OTel Collector for external telemetry"
+    cidr_blocks = [var.vpc.cidr_block]
+  }
+
+  egress {
+    from_port   = module.otel_collector.grpc_port_external
+    to_port     = module.otel_collector.grpc_port_external
+    protocol    = "tcp"
+    description = "Allow outbound to OTel Collector for external telemetry"
+    cidr_blocks = [var.vpc.cidr_block]
+  }
+
+  # Allow outbound to OTel Collector health check port
+  egress {
+    from_port   = module.otel_collector.health_port
+    to_port     = module.otel_collector.health_port
+    protocol    = "tcp"
+    description = "Allow health checks to OTel Collector"
+    cidr_blocks = [var.vpc.cidr_block]
+  }
+
+  tags = {
+    Name    = "${var.prefix}-external-sg"
+    Purpose = "External observability ALB security group"
+  }
+}
+
+# External HTTPS listener for grafana.hash.ai and telemetry.hash.ai
+resource "aws_lb_listener" "external_https" {
+  load_balancer_arn = aws_lb.observability_external.arn
   port              = "443"
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-Res-2021-06"
   certificate_arn   = data.aws_acm_certificate.hash_wildcard_cert.arn
 
+  # Default action - return 404 for unknown hosts
   default_action {
     type = "fixed-response"
 
     fixed_response {
       content_type = "text/plain"
-      message_body = "Only OpenTelemetry gRPC and HTTP requests are allowed"
-      status_code  = "400"
+      message_body = "Not Found"
+      status_code  = "404"
     }
   }
 
   tags = {
-    Name = "${var.prefix}-otel-external-listener"
+    Name = "${var.prefix}-external-https-listener"
   }
 }
 
-# External listener routing rules
-resource "aws_lb_listener_rule" "otel_external_http_routing" {
-  listener_arn = aws_lb_listener.otel_external.arn
+# Grafana routing rule for grafana.hash.ai
+resource "aws_lb_listener_rule" "grafana_routing" {
+  listener_arn = aws_lb_listener.external_https.arn
+  priority     = 50
 
   action {
     type             = "forward"
-    target_group_arn = module.otel_collector.http_target_group_arn
+    target_group_arn = module.grafana.target_group_arn
+  }
+
+  condition {
+    host_header {
+      values = ["grafana.hash.ai"]
+    }
+  }
+
+  tags = {
+    Name = "${var.prefix}-grafana-routing"
+  }
+}
+
+# External telemetry routing rules for telemetry.hash.ai
+resource "aws_lb_listener_rule" "telemetry_external_http_routing" {
+  listener_arn = aws_lb_listener.external_https.arn
+  priority     = 100
+
+  action {
+    type             = "forward"
+    target_group_arn = module.otel_collector.http_external_target_group_arn
+  }
+
+  condition {
+    host_header {
+      values = ["telemetry.hash.ai"]
+    }
   }
 
   condition {
@@ -92,16 +192,23 @@ resource "aws_lb_listener_rule" "otel_external_http_routing" {
   }
 
   tags = {
-    Name = "${var.prefix}-otel-external-http-routing"
+    Name = "${var.prefix}-telemetry-external-http-routing"
   }
 }
 
-resource "aws_lb_listener_rule" "otel_external_grpc_routing" {
-  listener_arn = aws_lb_listener.otel_external.arn
+resource "aws_lb_listener_rule" "telemetry_external_grpc_routing" {
+  listener_arn = aws_lb_listener.external_https.arn
+  priority     = 101
 
   action {
     type             = "forward"
-    target_group_arn = module.otel_collector.grpc_target_group_arn
+    target_group_arn = module.otel_collector.grpc_external_target_group_arn
+  }
+
+  condition {
+    host_header {
+      values = ["telemetry.hash.ai"]
+    }
   }
 
   condition {
@@ -112,22 +219,22 @@ resource "aws_lb_listener_rule" "otel_external_grpc_routing" {
   }
 
   tags = {
-    Name = "${var.prefix}-otel-external-grpc-routing"
+    Name = "${var.prefix}-telemetry-external-grpc-routing"
   }
 }
 
 # Internal HTTP listener for app cluster OTel collector
-resource "aws_lb_listener" "otel_internal" {
-  load_balancer_arn = aws_lb.observability.arn
-  port              = module.otel_collector.http_port
+resource "aws_lb_listener" "otel_internal_http" {
+  load_balancer_arn = aws_lb.observability_internal.arn
+  port              = module.otel_collector.http_port_internal
   protocol          = "HTTP"
 
   default_action {
     type             = "forward"
-    target_group_arn = module.otel_collector.http_target_group_arn
+    target_group_arn = module.otel_collector.http_internal_target_group_arn
   }
 
   tags = {
-    Name = "${var.prefix}-otel-internal-listener"
+    Name = "${var.prefix}-otel-internal-http-listener"
   }
 }

--- a/infra/terraform/hash/observability/otel_collector/config.tf
+++ b/infra/terraform/hash/observability/otel_collector/config.tf
@@ -1,5 +1,17 @@
 # OpenTelemetry Collector configuration management
 
+# Map Terraform workspace names to OpenTelemetry environment names
+locals {
+  environment_mapping = {
+    "prod"  = "production"
+    "stage" = "staging"
+    "dev"   = "development"
+  }
+  
+  # Use mapped environment name, fallback to workspace name if not in mapping
+  otel_environment = lookup(local.environment_mapping, terraform.workspace, terraform.workspace)
+}
+
 # Upload OpenTelemetry Collector configuration generated from template
 resource "aws_s3_object" "otel_collector_config" {
   bucket = var.config_bucket.id
@@ -7,13 +19,16 @@ resource "aws_s3_object" "otel_collector_config" {
 
   # Generate config from template with environment-specific parameters
   content = templatefile("${path.module}/templates/otel-collector.yaml.tpl", {
-    environment     = terraform.workspace
-    debug_verbosity = terraform.workspace == "prod" ? "basic" : "normal"
-    batch_timeout   = "1s"
-    batch_size      = 8192
-    grpc_port       = local.grpc_port
-    http_port       = local.http_port
-    health_port     = local.health_port
+    environment            = local.otel_environment
+    batch_timeout          = "1s"
+    batch_size             = 8192
+    grpc_port_internal     = local.grpc_port_internal
+    http_port_internal     = local.http_port_internal
+    grpc_port_external     = local.grpc_port_external
+    http_port_external     = local.http_port_external
+    health_port            = local.health_port
+    tempo_otlp_grpc_dns    = var.tempo_otlp_grpc_dns
+    tempo_otlp_grpc_port   = var.tempo_otlp_grpc_port
   })
 
   content_type = "application/x-yaml"

--- a/infra/terraform/hash/observability/otel_collector/main.tf
+++ b/infra/terraform/hash/observability/otel_collector/main.tf
@@ -5,12 +5,18 @@ locals {
   prefix       = "${var.prefix}-${local.service_name}"
 
   # Port definitions for OpenTelemetry Collector
-  grpc_port   = 4317
-  http_port   = 4318
+  # Internal ports for service-to-service communication (Tempo, etc.)
+  grpc_port_internal = 4317
+  http_port_internal = 4318
+  
+  # External ports for client applications sending traces/metrics
+  grpc_port_external = 4319  
+  http_port_external = 4320
+  
   health_port = 13133
   
-  # Port names for Service Connect
-  grpc_port_name   = "${local.service_name}-grpc"
-  http_port_name   = "${local.service_name}-http"
-  health_port_name = "${local.service_name}-health"
+  # Port names for Service Connect (internal communication only)
+  grpc_port_name_internal = "${local.service_name}-grpc-internal"
+  http_port_name_internal = "${local.service_name}-http-internal"
+  health_port_name        = "${local.service_name}-health"
 }

--- a/infra/terraform/hash/observability/otel_collector/outputs.tf
+++ b/infra/terraform/hash/observability/otel_collector/outputs.tf
@@ -1,13 +1,25 @@
 # Service ports for parent module to use in load balancer configuration
 
-output "grpc_port" {
-  description = "gRPC port for OpenTelemetry Collector"
-  value       = local.grpc_port
+# Internal ports (service-to-service communication)
+output "grpc_port_internal" {
+  description = "Internal gRPC port for OpenTelemetry Collector"
+  value       = local.grpc_port_internal
 }
 
-output "http_port" {
-  description = "HTTP port for OpenTelemetry Collector"
-  value       = local.http_port
+output "http_port_internal" {
+  description = "Internal HTTP port for OpenTelemetry Collector"
+  value       = local.http_port_internal
+}
+
+# External ports (client applications)
+output "grpc_port_external" {
+  description = "External gRPC port for OpenTelemetry Collector"
+  value       = local.grpc_port_external
+}
+
+output "http_port_external" {
+  description = "External HTTP port for OpenTelemetry Collector"
+  value       = local.http_port_external
 }
 
 output "health_port" {
@@ -15,30 +27,32 @@ output "health_port" {
   value       = local.health_port
 }
 
-# Port names for Service Connect
-output "grpc_port_name" {
-  description = "Service Connect port name for gRPC"
-  value       = local.grpc_port_name
+# Port names for Service Connect (internal only)
+output "grpc_port_name_internal" {
+  description = "Service Connect port name for internal gRPC"
+  value       = local.grpc_port_name_internal
 }
 
-output "http_port_name" {
-  description = "Service Connect port name for HTTP"
-  value       = local.http_port_name
-}
-
-output "health_port_name" {
-  description = "Service Connect port name for health check"
-  value       = local.health_port_name
+output "http_port_name_internal" {
+  description = "Service Connect port name for internal HTTP"
+  value       = local.http_port_name_internal
 }
 
 # Target groups for load balancer attachment
-output "http_target_group_arn" {
-  description = "HTTP target group ARN"
-  value       = aws_lb_target_group.http.arn
+
+# Internal target groups (service-to-service communication)
+output "http_internal_target_group_arn" {
+  description = "Internal HTTP target group ARN"
+  value       = aws_lb_target_group.http_internal.arn
 }
 
-output "grpc_target_group_arn" {
-  description = "gRPC target group ARN"
-  value       = aws_lb_target_group.grpc.arn
+# External target groups (client applications)
+output "http_external_target_group_arn" {
+  description = "External HTTP target group ARN"
+  value       = aws_lb_target_group.http_external.arn
 }
 
+output "grpc_external_target_group_arn" {
+  description = "External gRPC target group ARN"
+  value       = aws_lb_target_group.grpc_external.arn
+}

--- a/infra/terraform/hash/observability/otel_collector/security_groups.tf
+++ b/infra/terraform/hash/observability/otel_collector/security_groups.tf
@@ -4,21 +4,39 @@ resource "aws_security_group" "otel_collector" {
   name_prefix = "${local.prefix}-"
   vpc_id      = var.vpc.id
 
-  # Allow inbound gRPC traffic
+  # Allow inbound gRPC traffic - internal (service-to-service)
   ingress {
-    from_port   = local.grpc_port
-    to_port     = local.grpc_port
+    from_port   = local.grpc_port_internal
+    to_port     = local.grpc_port_internal
     protocol    = "tcp"
-    description = "OpenTelemetry gRPC receiver"
+    description = "OpenTelemetry internal gRPC receiver"
     cidr_blocks = [var.vpc.cidr_block]
   }
 
-  # Allow inbound HTTP traffic
+  # Allow inbound HTTP traffic - internal (service-to-service)
   ingress {
-    from_port   = local.http_port
-    to_port     = local.http_port
+    from_port   = local.http_port_internal
+    to_port     = local.http_port_internal
     protocol    = "tcp"
-    description = "OpenTelemetry HTTP receiver"
+    description = "OpenTelemetry internal HTTP receiver"
+    cidr_blocks = [var.vpc.cidr_block]
+  }
+
+  # Allow inbound gRPC traffic - external (client applications via ALB)
+  ingress {
+    from_port   = local.grpc_port_external
+    to_port     = local.grpc_port_external
+    protocol    = "tcp"
+    description = "OpenTelemetry external gRPC receiver"
+    cidr_blocks = [var.vpc.cidr_block]
+  }
+
+  # Allow inbound HTTP traffic - external (client applications via ALB)
+  ingress {
+    from_port   = local.http_port_external
+    to_port     = local.http_port_external
+    protocol    = "tcp"
+    description = "OpenTelemetry external HTTP receiver"
     cidr_blocks = [var.vpc.cidr_block]
   }
 
@@ -40,6 +58,15 @@ resource "aws_security_group" "otel_collector" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  # Allow outbound HTTP for package downloads during SSL setup
+  egress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    description = "HTTP outbound for package downloads"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
   # Allow outbound DNS
   egress {
     from_port   = 53
@@ -47,6 +74,15 @@ resource "aws_security_group" "otel_collector" {
     protocol    = "tcp"
     description = "DNS resolution"
     cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # Allow outbound traffic to Tempo OTLP gRPC
+  egress {
+    from_port   = var.tempo_otlp_grpc_port
+    to_port     = var.tempo_otlp_grpc_port
+    protocol    = "tcp"
+    description = "OTLP gRPC to Tempo"
+    cidr_blocks = [var.vpc.cidr_block]
   }
 
   tags = {

--- a/infra/terraform/hash/observability/otel_collector/templates/otel-collector.yaml.tpl
+++ b/infra/terraform/hash/observability/otel_collector/templates/otel-collector.yaml.tpl
@@ -3,21 +3,60 @@
 # Generated from Terraform template
 
 receivers:
-  otlp:
+  # Internal OTLP receiver for service-to-service communication (Tempo, etc.)
+  otlp/internal:
     protocols:
       grpc:
-        endpoint: 0.0.0.0:${grpc_port}
+        endpoint: 0.0.0.0:${grpc_port_internal}
       http:
-        endpoint: 0.0.0.0:${http_port}
+        endpoint: 0.0.0.0:${http_port_internal}
+
+  # External OTLP receiver for client applications
+  otlp/external:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:${grpc_port_external}
+      http:
+        endpoint: 0.0.0.0:${http_port_external}
 
 processors:
+  # Memory limiter to prevent OOM kills (512MB container - 50MB overhead = ~450MB limit)
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 400
+    spike_limit_mib: 80  # 20% of limit_mib
+
   batch:
     timeout: ${batch_timeout}
     send_batch_size: ${batch_size}
 
+  # Resource processor for internal services - preserve existing environment attributes
+  resource/internal:
+    attributes:
+      # https://opentelemetry.io/docs/specs/semconv/resource/deployment-environment/
+      - key: deployment.environment.name
+        value: ${environment}
+        action: insert  # Preserve existing environment attributes (e.g., "development", "staging")
+
+  # Resource processor for external services - upsert environment attribute
+  resource/external:
+    attributes:
+      # https://opentelemetry.io/docs/specs/semconv/resource/deployment-environment/
+      - key: deployment.environment.name
+        value: external
+        action: upsert  # Always set external services to "external" environment
+
+connectors:
+  forward/traces:
+  forward/metrics:
+  forward/logs:
+
 exporters:
-  debug:
-    verbosity: ${debug_verbosity}
+  nop:
+  otlp/tempo:
+    endpoint: ${tempo_otlp_grpc_dns}:${tempo_otlp_grpc_port}
+    tls:
+      insecure: true
 
 extensions:
   health_check:
@@ -27,17 +66,51 @@ service:
   extensions: [health_check]
 
   pipelines:
+    # Input pipelines - add environment attributes and forward to common processing
+    traces/internal:
+      receivers: [otlp/internal]
+      processors: [memory_limiter, resource/internal]
+      exporters: [forward/traces]
+
+    metrics/internal:
+      receivers: [otlp/internal]
+      processors: [memory_limiter, resource/internal]
+      exporters: [forward/metrics]
+
+    logs/internal:
+      receivers: [otlp/internal]
+      processors: [memory_limiter, resource/internal]
+      exporters: [forward/logs]
+
+
+    traces/external:
+      receivers: [otlp/external]
+      processors: [memory_limiter, resource/external]
+      exporters: [forward/traces]
+
+    metrics/external:
+      receivers: [otlp/external]
+      processors: [memory_limiter, resource/external]
+      exporters: [forward/metrics]
+
+    logs/external:
+      receivers: [otlp/external]
+      processors: [memory_limiter, resource/external]
+      exporters: [forward/logs]
+
+
+    # Common output pipelines - shared processing and export
     traces:
-      receivers: [otlp]
+      receivers: [forward/traces]
       processors: [batch]
-      exporters: [debug]
+      exporters: [otlp/tempo]
 
     metrics:
-      receivers: [otlp]
+      receivers: [forward/metrics]
       processors: [batch]
-      exporters: [debug]
+      exporters: [nop]
 
     logs:
-      receivers: [otlp]
+      receivers: [forward/logs]
       processors: [batch]
-      exporters: [debug]
+      exporters: [nop]

--- a/infra/terraform/hash/observability/outputs.tf
+++ b/infra/terraform/hash/observability/outputs.tf
@@ -1,10 +1,10 @@
 # Observability stack DNS name and OTLP ports
 output "otlp_dns" {
-  description = "OTLP DNS name for sending telemetry to the observability cluster"
-  value       = aws_lb.observability.dns_name
+  description = "OTLP DNS name for sending telemetry to the observability cluster (internal ALB)"
+  value       = aws_lb.observability_internal.dns_name
 }
 
 output "otlp_http_port" {
-  description = "OTLP HTTP port number for sending telemetry to the observability cluster"
-  value       = module.otel_collector.http_port
+  description = "OTLP HTTP port number for sending telemetry to the observability cluster (internal)"
+  value       = module.otel_collector.http_port_internal
 }

--- a/infra/terraform/hash/observability/tempo/config.tf
+++ b/infra/terraform/hash/observability/tempo/config.tf
@@ -1,0 +1,23 @@
+# Tempo configuration management
+
+# Upload Tempo configuration generated from template
+resource "aws_s3_object" "tempo_config" {
+  bucket = var.config_bucket.id
+  key    = "tempo/config.yaml"
+
+  # Generate config from template with environment-specific parameters
+  content = templatefile("${path.module}/templates/tempo.yaml.tpl", {
+    environment  = terraform.workspace
+    api_port     = local.api_port
+    otlp_port    = local.otlp_port
+    tempo_bucket = aws_s3_bucket.tempo_traces.bucket
+    aws_region   = var.region
+  })
+
+  content_type = "application/x-yaml"
+
+  tags = {
+    Purpose = "Tempo Configuration"
+    Service = "tempo"
+  }
+}

--- a/infra/terraform/hash/observability/tempo/iam.tf
+++ b/infra/terraform/hash/observability/tempo/iam.tf
@@ -1,0 +1,99 @@
+# IAM roles for Tempo ECS tasks
+
+# Execution role for ECS tasks (used by ECS agent)
+resource "aws_iam_role" "execution_role" {
+  name = "${local.prefix}-execution-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+# Attach standard ECS execution role policy
+resource "aws_iam_role_policy_attachment" "execution_role" {
+  role       = aws_iam_role.execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+# Task role for running containers (used by application)
+resource "aws_iam_role" "task_role" {
+  name = "${local.prefix}-task-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      }
+    ]
+  })
+
+  inline_policy {
+    name = "s3-config-access"
+    policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Effect = "Allow"
+          Action = [
+            "s3:ListBucket"
+          ]
+          Resource = var.config_bucket.arn
+        },
+        {
+          Effect = "Allow"
+          Action = [
+            "s3:GetObject"
+          ]
+          Resource = "${var.config_bucket.arn}/tempo/*"
+        }
+      ]
+    })
+  }
+
+  inline_policy {
+    name = "s3-traces-access"
+    policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Effect = "Allow"
+          Action = [
+            "s3:ListBucket"
+          ]
+          Resource = aws_s3_bucket.tempo_traces.arn
+        },
+        {
+          Effect = "Allow"
+          Action = [
+            "s3:GetObject",
+            "s3:PutObject",
+            "s3:DeleteObject",
+            "s3:GetObjectTagging",
+            "s3:PutObjectTagging"
+          ]
+          Resource = "${aws_s3_bucket.tempo_traces.arn}/*"
+        }
+      ]
+    })
+  }
+}
+
+# Attach SSM policy for ECS Execute Command
+resource "aws_iam_role_policy_attachment" "task_role_ssm" {
+  role       = aws_iam_role.task_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}

--- a/infra/terraform/hash/observability/tempo/main.tf
+++ b/infra/terraform/hash/observability/tempo/main.tf
@@ -1,0 +1,18 @@
+# Tempo service definition
+
+locals {
+  service_name = "tempo"
+  prefix       = "${var.prefix}-${local.service_name}"
+
+  # Port definitions for Tempo
+  api_port      = 3200  # Tempo API for Grafana queries
+  otlp_port     = 4317  # OTLP gRPC receiver for traces
+  
+  # Port names for Service Connect
+  api_port_name       = "${local.service_name}-api"
+  otlp_grpc_port_name = "${local.service_name}-otlp-grpc"
+  
+  # DNS names for Service Connect
+  api_port_dns       = "${local.api_port_name}.${var.service_discovery_namespace_name}"
+  otlp_grpc_port_dns = "${local.otlp_grpc_port_name}.${var.service_discovery_namespace_name}"
+}

--- a/infra/terraform/hash/observability/tempo/outputs.tf
+++ b/infra/terraform/hash/observability/tempo/outputs.tf
@@ -1,0 +1,32 @@
+# Tempo service outputs for Service Connect integration
+
+output "otlp_grpc_port" {
+  description = "OTLP gRPC port for traces (for otel_collector config)"
+  value       = local.otlp_port
+}
+
+output "otlp_grpc_port_name" {
+  description = "Service Connect port name for OTLP gRPC"
+  value       = local.otlp_grpc_port_name
+}
+
+output "api_port" {
+  description = "API port for Tempo queries (for Grafana)"
+  value       = local.api_port
+}
+
+output "api_port_name" {
+  description = "Service Connect port name for API"
+  value       = local.api_port_name
+}
+
+# DNS names for Service Connect
+output "otlp_grpc_dns" {
+  description = "Service Connect DNS name for OTLP gRPC (for otel_collector config)"
+  value       = local.otlp_grpc_port_dns
+}
+
+output "api_dns" {
+  description = "Service Connect DNS name for API (for Grafana)"
+  value       = local.api_port_dns
+}

--- a/infra/terraform/hash/observability/tempo/security_groups.tf
+++ b/infra/terraform/hash/observability/tempo/security_groups.tf
@@ -1,0 +1,64 @@
+# Security group for Tempo
+
+resource "aws_security_group" "tempo" {
+  name_prefix = "${local.prefix}-"
+  vpc_id      = var.vpc.id
+
+  # Allow inbound OTLP gRPC traces from OpenTelemetry Collector
+  ingress {
+    from_port   = local.otlp_port
+    to_port     = local.otlp_port
+    protocol    = "tcp"
+    description = "Tempo OTLP gRPC receiver for traces"
+    cidr_blocks = [var.vpc.cidr_block]
+  }
+
+  # Allow inbound API queries from Grafana
+  ingress {
+    from_port   = local.api_port
+    to_port     = local.api_port
+    protocol    = "tcp"
+    description = "Tempo API for Grafana queries"
+    cidr_blocks = [var.vpc.cidr_block]
+  }
+
+  # Allow outbound HTTPS for S3 trace storage and config download
+  egress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    description = "HTTPS for S3 access"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # Allow outbound HTTP for package downloads during SSL setup
+  egress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    description = "HTTP outbound for package downloads"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # Allow outbound DNS
+  egress {
+    from_port   = 53
+    to_port     = 53
+    protocol    = "tcp"
+    description = "DNS resolution"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 53
+    to_port     = 53
+    protocol    = "udp"
+    description = "DNS resolution"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name    = "${local.prefix}-sg"
+    Purpose = "Tempo security group"
+  }
+}

--- a/infra/terraform/hash/observability/tempo/service.tf
+++ b/infra/terraform/hash/observability/tempo/service.tf
@@ -11,8 +11,8 @@ locals {
 resource "aws_ecs_task_definition" "tempo" {
   family                   = "${local.prefix}-${substr(local.config_hash, 0, 8)}"
   requires_compatibilities = ["FARGATE"]
-  cpu                      = 256
-  memory                   = 2048
+  cpu                      = 1024
+  memory                   = 8192
   network_mode             = "awsvpc"
   execution_role_arn       = aws_iam_role.execution_role.arn
   task_role_arn            = aws_iam_role.task_role.arn

--- a/infra/terraform/hash/observability/tempo/storage.tf
+++ b/infra/terraform/hash/observability/tempo/storage.tf
@@ -1,0 +1,47 @@
+# S3 bucket for Tempo trace storage
+# Stores distributed tracing data with lifecycle management
+
+resource "aws_s3_bucket" "tempo_traces" {
+  bucket = "${var.prefix}-tempo-traces"
+  tags = {
+    Purpose = "Tempo distributed tracing storage"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "tempo_traces" {
+  bucket = aws_s3_bucket.tempo_traces.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "tempo_traces" {
+  bucket = aws_s3_bucket.tempo_traces.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "tempo_traces" {
+  bucket = aws_s3_bucket.tempo_traces.id
+
+  rule {
+    id     = "tempo_traces_lifecycle"
+    status = "Enabled"
+
+    # Delete traces after 7 days to manage storage costs
+    expiration {
+      days = 7
+    }
+
+    # Clean up incomplete multipart uploads
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 1
+    }
+  }
+}

--- a/infra/terraform/hash/observability/tempo/templates/tempo.yaml.tpl
+++ b/infra/terraform/hash/observability/tempo/templates/tempo.yaml.tpl
@@ -1,0 +1,87 @@
+# Tempo Configuration - Environment: ${environment}
+# Generated from Terraform template
+#
+# TODO: Consider persistent WAL storage (EFS) vs current /tmp approach for better durability
+# TODO: Configure shared ring storage (Redis/memberlist) for multi-instance scaling
+
+server:
+  http_listen_port: ${api_port}
+  log_level: info
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:${otlp_port}
+
+ingester:
+  # Memory management - balance between performance and memory usage  
+  max_block_duration: 5m         # Force block creation every 5 minutes (default: 30m)
+  max_block_bytes: 50000000      # Force block creation at 50MB (default: 500MB)
+  complete_block_timeout: 3m     # Wait 3min for late spans before flushing (default: 15m)
+  trace_idle_period: 5s          # Flush traces from memory after 5s of inactivity (default: 5s)
+  flush_check_period: 10s        # Check for flushable traces every 10s (default: 10s)
+  lifecycler:
+    ring:
+      kvstore:
+        store: memberlist
+      replication_factor: 1
+
+# TODO: Tune querier limits for performance vs resource usage
+querier:
+  # TODO: Adjust concurrent queries based on memory capacity
+  max_concurrent_queries: 3           # TODO: Increase to 10 when memory issues resolved
+  search:
+    # TODO: Tune query timeout based on acceptable response times
+    query_timeout: 30s                # TODO: Consider increasing to 60s for complex queries
+  trace_by_id:
+    # TODO: Tune trace lookup timeout
+    query_timeout: 10s                # TODO: Consider increasing if needed
+
+storage:
+  trace:
+    backend: s3
+    # TODO: Upgrade to vParquet4 for better TraceQL performance, but requires 1.5x more memory
+    # Currently using default format due to memory constraints - need 3GB+ RAM for Parquet
+    # block:
+    #   version: vParquet4  # Would enable better search performance but increase memory usage
+    wal:
+      # Using /tmp for WAL (Write-Ahead Log) storage
+      # Data loss on container restart is acceptable for this deployment phase:
+      # - WAL is temporary storage for in-flight traces before S3 persistence
+      # - Container restarts are rare in ECS with proper health checks
+      # - S3 backend provides durability for completed trace data
+      # - EFS would add latency and potential concurrency issues (WAL is local per-instance storage)
+      # - WAL is designed for local file system persistence, not shared storage
+      path: /tmp/tempo-wal
+    s3:
+      bucket: ${tempo_bucket}
+      region: ${aws_region}
+      endpoint: s3.${aws_region}.amazonaws.com
+
+# TODO: Replace temporary local storage with Mimir integration for persistent metrics
+# Currently using /tmp storage - metrics will be lost on container restart
+# Need to configure remote_write to Mimir when available
+metrics_generator:
+  storage:
+    path: /tmp/tempo-metrics          # TODO: Replace with persistent storage or remote_write to Mimir
+  ring:
+    kvstore:
+      store: memberlist
+  # TODO: Tune ingestion controls for memory management
+  metrics_ingestion_time_range_slack: 30s   # TODO: Reduce to 15s when memory issues resolved
+  # TODO: Adjust query timeout for metrics queries
+  query_timeout: 30s                        # TODO: Consider reducing to 15s for faster failures  
+  processor:
+    service_graphs:
+      # TODO: Tune max_items based on actual service topology
+      max_items: 1000                 # TODO: Increase to 10000 when memory issues resolved
+    span_metrics:
+      # TODO: Add more dimensions when memory allows (http.method, status.code, etc)
+      dimensions: ["service.name"]    # TODO: Add resource.deployment.environment, http.method
+
+compactor:
+  compaction:
+    compaction_cycle: 5m   # Reduced from 30m to prevent memory spikes from large batches
+    block_retention: 168h  # 7 days (matches S3 lifecycle policy)

--- a/infra/terraform/hash/observability/tempo/variables.tf
+++ b/infra/terraform/hash/observability/tempo/variables.tf
@@ -36,14 +36,9 @@ variable "service_discovery_namespace_arn" {
   description = "ARN of the service discovery namespace for Service Connect"
 }
 
-variable "tempo_otlp_grpc_dns" {
+variable "service_discovery_namespace_name" {
   type        = string
-  description = "Tempo OTLP gRPC DNS name for trace forwarding"
-}
-
-variable "tempo_otlp_grpc_port" {
-  type        = number
-  description = "Tempo OTLP gRPC port number"
+  description = "Name of the service discovery namespace for DNS resolution"
 }
 
 variable "ssl_config" {

--- a/infra/terraform/hash/observability/terraform.tf
+++ b/infra/terraform/hash/observability/terraform.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.67"
+    }
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 4.0"
+    }
+  }
+}
+

--- a/infra/terraform/hash/observability/variables.tf
+++ b/infra/terraform/hash/observability/variables.tf
@@ -26,3 +26,25 @@ variable "subnets" {
   type        = list(string)
   description = "List of subnet IDs for the ECS services"
 }
+
+variable "grafana_database_host" {
+  type        = string
+  description = "PostgreSQL database host for Grafana"
+}
+
+variable "grafana_database_port" {
+  type        = number
+  description = "PostgreSQL database port for Grafana"
+}
+
+variable "grafana_database_password" {
+  type        = string
+  sensitive   = true
+  description = "PostgreSQL database password for Grafana user"
+}
+
+variable "grafana_secret_key" {
+  type        = string
+  sensitive   = true
+  description = "Grafana secret key"
+}

--- a/infra/terraform/hash/postgres_roles/postgres_roles.tf
+++ b/infra/terraform/hash/postgres_roles/postgres_roles.tf
@@ -230,3 +230,32 @@ resource "postgresql_default_privileges" "temporal_visibility_readwrite_tables" 
   object_type = "table"
   privileges  = ["SELECT", "INSERT", "UPDATE", "DELETE"]
 }
+
+# Grafana
+resource "postgresql_role" "grafana_user" {
+  name           = "grafana"
+  login          = true
+  password       = var.pg_grafana_user_password_hash
+  inherit        = true
+  roles          = [postgresql_role.readwrite.name]
+  skip_drop_role = false
+}
+
+resource "postgresql_database" "grafana" {
+  name              = "grafana"
+  owner             = postgresql_role.grafana_user.name
+  template          = "template0"
+  lc_collate        = "C"
+  connection_limit  = -1
+  allow_connections = true
+}
+
+resource "postgresql_default_privileges" "grafana_readwrite_tables" {
+  owner    = var.pg_superuser_username
+  role     = postgresql_role.grafana_user.name
+  database = postgresql_database.grafana.name
+  schema   = "public"
+
+  object_type = "table"
+  privileges  = ["SELECT", "INSERT", "UPDATE", "DELETE"]
+}

--- a/infra/terraform/hash/postgres_roles/variables.tf
+++ b/infra/terraform/hash/postgres_roles/variables.tf
@@ -38,3 +38,9 @@ variable "pg_temporal_user_password_hash" {
   sensitive   = true
   description = "Hashed form of the 'temporal' user Postgres password."
 }
+
+variable "pg_grafana_user_password_hash" {
+  type        = string
+  sensitive   = true
+  description = "Hashed form of the 'grafana' user Postgres password."
+}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR implements a production-ready distributed tracing system with **Tempo** as the primary focus, along with foundational Grafana setup for AWS observability infrastructure. The main deliverable is enabling TraceQL queries for sophisticated trace analysis and service dependency mapping.

Key improvements include:

- **Production Tempo deployment** with TraceQL support through metrics-generator
- **Grafana foundation** (working but incomplete setup) for observability dashboards
- **SSL certificate management** across all observability services
- **Dual-port OTel Collector architecture** with environment-aware resource attribution
- **Memory optimization** to handle high-throughput telemetry without OOM kills
- **Scalable forwarding architecture** reducing configuration duplication

## 🚫 Blocked by

- H-5057

## 🔍 What does this change?

### OpenTelemetry Collector Enhancements

- **Separate internal/external ports**: Internal services use 4317/4318, external clients use 4319/4320
- **Environment resource attribution**: Internal telemetry tagged with `terraform.workspace`, external with `"external"`
- **Forward connector architecture**: Input pipelines (6x) process and route to common output pipelines (3x), reducing configuration duplication
- **Memory limiter processor**: 400MiB limit with 80MiB spike protection to prevent container OOM kills
- **Enhanced target groups**: Clean separation of internal HTTP, external HTTP, and external gRPC endpoints

### Tempo Configuration Improvements

- **TraceQL support**: Enabled metrics-generator with proper storage configuration
- **Memory optimization**: Increased to 2GB with optimized flush intervals (5min blocks, 50MB max)
- **Ring system**: Changed from inmemory to memberlist for distributed stability
- **SSL certificate integration**: Proper CA certificate loading for S3 and plugin operations
- **TODO documentation**: Added comprehensive notes for v2 blocks upgrade (requires 1.5x more memory)

### Infrastructure SSL Management

- **Shared SSL configuration**: Centralized SSL certificate loading via init containers
- **Volume-based sharing**: SSL certificates distributed across all observability services
- **Certificate path standardization**: Consistent `/usr/local/ssl` paths with proper environment variables

### Database and IAM

- **Grafana database setup**: Added dedicated PostgreSQL user and database provisioning
- **Enhanced IAM policies**: SSL configuration access and S3 config bucket permissions
- **ECS execute permissions**: Container debugging and troubleshooting support

### Telemetry Library Updates

- **TLS support for OTLP exporters**: Added `ClientTlsConfig::new().with_enabled_roots()` to traces, logs, and metrics OTLP exporters for secure telemetry transmission
- **OTLP configuration**: Enhanced endpoint and timeout settings in `@local/telemetry`
- **Version bump**: Updated Cargo.toml dependency versions

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] modifies a **Cargo**-publishable library and **I have amended the version**

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

- **Memory constraints**: Tempo v2 blocks (Parquet) require 1.5x more memory but provide better TraceQL performance - currently disabled due to memory limits
- **Temporary storage**: Metrics-generator uses `/tmp` storage, will be lost on container restart until Mimir integration

## 🐾 Next steps

- **H-5059**: Set up Loki in AWS for log aggregation and analysis
- **H-5060**: Set up Prometheus/Mimir in AWS for metrics storage and alerting
- **H-5061**: Complete Grafana setup with datasources, dashboards, and CloudWatch integration

## 🛡 What tests cover this?

- Infrastructure validation through Terraform plan/apply
- Container startup and health check verification
- SSL certificate loading and validation
- TraceQL query functionality testing
- Memory usage monitoring and OOM prevention

## 📹 Demo

Go to `https://grafana.hash.ai` to access the working Grafana instance with Tempo datasource enabled for TraceQL queries.
