### PR TITLE
H-4628: Allow batch-creation of policies

### DIFF
--- a/libs/@local/graph/authorization/src/policies/store/error.rs
+++ b/libs/@local/graph/authorization/src/policies/store/error.rs
@@ -5,7 +5,6 @@ use type_system::{
     knowledge::entity::id::EntityEditionId,
     ontology::VersionedUrl,
     principal::{
-        PrincipalId,
         actor::{ActorEntityUuid, ActorId},
         actor_group::{ActorGroupId, TeamId, WebId},
         role::RoleName,
@@ -296,12 +295,12 @@ impl Error for PolicyStoreError {}
 #[derive(Debug, derive_more::Display)]
 #[display("Policy operation failed: {_variant}")]
 pub enum CreatePolicyError {
-    #[display("Principal with ID `{id}` doesn't exist")]
-    PrincipalNotFound { id: PrincipalId },
-    #[display("Action `{id}` doesn't exist")]
-    ActionNotFound { id: ActionName },
-    #[display("Policy with ID `{id}` already exists")]
-    PolicyAlreadyExists { id: PolicyId },
+    #[display("One or more principals don't exist")]
+    PrincipalsNotFound,
+    #[display("One or more actions don't exist")]
+    ActionsNotFound,
+    #[display("One or more policies already exist")]
+    PoliciesAlreadyExist,
     #[display("No actions specified in policy")]
     PolicyHasNoActions,
     #[display("Invalid principal constraint")]

--- a/libs/@local/graph/authorization/src/policies/store/mod.rs
+++ b/libs/@local/graph/authorization/src/policies/store/mod.rs
@@ -177,16 +177,16 @@ pub trait PolicyStore {
     ///
     /// # Errors
     ///
-    /// - [`PolicyAlreadyExists`] if a policy with the same ID already exists
-    /// - [`PrincipalNotFound`] if the referenced principal does not exist
+    /// - [`PoliciesAlreadyExist`] if a policy with the same ID already exists
+    /// - [`PrincipalsNotFound`] if the referenced principal does not exist
     /// - [`PolicyHasNoActions`] if the policy is missing actions
-    /// - [`ActionNotFound`] if any of the actions do not exist
+    /// - [`ActionsNotFound`] if any of the actions do not exist
     /// - [`StoreError`] if a database or storage level error occurs
     ///
-    /// [`PolicyAlreadyExists`]: CreatePolicyError::PolicyAlreadyExists
-    /// [`PrincipalNotFound`]: CreatePolicyError::PrincipalNotFound
+    /// [`PoliciesAlreadyExist`]: CreatePolicyError::PoliciesAlreadyExist
+    /// [`PrincipalsNotFound`]: CreatePolicyError::PrincipalsNotFound
     /// [`PolicyHasNoActions`]: CreatePolicyError::PolicyHasNoActions
-    /// [`ActionNotFound`]: CreatePolicyError::ActionNotFound
+    /// [`ActionsNotFound`]: CreatePolicyError::ActionsNotFound
     /// [`StoreError`]: CreatePolicyError::StoreError
     async fn create_policy(
         &mut self,

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
@@ -1124,12 +1124,10 @@ where
             }
         }
 
-        for policy in policies {
-            transaction
-                .insert_policy_into_database(&policy)
-                .await
-                .change_context(InsertionError)?;
-        }
+        transaction
+            .insert_policies_into_database(policies)
+            .await
+            .change_context(InsertionError)?;
 
         ensure!(
             validation_reports.is_empty(),

--- a/libs/@local/graph/postgres-store/src/store/postgres/seed_policies.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/seed_policies.rs
@@ -1040,16 +1040,14 @@ impl PostgresStore<Transaction<'_>> {
                 .await
                 .change_context(EnsureSystemPoliciesError::RemoveOldPolicyFailed)?;
         }
-        for (index, policy) in policies_to_add.iter().enumerate() {
-            tracing::debug!(
-                policy_name = policy.name,
-                "Adding policy to database {index}/{}",
-                policies_to_add.len()
-            );
-            self.insert_policy_into_database(policy)
+
+        if !policies_to_add.is_empty() {
+            tracing::debug!("Adding {} policies to database", policies_to_add.len());
+            self.insert_policies_into_database(policies_to_add)
                 .await
                 .change_context(EnsureSystemPoliciesError::AddRequiredPoliciesFailed)?;
         }
+
         for (index, (policy_id, operations)) in policies_to_update.iter().enumerate() {
             tracing::debug!(
                 %policy_id,

--- a/libs/@local/graph/postgres-store/tests/principals/main.rs
+++ b/libs/@local/graph/postgres-store/tests/principals/main.rs
@@ -114,13 +114,13 @@ impl DatabaseTestWrapper {
 
         // Create a policy to allow the actor to create new policies
         transaction
-            .insert_policy_into_database(&PolicyCreationParams {
+            .insert_policies_into_database(&[PolicyCreationParams {
                 name: None,
                 effect: Effect::Permit,
                 principal: Some(PrincipalConstraint::Actor { actor }),
                 actions: vec![ActionName::CreatePolicy, ActionName::DeletePolicy],
                 resource: None,
-            })
+            }])
             .await
             .change_context(StoreError)?;
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

While we don't necessarily need batch-creation of policies in production, seeding tests and benchmarks are quite slow without it.

## 🔍 What does this change?

Change the internal `insert_policy_into_database` to take a batch of policies.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

The changes in this PR:

- [x] do not affect the execution graph