### PR TITLE
BE-50: HashQL: Introduce a `DiagnosticResult` type

### DIFF
--- a/libs/@local/hashql/diagnostics/src/diagnostic.rs
+++ b/libs/@local/hashql/diagnostics/src/diagnostic.rs
@@ -43,9 +43,9 @@ impl<C, S> Diagnostic<C, S> {
     /// Initializes an empty diagnostic that can be populated with message, labels, notes,
     /// and help messages through the appropriate methods. The category and severity
     /// determine how the diagnostic will be classified and displayed.
-    pub fn new(category: impl Into<C>, severity: Severity) -> Self {
+    pub const fn new(category: C, severity: Severity) -> Self {
         Self {
-            category: category.into(),
+            category,
             severity,
             message: None,
             labels: Vec::new(),

--- a/libs/@local/hashql/diagnostics/src/issues.rs
+++ b/libs/@local/hashql/diagnostics/src/issues.rs
@@ -1,0 +1,120 @@
+use crate::{Diagnostic, category::DiagnosticCategory};
+
+pub type BoxedDiagnosticIssues<'category, S> =
+    DiagnosticIssues<Box<dyn DiagnosticCategory + 'category>, S>;
+
+pub struct DiagnosticIssues<C, S> {
+    diagnostics: Vec<Diagnostic<C, S>>,
+    fatal: usize,
+}
+
+impl<C, S> DiagnosticIssues<C, S> {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            diagnostics: Vec::new(),
+            fatal: 0,
+        }
+    }
+
+    pub fn map<C2, S2>(
+        self,
+        func: impl FnMut(Diagnostic<C, S>) -> Diagnostic<C2, S2>,
+    ) -> DiagnosticIssues<C2, S2> {
+        DiagnosticIssues {
+            diagnostics: self.diagnostics.into_iter().map(func).collect(),
+            fatal: self.fatal,
+        }
+    }
+
+    pub fn map_category<C2>(self, mut func: impl FnMut(C) -> C2) -> DiagnosticIssues<C2, S> {
+        DiagnosticIssues {
+            diagnostics: self
+                .diagnostics
+                .into_iter()
+                .map(|diagnostic| diagnostic.map_category(&mut func))
+                .collect(),
+            fatal: self.fatal,
+        }
+    }
+
+    pub fn boxed<'category>(self) -> BoxedDiagnosticIssues<'category, S>
+    where
+        C: DiagnosticCategory + 'category,
+    {
+        DiagnosticIssues {
+            diagnostics: self
+                .diagnostics
+                .into_iter()
+                .map(Diagnostic::boxed)
+                .collect(),
+            fatal: self.fatal,
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.diagnostics.clear();
+        self.fatal = 0;
+    }
+
+    #[must_use]
+    pub const fn fatal(&self) -> usize {
+        self.fatal
+    }
+
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.diagnostics.len()
+    }
+
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.diagnostics.is_empty()
+    }
+
+    pub fn push(&mut self, diagnostic: Diagnostic<C, S>) {
+        self.fatal += usize::from(diagnostic.severity.is_fatal());
+        self.diagnostics.push(diagnostic);
+    }
+
+    pub fn append(&mut self, other: &mut Self) {
+        self.fatal += other.fatal;
+        self.diagnostics.append(&mut other.diagnostics);
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &Diagnostic<C, S>> {
+        self.diagnostics.iter()
+    }
+}
+
+impl<C, S> Extend<Diagnostic<C, S>> for DiagnosticIssues<C, S> {
+    #[expect(clippy::indexing_slicing, reason = "indexing is checke")]
+    fn extend<T: IntoIterator<Item = Diagnostic<C, S>>>(&mut self, iter: T) {
+        let previous = self.diagnostics.len();
+        self.diagnostics.extend(iter);
+
+        if self.diagnostics.len() == previous {
+            return;
+        }
+
+        self.fatal += self.diagnostics[previous..]
+            .iter()
+            .filter(|diagnostic| diagnostic.severity.is_fatal())
+            .count();
+    }
+}
+
+impl<C, S> IntoIterator for DiagnosticIssues<C, S> {
+    type IntoIter = alloc::vec::IntoIter<Self::Item>;
+    type Item = Diagnostic<C, S>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.diagnostics.into_iter()
+    }
+}
+
+impl<C, S> Default for DiagnosticIssues<C, S> {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/libs/@local/hashql/diagnostics/src/issues.rs
+++ b/libs/@local/hashql/diagnostics/src/issues.rs
@@ -1,8 +1,60 @@
 use crate::{Diagnostic, category::DiagnosticCategory};
 
+/// Type alias for [`DiagnosticIssues`] with type-erased diagnostic categories.
+///
+/// This convenience type allows working with collections of diagnostics where the
+/// specific category types may vary.
 pub type BoxedDiagnosticIssues<'category, S> =
     DiagnosticIssues<Box<dyn DiagnosticCategory + 'category>, S>;
 
+/// A collection of diagnostic messages for error reporting.
+///
+/// `DiagnosticIssues` collects diagnostic messages during compilation phases,
+/// allowing you to accumulate errors, warnings, and other messages before
+/// deciding how to handle them. Fatal diagnostics are errors that prevent
+/// successful compilation (severity codes ≥ 400).
+///
+/// # Examples
+///
+/// Basic usage:
+///
+/// ```
+/// use hashql_diagnostics::{Diagnostic, DiagnosticIssues, Severity};
+/// # use hashql_diagnostics::category::TerminalDiagnosticCategory;
+/// # const CATEGORY: TerminalDiagnosticCategory = TerminalDiagnosticCategory {
+/// #     id: "example", name: "Example"
+/// # };
+///
+/// let mut issues = DiagnosticIssues::new();
+/// issues.push(Diagnostic::new(CATEGORY, Severity::Error));
+/// issues.push(Diagnostic::new(CATEGORY, Severity::Warning));
+///
+/// assert_eq!(issues.len(), 2);
+/// assert_eq!(issues.fatal(), 1);
+/// ```
+///
+/// Working with the [`DiagnosticSink`] trait to process results:
+///
+/// ```
+/// use hashql_diagnostics::{Diagnostic, DiagnosticIssues, DiagnosticSink, Severity};
+/// # use hashql_diagnostics::category::TerminalDiagnosticCategory;
+/// # const CATEGORY: TerminalDiagnosticCategory = TerminalDiagnosticCategory {
+/// #     id: "example", name: "Example"
+/// # };
+///
+/// let mut issues = DiagnosticIssues::new();
+///
+/// // Success case - value is extracted
+/// let success: Result<i32, Diagnostic<_, ()>> = Ok(42);
+/// if let Some(value) = issues.sink(success) {
+///     assert_eq!(value, 42);
+/// }
+///
+/// // Error case - diagnostic is collected
+/// let error = Result::<i32, _>::Err(Diagnostic::new(CATEGORY, Severity::Error));
+/// assert!(issues.sink(error).is_none());
+/// assert_eq!(issues.len(), 1);
+/// ```
 #[must_use]
 #[derive(Debug)]
 pub struct DiagnosticIssues<C, S> {
@@ -11,6 +63,18 @@ pub struct DiagnosticIssues<C, S> {
 }
 
 impl<C, S> DiagnosticIssues<C, S> {
+    /// Creates a new, empty collection of diagnostic issues.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hashql_diagnostics::DiagnosticIssues;
+    ///
+    /// let issues: DiagnosticIssues<(), ()> = DiagnosticIssues::new();
+    /// assert_eq!(issues.len(), 0);
+    /// assert_eq!(issues.fatal(), 0);
+    /// assert!(issues.is_empty());
+    /// ```
     pub const fn new() -> Self {
         Self {
             diagnostics: Vec::new(),
@@ -18,16 +82,62 @@ impl<C, S> DiagnosticIssues<C, S> {
         }
     }
 
+    /// Transforms each diagnostic using the provided function.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hashql_diagnostics::{Diagnostic, DiagnosticIssues, Severity};
+    /// # use hashql_diagnostics::category::TerminalDiagnosticCategory;
+    /// # const OLD_CATEGORY: TerminalDiagnosticCategory = TerminalDiagnosticCategory {
+    /// #     id: "old", name: "Old"
+    /// # };
+    /// # const NEW_CATEGORY: TerminalDiagnosticCategory = TerminalDiagnosticCategory {
+    /// #     id: "new", name: "New"
+    /// # };
+    ///
+    /// let mut issues = DiagnosticIssues::new();
+    /// issues.push(Diagnostic::new(OLD_CATEGORY, Severity::Error));
+    ///
+    /// let transformed = issues.map(|diagnostic| Diagnostic::new(NEW_CATEGORY, diagnostic.severity));
+    /// ```
     pub fn map<C2, S2>(
         self,
         func: impl FnMut(Diagnostic<C, S>) -> Diagnostic<C2, S2>,
     ) -> DiagnosticIssues<C2, S2> {
-        DiagnosticIssues {
-            diagnostics: self.diagnostics.into_iter().map(func).collect(),
-            fatal: self.fatal,
-        }
+        let diagnostics: Vec<_> = self.diagnostics.into_iter().map(func).collect();
+
+        // re-calculate the fatal count as it might have changed during iteration
+        let fatal = diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.severity.is_fatal())
+            .count();
+
+        DiagnosticIssues { diagnostics, fatal }
     }
 
+    /// Transforms the category of each diagnostic.
+    ///
+    /// This is useful when moving diagnostics between compilation phases that
+    /// use different category types.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hashql_diagnostics::{Diagnostic, DiagnosticIssues, Severity};
+    /// # use hashql_diagnostics::category::TerminalDiagnosticCategory;
+    /// # const PARSER_CATEGORY: TerminalDiagnosticCategory = TerminalDiagnosticCategory {
+    /// #     id: "parser", name: "Parser"
+    /// # };
+    /// # const LOWERING_CATEGORY: TerminalDiagnosticCategory = TerminalDiagnosticCategory {
+    /// #     id: "lowering", name: "Lowering"
+    /// # };
+    ///
+    /// let mut issues = DiagnosticIssues::new();
+    /// issues.push(Diagnostic::new(PARSER_CATEGORY, Severity::Error));
+    ///
+    /// let lowering_issues = issues.map_category(|_| LOWERING_CATEGORY);
+    /// ```
     pub fn map_category<C2>(self, mut func: impl FnMut(C) -> C2) -> DiagnosticIssues<C2, S> {
         DiagnosticIssues {
             diagnostics: self
@@ -39,6 +149,25 @@ impl<C, S> DiagnosticIssues<C, S> {
         }
     }
 
+    /// Converts to a collection with type-erased categories.
+    ///
+    /// When combining diagnostics from different compilation phases that use
+    /// different category types, this method allows them to be stored together.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hashql_diagnostics::{Diagnostic, DiagnosticIssues, Severity};
+    /// # use hashql_diagnostics::category::TerminalDiagnosticCategory;
+    /// # const CATEGORY: TerminalDiagnosticCategory = TerminalDiagnosticCategory {
+    /// #     id: "example", name: "Example"
+    /// # };
+    ///
+    /// let mut issues = DiagnosticIssues::new();
+    /// issues.push(Diagnostic::new(CATEGORY, Severity::Error));
+    ///
+    /// let boxed_issues = issues.boxed();
+    /// ```
     pub fn boxed<'category>(self) -> BoxedDiagnosticIssues<'category, S>
     where
         C: DiagnosticCategory + 'category,
@@ -53,36 +182,178 @@ impl<C, S> DiagnosticIssues<C, S> {
         }
     }
 
+    /// Removes all diagnostics from the collection.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hashql_diagnostics::{Diagnostic, DiagnosticIssues, Severity};
+    /// # use hashql_diagnostics::category::TerminalDiagnosticCategory;
+    /// # const CATEGORY: TerminalDiagnosticCategory = TerminalDiagnosticCategory {
+    /// #     id: "example", name: "Example"
+    /// # };
+    ///
+    /// let mut issues = DiagnosticIssues::new();
+    /// issues.push(Diagnostic::new(CATEGORY, Severity::Error));
+    /// assert_eq!(issues.len(), 1);
+    ///
+    /// issues.clear();
+    /// assert_eq!(issues.len(), 0);
+    /// assert_eq!(issues.fatal(), 0);
+    /// assert!(issues.is_empty());
+    /// ```
     pub fn clear(&mut self) {
         self.diagnostics.clear();
         self.fatal = 0;
     }
 
+    /// Returns the number of fatal diagnostics.
+    ///
+    /// Fatal diagnostics are errors that prevent successful compilation
+    /// (severity codes ≥ 400). This method runs in O(1) time.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hashql_diagnostics::{Diagnostic, DiagnosticIssues, Severity};
+    /// # use hashql_diagnostics::category::TerminalDiagnosticCategory;
+    /// # const CATEGORY: TerminalDiagnosticCategory = TerminalDiagnosticCategory {
+    /// #     id: "example", name: "Example"
+    /// # };
+    ///
+    /// let mut issues = DiagnosticIssues::new();
+    /// assert_eq!(issues.fatal(), 0);
+    ///
+    /// issues.push(Diagnostic::new(CATEGORY, Severity::Error));
+    /// assert_eq!(issues.fatal(), 1);
+    ///
+    /// issues.push(Diagnostic::new(CATEGORY, Severity::Warning));
+    /// assert_eq!(issues.fatal(), 1); // Warnings are not fatal
+    /// ```
     #[must_use]
     pub const fn fatal(&self) -> usize {
         self.fatal
     }
 
+    /// Returns the total number of diagnostics.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hashql_diagnostics::{Diagnostic, DiagnosticIssues, Severity};
+    /// # use hashql_diagnostics::category::TerminalDiagnosticCategory;
+    /// # const CATEGORY: TerminalDiagnosticCategory = TerminalDiagnosticCategory {
+    /// #     id: "example", name: "Example"
+    /// # };
+    ///
+    /// let mut issues = DiagnosticIssues::new();
+    /// assert_eq!(issues.len(), 0);
+    ///
+    /// issues.push(Diagnostic::new(CATEGORY, Severity::Error));
+    /// issues.push(Diagnostic::new(CATEGORY, Severity::Warning));
+    /// assert_eq!(issues.len(), 2);
+    /// ```
     #[must_use]
     pub const fn len(&self) -> usize {
         self.diagnostics.len()
     }
 
+    /// Returns `true` if the collection contains no diagnostics.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hashql_diagnostics::{Diagnostic, DiagnosticIssues, Severity};
+    /// # use hashql_diagnostics::category::TerminalDiagnosticCategory;
+    /// # const CATEGORY: TerminalDiagnosticCategory = TerminalDiagnosticCategory {
+    /// #     id: "example", name: "Example"
+    /// # };
+    ///
+    /// let mut issues = DiagnosticIssues::new();
+    /// assert!(issues.is_empty());
+    ///
+    /// issues.push(Diagnostic::new(CATEGORY, Severity::Warning));
+    /// assert!(!issues.is_empty());
+    /// ```
     #[must_use]
     pub const fn is_empty(&self) -> bool {
         self.diagnostics.is_empty()
     }
 
+    /// Inserts a diagnostic at the beginning of the collection.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hashql_diagnostics::{Diagnostic, DiagnosticIssues, Severity};
+    /// # use hashql_diagnostics::category::TerminalDiagnosticCategory;
+    /// # const CATEGORY: TerminalDiagnosticCategory = TerminalDiagnosticCategory {
+    /// #     id: "example", name: "Example"
+    /// # };
+    ///
+    /// let mut issues = DiagnosticIssues::new();
+    /// issues.push(Diagnostic::new(CATEGORY, Severity::Warning));
+    /// issues.insert_front(Diagnostic::new(CATEGORY, Severity::Error));
+    ///
+    /// // The error is now first
+    /// let first = issues.iter().next().unwrap();
+    /// assert_eq!(first.severity, Severity::Error);
+    /// ```
     pub fn insert_front(&mut self, diagnostic: Diagnostic<C, S>) {
         self.fatal += usize::from(diagnostic.severity.is_fatal());
         self.diagnostics.insert(0, diagnostic);
     }
 
+    /// Adds a diagnostic to the collection.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hashql_diagnostics::{Diagnostic, DiagnosticIssues, Severity};
+    /// # use hashql_diagnostics::category::TerminalDiagnosticCategory;
+    /// # const CATEGORY: TerminalDiagnosticCategory = TerminalDiagnosticCategory {
+    /// #     id: "example", name: "Example"
+    /// # };
+    ///
+    /// let mut issues = DiagnosticIssues::new();
+    /// issues.push(Diagnostic::new(CATEGORY, Severity::Error));
+    /// issues.push(Diagnostic::new(CATEGORY, Severity::Warning));
+    ///
+    /// assert_eq!(issues.len(), 2);
+    /// assert_eq!(issues.fatal(), 1);
+    /// ```
     pub fn push(&mut self, diagnostic: Diagnostic<C, S>) {
         self.fatal += usize::from(diagnostic.severity.is_fatal());
         self.diagnostics.push(diagnostic);
     }
 
+    /// Removes and returns the last diagnostic.
+    ///
+    /// Returns [`None`] if the collection is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hashql_diagnostics::{Diagnostic, DiagnosticIssues, Severity};
+    /// # use hashql_diagnostics::category::TerminalDiagnosticCategory;
+    /// # const CATEGORY: TerminalDiagnosticCategory = TerminalDiagnosticCategory {
+    /// #     id: "example", name: "Example"
+    /// # };
+    ///
+    /// let mut issues = DiagnosticIssues::new();
+    /// issues.push(Diagnostic::new(CATEGORY, Severity::Error));
+    /// issues.push(Diagnostic::new(CATEGORY, Severity::Warning));
+    ///
+    /// let last = issues.pop().unwrap();
+    /// assert_eq!(last.severity, Severity::Warning);
+    /// assert_eq!(issues.len(), 1);
+    ///
+    /// let first = issues.pop().unwrap();
+    /// assert_eq!(first.severity, Severity::Error);
+    /// assert_eq!(issues.len(), 0);
+    ///
+    /// assert!(issues.pop().is_none());
+    /// ```
     pub fn pop(&mut self) -> Option<Diagnostic<C, S>> {
         let diagnostic = self.diagnostics.pop();
 
@@ -93,6 +364,31 @@ impl<C, S> DiagnosticIssues<C, S> {
         diagnostic
     }
 
+    /// Removes and returns the first fatal diagnostic found.
+    ///
+    /// Returns [`None`] if no fatal diagnostics are present.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hashql_diagnostics::{Diagnostic, DiagnosticIssues, Severity};
+    /// # use hashql_diagnostics::category::TerminalDiagnosticCategory;
+    /// # const CATEGORY: TerminalDiagnosticCategory = TerminalDiagnosticCategory {
+    /// #     id: "example", name: "Example"
+    /// # };
+    ///
+    /// let mut issues = DiagnosticIssues::new();
+    /// issues.push(Diagnostic::new(CATEGORY, Severity::Warning));
+    /// issues.push(Diagnostic::new(CATEGORY, Severity::Error));
+    /// issues.push(Diagnostic::new(CATEGORY, Severity::Note));
+    ///
+    /// let fatal = issues.pop_fatal().unwrap();
+    /// assert_eq!(fatal.severity, Severity::Error);
+    /// assert_eq!(issues.fatal(), 0);
+    /// assert_eq!(issues.len(), 2);
+    ///
+    /// assert!(issues.pop_fatal().is_none());
+    /// ```
     pub fn pop_fatal(&mut self) -> Option<Diagnostic<C, S>> {
         let position = self
             .diagnostics
@@ -108,19 +404,63 @@ impl<C, S> DiagnosticIssues<C, S> {
         }
     }
 
+    /// Moves all diagnostics from another collection into this one.
+    ///
+    /// The other collection is left empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hashql_diagnostics::{Diagnostic, DiagnosticIssues, Severity};
+    /// # use hashql_diagnostics::category::TerminalDiagnosticCategory;
+    /// # const CATEGORY: TerminalDiagnosticCategory = TerminalDiagnosticCategory {
+    /// #     id: "example", name: "Example"
+    /// # };
+    ///
+    /// let mut main_issues = DiagnosticIssues::new();
+    /// main_issues.push(Diagnostic::new(CATEGORY, Severity::Warning));
+    ///
+    /// let mut other_issues = DiagnosticIssues::new();
+    /// other_issues.push(Diagnostic::new(CATEGORY, Severity::Error));
+    ///
+    /// main_issues.append(&mut other_issues);
+    ///
+    /// assert_eq!(main_issues.len(), 2);
+    /// assert_eq!(main_issues.fatal(), 1);
+    /// assert!(other_issues.is_empty());
+    /// ```
     pub fn append(&mut self, other: &mut Self) {
         self.fatal += other.fatal;
         self.diagnostics.append(&mut other.diagnostics);
         other.fatal = 0;
     }
 
+    /// Returns an iterator over the diagnostics.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hashql_diagnostics::{Diagnostic, DiagnosticIssues, Severity};
+    /// # use hashql_diagnostics::category::TerminalDiagnosticCategory;
+    /// # const CATEGORY: TerminalDiagnosticCategory = TerminalDiagnosticCategory {
+    /// #     id: "example", name: "Example"
+    /// # };
+    ///
+    /// let mut issues = DiagnosticIssues::new();
+    /// issues.push(Diagnostic::new(CATEGORY, Severity::Error));
+    /// issues.push(Diagnostic::new(CATEGORY, Severity::Warning));
+    ///
+    /// for diagnostic in issues.iter() {
+    ///     println!("Severity: {:?}", diagnostic.severity);
+    /// }
+    /// ```
     pub fn iter(&self) -> impl Iterator<Item = &Diagnostic<C, S>> {
         self.diagnostics.iter()
     }
 }
 
 impl<C, S> Extend<Diagnostic<C, S>> for DiagnosticIssues<C, S> {
-    #[expect(clippy::indexing_slicing, reason = "indexing is checke")]
+    #[expect(clippy::indexing_slicing, reason = "indexing is checked")]
     fn extend<T: IntoIterator<Item = Diagnostic<C, S>>>(&mut self, iter: T) {
         let previous = self.diagnostics.len();
         self.diagnostics.extend(iter);
@@ -151,9 +491,42 @@ impl<C, S> Default for DiagnosticIssues<C, S> {
     }
 }
 
+/// A trait for collecting diagnostic information from fallible operations.
+///
+/// `DiagnosticSink` provides a way to process [`Result`] values that may contain
+/// either successful outcomes or diagnostic information. This allows you to
+/// separate success values from diagnostics while accumulating all diagnostic
+/// information for later reporting.
+///
+/// # Examples
+///
+/// ```
+/// use hashql_diagnostics::{Diagnostic, DiagnosticIssues, DiagnosticSink, Severity};
+/// # use hashql_diagnostics::category::TerminalDiagnosticCategory;
+/// # const CATEGORY: TerminalDiagnosticCategory = TerminalDiagnosticCategory {
+/// #     id: "example", name: "Example"
+/// # };
+///
+/// let mut issues = DiagnosticIssues::new();
+///
+/// // Process successful operations
+/// let success: Result<i32, Diagnostic<_, ()>> = Ok(42);
+/// if let Some(value) = issues.sink(success) {
+///     println!("Got value: {}", value);
+/// }
+///
+/// // Process failed operations - diagnostics are collected
+/// let error = Result::<i32, _>::Err(Diagnostic::new(CATEGORY, Severity::Error));
+/// assert!(issues.sink(error).is_none());
+/// assert_eq!(issues.len(), 1);
+/// ```
 pub trait DiagnosticSink<T> {
     type Output;
 
+    /// Processes the input value, extracting success values and collecting diagnostics.
+    ///
+    /// Returns [`Some`] for successful operations and [`None`] when diagnostics
+    /// are collected instead.
     fn sink(&mut self, value: T) -> Option<Self::Output>;
 }
 

--- a/libs/@local/hashql/diagnostics/src/issues.rs
+++ b/libs/@local/hashql/diagnostics/src/issues.rs
@@ -25,7 +25,7 @@ pub type BoxedDiagnosticIssues<'category, S> =
 /// #     id: "example", name: "Example"
 /// # };
 ///
-/// let mut issues = DiagnosticIssues::new();
+/// let mut issues: DiagnosticIssues<_, ()> = DiagnosticIssues::new();
 /// issues.push(Diagnostic::new(CATEGORY, Severity::Error));
 /// issues.push(Diagnostic::new(CATEGORY, Severity::Warning));
 ///
@@ -42,7 +42,7 @@ pub type BoxedDiagnosticIssues<'category, S> =
 /// #     id: "example", name: "Example"
 /// # };
 ///
-/// let mut issues = DiagnosticIssues::new();
+/// let mut issues: DiagnosticIssues<_, ()> = DiagnosticIssues::new();
 ///
 /// // Success case - value is extracted
 /// let success: Result<i32, Diagnostic<_, ()>> = Ok(42);
@@ -96,10 +96,11 @@ impl<C, S> DiagnosticIssues<C, S> {
     /// #     id: "new", name: "New"
     /// # };
     ///
-    /// let mut issues = DiagnosticIssues::new();
+    /// let mut issues: DiagnosticIssues<_, ()> = DiagnosticIssues::new();
     /// issues.push(Diagnostic::new(OLD_CATEGORY, Severity::Error));
     ///
-    /// let transformed = issues.map(|diagnostic| Diagnostic::new(NEW_CATEGORY, diagnostic.severity));
+    /// let transformed: DiagnosticIssues<_, ()> =
+    ///     issues.map(|diagnostic| Diagnostic::new(NEW_CATEGORY, diagnostic.severity));
     /// ```
     pub fn map<C2, S2>(
         self,
@@ -133,7 +134,7 @@ impl<C, S> DiagnosticIssues<C, S> {
     /// #     id: "lowering", name: "Lowering"
     /// # };
     ///
-    /// let mut issues = DiagnosticIssues::new();
+    /// let mut issues: DiagnosticIssues<_, ()> = DiagnosticIssues::new();
     /// issues.push(Diagnostic::new(PARSER_CATEGORY, Severity::Error));
     ///
     /// let lowering_issues = issues.map_category(|_| LOWERING_CATEGORY);
@@ -163,7 +164,7 @@ impl<C, S> DiagnosticIssues<C, S> {
     /// #     id: "example", name: "Example"
     /// # };
     ///
-    /// let mut issues = DiagnosticIssues::new();
+    /// let mut issues: DiagnosticIssues<_, ()> = DiagnosticIssues::new();
     /// issues.push(Diagnostic::new(CATEGORY, Severity::Error));
     ///
     /// let boxed_issues = issues.boxed();
@@ -193,7 +194,7 @@ impl<C, S> DiagnosticIssues<C, S> {
     /// #     id: "example", name: "Example"
     /// # };
     ///
-    /// let mut issues = DiagnosticIssues::new();
+    /// let mut issues: DiagnosticIssues<_, ()> = DiagnosticIssues::new();
     /// issues.push(Diagnostic::new(CATEGORY, Severity::Error));
     /// assert_eq!(issues.len(), 1);
     ///
@@ -221,7 +222,7 @@ impl<C, S> DiagnosticIssues<C, S> {
     /// #     id: "example", name: "Example"
     /// # };
     ///
-    /// let mut issues = DiagnosticIssues::new();
+    /// let mut issues: DiagnosticIssues<_, ()> = DiagnosticIssues::new();
     /// assert_eq!(issues.fatal(), 0);
     ///
     /// issues.push(Diagnostic::new(CATEGORY, Severity::Error));
@@ -246,7 +247,7 @@ impl<C, S> DiagnosticIssues<C, S> {
     /// #     id: "example", name: "Example"
     /// # };
     ///
-    /// let mut issues = DiagnosticIssues::new();
+    /// let mut issues: DiagnosticIssues<_, ()> = DiagnosticIssues::new();
     /// assert_eq!(issues.len(), 0);
     ///
     /// issues.push(Diagnostic::new(CATEGORY, Severity::Error));
@@ -269,7 +270,7 @@ impl<C, S> DiagnosticIssues<C, S> {
     /// #     id: "example", name: "Example"
     /// # };
     ///
-    /// let mut issues = DiagnosticIssues::new();
+    /// let mut issues: DiagnosticIssues<_, ()> = DiagnosticIssues::new();
     /// assert!(issues.is_empty());
     ///
     /// issues.push(Diagnostic::new(CATEGORY, Severity::Warning));
@@ -291,12 +292,12 @@ impl<C, S> DiagnosticIssues<C, S> {
     /// #     id: "example", name: "Example"
     /// # };
     ///
-    /// let mut issues = DiagnosticIssues::new();
+    /// let mut issues: DiagnosticIssues<_, ()> = DiagnosticIssues::new();
     /// issues.push(Diagnostic::new(CATEGORY, Severity::Warning));
     /// issues.insert_front(Diagnostic::new(CATEGORY, Severity::Error));
     ///
     /// // The error is now first
-    /// let first = issues.iter().next().unwrap();
+    /// let first = issues.iter().next().expect("should have diagnostics");
     /// assert_eq!(first.severity, Severity::Error);
     /// ```
     pub fn insert_front(&mut self, diagnostic: Diagnostic<C, S>) {
@@ -315,7 +316,7 @@ impl<C, S> DiagnosticIssues<C, S> {
     /// #     id: "example", name: "Example"
     /// # };
     ///
-    /// let mut issues = DiagnosticIssues::new();
+    /// let mut issues: DiagnosticIssues<_, ()> = DiagnosticIssues::new();
     /// issues.push(Diagnostic::new(CATEGORY, Severity::Error));
     /// issues.push(Diagnostic::new(CATEGORY, Severity::Warning));
     ///
@@ -340,15 +341,15 @@ impl<C, S> DiagnosticIssues<C, S> {
     /// #     id: "example", name: "Example"
     /// # };
     ///
-    /// let mut issues = DiagnosticIssues::new();
+    /// let mut issues: DiagnosticIssues<_, ()> = DiagnosticIssues::new();
     /// issues.push(Diagnostic::new(CATEGORY, Severity::Error));
     /// issues.push(Diagnostic::new(CATEGORY, Severity::Warning));
     ///
-    /// let last = issues.pop().unwrap();
+    /// let last = issues.pop().expect("should have diagnostic");
     /// assert_eq!(last.severity, Severity::Warning);
     /// assert_eq!(issues.len(), 1);
     ///
-    /// let first = issues.pop().unwrap();
+    /// let first = issues.pop().expect("should have one diagnostic");
     /// assert_eq!(first.severity, Severity::Error);
     /// assert_eq!(issues.len(), 0);
     ///
@@ -377,12 +378,12 @@ impl<C, S> DiagnosticIssues<C, S> {
     /// #     id: "example", name: "Example"
     /// # };
     ///
-    /// let mut issues = DiagnosticIssues::new();
+    /// let mut issues: DiagnosticIssues<_, ()> = DiagnosticIssues::new();
     /// issues.push(Diagnostic::new(CATEGORY, Severity::Warning));
     /// issues.push(Diagnostic::new(CATEGORY, Severity::Error));
     /// issues.push(Diagnostic::new(CATEGORY, Severity::Note));
     ///
-    /// let fatal = issues.pop_fatal().unwrap();
+    /// let fatal = issues.pop_fatal().expect("should have fatal diagnostic");
     /// assert_eq!(fatal.severity, Severity::Error);
     /// assert_eq!(issues.fatal(), 0);
     /// assert_eq!(issues.len(), 2);
@@ -417,10 +418,10 @@ impl<C, S> DiagnosticIssues<C, S> {
     /// #     id: "example", name: "Example"
     /// # };
     ///
-    /// let mut main_issues = DiagnosticIssues::new();
+    /// let mut main_issues: DiagnosticIssues<_, ()> = DiagnosticIssues::new();
     /// main_issues.push(Diagnostic::new(CATEGORY, Severity::Warning));
     ///
-    /// let mut other_issues = DiagnosticIssues::new();
+    /// let mut other_issues: DiagnosticIssues<_, ()> = DiagnosticIssues::new();
     /// other_issues.push(Diagnostic::new(CATEGORY, Severity::Error));
     ///
     /// main_issues.append(&mut other_issues);
@@ -446,7 +447,7 @@ impl<C, S> DiagnosticIssues<C, S> {
     /// #     id: "example", name: "Example"
     /// # };
     ///
-    /// let mut issues = DiagnosticIssues::new();
+    /// let mut issues: DiagnosticIssues<_, ()> = DiagnosticIssues::new();
     /// issues.push(Diagnostic::new(CATEGORY, Severity::Error));
     /// issues.push(Diagnostic::new(CATEGORY, Severity::Warning));
     ///

--- a/libs/@local/hashql/diagnostics/src/issues.rs
+++ b/libs/@local/hashql/diagnostics/src/issues.rs
@@ -664,7 +664,7 @@ mod tests {
 
     #[test]
     fn default_trait_creates_empty_collection() {
-        let issues: DiagnosticIssues<(), ()> = Default::default();
+        let issues: DiagnosticIssues<(), ()> = DiagnosticIssues::default();
 
         assert_eq!(issues.len(), 0);
         assert_eq!(issues.fatal(), 0);

--- a/libs/@local/hashql/diagnostics/src/lib.rs
+++ b/libs/@local/hashql/diagnostics/src/lib.rs
@@ -5,10 +5,12 @@
 #![feature(
     // Language Features
     trait_alias,
+    never_type,
 
     // Library Features
     int_from_ascii,
     variant_count,
+    try_trait_v2
 )]
 
 extern crate alloc;
@@ -17,17 +19,23 @@ pub mod category;
 pub mod config;
 pub mod diagnostic;
 #[cfg(feature = "serde")]
-pub mod encoding;
+pub(crate) mod encoding;
 pub mod error;
 pub mod help;
 pub mod issues;
 pub mod label;
 pub mod note;
+pub mod result;
 pub mod severity;
 pub mod span;
 
 pub use anstyle as color;
 
 pub use self::{
-    diagnostic::Diagnostic, help::Help, issues::DiagnosticIssues, note::Note, severity::Severity,
+    diagnostic::Diagnostic,
+    help::Help,
+    issues::{DiagnosticIssues, DiagnosticSink},
+    note::Note,
+    result::{DiagnosticError, DiagnosticResult, DiagnosticValue},
+    severity::Severity,
 };

--- a/libs/@local/hashql/diagnostics/src/lib.rs
+++ b/libs/@local/hashql/diagnostics/src/lib.rs
@@ -20,6 +20,7 @@ pub mod diagnostic;
 pub mod encoding;
 pub mod error;
 pub mod help;
+pub mod issues;
 pub mod label;
 pub mod note;
 pub mod severity;
@@ -27,4 +28,6 @@ pub mod span;
 
 pub use anstyle as color;
 
-pub use self::{diagnostic::Diagnostic, help::Help, note::Note, severity::Severity};
+pub use self::{
+    diagnostic::Diagnostic, help::Help, issues::DiagnosticIssues, note::Note, severity::Severity,
+};

--- a/libs/@local/hashql/diagnostics/src/lib.rs
+++ b/libs/@local/hashql/diagnostics/src/lib.rs
@@ -4,13 +4,14 @@
 #![cfg_attr(doc, doc = simple_mermaid::mermaid!("../docs/dependency-diagram.mmd"))]
 #![feature(
     // Language Features
-    trait_alias,
     never_type,
+    trait_alias,
+    try_blocks,
 
     // Library Features
-    int_from_ascii,
+    try_trait_v2,
     variant_count,
-    try_trait_v2
+    int_from_ascii,
 )]
 
 extern crate alloc;

--- a/libs/@local/hashql/diagnostics/src/result.rs
+++ b/libs/@local/hashql/diagnostics/src/result.rs
@@ -638,8 +638,8 @@ impl<T, C, S> Try for DiagnosticResult<T, C, S> {
 
 #[cfg(test)]
 mod tests {
-    use core::ops::Try;
-    use std::borrow::Cow;
+    use alloc::borrow::Cow;
+    use core::ops::Try as _;
 
     use crate::{
         Diagnostic, DiagnosticError, DiagnosticIssues, DiagnosticResult, DiagnosticValue, Severity,

--- a/libs/@local/hashql/diagnostics/src/result.rs
+++ b/libs/@local/hashql/diagnostics/src/result.rs
@@ -5,12 +5,69 @@ use core::{
 
 use crate::{Diagnostic, DiagnosticIssues, category::DiagnosticCategory};
 
+/// A successful result combined with any accumulated diagnostic messages.
+///
+/// `DiagnosticValue` represents a computation that succeeded but may have
+/// encountered warnings or other non-fatal issues along the way. The value
+/// represents the successful result, while diagnostics contains any warnings
+/// or informational messages that were collected during processing.
+///
+/// # Examples
+///
+/// ```
+/// use hashql_diagnostics::{Diagnostic, DiagnosticIssues, DiagnosticValue, Severity};
+/// # use hashql_diagnostics::category::TerminalDiagnosticCategory;
+/// # const CATEGORY: TerminalDiagnosticCategory = TerminalDiagnosticCategory {
+/// #     id: "example", name: "Example"
+/// # };
+///
+/// let mut diagnostics = DiagnosticIssues::new();
+/// diagnostics.push(Diagnostic::new(CATEGORY, Severity::Warning));
+///
+/// let result = DiagnosticValue {
+///     value: 42,
+///     diagnostics,
+/// };
+///
+/// assert_eq!(result.value, 42);
+/// assert_eq!(result.diagnostics.len(), 1);
+/// assert_eq!(result.diagnostics.fatal(), 0);
+/// ```
 #[derive(Debug)]
 pub struct DiagnosticValue<T, C, S> {
     pub value: T,
     pub diagnostics: DiagnosticIssues<C, S>,
 }
 
+/// An error result with additional diagnostic context.
+///
+/// `DiagnosticError` represents a computation that failed with a primary fatal
+/// error, along with any secondary diagnostic messages that were collected
+/// before the failure occurred.
+///
+/// # Examples
+///
+/// ```
+/// use hashql_diagnostics::{Diagnostic, DiagnosticError, DiagnosticIssues, Severity};
+/// # use hashql_diagnostics::category::TerminalDiagnosticCategory;
+/// # const ERROR_CATEGORY: TerminalDiagnosticCategory = TerminalDiagnosticCategory {
+/// #     id: "error", name: "Error"
+/// # };
+/// # const WARNING_CATEGORY: TerminalDiagnosticCategory = TerminalDiagnosticCategory {
+/// #     id: "warning", name: "Warning"
+/// # };
+///
+/// let mut secondary = DiagnosticIssues::new();
+/// secondary.push(Diagnostic::new(WARNING_CATEGORY, Severity::Warning));
+///
+/// let error = DiagnosticError {
+///     primary: Diagnostic::new(ERROR_CATEGORY, Severity::Error),
+///     secondary,
+/// };
+///
+/// assert!(error.primary.severity.is_fatal());
+/// assert_eq!(error.secondary.len(), 1);
+/// ```
 #[derive(Debug)]
 pub struct DiagnosticError<C, S> {
     pub primary: Diagnostic<C, S>,
@@ -18,20 +75,121 @@ pub struct DiagnosticError<C, S> {
 }
 
 impl<C, S> DiagnosticError<C, S> {
+    /// Converts the error into a collection of diagnostic issues.
+    ///
+    /// The primary error is inserted at the front of the secondary diagnostics,
+    /// creating a single collection containing all diagnostic information.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hashql_diagnostics::{Diagnostic, DiagnosticError, DiagnosticIssues, Severity};
+    /// # use hashql_diagnostics::category::TerminalDiagnosticCategory;
+    /// # const ERROR_CATEGORY: TerminalDiagnosticCategory = TerminalDiagnosticCategory {
+    /// #     id: "error", name: "Error"
+    /// # };
+    /// # const WARNING_CATEGORY: TerminalDiagnosticCategory = TerminalDiagnosticCategory {
+    /// #     id: "warning", name: "Warning"
+    /// # };
+    ///
+    /// let mut secondary = DiagnosticIssues::new();
+    /// secondary.push(Diagnostic::new(WARNING_CATEGORY, Severity::Warning));
+    ///
+    /// let error = DiagnosticError {
+    ///     primary: Diagnostic::new(ERROR_CATEGORY, Severity::Error),
+    ///     secondary,
+    /// };
+    ///
+    /// let issues = error.into_issues();
+    /// assert_eq!(issues.len(), 2);
+    /// assert_eq!(issues.fatal(), 1);
+    /// // Primary error is now first in the collection
+    /// assert_eq!(issues.iter().next().unwrap().severity, Severity::Error);
+    /// ```
     pub fn into_issues(mut self) -> DiagnosticIssues<C, S> {
         self.secondary.insert_front(self.primary);
         self.secondary
     }
 }
 
+/// A result type that can accumulate diagnostics while processing.
+///
+/// `DiagnosticResult` is similar to [`Result`] but allows collecting diagnostic
+/// messages (warnings, notes, etc.) even when the operation succeeds. It
+/// maintains the invariant that fatal diagnostics are always promoted to the
+/// error variant, while non-fatal diagnostics are collected separately.
+///
+/// This type supports the `?` operator and can be used in `try` blocks,
+/// making it convenient for error handling patterns that need to accumulate
+/// diagnostic information.
+///
+/// # Examples
+///
+/// Basic usage:
+///
+/// ```
+/// use hashql_diagnostics::{Diagnostic, DiagnosticResult, Severity};
+/// # use hashql_diagnostics::category::TerminalDiagnosticCategory;
+/// # const CATEGORY: TerminalDiagnosticCategory = TerminalDiagnosticCategory {
+/// #     id: "example", name: "Example"
+/// # };
+///
+/// let success = DiagnosticResult::ok(42);
+/// let error = DiagnosticResult::err(Diagnostic::new(CATEGORY, Severity::Error));
+///
+/// // Converting to regular Result
+/// let success_result = success.into_result().unwrap();
+/// assert_eq!(success_result.value, 42);
+/// assert_eq!(success_result.diagnostics.len(), 0);
+///
+/// let error_result = error.into_result().unwrap_err();
+/// assert!(error_result.primary.severity.is_fatal());
+/// ```
+///
+/// Accumulating diagnostics:
+///
+/// ```
+/// use hashql_diagnostics::{Diagnostic, DiagnosticResult, Severity};
+/// # use hashql_diagnostics::category::TerminalDiagnosticCategory;
+/// # const CATEGORY: TerminalDiagnosticCategory = TerminalDiagnosticCategory {
+/// #     id: "example", name: "Example"
+/// # };
+///
+/// let mut result = DiagnosticResult::ok(100);
+///
+/// // Add a warning - doesn't change the success state
+/// result.push_diagnostic(Diagnostic::new(CATEGORY, Severity::Warning));
+///
+/// // Add a fatal error - promotes to error state
+/// result.push_diagnostic(Diagnostic::new(CATEGORY, Severity::Error));
+///
+/// // Now it's an error
+/// assert!(result.into_result().is_err());
+/// ```
 #[must_use]
 #[derive(Debug)]
+#[expect(
+    clippy::field_scoped_visibility_modifiers,
+    reason = "required for `DiagnosticIssues`"
+)]
 pub struct DiagnosticResult<T, C, S> {
-    diagnostics: DiagnosticIssues<C, S>,
-    result: Result<T, Diagnostic<C, S>>,
+    pub(crate) diagnostics: DiagnosticIssues<C, S>,
+    pub(crate) result: Result<T, Diagnostic<C, S>>,
 }
 
 impl<T, C, S> DiagnosticResult<T, C, S> {
+    /// Creates a successful `DiagnosticResult` with the given value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hashql_diagnostics::DiagnosticResult;
+    ///
+    /// let result = DiagnosticResult::ok(42);
+    /// let success = result.into_result().unwrap();
+    /// assert_eq!(success.value, 42);
+    /// assert_eq!(success.diagnostics.len(), 0);
+    /// ```
     pub const fn ok(value: T) -> Self {
         Self {
             diagnostics: DiagnosticIssues::new(),
@@ -39,6 +197,25 @@ impl<T, C, S> DiagnosticResult<T, C, S> {
         }
     }
 
+    /// Creates a failed `DiagnosticResult` with the given fatal diagnostic.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the diagnostic is not fatal (severity code < 400).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hashql_diagnostics::{Diagnostic, DiagnosticResult, Severity};
+    /// # use hashql_diagnostics::category::TerminalDiagnosticCategory;
+    /// # const CATEGORY: TerminalDiagnosticCategory = TerminalDiagnosticCategory {
+    /// #     id: "example", name: "Example"
+    /// # };
+    ///
+    /// let result = DiagnosticResult::err(Diagnostic::new(CATEGORY, Severity::Error));
+    /// let error = result.into_result().unwrap_err();
+    /// assert!(error.primary.severity.is_fatal());
+    /// ```
     pub const fn err(diagnostic: Diagnostic<C, S>) -> Self {
         assert!(
             diagnostic.severity.is_fatal(),
@@ -51,6 +228,34 @@ impl<T, C, S> DiagnosticResult<T, C, S> {
         }
     }
 
+    /// Creates a failed `DiagnosticResult` if the diagnostic is fatal.
+    ///
+    /// Returns the diagnostic unchanged if it's not fatal, allowing the caller
+    /// to handle non-fatal diagnostics differently.
+    ///
+    /// # Errors
+    ///
+    /// Returns the original diagnostic if it is not fatal (severity code < 400).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hashql_diagnostics::{Diagnostic, DiagnosticResult, Severity};
+    /// # use hashql_diagnostics::category::TerminalDiagnosticCategory;
+    /// # const CATEGORY: TerminalDiagnosticCategory = TerminalDiagnosticCategory {
+    /// #     id: "example", name: "Example"
+    /// # };
+    ///
+    /// // Fatal diagnostic - creates error result
+    /// let fatal = Diagnostic::new(CATEGORY, Severity::Error);
+    /// let result = DiagnosticResult::try_err(fatal).unwrap();
+    /// assert!(result.into_result().is_err());
+    ///
+    /// // Non-fatal diagnostic - returns the diagnostic
+    /// let warning = Diagnostic::new(CATEGORY, Severity::Warning);
+    /// let returned_diagnostic = DiagnosticResult::try_err(warning).unwrap_err();
+    /// assert_eq!(returned_diagnostic.severity, Severity::Warning);
+    /// ```
     pub const fn try_err(diagnostic: Diagnostic<C, S>) -> Result<Self, Diagnostic<C, S>> {
         if !diagnostic.severity.is_fatal() {
             return Err(diagnostic);
@@ -62,6 +267,28 @@ impl<T, C, S> DiagnosticResult<T, C, S> {
         })
     }
 
+    /// Converts to a result with type-erased diagnostic categories.
+    ///
+    /// When combining diagnostics from different compilation phases that use
+    /// different category types, this method allows them to be stored together.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hashql_diagnostics::{Diagnostic, DiagnosticResult, Severity};
+    /// # use hashql_diagnostics::category::TerminalDiagnosticCategory;
+    /// # const CATEGORY: TerminalDiagnosticCategory = TerminalDiagnosticCategory {
+    /// #     id: "example", name: "Example"
+    /// # };
+    ///
+    /// let mut result = DiagnosticResult::ok(42);
+    /// result.push_diagnostic(Diagnostic::new(CATEGORY, Severity::Warning));
+    ///
+    /// let boxed_result = result.boxed();
+    /// let success = boxed_result.into_result().unwrap();
+    /// assert_eq!(success.value, 42);
+    /// assert_eq!(success.diagnostics.len(), 1);
+    /// ```
     pub fn boxed<'category>(self) -> DiagnosticResult<T, Box<dyn DiagnosticCategory + 'category>, S>
     where
         C: DiagnosticCategory + 'category,
@@ -80,6 +307,25 @@ impl<T, C, S> DiagnosticResult<T, C, S> {
         }
     }
 
+    /// Transforms the success value using the provided function.
+    ///
+    /// If the result is an error, the error and diagnostics are left unchanged.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hashql_diagnostics::{Diagnostic, DiagnosticResult, Severity};
+    /// # use hashql_diagnostics::category::TerminalDiagnosticCategory;
+    /// # const CATEGORY: TerminalDiagnosticCategory = TerminalDiagnosticCategory {
+    /// #     id: "example", name: "Example"
+    /// # };
+    ///
+    /// let result = DiagnosticResult::ok(21);
+    /// let doubled = result.map_ok(|x| x * 2);
+    ///
+    /// let success = doubled.into_result().unwrap();
+    /// assert_eq!(success.value, 42);
+    /// ```
     pub fn map_ok<U>(self, func: impl FnOnce(T) -> U) -> DiagnosticResult<U, C, S> {
         let Self {
             diagnostics,
@@ -94,6 +340,29 @@ impl<T, C, S> DiagnosticResult<T, C, S> {
         }
     }
 
+    /// Transforms all diagnostics using the provided function.
+    ///
+    /// This applies the transformation to both the collected diagnostics and
+    /// any error diagnostic, allowing you to change category and span types.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hashql_diagnostics::{Diagnostic, DiagnosticResult, Severity};
+    /// # use hashql_diagnostics::category::TerminalDiagnosticCategory;
+    /// # const OLD_CATEGORY: TerminalDiagnosticCategory = TerminalDiagnosticCategory {
+    /// #     id: "old", name: "Old"
+    /// # };
+    /// # const NEW_CATEGORY: TerminalDiagnosticCategory = TerminalDiagnosticCategory {
+    /// #     id: "new", name: "New"
+    /// # };
+    ///
+    /// let mut result = DiagnosticResult::ok(42);
+    /// result.push_diagnostic(Diagnostic::new(OLD_CATEGORY, Severity::Warning));
+    ///
+    /// let transformed =
+    ///     result.map_diagnostics(|diagnostic| Diagnostic::new(NEW_CATEGORY, diagnostic.severity));
+    /// ```
     pub fn map_diagnostics<C2, S2>(
         self,
         mut func: impl FnMut(Diagnostic<C, S>) -> Diagnostic<C2, S2>,
@@ -112,6 +381,32 @@ impl<T, C, S> DiagnosticResult<T, C, S> {
         }
     }
 
+    /// Adds a diagnostic to the result.
+    ///
+    /// If the result is currently successful and the diagnostic is fatal,
+    /// the result is converted to an error state. Otherwise, the diagnostic
+    /// is added to the collection of non-fatal diagnostics.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hashql_diagnostics::{Diagnostic, DiagnosticResult, Severity};
+    /// # use hashql_diagnostics::category::TerminalDiagnosticCategory;
+    /// # const CATEGORY: TerminalDiagnosticCategory = TerminalDiagnosticCategory {
+    /// #     id: "example", name: "Example"
+    /// # };
+    ///
+    /// let mut result = DiagnosticResult::ok(42);
+    ///
+    /// // Add a warning - still successful
+    /// result.push_diagnostic(Diagnostic::new(CATEGORY, Severity::Warning));
+    /// assert!(result.into_result().is_ok());
+    ///
+    /// let mut result = DiagnosticResult::ok(42);
+    /// // Add a fatal error - becomes error
+    /// result.push_diagnostic(Diagnostic::new(CATEGORY, Severity::Error));
+    /// assert!(result.into_result().is_err());
+    /// ```
     pub fn push_diagnostic(&mut self, diagnostic: Diagnostic<C, S>) {
         if self.result.is_ok() && diagnostic.severity.is_fatal() {
             self.result = Err(diagnostic);
@@ -120,6 +415,32 @@ impl<T, C, S> DiagnosticResult<T, C, S> {
         }
     }
 
+    /// Adds all diagnostics from another collection to this result.
+    ///
+    /// If the result is currently successful and any of the added diagnostics
+    /// are fatal, the result is converted to an error state using the first
+    /// fatal diagnostic found.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hashql_diagnostics::{Diagnostic, DiagnosticIssues, DiagnosticResult, Severity};
+    /// # use hashql_diagnostics::category::TerminalDiagnosticCategory;
+    /// # const CATEGORY: TerminalDiagnosticCategory = TerminalDiagnosticCategory {
+    /// #     id: "example", name: "Example"
+    /// # };
+    ///
+    /// let mut result = DiagnosticResult::ok(42);
+    /// let mut additional = DiagnosticIssues::new();
+    /// additional.push(Diagnostic::new(CATEGORY, Severity::Warning));
+    /// additional.push(Diagnostic::new(CATEGORY, Severity::Error));
+    ///
+    /// result.append_diagnostics(&mut additional);
+    ///
+    /// // Result became an error due to the fatal diagnostic
+    /// assert!(result.into_result().is_err());
+    /// assert!(additional.is_empty()); // Diagnostics were moved
+    /// ```
     pub fn append_diagnostics(&mut self, diagnostics: &mut DiagnosticIssues<C, S>) {
         self.diagnostics.append(diagnostics);
 
@@ -130,6 +451,38 @@ impl<T, C, S> DiagnosticResult<T, C, S> {
         }
     }
 
+    /// Converts the result into a standard [`Result`] type.
+    ///
+    /// Success cases become [`DiagnosticValue`] containing the value and any
+    /// collected diagnostics. Error cases become [`DiagnosticError`] containing
+    /// the primary error and any secondary diagnostics.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DiagnosticError`] if the result contains a fatal diagnostic.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hashql_diagnostics::{Diagnostic, DiagnosticResult, Severity};
+    /// # use hashql_diagnostics::category::TerminalDiagnosticCategory;
+    /// # const CATEGORY: TerminalDiagnosticCategory = TerminalDiagnosticCategory {
+    /// #     id: "example", name: "Example"
+    /// # };
+    ///
+    /// // Success case
+    /// let mut success = DiagnosticResult::ok(42);
+    /// success.push_diagnostic(Diagnostic::new(CATEGORY, Severity::Warning));
+    ///
+    /// let result = success.into_result().unwrap();
+    /// assert_eq!(result.value, 42);
+    /// assert_eq!(result.diagnostics.len(), 1);
+    ///
+    /// // Error case
+    /// let error = DiagnosticResult::err(Diagnostic::new(CATEGORY, Severity::Error));
+    /// let error_result = error.into_result().unwrap_err();
+    /// assert!(error_result.primary.severity.is_fatal());
+    /// ```
     pub fn into_result(self) -> Result<DiagnosticValue<T, C, S>, Box<DiagnosticError<C, S>>> {
         match self.result {
             Ok(value) => {
@@ -160,7 +513,20 @@ impl<T, C, S> DiagnosticResult<T, C, S> {
 }
 
 impl<T, C, S> From<DiagnosticValue<T, C, S>> for DiagnosticResult<T, C, S> {
-    fn from(DiagnosticValue { value, diagnostics }: DiagnosticValue<T, C, S>) -> Self {
+    fn from(
+        DiagnosticValue {
+            value,
+            mut diagnostics,
+        }: DiagnosticValue<T, C, S>,
+    ) -> Self {
+        // in case the `DiagnosticValue` contains fatal diagnostics convert into an error
+        if let Some(diagnostic) = diagnostics.pop_fatal() {
+            return Self {
+                result: Err(diagnostic),
+                diagnostics,
+            };
+        }
+
         Self {
             result: Ok(value),
             diagnostics,

--- a/libs/@local/hashql/diagnostics/src/result.rs
+++ b/libs/@local/hashql/diagnostics/src/result.rs
@@ -1,0 +1,260 @@
+use core::{
+    convert::Infallible,
+    ops::{ControlFlow, FromResidual, Try},
+};
+
+use crate::{Diagnostic, DiagnosticIssues, category::DiagnosticCategory};
+
+#[derive(Debug)]
+pub struct DiagnosticValue<T, C, S> {
+    pub value: T,
+    pub diagnostics: DiagnosticIssues<C, S>,
+}
+
+#[derive(Debug)]
+pub struct DiagnosticError<C, S> {
+    pub primary: Diagnostic<C, S>,
+    pub secondary: DiagnosticIssues<C, S>,
+}
+
+impl<C, S> DiagnosticError<C, S> {
+    pub fn into_issues(mut self) -> DiagnosticIssues<C, S> {
+        self.secondary.insert_front(self.primary);
+        self.secondary
+    }
+}
+
+#[must_use]
+#[derive(Debug)]
+pub struct DiagnosticResult<T, C, S> {
+    diagnostics: DiagnosticIssues<C, S>,
+    result: Result<T, Diagnostic<C, S>>,
+}
+
+impl<T, C, S> DiagnosticResult<T, C, S> {
+    pub const fn ok(value: T) -> Self {
+        Self {
+            diagnostics: DiagnosticIssues::new(),
+            result: Ok(value),
+        }
+    }
+
+    pub const fn err(diagnostic: Diagnostic<C, S>) -> Self {
+        assert!(
+            diagnostic.severity.is_fatal(),
+            "Diagnostic severity must be fatal"
+        );
+
+        Self {
+            diagnostics: DiagnosticIssues::new(),
+            result: Err(diagnostic),
+        }
+    }
+
+    pub const fn try_err(diagnostic: Diagnostic<C, S>) -> Result<Self, Diagnostic<C, S>> {
+        if !diagnostic.severity.is_fatal() {
+            return Err(diagnostic);
+        }
+
+        Ok(Self {
+            diagnostics: DiagnosticIssues::new(),
+            result: Err(diagnostic),
+        })
+    }
+
+    pub fn boxed<'category>(self) -> DiagnosticResult<T, Box<dyn DiagnosticCategory + 'category>, S>
+    where
+        C: DiagnosticCategory + 'category,
+    {
+        let Self {
+            diagnostics,
+            result,
+        } = self;
+
+        let diagnostics = diagnostics.boxed();
+        let result = result.map_err(Diagnostic::boxed);
+
+        DiagnosticResult {
+            diagnostics,
+            result,
+        }
+    }
+
+    pub fn map_ok<U>(self, func: impl FnOnce(T) -> U) -> DiagnosticResult<U, C, S> {
+        let Self {
+            diagnostics,
+            result,
+        } = self;
+
+        let result = result.map(func);
+
+        DiagnosticResult {
+            diagnostics,
+            result,
+        }
+    }
+
+    pub fn map_diagnostics<C2, S2>(
+        self,
+        mut func: impl FnMut(Diagnostic<C, S>) -> Diagnostic<C2, S2>,
+    ) -> DiagnosticResult<T, C2, S2> {
+        let Self {
+            diagnostics,
+            result,
+        } = self;
+
+        let diagnostics = diagnostics.map(&mut func);
+        let result = result.map_err(func);
+
+        DiagnosticResult {
+            diagnostics,
+            result,
+        }
+    }
+
+    pub fn push_diagnostic(&mut self, diagnostic: Diagnostic<C, S>) {
+        if self.result.is_ok() && diagnostic.severity.is_fatal() {
+            self.result = Err(diagnostic);
+        } else {
+            self.diagnostics.push(diagnostic);
+        }
+    }
+
+    pub fn append_diagnostics(&mut self, diagnostics: &mut DiagnosticIssues<C, S>) {
+        self.diagnostics.append(diagnostics);
+
+        if self.result.is_ok()
+            && let Some(fatal) = self.diagnostics.pop_fatal()
+        {
+            self.result = Err(fatal);
+        }
+    }
+
+    pub fn into_result(self) -> Result<DiagnosticValue<T, C, S>, Box<DiagnosticError<C, S>>> {
+        match self.result {
+            Ok(value) => {
+                debug_assert_eq!(
+                    self.diagnostics.fatal(),
+                    0,
+                    "Fatal diagnostics should have been promoted to an error variant"
+                );
+
+                Ok(DiagnosticValue {
+                    value,
+                    diagnostics: self.diagnostics,
+                })
+            }
+            Err(diagnostic) => {
+                debug_assert!(
+                    diagnostic.severity.is_fatal(),
+                    "Fatal diagnostics should only be present in error variants"
+                );
+
+                Err(Box::new(DiagnosticError {
+                    primary: diagnostic,
+                    secondary: self.diagnostics,
+                }))
+            }
+        }
+    }
+}
+
+impl<T, C, S> From<DiagnosticValue<T, C, S>> for DiagnosticResult<T, C, S> {
+    fn from(DiagnosticValue { value, diagnostics }: DiagnosticValue<T, C, S>) -> Self {
+        Self {
+            result: Ok(value),
+            diagnostics,
+        }
+    }
+}
+
+impl<T, C, S> From<DiagnosticError<C, S>> for DiagnosticResult<T, C, S> {
+    fn from(DiagnosticError { primary, secondary }: DiagnosticError<C, S>) -> Self {
+        Self {
+            result: Err(primary),
+            diagnostics: secondary,
+        }
+    }
+}
+
+impl<T, C, S> FromResidual<Result<Infallible, DiagnosticIssues<C, S>>>
+    for DiagnosticResult<T, C, S>
+{
+    fn from_residual(Err(mut diagnostics): Result<Infallible, DiagnosticIssues<C, S>>) -> Self {
+        let error = diagnostics
+            .pop_fatal()
+            .expect("error variant should have at least one fatal error");
+
+        Self {
+            result: Err(error),
+            diagnostics,
+        }
+    }
+}
+
+impl<T, C, S> FromResidual<Result<Infallible, Diagnostic<C, S>>> for DiagnosticResult<T, C, S> {
+    fn from_residual(Err(diagnostic): Result<Infallible, Diagnostic<C, S>>) -> Self {
+        assert!(
+            diagnostic.severity.is_fatal(),
+            "Error diagnostic must always be fatal"
+        );
+
+        Self {
+            result: Err(diagnostic),
+            diagnostics: DiagnosticIssues::new(),
+        }
+    }
+}
+
+impl<T, C, S> FromResidual<DiagnosticResult<!, C, S>> for DiagnosticResult<T, C, S> {
+    fn from_residual(residual: DiagnosticResult<!, C, S>) -> Self {
+        let Err(error) = residual.result;
+
+        Self {
+            result: Err(error),
+            diagnostics: residual.diagnostics,
+        }
+    }
+}
+
+impl<T, C, S> Try for DiagnosticResult<T, C, S> {
+    type Output = DiagnosticValue<T, C, S>;
+    type Residual = DiagnosticResult<!, C, S>;
+
+    fn from_output(output: Self::Output) -> Self {
+        let DiagnosticValue { value, diagnostics } = output;
+
+        Self {
+            result: Ok(value),
+            diagnostics,
+        }
+    }
+
+    fn branch(self) -> ControlFlow<Self::Residual, Self::Output> {
+        match self.result {
+            Ok(value) => {
+                debug_assert_eq!(
+                    self.diagnostics.fatal(),
+                    0,
+                    "Fatal diagnostics should have been promoted to an error variant"
+                );
+
+                ControlFlow::Continue(DiagnosticValue {
+                    value,
+                    diagnostics: self.diagnostics,
+                })
+            }
+            Err(diagnostic) => {
+                debug_assert!(
+                    diagnostic.severity.is_fatal(),
+                    "Fatal diagnostics should only be present in error variants"
+                );
+
+                ControlFlow::Break(DiagnosticResult {
+                    result: Err(diagnostic),
+                    diagnostics: self.diagnostics,
+                })
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Currently, we handle errors through the use of a `Result<…, Vec<Diagnostic>` or `(Option<…>, Vec<Diagnostic>)` (in case of cases where errors can happen.)

This makes handling the diagnostics quite painful and error-prone. Instead, we should switch to a more sophisticated approach, using a `sink` and `DiagnosticResult`, which looks somewhat like:

```rust
struct DiagnosticResult<T, C, S> {
  value: Result<T, Diagnostic<C, S>>,
  diagnostics: DiagnosticIssues
}
```

This would allow us to store the diagnostics and then retrieve the value. The error would always be a fatal diagnostic.

We introduce two new types: `DiagnosticIssues`, which replaces the `Diagnostics` type in the type system, and `DiagnosticResult` for error propagation.

This has been introduced before https://linear.app/hash/issue/BE-39/hashql-handle-errors-in-the-graph-api-properly, as otherwise the rendering of the diagnostics would have been more complicated than necessary.


## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
