### PR TITLE
SRE-24: Prevent Vercel build step from downloading Rust multiple times

### DIFF
--- a/apps/hash-frontend/vercel-install.sh
+++ b/apps/hash-frontend/vercel-install.sh
@@ -16,9 +16,12 @@ eval "$(mise activate bash --shims)"
 
 echo "Installing Rust toolchain: $(yq '.toolchain.channel' rust-toolchain.toml)"
 mise install yq
+export RUSTUP_AUTO_INSTALL=0
 mise use --global rust[profile=minimal]@$(yq '.toolchain.channel' rust-toolchain.toml)
+
 echo "Installing prerequisites"
 mise install node npm:turbo java biome npm:@redocly/cli cargo-binstall cargo:wasm-pack cargo:wasm-opt protoc
+
 echo "Rust installation completed. Checking versions:"
 mise list rust
 rustc --version


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This caused Vercel builds to fail