### PR TITLE
H-5015: Allow all web members to see usage records

### DIFF
--- a/libs/@local/graph/postgres-store/src/store/postgres/seed_policies.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/seed_policies.rs
@@ -620,12 +620,7 @@ fn web_view_entity_policies(role: &WebRole) -> impl Iterator<Item = PolicyCreati
                         EntityResourceFilter::CreatedByPrincipal,
                         EntityResourceFilter::Not {
                             filter: Box::new(EntityResourceFilter::Any {
-                                filters: vec![
-                                    USER_SECRET.entity_is_of_base_type(),
-                                    USAGE_RECORD.entity_is_of_base_type(),
-                                    INCURRED_IN.entity_is_of_base_type(),
-                                    RECORDS_USAGE_OF.entity_is_of_base_type(),
-                                ],
+                                filters: vec![USER_SECRET.entity_is_of_base_type()],
                             }),
                         },
                     ],


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Web bots needs to see usage records. The easiest way is to grant view permissions to web members.

## 🔗 Related links

- [Slack discussion](https://hashintel.slack.com/archives/C022217GAHF/p1752837109813639?thread_ts=1751998121.248029&cid=C022217GAHF) _(internal)_