### PR TITLE
H-4943: Add new data sources

### DIFF
--- a/apps/hash-frontend/public/icons/integrations/00-README.md
+++ b/apps/hash-frontend/public/icons/integrations/00-README.md
@@ -3,3 +3,5 @@
 These icons are referenced from MDX files in `hashdotai/integrations`.
 
 Don't change them or move them without updating the references in those files.
+
+These SVGs will all be deprecated in due course as outlined in [hash#7738](https://github.com/hashintel/hash/pull/7738).

--- a/content/hashdotai/integrations/integration-list.json
+++ b/content/hashdotai/integrations/integration-list.json
@@ -348,5 +348,85 @@
     "availability": "Considered",
     "audience": ["Enterprise", "Startup"],
     "category": ["Project Management"]
+  },
+  {
+    "name": "Databricks",
+    "logoUrl": "https://app.hash.ai/icons/integrations/icon_databricks.svg",
+    "productUrl": "https://www.databricks.com/product/data-intelligence-platform",
+    "summaryHtml": "Full access to lakehouse and data intelligence",
+    "integrationUrl": "https://app.hash.ai/settings/integrations/databricks",
+    "availability": "Available",
+    "audience": ["Enterprise", "Startup"],
+    "category": ["Data"]
+  },
+  {
+    "name": "Snowflake",
+    "logoUrl": "https://app.hash.ai/icons/integrations/icon_snowflake.svg",
+    "productUrl": "https://www.snowflake.com/en/product/platform/",
+    "summaryHtml": "Full access to data cloud assets",
+    "integrationUrl": "https://app.hash.ai/settings/integrations/snowflake",
+    "availability": "Considered",
+    "audience": ["Enterprise", "Startup"],
+    "category": ["Data"]
+  },
+  {
+    "name": "BigQuery",
+    "logoUrl": "https://app.hash.ai/icons/integrations/icon_bigquery.svg",
+    "productUrl": "https://cloud.google.com/bigquery",
+    "summaryHtml": "Full access to data warehouse",
+    "integrationUrl": "https://app.hash.ai/settings/integrations/bigquery",
+    "availability": "Considered",
+    "audience": ["Enterprise", "Startup"],
+    "category": ["Data"]
+  },
+  {
+    "name": "Amazon Redshift",
+    "logoUrl": "https://app.hash.ai/icons/integrations/icon_redshift.svg",
+    "productUrl": "https://aws.amazon.com/redshift/",
+    "summaryHtml": "Full access to cloud data warehouse",
+    "integrationUrl": "https://app.hash.ai/settings/integrations/redshift",
+    "availability": "Considered",
+    "audience": ["Enterprise", "Startup"],
+    "category": ["Data"]
+  },
+  {
+    "name": "Cloudflare R2",
+    "logoUrl": "https://app.hash.ai/icons/integrations/icon_cloudflare.svg",
+    "productUrl": "https://www.cloudflare.com/developer-platform/products/r2/",
+    "summaryHtml": "Full access to object storage and data",
+    "integrationUrl": "https://app.hash.ai/settings/integrations/cloudflare-r2",
+    "availability": "Considered",
+    "audience": ["Enterprise", "Startup"],
+    "category": ["Data"]
+  },
+  {
+    "name": "Cloudflare D1",
+    "logoUrl": "https://app.hash.ai/icons/integrations/icon_cloudflare.svg",
+    "productUrl": "https://www.cloudflare.com/developer-platform/products/d1/",
+    "summaryHtml": "Full access to Cloudflare SQL databases",
+    "integrationUrl": "https://app.hash.ai/settings/integrations/cloudflare-d1",
+    "availability": "Considered",
+    "audience": ["Enterprise", "Startup"],
+    "category": ["Data"]
+  },
+  {
+    "name": "Azure Data Lake Storage",
+    "logoUrl": "https://app.hash.ai/icons/integrations/icon_azure.svg",
+    "productUrl": "https://azure.microsoft.com/en-us/products/storage/data-lake-storage",
+    "summaryHtml": "Full access to secure data lake",
+    "integrationUrl": "https://app.hash.ai/settings/integrations/azure-data-lake-storage",
+    "availability": "Considered",
+    "audience": ["Enterprise", "Startup"],
+    "category": ["Data"]
+  },
+  {
+    "name": "Postgres",
+    "logoUrl": "https://app.hash.ai/icons/integrations/icon_postgres.svg",
+    "productUrl": "https://www.postgresql.org/",
+    "summaryHtml": "Full access to PostgreSQL object-relational databases",
+    "integrationUrl": "https://app.hash.ai/settings/integrations/postgres",
+    "availability": "Considered",
+    "audience": ["Enterprise", "Startup"],
+    "category": ["Data"]
   }
 ]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Adds homepage-featured data sources to the list of integrations at `/integrations`.

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

`.tsx` icons for these integrations do all exist in the [internal repo](https://github.com/hashintel/internal/tree/main/apps/hashdotai/src/app/shared/icons/integrations)... but not at the public URLs stated in the metadata here (which would be [in this dir](https://github.com/hashintel/hash/tree/main/apps/hash-frontend/public/icons/integrations) if they did exist). This means the icons will be broken in the HASH app. Creating these assets would be a waste of time, however, for the reasons outlined below.

## 🐾 Next steps

Rather than maintain a list of integrations separately in the `hash` repo and `internal` repo, along with `tsx` _and_ `svg` icons, we want one source of truth.

We will move towards the `tsx`-based approach to icon rendering globally, in lieu of having SVG URLs, and we will use this `integration-list.json` file as the definitive list of all integrations to be shown inside of the HASH application, as well as on the [hash.ai](https://hash.ai/) website (and in future [hash.dev](https://hash.dev/) website).

When we do that:

- [ ] We will move this `integration-list.json` file into a new package in the `/libs` directory of this repo, out of its current `/content/hashdotai/integrations` location.
- [ ] We will move the `.tsx` icons out of the `internal` repo and into this new package in this public repo.
- [ ] We will publish this package and consume it in both the HASH application, and our sales site(s).
