### PR TITLE
H-5328: Add Pyroscope continuous profiling infrastructure to AWS observability stack

### DIFF
--- a/infra/terraform/hash/observability/alloy/config.tf
+++ b/infra/terraform/hash/observability/alloy/config.tf
@@ -7,9 +7,15 @@ resource "aws_s3_object" "alloy_config" {
 
   # Grafana Alloy configuration
   content = templatefile("${path.module}/templates/alloy-config.alloy.tpl", {
-    region          = var.region
-    mimir_http_dns  = var.mimir_http_dns
-    mimir_http_port = var.mimir_http_port
+    environment           = terraform.workspace
+    region                = var.region
+    profile_port_internal = local.profile_port_internal
+    profile_port_external = local.profile_port_external
+    mimir_http_dns        = var.mimir_http_dns
+    mimir_http_port       = var.mimir_http_port
+    pyroscope_http_dns    = var.pyroscope_http_dns
+    pyroscope_http_port   = var.pyroscope_http_port
+
   })
 
   content_type = "text/plain"

--- a/infra/terraform/hash/observability/alloy/main.tf
+++ b/infra/terraform/hash/observability/alloy/main.tf
@@ -5,11 +5,15 @@ locals {
   prefix       = "${var.prefix}-${local.service_name}"
 
   # Port definitions for Alloy
-  http_port = 5000 # Alloy HTTP API for metrics scraping
+  http_port             = 5000 # Alloy HTTP API for metrics scraping
+  profile_port_internal = 4040
+  profile_port_external = 4042
 
   # Port names for Service Connect
-  http_port_name = "${local.service_name}-http" # HTTP API
+  http_port_name    = "${local.service_name}-http" # HTTP API
+  profile_port_name = "${local.service_name}-profile"
 
   # DNS names for Service Connect
-  http_port_dns = "${local.http_port_name}.${var.service_discovery_namespace_name}"
+  http_port_dns    = "${local.http_port_name}.${var.service_discovery_namespace_name}"
+  profile_port_dns = "${local.profile_port_name}.${var.service_discovery_namespace_name}"
 }

--- a/infra/terraform/hash/observability/alloy/outputs.tf
+++ b/infra/terraform/hash/observability/alloy/outputs.tf
@@ -2,7 +2,15 @@ output "http_port" {
   description = "Port number for Grafana Alloy HTTP API"
   value       = local.http_port
 }
+output "profile_port_internal" {
+  description = "Port number for Grafana Alloy Profile API"
+  value       = local.profile_port_internal
+}
 
+output "profile_port_external" {
+  description = "Port number for Grafana Alloy Profile API"
+  value       = local.profile_port_external
+}
 output "http_port_name" {
   description = "Port name for Service Connect"
   value       = local.http_port_name
@@ -11,4 +19,18 @@ output "http_port_name" {
 output "http_port_dns" {
   description = "Service Connect DNS name for Grafana Alloy metrics endpoint"
   value       = local.http_port_dns
+}
+
+# Target groups for load balancer attachment
+
+# Internal target groups (service-to-service communication)
+output "profile_internal_target_group_arn" {
+  description = "Internal profile target group ARN"
+  value       = aws_lb_target_group.profile_internal.arn
+}
+
+# External target groups (client applications)
+output "profile_external_target_group_arn" {
+  description = "External profile target group ARN"
+  value       = aws_lb_target_group.profile_external.arn
 }

--- a/infra/terraform/hash/observability/alloy/security_groups.tf
+++ b/infra/terraform/hash/observability/alloy/security_groups.tf
@@ -13,6 +13,22 @@ resource "aws_security_group" "alloy" {
     cidr_blocks = [var.vpc.cidr_block]
   }
 
+  # Allow inbound HTTP for profile ingestion
+  ingress {
+    from_port   = local.profile_port_internal
+    to_port     = local.profile_port_internal
+    protocol    = "tcp"
+    description = "Grafana Alloy profile ingestion endpoint"
+    cidr_blocks = [var.vpc.cidr_block]
+  }
+  ingress {
+    from_port   = local.profile_port_external
+    to_port     = local.profile_port_external
+    protocol    = "tcp"
+    description = "Grafana Alloy profile ingestion endpoint"
+    cidr_blocks = [var.vpc.cidr_block]
+  }
+
   # Allow outbound HTTPS for CloudWatch API calls and S3 config download
   egress {
     from_port   = 443
@@ -45,6 +61,15 @@ resource "aws_security_group" "alloy" {
     to_port     = var.mimir_http_port
     protocol    = "tcp"
     description = "HTTP to Mimir for OTLP metrics forwarding"
+    cidr_blocks = [var.vpc.cidr_block]
+  }
+
+  # Allow outbound HTTP to Pyroscope for profile forwarding
+  egress {
+    from_port   = var.pyroscope_http_port
+    to_port     = var.pyroscope_http_port
+    protocol    = "tcp"
+    description = "HTTP to Pyroscope for profile forwarding"
     cidr_blocks = [var.vpc.cidr_block]
   }
 

--- a/infra/terraform/hash/observability/alloy/target_groups.tf
+++ b/infra/terraform/hash/observability/alloy/target_groups.tf
@@ -1,0 +1,51 @@
+# Internal HTTP target group for profiles
+resource "aws_lb_target_group" "profile_internal" {
+  name        = "${var.prefix}-profile-int"
+  port        = local.profile_port_internal
+  protocol    = "HTTP"
+  target_type = "ip"
+  vpc_id      = var.vpc.id
+
+  health_check {
+    enabled             = true
+    healthy_threshold   = 2
+    interval            = 30
+    matcher             = "200"
+    path                = "/"
+    port                = tostring(local.http_port)
+    protocol            = "HTTP"
+    timeout             = 5
+    unhealthy_threshold = 2
+  }
+
+  tags = {
+    Name    = "${var.prefix}-profile-int"
+    Purpose = "OpenTelemetry Collector internal profile target group"
+  }
+}
+
+# External HTTP target group for profiles
+resource "aws_lb_target_group" "profile_external" {
+  name        = "${var.prefix}-profile-ext"
+  port        = local.profile_port_external
+  protocol    = "HTTP"
+  target_type = "ip"
+  vpc_id      = var.vpc.id
+
+  health_check {
+    enabled             = true
+    healthy_threshold   = 2
+    interval            = 30
+    matcher             = "200"
+    path                = "/"
+    port                = tostring(local.http_port)
+    protocol            = "HTTP"
+    timeout             = 5
+    unhealthy_threshold = 2
+  }
+
+  tags = {
+    Name    = "${var.prefix}-profile-ext"
+    Purpose = "OpenTelemetry Collector external profile target group"
+  }
+}

--- a/infra/terraform/hash/observability/alloy/templates/alloy-config.alloy.tpl
+++ b/infra/terraform/hash/observability/alloy/templates/alloy-config.alloy.tpl
@@ -275,3 +275,41 @@ otelcol.exporter.otlphttp "mimir" {
     }
   }
 }
+
+pyroscope.receive_http "profiles_internal" {
+  http {
+    listen_address = "0.0.0.0"
+    listen_port    = ${profile_port_internal}
+  }
+
+  forward_to = [pyroscope.write.pyroscope_internal.receiver]
+}
+
+pyroscope.write "pyroscope_internal" {
+  endpoint {
+    url = "http://${pyroscope_http_dns}:${pyroscope_http_port}"
+  }
+
+  external_labels = {
+    "env" = "${environment}",
+  }
+}
+
+pyroscope.receive_http "profiles_external" {
+  http {
+    listen_address = "0.0.0.0"
+    listen_port    = ${profile_port_external}
+  }
+
+  forward_to = [pyroscope.write.pyroscope_external.receiver]
+}
+
+pyroscope.write "pyroscope_external" {
+  endpoint {
+    url = "http://${pyroscope_http_dns}:${pyroscope_http_port}"
+  }
+
+  external_labels = {
+    "env" = "external",
+  }
+}

--- a/infra/terraform/hash/observability/grafana/config.tf
+++ b/infra/terraform/hash/observability/grafana/config.tf
@@ -3,10 +3,11 @@
 # Configuration hash for task definition versioning
 locals {
   config_hash = sha256(jsonencode({
-    grafana_config   = aws_s3_object.grafana_config.content
-    tempo_datasource = aws_s3_object.grafana_tempo_datasource.content
-    loki_datasource  = aws_s3_object.grafana_loki_datasource.content
-    mimi_datasource  = aws_s3_object.grafana_mimir_datasource.content
+    grafana_config       = aws_s3_object.grafana_config.content
+    tempo_datasource     = aws_s3_object.grafana_tempo_datasource.content
+    loki_datasource      = aws_s3_object.grafana_loki_datasource.content
+    mimir_datasource     = aws_s3_object.grafana_mimir_datasource.content
+    pyroscope_datasource = aws_s3_object.grafana_pyroscope_datasource.content
   }))
 }
 
@@ -76,6 +77,22 @@ resource "aws_s3_object" "grafana_mimir_datasource" {
 
   tags = {
     Purpose = "Grafana Mimir Datasource"
+    Service = "grafana"
+  }
+}
+
+# Pyroscope datasource provisioning
+resource "aws_s3_object" "grafana_pyroscope_datasource" {
+  bucket = var.config_bucket.id
+  key    = "grafana/provisioning/datasources/pyroscope.yaml"
+  content = templatefile("${path.module}/templates/provisioning/datasources/pyroscope.yaml.tpl", {
+    pyroscope_http_dns  = var.pyroscope_http_dns
+    pyroscope_http_port = var.pyroscope_http_port
+  })
+  content_type = "application/x-yaml"
+
+  tags = {
+    Purpose = "Grafana Pyroscope Datasource"
     Service = "grafana"
   }
 }

--- a/infra/terraform/hash/observability/grafana/security_groups.tf
+++ b/infra/terraform/hash/observability/grafana/security_groups.tf
@@ -58,6 +58,15 @@ resource "aws_security_group" "grafana" {
     cidr_blocks = [var.vpc.cidr_block]
   }
 
+  # Allow outbound HTTP for Pyroscope API
+  egress {
+    from_port   = var.pyroscope_http_port
+    to_port     = var.pyroscope_http_port
+    protocol    = "tcp"
+    description = "Pyroscope API access"
+    cidr_blocks = [var.vpc.cidr_block]
+  }
+
   # Allow outbound PostgreSQL
   egress {
     from_port   = var.grafana_database_port

--- a/infra/terraform/hash/observability/grafana/templates/provisioning/datasources/pyroscope.yaml.tpl
+++ b/infra/terraform/hash/observability/grafana/templates/provisioning/datasources/pyroscope.yaml.tpl
@@ -1,0 +1,15 @@
+# Pyroscope data source provisioning for Grafana
+# Generated from Terraform template
+
+apiVersion: 1
+
+prune: true
+
+datasources:
+  - name: Pyroscope
+    type: grafana-pyroscope-datasource
+    uid: pyroscope
+    access: proxy
+    url: http://${pyroscope_http_dns}:${pyroscope_http_port}
+    isDefault: false
+    editable: false

--- a/infra/terraform/hash/observability/grafana/variables.tf
+++ b/infra/terraform/hash/observability/grafana/variables.tf
@@ -98,6 +98,16 @@ variable "mimir_http_port" {
   description = "Port for Mimir HTTP API service"
 }
 
+variable "pyroscope_http_dns" {
+  type        = string
+  description = "DNS name for Pyroscope HTTP API service"
+}
+
+variable "pyroscope_http_port" {
+  type        = number
+  description = "Port for Pyroscope HTTP API service"
+}
+
 variable "ssl_config" {
   description = "Shared SSL configuration for container certificates"
 }

--- a/infra/terraform/hash/observability/load_balancer.tf
+++ b/infra/terraform/hash/observability/load_balancer.tf
@@ -54,6 +54,22 @@ resource "aws_security_group" "alb_internal" {
     cidr_blocks = [var.vpc.cidr_block]
   }
 
+  egress {
+    from_port   = module.alloy.http_port
+    to_port     = module.alloy.http_port
+    protocol    = "tcp"
+    description = "Allow health checks to Alloy"
+    cidr_blocks = [var.vpc.cidr_block]
+  }
+
+  egress {
+    from_port   = module.alloy.profile_port_internal
+    to_port     = module.alloy.profile_port_internal
+    protocol    = "tcp"
+    description = "Allow connecting to the Alloy Profile endpoints"
+    cidr_blocks = [var.vpc.cidr_block]
+  }
+
   tags = {
     Name    = "${var.prefix}-internal-sg"
     Purpose = "Internal observability ALB security group"
@@ -130,6 +146,22 @@ resource "aws_security_group" "alb_external" {
     cidr_blocks = [var.vpc.cidr_block]
   }
 
+  egress {
+    from_port   = module.alloy.http_port
+    to_port     = module.alloy.http_port
+    protocol    = "tcp"
+    description = "Allow health checks to Alloy"
+    cidr_blocks = [var.vpc.cidr_block]
+  }
+
+  egress {
+    from_port   = module.alloy.profile_port_external
+    to_port     = module.alloy.profile_port_external
+    protocol    = "tcp"
+    description = "Allow connecting to the Alloy Profile endpoints"
+    cidr_blocks = [var.vpc.cidr_block]
+  }
+
   tags = {
     Name    = "${var.prefix}-external-sg"
     Purpose = "External observability ALB security group"
@@ -193,6 +225,16 @@ resource "aws_lb_listener_rule" "grafana_routing" {
 resource "cloudflare_dns_record" "cname_telemetry" {
   zone_id = data.cloudflare_zones.hash_ai.result[0].id
   name    = "telemetry"
+  type    = "CNAME"
+  content = aws_lb.observability_external.dns_name
+  ttl     = 1
+  proxied = true
+  tags    = ["terraform"]
+}
+
+resource "cloudflare_dns_record" "cname_profile" {
+  zone_id = data.cloudflare_zones.hash_ai.result[0].id
+  name    = "profile"
   type    = "CNAME"
   content = aws_lb.observability_external.dns_name
   ttl     = 1
@@ -317,5 +359,47 @@ resource "aws_lb_listener_rule" "telemetry_internal_grpc_routing" {
 
   tags = {
     Name = "${var.prefix}-telemetry-internal-grpc-routing"
+  }
+}
+
+
+resource "aws_lb_listener_rule" "profile_external_http_routing" {
+  listener_arn = aws_lb_listener.external_https.arn
+  priority     = 102
+
+  action {
+    type             = "forward"
+    target_group_arn = module.alloy.profile_external_target_group_arn
+  }
+
+  condition {
+    host_header {
+      values = ["${cloudflare_dns_record.cname_profile.name}.hash.ai"]
+    }
+  }
+
+  tags = {
+    Name = "${var.prefix}-profile-external-http-routing"
+  }
+}
+
+
+resource "aws_lb_listener_rule" "profile_internal_http_routing" {
+  listener_arn = aws_lb_listener.internal_https.arn
+  priority     = 102
+
+  action {
+    type             = "forward"
+    target_group_arn = module.alloy.profile_internal_target_group_arn
+  }
+
+  condition {
+    host_header {
+      values = [aws_route53_record.profile.fqdn]
+    }
+  }
+
+  tags = {
+    Name = "${var.prefix}-profile-internal-http-routing"
   }
 }

--- a/infra/terraform/hash/observability/main.tf
+++ b/infra/terraform/hash/observability/main.tf
@@ -154,6 +154,8 @@ module "otel_collector" {
   grafana_port                     = module.grafana.grafana_port
   tempo_api_dns                    = module.tempo.api_dns
   tempo_api_port                   = module.tempo.api_port
+  pyroscope_http_dns               = module.pyroscope.http_dns
+  pyroscope_http_port              = module.pyroscope.http_port
   alloy_dns                        = module.alloy.http_port_dns
   alloy_port                       = module.alloy.http_port
 
@@ -210,6 +212,22 @@ module "mimir" {
   ssl_config = local.aws_ca_ssl_config
 }
 
+# Pyroscope service for metrics storage
+module "pyroscope" {
+  source                           = "./pyroscope"
+  prefix                           = var.prefix
+  cluster_arn                      = aws_ecs_cluster.observability.arn
+  vpc                              = var.vpc
+  subnets                          = var.subnets
+  config_bucket                    = aws_s3_bucket.configs
+  log_group_name                   = aws_cloudwatch_log_group.observability.name
+  region                           = var.region
+  service_discovery_namespace_arn  = aws_service_discovery_private_dns_namespace.observability.arn
+  service_discovery_namespace_name = aws_service_discovery_private_dns_namespace.observability.name
+
+  ssl_config = local.aws_ca_ssl_config
+}
+
 # Grafana service for distributed tracing visualization
 module "grafana" {
   source                            = "./grafana"
@@ -233,6 +251,8 @@ module "grafana" {
   loki_http_port                    = module.loki.http_port
   mimir_http_dns                    = module.mimir.http_dns
   mimir_http_port                   = module.mimir.http_port
+  pyroscope_http_dns                = module.pyroscope.http_dns
+  pyroscope_http_port               = module.pyroscope.http_port
   external_load_balancer_arn_suffix = aws_lb.observability_external.arn_suffix
   critical_alerts_topic_arn         = var.critical_alerts_topic_arn
 
@@ -253,6 +273,8 @@ module "alloy" {
   service_discovery_namespace_name = aws_service_discovery_private_dns_namespace.observability.name
   mimir_http_dns                   = module.mimir.http_dns
   mimir_http_port                  = module.mimir.http_port
+  pyroscope_http_dns               = module.pyroscope.http_dns
+  pyroscope_http_port              = module.pyroscope.http_port
 
   ssl_config = local.aws_ca_ssl_config
 }

--- a/infra/terraform/hash/observability/otel_collector/config.tf
+++ b/infra/terraform/hash/observability/otel_collector/config.tf
@@ -36,6 +36,8 @@ resource "aws_s3_object" "otel_collector_config" {
     loki_http_port       = var.loki_http_port
     mimir_http_dns       = var.mimir_http_dns
     mimir_http_port      = var.mimir_http_port
+    pyroscope_http_dns   = var.pyroscope_http_dns
+    pyroscope_http_port  = var.pyroscope_http_port
     grafana_dns          = var.grafana_dns
     grafana_port         = var.grafana_port
     alloy_dns            = var.alloy_dns

--- a/infra/terraform/hash/observability/otel_collector/security_groups.tf
+++ b/infra/terraform/hash/observability/otel_collector/security_groups.tf
@@ -112,6 +112,15 @@ resource "aws_security_group" "otel_collector" {
     cidr_blocks = [var.vpc.cidr_block]
   }
 
+  # Allow outbound traffic to Pyroscope HTTP API
+  egress {
+    from_port   = var.pyroscope_http_port
+    to_port     = var.pyroscope_http_port
+    protocol    = "tcp"
+    description = "OTLP HTTP to Pyroscope"
+    cidr_blocks = [var.vpc.cidr_block]
+  }
+
   # Allow outbound traffic to Tempo API for metrics scraping
   egress {
     from_port   = var.tempo_api_port

--- a/infra/terraform/hash/observability/otel_collector/templates/otel-collector.yaml.tpl
+++ b/infra/terraform/hash/observability/otel_collector/templates/otel-collector.yaml.tpl
@@ -47,6 +47,11 @@ receivers:
           static_configs:
             - targets: ['${tempo_api_dns}:${tempo_api_port}']
           metrics_path: '/metrics'
+        - job_name: '${prefix}-pyroscope'
+          scrape_interval: 30s
+          static_configs:
+            - targets: ['${pyroscope_http_dns}:${pyroscope_http_port}']
+          metrics_path: '/metrics'
         - job_name: '${prefix}-alloy'
           scrape_interval: 60s
           static_configs:

--- a/infra/terraform/hash/observability/otel_collector/variables.tf
+++ b/infra/terraform/hash/observability/otel_collector/variables.tf
@@ -81,6 +81,16 @@ variable "mimir_http_port" {
   description = "Mimir HTTP API port number"
 }
 
+variable "pyroscope_http_dns" {
+  type        = string
+  description = "Pyroscope HTTP API DNS name for metrics forwarding"
+}
+
+variable "pyroscope_http_port" {
+  type        = number
+  description = "Pyroscope HTTP API port number"
+}
+
 variable "ssl_config" {
   description = "Shared SSL configuration for container certificates"
 }

--- a/infra/terraform/hash/observability/pyroscope/config.tf
+++ b/infra/terraform/hash/observability/pyroscope/config.tf
@@ -1,0 +1,23 @@
+# Pyroscope configuration management
+
+# Upload Pyroscope configuration generated from template
+resource "aws_s3_object" "pyroscope_config" {
+  bucket = var.config_bucket.id
+  key    = "pyroscope/config.yaml"
+
+  # Generate config from template with environment-specific parameters
+  content = templatefile("${path.module}/templates/pyroscope.yaml.tpl", {
+    environment      = terraform.workspace
+    http_port        = local.http_port
+    grpc_port        = local.grpc_port
+    pyroscope_bucket = aws_s3_bucket.pyroscope_profiles.bucket
+    aws_region       = var.region
+  })
+
+  content_type = "application/x-yaml"
+
+  tags = {
+    Purpose = "Pyroscope Configuration"
+    Service = "pyroscope"
+  }
+}

--- a/infra/terraform/hash/observability/pyroscope/iam.tf
+++ b/infra/terraform/hash/observability/pyroscope/iam.tf
@@ -1,0 +1,99 @@
+# IAM roles for Pyroscope ECS tasks
+
+# Execution role for ECS tasks (used by ECS agent)
+resource "aws_iam_role" "execution_role" {
+  name = "${local.prefix}-execution-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+# Attach standard ECS execution role policy
+resource "aws_iam_role_policy_attachment" "execution_role" {
+  role       = aws_iam_role.execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+# Task role for running containers (used by application)
+resource "aws_iam_role" "task_role" {
+  name = "${local.prefix}-task-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      }
+    ]
+  })
+
+  inline_policy {
+    name = "s3-config-access"
+    policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Effect = "Allow"
+          Action = [
+            "s3:ListBucket"
+          ]
+          Resource = var.config_bucket.arn
+        },
+        {
+          Effect = "Allow"
+          Action = [
+            "s3:GetObject"
+          ]
+          Resource = "${var.config_bucket.arn}/pyroscope/*"
+        }
+      ]
+    })
+  }
+
+  inline_policy {
+    name = "s3-profiles-access"
+    policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Effect = "Allow"
+          Action = [
+            "s3:ListBucket"
+          ]
+          Resource = aws_s3_bucket.pyroscope_profiles.arn
+        },
+        {
+          Effect = "Allow"
+          Action = [
+            "s3:GetObject",
+            "s3:PutObject",
+            "s3:DeleteObject",
+            "s3:GetObjectTagging",
+            "s3:PutObjectTagging"
+          ]
+          Resource = "${aws_s3_bucket.pyroscope_profiles.arn}/*"
+        }
+      ]
+    })
+  }
+}
+
+# Attach SSM policy for ECS Execute Command
+resource "aws_iam_role_policy_attachment" "task_role_ssm" {
+  role       = aws_iam_role.task_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}

--- a/infra/terraform/hash/observability/pyroscope/main.tf
+++ b/infra/terraform/hash/observability/pyroscope/main.tf
@@ -1,4 +1,4 @@
-# Loki service definition
+# Pyroscope service definition
 
 locals {
   service_name = "pyroscope"

--- a/infra/terraform/hash/observability/pyroscope/main.tf
+++ b/infra/terraform/hash/observability/pyroscope/main.tf
@@ -1,0 +1,18 @@
+# Loki service definition
+
+locals {
+  service_name = "pyroscope"
+  prefix       = "${var.prefix}-${local.service_name}"
+
+  # Port definitions for Pyroscope
+  http_port = 4040 # Pyroscope HTTP
+  grpc_port = 4041 # Pyroscope gRPC
+
+  # Port names for Service Connect
+  http_port_name = "${local.service_name}-http" # HTTP API
+  grpc_port_name = "${local.service_name}-grpc" # gRPC API
+
+  # DNS names for Service Connect
+  http_port_dns = "${local.http_port_name}.${var.service_discovery_namespace_name}"
+  grpc_port_dns = "${local.grpc_port_name}.${var.service_discovery_namespace_name}"
+}

--- a/infra/terraform/hash/observability/pyroscope/outputs.tf
+++ b/infra/terraform/hash/observability/pyroscope/outputs.tf
@@ -1,0 +1,32 @@
+# Pyroscope service outputs for Service Connect integration
+
+output "http_port" {
+  description = "HTTP API port for Pyroscope log ingestion and queries"
+  value       = local.http_port
+}
+
+output "http_port_name" {
+  description = "Service Connect port name for HTTP API"
+  value       = local.http_port_name
+}
+
+output "grpc_port" {
+  description = "gRPC API port for Pyroscope live tail streaming"
+  value       = local.grpc_port
+}
+
+output "grpc_port_name" {
+  description = "Service Connect port name for gRPC API"
+  value       = local.grpc_port_name
+}
+
+# DNS names for Service Connect
+output "http_dns" {
+  description = "Service Connect DNS name for HTTP API (for OTel collector and Grafana)"
+  value       = local.http_port_dns
+}
+
+output "grpc_dns" {
+  description = "Service Connect DNS name for gRPC API (for live tail streaming)"
+  value       = local.grpc_port_dns
+}

--- a/infra/terraform/hash/observability/pyroscope/security_groups.tf
+++ b/infra/terraform/hash/observability/pyroscope/security_groups.tf
@@ -1,0 +1,64 @@
+# Security group for Pyroscope
+
+resource "aws_security_group" "pyroscope" {
+  name_prefix = "${local.prefix}-"
+  vpc_id      = var.vpc.id
+
+  # Allow inbound HTTP API from OpenTelemetry Collector and Grafana
+  ingress {
+    from_port   = local.http_port
+    to_port     = local.http_port
+    protocol    = "tcp"
+    description = "Pyroscope HTTP API for log ingestion and queries"
+    cidr_blocks = [var.vpc.cidr_block]
+  }
+
+  # Allow inbound gRPC API for live tail streaming from Grafana
+  ingress {
+    from_port   = local.grpc_port
+    to_port     = local.grpc_port
+    protocol    = "tcp"
+    description = "Pyroscope gRPC API for live tail streaming"
+    cidr_blocks = [var.vpc.cidr_block]
+  }
+
+  # Allow outbound HTTPS for S3 log storage and config download
+  egress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    description = "HTTPS for S3 access"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # Allow outbound HTTP for package downloads during SSL setup
+  egress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    description = "HTTP outbound for package downloads"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # Allow outbound DNS
+  egress {
+    from_port   = 53
+    to_port     = 53
+    protocol    = "tcp"
+    description = "DNS resolution"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 53
+    to_port     = 53
+    protocol    = "udp"
+    description = "DNS resolution"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name    = "${local.prefix}-sg"
+    Purpose = "Pyroscope security group"
+  }
+}

--- a/infra/terraform/hash/observability/pyroscope/service.tf
+++ b/infra/terraform/hash/observability/pyroscope/service.tf
@@ -167,6 +167,6 @@ resource "aws_ecs_service" "pyroscope" {
 
   tags = {
     Name    = local.service_name
-    Purpose = "Pyroscope log aggregation"
+    Purpose = "Pyroscope continuous profiling"
   }
 }

--- a/infra/terraform/hash/observability/pyroscope/storage.tf
+++ b/infra/terraform/hash/observability/pyroscope/storage.tf
@@ -1,0 +1,47 @@
+# S3 bucket for Pyroscope log storage
+# Stores profile data with lifecycle management
+
+resource "aws_s3_bucket" "pyroscope_profiles" {
+  bucket = "${var.prefix}-pyroscope-profiles"
+  tags = {
+    Purpose = "Pyroscope profile storage"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "pyroscope_profiles" {
+  bucket = aws_s3_bucket.pyroscope_profiles.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "pyroscope_profiles" {
+  bucket = aws_s3_bucket.pyroscope_profiles.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "pyroscope_profiles" {
+  bucket = aws_s3_bucket.pyroscope_profiles.id
+
+  rule {
+    id     = "pyroscope_profiles_lifecycle"
+    status = "Enabled"
+
+    # Delete profiles after 7 days to manage storage costs
+    expiration {
+      days = 7
+    }
+
+    # Clean up incomplete multipart uploads
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 1
+    }
+  }
+}

--- a/infra/terraform/hash/observability/pyroscope/templates/pyroscope.yaml.tpl
+++ b/infra/terraform/hash/observability/pyroscope/templates/pyroscope.yaml.tpl
@@ -1,0 +1,16 @@
+# Pyroscope Configuration - Environment: ${environment}
+# Generated from Terraform template
+
+# Minimal Pyroscope Configuration
+target: all
+
+server:
+  http_listen_port: ${http_port}
+  grpc_listen_port: ${grpc_port}
+
+storage:
+  backend: s3
+  s3:
+    bucket_name: ${pyroscope_bucket}
+    region: ${aws_region}
+    endpoint: s3.${aws_region}.amazonaws.com

--- a/infra/terraform/hash/observability/pyroscope/variables.tf
+++ b/infra/terraform/hash/observability/pyroscope/variables.tf
@@ -38,29 +38,9 @@ variable "service_discovery_namespace_arn" {
 
 variable "service_discovery_namespace_name" {
   type        = string
-  description = "Name of the service discovery namespace for Service Connect"
+  description = "Name of the service discovery namespace for DNS resolution"
 }
 
 variable "ssl_config" {
   description = "Shared SSL configuration for container certificates"
-}
-
-variable "mimir_http_dns" {
-  type        = string
-  description = "Mimir HTTP API DNS name for metrics forwarding"
-}
-
-variable "mimir_http_port" {
-  type        = number
-  description = "Mimir HTTP API port number"
-}
-
-variable "pyroscope_http_dns" {
-  type        = string
-  description = "Pyroscope HTTP API DNS name for metrics forwarding"
-}
-
-variable "pyroscope_http_port" {
-  type        = number
-  description = "Pyroscope HTTP API port number"
 }

--- a/infra/terraform/hash/observability/tls.tf
+++ b/infra/terraform/hash/observability/tls.tf
@@ -1,15 +1,15 @@
 # Get Cloudflare zone for hash.ai
 
+data "cloudflare_zones" "hash_ai" {
+  name = "hash.ai"
+}
+
 resource "aws_route53_record" "otlp" {
   zone_id = var.vpc_zone_id
   name    = "otlp"
   type    = "CNAME"
   ttl     = 300
   records = [aws_lb.observability_internal.dns_name]
-}
-
-data "cloudflare_zones" "hash_ai" {
-  name = "hash.ai"
 }
 
 resource "aws_acm_certificate" "otlp" {
@@ -48,6 +48,57 @@ resource "cloudflare_dns_record" "otlp_cert_validation" {
 resource "aws_acm_certificate_validation" "otlp" {
   certificate_arn         = aws_acm_certificate.otlp.arn
   validation_record_fqdns = [for record in cloudflare_dns_record.otlp_cert_validation : trimsuffix(record.name, ".")]
+
+  timeouts {
+    create = "5m"
+  }
+}
+
+resource "aws_route53_record" "profile" {
+  zone_id = var.vpc_zone_id
+  name    = "profile"
+  type    = "CNAME"
+  ttl     = 300
+  records = [aws_lb.observability_internal.dns_name]
+}
+
+
+resource "aws_acm_certificate" "profile" {
+  domain_name       = "profile.vpc.hash.ai"
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = {
+    Name = "profile.vpc.hash.ai"
+  }
+}
+
+# Cloudflare DNS Records for ACM validation
+resource "cloudflare_dns_record" "profile_cert_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.profile.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  zone_id = data.cloudflare_zones.hash_ai.result[0].id
+  name    = each.value.name
+  content = each.value.record
+  type    = each.value.type
+  ttl     = 1
+
+  tags = ["terraform"]
+}
+
+# Wait for ACM validation
+resource "aws_acm_certificate_validation" "profile" {
+  certificate_arn         = aws_acm_certificate.profile.arn
+  validation_record_fqdns = [for record in cloudflare_dns_record.profile_cert_validation : trimsuffix(record.name, ".")]
 
   timeouts {
     create = "5m"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR implements a complete Pyroscope continuous profiling service within our AWS observability infrastructure. Pyroscope enables continuous profiling of applications in production, allowing developers to identify performance bottlenecks, memory leaks, and CPU hotspots with minimal overhead.

The implementation provides a production-ready Pyroscope deployment with S3-based storage, proper security configurations, and seamless integration with our existing observability stack (Grafana, Alloy, OpenTelemetry Collector).

Note on Rust profiling:
- We will have CPU profiling by looking at the stack trace with a certain frequency to get CPU time spent over time
- We will have Wall time profiling through tracing
- Memory profiling could be achieved by using a global allocator which supports this. This is not planned, yet, but is possible for example with Jemalloc.

## 🔗 Related links

- Linear Issue: [H-5328: Support profiling in production](https://linear.app/hashintel/issue/H-5328/support-profiling-in-production)
- [Pyroscope Documentation](https://pyroscope.io/docs/)
- [Grafana Pyroscope Plugin](https://grafana.com/docs/grafana/latest/datasources/pyroscope/)

## 🔍 What does this change?

### New Pyroscope Module (`infra/terraform/hash/observability/pyroscope/`)
- **Complete ECS service configuration** with proper resource allocation and health checks
- **S3 storage backend** with lifecycle policies for cost optimization
- **IAM roles and policies** with least-privilege access for S3 and ECS operations
- **Security groups** allowing proper ingress/egress for HTTP and gRPC APIs
- **Service discovery integration** for seamless communication with other observability services

### Alloy Integration Enhancements
- **Dual profile ingestion endpoints**: Internal (port 4040) and external (port 4042) for different use cases
- **Profile forwarding configuration** to send collected profiles to Pyroscope
- **Target groups and load balancer integration** for external profile submission
- **Security group updates** to allow profile data transmission

### Grafana Integration
- **Pyroscope datasource provisioning** with automatic configuration
- **Security group updates** to allow Grafana to query Pyroscope APIs
- **Template-based configuration** for environment-specific settings

### OpenTelemetry Collector Updates
- **Pyroscope metrics scraping** added to monitoring configuration
- **Network security updates** for Pyroscope communication
- **Configuration template updates** to include Pyroscope endpoints

### Load Balancer and DNS Configuration
- **External profile endpoint**: `profile.hash.ai` for client application profiling
- **Internal profile routing** for service-to-service profiling
- **Proper SSL termination** and health check configuration

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:
- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:
- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:
- [x] do not affect the execution graph
