### PR TITLE
H-4984: HashQL: Ensure J-Expr consistency with dissertation

### DIFF
--- a/libs/@local/hashql/syntax-jexpr/src/parser/array/mod.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/array/mod.rs
@@ -167,9 +167,8 @@ fn parse_labelled_argument<'heap>(
         return Err(labeled_arguments_length_mismatch(
             state.insert_range(range),
             labeled_arguments
-                .get(1..)
-                .into_iter()
-                .flatten()
+                .iter()
+                .skip(1)
                 .map(|argument| argument.span),
             labeled_arguments.len(),
         )

--- a/libs/@local/hashql/syntax-jexpr/src/parser/array/mod.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/array/mod.rs
@@ -94,6 +94,8 @@ fn parse_labelled_argument<'heap>(
 
     if let TokenKind::String(peek1) = &peek1.kind
         && peek1.starts_with(':')
+        // ignore absolute paths
+        && !peek1.starts_with("::")
     {
         return parse_labelled_argument_shorthand(state).map(Some);
     }

--- a/libs/@local/hashql/syntax-jexpr/src/parser/array/snapshots/hashql_syntax_jexpr__parser__array__tests__parse_function_call_with_empty_object.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/array/snapshots/hashql_syntax_jexpr__parser__array__tests__parse_function_call_with_empty_object.snap
@@ -1,0 +1,24 @@
+---
+source: libs/@local/hashql/syntax-jexpr/src/parser/array/mod.rs
+description: Empty objects are not allowed
+expression: "[\"greet\", {}]"
+---
+[31m[parser::object::empty] Error:[0m Empty object not allowed
+   ╭─[ <unknown>:1:11 ]
+   │
+ 1 │ ["greet", {}]
+   │           ─┬  
+   │            ╰── Add required fields to this object
+   │ 
+   │ Help: J-Expr objects must contain at least one key-value pair with a specific structure. For example: `{"#literal": 42}` or `{"#struct": {"name": {"#literal": "value"}}}`
+   │ 
+   │ Note: J-Expr requires objects to have a specific structure represented by one of these constructs:
+   │       - `{"#struct": {...}, "#type"?: ...}` - For structured data with named fields
+   │       - `{"#dict": {...}, "#type"?: ...}` - For dictionary/map-like data
+   │       - `{"#tuple": [...], "#type"?: ...}` - For fixed-size ordered collections
+   │       - `{"#list": [...], "#type"?: ...}` - For variable-length ordered collections
+   │       - `{"#literal": value}` - For simple scalar values
+   │       - `{"#type": "typename"}` - For type declarations
+   │       
+   │       Empty objects don't have semantic meaning in J-Expr.
+───╯

--- a/libs/@local/hashql/syntax-jexpr/src/parser/array/snapshots/hashql_syntax_jexpr__parser__array__tests__parse_function_call_with_labeled_arguments_shorthand.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/array/snapshots/hashql_syntax_jexpr__parser__array__tests__parse_function_call_with_labeled_arguments_shorthand.snap
@@ -1,0 +1,23 @@
+---
+source: libs/@local/hashql/syntax-jexpr/src/parser/array/mod.rs
+description: Parses a function call with labeled arguments
+expression: "[\"greet\", \"age\", \":name\"]"
+---
+Expr#4294967040@10
+  ExprKind (Call)
+    CallExpr#4294967040@10
+      Expr#4294967040@3
+        ExprKind (Path)
+          Path#4294967040@3 (rooted: false)
+            PathSegment#4294967040@2 (name: greet)
+      Argument#4294967040@7
+        Expr#4294967040@7
+          ExprKind (Path)
+            Path#4294967040@7 (rooted: false)
+              PathSegment#4294967040@6 (name: age)
+      LabeledArgument#4294967040@8 (label: name)
+        Argument#4294967040@8
+          Expr#4294967040@8
+            ExprKind (Path)
+              Path#4294967040@8 (rooted: false)
+                PathSegment#4294967040@8 (name: name)

--- a/libs/@local/hashql/syntax-jexpr/src/parser/array/snapshots/hashql_syntax_jexpr__parser__array__tests__parse_function_call_with_multiple_labeled_arguments.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/array/snapshots/hashql_syntax_jexpr__parser__array__tests__parse_function_call_with_multiple_labeled_arguments.snap
@@ -1,0 +1,25 @@
+---
+source: libs/@local/hashql/syntax-jexpr/src/parser/array/mod.rs
+description: Multiple labeled arguments cannot exist in a single object
+expression: "\n                [\"greet\",\n                    {\":age\": {\"#literal\": 30},\n                     \":gender\": {\"#literal\": \"non-binary\"}\n                    }\n                ]"
+---
+[31m[parser::array::labeled-argument-length-mismatch] Error:[0m Invalid number of labeled arguments
+   ╭─[ <unknown>:3:21 ]
+   │
+ 3 │ ╭─▶                     {":age": {"#literal": 30},
+ 4 │ │                        ":gender": {"#literal": "non-binary"}
+   │ │                        ──────────────────┬──────────────────  
+   │ │                                          ╰──────────────────── ... remove this extraneous argument
+ 5 │ ├─▶                     }
+   │ │                           
+   │ ╰─────────────────────────── Remove extra arguments
+   │     
+   │     Help: Labeled arguments must contain exactly one key-value pair, but 2 were provided
+   │     
+   │     Note: In J-Expr, labeled arguments use the format:
+   │           - `["function", {":label": value}]`
+   │           - `["function", {":label1": value1}, {":label2": value2}]`
+   │           - `["function", ":variable1"]`
+   │           
+   │           The colon prefix (':') is required to distinguish labeled arguments from positional arguments.
+───╯

--- a/libs/@local/hashql/syntax-jexpr/src/parser/array/snapshots/hashql_syntax_jexpr__parser__array__tests__parse_malformed_labeled_argument.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/array/snapshots/hashql_syntax_jexpr__parser__array__tests__parse_malformed_labeled_argument.snap
@@ -13,8 +13,9 @@ expression: "[\"func\", {\":name\": {\"#literal\": \"value\"}, \"extra\": {\"#li
    │ Help: Add ':' prefix to 'extra' to make it a valid labeled argument
    │ 
    │ Note: In J-Expr, labeled arguments use the format:
-   │       - `["function", ":label", value]`
-   │       - `["function", ":label1", value1, ":label2", value2]`
+   │       - `["function", {":label": value}]`
+   │       - `["function", {":label1": value1}, {":label2": value2}]`
+   │       - `["function", ":variable1"]`
    │       
    │       The colon prefix (':') is required to distinguish labeled arguments from positional arguments.
 ───╯

--- a/libs/@local/hashql/syntax-jexpr/src/parser/object/literal.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/object/literal.rs
@@ -88,7 +88,7 @@ fn parse_literal<'heap>(
     let kind = match token.kind {
         TokenKind::Null => LiteralKind::Null,
         TokenKind::Number(number) => {
-            if number.has_fraction() {
+            if number.has_fraction() || number.has_exponent() {
                 LiteralKind::Float(FloatLiteral {
                     value: state.intern_symbol(number.as_str()),
                 })

--- a/libs/@local/hashql/syntax-jexpr/src/parser/string/snapshots/hashql_syntax_jexpr__parser__string__expr__tests__empty_brackets.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/string/snapshots/hashql_syntax_jexpr__parser__string__expr__tests__empty_brackets.snap
@@ -6,5 +6,6 @@ info:
   kind: Err
 ---
 []
- ^
+  ^
 invalid index
+expected `]`

--- a/libs/@local/hashql/syntax-jexpr/src/parser/string/snapshots/hashql_syntax_jexpr__parser__string__expr__tests__index_access_field_access.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/string/snapshots/hashql_syntax_jexpr__parser__string__expr__tests__index_access_field_access.snap
@@ -1,0 +1,21 @@
+---
+source: libs/@local/hashql/syntax-jexpr/src/parser/string/expr.rs
+description: Field then index access
+expression: "foo[bar.0]"
+info:
+  kind: Ok
+---
+Expr#4294967040@9
+  ExprKind (Index)
+    IndexExpr#4294967040@9
+      Expr#4294967040@3
+        ExprKind (Path)
+          Path#4294967040@3 (rooted: false)
+            PathSegment#4294967040@2 (name: foo)
+      Expr#4294967040@8
+        ExprKind (Field)
+          FieldExpr#4294967040@8 (field: 0)
+            Expr#4294967040@6
+              ExprKind (Path)
+                Path#4294967040@6 (rooted: false)
+                  PathSegment#4294967040@5 (name: bar)

--- a/libs/@local/hashql/syntax-jexpr/src/parser/string/snapshots/hashql_syntax_jexpr__parser__string__expr__tests__index_access_mixed.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/string/snapshots/hashql_syntax_jexpr__parser__string__expr__tests__index_access_mixed.snap
@@ -1,0 +1,26 @@
+---
+source: libs/@local/hashql/syntax-jexpr/src/parser/string/expr.rs
+description: Mixed index access
+expression: "foo[bar][0]"
+info:
+  kind: Ok
+---
+Expr#4294967040@9
+  ExprKind (Index)
+    IndexExpr#4294967040@9
+      Expr#4294967040@8
+        ExprKind (Index)
+          IndexExpr#4294967040@8
+            Expr#4294967040@3
+              ExprKind (Path)
+                Path#4294967040@3 (rooted: false)
+                  PathSegment#4294967040@2 (name: foo)
+            Expr#4294967040@6
+              ExprKind (Path)
+                Path#4294967040@6 (rooted: false)
+                  PathSegment#4294967040@5 (name: bar)
+      Expr#4294967040@7
+        ExprKind (Literal)
+          LiteralExpr#4294967040@7
+            LiteralKind (Integer)
+              IntegerLiteral (0)

--- a/libs/@local/hashql/syntax-jexpr/src/parser/string/snapshots/hashql_syntax_jexpr__parser__string__expr__tests__index_access_with_ident.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/string/snapshots/hashql_syntax_jexpr__parser__string__expr__tests__index_access_with_ident.snap
@@ -1,0 +1,18 @@
+---
+source: libs/@local/hashql/syntax-jexpr/src/parser/string/expr.rs
+description: Index access with identifier
+expression: "foo[bar]"
+info:
+  kind: Ok
+---
+Expr#4294967040@7
+  ExprKind (Index)
+    IndexExpr#4294967040@7
+      Expr#4294967040@3
+        ExprKind (Path)
+          Path#4294967040@3 (rooted: false)
+            PathSegment#4294967040@2 (name: foo)
+      Expr#4294967040@6
+        ExprKind (Path)
+          Path#4294967040@6 (rooted: false)
+            PathSegment#4294967040@5 (name: bar)

--- a/libs/@local/hashql/syntax-jexpr/src/parser/string/snapshots/hashql_syntax_jexpr__parser__string__expr__tests__index_access_with_ident_chained.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/string/snapshots/hashql_syntax_jexpr__parser__string__expr__tests__index_access_with_ident_chained.snap
@@ -1,0 +1,25 @@
+---
+source: libs/@local/hashql/syntax-jexpr/src/parser/string/expr.rs
+description: Chained index access with identifier
+expression: "foo[bar][baz]"
+info:
+  kind: Ok
+---
+Expr#4294967040@11
+  ExprKind (Index)
+    IndexExpr#4294967040@11
+      Expr#4294967040@10
+        ExprKind (Index)
+          IndexExpr#4294967040@10
+            Expr#4294967040@3
+              ExprKind (Path)
+                Path#4294967040@3 (rooted: false)
+                  PathSegment#4294967040@2 (name: foo)
+            Expr#4294967040@6
+              ExprKind (Path)
+                Path#4294967040@6 (rooted: false)
+                  PathSegment#4294967040@5 (name: bar)
+      Expr#4294967040@9
+        ExprKind (Path)
+          Path#4294967040@9 (rooted: false)
+            PathSegment#4294967040@8 (name: baz)

--- a/libs/@local/hashql/syntax-jexpr/src/parser/string/snapshots/hashql_syntax_jexpr__parser__string__expr__tests__multi_digit_index.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/string/snapshots/hashql_syntax_jexpr__parser__string__expr__tests__multi_digit_index.snap
@@ -5,7 +5,7 @@ expression: "[123]"
 info:
   kind: Ok
 ---
-Index(
+IndexByLiteral(
     LiteralExpr {
         id: NodeId(
             4294967040,

--- a/libs/@local/hashql/syntax-jexpr/src/parser/string/snapshots/hashql_syntax_jexpr__parser__string__expr__tests__non_numeric_index.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/string/snapshots/hashql_syntax_jexpr__parser__string__expr__tests__non_numeric_index.snap
@@ -3,8 +3,46 @@ source: libs/@local/hashql/syntax-jexpr/src/parser/string/expr.rs
 description: Non-numeric index
 expression: "[abc]"
 info:
-  kind: Err
+  kind: Ok
 ---
-[abc]
- ^
-invalid index
+IndexByExpr(
+    Expr {
+        id: NodeId(
+            4294967040,
+        ),
+        span: SpanId(
+            3,
+        ),
+        kind: Path(
+            Path {
+                id: NodeId(
+                    4294967040,
+                ),
+                span: SpanId(
+                    3,
+                ),
+                rooted: false,
+                segments: [
+                    PathSegment {
+                        id: NodeId(
+                            4294967040,
+                        ),
+                        span: SpanId(
+                            2,
+                        ),
+                        name: Ident {
+                            span: SpanId(
+                                1,
+                            ),
+                            value: Symbol(
+                                "abc",
+                            ),
+                            kind: Lexical,
+                        },
+                        arguments: [],
+                    },
+                ],
+            },
+        ),
+    },
+)

--- a/libs/@local/hashql/syntax-jexpr/src/parser/string/snapshots/hashql_syntax_jexpr__parser__string__expr__tests__simple_index.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/string/snapshots/hashql_syntax_jexpr__parser__string__expr__tests__simple_index.snap
@@ -5,7 +5,7 @@ expression: "[0]"
 info:
   kind: Ok
 ---
-Index(
+IndexByLiteral(
     LiteralExpr {
         id: NodeId(
             4294967040,

--- a/libs/@local/hashql/syntax-jexpr/src/parser/string/snapshots/hashql_syntax_jexpr__parser__string__expr__tests__whitespace_in_brackets.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/string/snapshots/hashql_syntax_jexpr__parser__string__expr__tests__whitespace_in_brackets.snap
@@ -5,7 +5,7 @@ expression: "[ 42 ]"
 info:
   kind: Ok
 ---
-Index(
+IndexByLiteral(
     LiteralExpr {
         id: NodeId(
             4294967040,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Ensures consistency with the features described in the dissertation, fixing the following points:
* allow for nested index expressions inside string shorthand
* only allow for a single labelled argument
* labelled argument shorthand

Additionally, it disables exponent support for literals on the parsing level (to be fixed in https://linear.app/hash/issue/H-5290/hashql-allow-for-integer-literals-with-exponents), as it was never supported in the backend in the first place.


## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

