### PR TITLE
H-5214: Implement distribution-based value sampling for string and number schemas

### DIFF
--- a/tests/graph/benches/graph/scenario/runner.rs
+++ b/tests/graph/benches/graph/scenario/runner.rs
@@ -266,7 +266,7 @@ impl Runner {
 
                 make_producer()
                     .change_context(ScenarioError::CreateProducer)?
-                    .iter_mut(&context)
+                    .iter_mut(context)
                     .take(take_n)
                     .map(|result| result.change_context(ScenarioError::Generate))
                     .collect::<Result<Vec<T>, Report<ScenarioError>>>()

--- a/tests/graph/test-data/rust/src/seeding/context.rs
+++ b/tests/graph/test-data/rust/src/seeding/context.rs
@@ -66,8 +66,6 @@ use rand::{Rng, RngCore, rand_core::impls::fill_bytes_via_next};
 use uuid::Uuid;
 use xxhash_rust::xxh3::xxh3_64;
 
-use super::producer::Producer;
-
 /// Identifies a run used to derive independent RNG streams.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct RunId(u16);
@@ -443,6 +441,11 @@ pub enum Scope {
     Conversions,
     Config,
     Metadata,
+    Boolean,
+    Number,
+    String,
+    Array,
+    Object,
     Anonymous = 0xFF,
 }
 
@@ -465,6 +468,11 @@ impl Scope {
             5 => Ok(Self::Conversions),
             6 => Ok(Self::Config),
             7 => Ok(Self::Metadata),
+            8 => Ok(Self::Boolean),
+            9 => Ok(Self::Number),
+            10 => Ok(Self::String),
+            11 => Ok(Self::Array),
+            12 => Ok(Self::Object),
             0xFF => Ok(Self::Anonymous),
             _ => Err(ParseScopeError { scope: value }),
         }

--- a/tests/graph/test-data/rust/src/seeding/distributions/mod.rs
+++ b/tests/graph/test-data/rust/src/seeding/distributions/mod.rs
@@ -2,6 +2,7 @@ use error_stack::IntoReport;
 
 pub mod adaptors;
 pub mod ontology;
+pub mod value;
 
 pub trait DistributionConfig {
     type Error: IntoReport;

--- a/tests/graph/test-data/rust/src/seeding/distributions/value/mod.rs
+++ b/tests/graph/test-data/rust/src/seeding/distributions/value/mod.rs
@@ -1,0 +1,5 @@
+mod number;
+mod string;
+
+pub use number::NumberValueDistribution;
+pub use string::{StringValueDistribution, StringValueDistributionError};

--- a/tests/graph/test-data/rust/src/seeding/distributions/value/number.rs
+++ b/tests/graph/test-data/rust/src/seeding/distributions/value/number.rs
@@ -57,10 +57,11 @@ impl<'e> NumberValueDistribution<'e> {
         };
 
         let (lo, hi, inclusive) = match (min, max) {
-            (Some((min, true)), Some((max, inclusive))) => (min + 0.0001, max, inclusive),
+            (Some((min, true)), Some((max, inclusive))) => (min.next_up(), max, inclusive),
             (Some((min, false)), Some((max, inclusive))) => (min, max, inclusive),
             (None, Some((max, inclusive))) => (max - (max * 0.01).abs(), max, inclusive),
-            (Some((min, inclusive)), None) => (min + 0.0001, min + (min * 100.).abs(), inclusive),
+            (Some((min, true)), None) => (min.next_up(), min + (min * 100.).abs(), true),
+            (Some((min, false)), None) => (min, min + (min * 100.).abs(), false),
             (None, None) => (-1000., 1000., true),
         };
 

--- a/tests/graph/test-data/rust/src/seeding/distributions/value/number.rs
+++ b/tests/graph/test-data/rust/src/seeding/distributions/value/number.rs
@@ -1,0 +1,129 @@
+use alloc::borrow::Cow;
+use core::{error::Error, f64};
+
+use error_stack::{Report, ResultExt as _};
+use hash_codec::numeric::Real;
+use rand::{Rng, seq::IndexedRandom as _};
+use rand_distr::{Distribution, Uniform};
+use type_system::ontology::json_schema::{NumberConstraints, NumberSchema};
+
+#[derive(Debug, derive_more::Display)]
+pub enum NumberValueDistributionError {
+    #[display("Enum is empty")]
+    EmptyEnum,
+    #[display("Invalid string length")]
+    MinMax,
+    #[display("Failed to convert number to real")]
+    Conversion,
+}
+
+impl Error for NumberValueDistributionError {}
+
+pub enum NumberValueDistribution<'e> {
+    Constraints { value: Uniform<f64> },
+    Enum { choices: Cow<'e, [Real]> },
+}
+
+impl<'e> NumberValueDistribution<'e> {
+    #[expect(clippy::todo, reason = "Incomplete implementation")]
+    #[expect(
+        clippy::float_arithmetic,
+        reason = "We need to calculate missing ranges"
+    )]
+    fn from_constraints(
+        constraints: &NumberConstraints,
+    ) -> Result<Self, Report<NumberValueDistributionError>> {
+        if constraints.multiple_of.is_some() {
+            todo!(
+                "https://linear.app/hash/issue/H-5238/support-value-seeding-for-mulipleof-numbers"
+            );
+        }
+
+        let min = match (&constraints.minimum, &constraints.exclusive_minimum) {
+            (Some(min), Some(exclusive_min)) if min > exclusive_min => {
+                Some((min.to_f64_lossy(), false))
+            }
+            (_, Some(exclusive_min)) => Some((exclusive_min.to_f64_lossy(), true)),
+            (Some(min), None) => Some((min.to_f64_lossy(), false)),
+            (None, None) => None,
+        };
+        let max = match (&constraints.maximum, &constraints.exclusive_maximum) {
+            (Some(max), Some(exclusive_max)) if max < exclusive_max => {
+                Some((max.to_f64_lossy(), false))
+            }
+            (_, Some(exclusive_max)) => Some((exclusive_max.to_f64_lossy(), true)),
+            (Some(max), None) => Some((max.to_f64_lossy(), false)),
+            (None, None) => None,
+        };
+
+        let (lo, hi, inclusive) = match (min, max) {
+            (Some((min, true)), Some((max, inclusive))) => (min + 0.0001, max, inclusive),
+            (Some((min, false)), Some((max, inclusive))) => (min, max, inclusive),
+            (None, Some((max, inclusive))) => (max - (max * 0.01).abs(), max, inclusive),
+            (Some((min, inclusive)), None) => (min + 0.0001, min + (min * 100.).abs(), inclusive),
+            (None, None) => (-1000., 1000., true),
+        };
+
+        Ok(Self::Constraints {
+            value: if inclusive {
+                Uniform::new_inclusive(lo, hi)
+                    .change_context(NumberValueDistributionError::MinMax)?
+            } else {
+                Uniform::new(lo, hi).change_context(NumberValueDistributionError::MinMax)?
+            },
+        })
+    }
+
+    fn from_enum(
+        choices: impl Into<Cow<'e, [Real]>>,
+    ) -> Result<Self, Report<NumberValueDistributionError>> {
+        let choices = choices.into();
+
+        if choices.is_empty() {
+            return Err(NumberValueDistributionError::EmptyEnum.into());
+        }
+
+        Ok(Self::Enum { choices })
+    }
+}
+
+impl TryFrom<NumberSchema> for NumberValueDistribution<'_> {
+    type Error = Report<NumberValueDistributionError>;
+
+    fn try_from(schema: NumberSchema) -> Result<Self, Self::Error> {
+        match schema {
+            NumberSchema::Constrained(constraints) => Self::from_constraints(&constraints),
+            NumberSchema::Enum { r#enum } => Self::from_enum(r#enum),
+        }
+    }
+}
+
+impl<'a> TryFrom<&'a NumberSchema> for NumberValueDistribution<'a> {
+    type Error = Report<NumberValueDistributionError>;
+
+    fn try_from(schema: &'a NumberSchema) -> Result<Self, Self::Error> {
+        match schema {
+            NumberSchema::Constrained(constraints) => Self::from_constraints(constraints),
+            NumberSchema::Enum { r#enum } => Self::from_enum(r#enum),
+        }
+    }
+}
+
+impl Distribution<Real> for NumberValueDistribution<'_> {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Real {
+        match self {
+            Self::Constraints { value } => {
+                let value = value.sample(rng);
+                Real::try_from(value).unwrap_or_else(|error| {
+                    unreachable!("Sampled value should never be `NaN`: {error}")
+                })
+            }
+            Self::Enum { choices } => {
+                let choice = choices
+                    .choose(rng)
+                    .unwrap_or_else(|| unreachable!("Choices somehow became empty"));
+                choice.clone()
+            }
+        }
+    }
+}

--- a/tests/graph/test-data/rust/src/seeding/distributions/value/string.rs
+++ b/tests/graph/test-data/rust/src/seeding/distributions/value/string.rs
@@ -28,6 +28,11 @@ pub enum StringValueDistribution<'e> {
 
 impl<'e> StringValueDistribution<'e> {
     #[expect(clippy::todo, reason = "Incomplete implementation")]
+    #[expect(
+        clippy::integer_division,
+        clippy::integer_division_remainder_used,
+        reason = "We need to fill missing ranges and precision is not important here"
+    )]
     fn from_constraints(
         constraints: &StringConstraints,
     ) -> Result<Self, Report<StringValueDistributionError>> {
@@ -41,8 +46,8 @@ impl<'e> StringValueDistribution<'e> {
 
         let (min, max) = match (constraints.min_length, constraints.max_length) {
             (Some(min), Some(max)) => (min, max),
-            (Some(min), None) => (min, min << 2),
-            (None, Some(max)) => (max >> 2, max),
+            (Some(min), None) => (min, min * 4),
+            (None, Some(max)) => (max / 4, max),
             (None, None) => (4, 16),
         };
 
@@ -99,7 +104,7 @@ impl Distribution<String> for StringValueDistribution<'_> {
             Self::Enum { choices } => {
                 let choice = choices
                     .choose(rng)
-                    .unwrap_or_else(|| unreachable!("Choices somehow became empty"));
+                    .expect("Enum should always have at least one choice");
                 choice.clone()
             }
         }

--- a/tests/graph/test-data/rust/src/seeding/distributions/value/string.rs
+++ b/tests/graph/test-data/rust/src/seeding/distributions/value/string.rs
@@ -1,0 +1,107 @@
+use alloc::borrow::Cow;
+use core::error::Error;
+
+use error_stack::{Report, ResultExt as _};
+use rand::{Rng, distr::Alphabetic, seq::IndexedRandom as _};
+use rand_distr::{Distribution, Uniform};
+use type_system::ontology::json_schema::{StringConstraints, StringSchema};
+
+#[derive(Debug, derive_more::Display)]
+pub enum StringValueDistributionError {
+    #[display("Enum is empty")]
+    EmptyEnum,
+    #[display("Invalid string length")]
+    StringLength,
+}
+
+impl Error for StringValueDistributionError {}
+
+pub enum StringValueDistribution<'e> {
+    Constraints {
+        length: Uniform<usize>,
+        alphabet: Alphabetic,
+    },
+    Enum {
+        choices: Cow<'e, [String]>,
+    },
+}
+
+impl<'e> StringValueDistribution<'e> {
+    #[expect(clippy::todo, reason = "Incomplete implementation")]
+    fn from_constraints(
+        constraints: &StringConstraints,
+    ) -> Result<Self, Report<StringValueDistributionError>> {
+        if constraints.format.is_some() {
+            todo!("https://linear.app/hash/issue/H-5236/support-value-seeding-for-format-strings");
+        }
+
+        if constraints.pattern.is_some() {
+            todo!("https://linear.app/hash/issue/H-5237/support-value-seeding-for-pattern-strings");
+        }
+
+        let (min, max) = match (constraints.min_length, constraints.max_length) {
+            (Some(min), Some(max)) => (min, max),
+            (Some(min), None) => (min, min << 2),
+            (None, Some(max)) => (max >> 2, max),
+            (None, None) => (4, 16),
+        };
+
+        Ok(Self::Constraints {
+            length: Uniform::new(min, max)
+                .change_context(StringValueDistributionError::StringLength)?,
+            alphabet: Alphabetic,
+        })
+    }
+
+    fn from_enum(
+        choices: impl Into<Cow<'e, [String]>>,
+    ) -> Result<Self, Report<StringValueDistributionError>> {
+        let choices = choices.into();
+
+        if choices.is_empty() {
+            return Err(StringValueDistributionError::EmptyEnum.into());
+        }
+
+        Ok(Self::Enum { choices })
+    }
+}
+
+impl TryFrom<StringSchema> for StringValueDistribution<'_> {
+    type Error = Report<StringValueDistributionError>;
+
+    fn try_from(schema: StringSchema) -> Result<Self, Self::Error> {
+        match schema {
+            StringSchema::Constrained(constraints) => Self::from_constraints(&constraints),
+            StringSchema::Enum { r#enum } => Self::from_enum(r#enum),
+        }
+    }
+}
+
+impl<'a> TryFrom<&'a StringSchema> for StringValueDistribution<'a> {
+    type Error = Report<StringValueDistributionError>;
+
+    fn try_from(schema: &'a StringSchema) -> Result<Self, Self::Error> {
+        match schema {
+            StringSchema::Constrained(constraints) => Self::from_constraints(constraints),
+            StringSchema::Enum { r#enum } => Self::from_enum(r#enum),
+        }
+    }
+}
+
+impl Distribution<String> for StringValueDistribution<'_> {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> String {
+        match self {
+            Self::Constraints { length, alphabet } => {
+                let length = length.sample(rng);
+                String::from_utf8(alphabet.sample_iter(rng).take(length).collect())
+                    .expect("should be able to convert chars to string")
+            }
+            Self::Enum { choices } => {
+                let choice = choices
+                    .choose(rng)
+                    .unwrap_or_else(|| unreachable!("Choices somehow became empty"));
+                choice.clone()
+            }
+        }
+    }
+}

--- a/tests/graph/test-data/rust/src/seeding/producer/data_type.rs
+++ b/tests/graph/test-data/rust/src/seeding/producer/data_type.rs
@@ -165,7 +165,7 @@ impl<U: WebCatalog, O: WebCatalog> Producer<CreateDataTypeParams> for DataTypePr
 
     const ID: ProducerId = ProducerId::DataType;
 
-    fn generate(&mut self, context: &ProduceContext) -> Result<CreateDataTypeParams, Self::Error> {
+    fn generate(&mut self, context: ProduceContext) -> Result<CreateDataTypeParams, Self::Error> {
         let local_id = self.local_id.take_and_advance();
 
         let domain_gid = context.global_id(local_id, Scope::Schema, SubScope::Domain);
@@ -735,7 +735,7 @@ pub(crate) mod tests {
             producer: UserProducer::ID,
         };
         let users: Vec<UserCreation> =
-            iter::repeat_with(|| user_prod.generate(&ctx).expect("should generate user"))
+            iter::repeat_with(|| user_prod.generate(ctx).expect("should generate user"))
                 .take(10)
                 .collect();
 

--- a/tests/graph/test-data/rust/src/seeding/producer/entity_type.rs
+++ b/tests/graph/test-data/rust/src/seeding/producer/entity_type.rs
@@ -180,10 +180,7 @@ impl<U: WebCatalog, O: WebCatalog, P: PropertyTypeCatalog> Producer<CreateEntity
 
     const ID: ProducerId = ProducerId::EntityType;
 
-    fn generate(
-        &mut self,
-        context: &ProduceContext,
-    ) -> Result<CreateEntityTypeParams, Self::Error> {
+    fn generate(&mut self, context: ProduceContext) -> Result<CreateEntityTypeParams, Self::Error> {
         let local_id = self.local_id.take_and_advance();
 
         let domain_gid = context.global_id(local_id, Scope::Schema, SubScope::Domain);
@@ -453,7 +450,7 @@ mod tests {
         };
 
         let entity_type = producer
-            .generate(&context)
+            .generate(context)
             .expect("should generate entity type");
 
         // Verify generated entity type structure

--- a/tests/graph/test-data/rust/src/seeding/producer/mod.rs
+++ b/tests/graph/test-data/rust/src/seeding/producer/mod.rs
@@ -32,6 +32,7 @@ pub mod data_type;
 pub mod ontology;
 pub mod property_type;
 pub mod user;
+pub mod value;
 
 /// Stateful producer of complex values composed from one or more distributions.
 ///
@@ -60,7 +61,7 @@ pub trait Producer<T> {
 }
 
 pub trait ProducerExt<T>: Producer<T> {
-    fn iter_mut<'c>(&mut self, context: ProduceContext) -> ProducerIter<'_, Self, T>
+    fn iter_mut(&mut self, context: ProduceContext) -> ProducerIter<'_, Self, T>
     where
         Self: Sized;
 }

--- a/tests/graph/test-data/rust/src/seeding/producer/property_type.rs
+++ b/tests/graph/test-data/rust/src/seeding/producer/property_type.rs
@@ -174,7 +174,7 @@ impl<U: WebCatalog, O: WebCatalog, D: DataTypeCatalog> Producer<CreatePropertyTy
 
     fn generate(
         &mut self,
-        context: &ProduceContext,
+        context: ProduceContext,
     ) -> Result<CreatePropertyTypeParams, Self::Error> {
         let local_id = self.local_id.take_and_advance();
 
@@ -375,7 +375,7 @@ pub(crate) mod tests {
         };
 
         let property_type = producer
-            .generate(&context)
+            .generate(context)
             .expect("should generate property type");
         assert!(!property_type.schema.title.is_empty());
         assert!(!property_type.schema.description.is_empty());

--- a/tests/graph/test-data/rust/src/seeding/producer/user.rs
+++ b/tests/graph/test-data/rust/src/seeding/producer/user.rs
@@ -76,7 +76,7 @@ impl Producer<UserCreation> for UserProducer {
 
     const ID: ProducerId = ProducerId::User;
 
-    fn generate(&mut self, context: &ProduceContext) -> Result<UserCreation, Self::Error> {
+    fn generate(&mut self, context: ProduceContext) -> Result<UserCreation, Self::Error> {
         let local_id = self.local_id.take_and_advance();
 
         let id_gid = context.global_id(local_id, Scope::Id, SubScope::Unknown);

--- a/tests/graph/test-data/rust/src/seeding/producer/value.rs
+++ b/tests/graph/test-data/rust/src/seeding/producer/value.rs
@@ -1,0 +1,159 @@
+use core::error::Error;
+
+use error_stack::{Report, ResultExt as _};
+use rand_distr::{Bernoulli, Distribution as _};
+use type_system::{
+    knowledge::PropertyValue,
+    ontology::{
+        data_type::schema::ValidateDataTypeError,
+        json_schema::{SingleValueConstraints, ValueConstraints},
+    },
+};
+
+use super::Producer;
+use crate::seeding::{
+    context::{LocalId, ProduceContext, ProducerId, Scope, SubScope},
+    distributions::value::{NumberValueDistribution, StringValueDistribution},
+};
+
+enum ValueDistribution<'c> {
+    Null,
+    Boolean(Bernoulli),
+    Number(NumberValueDistribution<'c>),
+    String(StringValueDistribution<'c>),
+}
+
+impl ValueDistribution<'_> {
+    fn boolean() -> Self {
+        ValueDistribution::Boolean(Bernoulli::new(0.5).unwrap_or_else(|error| {
+            unreachable!("Bernoulli distribution should always be able to be created: {error}")
+        }))
+    }
+}
+
+#[derive(Debug, derive_more::Display)]
+#[display("Invalid {_variant} distribution")]
+pub enum ValueProducerError {
+    #[display("number")]
+    Number,
+    #[display("string")]
+    String,
+}
+
+impl Error for ValueProducerError {}
+
+impl TryFrom<ValueConstraints> for ValueDistribution<'_> {
+    type Error = Report<ValueProducerError>;
+
+    #[expect(clippy::todo, reason = "Incomplete implementation")]
+    fn try_from(constraints: ValueConstraints) -> Result<Self, Self::Error> {
+        match constraints {
+            ValueConstraints::Typed(typed) => match *typed {
+                SingleValueConstraints::Null => Ok(Self::Null),
+                SingleValueConstraints::Boolean => Ok(Self::boolean()),
+                SingleValueConstraints::Number(number) => NumberValueDistribution::try_from(number)
+                    .map(Self::Number)
+                    .change_context(ValueProducerError::Number),
+                SingleValueConstraints::String(string) => StringValueDistribution::try_from(string)
+                    .map(Self::String)
+                    .change_context(ValueProducerError::String),
+                SingleValueConstraints::Array(_) => {
+                    todo!("https://linear.app/hash/issue/H-5239/support-value-seeding-for-arrays")
+                }
+                SingleValueConstraints::Object => {
+                    todo!("https://linear.app/hash/issue/H-5240/support-value-seeding-for-objects")
+                }
+            },
+            ValueConstraints::AnyOf(_) => {
+                todo!("https://linear.app/hash/issue/H-5241/support-value-seeding-for-anyof-types")
+            }
+        }
+    }
+}
+
+impl<'c> TryFrom<&'c ValueConstraints> for ValueDistribution<'c> {
+    type Error = Report<ValueProducerError>;
+
+    #[expect(clippy::todo, reason = "Incomplete implementation")]
+    fn try_from(constraints: &'c ValueConstraints) -> Result<Self, Self::Error> {
+        match constraints {
+            ValueConstraints::Typed(typed) => match &**typed {
+                SingleValueConstraints::Null => Ok(Self::Null),
+                SingleValueConstraints::Boolean => Ok(Self::boolean()),
+                SingleValueConstraints::Number(number) => NumberValueDistribution::try_from(number)
+                    .map(Self::Number)
+                    .change_context(ValueProducerError::Number),
+                SingleValueConstraints::String(string) => StringValueDistribution::try_from(string)
+                    .map(Self::String)
+                    .change_context(ValueProducerError::String),
+                SingleValueConstraints::Array(_) => {
+                    todo!("https://linear.app/hash/issue/H-5239/support-value-seeding-for-arrays")
+                }
+                SingleValueConstraints::Object => {
+                    todo!("https://linear.app/hash/issue/H-5240/support-value-seeding-for-objects")
+                }
+            },
+            ValueConstraints::AnyOf(_) => {
+                todo!("https://linear.app/hash/issue/H-5241/support-value-seeding-for-anyof-types")
+            }
+        }
+    }
+}
+
+pub struct ValueProducer<'e> {
+    local_id: LocalId,
+    value: ValueDistribution<'e>,
+}
+
+impl TryFrom<ValueConstraints> for ValueProducer<'_> {
+    type Error = Report<ValueProducerError>;
+
+    fn try_from(constraints: ValueConstraints) -> Result<Self, Self::Error> {
+        Ok(ValueProducer {
+            local_id: LocalId::default(),
+            value: ValueDistribution::try_from(constraints)?,
+        })
+    }
+}
+
+impl<'c> TryFrom<&'c ValueConstraints> for ValueProducer<'c> {
+    type Error = Report<ValueProducerError>;
+
+    fn try_from(constraints: &'c ValueConstraints) -> Result<Self, Self::Error> {
+        Ok(ValueProducer {
+            local_id: LocalId::default(),
+            value: ValueDistribution::try_from(constraints)?,
+        })
+    }
+}
+
+impl Producer<PropertyValue> for ValueProducer<'_> {
+    type Error = Report<ValidateDataTypeError>;
+
+    const ID: ProducerId = ProducerId::Value;
+
+    fn generate(&mut self, context: ProduceContext) -> Result<PropertyValue, Self::Error> {
+        let local_id = self.local_id.take_and_advance();
+
+        let value = match &self.value {
+            ValueDistribution::Null => PropertyValue::Null,
+            ValueDistribution::Boolean(boolean) => {
+                let boolean_gid = context.global_id(local_id, Scope::Boolean, SubScope::Unknown);
+
+                PropertyValue::Bool(boolean.sample(&mut boolean_gid.rng()))
+            }
+            ValueDistribution::Number(number) => {
+                let number_gid = context.global_id(local_id, Scope::Number, SubScope::Unknown);
+
+                PropertyValue::Number(number.sample(&mut number_gid.rng()))
+            }
+            ValueDistribution::String(string) => {
+                let string_gid = context.global_id(local_id, Scope::String, SubScope::Unknown);
+
+                PropertyValue::String(string.sample(&mut string_gid.rng()))
+            }
+        };
+
+        Ok(value)
+    }
+}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR implements value generation capabilities for the test data seeding framework, enabling the creation of valid `PropertyValue` instances from `ValueConstraints` definitions. This is a critical component for generating realistic test data that respects JSON schema constraints defined in data types.

The implementation provides distribution-based sampling for primitive value types (null, boolean, number, string), laying the groundwork for comprehensive property type testing with deterministic, reproducible test data.

## 🔗 Related links

- Linear Issue: [H-5214](https://linear.app/hash/issue/H-5214)
- Related PRs:
  - [H-5198: PropertyType generation MVP](https://github.com/hashintel/hash/pull/7736)
  - [H-5174: Initial deterministic seeding functionality](https://github.com/hashintel/hash/pull/7727)
  - [H-5191: Multi-stage scenario runner](https://github.com/hashintel/hash/pull/7735)

## 🚫 Blocked by

_None_

## 🔍 What does this change?

### Core Implementation

- **Added `ValueProducer`** (`tests/graph/test-data/rust/src/seeding/producer/value.rs`)
  - Implements the `Producer<PropertyValue>` trait for generating values
  - Converts `ValueConstraints` into sampling distributions
  - Maintains deterministic generation through seeded RNG with `GlobalId`

- **Distribution modules** (`tests/graph/test-data/rust/src/seeding/distributions/value/`)
  - `NumberValueDistribution`: Handles numeric constraints including min/max ranges, exclusive bounds, and enum values
  - `StringValueDistribution`: Generates strings with length constraints and enum support
  - Both distributions properly handle edge cases like empty enums and invalid ranges

### Supporting Changes

- **Made `ProducerConfig` copyable** (commit 7401a4f7b)
  - Changed `ProduceContext` from using references to owned values
  - Enables easier context propagation between producers
  - Added `for_producer()` method for creating derived contexts

- **Extended scope system** (`tests/graph/test-data/rust/src/seeding/context.rs`)
  - Added new `Scope` variants: `Boolean`, `Number`, `String`, `Array`, `Object`
  - Added `ProducerId::Value` for identifying value producers
  - These scopes ensure deterministic RNG seeding for each value type

### Technical Design Decisions

1. **Distribution-based approach**: Rather than simple random generation, we use proper statistical distributions (Uniform, Bernoulli) to ensure values are well-distributed within constraints

2. **Borrowing strategy**: The distributions can work with both owned and borrowed schemas through separate `TryFrom` implementations, avoiding unnecessary clones

3. **Deterministic generation**: Each value gets a unique `GlobalId` based on its type scope, ensuring reproducible test data across runs

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

### Not Yet Implemented (with Linear tracking)

- **Format strings**: [H-5236](https://linear.app/hash/issue/H-5236) - Support value seeding for format strings (email, uuid, etc.)
- **Pattern strings**: [H-5237](https://linear.app/hash/issue/H-5237) - Support regex pattern constraints
- **Multiple of numbers**: [H-5238](https://linear.app/hash/issue/H-5238) - Support multipleOf numeric constraint
- **Arrays**: [H-5239](https://linear.app/hash/issue/H-5239) - Support array value generation
- **Objects**: [H-5240](https://linear.app/hash/issue/H-5240) - Support object value generation
- **AnyOf types**: [H-5241](https://linear.app/hash/issue/H-5241) - Support union type constraints

### Current Limitations

- String generation uses only alphabetic characters (via `rand::distr::Alphabetic`)
- No support for complex string patterns or formats yet

## 🐾 Next steps

1. Integrate `ValueProducer` into entity generation pipeline for property values
2. Add support for array and object value types (most critical for realistic entities)
3. Implement format string generators for common formats (email, URL, UUID)
4. Add configurable string character sets beyond alphabetic
