### PR TITLE
BE-29: Fix graph telemetry creating file logs even it's disabled

### DIFF
--- a/libs/@local/telemetry/src/logging/mod.rs
+++ b/libs/@local/telemetry/src/logging/mod.rs
@@ -420,12 +420,30 @@ pub(crate) fn file_layer<S>(config: FileConfig) -> (impl Layer<S>, impl Drop)
 where
     S: Subscriber + for<'a> LookupSpan<'a>,
 {
+    struct DropGuard {
+        _guard: Option<tracing_appender::non_blocking::WorkerGuard>,
+    }
+
+    #[expect(clippy::empty_drop)]
+    impl Drop for DropGuard {
+        fn drop(&mut self) {}
+    }
+
+    if !config.enabled {
+        return (None, DropGuard { _guard: None });
+    }
+
     let appender = config.rotation.appender(config.output);
     let (writer, guard) = tracing_appender::non_blocking(appender);
 
     let layer = delegate_to_correct_layer(config.format, config.level, writer, AnsiSupport::Never);
 
-    (layer, guard)
+    (
+        Some(layer),
+        DropGuard {
+            _guard: Some(guard),
+        },
+    )
 }
 
 // pub type ConsoleLayer<S>


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The `enabled` flag was not used.