### PR TITLE
H-5078: Replace axum-tracing-opentelemetry with custom HttpTracingLayer

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -170,3 +170,4 @@ seed-users.json
 # Turbo
 .turbo/
 out/
+**/out/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -927,32 +927,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "axum"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d6fd624c75e18b3b4c6b9caf42b1afe24437daaee904069137d8bab077be8b8"
-dependencies = [
- "axum-core 0.5.0",
- "bytes",
- "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
- "http-body-util",
- "itoa",
- "matchit 0.8.4",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper",
- "tower 0.5.2",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
 name = "axum-core"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -990,24 +964,6 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
-]
-
-[[package]]
-name = "axum-tracing-opentelemetry"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd3e188039e0e9e3dce1ad873358fd6bab72e6496e18b898bc36d72c07af4b26"
-dependencies = [
- "axum 0.8.1",
- "futures-core",
- "futures-util",
- "http 1.3.1",
- "opentelemetry",
- "pin-project-lite",
- "tower 0.5.2",
- "tracing",
- "tracing-opentelemetry",
- "tracing-opentelemetry-instrumentation-sdk",
 ]
 
 [[package]]
@@ -3374,7 +3330,7 @@ dependencies = [
 name = "hash-graph"
 version = "0.0.0"
 dependencies = [
- "axum 0.7.5",
+ "axum",
  "clap",
  "clap_complete",
  "error-stack",
@@ -3409,9 +3365,8 @@ name = "hash-graph-api"
 version = "0.0.0"
 dependencies = [
  "async-trait",
- "axum 0.7.5",
+ "axum",
  "axum-core 0.5.0",
- "axum-tracing-opentelemetry",
  "bytes",
  "derive-where",
  "derive_more 2.0.1",
@@ -3441,6 +3396,7 @@ dependencies = [
  "include_dir",
  "mime",
  "opentelemetry",
+ "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "sentry",
  "serde",
@@ -3693,8 +3649,7 @@ dependencies = [
 name = "hash-graph-test-server"
 version = "0.0.0"
 dependencies = [
- "axum 0.7.5",
- "axum-tracing-opentelemetry",
+ "axum",
  "error-stack",
  "futures",
  "hash-codec",
@@ -9532,7 +9487,7 @@ checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum 0.7.5",
+ "axum",
  "base64 0.22.1",
  "bytes",
  "h2",
@@ -9575,7 +9530,9 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
+ "rustls-native-certs",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tower 0.5.2",
  "tower-layer",
@@ -9780,24 +9737,10 @@ dependencies = [
  "once_cell",
  "opentelemetry",
  "opentelemetry_sdk",
- "smallvec 1.15.1",
  "tracing",
  "tracing-core",
- "tracing-log",
  "tracing-subscriber",
  "web-time",
-]
-
-[[package]]
-name = "tracing-opentelemetry-instrumentation-sdk"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dda3080d8657b99ddd303a4bda25ebd3479820abbd5a67af70a9dafd06b1713"
-dependencies = [
- "http 1.3.1",
- "opentelemetry",
- "tracing",
- "tracing-opentelemetry",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,200 +97,200 @@ hashql-syntax-jexpr.path            = "libs/@local/hashql/syntax-jexpr"
 type-system.path                    = "libs/@blockprotocol/type-system/rust"
 
 # External dependencies
-ada-url                    = { version = "=3.2.6", default-features = false }
-ansi-to-html               = { version = "=0.2.2", default-features = false }
-anstream                   = { version = "=0.6.19", default-features = false }
-anstyle                    = { version = "=1.0.11", default-features = false }
-anstyle-lossy              = { version = "=1.1.4", default-features = false }
-anstyle-yansi              = { version = "=2.0.3", default-features = false }
-approx                     = { version = "=0.5.1", default-features = false }
-ariadne                    = { version = "=0.5.1", default-features = false }
-async-scoped               = { version = "=0.9.0", default-features = false }
-async-trait                = { version = "=0.1.88", default-features = false }
-aws-config                 = { version = "=1.8.2" }
-aws-sdk-s3                 = { version = "=1.98.0", default-features = false }
-aws-types                  = { version = "=1.3.7", default-features = false }
-axum                       = { version = "=0.7.5" }
-axum-core                  = { version = "=0.5.0" }
-axum-tracing-opentelemetry = { version = "=0.29.0", default-features = false }
-bitvec                     = { version = "=1.0.1", default-features = false }
-bumpalo                    = { version = "=3.17.0", default-features = false, features = ["allocator_api"] }
-bytes                      = { version = "=1.10.1" }
-bytes-utils                = { version = "=0.1.4", default-features = false }
-camino                     = { version = "=1.1.10", default-features = false }
-cargo_metadata             = { version = "=0.21.0", default-features = false }
+ada-url        = { version = "=3.2.6", default-features = false }
+ansi-to-html   = { version = "=0.2.2", default-features = false }
+anstream       = { version = "=0.6.19", default-features = false }
+anstyle        = { version = "=1.0.11", default-features = false }
+anstyle-lossy  = { version = "=1.1.4", default-features = false }
+anstyle-yansi  = { version = "=2.0.3", default-features = false }
+approx         = { version = "=0.5.1", default-features = false }
+ariadne        = { version = "=0.5.1", default-features = false }
+async-scoped   = { version = "=0.9.0", default-features = false }
+async-trait    = { version = "=0.1.88", default-features = false }
+aws-config     = { version = "=1.8.2" }
+aws-sdk-s3     = { version = "=1.98.0", default-features = false }
+aws-types      = { version = "=1.3.7", default-features = false }
+axum           = { version = "=0.7.5" }
+axum-core      = { version = "=0.5.0" }
+bitvec         = { version = "=1.0.1", default-features = false }
+bumpalo        = { version = "=3.17.0", default-features = false, features = ["allocator_api"] }
+bytes          = { version = "=1.10.1" }
+bytes-utils    = { version = "=0.1.4", default-features = false }
+camino         = { version = "=1.1.10", default-features = false }
+cargo_metadata = { version = "=0.21.0", default-features = false }
 # FIXME: Remove `decimal`: https://github.com/cedar-policy/cedar/issues/1700
-cedar-policy-core              = { version = "=4.5.0", default-features = false, features = ["decimal"] }
-circular-buffer                = { version = "=1.1.0", default-features = false }
-clap                           = { version = "=4.5.41", features = ["color", "error-context", "help", "std", "suggestions", "usage"] }
-clap_builder                   = { version = "=4.5.41", default-features = false, features = ["std"] }
-clap_complete                  = { version = "=4.5.55", default-features = false }
-console_error_panic_hook       = { version = "=0.1.7", default-features = false }
-convert_case                   = { version = "=0.8.0", default-features = false }
-criterion                      = { version = "=0.6.0" }
-criterion-macro                = { version = "=0.4.0", default-features = false }
-dashu-base                     = { version = "=0.4.1", default-features = false }
-dashu-float                    = { version = "=0.4.3", default-features = false }
-deadpool                       = { version = "=0.12.2", default-features = false }
-deadpool-postgres              = { version = "=0.14.1", default-features = false }
-derive-where                   = { version = "=1.5.0", default-features = false, features = ["nightly"] }
-derive_more                    = { version = "=2.0.1", default-features = false }
-dotenv-flow                    = { version = "=0.16.2", default-features = false }
-ecow                           = { version = "=0.2.5", default-features = false }
-either                         = { version = "=1.15.0", default-features = false }
-email_address                  = { version = "=0.2.9", default-features = false }
-ena                            = { version = "=0.14.3", default-features = false }
-enum-iterator                  = { version = "=2.1.0", default-features = false }
-enumflags2                     = { version = "=0.7.12", default-features = false }
-erased-serde                   = { version = "=0.4.6", default-features = false }
-expect-test                    = { version = "=1.5.1", default-features = false }
-foldhash                       = { version = "=0.1.5", default-features = false }
-frunk                          = { version = "=0.4.4", default-features = false }
-frunk_core                     = { version = "=0.4.4", default-features = false }
-futures                        = { version = "=0.3.31", default-features = false }
-futures-channel                = { version = "=0.3.31", default-features = false }
-futures-core                   = { version = "=0.3.31", default-features = false }
-futures-io                     = { version = "=0.3.31", default-features = false }
-futures-sink                   = { version = "=0.3.31", default-features = false }
-futures-util                   = { version = "=0.3.31", default-features = false }
-globset                        = { version = "=0.4.16", default-features = false }
-guppy                          = { version = "=0.17.20", default-features = false }
-hashbrown                      = { version = "=0.15.4", default-features = false, features = ["inline-more", "nightly"] }
-hifijson                       = { version = "=0.2.2", default-features = false }
-http                           = { version = "=1.3.1", default-features = false }
-humansize                      = { version = "=2.1.3", default-features = false }
-hyper                          = { version = "=1.6.0", default-features = false }
-image                          = { version = "=0.25.6", default-features = false }
-include_dir                    = { version = "=0.7.4", default-features = false }
-include_dir_macros             = { version = "=0.7.4", default-features = false }
-indicatif                      = { version = "=0.18.0", default-features = false }
-indoc                          = { version = "=2.0.6", default-features = false }
-inferno                        = { version = "=0.12.3", default-features = false }
-insta                          = { version = "=1.43.1", default-features = false }
-iso8601-duration               = { version = "=0.2.0", default-features = false }
-itertools                      = { version = "=0.14.0", default-features = false }
-json-number                    = { version = "=0.4.9", default-features = false }
-jsonptr                        = { version = "=0.7.1", default-features = false }
-jsonschema                     = { version = "=0.30.0", default-features = false }
-justjson                       = { version = "=0.3.0", default-features = false }
-lexical                        = { version = "=7.0.4", default-features = false }
-libp2p                         = { version = "=0.55.0", default-features = false }
-libp2p-core                    = { version = "=0.43.0", default-features = false }
-libp2p-identity                = { version = "=0.2.11", default-features = false }
-libp2p-ping                    = { version = "=0.46.0", default-features = false }
-libp2p-stream                  = { version = "=0.3.0-alpha", default-features = false }
-libp2p-swarm                   = { version = "=0.46.0", default-features = false }
-libp2p-yamux                   = { version = "=0.47.0", default-features = false }
-libtest-mimic                  = { version = "=0.8.1", default-features = false }
-line-index                     = { version = "=0.1.2", default-features = false }
-logos                          = { version = "=0.15.0", default-features = false }
-memchr                         = { version = "=2.7.5", default-features = false }
-mimalloc                       = { version = "=0.1.47", default-features = false }
-mime                           = { version = "=0.3.17", default-features = false }
-multiaddr                      = { version = "=0.18.2", default-features = false }
-multistream-select             = { version = "=0.13.0", default-features = false }
-napi                           = { version = "=2.16.17", default-features = false }
-napi-build                     = { version = "=2.2.2", default-features = false }
-napi-derive                    = { version = "=2.16.13", default-features = false }
-nextest-filtering              = { version = "=0.16.0", default-features = false }
-nextest-metadata               = { version = "=0.12.2", default-features = false }
-num-traits                     = { version = "=0.2.19", default-features = false }
-opentelemetry                  = { version = "=0.30.0", default-features = false }
-opentelemetry-appender-tracing = { version = "=0.30.1", default-features = false }
-opentelemetry-otlp             = { version = "=0.30.0", default-features = false }
-opentelemetry_sdk              = { version = "=0.30.0", default-features = false }
-orx-concurrent-vec             = { version = "=3.6.0", default-features = false }
-owo-colors                     = { version = "=4.2.2", default-features = false }
-oxc                            = { version = "=0.67.0", default-features = false, features = ["allocator_api"] }
-paste                          = { version = "=1.0.15", default-features = false }
-pdfium-render                  = { version = "=0.8.26" }
-pin-project                    = { version = "=1.1.10", default-features = false }
-pin-project-lite               = { version = "=0.2.16", default-features = false }
-postgres                       = { version = "=0.19.10", default-features = false }
-postgres-protocol              = { version = "=0.6.8", default-features = false }
-postgres-types                 = { version = "=0.2.9", default-features = false }
-pretty                         = { version = "=0.12.4", default-features = false }
-pretty_assertions              = { version = "=1.4.1", default-features = false, features = ["alloc"] }
-proc-macro-error2              = { version = "=2.0.1", default-features = false }
-proc-macro2                    = { version = "=1.0.95", default-features = false }
-prometheus-client              = { version = "=0.23.1", default-features = false }
-proptest                       = { version = "=1.7.0", default-features = false, features = ["alloc", "std"] }                                                                                  # `std` or `no_std` are required, `no_std` pulls in `libm`
-quote                          = { version = "=1.0.40", default-features = false }
-radix_trie                     = { version = "=0.2.1", default-features = false }
-rand                           = { version = "=0.9.2", default-features = false }
-rapidfuzz                      = { version = "=0.5.0", default-features = false }
-rayon                          = { version = "=1.10.0", default-features = false }
-refinery                       = { version = "=0.8.16", default-features = false }
-regex                          = { version = "=1.11.1", default-features = false, features = ["perf", "unicode"] }
-reqwest                        = { version = "=0.12.22", default-features = false, features = ["rustls-tls"] }
-reqwest-middleware             = { version = "=0.4.2", default-features = false }
-reqwest-tracing                = { version = "=0.5.8", default-features = false }
-roaring                        = { version = "=0.11.1", default-features = false }
-rpds                           = { version = "=1.1.1", default-features = false }
-rstest                         = { version = "=0.25.0", default-features = false }
-rustc_version                  = { version = "=0.4.1", default-features = false }
-scc                            = { version = "=2.3.4", default-features = false }
-semver                         = { version = "=1.0.26", default-features = false }
-sentry                         = { version = "=0.41.0", default-features = false, features = ["backtrace", "contexts", "debug-images", "panic", "reqwest", "rustls", "tower-http", "tracing"] }
-sentry-core                    = { version = "=0.41.0", default-features = false }
-sentry-types                   = { version = "=0.41.0", default-features = false }
-seq-macro                      = { version = "=0.3.6", default-features = false }
-serde                          = { version = "=1.0.219", default-features = false }
-serde_json                     = { version = "=1.0.141" }
-serde_plain                    = { version = "=1.0.2", default-features = false }
-sha2                           = { version = "=0.10.9", default-features = false }
-similar-asserts                = { version = "=1.7.0", default-features = false }
-simple-mermaid                 = { version = "=0.2.0", default-features = false }
-smallvec                       = { version = "=2.0.0-alpha.11", default-features = false }
-smol_str                       = { version = "=0.3.2" }
-specta                         = { version = "=2.0.0-rc.22", default-features = false }
-supports-color                 = { version = "=3.0.2", default-features = false }
-supports-unicode               = { version = "=3.0.0", default-features = false }
-syn                            = { version = "=2.0.104", default-features = false }
-tachyonix                      = { version = "=0.3.1", default-features = false }
-tarpc                          = { version = "=0.36.0", default-features = false, git = "https://github.com/google/tarpc", rev = "f55f36d2d876b1868cfcf52f41d0456a60cf726c" }
-temporal-client                = { git = "https://github.com/temporalio/sdk-core", rev = "4a2368d" }
-temporal-sdk-core-protos       = { git = "https://github.com/temporalio/sdk-core", rev = "4a2368d" }
-test-fuzz                      = { version = "=7.2.1", default-features = false }
-test-log                       = { version = "=0.2.18", default-features = false }
-test-strategy                  = { version = "=0.4.3", default-features = false }
-text-size                      = { version = "=1.1.1", default-features = false }
-thiserror                      = { version = "=2.0.12", default-features = false }
-time                           = { version = "=0.3.41", default-features = false }
-tokio                          = { version = "=1.46.1", default-features = false }
-tokio-postgres                 = { version = "=0.7.13", default-features = false }
-tokio-stream                   = { version = "=0.1.17", default-features = false }
-tokio-test                     = { version = "=0.4.4", default-features = false }
-tokio-util                     = { version = "=0.7.15", default-features = false }
-toml                           = { version = "=0.9.2", default-features = false }
-tower                          = { version = "=0.5.2", default-features = false }
-tower-http                     = { version = "=0.6.6", features = ["trace"] }
-tower-layer                    = { version = "=0.3.3", default-features = false }
-tower-service                  = { version = "=0.3.3", default-features = false }
-tower-test                     = { version = "=0.4.0", default-features = false }
-tracing                        = { version = "=0.1.41", default-features = false }
-tracing-appender               = { version = "=0.2.3", default-features = false }
-tracing-core                   = { version = "=0.1.34", default-features = false }
-tracing-error                  = { version = "=0.2.1", default-features = false }
-tracing-flame                  = { version = "=0.2.0", default-features = false }
-tracing-indicatif              = { version = "=0.3.11", default-features = false }
-tracing-opentelemetry          = { version = "=0.31.0", default-features = false }
-tracing-subscriber             = { version = "=0.3.19", default-features = false }
-trait-variant                  = { version = "=0.1.2", default-features = false }
-trybuild                       = { version = "=1.0.106", default-features = false }
-tsify-next                     = { version = "=0.5.6", default-features = false }
-unicase                        = { version = "2.8.1", default-features = false }
-unicode-ident                  = { version = "=1.0.18", default-features = false }
-unicode-normalization          = { version = "=0.1.24", default-features = false }
-unicode-properties             = { version = "=0.1.3", default-features = false }
-unicode-segmentation           = { version = "=1.12.0", default-features = false }
-url                            = { version = "=2.5.4", default-features = false }
-utoipa                         = { version = "=4.2.3", default-features = false }
-uuid                           = { version = "=1.17.0", default-features = false }
-walkdir                        = { version = "=2.5.0", default-features = false }
-wasm-bindgen                   = { version = "=0.2.100", default-features = false }
-wasm-bindgen-test              = { version = "=0.3.50", default-features = false }
-winnow                         = { version = "=0.7.12", default-features = false }
+cedar-policy-core                  = { version = "=4.5.0", default-features = false, features = ["decimal"] }
+circular-buffer                    = { version = "=1.1.0", default-features = false }
+clap                               = { version = "=4.5.41", features = ["color", "error-context", "help", "std", "suggestions", "usage"] }
+clap_builder                       = { version = "=4.5.41", default-features = false, features = ["std"] }
+clap_complete                      = { version = "=4.5.55", default-features = false }
+console_error_panic_hook           = { version = "=0.1.7", default-features = false }
+convert_case                       = { version = "=0.8.0", default-features = false }
+criterion                          = { version = "=0.6.0" }
+criterion-macro                    = { version = "=0.4.0", default-features = false }
+dashu-base                         = { version = "=0.4.1", default-features = false }
+dashu-float                        = { version = "=0.4.3", default-features = false }
+deadpool                           = { version = "=0.12.2", default-features = false }
+deadpool-postgres                  = { version = "=0.14.1", default-features = false }
+derive-where                       = { version = "=1.5.0", default-features = false, features = ["nightly"] }
+derive_more                        = { version = "=2.0.1", default-features = false }
+dotenv-flow                        = { version = "=0.16.2", default-features = false }
+ecow                               = { version = "=0.2.5", default-features = false }
+either                             = { version = "=1.15.0", default-features = false }
+email_address                      = { version = "=0.2.9", default-features = false }
+ena                                = { version = "=0.14.3", default-features = false }
+enum-iterator                      = { version = "=2.1.0", default-features = false }
+enumflags2                         = { version = "=0.7.12", default-features = false }
+erased-serde                       = { version = "=0.4.6", default-features = false }
+expect-test                        = { version = "=1.5.1", default-features = false }
+foldhash                           = { version = "=0.1.5", default-features = false }
+frunk                              = { version = "=0.4.4", default-features = false }
+frunk_core                         = { version = "=0.4.4", default-features = false }
+futures                            = { version = "=0.3.31", default-features = false }
+futures-channel                    = { version = "=0.3.31", default-features = false }
+futures-core                       = { version = "=0.3.31", default-features = false }
+futures-io                         = { version = "=0.3.31", default-features = false }
+futures-sink                       = { version = "=0.3.31", default-features = false }
+futures-util                       = { version = "=0.3.31", default-features = false }
+globset                            = { version = "=0.4.16", default-features = false }
+guppy                              = { version = "=0.17.20", default-features = false }
+hashbrown                          = { version = "=0.15.4", default-features = false, features = ["inline-more", "nightly"] }
+hifijson                           = { version = "=0.2.2", default-features = false }
+http                               = { version = "=1.3.1", default-features = false }
+humansize                          = { version = "=2.1.3", default-features = false }
+hyper                              = { version = "=1.6.0", default-features = false }
+image                              = { version = "=0.25.6", default-features = false }
+include_dir                        = { version = "=0.7.4", default-features = false }
+include_dir_macros                 = { version = "=0.7.4", default-features = false }
+indicatif                          = { version = "=0.18.0", default-features = false }
+indoc                              = { version = "=2.0.6", default-features = false }
+inferno                            = { version = "=0.12.3", default-features = false }
+insta                              = { version = "=1.43.1", default-features = false }
+iso8601-duration                   = { version = "=0.2.0", default-features = false }
+itertools                          = { version = "=0.14.0", default-features = false }
+json-number                        = { version = "=0.4.9", default-features = false }
+jsonptr                            = { version = "=0.7.1", default-features = false }
+jsonschema                         = { version = "=0.30.0", default-features = false }
+justjson                           = { version = "=0.3.0", default-features = false }
+lexical                            = { version = "=7.0.4", default-features = false }
+libp2p                             = { version = "=0.55.0", default-features = false }
+libp2p-core                        = { version = "=0.43.0", default-features = false }
+libp2p-identity                    = { version = "=0.2.11", default-features = false }
+libp2p-ping                        = { version = "=0.46.0", default-features = false }
+libp2p-stream                      = { version = "=0.3.0-alpha", default-features = false }
+libp2p-swarm                       = { version = "=0.46.0", default-features = false }
+libp2p-yamux                       = { version = "=0.47.0", default-features = false }
+libtest-mimic                      = { version = "=0.8.1", default-features = false }
+line-index                         = { version = "=0.1.2", default-features = false }
+logos                              = { version = "=0.15.0", default-features = false }
+memchr                             = { version = "=2.7.5", default-features = false }
+mimalloc                           = { version = "=0.1.47", default-features = false }
+mime                               = { version = "=0.3.17", default-features = false }
+multiaddr                          = { version = "=0.18.2", default-features = false }
+multistream-select                 = { version = "=0.13.0", default-features = false }
+napi                               = { version = "=2.16.17", default-features = false }
+napi-build                         = { version = "=2.2.2", default-features = false }
+napi-derive                        = { version = "=2.16.13", default-features = false }
+nextest-filtering                  = { version = "=0.16.0", default-features = false }
+nextest-metadata                   = { version = "=0.12.2", default-features = false }
+num-traits                         = { version = "=0.2.19", default-features = false }
+opentelemetry                      = { version = "=0.30.0", default-features = false }
+opentelemetry-appender-tracing     = { version = "=0.30.1", default-features = false }
+opentelemetry-otlp                 = { version = "=0.30.0", default-features = false }
+opentelemetry-semantic-conventions = { version = "=0.30.0", default-features = false }
+opentelemetry_sdk                  = { version = "=0.30.0", default-features = false }
+orx-concurrent-vec                 = { version = "=3.6.0", default-features = false }
+owo-colors                         = { version = "=4.2.2", default-features = false }
+oxc                                = { version = "=0.67.0", default-features = false, features = ["allocator_api"] }
+paste                              = { version = "=1.0.15", default-features = false }
+pdfium-render                      = { version = "=0.8.26" }
+pin-project                        = { version = "=1.1.10", default-features = false }
+pin-project-lite                   = { version = "=0.2.16", default-features = false }
+postgres                           = { version = "=0.19.10", default-features = false }
+postgres-protocol                  = { version = "=0.6.8", default-features = false }
+postgres-types                     = { version = "=0.2.9", default-features = false }
+pretty                             = { version = "=0.12.4", default-features = false }
+pretty_assertions                  = { version = "=1.4.1", default-features = false, features = ["alloc"] }
+proc-macro-error2                  = { version = "=2.0.1", default-features = false }
+proc-macro2                        = { version = "=1.0.95", default-features = false }
+prometheus-client                  = { version = "=0.23.1", default-features = false }
+proptest                           = { version = "=1.7.0", default-features = false, features = ["alloc", "std"] }                                                                                  # `std` or `no_std` are required, `no_std` pulls in `libm`
+quote                              = { version = "=1.0.40", default-features = false }
+radix_trie                         = { version = "=0.2.1", default-features = false }
+rand                               = { version = "=0.9.2", default-features = false }
+rapidfuzz                          = { version = "=0.5.0", default-features = false }
+rayon                              = { version = "=1.10.0", default-features = false }
+refinery                           = { version = "=0.8.16", default-features = false }
+regex                              = { version = "=1.11.1", default-features = false, features = ["perf", "unicode"] }
+reqwest                            = { version = "=0.12.22", default-features = false, features = ["rustls-tls"] }
+reqwest-middleware                 = { version = "=0.4.2", default-features = false }
+reqwest-tracing                    = { version = "=0.5.8", default-features = false }
+roaring                            = { version = "=0.11.1", default-features = false }
+rpds                               = { version = "=1.1.1", default-features = false }
+rstest                             = { version = "=0.25.0", default-features = false }
+rustc_version                      = { version = "=0.4.1", default-features = false }
+scc                                = { version = "=2.3.4", default-features = false }
+semver                             = { version = "=1.0.26", default-features = false }
+sentry                             = { version = "=0.41.0", default-features = false, features = ["backtrace", "contexts", "debug-images", "panic", "reqwest", "rustls", "tower-http", "tracing"] }
+sentry-core                        = { version = "=0.41.0", default-features = false }
+sentry-types                       = { version = "=0.41.0", default-features = false }
+seq-macro                          = { version = "=0.3.6", default-features = false }
+serde                              = { version = "=1.0.219", default-features = false }
+serde_json                         = { version = "=1.0.141" }
+serde_plain                        = { version = "=1.0.2", default-features = false }
+sha2                               = { version = "=0.10.9", default-features = false }
+similar-asserts                    = { version = "=1.7.0", default-features = false }
+simple-mermaid                     = { version = "=0.2.0", default-features = false }
+smallvec                           = { version = "=2.0.0-alpha.11", default-features = false }
+smol_str                           = { version = "=0.3.2" }
+specta                             = { version = "=2.0.0-rc.22", default-features = false }
+supports-color                     = { version = "=3.0.2", default-features = false }
+supports-unicode                   = { version = "=3.0.0", default-features = false }
+syn                                = { version = "=2.0.104", default-features = false }
+tachyonix                          = { version = "=0.3.1", default-features = false }
+tarpc                              = { version = "=0.36.0", default-features = false, git = "https://github.com/google/tarpc", rev = "f55f36d2d876b1868cfcf52f41d0456a60cf726c" }
+temporal-client                    = { git = "https://github.com/temporalio/sdk-core", rev = "4a2368d" }
+temporal-sdk-core-protos           = { git = "https://github.com/temporalio/sdk-core", rev = "4a2368d" }
+test-fuzz                          = { version = "=7.2.1", default-features = false }
+test-log                           = { version = "=0.2.18", default-features = false }
+test-strategy                      = { version = "=0.4.3", default-features = false }
+text-size                          = { version = "=1.1.1", default-features = false }
+thiserror                          = { version = "=2.0.12", default-features = false }
+time                               = { version = "=0.3.41", default-features = false }
+tokio                              = { version = "=1.46.1", default-features = false }
+tokio-postgres                     = { version = "=0.7.13", default-features = false }
+tokio-stream                       = { version = "=0.1.17", default-features = false }
+tokio-test                         = { version = "=0.4.4", default-features = false }
+tokio-util                         = { version = "=0.7.15", default-features = false }
+toml                               = { version = "=0.9.2", default-features = false }
+tower                              = { version = "=0.5.2", default-features = false }
+tower-http                         = { version = "=0.6.6", features = ["trace"] }
+tower-layer                        = { version = "=0.3.3", default-features = false }
+tower-service                      = { version = "=0.3.3", default-features = false }
+tower-test                         = { version = "=0.4.0", default-features = false }
+tracing                            = { version = "=0.1.41", default-features = false }
+tracing-appender                   = { version = "=0.2.3", default-features = false }
+tracing-core                       = { version = "=0.1.34", default-features = false }
+tracing-error                      = { version = "=0.2.1", default-features = false }
+tracing-flame                      = { version = "=0.2.0", default-features = false }
+tracing-indicatif                  = { version = "=0.3.11", default-features = false }
+tracing-opentelemetry              = { version = "=0.31.0", default-features = false }
+tracing-subscriber                 = { version = "=0.3.19", default-features = false }
+trait-variant                      = { version = "=0.1.2", default-features = false }
+trybuild                           = { version = "=1.0.106", default-features = false }
+tsify-next                         = { version = "=0.5.6", default-features = false }
+unicase                            = { version = "2.8.1", default-features = false }
+unicode-ident                      = { version = "=1.0.18", default-features = false }
+unicode-normalization              = { version = "=0.1.24", default-features = false }
+unicode-properties                 = { version = "=0.1.3", default-features = false }
+unicode-segmentation               = { version = "=1.12.0", default-features = false }
+url                                = { version = "=2.5.4", default-features = false }
+utoipa                             = { version = "=4.2.3", default-features = false }
+uuid                               = { version = "=1.17.0", default-features = false }
+walkdir                            = { version = "=2.5.0", default-features = false }
+wasm-bindgen                       = { version = "=0.2.100", default-features = false }
+wasm-bindgen-test                  = { version = "=0.3.50", default-features = false }
+winnow                             = { version = "=0.7.12", default-features = false }
 
 [profile.dev]
 # TODO: Use `codegen-backend = "cranelift"`

--- a/libs/@local/graph/api/Cargo.toml
+++ b/libs/@local/graph/api/Cargo.toml
@@ -43,28 +43,28 @@ hash-graph-validation          = { workspace = true }
 type-system                    = { workspace = true, features = ["utoipa"] }
 
 # Private third-party dependencies
-async-trait                = { workspace = true }
-axum-tracing-opentelemetry = { workspace = true }
-bytes                      = { workspace = true }
-derive-where               = { workspace = true }
-derive_more                = { workspace = true, features = ["display", "error"] }
-error-stack                = { workspace = true, features = ["futures", "spantrace", "unstable"] }
-frunk                      = { workspace = true }
-futures                    = { workspace = true }
-hyper                      = { workspace = true }
-include_dir                = { workspace = true }
-mime                       = { workspace = true }
-opentelemetry              = { workspace = true }
-opentelemetry_sdk          = { workspace = true, features = ["rt-tokio"] }
-sentry                     = { workspace = true }
-serde                      = { workspace = true, features = ['derive'] }
-serde_json                 = { workspace = true }
-simple-mermaid             = { workspace = true }
-time                       = { workspace = true }
-tower                      = { workspace = true }
-tracing-opentelemetry      = { workspace = true }
-utoipa                     = { workspace = true }
-uuid                       = { workspace = true }
+async-trait                        = { workspace = true }
+bytes                              = { workspace = true }
+derive-where                       = { workspace = true }
+derive_more                        = { workspace = true, features = ["display", "error"] }
+error-stack                        = { workspace = true, features = ["futures", "spantrace", "unstable"] }
+frunk                              = { workspace = true }
+futures                            = { workspace = true }
+hyper                              = { workspace = true }
+include_dir                        = { workspace = true }
+mime                               = { workspace = true }
+opentelemetry                      = { workspace = true }
+opentelemetry-semantic-conventions = { workspace = true, features = ["semconv_experimental"] }
+opentelemetry_sdk                  = { workspace = true, features = ["rt-tokio"] }
+sentry                             = { workspace = true }
+serde                              = { workspace = true, features = ['derive'] }
+serde_json                         = { workspace = true }
+simple-mermaid                     = { workspace = true }
+time                               = { workspace = true }
+tower                              = { workspace = true }
+tracing-opentelemetry              = { workspace = true }
+utoipa                             = { workspace = true }
+uuid                               = { workspace = true }
 
 [lints]
 workspace = true

--- a/libs/@local/graph/api/src/rest/http_tracing_layer.rs
+++ b/libs/@local/graph/api/src/rest/http_tracing_layer.rs
@@ -1,0 +1,179 @@
+use core::{future::Future, net::SocketAddr};
+
+use axum::extract::{ConnectInfo, Request};
+use http::Response;
+use opentelemetry::{
+    Context, global,
+    propagation::{Extractor, Injector},
+};
+use opentelemetry_semantic_conventions::trace;
+use tower::{Layer, Service};
+use tracing::{Instrument as _, Span, field::Empty};
+use tracing_opentelemetry::OpenTelemetrySpanExt as _;
+
+// Header extractor for OpenTelemetry trace propagation
+struct HeaderExtractor<'a>(&'a http::HeaderMap);
+
+impl Extractor for HeaderExtractor<'_> {
+    fn get(&self, key: &str) -> Option<&str> {
+        let value = self.0.get(key)?;
+        value.to_str().ok()
+    }
+
+    fn keys(&self) -> Vec<&str> {
+        self.0.keys().map(http::HeaderName::as_str).collect()
+    }
+}
+
+// Header injector for OpenTelemetry trace propagation
+struct HeaderInjector<'a>(&'a mut http::HeaderMap);
+
+impl Injector for HeaderInjector<'_> {
+    fn set(&mut self, key: &str, value: String) {
+        if let Ok(name) = http::header::HeaderName::from_bytes(key.as_bytes())
+            && let Ok(val) = http::header::HeaderValue::from_str(&value)
+        {
+            self.0.insert(name, val);
+        }
+    }
+}
+
+// Extract OpenTelemetry context from HTTP headers
+fn extract_context_from_headers(headers: &http::HeaderMap) -> Context {
+    let extractor = HeaderExtractor(headers);
+    global::get_text_map_propagator(|propagator| propagator.extract(&extractor))
+}
+
+// Create HTTP span with all request attributes and parent context
+fn create_http_span<B>(request: &Request<B>) -> Span {
+    let http_span = tracing::info_span!(
+        "HTTP request",
+        otel.kind = "server",
+        otel.name = format!("{} {}", request.method(), request.uri().path()),
+        { trace::HTTP_REQUEST_METHOD } = %request.method(),
+        { trace::URL_PATH } = request.uri().path(),
+        { trace::HTTP_RESPONSE_STATUS_CODE } = Empty
+    );
+
+    // Set parent context for distributed tracing
+    http_span.set_parent(extract_context_from_headers(request.headers()));
+
+    // Record URL scheme
+    if let Some(schema) = request.uri().scheme_str() {
+        http_span.record(trace::URL_SCHEME, schema);
+    }
+
+    // Record user agent
+    if let Some(user_agent) = request.headers().get("user-agent")
+        && let Ok(user_agent_str) = user_agent.to_str()
+    {
+        http_span.record(trace::USER_AGENT_ORIGINAL, user_agent_str);
+    }
+
+    // Record server address
+    if let Some(host) = request.headers().get("host")
+        && let Ok(host_str) = host.to_str()
+    {
+        http_span.record(trace::SERVER_ADDRESS, host_str);
+    }
+
+    // Record request body size
+    if let Some(content_length) = request.headers().get("content-length")
+        && let Ok(content_length_str) = content_length.to_str()
+        && let Ok(body_size) = content_length_str.parse::<u64>()
+    {
+        http_span.record(trace::HTTP_REQUEST_BODY_SIZE, body_size);
+    }
+
+    // Record client address
+    if let Some(ConnectInfo(addr)) = request.extensions().get::<ConnectInfo<SocketAddr>>() {
+        http_span.record(trace::NETWORK_PEER_ADDRESS, addr.ip().to_string());
+        http_span.record(trace::NETWORK_PEER_PORT, i64::from(addr.port()));
+    }
+
+    http_span
+}
+
+// Record response-specific attributes on the span
+fn record_response_attributes(span: &Span, response: &http::Response<axum::body::Body>) {
+    let status_code = response.status().as_u16();
+    span.record(trace::HTTP_RESPONSE_STATUS_CODE, status_code);
+
+    // Record response body size
+    if let Some(content_length) = response.headers().get("content-length")
+        && let Ok(content_length_str) = content_length.to_str()
+        && let Ok(body_size) = content_length_str.parse::<u64>()
+    {
+        span.record(trace::HTTP_RESPONSE_BODY_SIZE, body_size);
+    }
+
+    // Add error attributes for 4xx/5xx responses
+    if status_code >= 400 {
+        span.record("error", true);
+    }
+}
+
+// Inject OpenTelemetry context into HTTP headers
+fn inject_context_to_headers(context: &Context, headers: &mut http::HeaderMap) {
+    let mut injector = HeaderInjector(headers);
+    global::get_text_map_propagator(|propagator| {
+        propagator.inject_context(context, &mut injector);
+    });
+}
+
+#[derive(Clone, Debug)]
+pub struct HttpTracingLayer;
+
+impl<S> Layer<S> for HttpTracingLayer {
+    type Service = HttpTracingService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        HttpTracingService { inner }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct HttpTracingService<S> {
+    inner: S,
+}
+
+impl<S, B> Service<Request<B>> for HttpTracingService<S>
+where
+    S: Service<Request<B>, Response = Response<axum::body::Body>> + Clone + Send + 'static,
+    S::Error: core::error::Error + 'static,
+    S::Future: Send + 'static,
+    B: Send + 'static,
+{
+    type Error = S::Error;
+    type Response = S::Response;
+
+    type Future = impl Future<Output = Result<Self::Response, Self::Error>> + Send;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut core::task::Context<'_>,
+    ) -> core::task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<B>) -> Self::Future {
+        let http_span = create_http_span(&req);
+        let future = self.inner.call(req);
+
+        async move {
+            let mut result = future.await;
+
+            // Record response attributes and inject headers (only for successful responses)
+            if let Ok(response) = &mut result {
+                let current_span = Span::current();
+                record_response_attributes(&current_span, response);
+
+                let otel_context = current_span.context();
+                inject_context_to_headers(&otel_context, response.headers_mut());
+            }
+
+            result
+        }
+        .instrument(http_span)
+    }
+}

--- a/libs/@local/graph/api/src/rest/mod.rs
+++ b/libs/@local/graph/api/src/rest/mod.rs
@@ -12,6 +12,8 @@ pub mod principal;
 pub mod property_type;
 pub mod status;
 
+pub mod http_tracing_layer;
+
 mod json;
 mod utoipa_typedef;
 use alloc::{borrow::Cow, sync::Arc};
@@ -30,7 +32,6 @@ use axum::{
     response::{IntoResponse as _, Response},
     routing::get,
 };
-use axum_tracing_opentelemetry::middleware::{OtelAxumLayer, OtelInResponseLayer};
 use error_stack::{Report, ResultExt as _};
 use futures::{SinkExt as _, channel::mpsc::Sender};
 use hash_codec::numeric::Real;
@@ -343,8 +344,7 @@ where
                 .layer(NewSentryLayer::new_from_top())
                 .layer(SentryHttpLayer::default().enable_transaction()),
         )
-        .layer(OtelAxumLayer::default())
-        .layer(OtelInResponseLayer)
+        .layer(http_tracing_layer::HttpTracingLayer)
         .layer(Extension(dependencies.store))
         .layer(Extension(dependencies.temporal_client.map(Arc::new)))
         .layer(Extension(dependencies.domain_regex));

--- a/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
@@ -1165,7 +1165,7 @@ where
         }))
     }
 
-    #[tracing::instrument(level = "debug", skip(self, context_builder))]
+    #[tracing::instrument(level = "info", skip(self, context_builder))]
     async fn build_principal_context(
         &self,
         actor_id: ActorId,
@@ -1943,7 +1943,7 @@ where
             .change_context(EnsureSystemPoliciesError::StoreError)
     }
 
-    #[tracing::instrument(level = "debug", skip(self, entity_type_ids))]
+    #[tracing::instrument(level = "info", skip(self, entity_type_ids))]
     async fn build_entity_type_context(
         &self,
         entity_type_ids: &[&VersionedUrl],
@@ -2043,7 +2043,7 @@ where
             .change_context(BuildEntityTypeContextError::StoreError)?)
     }
 
-    #[tracing::instrument(level = "debug", skip(self, property_type_ids))]
+    #[tracing::instrument(level = "info", skip(self, property_type_ids))]
     async fn build_property_type_context(
         &self,
         property_type_ids: &[&VersionedUrl],
@@ -2125,7 +2125,7 @@ where
             .change_context(BuildPropertyTypeContextError::StoreError)?)
     }
 
-    #[tracing::instrument(level = "debug", skip(self, data_type_ids))]
+    #[tracing::instrument(level = "info", skip(self, data_type_ids))]
     async fn build_data_type_context(
         &self,
         data_type_ids: &[&VersionedUrl],
@@ -2204,7 +2204,7 @@ where
             .change_context(BuildDataTypeContextError::StoreError)?)
     }
 
-    #[tracing::instrument(level = "debug", skip(self, entity_edition_ids))]
+    #[tracing::instrument(level = "info", skip(self, entity_edition_ids))]
     #[expect(
         clippy::too_many_lines,
         reason = "A large part of this function is for a SQL query that is complex but necessary \
@@ -2761,7 +2761,7 @@ where
     /// # Errors
     ///
     /// - if inserting failed.
-    #[tracing::instrument(level = "debug", skip(self))]
+    #[tracing::instrument(level = "info", skip(self))]
     async fn insert_data_type_with_id(
         &self,
         ontology_id: DataTypeUuid,
@@ -2803,7 +2803,7 @@ where
     /// # Errors
     ///
     /// Returns [`InsertionError`] if the database insertion operation fails.
-    #[tracing::instrument(level = "debug", skip(self))]
+    #[tracing::instrument(level = "info", skip(self))]
     pub async fn insert_data_type_references(
         &self,
         ontology_id: DataTypeUuid,
@@ -2843,7 +2843,7 @@ where
     /// # Errors
     ///
     /// - if inserting failed.
-    #[tracing::instrument(level = "debug", skip(self))]
+    #[tracing::instrument(level = "info", skip(self))]
     async fn insert_property_type_with_id(
         &self,
         ontology_id: OntologyTypeUuid,
@@ -2878,7 +2878,7 @@ where
     /// # Errors
     ///
     /// - if inserting failed.
-    #[tracing::instrument(level = "debug", skip(self))]
+    #[tracing::instrument(level = "info", skip(self))]
     async fn insert_entity_type_with_id(
         &self,
         ontology_id: EntityTypeUuid,
@@ -2910,7 +2910,7 @@ where
             .map(|row| row.get(0)))
     }
 
-    #[tracing::instrument(level = "debug", skip(self, property_type))]
+    #[tracing::instrument(level = "info", skip(self, property_type))]
     async fn insert_property_type_references(
         &self,
         property_type: &PropertyType,
@@ -2977,7 +2977,7 @@ where
         Ok(())
     }
 
-    #[tracing::instrument(level = "debug", skip(self))]
+    #[tracing::instrument(level = "info", skip(self))]
     #[expect(clippy::too_many_lines)]
     async fn insert_entity_type_references(
         &self,
@@ -3179,7 +3179,7 @@ impl PostgresStore<tokio_postgres::Transaction<'_>> {
     /// - [`VersionedUrlAlreadyExists`] if [`VersionedUrl`] does already exist in the database
     /// - [`OntologyVersionDoesNotExist`] if the previous version does not exist
     /// - [`OntologyTypeIsNotOwned`] if ontology type is an external ontology type
-    #[tracing::instrument(level = "debug", skip(self))]
+    #[tracing::instrument(level = "info", skip(self))]
     async fn update_owned_ontology_id(
         &self,
         url: &VersionedUrl,

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/compile.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/compile.rs
@@ -406,7 +406,7 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
     /// # Errors
     ///
     /// Returns an error if the filter compilation fails.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(level = "info", skip_all)]
     pub fn add_filter<'f: 'q>(
         &mut self,
         filter: &'p Filter<'f, R>,
@@ -421,7 +421,7 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
     }
 
     /// Transpiles the statement into SQL and the parameter to be passed to a prepared statement.
-    #[instrument(level = "debug", skip_all)]
+    #[instrument(level = "info", skip_all)]
     pub fn compile(&self) -> (String, &[&'p (dyn ToSql + Sync)]) {
         (
             self.statement.transpile_to_string(),

--- a/libs/@local/graph/store/src/query/mod.rs
+++ b/libs/@local/graph/store/src/query/mod.rs
@@ -64,7 +64,7 @@ pub trait ReadPaginated<R: QueryRecord, S: Sorting + Sync>: Read<R> {
         clippy::type_complexity,
         reason = "simplification of type would lead to more unreadable code"
     )]
-    #[tracing::instrument(level = "debug", skip(self, filters, sorting))]
+    #[tracing::instrument(level = "info", skip(self, filters, sorting))]
     fn read_paginated_vec(
         &self,
         filters: &[Filter<'_, R>],
@@ -102,7 +102,7 @@ pub trait Read<R: QueryRecord>: Sync {
         include_drafts: bool,
     ) -> impl Future<Output = Result<Self::ReadStream, Report<QueryError>>> + Send;
 
-    #[tracing::instrument(level = "debug", skip(self, filters))]
+    #[tracing::instrument(level = "info", skip(self, filters))]
     fn read_vec(
         &self,
         filters: &[Filter<'_, R>],

--- a/libs/@local/graph/test-server/Cargo.toml
+++ b/libs/@local/graph/test-server/Cargo.toml
@@ -16,14 +16,13 @@ hash-graph-postgres-store = { workspace = true, public = true, features = ["utoi
 axum = { workspace = true, public = true }
 
 # Private workspace dependencies
-axum-tracing-opentelemetry = { workspace = true }
-error-stack                = { workspace = true }
-hash-codec                 = { workspace = true }
-hash-graph-api             = { workspace = true }
-hash-graph-store           = { workspace = true }
-hash-graph-type-defs       = { workspace = true }
-hash-status                = { workspace = true }
-type-system                = { workspace = true }
+error-stack          = { workspace = true }
+hash-codec           = { workspace = true }
+hash-graph-api       = { workspace = true }
+hash-graph-store     = { workspace = true }
+hash-graph-type-defs = { workspace = true }
+hash-status          = { workspace = true }
+type-system          = { workspace = true }
 
 # Private third-party dependencies
 futures        = { workspace = true }

--- a/libs/@local/graph/test-server/src/lib.rs
+++ b/libs/@local/graph/test-server/src/lib.rs
@@ -15,11 +15,10 @@ use axum::{
     response::Response,
     routing::{delete, post},
 };
-use axum_tracing_opentelemetry::middleware::{OtelAxumLayer, OtelInResponseLayer};
 use error_stack::Report;
 use futures::TryStreamExt as _;
 use hash_codec::bytes::JsonLinesDecoder;
-use hash_graph_api::rest::status::status_to_response;
+use hash_graph_api::rest::{http_tracing_layer, status::status_to_response};
 use hash_graph_postgres_store::{snapshot::SnapshotStore, store::PostgresStorePool};
 use hash_graph_store::pool::StorePool as _;
 use hash_graph_type_defs::error::{ErrorInfo, StatusPayloadInfo};
@@ -32,8 +31,7 @@ use uuid::Uuid;
 /// Create routes for interacting with entities.
 pub fn routes(store_pool: PostgresStorePool) -> Router {
     Router::new()
-        .layer(OtelAxumLayer::default())
-        .layer(OtelInResponseLayer)
+        .layer(http_tracing_layer::HttpTracingLayer)
         .route("/snapshot", post(restore_snapshot))
         .route("/accounts", delete(delete_accounts))
         .route("/data-types", delete(delete_data_types))

--- a/libs/@local/graph/type-fetcher/src/store.rs
+++ b/libs/@local/graph/type-fetcher/src/store.rs
@@ -297,7 +297,6 @@ where
         self.store.query_policies(authenticated_actor, filter).await
     }
 
-    #[tracing::instrument(level = "debug", skip(self))]
     async fn resolve_policies_for_actor(
         &self,
         authenticated_actor: AuthenticatedActor,
@@ -540,7 +539,7 @@ where
         Ok(references)
     }
 
-    #[tracing::instrument(level = "debug", skip(self, ontology_type_references))]
+    #[tracing::instrument(level = "info", skip(self, ontology_type_references))]
     #[expect(clippy::too_many_lines)]
     async fn fetch_external_ontology_types(
         &self,
@@ -669,7 +668,7 @@ where
         Ok(fetched_ontology_types)
     }
 
-    #[tracing::instrument(level = "debug", skip(self, ontology_types))]
+    #[tracing::instrument(level = "info", skip(self, ontology_types))]
     async fn insert_external_types<'o, T: OntologyTypeSchema + Sync + 'o>(
         &mut self,
         actor_id: ActorEntityUuid,
@@ -773,7 +772,7 @@ where
         Ok(())
     }
 
-    #[tracing::instrument(level = "debug", skip(self))]
+    #[tracing::instrument(level = "info", skip(self))]
     async fn insert_external_types_by_reference(
         &mut self,
         actor_id: ActorEntityUuid,
@@ -891,7 +890,7 @@ where
     A: ToSocketAddrs + Send + Sync,
     S: DataTypeStore + PropertyTypeStore + EntityTypeStore + Send + Sync,
 {
-    #[tracing::instrument(level = "debug", skip(self))]
+    #[tracing::instrument(level = "info", skip(self))]
     async fn insert_external_ontology_type(
         &mut self,
         actor_id: ActorEntityUuid,

--- a/libs/@local/telemetry/Cargo.toml
+++ b/libs/@local/telemetry/Cargo.toml
@@ -10,7 +10,7 @@ authors.workspace = true
 # Public workspace dependencies
 error-stack        = { workspace = true, public = true }
 opentelemetry      = { workspace = true, public = true }
-opentelemetry-otlp = { workspace = true, public = true, features = ["trace", "logs", "metrics", "grpc-tonic"] }
+opentelemetry-otlp = { workspace = true, public = true, features = ["trace", "logs", "metrics", "grpc-tonic", "tls", "tls-roots"] }
 
 # Public third-party dependencies
 clap_builder       = { workspace = true, public = true }

--- a/libs/@local/telemetry/src/metrics/otlp.rs
+++ b/libs/@local/telemetry/src/metrics/otlp.rs
@@ -1,5 +1,8 @@
 use error_stack::Report;
-use opentelemetry_otlp::{ExporterBuildError, MetricExporter, WithExportConfig as _};
+use opentelemetry_otlp::{
+    ExporterBuildError, MetricExporter, WithExportConfig as _, WithTonicConfig as _,
+    tonic_types::transport::ClientTlsConfig,
+};
 use opentelemetry_sdk::{Resource, metrics::SdkMeterProvider};
 
 use crate::OtlpConfig;
@@ -12,15 +15,20 @@ pub(crate) fn provider(
         return Ok(None);
     };
 
+    let mut exporter = MetricExporter::builder()
+        .with_tonic()
+        .with_endpoint(endpoint);
+
+    // TODO: Properly check for `OTEL_EXPORTER_*` variables
+    //  see https://linear.app/hash/issue/H-5071/modernize-rust-opentelemetry-metrics-module-to-be-fully-standard
+    if endpoint.starts_with("https://") {
+        exporter = exporter.with_tls_config(ClientTlsConfig::new().with_enabled_roots());
+    }
+
     Ok(Some(
         SdkMeterProvider::builder()
             .with_resource(Resource::builder().with_service_name(service_name).build())
-            .with_periodic_exporter(
-                MetricExporter::builder()
-                    .with_tonic()
-                    .with_endpoint(endpoint)
-                    .build()?,
-            )
+            .with_periodic_exporter(exporter.build()?)
             .build(),
     ))
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR replaces the external `axum-tracing-opentelemetry` dependency with a custom `HttpTracingLayer` implementation. The external dependency worked locally but failed in production, and this custom implementation resolves the production issues while providing the same distributed tracing capabilities.

## 🔍 What does this change?

- **Remove external dependency**: Eliminated `axum-tracing-opentelemetry = "=0.29.0"` from multiple Cargo.toml files (root, api, test-server)
- **Add semantic conventions**: Added `opentelemetry-semantic-conventions` with `semconv_experimental` feature for proper HTTP attribute naming
- **Custom HttpTracingLayer implementation**: Created `libs/@local/graph/api/src/rest/http_tracing_layer.rs` with:
  - HTTP request span creation with proper semantic conventions
  - Bidirectional trace propagation (request header extraction + response header injection)
  - Response attribute recording (status codes, response sizes)
  - Support for client IP extraction and server address recording
- **Updated API router**: Replaced `OtelAxumLayer + OtelInResponseLayer` with single `HttpTracingLayer` in `libs/@local/graph/api/src/rest/mod.rs`
- **Updated test server**: Modified `libs/@local/graph/test-server/src/lib.rs` to use the same tracing implementation
- **Code structure improvements**: Organized implementation into focused functions for span creation, response recording, and context injection

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ❓ How to test this?

1. Checkout the branch and run the API server
2. Make HTTP requests to any API endpoint
3. Check OpenTelemetry traces for proper HTTP span attributes and distributed tracing context
4. Verify trace propagation works correctly between services

## 📹 Demo

Distributed tracing functionality can be observed at [grafana.hash.ai](https://grafana.hash.ai) where traces will show proper HTTP semantic conventions and context propagation.