### PR TITLE
H-5221: Create explicit turbo-prune dependencies to `@apps/hash-graph` from type fetcher and test server

### DIFF
--- a/.github/actions/prune-repository/action.yml
+++ b/.github/actions/prune-repository/action.yml
@@ -32,6 +32,12 @@ runs:
           if echo "$DEPENDENCIES" | grep -q "@rust/hash-graph-postgres-queries"; then
             SCOPES="$SCOPES @local/repo-chores"
           fi
+          if echo "$DEPENDENCIES" | grep -q "@rust/hash-graph-type-fetcher"; then
+            SCOPES="$SCOPES @apps/hash-graph"
+          fi
+          if echo "$DEPENDENCIES" | grep -q "@rust/hash-graph-test-server"; then
+            SCOPES="$SCOPES @apps/hash-graph"
+          fi
         done <<< "${{ inputs.scope }}"
 
         # Deduplicate scopes


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Turbo has issues with circular dependencies so we need to manually add some dependencies in CI. Two dependencies are not modeled, yet:

* `@rust/hash-graph-type-fetcher` -> `@apps/hash-graph`
* `@rust/hash-graph-test-server` -> `@apps/hash-graph`
