### PR TITLE
H-5059: Set up Loki in AWS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,10 +4,15 @@
 
 **IMPORTANT: Always critically evaluate and challenge user suggestions, even when they seem reasonable.**
 
+**USE BRUTAL HONESTY**: Don't try to be polite or agreeable. Be direct, challenge assumptions, and point out flaws immediately.
+
 - **Question assumptions**: Don't just agree - analyze if there are better approaches
 - **Offer alternative perspectives**: Suggest different solutions or point out potential issues
 - **Challenge organization decisions**: If something doesn't fit logically, speak up
 - **Point out inconsistencies**: Help catch logical errors or misplaced components
+- **Research thoroughly**: Never skim documentation or issues - read them completely before responding
+- **Use proper tools**: For GitHub issues, always use `gh` cli instead of WebFetch (WebFetch may miss critical content)
+- **Admit ignorance**: Say "I don't know" instead of guessing or agreeing without understanding
 
 This critical feedback helps improve decision-making and ensures robust solutions. Being agreeable is less valuable than being thoughtful and analytical.
 

--- a/infra/terraform/hash/observability/grafana/config.tf
+++ b/infra/terraform/hash/observability/grafana/config.tf
@@ -52,8 +52,8 @@ resource "aws_s3_object" "grafana_loki_datasource" {
   bucket = var.config_bucket.id
   key    = "grafana/provisioning/datasources/loki.yaml"
   content = templatefile("${path.module}/templates/provisioning/datasources/loki.yaml.tpl", {
-    loki_api_dns  = var.loki_api_dns
-    loki_api_port = var.loki_api_port
+    loki_http_dns  = var.loki_http_dns
+    loki_http_port = var.loki_http_port
   })
   content_type = "application/x-yaml"
 

--- a/infra/terraform/hash/observability/grafana/security_groups.tf
+++ b/infra/terraform/hash/observability/grafana/security_groups.tf
@@ -42,10 +42,19 @@ resource "aws_security_group" "grafana" {
 
   # Allow outbound HTTP for Loki API
   egress {
-    from_port   = var.loki_api_port
-    to_port     = var.loki_api_port
+    from_port   = var.loki_http_port
+    to_port     = var.loki_http_port
     protocol    = "tcp"
     description = "Loki API access"
+    cidr_blocks = [var.vpc.cidr_block]
+  }
+
+  # Allow outbound gRPC for Loki live tail streaming
+  egress {
+    from_port   = var.loki_grpc_port
+    to_port     = var.loki_grpc_port
+    protocol    = "tcp"
+    description = "Loki gRPC API for live tail streaming"
     cidr_blocks = [var.vpc.cidr_block]
   }
 

--- a/infra/terraform/hash/observability/grafana/security_groups.tf
+++ b/infra/terraform/hash/observability/grafana/security_groups.tf
@@ -49,15 +49,6 @@ resource "aws_security_group" "grafana" {
     cidr_blocks = [var.vpc.cidr_block]
   }
 
-  # Allow outbound gRPC for Loki live tail streaming
-  egress {
-    from_port   = var.loki_grpc_port
-    to_port     = var.loki_grpc_port
-    protocol    = "tcp"
-    description = "Loki gRPC API for live tail streaming"
-    cidr_blocks = [var.vpc.cidr_block]
-  }
-
   # Allow outbound PostgreSQL
   egress {
     from_port   = var.grafana_database_port

--- a/infra/terraform/hash/observability/grafana/security_groups.tf
+++ b/infra/terraform/hash/observability/grafana/security_groups.tf
@@ -40,6 +40,15 @@ resource "aws_security_group" "grafana" {
     cidr_blocks = [var.vpc.cidr_block]
   }
 
+  # Allow outbound HTTP for Loki API
+  egress {
+    from_port   = var.loki_api_port
+    to_port     = var.loki_api_port
+    protocol    = "tcp"
+    description = "Loki API access"
+    cidr_blocks = [var.vpc.cidr_block]
+  }
+
   # Allow outbound PostgreSQL
   egress {
     from_port   = var.grafana_database_port

--- a/infra/terraform/hash/observability/grafana/templates/grafana.ini.tpl
+++ b/infra/terraform/hash/observability/grafana/templates/grafana.ini.tpl
@@ -28,7 +28,7 @@ disable_login_form = false
 
 [log]
 mode = console
-level = info
+level = warn
 
 [paths]
 # Provision configuration from mounted volume

--- a/infra/terraform/hash/observability/grafana/templates/provisioning/datasources/loki.yaml.tpl
+++ b/infra/terraform/hash/observability/grafana/templates/provisioning/datasources/loki.yaml.tpl
@@ -7,11 +7,10 @@ prune: true
 
 datasources:
   - name: Loki
-    version: 1
     type: loki
     uid: loki
     access: proxy
-    url: http://${loki_api_dns}:${loki_api_port}
+    url: http://${loki_http_dns}:${loki_http_port}
     isDefault: false
     editable: false
     jsonData:

--- a/infra/terraform/hash/observability/grafana/templates/provisioning/datasources/loki.yaml.tpl
+++ b/infra/terraform/hash/observability/grafana/templates/provisioning/datasources/loki.yaml.tpl
@@ -1,0 +1,25 @@
+# Loki data source provisioning for Grafana
+# Generated from Terraform template
+
+apiVersion: 1
+
+prune: true
+
+datasources:
+  - name: Loki
+    version: 1
+    type: loki
+    uid: loki
+    access: proxy
+    url: http://${loki_api_dns}:${loki_api_port}
+    isDefault: false
+    editable: false
+    jsonData:
+      httpMethod: GET
+      derivedFields:
+        - name: Trace ID
+          datasourceUid: tempo
+          matcherType: label
+          matcherRegex: trace_id
+          url: $$${__value.raw}
+          urlDisplayLabel: View Trace

--- a/infra/terraform/hash/observability/grafana/templates/provisioning/datasources/tempo.yaml.tpl
+++ b/infra/terraform/hash/observability/grafana/templates/provisioning/datasources/tempo.yaml.tpl
@@ -3,8 +3,11 @@
 
 apiVersion: 1
 
+prune: true
+
 datasources:
   - name: Tempo
+    version: 1
     type: tempo
     uid: tempo
     access: proxy
@@ -17,4 +20,13 @@ datasources:
         hide: false
       nodeGraph:
         enabled: true
-    version: 1
+      tracesToLogs:
+        datasourceUid: loki
+        tags: ['service.name']
+        mappedTags: [
+          { key: 'service.name', value: 'service_name' }
+        ]
+        mapTagNamesEnabled: true
+        filterByTraceID: true
+      lokiSearch:
+        datasourceUid: loki

--- a/infra/terraform/hash/observability/grafana/templates/provisioning/datasources/tempo.yaml.tpl
+++ b/infra/terraform/hash/observability/grafana/templates/provisioning/datasources/tempo.yaml.tpl
@@ -7,7 +7,6 @@ prune: true
 
 datasources:
   - name: Tempo
-    version: 1
     type: tempo
     uid: tempo
     access: proxy

--- a/infra/terraform/hash/observability/grafana/variables.tf
+++ b/infra/terraform/hash/observability/grafana/variables.tf
@@ -88,11 +88,6 @@ variable "loki_http_port" {
   description = "Port for Loki HTTP API service"
 }
 
-variable "loki_grpc_port" {
-  type        = number
-  description = "Port for Loki gRPC API service"
-}
-
 variable "ssl_config" {
   description = "Shared SSL configuration for container certificates"
 }

--- a/infra/terraform/hash/observability/grafana/variables.tf
+++ b/infra/terraform/hash/observability/grafana/variables.tf
@@ -78,14 +78,19 @@ variable "tempo_api_port" {
   description = "Port for Tempo API service"
 }
 
-variable "loki_api_dns" {
+variable "loki_http_dns" {
   type        = string
-  description = "DNS name for Loki API service"
+  description = "DNS name for Loki HTTP API service"
 }
 
-variable "loki_api_port" {
+variable "loki_http_port" {
   type        = number
-  description = "Port for Loki API service"
+  description = "Port for Loki HTTP API service"
+}
+
+variable "loki_grpc_port" {
+  type        = number
+  description = "Port for Loki gRPC API service"
 }
 
 variable "ssl_config" {

--- a/infra/terraform/hash/observability/loki/config.tf
+++ b/infra/terraform/hash/observability/loki/config.tf
@@ -1,0 +1,22 @@
+# Loki configuration management
+
+# Upload Loki configuration generated from template
+resource "aws_s3_object" "loki_config" {
+  bucket = var.config_bucket.id
+  key    = "loki/config.yaml"
+
+  # Generate config from template with environment-specific parameters
+  content = templatefile("${path.module}/templates/loki.yaml.tpl", {
+    environment = terraform.workspace
+    api_port    = local.api_port
+    loki_bucket = aws_s3_bucket.loki_logs.bucket
+    aws_region  = var.region
+  })
+
+  content_type = "application/x-yaml"
+
+  tags = {
+    Purpose = "Loki Configuration"
+    Service = "loki"
+  }
+}

--- a/infra/terraform/hash/observability/loki/config.tf
+++ b/infra/terraform/hash/observability/loki/config.tf
@@ -8,7 +8,8 @@ resource "aws_s3_object" "loki_config" {
   # Generate config from template with environment-specific parameters
   content = templatefile("${path.module}/templates/loki.yaml.tpl", {
     environment = terraform.workspace
-    api_port    = local.api_port
+    http_port   = local.http_port
+    grpc_port   = local.grpc_port
     loki_bucket = aws_s3_bucket.loki_logs.bucket
     aws_region  = var.region
   })

--- a/infra/terraform/hash/observability/loki/iam.tf
+++ b/infra/terraform/hash/observability/loki/iam.tf
@@ -1,0 +1,99 @@
+# IAM roles for Loki ECS tasks
+
+# Execution role for ECS tasks (used by ECS agent)
+resource "aws_iam_role" "execution_role" {
+  name = "${local.prefix}-execution-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+# Attach standard ECS execution role policy
+resource "aws_iam_role_policy_attachment" "execution_role" {
+  role       = aws_iam_role.execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+# Task role for running containers (used by application)
+resource "aws_iam_role" "task_role" {
+  name = "${local.prefix}-task-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      }
+    ]
+  })
+
+  inline_policy {
+    name = "s3-config-access"
+    policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Effect = "Allow"
+          Action = [
+            "s3:ListBucket"
+          ]
+          Resource = var.config_bucket.arn
+        },
+        {
+          Effect = "Allow"
+          Action = [
+            "s3:GetObject"
+          ]
+          Resource = "${var.config_bucket.arn}/loki/*"
+        }
+      ]
+    })
+  }
+
+  inline_policy {
+    name = "s3-logs-access"
+    policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Effect = "Allow"
+          Action = [
+            "s3:ListBucket"
+          ]
+          Resource = aws_s3_bucket.loki_logs.arn
+        },
+        {
+          Effect = "Allow"
+          Action = [
+            "s3:GetObject",
+            "s3:PutObject",
+            "s3:DeleteObject",
+            "s3:GetObjectTagging",
+            "s3:PutObjectTagging"
+          ]
+          Resource = "${aws_s3_bucket.loki_logs.arn}/*"
+        }
+      ]
+    })
+  }
+}
+
+# Attach SSM policy for ECS Execute Command
+resource "aws_iam_role_policy_attachment" "task_role_ssm" {
+  role       = aws_iam_role.task_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}

--- a/infra/terraform/hash/observability/loki/main.tf
+++ b/infra/terraform/hash/observability/loki/main.tf
@@ -1,0 +1,15 @@
+# Loki service definition
+
+locals {
+  service_name = "loki"
+  prefix       = "${var.prefix}-${local.service_name}"
+
+  # Port definitions for Loki
+  api_port      = 3100  # Loki HTTP API for log ingestion and queries
+  
+  # Port names for Service Connect
+  api_port_name = "${local.service_name}-api"
+  
+  # DNS names for Service Connect
+  api_port_dns = "${local.api_port_name}.${var.service_discovery_namespace_name}"
+}

--- a/infra/terraform/hash/observability/loki/main.tf
+++ b/infra/terraform/hash/observability/loki/main.tf
@@ -5,11 +5,14 @@ locals {
   prefix       = "${var.prefix}-${local.service_name}"
 
   # Port definitions for Loki
-  api_port      = 3100  # Loki HTTP API for log ingestion and queries
+  http_port = 3100  # Loki HTTP API for log ingestion and queries
+  grpc_port = 9096  # Loki gRPC API for live tail streaming
   
   # Port names for Service Connect
-  api_port_name = "${local.service_name}-api"
+  http_port_name = "${local.service_name}-http"   # HTTP API
+  grpc_port_name = "${local.service_name}-grpc"   # gRPC API
   
-  # DNS names for Service Connect
-  api_port_dns = "${local.api_port_name}.${var.service_discovery_namespace_name}"
+  # DNS names for Service Connect  
+  http_port_dns = "${local.http_port_name}.${var.service_discovery_namespace_name}"
+  grpc_port_dns = "${local.grpc_port_name}.${var.service_discovery_namespace_name}"
 }

--- a/infra/terraform/hash/observability/loki/outputs.tf
+++ b/infra/terraform/hash/observability/loki/outputs.tf
@@ -1,17 +1,32 @@
 # Loki service outputs for Service Connect integration
 
-output "api_port" {
+output "http_port" {
   description = "HTTP API port for Loki log ingestion and queries"
-  value       = local.api_port
+  value       = local.http_port
 }
 
-output "api_port_name" {
+output "http_port_name" {
   description = "Service Connect port name for HTTP API"
-  value       = local.api_port_name
+  value       = local.http_port_name
+}
+
+output "grpc_port" {
+  description = "gRPC API port for Loki live tail streaming"
+  value       = local.grpc_port
+}
+
+output "grpc_port_name" {
+  description = "Service Connect port name for gRPC API"
+  value       = local.grpc_port_name
 }
 
 # DNS names for Service Connect
-output "api_dns" {
+output "http_dns" {
   description = "Service Connect DNS name for HTTP API (for OTel collector and Grafana)"
-  value       = local.api_port_dns
+  value       = local.http_port_dns
+}
+
+output "grpc_dns" {
+  description = "Service Connect DNS name for gRPC API (for live tail streaming)"
+  value       = local.grpc_port_dns
 }

--- a/infra/terraform/hash/observability/loki/outputs.tf
+++ b/infra/terraform/hash/observability/loki/outputs.tf
@@ -1,0 +1,17 @@
+# Loki service outputs for Service Connect integration
+
+output "api_port" {
+  description = "HTTP API port for Loki log ingestion and queries"
+  value       = local.api_port
+}
+
+output "api_port_name" {
+  description = "Service Connect port name for HTTP API"
+  value       = local.api_port_name
+}
+
+# DNS names for Service Connect
+output "api_dns" {
+  description = "Service Connect DNS name for HTTP API (for OTel collector and Grafana)"
+  value       = local.api_port_dns
+}

--- a/infra/terraform/hash/observability/loki/security_groups.tf
+++ b/infra/terraform/hash/observability/loki/security_groups.tf
@@ -6,10 +6,19 @@ resource "aws_security_group" "loki" {
 
   # Allow inbound HTTP API from OpenTelemetry Collector and Grafana
   ingress {
-    from_port   = local.api_port
-    to_port     = local.api_port
+    from_port   = local.http_port
+    to_port     = local.http_port
     protocol    = "tcp"
     description = "Loki HTTP API for log ingestion and queries"
+    cidr_blocks = [var.vpc.cidr_block]
+  }
+
+  # Allow inbound gRPC API for live tail streaming from Grafana
+  ingress {
+    from_port   = local.grpc_port
+    to_port     = local.grpc_port
+    protocol    = "tcp"
+    description = "Loki gRPC API for live tail streaming"
     cidr_blocks = [var.vpc.cidr_block]
   }
 

--- a/infra/terraform/hash/observability/loki/security_groups.tf
+++ b/infra/terraform/hash/observability/loki/security_groups.tf
@@ -1,0 +1,55 @@
+# Security group for Loki
+
+resource "aws_security_group" "loki" {
+  name_prefix = "${local.prefix}-"
+  vpc_id      = var.vpc.id
+
+  # Allow inbound HTTP API from OpenTelemetry Collector and Grafana
+  ingress {
+    from_port   = local.api_port
+    to_port     = local.api_port
+    protocol    = "tcp"
+    description = "Loki HTTP API for log ingestion and queries"
+    cidr_blocks = [var.vpc.cidr_block]
+  }
+
+  # Allow outbound HTTPS for S3 log storage and config download
+  egress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    description = "HTTPS for S3 access"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # Allow outbound HTTP for package downloads during SSL setup
+  egress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    description = "HTTP outbound for package downloads"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # Allow outbound DNS
+  egress {
+    from_port   = 53
+    to_port     = 53
+    protocol    = "tcp"
+    description = "DNS resolution"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 53
+    to_port     = 53
+    protocol    = "udp"
+    description = "DNS resolution"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name    = "${local.prefix}-sg"
+    Purpose = "Loki security group"
+  }
+}

--- a/infra/terraform/hash/observability/loki/service.tf
+++ b/infra/terraform/hash/observability/loki/service.tf
@@ -85,14 +85,19 @@ resource "aws_ecs_task_definition" "loki" {
 
       portMappings = [
         {
-          name          = local.api_port_name
-          containerPort = local.api_port
+          name          = local.http_port_name
+          containerPort = local.http_port
+          protocol      = "tcp"
+        },
+        {
+          name          = local.grpc_port_name
+          containerPort = local.grpc_port
           protocol      = "tcp"
         }
       ]
 
       healthCheck = {
-        command     = ["CMD", "wget", "--spider", "-q", "http://localhost:${local.api_port}/ready"]
+        command     = ["CMD", "wget", "--spider", "-q", "http://localhost:${local.http_port}/ready"]
         interval    = 30
         timeout     = 5
         retries     = 3
@@ -152,10 +157,18 @@ resource "aws_ecs_service" "loki" {
     namespace = var.service_discovery_namespace_arn
 
     service {
-      port_name = local.api_port_name
+      port_name = local.http_port_name
 
       client_alias {
-        port = local.api_port
+        port = local.http_port
+      }
+    }
+
+    service {
+      port_name = local.grpc_port_name
+
+      client_alias {
+        port = local.grpc_port
       }
     }
   }

--- a/infra/terraform/hash/observability/loki/storage.tf
+++ b/infra/terraform/hash/observability/loki/storage.tf
@@ -1,0 +1,47 @@
+# S3 bucket for Loki log storage
+# Stores log data with lifecycle management
+
+resource "aws_s3_bucket" "loki_logs" {
+  bucket = "${var.prefix}-loki-logs"
+  tags = {
+    Purpose = "Loki log storage"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "loki_logs" {
+  bucket = aws_s3_bucket.loki_logs.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "loki_logs" {
+  bucket = aws_s3_bucket.loki_logs.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "loki_logs" {
+  bucket = aws_s3_bucket.loki_logs.id
+
+  rule {
+    id     = "loki_logs_lifecycle"
+    status = "Enabled"
+
+    # Delete logs after 7 days to manage storage costs (same as Tempo)
+    expiration {
+      days = 7
+    }
+
+    # Clean up incomplete multipart uploads
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 1
+    }
+  }
+}

--- a/infra/terraform/hash/observability/loki/templates/loki.yaml.tpl
+++ b/infra/terraform/hash/observability/loki/templates/loki.yaml.tpl
@@ -4,7 +4,9 @@
 auth_enabled: false
 
 server:
-  http_listen_port: ${api_port}
+  http_listen_port: ${http_port}
+  grpc_listen_port: ${grpc_port}
+  grpc_server_max_concurrent_streams: 1000
 
 common:
   instance_addr: 127.0.0.1
@@ -61,3 +63,8 @@ query_range:
 frontend:
   max_outstanding_per_tenant: 2048
   compress_responses: true
+
+# Pattern ingester for live tail streaming in Loki 3.x
+pattern_ingester:
+  enabled: true
+

--- a/infra/terraform/hash/observability/loki/templates/loki.yaml.tpl
+++ b/infra/terraform/hash/observability/loki/templates/loki.yaml.tpl
@@ -1,0 +1,63 @@
+# Loki Configuration - Environment: ${environment}
+# Generated from Terraform template
+
+auth_enabled: false
+
+server:
+  http_listen_port: ${api_port}
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: memberlist
+
+# Schema configuration for S3 backend with TSDB
+schema_config:
+  configs:
+    - from: 2024-04-01
+      store: tsdb
+      object_store: s3
+      schema: v13
+      index:
+        prefix: loki_index_
+        period: 24h
+
+# S3 storage configuration
+storage_config:
+  aws:
+    s3: s3://${aws_region}/${loki_bucket}
+
+  # TSDB shipper configuration for index storage
+  tsdb_shipper:
+    active_index_directory: /loki/index
+    cache_location: /loki/index_cache
+
+# Limits and retention configuration
+limits_config:
+  volume_enabled: true
+  allow_structured_metadata: true
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h  # 7 days (matches S3 lifecycle policy)
+  retention_period: 168h            # 7 days retention
+
+# Compactor for index management
+compactor:
+  working_directory: /loki/compactor
+  compaction_interval: 5m
+  retention_enabled: true
+  retention_delete_delay: 2h
+  retention_delete_worker_count: 150
+  delete_request_store: aws
+
+# Query performance configuration
+query_range:
+  align_queries_with_step: true
+  max_retries: 5
+  cache_results: true
+
+frontend:
+  max_outstanding_per_tenant: 2048
+  compress_responses: true

--- a/infra/terraform/hash/observability/loki/variables.tf
+++ b/infra/terraform/hash/observability/loki/variables.tf
@@ -31,11 +31,6 @@ variable "region" {
   description = "AWS region"
 }
 
-variable "root_url" {
-  type        = string
-  description = "Public DNS name for Grafana"
-}
-
 variable "service_discovery_namespace_arn" {
   type        = string
   description = "ARN of the service discovery namespace for Service Connect"
@@ -44,48 +39,6 @@ variable "service_discovery_namespace_arn" {
 variable "service_discovery_namespace_name" {
   type        = string
   description = "Name of the service discovery namespace for DNS resolution"
-}
-
-variable "grafana_database_host" {
-  type        = string
-  description = "PostgreSQL database host"
-}
-
-variable "grafana_database_port" {
-  type        = number
-  description = "PostgreSQL database port"
-}
-
-variable "grafana_database_password" {
-  type        = string
-  sensitive   = true
-  description = "PostgreSQL database password for grafana user"
-}
-
-variable "grafana_secret_key" {
-  type        = string
-  sensitive   = true
-  description = "Grafana secret key"
-}
-
-variable "tempo_api_dns" {
-  type        = string
-  description = "DNS name for Tempo API service"
-}
-
-variable "tempo_api_port" {
-  type        = number
-  description = "Port for Tempo API service"
-}
-
-variable "loki_api_dns" {
-  type        = string
-  description = "DNS name for Loki API service"
-}
-
-variable "loki_api_port" {
-  type        = number
-  description = "Port for Loki API service"
 }
 
 variable "ssl_config" {

--- a/infra/terraform/hash/observability/main.tf
+++ b/infra/terraform/hash/observability/main.tf
@@ -91,6 +91,8 @@ module "otel_collector" {
   service_discovery_namespace_arn = aws_service_discovery_private_dns_namespace.observability.arn
   tempo_otlp_grpc_dns             = module.tempo.otlp_grpc_dns
   tempo_otlp_grpc_port            = module.tempo.otlp_grpc_port
+  loki_api_dns                    = module.loki.api_dns
+  loki_api_port                   = module.loki.api_port
 
   # Shared SSL configuration
   ssl_config = local.ssl_config
@@ -99,6 +101,23 @@ module "otel_collector" {
 # Tempo service for distributed tracing
 module "tempo" {
   source                           = "./tempo"
+  prefix                           = var.prefix
+  cluster_arn                      = aws_ecs_cluster.observability.arn
+  vpc                              = var.vpc
+  subnets                          = var.subnets
+  config_bucket                    = aws_s3_bucket.configs
+  log_group_name                   = aws_cloudwatch_log_group.observability.name
+  region                           = var.region
+  service_discovery_namespace_arn  = aws_service_discovery_private_dns_namespace.observability.arn
+  service_discovery_namespace_name = aws_service_discovery_private_dns_namespace.observability.name
+
+  # Shared SSL configuration
+  ssl_config = local.ssl_config
+}
+
+# Loki service for log aggregation
+module "loki" {
+  source                           = "./loki"
   prefix                           = var.prefix
   cluster_arn                      = aws_ecs_cluster.observability.arn
   vpc                              = var.vpc
@@ -132,6 +151,8 @@ module "grafana" {
   grafana_secret_key               = var.grafana_secret_key
   tempo_api_dns                    = module.tempo.api_dns
   tempo_api_port                   = module.tempo.api_port
+  loki_api_dns                     = module.loki.api_dns
+  loki_api_port                    = module.loki.api_port
 
   # Shared SSL configuration
   ssl_config = local.ssl_config

--- a/infra/terraform/hash/observability/main.tf
+++ b/infra/terraform/hash/observability/main.tf
@@ -153,7 +153,6 @@ module "grafana" {
   tempo_api_port                   = module.tempo.api_port
   loki_http_dns                    = module.loki.http_dns
   loki_http_port                   = module.loki.http_port
-  loki_grpc_port                   = module.loki.grpc_port
 
   # Shared SSL configuration
   ssl_config = local.ssl_config

--- a/infra/terraform/hash/observability/main.tf
+++ b/infra/terraform/hash/observability/main.tf
@@ -91,8 +91,8 @@ module "otel_collector" {
   service_discovery_namespace_arn = aws_service_discovery_private_dns_namespace.observability.arn
   tempo_otlp_grpc_dns             = module.tempo.otlp_grpc_dns
   tempo_otlp_grpc_port            = module.tempo.otlp_grpc_port
-  loki_api_dns                    = module.loki.api_dns
-  loki_api_port                   = module.loki.api_port
+  loki_http_dns                   = module.loki.http_dns
+  loki_http_port                  = module.loki.http_port
 
   # Shared SSL configuration
   ssl_config = local.ssl_config
@@ -151,8 +151,9 @@ module "grafana" {
   grafana_secret_key               = var.grafana_secret_key
   tempo_api_dns                    = module.tempo.api_dns
   tempo_api_port                   = module.tempo.api_port
-  loki_api_dns                     = module.loki.api_dns
-  loki_api_port                    = module.loki.api_port
+  loki_http_dns                    = module.loki.http_dns
+  loki_http_port                   = module.loki.http_port
+  loki_grpc_port                   = module.loki.grpc_port
 
   # Shared SSL configuration
   ssl_config = local.ssl_config

--- a/infra/terraform/hash/observability/otel_collector/config.tf
+++ b/infra/terraform/hash/observability/otel_collector/config.tf
@@ -29,8 +29,8 @@ resource "aws_s3_object" "otel_collector_config" {
     health_port            = local.health_port
     tempo_otlp_grpc_dns    = var.tempo_otlp_grpc_dns
     tempo_otlp_grpc_port   = var.tempo_otlp_grpc_port
-    loki_api_dns           = var.loki_api_dns
-    loki_api_port          = var.loki_api_port
+    loki_http_dns          = var.loki_http_dns
+    loki_http_port         = var.loki_http_port
   })
 
   content_type = "application/x-yaml"

--- a/infra/terraform/hash/observability/otel_collector/config.tf
+++ b/infra/terraform/hash/observability/otel_collector/config.tf
@@ -29,6 +29,8 @@ resource "aws_s3_object" "otel_collector_config" {
     health_port            = local.health_port
     tempo_otlp_grpc_dns    = var.tempo_otlp_grpc_dns
     tempo_otlp_grpc_port   = var.tempo_otlp_grpc_port
+    loki_api_dns           = var.loki_api_dns
+    loki_api_port          = var.loki_api_port
   })
 
   content_type = "application/x-yaml"

--- a/infra/terraform/hash/observability/otel_collector/security_groups.tf
+++ b/infra/terraform/hash/observability/otel_collector/security_groups.tf
@@ -67,12 +67,21 @@ resource "aws_security_group" "otel_collector" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  # Allow outbound DNS
+  # Allow outbound DNS (TCP)
   egress {
     from_port   = 53
     to_port     = 53
     protocol    = "tcp"
-    description = "DNS resolution"
+    description = "DNS resolution TCP"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # Allow outbound DNS (UDP)
+  egress {
+    from_port   = 53
+    to_port     = 53
+    protocol    = "udp"
+    description = "DNS resolution UDP"
     cidr_blocks = ["0.0.0.0/0"]
   }
 
@@ -82,6 +91,15 @@ resource "aws_security_group" "otel_collector" {
     to_port     = var.tempo_otlp_grpc_port
     protocol    = "tcp"
     description = "OTLP gRPC to Tempo"
+    cidr_blocks = [var.vpc.cidr_block]
+  }
+
+  # Allow outbound traffic to Loki HTTP API
+  egress {
+    from_port   = var.loki_api_port
+    to_port     = var.loki_api_port
+    protocol    = "tcp"
+    description = "OTLP HTTP to Loki"
     cidr_blocks = [var.vpc.cidr_block]
   }
 

--- a/infra/terraform/hash/observability/otel_collector/security_groups.tf
+++ b/infra/terraform/hash/observability/otel_collector/security_groups.tf
@@ -96,8 +96,8 @@ resource "aws_security_group" "otel_collector" {
 
   # Allow outbound traffic to Loki HTTP API
   egress {
-    from_port   = var.loki_api_port
-    to_port     = var.loki_api_port
+    from_port   = var.loki_http_port
+    to_port     = var.loki_http_port
     protocol    = "tcp"
     description = "OTLP HTTP to Loki"
     cidr_blocks = [var.vpc.cidr_block]

--- a/infra/terraform/hash/observability/otel_collector/templates/otel-collector.yaml.tpl
+++ b/infra/terraform/hash/observability/otel_collector/templates/otel-collector.yaml.tpl
@@ -57,6 +57,10 @@ exporters:
     endpoint: ${tempo_otlp_grpc_dns}:${tempo_otlp_grpc_port}
     tls:
       insecure: true
+  otlphttp/loki:
+    endpoint: http://${loki_api_dns}:${loki_api_port}/otlp
+    tls:
+      insecure: true
 
 extensions:
   health_check:
@@ -113,4 +117,4 @@ service:
     logs:
       receivers: [forward/logs]
       processors: [batch]
-      exporters: [nop]
+      exporters: [otlphttp/loki]

--- a/infra/terraform/hash/observability/otel_collector/templates/otel-collector.yaml.tpl
+++ b/infra/terraform/hash/observability/otel_collector/templates/otel-collector.yaml.tpl
@@ -58,7 +58,7 @@ exporters:
     tls:
       insecure: true
   otlphttp/loki:
-    endpoint: http://${loki_api_dns}:${loki_api_port}/otlp
+    endpoint: http://${loki_http_dns}:${loki_http_port}/otlp
     tls:
       insecure: true
 

--- a/infra/terraform/hash/observability/otel_collector/variables.tf
+++ b/infra/terraform/hash/observability/otel_collector/variables.tf
@@ -46,6 +46,16 @@ variable "tempo_otlp_grpc_port" {
   description = "Tempo OTLP gRPC port number"
 }
 
+variable "loki_api_dns" {
+  type        = string
+  description = "Loki HTTP API DNS name for log forwarding"
+}
+
+variable "loki_api_port" {
+  type        = number
+  description = "Loki HTTP API port number"
+}
+
 variable "ssl_config" {
   description = "Shared SSL configuration for container certificates"
 }

--- a/infra/terraform/hash/observability/otel_collector/variables.tf
+++ b/infra/terraform/hash/observability/otel_collector/variables.tf
@@ -46,12 +46,12 @@ variable "tempo_otlp_grpc_port" {
   description = "Tempo OTLP gRPC port number"
 }
 
-variable "loki_api_dns" {
+variable "loki_http_dns" {
   type        = string
   description = "Loki HTTP API DNS name for log forwarding"
 }
 
-variable "loki_api_port" {
+variable "loki_http_port" {
   type        = number
   description = "Loki HTTP API port number"
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR implements Loki log aggregation service in the AWS observability infrastructure to complete the telemetry stack alongside existing Tempo (tracing) and OpenTelemetry Collector components. Loki provides centralized log storage and querying capabilities with S3 backend storage and integrates seamlessly with Grafana for log visualization and correlation with traces.

## 🚫 Blocked by

- https://github.com/hashintel/hash/pull/7690

## 🔍 What does this change?

- **Creates complete Loki service infrastructure** in `infra/terraform/hash/observability/loki/`:
  - ECS task definition and service configuration with Fargate deployment
  - S3 bucket for log storage with 7-day lifecycle policy (consistent with Tempo)
  - IAM roles with least-privilege permissions for S3 config and log storage access
  - Security groups allowing HTTP API access from OTel Collector and Grafana
  - Loki configuration template with TSDB schema and S3 backend

- **Integrates Loki with existing observability stack**:
  - Updates OpenTelemetry Collector to forward logs to Loki via OTLP HTTP endpoint
  - Configures Grafana with Loki datasource provisioning and trace-to-logs correlation
  - Adds Service Connect integration for service discovery between components

- **Updates Grafana configuration**:
  - Adds Loki datasource with trace ID correlation for seamless log-to-trace navigation
  - Enhances Tempo datasource with traces-to-logs mapping for bidirectional correlation
  - Moves configuration hash calculation to include all datasources for proper versioning

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

None - this implementation follows the same patterns as existing Tempo service.

## 🛡 What tests cover this?

- Terraform plan validation ensures resource configuration correctness
- ECS health checks validate Loki service availability
- Service Connect integration tested through existing observability stack patterns
