### PR TITLE
BE-40: HashQL: Fix `use` expression resolving

### DIFF
--- a/libs/@local/hashql/ast/src/lowering/import_resolver/error.rs
+++ b/libs/@local/hashql/ast/src/lowering/import_resolver/error.rs
@@ -691,13 +691,13 @@ pub(crate) fn from_resolution_error<'heap>(
             let item_span = segments
                 .iter()
                 .find_map(|&(segment_span, segment_name)| {
-                    (segment_name == item.name).then_some(segment_span)
+                    (segment_name == item.name()).then_some(segment_span)
                 })
                 .unwrap_or(path.span);
 
             diagnostic.labels.extend([
                 // Primary label, pointing to the problem
-                Label::new(item_span, format!("'{}' is ambiguous", item.name))
+                Label::new(item_span, format!("'{}' is ambiguous", item.name()))
                     .with_order(0)
                     .with_color(Color::Ansi(AnsiColor::Red)),
                 // Secondary label, pointing to the path
@@ -709,7 +709,7 @@ pub(crate) fn from_resolution_error<'heap>(
             diagnostic.add_help(Help::new(format!(
                 "The name '{}' could refer to multiple different items in {}. Use a fully \
                  qualified path to specify which one you want.",
-                item.name,
+                item.name(),
                 FormatPath(path.rooted, &segments, None)
             )));
 

--- a/libs/@local/hashql/ast/src/lowering/import_resolver/mod.rs
+++ b/libs/@local/hashql/ast/src/lowering/import_resolver/mod.rs
@@ -278,7 +278,7 @@ impl<'heap> Visitor<'heap> for ImportResolver<'_, 'heap> {
                 suggestions,
             }) if modules.is_empty() => {
                 self.diagnostics.push(unresolved_variable(
-                    self.namespace.registry,
+                    self.namespace.registry(),
                     self.current_universe,
                     ident.name,
                     match self.current_universe {
@@ -300,7 +300,7 @@ impl<'heap> Visitor<'heap> for ImportResolver<'_, 'heap> {
             }
         };
 
-        let segments: Vec<_> = item.absolute_path(self.namespace.registry).collect();
+        let segments: Vec<_> = item.absolute_path(self.namespace.registry()).collect();
 
         // The trailing segments might not be the same due to renames, reset the symbol to the
         // canonical form (but retain the span)

--- a/libs/@local/hashql/ast/src/lowering/pre_expansion_name_resolver.rs
+++ b/libs/@local/hashql/ast/src/lowering/pre_expansion_name_resolver.rs
@@ -94,7 +94,7 @@ use hashql_core::{
     collection::FastHashMap,
     heap::Heap,
     module::{
-        ModuleRegistry, Universe,
+        ModuleRegistry, Reference, Universe,
         item::{IntrinsicItem, IntrinsicValueItem, ItemKind},
         namespace::{ModuleNamespace, ResolutionMode, ResolveOptions},
     },
@@ -238,7 +238,7 @@ impl<'env, 'heap> PreExpansionNameResolver<'env, 'heap> {
         // This is very conservative, in *theory* we should take a look at the whole path and use
         // that as import, but as we're only interested in special-forms, which are only imported as
         // name, we can safely just use the name.
-        let import = self
+        let reference = self
             .namespace
             .resolve(
                 [name],
@@ -248,6 +248,10 @@ impl<'env, 'heap> PreExpansionNameResolver<'env, 'heap> {
                 },
             )
             .ok()?;
+
+        let Reference::Item(import) = reference else {
+            return None;
+        };
 
         // We're only interested in intrinsics
         let ItemKind::Intrinsic(IntrinsicItem::Value(IntrinsicValueItem {

--- a/libs/@local/hashql/ast/src/lowering/pre_expansion_name_resolver.rs
+++ b/libs/@local/hashql/ast/src/lowering/pre_expansion_name_resolver.rs
@@ -240,7 +240,7 @@ impl<'env, 'heap> PreExpansionNameResolver<'env, 'heap> {
         // name, we can safely just use the name.
         let import = self
             .namespace
-            .resolve_relative(
+            .resolve(
                 [name],
                 ResolveOptions {
                     mode: ResolutionMode::Relative,

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/use-shadowing-let.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/use-shadowing-let.jsonc
@@ -1,3 +1,8 @@
 //@ run: pass
 //@ description: Verify that shadowing via `let` works as expected.
-["use", "::core::math", {"#tuple": ["add"]}, ["let", "add", {"#literal": 2}, "add"]]
+[
+  "use",
+  "::core::math",
+  { "#tuple": ["add"] },
+  ["let", "add", { "#literal": 2 }, "add"]
+]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/use-shadowing-let.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/use-shadowing-let.jsonc
@@ -1,0 +1,3 @@
+//@ run: pass
+//@ description: Verify that shadowing via `let` works as expected.
+["use", "::core::math", {"#tuple": ["add"]}, ["let", "add", {"#literal": 2}, "add"]]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/use-shadowing-let.stdout
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/use-shadowing-let.stdout
@@ -1,0 +1,12 @@
+Expr#4294967040@30
+  ExprKind (Let)
+    LetExpr#4294967040@30 (name: add)
+      Expr#4294967040@25
+        ExprKind (Literal)
+          LiteralExpr#4294967040@24
+            LiteralKind (Integer)
+              IntegerLiteral (2)
+      Expr#4294967040@29
+        ExprKind (Path)
+          Path#4294967040@29 (rooted: false)
+            PathSegment#4294967040@28 (name: add)

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/use-shadowing-use.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/use-shadowing-use.jsonc
@@ -1,3 +1,8 @@
 //@ run: pass
 //@ description: Verify that shadowing via `use` works as expected.
-["let", "add", {"#literal": 2}, ["use", "::core::math", {"#tuple": ["add"]}, "add"]]
+[
+  "let",
+  "add",
+  { "#literal": 2 },
+  ["use", "::core::math", { "#tuple": ["add"] }, "add"]
+]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/use-shadowing-use.jsonc
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/use-shadowing-use.jsonc
@@ -1,0 +1,3 @@
+//@ run: pass
+//@ description: Verify that shadowing via `use` works as expected.
+["let", "add", {"#literal": 2}, ["use", "::core::math", {"#tuple": ["add"]}, "add"]]

--- a/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/use-shadowing-use.stdout
+++ b/libs/@local/hashql/ast/tests/ui/lowering/import-resolver/use-shadowing-use.stdout
@@ -1,0 +1,14 @@
+Expr#4294967040@31
+  ExprKind (Let)
+    LetExpr#4294967040@31 (name: add)
+      Expr#4294967040@9
+        ExprKind (Literal)
+          LiteralExpr#4294967040@8
+            LiteralKind (Integer)
+              IntegerLiteral (2)
+      Expr#4294967040@29
+        ExprKind (Path)
+          Path#4294967040@29 (rooted: true)
+            PathSegment#4294967040@28 (name: core)
+            PathSegment#4294967040@28 (name: math)
+            PathSegment#4294967040@28 (name: add)

--- a/libs/@local/hashql/core/src/module/error.rs
+++ b/libs/@local/hashql/core/src/module/error.rs
@@ -1,4 +1,4 @@
-use super::{ModuleId, Universe, import::Import, item::Item};
+use super::{ModuleId, Universe, import::Import, item::Item, resolver::Reference};
 use crate::symbol::Symbol;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -40,7 +40,7 @@ pub enum ResolutionError<'heap> {
         suggestions: Vec<ResolutionSuggestion<'heap, Item<'heap>>>,
     },
 
-    Ambiguous(Item<'heap>),
+    Ambiguous(Reference<'heap>),
 
     ModuleEmpty {
         depth: usize,

--- a/libs/@local/hashql/core/src/module/locals.rs
+++ b/libs/@local/hashql/core/src/module/locals.rs
@@ -175,3 +175,9 @@ impl<'heap, T> Index<Symbol<'heap>> for Locals<'heap, T> {
 }
 
 pub type TypeLocals<'heap> = Locals<'heap, TypeDef<'heap>>;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct LocalBinding<'heap, T> {
+    pub name: Symbol<'heap>,
+    pub value: T,
+}

--- a/libs/@local/hashql/core/src/module/mod.rs
+++ b/libs/@local/hashql/core/src/module/mod.rs
@@ -19,7 +19,7 @@ pub use self::universe::Universe;
 use self::{
     error::{ResolutionError, ResolutionSuggestion},
     item::{Item, ItemKind},
-    resolver::{Resolver, ResolverMode, ResolverOptions},
+    resolver::{Reference, Resolver, ResolverMode, ResolverOptions},
     std_lib::StandardLibrary,
 };
 use crate::{
@@ -176,7 +176,7 @@ impl<'heap> ModuleRegistry<'heap> {
         &self,
         path: impl IntoIterator<Item = Symbol<'heap>>,
         universe: Universe,
-    ) -> Result<Item<'heap>, ResolutionError<'heap>> {
+    ) -> Result<Reference<'heap>, ResolutionError<'heap>> {
         let resolver = Resolver {
             registry: self,
             options: ResolverOptions {
@@ -215,7 +215,7 @@ impl<'heap> ModuleRegistry<'heap> {
         &self,
         path: impl IntoIterator<Item = Symbol<'heap>>,
         universe: Universe,
-    ) -> Option<Item<'heap>> {
+    ) -> Option<Reference<'heap>> {
         let resolver = Resolver {
             registry: self,
             options: ResolverOptions {

--- a/libs/@local/hashql/core/src/module/namespace.rs
+++ b/libs/@local/hashql/core/src/module/namespace.rs
@@ -10,6 +10,7 @@ use super::{
     resolver::{Reference, ResolveIter},
 };
 use crate::{
+    collection::FastHashSet,
     module::resolver::{Resolver, ResolverMode, ResolverOptions},
     symbol::Symbol,
 };
@@ -170,6 +171,20 @@ impl<'env, 'heap> ModuleNamespace<'env, 'heap> {
             name,
             item: ImportReference::Binding(universe),
         });
+    }
+
+    /// Return all the locals that have been registered so far
+    #[must_use]
+    pub fn locals(&self, universe: Universe) -> FastHashSet<Symbol<'heap>> {
+        self.imports
+            .iter()
+            .filter_map(|import| match import.item {
+                ImportReference::Binding(binding_universe) if binding_universe == universe => {
+                    Some(import.name)
+                }
+                ImportReference::Binding(_) | ImportReference::Item(_) => None,
+            })
+            .collect()
     }
 
     fn import_absolute_static(

--- a/libs/@local/hashql/core/src/module/resolver.rs
+++ b/libs/@local/hashql/core/src/module/resolver.rs
@@ -1,27 +1,50 @@
 use core::{fmt::Debug, iter};
 
 use super::{
-    Module, ModuleRegistry, Universe,
+    Module, ModuleId, ModuleRegistry, Universe,
     error::{ResolutionError, ResolutionSuggestion},
     import::Import,
     item::{Item, ItemKind},
+    locals::LocalBinding,
 };
-use crate::symbol::Symbol;
+use crate::{module::import::ImportReference, symbol::Symbol};
 
-pub(crate) type ModuleItemIterator<'heap> = impl ExactSizeIterator<Item = Item<'heap>> + Debug;
-pub(crate) type MultiResolveItemIterator<'heap> = impl Iterator<Item = Item<'heap>> + Debug;
-pub(crate) type MultiResolveImportIterator<'heap> = impl Iterator<Item = Item<'heap>> + Debug;
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Reference<'heap> {
+    Binding(LocalBinding<'heap, Universe>),
+    Item(Item<'heap>),
+}
+
+impl<'heap> Reference<'heap> {
+    pub const fn name(&self) -> Symbol<'heap> {
+        match self {
+            Self::Binding(binding) => binding.name,
+            Self::Item(item) => item.name,
+        }
+    }
+
+    pub const fn universe(&self) -> Option<Universe> {
+        match self {
+            Self::Binding(binding) => Some(binding.value),
+            Self::Item(item) => item.kind.universe(),
+        }
+    }
+}
+
+pub(crate) type ModuleItemIterator<'heap> = impl ExactSizeIterator<Item = Reference<'heap>> + Debug;
+pub(crate) type MultiResolveItemIterator<'heap> = impl Iterator<Item = Reference<'heap>> + Debug;
+pub(crate) type MultiResolveImportIterator<'heap> = impl Iterator<Item = Reference<'heap>> + Debug;
 
 #[derive(Debug)]
 pub(crate) enum ResolveIter<'heap> {
-    Single(iter::Once<Item<'heap>>),
+    Single(iter::Once<Reference<'heap>>),
     MultiResolve(MultiResolveItemIterator<'heap>),
     MultiImport(MultiResolveImportIterator<'heap>),
     Glob(ModuleItemIterator<'heap>),
 }
 
 impl<'heap> Iterator for ResolveIter<'heap> {
-    type Item = Item<'heap>;
+    type Item = Reference<'heap>;
 
     fn next(&mut self) -> Option<Self::Item> {
         match self {
@@ -29,6 +52,15 @@ impl<'heap> Iterator for ResolveIter<'heap> {
             ResolveIter::MultiResolve(iter) => iter.next(),
             ResolveIter::MultiImport(iter) => iter.next(),
             ResolveIter::Glob(iter) => iter.next(),
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self {
+            ResolveIter::Single(iter) => iter.size_hint(),
+            ResolveIter::MultiResolve(iter) => iter.size_hint(),
+            ResolveIter::MultiImport(iter) => iter.size_hint(),
+            ResolveIter::Glob(iter) => iter.size_hint(),
         }
     }
 }
@@ -69,7 +101,7 @@ impl<'heap> Resolver<'_, 'heap> {
         universe: Universe,
         name: Symbol<'heap>,
         depth: usize,
-    ) -> Result<iter::Once<Item<'heap>>, ResolutionError<'heap>> {
+    ) -> Result<iter::Once<Reference<'heap>>, ResolutionError<'heap>> {
         let item = module
             .items
             .iter()
@@ -85,7 +117,7 @@ impl<'heap> Resolver<'_, 'heap> {
             });
         };
 
-        Ok(iter::once(item))
+        Ok(iter::once(Reference::Item(item)))
     }
 
     #[define_opaque(MultiResolveItemIterator)]
@@ -100,6 +132,7 @@ impl<'heap> Resolver<'_, 'heap> {
             .into_iter()
             .copied()
             .filter(move |item| item.name == name)
+            .map(Reference::Item)
             .peekable();
 
         if item.peek().is_none() {
@@ -148,7 +181,7 @@ impl<'heap> Resolver<'_, 'heap> {
             return Err(ResolutionError::ModuleEmpty { depth });
         }
 
-        Ok(module.items.into_iter().copied())
+        Ok(module.items.into_iter().copied().map(Reference::Item))
     }
 
     #[define_opaque(ModuleItemIterator)]
@@ -166,7 +199,9 @@ impl<'heap> Resolver<'_, 'heap> {
                 return Err(ResolutionError::ModuleEmpty { depth: 0 });
             }
 
-            return Ok(ResolveIter::Glob(module.items.into_iter().copied()));
+            return Ok(ResolveIter::Glob(
+                module.items.into_iter().copied().map(Reference::Item),
+            ));
         }
 
         // Traverse the entry until we're at the last item
@@ -243,11 +278,11 @@ impl<'heap> Resolver<'_, 'heap> {
         name: Symbol<'heap>,
         imports: &[Import<'heap>],
         universe: Universe,
-    ) -> Result<iter::Once<Item<'heap>>, ResolutionError<'heap>> {
+    ) -> Result<iter::Once<Reference<'heap>>, ResolutionError<'heap>> {
         let import = imports
             .iter()
             .rev()
-            .find(|import| import.name == name && import.item.kind.universe() == Some(universe));
+            .find(|import| import.name == name && import.item.universe() == Some(universe));
 
         let Some(import) = import else {
             return Err(ResolutionError::ImportNotFound {
@@ -256,7 +291,7 @@ impl<'heap> Resolver<'_, 'heap> {
                 suggestions: self.suggest(|| {
                     imports
                         .iter()
-                        .filter(|import| import.item.kind.universe() == Some(universe))
+                        .filter(|import| import.item.universe() == Some(universe))
                         .map(|&import| ResolutionSuggestion {
                             item: import,
                             name: import.name,
@@ -266,7 +301,7 @@ impl<'heap> Resolver<'_, 'heap> {
             });
         };
 
-        Ok(iter::once(import.item))
+        Ok(iter::once(import.into_reference()))
     }
 
     #[define_opaque(MultiResolveImportIterator)]
@@ -284,13 +319,22 @@ impl<'heap> Resolver<'_, 'heap> {
         // try to import one of every type
         let value = base
             .clone()
-            .find(|import| import.item.kind.universe() == Some(Universe::Value));
+            .find(|import| import.item.universe() == Some(Universe::Value));
 
         let r#type = base
             .clone()
-            .find(|import| import.item.kind.universe() == Some(Universe::Type));
+            .find(|import| import.item.universe() == Some(Universe::Type));
 
-        let module = base.find(|import| matches!(import.item.kind, ItemKind::Module(_)));
+        let module = base.find(|import| {
+            matches!(
+                import.item,
+                ImportReference::Item(Item {
+                    kind: ItemKind::Module(_),
+                    module: _,
+                    name: _
+                })
+            )
+        });
 
         if value.is_none() && r#type.is_none() && module.is_none() {
             return Err(ResolutionError::ImportNotFound {
@@ -312,7 +356,30 @@ impl<'heap> Resolver<'_, 'heap> {
             .into_iter()
             .chain(r#type)
             .chain(module)
-            .map(|import| import.item))
+            .map(Import::into_reference))
+    }
+
+    fn find_module_from_imports(
+        name: Symbol<'heap>,
+        imports: &[Import<'heap>],
+    ) -> Option<ModuleId> {
+        imports.iter().rev().find_map(|import| match import.item {
+            ImportReference::Item(Item {
+                kind: ItemKind::Module(module),
+                module: _,
+                name: _,
+            }) if import.name == name => Some(module),
+            ImportReference::Item(Item {
+                kind:
+                    ItemKind::Module(_)
+                    | ItemKind::Type(_)
+                    | ItemKind::Constructor(_)
+                    | ItemKind::Intrinsic(_),
+                module: _,
+                name: _,
+            })
+            | ImportReference::Binding(_) => None,
+        })
     }
 
     #[define_opaque(ModuleItemIterator)]
@@ -321,16 +388,7 @@ impl<'heap> Resolver<'_, 'heap> {
         name: Symbol<'heap>,
         imports: &[Import<'heap>],
     ) -> Result<ModuleItemIterator<'heap>, ResolutionError<'heap>> {
-        let module = imports
-            .iter()
-            .rev()
-            .find_map(|import| match import.item.kind {
-                ItemKind::Module(module) if import.name == name => Some(module),
-                ItemKind::Module(_)
-                | ItemKind::Type(_)
-                | ItemKind::Constructor(_)
-                | ItemKind::Intrinsic(_) => None,
-            });
+        let module = Self::find_module_from_imports(name, imports);
 
         let Some(module) = module else {
             return Err(ResolutionError::ModuleRequired {
@@ -345,7 +403,7 @@ impl<'heap> Resolver<'_, 'heap> {
             return Err(ResolutionError::ModuleEmpty { depth: 0 });
         }
 
-        Ok(module.items.into_iter().copied())
+        Ok(module.items.into_iter().copied().map(Reference::Item))
     }
 
     #[expect(clippy::panic_in_result_fn, reason = "sanity check")]
@@ -363,16 +421,7 @@ impl<'heap> Resolver<'_, 'heap> {
         let has_next = query.peek().is_some();
 
         if has_next {
-            let module = imports
-                .iter()
-                .rev()
-                .find_map(|import| match import.item.kind {
-                    ItemKind::Module(module) if import.name == name => Some(module),
-                    ItemKind::Module(_)
-                    | ItemKind::Type(_)
-                    | ItemKind::Constructor(_)
-                    | ItemKind::Intrinsic(_) => None,
-                });
+            let module = Self::find_module_from_imports(name, imports);
 
             let Some(module) = module else {
                 return Err(ResolutionError::ModuleNotFound {
@@ -382,11 +431,9 @@ impl<'heap> Resolver<'_, 'heap> {
                         // take every unique name from the imports (that are modules)
                         let mut names: Vec<_> = imports
                             .iter()
-                            .filter(|import| matches!(import.item.kind, ItemKind::Module(_)))
-                            .map(|import| ResolutionSuggestion {
-                                item: import.item,
-                                name: import.name,
-                            })
+                            .filter_map(|import| import.into_item().map(|item| (import.name, item)))
+                            .filter(|(_, item)| matches!(item.kind, ItemKind::Module(_)))
+                            .map(|(name, item)| ResolutionSuggestion { item, name })
                             .collect();
 
                         names.sort_unstable_by_key(|ResolutionSuggestion { item: _, name }| *name);
@@ -419,19 +466,31 @@ impl<'heap> Resolver<'_, 'heap> {
 
 #[cfg(test)]
 mod test {
+    #![coverage(off)]
     use core::assert_matches::assert_matches;
 
-    use super::ResolutionError;
+    use super::{Reference, ResolutionError};
     use crate::{
         heap::Heap,
         module::{
             ModuleId, ModuleRegistry, PartialModule, Universe,
+            item::Item,
             namespace::{ImportOptions, ModuleNamespace, ResolutionMode},
             resolver::{Resolver, ResolverMode, ResolverOptions},
         },
         span::SpanId,
         r#type::environment::Environment,
     };
+
+    impl<'heap> Reference<'heap> {
+        #[track_caller]
+        pub(crate) fn expect_item(self) -> Item<'heap> {
+            match self {
+                Self::Binding(_) => panic!("Expected an item, received a binding"),
+                Self::Item(item) => item,
+            }
+        }
+    }
 
     #[test]
     fn single_mode_resolve_type() {
@@ -457,8 +516,10 @@ mod test {
 
         let items: Vec<_> = result.collect();
         assert_eq!(items.len(), 1);
-        assert_eq!(items[0].name.as_str(), "Dict",);
-        assert_eq!(items[0].kind.universe(), Some(Universe::Type),);
+
+        let item = items[0].expect_item();
+        assert_eq!(item.name.as_str(), "Dict");
+        assert_eq!(item.kind.universe(), Some(Universe::Type));
     }
 
     #[test]
@@ -485,8 +546,10 @@ mod test {
 
         let items: Vec<_> = result.collect();
         assert_eq!(items.len(), 1);
-        assert_eq!(items[0].name.as_str(), "Url");
-        assert_eq!(items[0].kind.universe(), Some(Universe::Value));
+
+        let item = items[0].expect_item();
+        assert_eq!(item.name.as_str(), "Url");
+        assert_eq!(item.kind.universe(), Some(Universe::Value));
     }
 
     #[test]
@@ -543,13 +606,13 @@ mod test {
         assert!(
             items
                 .iter()
-                .any(|item| item.kind.universe() == Some(Universe::Type))
+                .any(|item| item.universe() == Some(Universe::Type))
         );
 
         assert!(
             items
                 .iter()
-                .any(|item| item.kind.universe() == Some(Universe::Value))
+                .any(|item| item.universe() == Some(Universe::Value))
         );
     }
 
@@ -577,7 +640,9 @@ mod test {
 
         let items: Vec<_> = result.collect();
         assert_eq!(items.len(), 1);
-        assert_eq!(items[0].kind.universe(), Some(Universe::Value));
+
+        let item = items[0].expect_item();
+        assert_eq!(item.kind.universe(), Some(Universe::Value));
     }
 
     #[test]
@@ -602,9 +667,9 @@ mod test {
         assert!(!items.is_empty());
 
         // Check for some known items in the "type" module
-        assert!(items.iter().any(|item| item.name.as_str() == "Dict"));
-        assert!(items.iter().any(|item| item.name.as_str() == "Boolean"));
-        assert!(items.iter().any(|item| item.name.as_str() == "Never"));
+        assert!(items.iter().any(|item| item.name().as_str() == "Dict"));
+        assert!(items.iter().any(|item| item.name().as_str() == "Boolean"));
+        assert!(items.iter().any(|item| item.name().as_str() == "Never"));
     }
 
     #[test]
@@ -629,11 +694,11 @@ mod test {
         assert!(!items.is_empty());
 
         // Check for some known items in the "type" module
-        assert!(items.iter().any(|item| item.name.as_str() == "type"));
+        assert!(items.iter().any(|item| item.name().as_str() == "type"));
         assert!(
             items
                 .iter()
-                .any(|item| item.name.as_str() == "special_form")
+                .any(|item| item.name().as_str() == "special_form")
         );
     }
 
@@ -858,8 +923,8 @@ mod test {
 
         let items: Vec<_> = result.collect();
         assert_eq!(items.len(), 1);
-        assert_eq!(items[0].name.as_str(), "Dict");
-        assert_eq!(items[0].kind.universe(), Some(Universe::Type));
+        assert_eq!(items[0].name().as_str(), "Dict");
+        assert_eq!(items[0].universe(), Some(Universe::Type));
     }
 
     #[test]
@@ -906,12 +971,12 @@ mod test {
         assert!(
             items
                 .iter()
-                .any(|item| item.kind.universe() == Some(Universe::Type))
+                .any(|item| item.universe() == Some(Universe::Type))
         );
         assert!(
             items
                 .iter()
-                .any(|item| item.kind.universe() == Some(Universe::Value))
+                .any(|item| item.universe() == Some(Universe::Value))
         );
 
         let result = resolver
@@ -925,12 +990,12 @@ mod test {
         assert!(
             items
                 .iter()
-                .any(|item| item.kind.universe() == Some(Universe::Type))
+                .any(|item| item.universe() == Some(Universe::Type))
         );
         assert!(
             items
                 .iter()
-                .any(|item| item.kind.universe() == Some(Universe::Value))
+                .any(|item| item.universe() == Some(Universe::Value))
         );
     }
 
@@ -1014,7 +1079,7 @@ mod test {
         assert!(!items.is_empty());
 
         // Check for some known items in the "type" module
-        assert!(items.iter().any(|item| item.name.as_str() == "Dict"));
-        assert!(items.iter().any(|item| item.name.as_str() == "Never"));
+        assert!(items.iter().any(|item| item.name().as_str() == "Dict"));
+        assert!(items.iter().any(|item| item.name().as_str() == "Never"));
     }
 }

--- a/libs/@local/hashql/core/src/module/resolver.rs
+++ b/libs/@local/hashql/core/src/module/resolver.rs
@@ -16,6 +16,7 @@ pub enum Reference<'heap> {
 }
 
 impl<'heap> Reference<'heap> {
+    #[must_use]
     pub const fn name(&self) -> Symbol<'heap> {
         match self {
             Self::Binding(binding) => binding.name,
@@ -23,6 +24,7 @@ impl<'heap> Reference<'heap> {
         }
     }
 
+    #[must_use]
     pub const fn universe(&self) -> Option<Universe> {
         match self {
             Self::Binding(binding) => Some(binding.value),


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Currently declared identifiers always take precedence. This is not correct, instead we should correctly resolve types and values, given:

```rust
use path::to::item in // defines item = 24
let item = 42 in
item == 42

// where as:
let item = 42 in
use path::to::item in
item == 24
```

The current evaluation rules effectively ignore imports for identifiers already declared, which is incorrect.

Current behaviour:

```rust
use path::to::item in // defines item = 24
let item = 42 in
item == 42

let item = 42 in
use path::to::item in
item == 42
```

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
