### PR TITLE
H-5104: Don't attach properties to tracing spans

### DIFF
--- a/libs/@local/graph/api/src/rest/entity.rs
+++ b/libs/@local/graph/api/src/rest/entity.rs
@@ -243,7 +243,7 @@ impl EntityResource {
         (status = 500, description = "Store error occurred"),
     ),
 )]
-#[tracing::instrument(level = "info", skip(store_pool, temporal_client))]
+#[tracing::instrument(level = "info", skip_all)]
 async fn create_entity<S>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
     store_pool: Extension<Arc<S>>,
@@ -327,7 +327,7 @@ where
         (status = 500, description = "Store error occurred"),
     ),
 )]
-#[tracing::instrument(level = "info", skip(store_pool, temporal_client))]
+#[tracing::instrument(level = "info", skip_all)]
 async fn validate_entity<S>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
     store_pool: Extension<Arc<S>>,
@@ -869,7 +869,7 @@ where
     ),
     request_body = PatchEntityParams,
 )]
-#[tracing::instrument(level = "info", skip(store_pool, temporal_client))]
+#[tracing::instrument(level = "info", skip(store_pool, temporal_client, params))]
 async fn patch_entity<S>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
     store_pool: Extension<Arc<S>>,
@@ -958,7 +958,7 @@ where
     ),
     request_body = DiffEntityParams,
 )]
-#[tracing::instrument(level = "info", skip(store_pool, temporal_client))]
+#[tracing::instrument(level = "info", skip(store_pool, temporal_client, params))]
 async fn diff_entity<S>(
     AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
     store_pool: Extension<Arc<S>>,

--- a/libs/@local/graph/api/src/rest/permissions.rs
+++ b/libs/@local/graph/api/src/rest/permissions.rs
@@ -226,7 +226,7 @@ where
         (status = 500, description = "Store error occurred"),
     )
 )]
-#[tracing::instrument(level = "info", skip(store_pool, temporal_client))]
+#[tracing::instrument(level = "info", skip(store_pool, temporal_client, operations))]
 async fn update_policy_by_id<S>(
     AuthenticatedUserHeader(authenticated_actor_id): AuthenticatedUserHeader,
     Path(policy_id): Path<PolicyId>,

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
@@ -368,7 +368,7 @@ where
         metadata.data_type_id = Some(target_data_type_id.clone());
     }
 
-    #[tracing::instrument(level = "info", skip(self, provider, entity, conversions))]
+    #[tracing::instrument(level = "info", skip_all)]
     async fn convert_entity<P: DataTypeLookup + Sync>(
         &self,
         provider: &P,
@@ -397,7 +397,7 @@ where
         Ok(())
     }
 
-    #[tracing::instrument(level = "info", skip(self, params, policy_components))]
+    #[tracing::instrument(level = "info", skip_all)]
     #[expect(clippy::too_many_lines)]
     async fn get_entities_impl(
         &self,
@@ -1154,7 +1154,7 @@ where
     //   see https://linear.app/hash/issue/H-1449
     // TODO: Restrict non-draft links to non-draft entities
     //   see https://linear.app/hash/issue/H-1450
-    #[tracing::instrument(level = "info", skip(self))]
+    #[tracing::instrument(level = "info", skip(self, params))]
     async fn validate_entities(
         &self,
         actor_id: ActorEntityUuid,
@@ -2368,7 +2368,7 @@ struct LockedEntityEdition {
 }
 
 impl PostgresStore<tokio_postgres::Transaction<'_>> {
-    #[tracing::instrument(level = "trace", skip(self, entity_type_ids))]
+    #[tracing::instrument(level = "info", skip_all)]
     async fn insert_entity_edition(
         &self,
         archived: bool,
@@ -2455,7 +2455,7 @@ impl PostgresStore<tokio_postgres::Transaction<'_>> {
         Ok(edition_id)
     }
 
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[tracing::instrument(level = "info", skip(self))]
     async fn lock_entity_edition(
         &self,
         entity_id: EntityId,
@@ -2540,7 +2540,7 @@ impl PostgresStore<tokio_postgres::Transaction<'_>> {
             })
     }
 
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[tracing::instrument(level = "info", skip(self))]
     async fn insert_temporal_metadata(
         &self,
         entity_id: EntityId,
@@ -2591,7 +2591,7 @@ impl PostgresStore<tokio_postgres::Transaction<'_>> {
         })
     }
 
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[tracing::instrument(level = "info", skip(self))]
     #[expect(clippy::too_many_lines)]
     async fn update_temporal_metadata(
         &self,
@@ -2783,7 +2783,7 @@ impl PostgresStore<tokio_postgres::Transaction<'_>> {
         })
     }
 
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[tracing::instrument(level = "info", skip(self))]
     #[expect(clippy::too_many_lines)]
     async fn archive_entity(
         &self,

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/read.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/read.rs
@@ -102,7 +102,7 @@ impl<C> PostgresStore<C>
 where
     C: AsClient,
 {
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[tracing::instrument(level = "info", skip(self))]
     pub(crate) async fn read_shared_edges<'t>(
         &self,
         traversal_data: &'t EntityEdgeTraversalData,
@@ -200,7 +200,7 @@ where
             }))
     }
 
-    #[tracing::instrument(level = "trace", skip(self, provider))]
+    #[tracing::instrument(level = "info", skip(self, provider))]
     #[expect(clippy::too_many_lines)]
     pub(crate) async fn read_knowledge_edges<'t>(
         &self,

--- a/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
@@ -3900,7 +3900,7 @@ where
     /// # Errors
     ///
     /// Returns [`DeletionError`] if any of the database deletion operations fail.
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[tracing::instrument(level = "info", skip(self))]
     pub async fn delete_principals(
         &self,
         actor_id: ActorEntityUuid,

--- a/libs/@local/graph/postgres-store/src/store/postgres/ontology/data_type.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/ontology/data_type.rs
@@ -70,7 +70,7 @@ impl<C> PostgresStore<C>
 where
     C: AsClient,
 {
-    #[tracing::instrument(level = "trace", skip(data_types, provider))]
+    #[tracing::instrument(level = "info", skip(data_types, provider))]
     pub(crate) async fn filter_data_types_by_permission<I, T>(
         data_types: impl IntoIterator<Item = (I, T)> + Send,
         provider: &StoreProvider<'_, Self>,

--- a/libs/@local/graph/postgres-store/src/store/postgres/ontology/entity_type.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/ontology/entity_type.rs
@@ -79,7 +79,7 @@ impl<C> PostgresStore<C>
 where
     C: AsClient,
 {
-    #[tracing::instrument(level = "trace", skip(entity_types, provider))]
+    #[tracing::instrument(level = "info", skip(entity_types, provider))]
     pub(crate) async fn filter_entity_types_by_permission<I, T>(
         entity_types: impl IntoIterator<Item = (I, T)> + Send,
         provider: &StoreProvider<'_, Self>,

--- a/libs/@local/graph/postgres-store/src/store/postgres/ontology/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/ontology/mod.rs
@@ -46,7 +46,7 @@ impl PostgresStore<Transaction<'_>> {
     /// # Errors
     ///
     /// Returns [`DeletionError`] if the database deletion operation fails.
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[tracing::instrument(level = "info", skip(self))]
     pub async fn delete_ontology_ids(
         &self,
         ontology_ids: &[OntologyTypeUuid],

--- a/libs/@local/graph/postgres-store/src/store/postgres/ontology/read.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/ontology/read.rs
@@ -60,7 +60,7 @@ pub struct OntologyEdgeTraversal<L, R> {
 }
 
 impl<C: AsClient> PostgresStore<C> {
-    #[tracing::instrument(level = "trace", skip(self, filter))]
+    #[tracing::instrument(level = "info", skip(self, filter))]
     pub(crate) async fn read_closed_schemas<'f>(
         &self,
         filter: &[Filter<'f, EntityTypeWithMetadata>],
@@ -134,7 +134,7 @@ impl<C: AsClient> PostgresStore<C> {
             }))
     }
 
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[tracing::instrument(level = "info", skip(self))]
     pub(crate) async fn read_ontology_edges<'r, L, R>(
         &self,
         record_ids: &'r OntologyTypeTraversalData,

--- a/libs/@local/graph/type-fetcher/src/store.rs
+++ b/libs/@local/graph/type-fetcher/src/store.rs
@@ -517,7 +517,7 @@ where
         .attach_printable("Could not check if ontology type exists")
     }
 
-    #[tracing::instrument(level = "trace", skip(self, ontology_type))]
+    #[tracing::instrument(level = "info", skip(self, ontology_type))]
     async fn collect_external_ontology_types<'o, T: OntologyTypeSchema + Sync>(
         &self,
         actor_id: ActorEntityUuid,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Spans with properties might become big, so we should not attach them.

## 🔍 What does this change?

- Avoid attaching properties to spans
- Raise a few spans to `info` level so they are discovered in prod

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change
- [x] are in a state where docs changes are not _yet_ required but will be

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph