### PR TITLE
H-5233: Fix wrong turbo configuration in postgres store

### DIFF
--- a/libs/@local/graph/postgres-store/turbo.json
+++ b/libs/@local/graph/postgres-store/turbo.json
@@ -4,7 +4,7 @@
     "dev": {
       "cache": false,
       "persistent": true,
-      "dependsOn": ["@apps/hash-graph#dev:migrate"]
+      "dependsOn": ["@apps/hash-graph#start:test:migrate"]
     },
     "test:integration": {
       "dependsOn": ["@rust/hash-graph-migrations#start:migrate:up"]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

`dev:migrate` does not exist, but `start:test:migrate` does.