### PR TITLE
BE-1: Fix Vercel not building wasm-opt

### DIFF
--- a/apps/hash-frontend/vercel-install.sh
+++ b/apps/hash-frontend/vercel-install.sh
@@ -14,10 +14,11 @@ yum-config-manager --add-repo https://mise.jdx.dev/rpm/mise.repo
 yum install -y mise
 eval "$(mise activate bash --shims)"
 
-echo "Installing prerequisites"
-mise install node npm:turbo java biome npm:@redocly/cli cargo-binstall cargo:wasm-pack cargo:wasm-opt protoc yq
 echo "Installing Rust toolchain: $(yq '.toolchain.channel' rust-toolchain.toml)"
+mise install yq
 mise use --global rust[profile=minimal]@$(yq '.toolchain.channel' rust-toolchain.toml)
+echo "Installing prerequisites"
+mise install node npm:turbo java biome npm:@redocly/cli cargo-binstall cargo:wasm-pack cargo:wasm-opt protoc
 echo "Rust installation completed. Checking versions:"
 mise list rust
 rustc --version


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

For some reason, `wasm-opt` cannot be downloaded in Vercel anymore. Typically, this means that `mise` will fallback to build it. However, `rust` is installed _after_ the attempt to install `wasm-opt`