### PR TITLE
SRE-25: Fix turbo-hack to bypass cyclic dependency issue

### DIFF
--- a/.github/actions/prune-repository/action.yml
+++ b/.github/actions/prune-repository/action.yml
@@ -23,6 +23,12 @@ runs:
           if echo "$DEPENDENCIES" | grep -q "@rust/hashql-ast"; then
             SCOPES="$SCOPES @rust/hashql-compiletest"
           fi
+          if echo "$DEPENDENCIES" | grep -q "@rust/hashql-hir"; then
+            SCOPES="$SCOPES @rust/hashql-compiletest"
+          fi
+          if echo "$DEPENDENCIES" | grep -q "@rust/hashql-eval"; then
+            SCOPES="$SCOPES @rust/hashql-compiletest"
+          fi
           if echo "$DEPENDENCIES" | grep -q "@blockprotocol/type-system-rs"; then
             SCOPES="$SCOPES @rust/hash-graph-test-data"
           fi


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

`turbo` does not support cyclic dependencies. We missed a few dependencies in our prune-logic. This was the reason why previously we achieved a test-failure on main, which otherwise would have been caught.