### PR TITLE
BE-38: HashQL: `meet` and `join` should consider subtyping

### DIFF
--- a/libs/@local/hashql/core/src/type/kind/tests/mod.rs
+++ b/libs/@local/hashql/core/src/type/kind/tests/mod.rs
@@ -5,7 +5,7 @@ use crate::{
     pretty::{PrettyOptions, PrettyPrint as _},
     r#type::{
         TypeId,
-        environment::{AnalysisEnvironment, Environment, LatticeEnvironment},
+        environment::{AnalysisEnvironment, Environment, LatticeEnvironment, Variance},
         lattice::Lattice as _,
     },
 };
@@ -76,6 +76,25 @@ pub(crate) fn assert_equivalent(env: &Environment, lhs: TypeId, rhs: TypeId) {
         .pretty_print(env, PrettyOptions::default());
 
     assert!(analysis.is_equivalent(lhs, rhs), "{lhs_repr} != {rhs_repr}");
+}
+
+#[track_caller]
+pub(crate) fn assert_is_subtype(env: &Environment, lhs: TypeId, rhs: TypeId) {
+    let mut analysis = AnalysisEnvironment::new(env);
+
+    let lhs_repr = analysis
+        .r#type(lhs)
+        .kind
+        .pretty_print(env, PrettyOptions::default());
+    let rhs_repr = analysis
+        .r#type(rhs)
+        .kind
+        .pretty_print(env, PrettyOptions::default());
+
+    assert!(
+        analysis.is_subtype_of(Variance::Covariant, lhs, rhs),
+        "{lhs_repr} !< {rhs_repr}"
+    );
 }
 
 macro_rules! ty {

--- a/libs/@local/hashql/core/src/type/kind/tests/tuple.rs
+++ b/libs/@local/hashql/core/src/type/kind/tests/tuple.rs
@@ -21,7 +21,7 @@ use crate::{
             intersection::IntersectionType,
             primitive::PrimitiveType,
             test::{assert_equiv, generic, intersection, primitive, tuple, union},
-            tests::{assert_equivalent, assert_is_subtype, assert_join, assert_meet},
+            tests::{assert_is_subtype, assert_join, assert_meet},
             union::UnionType,
         },
         lattice::{Lattice as _, Projection, Subscript, test::assert_lattice_laws},

--- a/libs/@local/hashql/core/src/type/kind/tests/tuple.rs
+++ b/libs/@local/hashql/core/src/type/kind/tests/tuple.rs
@@ -7,6 +7,7 @@ use crate::{
     symbol::Ident,
     r#type::{
         PartialType,
+        builder::lazy,
         environment::{
             AnalysisEnvironment, Environment, InferenceEnvironment, LatticeEnvironment,
             SimplifyEnvironment, Variance, instantiate::InstantiateEnvironment,
@@ -20,10 +21,11 @@ use crate::{
             intersection::IntersectionType,
             primitive::PrimitiveType,
             test::{assert_equiv, generic, intersection, primitive, tuple, union},
+            tests::{assert_equivalent, assert_is_subtype, assert_join, assert_meet},
             union::UnionType,
         },
         lattice::{Lattice as _, Projection, Subscript, test::assert_lattice_laws},
-        tests::{instantiate, instantiate_infer, instantiate_param},
+        tests::{instantiate, instantiate_infer, instantiate_param, scaffold},
     },
 };
 
@@ -1136,4 +1138,58 @@ fn subscript() {
         diagnostics[0].category,
         TypeCheckDiagnosticCategory::UnsupportedSubscript
     );
+}
+
+#[test]
+fn meet_recursive_tuple() {
+    scaffold!(heap, env, builder, [lattice: lattice]);
+
+    let lhs = builder.tuple(lazy(|this, builder| [builder.integer(), this.value()]));
+    let rhs = builder.tuple(lazy(|this, builder| [builder.number(), this.value()]));
+
+    assert_meet(&mut lattice, lhs, rhs, &[lhs]);
+    assert_meet(&mut lattice, rhs, lhs, &[lhs]);
+}
+
+#[test]
+fn meet_recursive_tuple_unrelated() {
+    scaffold!(heap, env, builder, [lattice: lattice]);
+
+    let lhs = builder.tuple(lazy(|this, builder| [builder.integer(), this.value()]));
+    let rhs = builder.tuple(lazy(|this, builder| [builder.string(), this.value()]));
+
+    let never = builder.never();
+
+    assert_meet(&mut lattice, lhs, rhs, &[never]);
+    assert_meet(&mut lattice, rhs, lhs, &[never]);
+}
+
+#[test]
+fn join_recursive_tuple() {
+    scaffold!(heap, env, builder, [lattice: lattice]);
+
+    let lhs = builder.tuple(lazy(|this, builder| [builder.integer(), this.value()]));
+    let rhs = builder.tuple(lazy(|this, builder| [builder.number(), this.value()]));
+
+    assert_join(&mut lattice, lhs, rhs, &[rhs]);
+    assert_join(&mut lattice, rhs, lhs, &[rhs]);
+}
+
+#[test]
+fn join_recursive_tuple_unrelated() {
+    scaffold!(heap, env, builder, [lattice: lattice]);
+
+    let lhs = builder.tuple(lazy(|this, builder| [builder.integer(), this.value()]));
+    let rhs = builder.tuple(lazy(|this, builder| [builder.string(), this.value()]));
+
+    // The type itself is a bit larger, than one might light (this is of the recursive property of
+    // the match), but the type approximation is still valid, as proven below.
+    let union = builder.union([builder.integer(), builder.string()]);
+    let expected = builder.tuple([union, builder.tuple([union, builder.union([lhs, rhs])])]);
+
+    assert_join(&mut lattice, lhs, rhs, &[expected]);
+    assert_join(&mut lattice, rhs, lhs, &[expected]);
+
+    assert_is_subtype(&env, lhs, expected);
+    assert_is_subtype(&env, rhs, expected);
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

`meet` and `join` currently indiscriminately choose `lhs` when recursion happens; instead, we should return the type depending on the subtype relationship. If `lhs <: rhs`, we return `lhs`, otherwise we should return `rhs` (on meet — reverse on join).

This has the downside that we traverse a recursive type essentially four times:

1. meet/join
2. Determine if lhs and rhs are recursive
3. subtype relationship
   1. Determine if `lhs` and `rhs` are recursive

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

