### PR TITLE
H-5234: Fix SemGrep CI job failing

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -18,6 +18,10 @@ jobs:
   semgrep:
     name: Scan
 
+    permissions:
+      contents: read
+      security-events: write
+
     # Change this in the event of future self-hosting of Action runner:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

SemGrep needs to upload its findings. This requires a permission.

## 🔗 Related links

- Failing job: https://github.com/hashintel/hash/actions/runs/17158231488/job/48680479129