### PR TITLE
H-5158: Increase memory limit for TS workers

### DIFF
--- a/infra/terraform/hash/main.tf
+++ b/infra/terraform/hash/main.tf
@@ -251,7 +251,7 @@ module "application" {
   cpu                          = 2048
   memory                       = 4096
   worker_cpu                   = 256
-  worker_memory                = 1024
+  worker_memory                = 2048
   ses_verified_domain_identity = var.ses_verified_domain_identity
   graph_image                  = module.graph_ecr
   graph_migration_env_vars = concat(var.hash_graph_env_vars, [


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The TS workers currently hsare 1 GB RAM. This works, but they're constantly using 80% of the memory and only spiking a bit would OOM them.