### PR TITLE
ES-19, ES-20: Allow trailing commas in bail macro to return `Report<C>`, not `Report<[C]>`

### DIFF
--- a/libs/error-stack/CHANGELOG.md
+++ b/libs/error-stack/CHANGELOG.md
@@ -9,7 +9,9 @@ All notable changes to `error-stack` will be documented in this file.
 
 ## Unreleased
 
--
+### Features
+
+- Support trailing commans in `bail!` macro. ([#7772](https://github.com/hashintel/hash/pull/7772))
 
 ## [0.6.0](https://github.com/hashintel/hash/tree/error-stack%400.6.0/libs/error-stack) - 2025-08-30
 

--- a/libs/error-stack/src/macros.rs
+++ b/libs/error-stack/src/macros.rs
@@ -129,7 +129,7 @@ macro_rules! bail {
     }};
 
     [$($err:expr),+ $(,)?] => {{
-        compile_error!("Enable to `unstable` feature flag to bail using multiple errors.")
+        compile_error!("enable the `unstable` feature flag to use `bail` to create multiple errors")
     }};
 }
 

--- a/libs/error-stack/src/macros.rs
+++ b/libs/error-stack/src/macros.rs
@@ -123,9 +123,13 @@ macro_rules! report {
 /// ```
 #[cfg(not(feature = "unstable"))]
 #[macro_export]
-macro_rules! bail {
-    ($err:expr) => {{
+macro_rules! bail {#[macro_export]
+    ($err:expr $(,)?) => {{
         return ::core::result::Result::Err($crate::IntoReport::into_report($err));
+    }};
+
+    [$($err:expr),+ $(,)?] => {{
+        compile_error!("Enable to `unstable` feature flag to bail using multiple errors.")
     }};
 }
 
@@ -235,7 +239,7 @@ macro_rules! bail {
 #[cfg_attr(doc, doc(cfg(all())))]
 #[macro_export]
 macro_rules! bail {
-    ($err:expr) => {{
+    ($err:expr $(,)?) => {{
         return ::core::result::Result::Err($crate::IntoReport::into_report($err));
     }};
 

--- a/libs/error-stack/src/macros.rs
+++ b/libs/error-stack/src/macros.rs
@@ -123,7 +123,7 @@ macro_rules! report {
 /// ```
 #[cfg(not(feature = "unstable"))]
 #[macro_export]
-macro_rules! bail {#[macro_export]
+macro_rules! bail {
     ($err:expr $(,)?) => {{
         return ::core::result::Result::Err($crate::IntoReport::into_report($err));
     }};

--- a/libs/error-stack/tests/ui/missing_args.stderr
+++ b/libs/error-stack/tests/ui/missing_args.stderr
@@ -19,7 +19,7 @@ error: unexpected end of macro invocation
 note: while trying to match meta-variable `$err:expr`
    --> src/macros.rs
     |
-    |     ($err:expr) => {{
+    |     ($err:expr $(,)?) => {{
     |      ^^^^^^^^^
 
 error: unexpected end of macro invocation


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Trailing commas are natural in macro calls.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] require changes to docs which **are made** as part of this PR

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph