### PR TITLE
H-5115: HashQL: allow for integer literals during field access

### DIFF
--- a/libs/@local/hashql/ast/src/lowering/special_form_expander/mod.rs
+++ b/libs/@local/hashql/ast/src/lowering/special_form_expander/mod.rs
@@ -454,6 +454,14 @@ impl<'heap> SpecialFormExpander<'heap> {
         Some(name)
     }
 
+    /// Attempts to extract a field identifier from an argument.
+    ///
+    /// This function handles both named field access (using identifiers) and indexed field access
+    /// (using integer literals). For literals, it validates that they are integers without type
+    /// annotations and within usize bounds. Otherwise, it falls back to `lower_argument_to_ident`
+    /// for named field access.
+    ///
+    /// The `mode` parameter is used for generating appropriate error diagnostics.
     fn lower_argument_to_field(
         &mut self,
         mode: BindingMode,

--- a/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/access-field-index-out-of-bounds.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/access-field-index-out-of-bounds.jsonc
@@ -1,4 +1,4 @@
 //@ run: fail
 //@ description: Field index out of bounds should error
-["::kernel::special_form::access", "data", {"#literal": 18446744073709551616}]
+["::kernel::special_form::access", "data", { "#literal": 18446744073709551616 }]
 //~^ ERROR Use a valid field index within usize bounds

--- a/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/access-field-index-out-of-bounds.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/access-field-index-out-of-bounds.jsonc
@@ -1,0 +1,4 @@
+//@ run: fail
+//@ description: Field index out of bounds should error
+["::kernel::special_form::access", "data", {"#literal": 18446744073709551616}]
+//~^ ERROR Use a valid field index within usize bounds

--- a/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/access-field-index-out-of-bounds.stderr
+++ b/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/access-field-index-out-of-bounds.stderr
@@ -1,9 +1,9 @@
 [special-form-expander::field-index-out-of-bounds] Error: Field index out of bounds
-   ╭─[ <unknown>:3:57 ]
+   ╭─[ <unknown>:3:58 ]
    │
- 3 │ ["::kernel::special_form::access", "data", {"#literal": 18446744073709551616}]
-   │                                                         ──────────┬─────────  
-   │                                                                   ╰─────────── Use a valid field index within usize bounds
+ 3 │ ["::kernel::special_form::access", "data", { "#literal": 18446744073709551616 }]
+   │                                                          ──────────┬─────────  
+   │                                                                    ╰─────────── Use a valid field index within usize bounds
    │ 
    │ Help: Field indices must be non-negative integers that fit within the bounds of usize. Very large numbers or negative numbers cannot be used as field indices.
    │ 

--- a/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/access-field-index-out-of-bounds.stderr
+++ b/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/access-field-index-out-of-bounds.stderr
@@ -1,0 +1,11 @@
+[special-form-expander::field-index-out-of-bounds] Error: Field index out of bounds
+   ╭─[ <unknown>:3:57 ]
+   │
+ 3 │ ["::kernel::special_form::access", "data", {"#literal": 18446744073709551616}]
+   │                                                         ──────────┬─────────  
+   │                                                                   ╰─────────── Use a valid field index within usize bounds
+   │ 
+   │ Help: Field indices must be non-negative integers that fit within the bounds of usize. Very large numbers or negative numbers cannot be used as field indices.
+   │ 
+   │ Note: Field indexing in HashQL uses zero-based indexing where the first field is at index 0, the second at index 1, and so on. The maximum valid index depends on the system's architecture, which is 64-bit.
+───╯

--- a/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/access-field-literal-boolean.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/access-field-literal-boolean.jsonc
@@ -1,4 +1,4 @@
 //@ run: fail
 //@ description: Field access with boolean literal should error
-["::kernel::special_form::access", "data", {"#literal": true}]
+["::kernel::special_form::access", "data", { "#literal": true }]
 //~^ ERROR Use an integer literal here

--- a/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/access-field-literal-boolean.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/access-field-literal-boolean.jsonc
@@ -1,0 +1,4 @@
+//@ run: fail
+//@ description: Field access with boolean literal should error
+["::kernel::special_form::access", "data", {"#literal": true}]
+//~^ ERROR Use an integer literal here

--- a/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/access-field-literal-boolean.stderr
+++ b/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/access-field-literal-boolean.stderr
@@ -1,0 +1,14 @@
+[special-form-expander::invalid-field-literal-type] Error: Invalid field literal type
+   ╭─[ <unknown>:3:57 ]
+   │
+ 3 │ ["::kernel::special_form::access", "data", {"#literal": true}]
+   │                                                         ──┬─  
+   │                                                           ╰─── Use an integer literal here
+   │ 
+   │ Help: Field access using literals requires an integer literal that specifies the field index. Other literal types like strings, booleans, or numbers cannot be used for field indexing.
+   │ 
+   │ Note: Valid field access examples:
+   │       - (access tuple 0) - accesses first field
+   │       - (access record 2) - accesses third field
+   │       - (access data my_field) - accesses named field
+───╯

--- a/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/access-field-literal-boolean.stderr
+++ b/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/access-field-literal-boolean.stderr
@@ -1,9 +1,9 @@
 [special-form-expander::invalid-field-literal-type] Error: Invalid field literal type
-   ╭─[ <unknown>:3:57 ]
+   ╭─[ <unknown>:3:58 ]
    │
- 3 │ ["::kernel::special_form::access", "data", {"#literal": true}]
-   │                                                         ──┬─  
-   │                                                           ╰─── Use an integer literal here
+ 3 │ ["::kernel::special_form::access", "data", { "#literal": true }]
+   │                                                          ──┬─  
+   │                                                            ╰─── Use an integer literal here
    │ 
    │ Help: Field access using literals requires an integer literal that specifies the field index. Other literal types like strings, booleans, or numbers cannot be used for field indexing.
    │ 

--- a/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/access-field-literal-string.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/access-field-literal-string.jsonc
@@ -1,0 +1,4 @@
+//@ run: fail
+//@ description: Field access with string literal should error
+["::kernel::special_form::access", "data", {"#literal": "field_name"}]
+//~^ ERROR Use an integer literal here

--- a/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/access-field-literal-string.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/access-field-literal-string.jsonc
@@ -1,4 +1,4 @@
 //@ run: fail
 //@ description: Field access with string literal should error
-["::kernel::special_form::access", "data", {"#literal": "field_name"}]
+["::kernel::special_form::access", "data", { "#literal": "field_name" }]
 //~^ ERROR Use an integer literal here

--- a/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/access-field-literal-string.stderr
+++ b/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/access-field-literal-string.stderr
@@ -1,9 +1,9 @@
 [special-form-expander::invalid-field-literal-type] Error: Invalid field literal type
-   ╭─[ <unknown>:3:57 ]
+   ╭─[ <unknown>:3:58 ]
    │
- 3 │ ["::kernel::special_form::access", "data", {"#literal": "field_name"}]
-   │                                                         ──────┬─────  
-   │                                                               ╰─────── Use an integer literal here
+ 3 │ ["::kernel::special_form::access", "data", { "#literal": "field_name" }]
+   │                                                          ──────┬─────  
+   │                                                                ╰─────── Use an integer literal here
    │ 
    │ Help: Field access using literals requires an integer literal that specifies the field index. Other literal types like strings, booleans, or numbers cannot be used for field indexing.
    │ 

--- a/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/access-field-literal-string.stderr
+++ b/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/access-field-literal-string.stderr
@@ -1,0 +1,14 @@
+[special-form-expander::invalid-field-literal-type] Error: Invalid field literal type
+   ╭─[ <unknown>:3:57 ]
+   │
+ 3 │ ["::kernel::special_form::access", "data", {"#literal": "field_name"}]
+   │                                                         ──────┬─────  
+   │                                                               ╰─────── Use an integer literal here
+   │ 
+   │ Help: Field access using literals requires an integer literal that specifies the field index. Other literal types like strings, booleans, or numbers cannot be used for field indexing.
+   │ 
+   │ Note: Valid field access examples:
+   │       - (access tuple 0) - accesses first field
+   │       - (access record 2) - accesses third field
+   │       - (access data my_field) - accesses named field
+───╯

--- a/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/access-field-literal-type-annotation.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/access-field-literal-type-annotation.jsonc
@@ -1,4 +1,8 @@
 //@ run: fail
 //@ description: Field literal with type annotation should error
-["::kernel::special_form::access", "tuple", {"#literal": 0, "#type": "Integer"}]
-//~^ ERROR Remove this type annotation
+[
+  "::kernel::special_form::access",
+  "tuple",
+  { "#literal": 0, "#type": "Integer" }
+  //~^ ERROR Remove this type annotation
+]

--- a/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/access-field-literal-type-annotation.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/access-field-literal-type-annotation.jsonc
@@ -1,0 +1,4 @@
+//@ run: fail
+//@ description: Field literal with type annotation should error
+["::kernel::special_form::access", "tuple", {"#literal": 0, "#type": "Integer"}]
+//~^ ERROR Remove this type annotation

--- a/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/access-field-literal-type-annotation.stderr
+++ b/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/access-field-literal-type-annotation.stderr
@@ -1,0 +1,11 @@
+[special-form-expander::field-literal-type-annotation] Error: Field literal with type annotation
+   ╭─[ <unknown>:3:71 ]
+   │
+ 3 │ ["::kernel::special_form::access", "tuple", {"#literal": 0, "#type": "Integer"}]
+   │                                                                       ───┬───  
+   │                                                                          ╰───── Remove this type annotation
+   │ 
+   │ Help: Field access using numeric literals cannot have type annotations. The literal represents the field index directly and doesn't need a separate type.
+   │ 
+   │ Note: When using numeric literals for field access (e.g., in tuple destructuring), the number itself indicates the position and cannot be annotated with a type.
+───╯

--- a/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/access-field-literal-type-annotation.stderr
+++ b/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/access-field-literal-type-annotation.stderr
@@ -1,9 +1,9 @@
 [special-form-expander::field-literal-type-annotation] Error: Field literal with type annotation
-   ╭─[ <unknown>:3:71 ]
+   ╭─[ <unknown>:6:30 ]
    │
- 3 │ ["::kernel::special_form::access", "tuple", {"#literal": 0, "#type": "Integer"}]
-   │                                                                       ───┬───  
-   │                                                                          ╰───── Remove this type annotation
+ 6 │   { "#literal": 0, "#type": "Integer" }
+   │                              ───┬───  
+   │                                 ╰───── Remove this type annotation
    │ 
    │ Help: Field access using numeric literals cannot have type annotations. The literal represents the field index directly and doesn't need a separate type.
    │ 

--- a/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/access-field-literal-valid.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/access-field-literal-valid.jsonc
@@ -1,0 +1,3 @@
+//@ run: pass
+//@ description: Field access with valid integer literal should compile
+["::kernel::special_form::access", "tuple", {"#literal": 0}]

--- a/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/access-field-literal-valid.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/access-field-literal-valid.jsonc
@@ -1,3 +1,3 @@
 //@ run: pass
 //@ description: Field access with valid integer literal should compile
-["::kernel::special_form::access", "tuple", {"#literal": 0}]
+["::kernel::special_form::access", "tuple", { "#literal": 0 }]

--- a/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/access-field-literal-valid.stdout
+++ b/libs/@local/hashql/ast/tests/ui/lowering/special-form-expander/access-field-literal-valid.stdout
@@ -1,0 +1,7 @@
+Expr#4294967040@14
+  ExprKind (Field)
+    FieldExpr#4294967040@14 (field: 0)
+      Expr#4294967040@11
+        ExprKind (Path)
+          Path#4294967040@11 (rooted: false)
+            PathSegment#4294967040@10 (name: tuple)

--- a/libs/@local/hashql/syntax-jexpr/src/parser/string/expr.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/string/expr.rs
@@ -46,7 +46,7 @@ where
                 .with_span()
                 .try_map(|(digits, range): (&str, _)| {
                     // Ensure the value is within bounds
-                    digits.parse::<usize>().map(|_value| (digits, range))
+                    digits.parse::<usize>().map(|_| (digits, range))
                 })
                 .map(|(digit, range)| {
                     Access::Field(Ident {

--- a/libs/@local/hashql/syntax-jexpr/src/parser/string/expr.rs
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/string/expr.rs
@@ -1,3 +1,5 @@
+use core::num::ParseIntError;
+
 use hashql_ast::node::{
     expr::{Expr, ExprKind, FieldExpr, IndexExpr, LiteralExpr},
     id::NodeId,
@@ -12,7 +14,7 @@ use winnow::{
     combinator::{
         alt, cut_err, delimited, dispatch, eof, fail, peek, preceded, repeat, terminated,
     },
-    error::{AddContext, ParserError, StrContext, StrContextValue},
+    error::{AddContext, FromExternalError, ParserError, StrContext, StrContextValue},
     token::any,
 };
 
@@ -31,6 +33,7 @@ fn parse_field_access<'heap, 'span, 'source, E>(
 ) -> ModalResult<Access<'heap>, E>
 where
     E: ParserError<Input<'heap, 'span, 'source>>
+        + FromExternalError<Input<'heap, 'span, 'source>, ParseIntError>
         + AddContext<Input<'heap, 'span, 'source>, StrContext>,
 {
     let context = input.state;
@@ -39,14 +42,20 @@ where
         ws("."),
         alt((
             parse_ident.map(Access::Field),
-            digit1.with_span().map(|(digit, range)| {
-                Access::Field(Ident {
-                    span: context.span(range),
-
-                    value: context.heap.intern_symbol(digit),
-                    kind: IdentKind::Lexical, // Do we need to specify a different kind here?
+            digit1
+                .with_span()
+                .try_map(|(digits, range): (&str, _)| {
+                    // Ensure the value is within bounds
+                    digits.parse::<usize>().map(|_value| (digits, range))
                 })
-            }),
+                .map(|(digit, range)| {
+                    Access::Field(Ident {
+                        span: context.span(range),
+
+                        value: context.heap.intern_symbol(digit),
+                        kind: IdentKind::Lexical, // Do we need to specify a different kind here?
+                    })
+                }),
         )),
     )
     .context(StrContext::Label("field"))
@@ -58,6 +67,7 @@ fn parse_index_access<'heap, 'span, 'source, E>(
 ) -> ModalResult<Access<'heap>, E>
 where
     E: ParserError<Input<'heap, 'span, 'source>>
+        + FromExternalError<Input<'heap, 'span, 'source>, ParseIntError>
         + AddContext<Input<'heap, 'span, 'source>, StrContext>,
 {
     let context = input.state;
@@ -91,6 +101,7 @@ pub(crate) fn parse_expr_path<'heap, 'span, 'source, E>(
 ) -> ModalResult<Expr<'heap>, E>
 where
     E: ParserError<Input<'heap, 'span, 'source>>
+        + FromExternalError<Input<'heap, 'span, 'source>, ParseIntError>
         + AddContext<Input<'heap, 'span, 'source>, StrContext>,
 {
     let context = input.state;
@@ -126,6 +137,9 @@ where
 
                 let span = context.span(range.clone());
 
+                // We de-sugar into expressions directly instead of special forms, not to save
+                // on memory, but just because it is a lot easier and terse to create these
+                // nodes instead of fully-fledged call nodes.
                 let kind = match access {
                     Access::IndexByLiteral(literal) => ExprKind::Index(IndexExpr {
                         id: NodeId::PLACEHOLDER,
@@ -169,6 +183,7 @@ pub(crate) fn parse_expr<'heap, 'span, 'source, E>(
 ) -> ModalResult<Expr<'heap>, E>
 where
     E: ParserError<Input<'heap, 'span, 'source>>
+        + FromExternalError<Input<'heap, 'span, 'source>, ParseIntError>
         + AddContext<Input<'heap, 'span, 'source>, StrContext>,
 {
     let context = input.state;
@@ -204,6 +219,7 @@ mod tests {
         // Error cases
         missing_field_name(".") => "Missing field name",
         invalid_field_name(".@field") => "Invalid field name",
+        index_too_large(".18446744073709551616") => "Index too large",
     );
 
     // Tests for index access

--- a/libs/@local/hashql/syntax-jexpr/src/parser/string/snapshots/hashql_syntax_jexpr__parser__string__expr__tests__index_too_large.snap
+++ b/libs/@local/hashql/syntax-jexpr/src/parser/string/snapshots/hashql_syntax_jexpr__parser__string__expr__tests__index_too_large.snap
@@ -1,0 +1,11 @@
+---
+source: libs/@local/hashql/syntax-jexpr/src/parser/string/expr.rs
+description: Index too large
+expression: ".18446744073709551616"
+info:
+  kind: Err
+---
+.18446744073709551616
+ ^
+invalid field
+number too large to fit in target type


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Element access (tuple indexing) was currently only possible using the string notation in j-expr, e.g. using `"value.field"`, this is insufficient in cases where the target is of a dynamic nature. This remedies it by allowing for `[".", "foo", {"#literal": 1}]`, e.g. access via a single integer literal that fits into usize.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
