### PR TITLE
T/h-5062-add-cloudwatch-metrics-receiver-for-ecs-cluster-wide-stats

### DIFF
--- a/infra/terraform/hash/observability/grafana/config.tf
+++ b/infra/terraform/hash/observability/grafana/config.tf
@@ -3,10 +3,11 @@
 # Configuration hash for task definition versioning
 locals {
   config_hash = sha256(jsonencode({
-    grafana_config   = aws_s3_object.grafana_config.content
-    tempo_datasource = aws_s3_object.grafana_tempo_datasource.content
-    loki_datasource  = aws_s3_object.grafana_loki_datasource.content
-    mimi_datasource  = aws_s3_object.grafana_mimir_datasource.content
+    grafana_config        = aws_s3_object.grafana_config.content
+    tempo_datasource      = aws_s3_object.grafana_tempo_datasource.content
+    loki_datasource       = aws_s3_object.grafana_loki_datasource.content
+    mimi_datasource       = aws_s3_object.grafana_mimir_datasource.content
+    cloudwatch_datasource = aws_s3_object.grafana_cloudwatch_datasource.content
   }))
 }
 
@@ -76,6 +77,21 @@ resource "aws_s3_object" "grafana_mimir_datasource" {
 
   tags = {
     Purpose = "Grafana Mimir Datasource"
+    Service = "grafana"
+  }
+}
+
+# CloudWatch datasource provisioning
+resource "aws_s3_object" "grafana_cloudwatch_datasource" {
+  bucket = var.config_bucket.id
+  key    = "grafana/provisioning/datasources/cloudwatch.yaml"
+  content = templatefile("${path.module}/templates/provisioning/datasources/cloudwatch.yaml.tpl", {
+    aws_region = var.region
+  })
+  content_type = "application/x-yaml"
+
+  tags = {
+    Purpose = "Grafana CloudWatch Datasource"
     Service = "grafana"
   }
 }

--- a/infra/terraform/hash/observability/grafana/iam.tf
+++ b/infra/terraform/hash/observability/grafana/iam.tf
@@ -105,4 +105,48 @@ resource "aws_iam_role" "task_role" {
     })
   }
 
+  inline_policy {
+    name = "cloudwatch-access"
+    policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Effect = "Allow"
+          Action = [
+            "cloudwatch:DescribeAlarmsForMetric",
+            "cloudwatch:DescribeAlarmHistory",
+            "cloudwatch:DescribeAlarms",
+            "cloudwatch:ListMetrics",
+            "cloudwatch:GetMetricData",
+            "cloudwatch:GetInsightRuleReport"
+          ]
+          Resource = "*"
+        },
+        {
+          Effect = "Allow"
+          Action = [
+            "logs:DescribeLogGroups",
+            "logs:DescribeLogStreams",
+            "logs:DescribeSubscriptionFilters",
+            "logs:DescribeMetricFilters",
+            "logs:DescribeQueries",
+            "logs:GetLogEvents",
+            "logs:FilterLogEvents",
+            "logs:StartQuery",
+            "logs:StopQuery",
+            "logs:GetQueryResults"
+          ]
+          Resource = "*"
+        },
+        {
+          Effect = "Allow"
+          Action = [
+            "tag:GetResources"
+          ]
+          Resource = "*"
+        }
+      ]
+    })
+  }
+
 }

--- a/infra/terraform/hash/observability/grafana/main.tf
+++ b/infra/terraform/hash/observability/grafana/main.tf
@@ -7,4 +7,5 @@ locals {
 
   grafana_port      = 3000
   grafana_port_name = "${local.service_name}-http"
+  grafana_dns       = "${local.grafana_port_name}.${var.service_discovery_namespace_name}"
 }

--- a/infra/terraform/hash/observability/grafana/outputs.tf
+++ b/infra/terraform/hash/observability/grafana/outputs.tf
@@ -12,3 +12,8 @@ output "grafana_port_name" {
   description = "Port name for Service Connect"
   value       = local.grafana_port_name
 }
+
+output "grafana_dns" {
+  description = "Service Connect DNS name for Grafana metrics endpoint"
+  value       = local.grafana_dns
+}

--- a/infra/terraform/hash/observability/grafana/service.tf
+++ b/infra/terraform/hash/observability/grafana/service.tf
@@ -84,7 +84,19 @@ resource "aws_ecs_task_definition" "grafana" {
         var.ssl_config.mount_point
       ]
 
-      environment = var.ssl_config.environment_vars
+      environment = concat(
+        var.ssl_config.environment_vars,
+        [
+          {
+            name  = "AWS_REGION"
+            value = var.region
+          },
+          {
+            name  = "AWS_DEFAULT_REGION"
+            value = var.region
+          }
+        ]
+      )
 
       secrets = [
         for env_name, ssm_param in aws_ssm_parameter.grafana_env_vars :

--- a/infra/terraform/hash/observability/grafana/templates/grafana.ini.tpl
+++ b/infra/terraform/hash/observability/grafana/templates/grafana.ini.tpl
@@ -37,3 +37,6 @@ provisioning = /etc/grafana/provisioning
 [analytics]
 reporting_enabled = false
 check_for_updates = false
+
+[metrics]
+enabled = true

--- a/infra/terraform/hash/observability/grafana/templates/provisioning/datasources/cloudwatch.yaml.tpl
+++ b/infra/terraform/hash/observability/grafana/templates/provisioning/datasources/cloudwatch.yaml.tpl
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+datasources:
+  - name: CloudWatch
+    type: cloudwatch
+    access: proxy
+    jsonData:
+      authType: default
+      defaultRegion: ${aws_region}
+      assumeRoleArn: ""
+    isDefault: false
+    editable: false

--- a/infra/terraform/hash/observability/main.tf
+++ b/infra/terraform/hash/observability/main.tf
@@ -12,6 +12,11 @@ data "aws_acm_certificate" "hash_wildcard_cert" {
 resource "aws_ecs_cluster" "observability" {
   name = var.prefix
 
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+
   service_connect_defaults {
     namespace = aws_service_discovery_private_dns_namespace.observability.arn
   }
@@ -145,6 +150,10 @@ module "otel_collector" {
   loki_http_port                   = module.loki.http_port
   mimir_http_dns                   = module.mimir.http_dns
   mimir_http_port                  = module.mimir.http_port
+  grafana_dns                      = module.grafana.grafana_dns
+  grafana_port                     = module.grafana.grafana_port
+  tempo_api_dns                    = module.tempo.api_dns
+  tempo_api_port                   = module.tempo.api_port
 
   ssl_config = local.aws_ca_ssl_config
 }

--- a/infra/terraform/hash/observability/otel_collector/config.tf
+++ b/infra/terraform/hash/observability/otel_collector/config.tf
@@ -20,6 +20,7 @@ resource "aws_s3_object" "otel_collector_config" {
   # Generate config from template with environment-specific parameters
   content = templatefile("${path.module}/templates/otel-collector.yaml.tpl", {
     environment          = local.otel_environment
+    prefix               = var.prefix
     batch_timeout        = "1s"
     batch_size           = 8192
     grpc_port_internal   = local.grpc_port_internal
@@ -27,12 +28,16 @@ resource "aws_s3_object" "otel_collector_config" {
     grpc_port_external   = local.grpc_port_external
     http_port_external   = local.http_port_external
     health_port          = local.health_port
+    tempo_api_dns        = var.tempo_api_dns
+    tempo_api_port       = var.tempo_api_port
     tempo_otlp_grpc_dns  = var.tempo_otlp_grpc_dns
     tempo_otlp_grpc_port = var.tempo_otlp_grpc_port
     loki_http_dns        = var.loki_http_dns
     loki_http_port       = var.loki_http_port
     mimir_http_dns       = var.mimir_http_dns
     mimir_http_port      = var.mimir_http_port
+    grafana_dns          = var.grafana_dns
+    grafana_port         = var.grafana_port
   })
 
   content_type = "application/x-yaml"

--- a/infra/terraform/hash/observability/otel_collector/security_groups.tf
+++ b/infra/terraform/hash/observability/otel_collector/security_groups.tf
@@ -112,6 +112,24 @@ resource "aws_security_group" "otel_collector" {
     cidr_blocks = [var.vpc.cidr_block]
   }
 
+  # Allow outbound traffic to Tempo API for metrics scraping
+  egress {
+    from_port   = var.tempo_api_port
+    to_port     = var.tempo_api_port
+    protocol    = "tcp"
+    description = "HTTP to Tempo API for metrics scraping"
+    cidr_blocks = [var.vpc.cidr_block]
+  }
+
+  # Allow outbound traffic to Grafana for metrics scraping
+  egress {
+    from_port   = var.grafana_port
+    to_port     = var.grafana_port
+    protocol    = "tcp"
+    description = "HTTP to Grafana for metrics scraping"
+    cidr_blocks = [var.vpc.cidr_block]
+  }
+
   tags = {
     Name    = "${local.prefix}-sg"
     Purpose = "OpenTelemetry Collector security group"

--- a/infra/terraform/hash/observability/otel_collector/templates/otel-collector.yaml.tpl
+++ b/infra/terraform/hash/observability/otel_collector/templates/otel-collector.yaml.tpl
@@ -19,6 +19,35 @@ receivers:
       http:
         endpoint: 0.0.0.0:${http_port_external}
 
+  prometheus:
+    config:
+      scrape_configs:
+        # Observability stack services self-monitoring
+        - job_name: ${prefix}-otel-gateway
+          scrape_interval: 5s
+          static_configs:
+            - targets: [localhost:8888]
+        - job_name: '${prefix}-grafana'
+          scrape_interval: 30s
+          static_configs:
+            - targets: ['${grafana_dns}:${grafana_port}']
+          metrics_path: '/metrics'
+        - job_name: '${prefix}-mimir'
+          scrape_interval: 30s
+          static_configs:
+            - targets: ['${mimir_http_dns}:${mimir_http_port}']
+          metrics_path: '/metrics'
+        - job_name: '${prefix}-loki'
+          scrape_interval: 30s
+          static_configs:
+            - targets: ['${loki_http_dns}:${loki_http_port}']
+          metrics_path: '/metrics'
+        - job_name: '${prefix}-tempo'
+          scrape_interval: 30s
+          static_configs:
+            - targets: ['${tempo_api_dns}:${tempo_api_port}']
+          metrics_path: '/metrics'
+
 processors:
   # Memory limiter to prevent OOM kills (512MB container - 50MB overhead = ~450MB limit)
   memory_limiter:
@@ -71,6 +100,19 @@ extensions:
 
 service:
   extensions: [health_check]
+  telemetry:
+    resource:
+      # This will set the `job` label for this service so it
+      # should be aligned with the `job_name`
+      service.name: ${prefix}-otel-gateway
+    metrics:
+      level: basic
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: 0.0.0.0
+                port: 8888
 
   pipelines:
     # Input pipelines - add environment attributes and forward to common processing
@@ -113,7 +155,7 @@ service:
       exporters: [otlp/tempo]
 
     metrics:
-      receivers: [forward/metrics]
+      receivers: [forward/metrics, prometheus]
       processors: [batch]
       exporters: [otlphttp/mimir]
 

--- a/infra/terraform/hash/observability/otel_collector/variables.tf
+++ b/infra/terraform/hash/observability/otel_collector/variables.tf
@@ -41,6 +41,16 @@ variable "service_discovery_namespace_name" {
   description = "Name of the service discovery namespace for Service Connect"
 }
 
+variable "tempo_api_dns" {
+  type        = string
+  description = "Tempo API DNS name for metrics scraping"
+}
+
+variable "tempo_api_port" {
+  type        = number
+  description = "Tempo API port number"
+}
+
 variable "tempo_otlp_grpc_dns" {
   type        = string
   description = "Tempo OTLP gRPC DNS name for trace forwarding"
@@ -73,4 +83,14 @@ variable "mimir_http_port" {
 
 variable "ssl_config" {
   description = "Shared SSL configuration for container certificates"
+}
+
+variable "grafana_dns" {
+  type        = string
+  description = "Grafana service DNS name for metrics scraping"
+}
+
+variable "grafana_port" {
+  type        = number
+  description = "Grafana service port number"
 }

--- a/infra/terraform/hash/observability/tempo/templates/tempo.yaml.tpl
+++ b/infra/terraform/hash/observability/tempo/templates/tempo.yaml.tpl
@@ -52,7 +52,7 @@ metrics_generator:
     path: /var/tempo/generator/traces
   processor:
     span_metrics:
-      dimensions: ["service.name", "http.method", "status_code"]
+      dimensions: ["service.name", "status_code"]
     service_graphs: {}
     local_blocks: {}
 

--- a/infra/terraform/modules/container_cluster/main.tf
+++ b/infra/terraform/modules/container_cluster/main.tf
@@ -1,5 +1,11 @@
 resource "aws_ecs_cluster" "ecs" {
   name = "${var.prefix}-${var.ecs_name}"
+  
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+  
   tags = {}
 }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To implement proper healthchecks, we require metrics from AWS through CloudWatch and ideally also various metrics we can read from the observability stack.

This PR adds a CloudWatch data source and connects the existing observability stack metrics.