### PR TITLE
BE-35: Support link entity generation in benchmarks

### DIFF
--- a/libs/@local/graph/type-fetcher/src/store.rs
+++ b/libs/@local/graph/type-fetcher/src/store.rs
@@ -540,7 +540,7 @@ where
         Ok(references)
     }
 
-    #[tracing::instrument(level = "info", skip(self, ontology_type_references))]
+    #[tracing::instrument(level = "info", skip(self, ontology_type_references, bypassed_types))]
     #[expect(clippy::too_many_lines)]
     async fn fetch_external_ontology_types(
         &self,
@@ -669,7 +669,7 @@ where
         Ok(fetched_ontology_types)
     }
 
-    #[tracing::instrument(level = "info", skip(self, ontology_types))]
+    #[tracing::instrument(level = "info", skip_all)]
     async fn insert_external_types<'o, T: OntologyTypeSchema + Sync + 'o>(
         &mut self,
         actor_id: ActorEntityUuid,

--- a/tests/graph/benches/config/scenarios/linked_queries.json
+++ b/tests/graph/benches/config/scenarios/linked_queries.json
@@ -15,7 +15,7 @@
       "type": "generate-users",
       "id": "generated-users",
       "configRef": "users/basic",
-      "count": 10
+      "count": 1
     },
     {
       "type": "persist-users",
@@ -150,13 +150,34 @@
         "entityTypeCatalog": "non-link-types",
         "entityObjectRegistry": "entity-object-registry"
       },
-      "count": 10000
+      "count": 1000
     },
     {
       "type": "persist-entities",
       "id": "persist-entities",
       "inputs": {
         "entities": ["entities"],
+        "webToUser": ["generated-users"]
+      }
+    },
+    {
+      "type": "generate-entities",
+      "id": "link-entities",
+      "configRef": "entities/basic",
+      "inputs": {
+        "userCatalog": "all-users",
+        "entityTypeCatalog": "link-types",
+        "sourceLinkTypeCatalog": "non-link-types",
+        "entityObjectRegistry": "entity-object-registry",
+        "entityCatalog": "persist-entities"
+      },
+      "count": 100
+    },
+    {
+      "type": "persist-entities",
+      "id": "persist-link-entities",
+      "inputs": {
+        "entities": ["link-entities"],
         "webToUser": ["generated-users"]
       }
     }

--- a/tests/graph/benches/graph/lib.rs
+++ b/tests/graph/benches/graph/lib.rs
@@ -122,9 +122,7 @@ fn scenarios(criterion: &mut Criterion) {
             .file_stem()
             .expect("Should be able to read scenario name")
             .to_string_lossy();
-        if scenario != "linked_queries" {
-            continue;
-        }
+
         run_scenario_file(&path, &runtime, criterion.benchmark_group(scenario));
     }
 }

--- a/tests/graph/benches/graph/lib.rs
+++ b/tests/graph/benches/graph/lib.rs
@@ -122,6 +122,9 @@ fn scenarios(criterion: &mut Criterion) {
             .file_stem()
             .expect("Should be able to read scenario name")
             .to_string_lossy();
+        if scenario != "linked_queries" {
+            continue;
+        }
         run_scenario_file(&path, &runtime, criterion.benchmark_group(scenario));
     }
 }

--- a/tests/graph/benches/graph/lib.rs
+++ b/tests/graph/benches/graph/lib.rs
@@ -76,6 +76,25 @@ fn scenarios(criterion: &mut Criterion) {
     let runtime = tokio::runtime::Runtime::new().expect("Should be able to create runtime");
 
     let _runtime_enter = runtime.enter();
+
+    let _telemetry_guard = TelemetryRegistry::default()
+        .with_error_layer()
+        .with_console_logging(ConsoleConfig {
+            enabled: true,
+            format: LogFormat::Pretty,
+            level: None,
+            color: ColorOption::Auto,
+            stream: ConsoleStream::Stderr,
+        })
+        .with_otlp(
+            OtlpConfig {
+                endpoint: Some("http://localhost:4317".to_owned()),
+            },
+            "Graph Benches",
+        )
+        .init_global()
+        .expect("Failed to initialize tracing");
+
     // TODO: Add resource usage monitoring (memory, CPU, database metrics) during benchmarks
     //   see https://linear.app/hashintel/issue/BE-32
 

--- a/tests/graph/benches/graph/scenario/runner.rs
+++ b/tests/graph/benches/graph/scenario/runner.rs
@@ -31,6 +31,7 @@ use type_system::ontology::json_schema::DomainValidator;
 use super::stages::{
     Stage,
     data_type::InMemoryDataTypeCatalog,
+    entity::InMemoryEntityCatalog,
     entity_type::{InMemoryEntityObjectRegistry, InMemoryEntityTypeCatalog},
     property_type::InMemoryPropertyTypeCatalog,
     web_catalog::InMemoryWebCatalog,
@@ -155,6 +156,7 @@ pub struct Resources {
     pub entity_types: HashMap<String, Vec<CreateEntityTypeParams>>,
     pub entity_type_catalogs: HashMap<String, InMemoryEntityTypeCatalog>,
     pub entity_object_catalogs: HashMap<String, InMemoryEntityObjectRegistry>,
+    pub entity_catalogs: HashMap<String, InMemoryEntityCatalog>,
     pub entities: HashMap<String, Vec<CreateEntityParams>>,
 }
 
@@ -215,7 +217,10 @@ impl Runner {
             &conn_info,
             &DatabasePoolConfig::default(),
             NoTls,
-            PostgresStoreSettings::default(),
+            PostgresStoreSettings {
+                validate_links: true,
+                skip_embedding_creation: true,
+            },
         )
         .await
         .change_context(ScenarioError::Db)?;

--- a/tests/graph/benches/graph/scenario/stages/data_type.rs
+++ b/tests/graph/benches/graph/scenario/stages/data_type.rs
@@ -8,7 +8,6 @@ use hash_graph_test_data::seeding::{
     context::StageId,
     producer::data_type::{DataTypeCatalog, DataTypeProducerDeps},
 };
-use rand::{Rng, seq::IndexedRandom as _};
 use type_system::{
     ontology::data_type::schema::DataTypeReference,
     principal::{actor::ActorEntityUuid, actor_group::WebId},
@@ -261,13 +260,6 @@ impl InMemoryDataTypeCatalog {
 impl DataTypeCatalog for InMemoryDataTypeCatalog {
     fn data_type_references(&self) -> &[DataTypeReference] {
         &self.data_types
-    }
-
-    fn sample_data_type<R: Rng + ?Sized>(&self, rng: &mut R) -> &DataTypeReference {
-        // Uniform selection from available data types using SliceRandom::choose
-        self.data_types
-            .choose(rng)
-            .unwrap_or_else(|| unreachable!("catalog should not be empty"))
     }
 }
 

--- a/tests/graph/benches/graph/scenario/stages/entity.rs
+++ b/tests/graph/benches/graph/scenario/stages/entity.rs
@@ -219,8 +219,8 @@ impl PersistEntitiesStage {
             for entity in created_entities {
                 for entity_type in &entity.metadata.entity_type_ids {
                     let id = entity.metadata.record_id.entity_id;
-                    if let Some(vec) = entity_ids_by_type.get_mut(entity_type) {
-                        vec.push(id);
+                    if let Some(entity_ids) = entity_ids_by_type.get_mut(entity_type) {
+                        entity_ids.push(id);
                     } else {
                         entity_ids_by_type.insert(entity_type.clone(), vec![id]);
                     }

--- a/tests/graph/benches/graph/scenario/stages/entity_type.rs
+++ b/tests/graph/benches/graph/scenario/stages/entity_type.rs
@@ -22,7 +22,6 @@ use hash_graph_test_data::seeding::{
     },
     producer::entity_type::{EntityTypeCatalog, EntityTypeProducerDeps},
 };
-use rand::{Rng, seq::IndexedRandom as _};
 use type_system::{
     ontology::{
         data_type::schema::DataTypeReference,
@@ -349,13 +348,6 @@ impl InMemoryEntityTypeCatalog {
 impl EntityTypeCatalog for InMemoryEntityTypeCatalog {
     fn entity_type_references(&self) -> &[EntityTypeReference] {
         &self.entity_types
-    }
-
-    fn sample_entity_type<R: Rng + ?Sized>(&self, rng: &mut R) -> &EntityTypeReference {
-        // Uniform selection from available data types using SliceRandom::choose
-        self.entity_types
-            .choose(rng)
-            .unwrap_or_else(|| unreachable!("catalog should not be empty"))
     }
 }
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/tests/graph/benches/graph/scenario/stages/mod.rs
+++ b/tests/graph/benches/graph/scenario/stages/mod.rs
@@ -58,6 +58,7 @@ pub enum Stage {
 }
 
 impl Stage {
+    #[tracing::instrument(skip(self, runner), fields(stage_id = %self.id(), otel.name = format!("execute({})", self.id())))]
     pub async fn execute(&self, runner: &mut Runner) -> Result<JsonValue, Report<StageError>> {
         match self {
             Self::ResetDb(stage) => stage

--- a/tests/graph/benches/graph/scenario/stages/property_type.rs
+++ b/tests/graph/benches/graph/scenario/stages/property_type.rs
@@ -8,7 +8,6 @@ use hash_graph_test_data::seeding::{
     context::StageId,
     producer::property_type::{PropertyTypeCatalog, PropertyTypeProducerDeps},
 };
-use rand::{Rng, seq::IndexedRandom as _};
 use type_system::{
     ontology::{property_type::schema::PropertyTypeReference, provenance::OntologyOwnership},
     principal::{actor::ActorEntityUuid, actor_group::WebId},
@@ -292,13 +291,6 @@ impl InMemoryPropertyTypeCatalog {
 impl PropertyTypeCatalog for InMemoryPropertyTypeCatalog {
     fn property_type_references(&self) -> &[PropertyTypeReference] {
         &self.property_types
-    }
-
-    fn sample_property_type<R: Rng + ?Sized>(&self, rng: &mut R) -> &PropertyTypeReference {
-        // Uniform selection from available data types using SliceRandom::choose
-        self.property_types
-            .choose(rng)
-            .unwrap_or_else(|| unreachable!("catalog should not be empty"))
     }
 }
 

--- a/tests/graph/test-data/rust/src/seeding/producer/entity.rs
+++ b/tests/graph/test-data/rust/src/seeding/producer/entity.rs
@@ -6,7 +6,10 @@ use hash_graph_store::entity::CreateEntityParams;
 use rand::{distr::Distribution as _, seq::IndexedRandom as _};
 use type_system::{
     self,
-    knowledge::entity::{EntityId, id::EntityUuid, provenance::ProvidedEntityEditionProvenance},
+    knowledge::{
+        entity::{EntityId, LinkData, id::EntityUuid, provenance::ProvidedEntityEditionProvenance},
+        property::metadata::PropertyProvenance,
+    },
     ontology::VersionedUrl,
 };
 
@@ -56,15 +59,20 @@ impl EntityProducerConfig {
     /// # Errors
     ///
     /// Returns an error if the producer cannot be created.
+    #[expect(
+        clippy::type_complexity,
+        reason = "False positive. The type is not complex, there are just some generics"
+    )]
     pub fn create_producer<
         U: WebCatalog,
         O: WebCatalog,
-        E: EntityTypeCatalog,
+        ET: EntityTypeCatalog,
         D: EntityObjectDistributionRegistry,
+        E: EntityCatalog,
     >(
         &self,
-        deps: EntityProducerDeps<U, O, E, D>,
-    ) -> Result<EntityProducer<U, O, E, D>, Report<[EntityProducerConfigError]>> {
+        deps: EntityProducerDeps<U, O, ET, D, E>,
+    ) -> Result<EntityProducer<U, O, ET, D, E>, Report<[EntityProducerConfigError]>> {
         let web = self
             .metadata
             .web
@@ -82,7 +90,9 @@ impl EntityProducerConfig {
             local_id: LocalId::default(),
             web,
             entity_type: deps.entity_type_catalog,
-            object: deps.entity_object_registry,
+            entity_object_registry: deps.entity_object_registry,
+            source_link_type_catalog: deps.source_link_type_catalog,
+            entity_catalog: deps.entity_catalog,
             provenance,
         })
     }
@@ -93,26 +103,32 @@ impl EntityProducerConfig {
 pub struct EntityProducerDeps<
     U: WebCatalog,
     O: WebCatalog,
-    E: EntityTypeCatalog,
+    ET: EntityTypeCatalog,
     D: EntityObjectDistributionRegistry,
+    E: EntityCatalog,
 > {
     pub user_catalog: Option<U>,
     pub org_catalog: Option<O>,
-    pub entity_type_catalog: E,
+    pub entity_type_catalog: ET,
+    pub source_link_type_catalog: Option<ET>,
     pub entity_object_registry: D,
+    pub entity_catalog: Option<E>,
 }
 
 #[derive(Debug)]
 pub struct EntityProducer<
     U: WebCatalog,
     O: WebCatalog,
-    E: EntityTypeCatalog,
+    ET: EntityTypeCatalog,
     D: EntityObjectDistributionRegistry,
+    E: EntityCatalog,
 > {
     local_id: LocalId,
     web: LocalChoiceSampler<U, O>,
-    entity_type: E,
-    object: D,
+    entity_type: ET,
+    entity_object_registry: D,
+    source_link_type_catalog: Option<ET>,
+    entity_catalog: Option<E>,
     provenance: ConstDistribution<ProvidedEntityEditionProvenance>,
 }
 
@@ -122,12 +138,19 @@ pub enum EntityProducerError {
     MissingObjectDistribution,
     #[display("Could not sample entity object distribution")]
     Object,
+    #[display("Tried to create a link but no entity catalog was bound")]
+    MissingEntityCatalog,
 }
 
 impl Error for EntityProducerError {}
 
-impl<U: WebCatalog, O: WebCatalog, E: EntityTypeCatalog, D: EntityObjectDistributionRegistry>
-    Producer<CreateEntityParams> for EntityProducer<U, O, E, D>
+impl<
+    U: WebCatalog,
+    O: WebCatalog,
+    ET: EntityTypeCatalog,
+    D: EntityObjectDistributionRegistry,
+    E: EntityCatalog,
+> Producer<CreateEntityParams> for EntityProducer<U, O, ET, D, E>
 {
     type Error = Report<EntityProducerError>;
 
@@ -138,6 +161,7 @@ impl<U: WebCatalog, O: WebCatalog, E: EntityTypeCatalog, D: EntityObjectDistribu
 
         let entity_gid = context.global_id(local_id, Scope::Id, SubScope::Unknown);
         let object_gid = context.global_id(local_id, Scope::Object, SubScope::Property);
+        let link_gid = context.global_id(local_id, Scope::Object, SubScope::Link);
         let web_gid = context.global_id(local_id, Scope::Metadata, SubScope::Web);
         let type_gid = context.global_id(local_id, Scope::Metadata, SubScope::Type);
         let provenance_gid = context.global_id(local_id, Scope::Metadata, SubScope::Provenance);
@@ -145,13 +169,46 @@ impl<U: WebCatalog, O: WebCatalog, E: EntityTypeCatalog, D: EntityObjectDistribu
         let (_, _, web) = self.web.sample(&mut web_gid.rng());
         let entity_type_url = self.entity_type.sample_entity_type(&mut type_gid.rng());
         let entity_object_distribution = self
-            .object
+            .entity_object_registry
             .get_distribution(entity_type_url)
             .ok_or(EntityProducerError::MissingObjectDistribution)?;
 
         let properties = entity_object_distribution
             .sample(&mut object_gid.rng())
             .change_context(EntityProducerError::Object)?;
+
+        let mut link_rng = link_gid.rng();
+
+        #[expect(clippy::todo, reason = "Incomplete implementation")]
+        let link_data = if let Some(source_entity_types) = &self.source_link_type_catalog
+            && let Some((source_type, target_type)) =
+                source_entity_types.sample_link(&entity_type_url.url, &mut link_rng)
+        {
+            let entity_catalog = self
+                .entity_catalog
+                .as_ref()
+                .ok_or(EntityProducerError::MissingEntityCatalog)?;
+
+            let target_type =
+                target_type.unwrap_or_else(|| todo!("https://linear.app/hash/issue/BE-101"));
+
+            let source_entity_id = entity_catalog
+                .sample_entity_id(source_type, &mut link_rng)
+                .unwrap_or_else(|| todo!("https://linear.app/hash/issue/BE-102"));
+            let target_entity_id = entity_catalog
+                .sample_entity_id(target_type, &mut link_rng)
+                .unwrap_or_else(|| todo!("https://linear.app/hash/issue/BE-102"));
+            Some(LinkData {
+                left_entity_id: source_entity_id,
+                left_entity_confidence: None,
+                left_entity_provenance: PropertyProvenance::default(),
+                right_entity_id: target_entity_id,
+                right_entity_confidence: None,
+                right_entity_provenance: PropertyProvenance::default(),
+            })
+        } else {
+            None
+        };
 
         Ok(CreateEntityParams {
             web_id: web,
@@ -160,7 +217,7 @@ impl<U: WebCatalog, O: WebCatalog, E: EntityTypeCatalog, D: EntityObjectDistribu
             entity_type_ids: HashSet::from([entity_type_url.url.clone()]),
             properties,
             confidence: None,
-            link_data: None,
+            link_data,
             draft: false,
             policies: Vec::new(),
             provenance: self.provenance.sample(&mut provenance_gid.rng()),
@@ -181,8 +238,8 @@ pub trait EntityCatalog {
         &self,
         entity_type: &VersionedUrl,
         rng: &mut R,
-    ) -> Option<&EntityId> {
-        self.entity_ids(entity_type)?.choose(rng)
+    ) -> Option<EntityId> {
+        self.entity_ids(entity_type)?.choose(rng).copied()
     }
 }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Link entities are a core part of the system. They are a bit more complex to create as they need to precisely match the entity type, so it has to pick the correct other entities. 

## 🚫 Blocked by

- #7778 

## 🔍 What does this change?

- Extend current functionality by link entity creation

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

- We currently don't track which user can access which entity (basically only their own entities at this stage). So the linked-entity scenario only creates a single user web currently.