### PR TITLE
BE-131: Add `Exists` filter to replace null-check patterns in query system

### DIFF
--- a/apps/hash-ai-worker-ts/src/workflows.ts
+++ b/apps/hash-ai-worker-ts/src/workflows.ts
@@ -473,9 +473,7 @@ export const updateAllDataTypeEmbeddings =
       filter: {
         all: [
           {
-            // @ts-expect-error -- Support null in Path parameter in structural queries in Node
-            //                     see https://linear.app/hash/issue/H-1207
-            equal: [{ path: ["embedding"] }, null],
+            exists: { path: ["embedding"] },
           },
           {
             equal: [{ path: ["version"] }, { parameter: "latest" }],
@@ -493,9 +491,7 @@ export const updateAllPropertyTypeEmbeddings =
       filter: {
         all: [
           {
-            // @ts-expect-error -- Support null in Path parameter in structural queries in Node
-            //                     see https://linear.app/hash/issue/H-1207
-            equal: [{ path: ["embedding"] }, null],
+            exists: { path: ["embedding"] },
           },
           {
             equal: [{ path: ["version"] }, { parameter: "latest" }],
@@ -513,9 +509,7 @@ export const updateAllEntityTypeEmbeddings =
       filter: {
         all: [
           {
-            // @ts-expect-error -- Support null in Path parameter in structural queries in Node
-            //                     see https://linear.app/hash/issue/H-1207
-            equal: [{ path: ["embedding"] }, null],
+            exists: { path: ["embedding"] },
           },
           {
             equal: [{ path: ["version"] }, { parameter: "latest" }],
@@ -539,12 +533,7 @@ export const updateAllEntityEmbeddings =
         filter: {
           all: [
             {
-              // @ts-expect-error -- Support null in Path parameter in structural queries in Node
-              //                     see https://linear.app/hash/issue/H-1207
-              // We can skip entities for which the embeddings were already generated.
-              // If a full regeneration is desired, either the database should be wiped manually or the
-              // `updateEntityEmbeddings` workflow should be called manually.
-              equal: [{ path: ["embedding"] }, null],
+              exists: { path: ["embedding"] },
             },
             {
               // Only embeddings for non-empty properties are generated

--- a/apps/hash-api/src/graph/knowledge/primitive/entity.ts
+++ b/apps/hash-api/src/graph/knowledge/primitive/entity.ts
@@ -220,12 +220,7 @@ export const getLatestEntityById: ImpureGraphFunction<
      * ...whether the prioritisation is fixed behavior or varied by parameter.
      */
     allFilter.push({
-      equal: [
-        { path: ["draftId"] },
-        // @ts-expect-error -- Support null in Path parameter in structural queries in Node
-        //                     see https://linear.app/hash/issue/H-1207
-        null,
-      ],
+      exists: { path: ["draftId"] },
     });
   }
 

--- a/apps/hash-api/src/graph/knowledge/system-types/notification.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/notification.ts
@@ -512,17 +512,12 @@ export const getCommentNotification: ImpureGraphFunction<
           {
             any: [
               {
-                equal: [
-                  {
-                    path: [
-                      "properties",
-                      systemPropertyTypes.archived.propertyTypeBaseUrl,
-                    ],
-                  },
-                  // @ts-expect-error -- We need to update the type definition of `EntityStructuralQuery` to allow for this
-                  //   @see https://linear.app/hash/issue/H-1207
-                  null,
-                ],
+                exists: {
+                  path: [
+                    "properties",
+                    systemPropertyTypes.archived.propertyTypeBaseUrl,
+                  ],
+                },
               },
               {
                 equal: [
@@ -546,6 +541,7 @@ export const getCommentNotification: ImpureGraphFunction<
       },
       temporalAxes: currentTimeInstantTemporalAxes,
       includeDrafts,
+      includePermissions: false,
     },
   );
 

--- a/apps/hash-frontend/src/pages/actions.page/draft-entities-context.tsx
+++ b/apps/hash-frontend/src/pages/actions.page/draft-entities-context.tsx
@@ -71,9 +71,11 @@ export const DraftEntitiesContextProvider: FunctionComponent<
           filter: {
             all: [
               {
-                // @ts-expect-error -- Support null in Path parameter in structural queries in Node
-                //                     @see https://linear.app/hash/issue/H-1207
-                notEqual: [{ path: ["draftId"] }, null],
+                not: {
+                  exists: {
+                    path: ["draftId"],
+                  },
+                },
               },
               {
                 equal: [{ path: ["archived"] }, { parameter: false }],
@@ -83,8 +85,8 @@ export const DraftEntitiesContextProvider: FunctionComponent<
           temporalAxes: currentTimeInstantTemporalAxes,
           graphResolveDepths: zeroedGraphResolveDepths,
           includeDrafts: true,
+          includePermissions: false,
         },
-        includePermissions: false,
       },
       onCompleted: (data) => setPreviouslyFetchedDraftEntitiesData(data),
       pollInterval,

--- a/apps/hash-frontend/src/shared/draft-entities-count-context.tsx
+++ b/apps/hash-frontend/src/shared/draft-entities-count-context.tsx
@@ -49,9 +49,11 @@ export const DraftEntitiesCountContextProvider: FunctionComponent<
           filter: {
             all: [
               {
-                // @ts-expect-error -- Support null in Path parameter in structural queries in Node
-                //                     @see https://linear.app/hash/issue/H-1207
-                notEqual: [{ path: ["draftId"] }, null],
+                not: {
+                  exists: {
+                    path: ["draftId"],
+                  },
+                },
               },
               {
                 equal: [{ path: ["archived"] }, { parameter: false }],

--- a/apps/hash-frontend/src/shared/use-entity-type-entities.tsx
+++ b/apps/hash-frontend/src/shared/use-entity-type-entities.tsx
@@ -57,8 +57,6 @@ export const generateUseEntityTypeEntitiesFilter = ({
   excludeWebIds?: WebId[];
 }): DistributiveField<QueryEntitySubgraphRequest, "filter"> => {
   return {
-    // @ts-expect-error -- We need to update the type definition of `EntityStructuralQuery` to allow for this
-    //   @see https://linear.app/hash/issue/H-1207
     all: [
       ...(!includeArchived
         ? [
@@ -68,15 +66,12 @@ export const generateUseEntityTypeEntitiesFilter = ({
             {
               any: [
                 {
-                  equal: [
-                    {
-                      path: [
-                        "properties",
-                        systemPropertyTypes.archived.propertyTypeBaseUrl,
-                      ],
-                    },
-                    null,
-                  ],
+                  exists: {
+                    path: [
+                      "properties",
+                      systemPropertyTypes.archived.propertyTypeBaseUrl,
+                    ],
+                  },
                 },
                 {
                   equal: [

--- a/libs/@local/graph/api/openapi/openapi.json
+++ b/libs/@local/graph/api/openapi/openapi.json
@@ -5100,6 +5100,18 @@
           },
           {
             "type": "object",
+            "title": "ExistsFilter",
+            "required": [
+              "exists"
+            ],
+            "properties": {
+              "exists": {
+                "$ref": "#/components/schemas/PathExpression"
+              }
+            }
+          },
+          {
+            "type": "object",
             "title": "GreaterFilter",
             "required": [
               "notEqual"
@@ -5239,72 +5251,10 @@
       "FilterExpression": {
         "oneOf": [
           {
-            "type": "object",
-            "title": "PathExpression",
-            "required": [
-              "path"
-            ],
-            "properties": {
-              "path": {
-                "type": "array",
-                "items": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/DataTypeQueryToken"
-                    },
-                    {
-                      "$ref": "#/components/schemas/PropertyTypeQueryToken"
-                    },
-                    {
-                      "$ref": "#/components/schemas/EntityTypeQueryToken"
-                    },
-                    {
-                      "$ref": "#/components/schemas/EntityQueryToken"
-                    },
-                    {
-                      "$ref": "#/components/schemas/Selector"
-                    },
-                    {
-                      "type": "string",
-                      "enum": [
-                        "convert"
-                      ]
-                    },
-                    {
-                      "type": "string"
-                    },
-                    {
-                      "type": "number"
-                    }
-                  ]
-                }
-              }
-            }
+            "$ref": "#/components/schemas/PathExpression"
           },
           {
-            "type": "object",
-            "title": "ParameterExpression",
-            "required": [
-              "parameter"
-            ],
-            "properties": {
-              "convert": {
-                "type": "object",
-                "required": [
-                  "from",
-                  "to"
-                ],
-                "properties": {
-                  "from": {
-                    "$ref": "#/components/schemas/VersionedUrl"
-                  },
-                  "to": {
-                    "$ref": "#/components/schemas/VersionedUrl"
-                  }
-                }
-              },
-              "parameter": {}
-            }
+            "$ref": "#/components/schemas/ParameterExpression"
           }
         ]
       },
@@ -6959,6 +6909,31 @@
         },
         "additionalProperties": false
       },
+      "ParameterExpression": {
+        "type": "object",
+        "title": "ParameterExpression",
+        "required": [
+          "parameter"
+        ],
+        "properties": {
+          "convert": {
+            "type": "object",
+            "required": [
+              "from",
+              "to"
+            ],
+            "properties": {
+              "from": {
+                "$ref": "#/components/schemas/VersionedUrl"
+              },
+              "to": {
+                "$ref": "#/components/schemas/VersionedUrl"
+              }
+            }
+          },
+          "parameter": {}
+        }
+      },
       "PartialEntityType": {
         "$ref": "./models/partial_entity_type.json"
       },
@@ -7009,6 +6984,49 @@
           }
         },
         "additionalProperties": false
+      },
+      "PathExpression": {
+        "type": "object",
+        "title": "PathExpression",
+        "required": [
+          "path"
+        ],
+        "properties": {
+          "path": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/DataTypeQueryToken"
+                },
+                {
+                  "$ref": "#/components/schemas/PropertyTypeQueryToken"
+                },
+                {
+                  "$ref": "#/components/schemas/EntityTypeQueryToken"
+                },
+                {
+                  "$ref": "#/components/schemas/EntityQueryToken"
+                },
+                {
+                  "$ref": "#/components/schemas/Selector"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "convert"
+                  ]
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                }
+              ]
+            }
+          }
+        }
       },
       "PermissionResponse": {
         "type": "object",

--- a/libs/@local/graph/api/src/rest/mod.rs
+++ b/libs/@local/graph/api/src/rest/mod.rs
@@ -694,6 +694,12 @@ impl Modify for FilterSchemaAddon {
                         )
                         .item(
                             ObjectBuilder::new()
+                                .title(Some("ExistsFilter"))
+                                .property("exists", Ref::from_schema_name("PathExpression"))
+                                .required("exists"),
+                        )
+                        .item(
+                            ObjectBuilder::new()
                                 .title(Some("GreaterFilter"))
                                 .property(
                                     "greater",
@@ -793,45 +799,47 @@ impl Modify for FilterSchemaAddon {
                 .into(),
             );
             components.schemas.insert(
+                "PathExpression".to_owned(),
+                ObjectBuilder::new()
+                    .title(Some("PathExpression"))
+                    .property(
+                        "path",
+                        ArrayBuilder::new().items(
+                            OneOfBuilder::new()
+                                .item(Ref::from_schema_name("DataTypeQueryToken"))
+                                .item(Ref::from_schema_name("PropertyTypeQueryToken"))
+                                .item(Ref::from_schema_name("EntityTypeQueryToken"))
+                                .item(Ref::from_schema_name("EntityQueryToken"))
+                                .item(Ref::from_schema_name("Selector"))
+                                .item(
+                                    ObjectBuilder::new()
+                                        .schema_type(SchemaType::String)
+                                        .enum_values(Some(["convert"])),
+                                )
+                                .item(ObjectBuilder::new().schema_type(SchemaType::String))
+                                .item(ObjectBuilder::new().schema_type(SchemaType::Number)),
+                        ),
+                    )
+                    .required("path")
+                    .build()
+                    .into(),
+            );
+            components.schemas.insert(
+                "ParameterExpression".to_owned(),
+                ObjectBuilder::new()
+                    .title(Some("ParameterExpression"))
+                    .property("parameter", Any::schema().1)
+                    .required("parameter")
+                    .property("convert", ParameterConversion::schema().1)
+                    .build()
+                    .into(),
+            );
+            components.schemas.insert(
                 "FilterExpression".to_owned(),
                 schema::Schema::OneOf(
                     OneOfBuilder::new()
-                        .item(
-                            ObjectBuilder::new()
-                                .title(Some("PathExpression"))
-                                .property(
-                                    "path",
-                                    ArrayBuilder::new().items(
-                                        OneOfBuilder::new()
-                                            .item(Ref::from_schema_name("DataTypeQueryToken"))
-                                            .item(Ref::from_schema_name("PropertyTypeQueryToken"))
-                                            .item(Ref::from_schema_name("EntityTypeQueryToken"))
-                                            .item(Ref::from_schema_name("EntityQueryToken"))
-                                            .item(Ref::from_schema_name("Selector"))
-                                            .item(
-                                                ObjectBuilder::new()
-                                                    .schema_type(SchemaType::String)
-                                                    .enum_values(Some(["convert"])),
-                                            )
-                                            .item(
-                                                ObjectBuilder::new()
-                                                    .schema_type(SchemaType::String),
-                                            )
-                                            .item(
-                                                ObjectBuilder::new()
-                                                    .schema_type(SchemaType::Number),
-                                            ),
-                                    ),
-                                )
-                                .required("path"),
-                        )
-                        .item(
-                            ObjectBuilder::new()
-                                .title(Some("ParameterExpression"))
-                                .property("parameter", Any::schema().1)
-                                .required("parameter")
-                                .property("convert", ParameterConversion::schema().1),
-                        )
+                        .item(Ref::from_schema_name("PathExpression"))
+                        .item(Ref::from_schema_name("ParameterExpression"))
                         .build(),
                 )
                 .into(),

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
@@ -1639,13 +1639,13 @@ where
         let previous_entity = Read::<Entity>::read_one(
             &transaction,
             &[Filter::Equal(
-                Some(FilterExpression::Path {
+                FilterExpression::Path {
                     path: EntityQueryPath::EditionId,
-                }),
-                Some(FilterExpression::Parameter {
+                },
+                FilterExpression::Parameter {
                     parameter: Parameter::Uuid(locked_row.entity_edition_id.into_uuid()),
                     convert: None,
-                }),
+                },
             )],
             Some(&QueryTemporalAxes::DecisionTime {
                 pinned: PinnedTemporalAxis::new(locked_transaction_time),

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/compile.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/compile.rs
@@ -237,13 +237,10 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
         if self.artifacts.table_info.tables.insert(table) {
             if !self.include_drafts {
                 self.add_condition(
-                    Condition::Equal(
-                        Some(Expression::ColumnReference {
-                            column: Column::EntityTemporalMetadata(EntityTemporalMetadata::DraftId),
-                            table_alias: Some(alias),
-                        }),
-                        None,
-                    ),
+                    Condition::Exists(Expression::ColumnReference {
+                        column: Column::EntityTemporalMetadata(EntityTemporalMetadata::DraftId),
+                        table_alias: Some(alias),
+                    }),
                     Some(table),
                 );
             }
@@ -462,17 +459,14 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
             ),
             Filter::Not(filter) => Condition::Not(Box::new(self.compile_filter(filter)?)),
             Filter::Equal(lhs, rhs) => Condition::Equal(
-                lhs.as_ref()
-                    .map(|expression| self.compile_filter_expression(expression).0),
-                rhs.as_ref()
-                    .map(|expression| self.compile_filter_expression(expression).0),
+                self.compile_filter_expression(lhs).0,
+                self.compile_filter_expression(rhs).0,
             ),
             Filter::NotEqual(lhs, rhs) => Condition::NotEqual(
-                lhs.as_ref()
-                    .map(|expression| self.compile_filter_expression(expression).0),
-                rhs.as_ref()
-                    .map(|expression| self.compile_filter_expression(expression).0),
+                self.compile_filter_expression(lhs).0,
+                self.compile_filter_expression(rhs).0,
             ),
+            Filter::Exists { path } => Condition::Exists(self.compile_path_column(path)),
             Filter::Greater(lhs, rhs) => Condition::Greater(
                 self.compile_filter_expression(lhs).0,
                 self.compile_filter_expression(rhs).0,
@@ -801,14 +795,14 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
 
         let alias = self.add_join_statements(path);
         // Join the table of `path` and compare the version to the latest version
-        let latest_version_expression = Some(Expression::ColumnReference {
+        let latest_version_expression = Expression::ColumnReference {
             column: Column::OntologyIds(OntologyIds::LatestVersion),
             table_alias: Some(alias),
-        });
-        let version_expression = Some(Expression::ColumnReference {
+        };
+        let version_expression = Expression::ColumnReference {
             column: version_column,
             table_alias: Some(alias),
-        });
+        };
 
         match operator {
             EqualityOperator::Equal => {
@@ -832,18 +826,18 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
         match filter {
             Filter::Equal(lhs, rhs) | Filter::NotEqual(lhs, rhs) => match (lhs, rhs) {
                 (
-                    Some(FilterExpression::Path { path }),
-                    Some(FilterExpression::Parameter {
+                    FilterExpression::Path { path },
+                    FilterExpression::Parameter {
                         parameter: Parameter::Text(parameter),
                         convert: None,
-                    }),
+                    },
                 )
                 | (
-                    Some(FilterExpression::Parameter {
+                    FilterExpression::Parameter {
                         parameter: Parameter::Text(parameter),
                         convert: None,
-                    }),
-                    Some(FilterExpression::Path { path }),
+                    },
+                    FilterExpression::Path { path },
                 ) => match (path.terminating_column().0, filter, parameter.as_ref()) {
                     (Column::OntologyIds(OntologyIds::Version), Filter::Equal(..), "latest") => {
                         Some(
@@ -866,6 +860,7 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
             Filter::All(_)
             | Filter::Any(_)
             | Filter::Not(_)
+            | Filter::Exists { .. }
             | Filter::Greater(..)
             | Filter::GreaterOrEqual(..)
             | Filter::Less(..)

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/expression/conditional.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/expression/conditional.rs
@@ -251,15 +251,6 @@ where
     }
 }
 
-impl Transpile for Option<Expression> {
-    fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Some(value) => value.transpile(fmt),
-            None => fmt.write_str("NULL"),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use hash_graph_store::data_type::DataTypeQueryPath;

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/expression/where_clause.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/expression/where_clause.rs
@@ -201,9 +201,9 @@ mod tests {
             )
         );
 
-        let filter_c = Filter::Exists {
+        let filter_c = Filter::Not(Box::new(Filter::Exists {
             path: DataTypeQueryPath::Description,
-        };
+        }));
         where_clause.add_condition(
             compiler
                 .compile_filter(&filter_c)

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/expression/where_clause.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/expression/where_clause.rs
@@ -145,13 +145,13 @@ mod tests {
         assert_eq!(where_clause.transpile_to_string(), "");
 
         let filter_a = Filter::Equal(
-            Some(FilterExpression::Path {
+            FilterExpression::Path {
                 path: DataTypeQueryPath::Version,
-            }),
-            Some(FilterExpression::Parameter {
+            },
+            FilterExpression::Parameter {
                 parameter: Parameter::Text(Cow::Borrowed("latest")),
                 convert: None,
-            }),
+            },
         );
         where_clause.add_condition(
             compiler
@@ -166,24 +166,24 @@ mod tests {
 
         let filter_b = Filter::All(vec![
             Filter::Equal(
-                Some(FilterExpression::Path {
+                FilterExpression::Path {
                     path: DataTypeQueryPath::BaseUrl,
-                }),
-                Some(FilterExpression::Parameter {
+                },
+                FilterExpression::Parameter {
                     parameter: Parameter::Text(Cow::Borrowed(
                         "https://blockprotocol.org/@blockprotocol/types/data-type/text/",
                     )),
                     convert: None,
-                }),
+                },
             ),
             Filter::Equal(
-                Some(FilterExpression::Path {
+                FilterExpression::Path {
                     path: DataTypeQueryPath::Version,
-                }),
-                Some(FilterExpression::Parameter {
+                },
+                FilterExpression::Parameter {
                     parameter: Parameter::Decimal(Real::from_natural(1, 1)),
                     convert: None,
-                }),
+                },
             ),
         ]);
         where_clause.add_condition(
@@ -201,12 +201,9 @@ mod tests {
             )
         );
 
-        let filter_c = Filter::NotEqual(
-            Some(FilterExpression::Path {
-                path: DataTypeQueryPath::Description,
-            }),
-            None,
-        );
+        let filter_c = Filter::Exists {
+            path: DataTypeQueryPath::Description,
+        };
         where_clause.add_condition(
             compiler
                 .compile_filter(&filter_c)
@@ -225,22 +222,22 @@ mod tests {
 
         let filter_d = Filter::Any(vec![
             Filter::Equal(
-                Some(FilterExpression::Path {
+                FilterExpression::Path {
                     path: DataTypeQueryPath::Title,
-                }),
-                Some(FilterExpression::Parameter {
+                },
+                FilterExpression::Parameter {
                     parameter: Parameter::Text(Cow::Borrowed("some title")),
                     convert: None,
-                }),
+                },
             ),
             Filter::Equal(
-                Some(FilterExpression::Path {
+                FilterExpression::Path {
                     path: DataTypeQueryPath::Description,
-                }),
-                Some(FilterExpression::Parameter {
+                },
+                FilterExpression::Parameter {
                     parameter: Parameter::Text(Cow::Borrowed("some description")),
                     convert: None,
-                }),
+                },
             ),
         ]);
         where_clause.add_condition(

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/statement/select.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/statement/select.rs
@@ -184,15 +184,15 @@ mod tests {
             SelectCompiler::<DataTypeWithMetadata>::with_asterisk(Some(&temporal_axes), false);
         compiler
             .add_filter(&Filter::Equal(
-                Some(FilterExpression::Path {
+                FilterExpression::Path {
                     path: DataTypeQueryPath::VersionedUrl,
-                }),
-                Some(FilterExpression::Parameter {
+                },
+                FilterExpression::Parameter {
                     parameter: Parameter::Text(Cow::Borrowed(
                         "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1",
                     )),
                     convert: None,
-                }),
+                },
             ))
             .expect("Failed to add filter");
         test_compilation(
@@ -217,13 +217,13 @@ mod tests {
         let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
         let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes), false);
         let filter = Filter::Equal(
-            Some(FilterExpression::Path {
+            FilterExpression::Path {
                 path: EntityQueryPath::Uuid,
-            }),
-            Some(FilterExpression::Parameter {
+            },
+            FilterExpression::Parameter {
                 parameter: Parameter::Uuid(Uuid::nil()),
                 convert: None,
-            }),
+            },
         );
         compiler.add_filter(&filter).expect("Failed to add filter");
         test_compilation(
@@ -248,13 +248,13 @@ mod tests {
     fn full_temporal() {
         let mut compiler = SelectCompiler::<Entity>::with_asterisk(None, false);
         let filter = Filter::Equal(
-            Some(FilterExpression::Path {
+            FilterExpression::Path {
                 path: EntityQueryPath::Uuid,
-            }),
-            Some(FilterExpression::Parameter {
+            },
+            FilterExpression::Parameter {
                 parameter: Parameter::Uuid(Uuid::nil()),
                 convert: None,
-            }),
+            },
         );
         compiler.add_filter(&filter).expect("Failed to add filter");
         test_compilation(
@@ -278,24 +278,24 @@ mod tests {
 
         let filter = Filter::All(vec![
             Filter::Equal(
-                Some(FilterExpression::Path {
+                FilterExpression::Path {
                     path: DataTypeQueryPath::BaseUrl,
-                }),
-                Some(FilterExpression::Parameter {
+                },
+                FilterExpression::Parameter {
                     parameter: Parameter::Text(Cow::Borrowed(
                         "https://blockprotocol.org/@blockprotocol/types/data-type/text/",
                     )),
                     convert: None,
-                }),
+                },
             ),
             Filter::Equal(
-                Some(FilterExpression::Path {
+                FilterExpression::Path {
                     path: DataTypeQueryPath::Version,
-                }),
-                Some(FilterExpression::Parameter {
+                },
+                FilterExpression::Parameter {
                     parameter: Parameter::Decimal(Real::from_natural(1, 1)),
                     convert: None,
-                }),
+                },
             ),
         ]);
         compiler.add_filter(&filter).expect("Failed to add filter");
@@ -327,13 +327,13 @@ mod tests {
 
         compiler
             .add_filter(&Filter::Equal(
-                Some(FilterExpression::Path {
+                FilterExpression::Path {
                     path: DataTypeQueryPath::Version,
-                }),
-                Some(FilterExpression::Parameter {
+                },
+                FilterExpression::Parameter {
                     parameter: Parameter::Text(Cow::Borrowed("latest")),
                     convert: None,
-                }),
+                },
             ))
             .expect("Failed to add filter");
 
@@ -361,13 +361,13 @@ mod tests {
 
         compiler
             .add_filter(&Filter::NotEqual(
-                Some(FilterExpression::Path {
+                FilterExpression::Path {
                     path: DataTypeQueryPath::Version,
-                }),
-                Some(FilterExpression::Parameter {
+                },
+                FilterExpression::Parameter {
                     parameter: Parameter::Text(Cow::Borrowed("latest")),
                     convert: None,
-                }),
+                },
             ))
             .expect("Failed to add filter");
 
@@ -395,16 +395,16 @@ mod tests {
 
         compiler
             .add_filter(&Filter::Equal(
-                Some(FilterExpression::Path {
+                FilterExpression::Path {
                     path: PropertyTypeQueryPath::DataTypeEdge {
                         edge_kind: OntologyEdgeKind::ConstrainsValuesOn,
                         path: DataTypeQueryPath::Title,
                     },
-                }),
-                Some(FilterExpression::Parameter {
+                },
+                FilterExpression::Parameter {
                     parameter: Parameter::Text(Cow::Borrowed("Text")),
                     convert: None,
-                }),
+                },
             ))
             .expect("Failed to add filter");
 
@@ -428,30 +428,30 @@ mod tests {
 
         let filter = Filter::All(vec![
             Filter::Equal(
-                Some(FilterExpression::Path {
+                FilterExpression::Path {
                     path: PropertyTypeQueryPath::DataTypeEdge {
                         edge_kind: OntologyEdgeKind::ConstrainsValuesOn,
                         path: DataTypeQueryPath::BaseUrl,
                     },
-                }),
-                Some(FilterExpression::Parameter {
+                },
+                FilterExpression::Parameter {
                     parameter: Parameter::Text(Cow::Borrowed(
                         "https://blockprotocol.org/@blockprotocol/types/data-type/text/",
                     )),
                     convert: None,
-                }),
+                },
             ),
             Filter::Equal(
-                Some(FilterExpression::Path {
+                FilterExpression::Path {
                     path: PropertyTypeQueryPath::DataTypeEdge {
                         edge_kind: OntologyEdgeKind::ConstrainsValuesOn,
                         path: DataTypeQueryPath::Version,
                     },
-                }),
-                Some(FilterExpression::Parameter {
+                },
+                FilterExpression::Parameter {
                     parameter: Parameter::Decimal(Real::from_natural(1, 1)),
                     convert: None,
-                }),
+                },
             ),
         ]);
         compiler.add_filter(&filter).expect("Failed to add filter");
@@ -496,17 +496,17 @@ mod tests {
             SelectCompiler::<PropertyTypeWithMetadata>::with_asterisk(Some(&temporal_axes), false);
 
         let filter = Filter::Equal(
-            Some(FilterExpression::Path {
+            FilterExpression::Path {
                 path: PropertyTypeQueryPath::PropertyTypeEdge {
                     edge_kind: OntologyEdgeKind::ConstrainsPropertiesOn,
                     path: Box::new(PropertyTypeQueryPath::Title),
                     direction: EdgeDirection::Outgoing,
                 },
-            }),
-            Some(FilterExpression::Parameter {
+            },
+            FilterExpression::Parameter {
                 parameter: Parameter::Text(Cow::Borrowed("Text")),
                 convert: None,
-            }),
+            },
         );
         compiler.add_filter(&filter).expect("Failed to add filter");
 
@@ -537,17 +537,17 @@ mod tests {
             SelectCompiler::<EntityTypeWithMetadata>::with_asterisk(Some(&temporal_axes), false);
 
         let filter = Filter::Equal(
-            Some(FilterExpression::Path {
+            FilterExpression::Path {
                 path: EntityTypeQueryPath::PropertyTypeEdge {
                     edge_kind: OntologyEdgeKind::ConstrainsPropertiesOn,
                     path: PropertyTypeQueryPath::Title,
                     inheritance_depth: Some(0),
                 },
-            }),
-            Some(FilterExpression::Parameter {
+            },
+            FilterExpression::Parameter {
                 parameter: Parameter::Text(Cow::Borrowed("Name")),
                 convert: None,
-            }),
+            },
         );
         compiler.add_filter(&filter).expect("Failed to add filter");
 
@@ -579,7 +579,7 @@ mod tests {
             SelectCompiler::<EntityTypeWithMetadata>::with_asterisk(Some(&temporal_axes), false);
 
         let filter = Filter::Equal(
-            Some(FilterExpression::Path {
+            FilterExpression::Path {
                 path: EntityTypeQueryPath::EntityTypeEdge {
                     edge_kind: OntologyEdgeKind::ConstrainsLinksOn,
                     path: Box::new(EntityTypeQueryPath::EntityTypeEdge {
@@ -591,11 +591,11 @@ mod tests {
                     direction: EdgeDirection::Outgoing,
                     inheritance_depth: Some(0),
                 },
-            }),
-            Some(FilterExpression::Parameter {
+            },
+            FilterExpression::Parameter {
                 parameter: Parameter::Text(Cow::Borrowed("Friend Of")),
                 convert: None,
-            }),
+            },
         );
         compiler.add_filter(&filter).expect("Failed to add filter");
 
@@ -634,20 +634,20 @@ mod tests {
             SelectCompiler::<EntityTypeWithMetadata>::with_asterisk(Some(&temporal_axes), false);
 
         let filter = Filter::Equal(
-            Some(FilterExpression::Path {
+            FilterExpression::Path {
                 path: EntityTypeQueryPath::EntityTypeEdge {
                     edge_kind: OntologyEdgeKind::InheritsFrom,
                     path: Box::new(EntityTypeQueryPath::BaseUrl),
                     direction: EdgeDirection::Outgoing,
                     inheritance_depth: Some(0),
                 },
-            }),
-            Some(FilterExpression::Parameter {
+            },
+            FilterExpression::Parameter {
                 parameter: Parameter::Text(Cow::Borrowed(
                     "https://blockprotocol.org/@blockprotocol/types/entity-type/link/",
                 )),
                 convert: None,
-            }),
+            },
         );
         compiler.add_filter(&filter).expect("Failed to add filter");
 
@@ -681,13 +681,13 @@ mod tests {
         let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes), false);
 
         let filter = Filter::Equal(
-            Some(FilterExpression::Path {
+            FilterExpression::Path {
                 path: EntityQueryPath::Uuid,
-            }),
-            Some(FilterExpression::Parameter {
+            },
+            FilterExpression::Parameter {
                 parameter: Parameter::Text(Cow::Borrowed("12345678-ABCD-4321-5678-ABCD5555DCBA")),
                 convert: None,
-            }),
+            },
         );
         compiler.add_filter(&filter).expect("Failed to add filter");
 
@@ -727,13 +727,13 @@ mod tests {
         compiler.add_selection_path(&EntityQueryPath::Properties(None));
 
         let filter = Filter::Equal(
-            Some(FilterExpression::Path {
+            FilterExpression::Path {
                 path: EntityQueryPath::DraftId,
-            }),
-            Some(FilterExpression::Parameter {
+            },
+            FilterExpression::Parameter {
                 parameter: Parameter::Uuid(Uuid::nil()),
                 convert: None,
-            }),
+            },
         );
         compiler.add_filter(&filter).expect("Failed to add filter");
 
@@ -772,13 +772,13 @@ mod tests {
         ))]);
 
         let filter = Filter::Equal(
-            Some(FilterExpression::Path {
+            FilterExpression::Path {
                 path: EntityQueryPath::Properties(Some(json_path.clone())),
-            }),
-            Some(FilterExpression::Parameter {
+            },
+            FilterExpression::Parameter {
                 parameter: Parameter::Text(Cow::Borrowed("Bob")),
                 convert: None,
-            }),
+            },
         );
         compiler.add_filter(&filter).expect("Failed to add filter");
 
@@ -812,12 +812,9 @@ mod tests {
             r#"$."https://blockprotocol.org/@alice/types/property-type/name/""#,
         ))]);
 
-        let filter = Filter::Equal(
-            Some(FilterExpression::Path {
-                path: EntityQueryPath::Properties(Some(json_path.clone())),
-            }),
-            None,
-        );
+        let filter = Filter::Exists {
+            path: EntityQueryPath::Properties(Some(json_path.clone())),
+        };
         compiler.add_filter(&filter).expect("Failed to add filter");
 
         test_compilation(
@@ -847,7 +844,7 @@ mod tests {
         let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes), false);
 
         let filter = Filter::Equal(
-            Some(FilterExpression::Path {
+            FilterExpression::Path {
                 path: EntityQueryPath::EntityEdge {
                     edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
                     path: Box::new(EntityQueryPath::EntityEdge {
@@ -857,11 +854,11 @@ mod tests {
                     }),
                     direction: EdgeDirection::Incoming,
                 },
-            }),
-            Some(FilterExpression::Parameter {
+            },
+            FilterExpression::Parameter {
                 parameter: Parameter::Decimal(Real::from_natural(10, 1)),
                 convert: None,
-            }),
+            },
         );
         compiler.add_filter(&filter).expect("Failed to add filter");
 
@@ -908,7 +905,7 @@ mod tests {
         let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes), false);
 
         let filter = Filter::Equal(
-            Some(FilterExpression::Path {
+            FilterExpression::Path {
                 path: EntityQueryPath::EntityEdge {
                     edge_kind: KnowledgeGraphEdgeKind::HasRightEntity,
                     path: Box::new(EntityQueryPath::EntityEdge {
@@ -918,11 +915,11 @@ mod tests {
                     }),
                     direction: EdgeDirection::Incoming,
                 },
-            }),
-            Some(FilterExpression::Parameter {
+            },
+            FilterExpression::Parameter {
                 parameter: Parameter::Decimal(Real::from_natural(10, 1)),
                 convert: None,
-            }),
+            },
         );
         compiler.add_filter(&filter).expect("Failed to add filter");
 
@@ -970,56 +967,56 @@ mod tests {
 
         let filter = Filter::All(vec![
             Filter::Equal(
-                Some(FilterExpression::Path {
+                FilterExpression::Path {
                     path: EntityQueryPath::EntityEdge {
                         edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
                         path: Box::new(EntityQueryPath::Uuid),
                         direction: EdgeDirection::Outgoing,
                     },
-                }),
-                Some(FilterExpression::Parameter {
+                },
+                FilterExpression::Parameter {
                     parameter: Parameter::Uuid(Uuid::nil()),
                     convert: None,
-                }),
+                },
             ),
             Filter::Equal(
-                Some(FilterExpression::Path {
+                FilterExpression::Path {
                     path: EntityQueryPath::EntityEdge {
                         edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
                         path: Box::new(EntityQueryPath::WebId),
                         direction: EdgeDirection::Outgoing,
                     },
-                }),
-                Some(FilterExpression::Parameter {
+                },
+                FilterExpression::Parameter {
                     parameter: Parameter::Uuid(Uuid::nil()),
                     convert: None,
-                }),
+                },
             ),
             Filter::Equal(
-                Some(FilterExpression::Path {
+                FilterExpression::Path {
                     path: EntityQueryPath::EntityEdge {
                         edge_kind: KnowledgeGraphEdgeKind::HasRightEntity,
                         path: Box::new(EntityQueryPath::Uuid),
                         direction: EdgeDirection::Outgoing,
                     },
-                }),
-                Some(FilterExpression::Parameter {
+                },
+                FilterExpression::Parameter {
                     parameter: Parameter::Uuid(Uuid::nil()),
                     convert: None,
-                }),
+                },
             ),
             Filter::Equal(
-                Some(FilterExpression::Path {
+                FilterExpression::Path {
                     path: EntityQueryPath::EntityEdge {
                         edge_kind: KnowledgeGraphEdgeKind::HasRightEntity,
                         path: Box::new(EntityQueryPath::WebId),
                         direction: EdgeDirection::Outgoing,
                     },
-                }),
-                Some(FilterExpression::Parameter {
+                },
+                FilterExpression::Parameter {
                     parameter: Parameter::Uuid(Uuid::nil()),
                     convert: None,
-                }),
+                },
             ),
         ]);
         compiler.add_filter(&filter).expect("Failed to add filter");
@@ -1064,31 +1061,31 @@ mod tests {
         let entity_b_uuid = Uuid::new_v4();
 
         let filter_a = Filter::Equal(
-            Some(FilterExpression::Path {
+            FilterExpression::Path {
                 path: EntityQueryPath::EntityEdge {
                     edge_kind: KnowledgeGraphEdgeKind::HasRightEntity,
                     path: Box::new(EntityQueryPath::Uuid),
                     direction: EdgeDirection::Outgoing,
                 },
-            }),
-            Some(FilterExpression::Parameter {
+            },
+            FilterExpression::Parameter {
                 parameter: Parameter::Uuid(entity_a_uuid),
                 convert: None,
-            }),
+            },
         );
 
         let filter_b = Filter::Equal(
-            Some(FilterExpression::Path {
+            FilterExpression::Path {
                 path: EntityQueryPath::EntityEdge {
                     edge_kind: KnowledgeGraphEdgeKind::HasRightEntity,
                     path: Box::new(EntityQueryPath::Uuid),
                     direction: EdgeDirection::Outgoing,
                 },
-            }),
-            Some(FilterExpression::Parameter {
+            },
+            FilterExpression::Parameter {
                 parameter: Parameter::Uuid(entity_b_uuid),
                 convert: None,
-            }),
+            },
         );
 
         let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes), false);
@@ -1163,7 +1160,7 @@ mod tests {
 
         let filter = Filter::All(vec![
             Filter::Equal(
-                Some(FilterExpression::Path {
+                FilterExpression::Path {
                     path: EntityQueryPath::EntityEdge {
                         edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
                         path: Box::new(EntityQueryPath::EntityTypeEdge {
@@ -1173,16 +1170,16 @@ mod tests {
                         }),
                         direction: EdgeDirection::Outgoing,
                     },
-                }),
-                Some(FilterExpression::Parameter {
+                },
+                FilterExpression::Parameter {
                     parameter: Parameter::Text(Cow::Borrowed(
                         "https://example.com/@example-org/types/entity-type/address",
                     )),
                     convert: None,
-                }),
+                },
             ),
             Filter::Equal(
-                Some(FilterExpression::Path {
+                FilterExpression::Path {
                     path: EntityQueryPath::EntityEdge {
                         edge_kind: KnowledgeGraphEdgeKind::HasRightEntity,
                         path: Box::new(EntityQueryPath::EntityTypeEdge {
@@ -1192,13 +1189,13 @@ mod tests {
                         }),
                         direction: EdgeDirection::Outgoing,
                     },
-                }),
-                Some(FilterExpression::Parameter {
+                },
+                FilterExpression::Parameter {
                     parameter: Parameter::Text(Cow::Borrowed(
                         "https://example.com/@example-org/types/entity-type/name",
                     )),
                     convert: None,
-                }),
+                },
             ),
         ]);
         compiler.add_filter(&filter).expect("Failed to add filter");

--- a/libs/@local/graph/store/src/data_type/query.rs
+++ b/libs/@local/graph/store/src/data_type/query.rs
@@ -69,8 +69,8 @@ pub enum DataTypeQueryPath<'p> {
     /// let filter_value = json!({ "equal": [{ "path": ["version"] }, { "parameter": "latest" }] });
     /// let path = Filter::<DataTypeWithMetadata>::deserialize(filter_value)?;
     /// assert_eq!(path, Filter::Equal(
-    ///     Some(FilterExpression::Path{ path: DataTypeQueryPath::Version }),
-    ///     Some(FilterExpression::Parameter { parameter: Parameter::Text(Cow::Borrowed("latest")), convert: None }))
+    ///     FilterExpression::Path{ path: DataTypeQueryPath::Version },
+    ///     FilterExpression::Parameter { parameter: Parameter::Text(Cow::Borrowed("latest")), convert: None })
     /// );
     /// # Ok::<(), serde_json::Error>(())
     /// ```

--- a/libs/@local/graph/store/src/entity_type/query.rs
+++ b/libs/@local/graph/store/src/entity_type/query.rs
@@ -64,8 +64,8 @@ pub enum EntityTypeQueryPath<'p> {
     /// let filter_value = json!({ "equal": [{ "path": ["version"] }, { "parameter": "latest" }] });
     /// let path = Filter::<EntityTypeWithMetadata>::deserialize(filter_value)?;
     /// assert_eq!(path, Filter::Equal(
-    ///     Some(FilterExpression::Path { path: EntityTypeQueryPath::Version }),
-    ///     Some(FilterExpression::Parameter { parameter: Parameter::Text(Cow::Borrowed("latest")), convert: None }))
+    ///     FilterExpression::Path { path: EntityTypeQueryPath::Version },
+    ///     FilterExpression::Parameter { parameter: Parameter::Text(Cow::Borrowed("latest")), convert: None })
     /// );
     /// # Ok::<(), serde_json::Error>(())
     /// ```

--- a/libs/@local/graph/store/src/filter/mod.rs
+++ b/libs/@local/graph/store/src/filter/mod.rs
@@ -1834,9 +1834,12 @@ mod tests {
                     let has_web_permit = permits.iter().any(|permit| {
                         matches!(
                             permit,
-                            Filter::Exists {
-                                path: EntityQueryPath::WebId
-                            }
+                            Filter::Equal(
+                                FilterExpression::Path {
+                                    path: EntityQueryPath::WebId
+                                },
+                                _
+                            )
                         )
                     });
 

--- a/libs/@local/graph/store/src/filter/mod.rs
+++ b/libs/@local/graph/store/src/filter/mod.rs
@@ -119,14 +119,11 @@ pub enum Filter<'p, R: QueryRecord> {
     All(Vec<Self>),
     Any(Vec<Self>),
     Not(Box<Self>),
-    Equal(
-        Option<FilterExpression<'p, R>>,
-        Option<FilterExpression<'p, R>>,
-    ),
-    NotEqual(
-        Option<FilterExpression<'p, R>>,
-        Option<FilterExpression<'p, R>>,
-    ),
+    Equal(FilterExpression<'p, R>, FilterExpression<'p, R>),
+    NotEqual(FilterExpression<'p, R>, FilterExpression<'p, R>),
+    Exists {
+        path: R::QueryPath<'p>,
+    },
     Greater(FilterExpression<'p, R>, FilterExpression<'p, R>),
     GreaterOrEqual(FilterExpression<'p, R>, FilterExpression<'p, R>),
     Less(FilterExpression<'p, R>, FilterExpression<'p, R>),
@@ -154,22 +151,22 @@ where
     pub fn for_versioned_url(versioned_url: &'p VersionedUrl) -> Self {
         Self::All(vec![
             Self::Equal(
-                Some(FilterExpression::Path {
+                FilterExpression::Path {
                     path: <R::QueryPath<'p>>::base_url(),
-                }),
-                Some(FilterExpression::Parameter {
+                },
+                FilterExpression::Parameter {
                     parameter: Parameter::Text(Cow::Borrowed(versioned_url.base_url.as_str())),
                     convert: None,
-                }),
+                },
             ),
             Self::Equal(
-                Some(FilterExpression::Path {
+                FilterExpression::Path {
                     path: <R::QueryPath<'p>>::version(),
-                }),
-                Some(FilterExpression::Parameter {
+                },
+                FilterExpression::Parameter {
                     parameter: Parameter::OntologyTypeVersion(versioned_url.version),
                     convert: None,
-                }),
+                },
             ),
         ])
     }
@@ -179,13 +176,13 @@ impl<'p> Filter<'p, DataTypeWithMetadata> {
     #[must_use]
     pub const fn for_data_type_uuid(data_type_uuid: DataTypeUuid) -> Self {
         Self::Equal(
-            Some(FilterExpression::Path {
+            FilterExpression::Path {
                 path: DataTypeQueryPath::OntologyId,
-            }),
-            Some(FilterExpression::Parameter {
+            },
+            FilterExpression::Parameter {
                 parameter: Parameter::Uuid(data_type_uuid.into_uuid()),
                 convert: None,
-            }),
+            },
         )
     }
 
@@ -224,18 +221,18 @@ impl<'p> Filter<'p, DataTypeWithMetadata> {
     ) -> Self {
         let data_type_id = DataTypeUuid::from_url(versioned_url);
         Filter::Equal(
-            Some(FilterExpression::Path {
+            FilterExpression::Path {
                 path: DataTypeQueryPath::DataTypeEdge {
                     edge_kind: OntologyEdgeKind::InheritsFrom,
                     direction: EdgeDirection::Outgoing,
                     inheritance_depth,
                     path: Box::new(DataTypeQueryPath::OntologyId),
                 },
-            }),
-            Some(FilterExpression::Parameter {
+            },
+            FilterExpression::Parameter {
                 parameter: Parameter::Uuid(data_type_id.into_uuid()),
                 convert: None,
-            }),
+            },
         )
     }
 
@@ -252,29 +249,26 @@ impl<'p> Filter<'p, DataTypeWithMetadata> {
                 Self::Not(Box::new(Self::for_resource_filter(filter)))
             }
             DataTypeResourceFilter::IsBaseUrl { base_url } => Self::Equal(
-                Some(FilterExpression::Path {
+                FilterExpression::Path {
                     path: DataTypeQueryPath::BaseUrl,
-                }),
-                Some(FilterExpression::Parameter {
+                },
+                FilterExpression::Parameter {
                     parameter: Parameter::Text(Cow::Borrowed(base_url.as_str())),
                     convert: None,
-                }),
+                },
             ),
             DataTypeResourceFilter::IsVersion { version } => Self::Equal(
-                Some(FilterExpression::Path {
+                FilterExpression::Path {
                     path: DataTypeQueryPath::Version,
-                }),
-                Some(FilterExpression::Parameter {
+                },
+                FilterExpression::Parameter {
                     parameter: Parameter::OntologyTypeVersion(*version),
                     convert: None,
-                }),
+                },
             ),
-            DataTypeResourceFilter::IsRemote => Self::Equal(
-                Some(FilterExpression::Path {
-                    path: DataTypeQueryPath::WebId,
-                }),
-                None,
-            ),
+            DataTypeResourceFilter::IsRemote => Self::Exists {
+                path: DataTypeQueryPath::WebId,
+            },
         }
     }
 
@@ -282,25 +276,25 @@ impl<'p> Filter<'p, DataTypeWithMetadata> {
     pub fn for_resource_constraint(resource_constraint: &'p ResourceConstraint) -> Self {
         match resource_constraint {
             ResourceConstraint::Web { web_id } => Self::Equal(
-                Some(FilterExpression::Path {
+                FilterExpression::Path {
                     path: DataTypeQueryPath::WebId,
-                }),
-                Some(FilterExpression::Parameter {
+                },
+                FilterExpression::Parameter {
                     parameter: Parameter::Uuid((*web_id).into()),
                     convert: None,
-                }),
+                },
             ),
             ResourceConstraint::DataType(data_type_constraint) => match data_type_constraint {
                 DataTypeResourceConstraint::Exact { id } => Self::for_versioned_url(id.as_url()),
                 DataTypeResourceConstraint::Web { web_id, filter } => Self::All(vec![
                     Self::Equal(
-                        Some(FilterExpression::Path {
+                        FilterExpression::Path {
                             path: DataTypeQueryPath::WebId,
-                        }),
-                        Some(FilterExpression::Parameter {
+                        },
+                        FilterExpression::Parameter {
                             parameter: Parameter::Uuid((*web_id).into()),
                             convert: None,
-                        }),
+                        },
                     ),
                     Self::for_resource_filter(filter),
                 ]),
@@ -359,13 +353,13 @@ impl<'p> Filter<'p, DataTypeWithMetadata> {
             [] => {}
             &[data_type_uuid] => {
                 permits.push(Self::Equal(
-                    Some(FilterExpression::Path {
+                    FilterExpression::Path {
                         path: DataTypeQueryPath::OntologyId,
-                    }),
-                    Some(FilterExpression::Parameter {
+                    },
+                    FilterExpression::Parameter {
                         parameter: Parameter::Uuid(data_type_uuid.into_uuid()),
                         convert: None,
-                    }),
+                    },
                 ));
             }
             data_type_uuids => {
@@ -384,13 +378,13 @@ impl<'p> Filter<'p, DataTypeWithMetadata> {
             [] => {}
             &[web_id] => {
                 permits.push(Self::Equal(
-                    Some(FilterExpression::Path {
+                    FilterExpression::Path {
                         path: DataTypeQueryPath::WebId,
-                    }),
-                    Some(FilterExpression::Parameter {
+                    },
+                    FilterExpression::Parameter {
                         parameter: Parameter::Uuid(web_id.into()),
                         convert: None,
-                    }),
+                    },
                 ));
             }
             web_ids => {
@@ -440,13 +434,13 @@ impl<'p> Filter<'p, PropertyTypeWithMetadata> {
     pub fn for_resource_constraint(resource_constraint: &'p ResourceConstraint) -> Self {
         match resource_constraint {
             ResourceConstraint::Web { web_id } => Self::Equal(
-                Some(FilterExpression::Path {
+                FilterExpression::Path {
                     path: PropertyTypeQueryPath::WebId,
-                }),
-                Some(FilterExpression::Parameter {
+                },
+                FilterExpression::Parameter {
                     parameter: Parameter::Uuid((*web_id).into()),
                     convert: None,
-                }),
+                },
             ),
             ResourceConstraint::PropertyType(property_type_constraint) => {
                 match property_type_constraint {
@@ -455,13 +449,13 @@ impl<'p> Filter<'p, PropertyTypeWithMetadata> {
                     }
                     PropertyTypeResourceConstraint::Web { web_id, filter } => Self::All(vec![
                         Self::Equal(
-                            Some(FilterExpression::Path {
+                            FilterExpression::Path {
                                 path: PropertyTypeQueryPath::WebId,
-                            }),
-                            Some(FilterExpression::Parameter {
+                            },
+                            FilterExpression::Parameter {
                                 parameter: Parameter::Uuid((*web_id).into()),
                                 convert: None,
-                            }),
+                            },
                         ),
                         Self::for_resource_filter(filter),
                     ]),
@@ -490,29 +484,26 @@ impl<'p> Filter<'p, PropertyTypeWithMetadata> {
                 Self::Not(Box::new(Self::for_resource_filter(filter)))
             }
             PropertyTypeResourceFilter::IsBaseUrl { base_url } => Self::Equal(
-                Some(FilterExpression::Path {
+                FilterExpression::Path {
                     path: PropertyTypeQueryPath::BaseUrl,
-                }),
-                Some(FilterExpression::Parameter {
+                },
+                FilterExpression::Parameter {
                     parameter: Parameter::Text(Cow::Borrowed(base_url.as_str())),
                     convert: None,
-                }),
+                },
             ),
             PropertyTypeResourceFilter::IsVersion { version } => Self::Equal(
-                Some(FilterExpression::Path {
+                FilterExpression::Path {
                     path: PropertyTypeQueryPath::Version,
-                }),
-                Some(FilterExpression::Parameter {
+                },
+                FilterExpression::Parameter {
                     parameter: Parameter::OntologyTypeVersion(*version),
                     convert: None,
-                }),
+                },
             ),
-            PropertyTypeResourceFilter::IsRemote => Self::Equal(
-                Some(FilterExpression::Path {
-                    path: PropertyTypeQueryPath::WebId,
-                }),
-                None,
-            ),
+            PropertyTypeResourceFilter::IsRemote => Self::Exists {
+                path: PropertyTypeQueryPath::WebId,
+            },
         }
     }
 
@@ -557,13 +548,13 @@ impl<'p> Filter<'p, PropertyTypeWithMetadata> {
             [] => {}
             &[property_type_uuid] => {
                 permits.push(Self::Equal(
-                    Some(FilterExpression::Path {
+                    FilterExpression::Path {
                         path: PropertyTypeQueryPath::OntologyId,
-                    }),
-                    Some(FilterExpression::Parameter {
+                    },
+                    FilterExpression::Parameter {
                         parameter: Parameter::Uuid(property_type_uuid.into_uuid()),
                         convert: None,
-                    }),
+                    },
                 ));
             }
             property_type_uuids => {
@@ -582,13 +573,13 @@ impl<'p> Filter<'p, PropertyTypeWithMetadata> {
             [] => {}
             &[web_id] => {
                 permits.push(Self::Equal(
-                    Some(FilterExpression::Path {
+                    FilterExpression::Path {
                         path: PropertyTypeQueryPath::WebId,
-                    }),
-                    Some(FilterExpression::Parameter {
+                    },
+                    FilterExpression::Parameter {
                         parameter: Parameter::Uuid(web_id.into()),
                         convert: None,
-                    }),
+                    },
                 ));
             }
             web_ids => {
@@ -647,29 +638,26 @@ impl<'p> Filter<'p, EntityTypeWithMetadata> {
                 Self::Not(Box::new(Self::for_resource_filter(filter)))
             }
             EntityTypeResourceFilter::IsBaseUrl { base_url } => Self::Equal(
-                Some(FilterExpression::Path {
+                FilterExpression::Path {
                     path: EntityTypeQueryPath::BaseUrl,
-                }),
-                Some(FilterExpression::Parameter {
+                },
+                FilterExpression::Parameter {
                     parameter: Parameter::Text(Cow::Borrowed(base_url.as_str())),
                     convert: None,
-                }),
+                },
             ),
             EntityTypeResourceFilter::IsVersion { version } => Self::Equal(
-                Some(FilterExpression::Path {
+                FilterExpression::Path {
                     path: EntityTypeQueryPath::Version,
-                }),
-                Some(FilterExpression::Parameter {
+                },
+                FilterExpression::Parameter {
                     parameter: Parameter::OntologyTypeVersion(*version),
                     convert: None,
-                }),
+                },
             ),
-            EntityTypeResourceFilter::IsRemote => Self::Equal(
-                Some(FilterExpression::Path {
-                    path: EntityTypeQueryPath::WebId,
-                }),
-                None,
-            ),
+            EntityTypeResourceFilter::IsRemote => Self::Exists {
+                path: EntityTypeQueryPath::WebId,
+            },
         }
     }
 
@@ -677,13 +665,13 @@ impl<'p> Filter<'p, EntityTypeWithMetadata> {
     pub fn for_resource_constraint(resource_constraint: &'p ResourceConstraint) -> Self {
         match resource_constraint {
             ResourceConstraint::Web { web_id } => Self::Equal(
-                Some(FilterExpression::Path {
+                FilterExpression::Path {
                     path: EntityTypeQueryPath::WebId,
-                }),
-                Some(FilterExpression::Parameter {
+                },
+                FilterExpression::Parameter {
                     parameter: Parameter::Uuid((*web_id).into()),
                     convert: None,
-                }),
+                },
             ),
             ResourceConstraint::EntityType(entity_type_constraint) => {
                 match entity_type_constraint {
@@ -692,13 +680,13 @@ impl<'p> Filter<'p, EntityTypeWithMetadata> {
                     }
                     EntityTypeResourceConstraint::Web { web_id, filter } => Self::All(vec![
                         Self::Equal(
-                            Some(FilterExpression::Path {
+                            FilterExpression::Path {
                                 path: EntityTypeQueryPath::OntologyId,
-                            }),
-                            Some(FilterExpression::Parameter {
+                            },
+                            FilterExpression::Parameter {
                                 parameter: Parameter::Uuid((*web_id).into()),
                                 convert: None,
-                            }),
+                            },
                         ),
                         Self::for_resource_filter(filter),
                     ]),
@@ -761,13 +749,13 @@ impl<'p> Filter<'p, EntityTypeWithMetadata> {
             [] => {}
             &[entity_type_uuid] => {
                 permits.push(Self::Equal(
-                    Some(FilterExpression::Path {
+                    FilterExpression::Path {
                         path: EntityTypeQueryPath::OntologyId,
-                    }),
-                    Some(FilterExpression::Parameter {
+                    },
+                    FilterExpression::Parameter {
                         parameter: Parameter::Uuid(entity_type_uuid.into_uuid()),
                         convert: None,
-                    }),
+                    },
                 ));
             }
             entity_type_uuids => {
@@ -786,13 +774,13 @@ impl<'p> Filter<'p, EntityTypeWithMetadata> {
             [] => {}
             &[web_id] => {
                 permits.push(Self::Equal(
-                    Some(FilterExpression::Path {
+                    FilterExpression::Path {
                         path: EntityTypeQueryPath::WebId,
-                    }),
-                    Some(FilterExpression::Parameter {
+                    },
+                    FilterExpression::Parameter {
                         parameter: Parameter::Uuid(web_id.into()),
                         convert: None,
-                    }),
+                    },
                 ));
             }
             web_ids => {
@@ -832,22 +820,22 @@ impl<'p> Filter<'p, Entity> {
     #[must_use]
     pub fn for_entity_by_entity_id(entity_id: EntityId) -> Self {
         let web_id_filter = Self::Equal(
-            Some(FilterExpression::Path {
+            FilterExpression::Path {
                 path: EntityQueryPath::WebId,
-            }),
-            Some(FilterExpression::Parameter {
+            },
+            FilterExpression::Parameter {
                 parameter: Parameter::Uuid(entity_id.web_id.into()),
                 convert: None,
-            }),
+            },
         );
         let entity_uuid_filter = Self::Equal(
-            Some(FilterExpression::Path {
+            FilterExpression::Path {
                 path: EntityQueryPath::Uuid,
-            }),
-            Some(FilterExpression::Parameter {
+            },
+            FilterExpression::Parameter {
                 parameter: Parameter::Uuid(entity_id.entity_uuid.into()),
                 convert: None,
-            }),
+            },
         );
 
         if let Some(draft_id) = entity_id.draft_id {
@@ -855,13 +843,13 @@ impl<'p> Filter<'p, Entity> {
                 web_id_filter,
                 entity_uuid_filter,
                 Self::Equal(
-                    Some(FilterExpression::Path {
+                    FilterExpression::Path {
                         path: EntityQueryPath::DraftId,
-                    }),
-                    Some(FilterExpression::Parameter {
+                    },
+                    FilterExpression::Parameter {
                         parameter: Parameter::Uuid(draft_id.into()),
                         convert: None,
-                    }),
+                    },
                 ),
             ])
         } else {
@@ -872,17 +860,17 @@ impl<'p> Filter<'p, Entity> {
     #[must_use]
     pub const fn for_entity_by_base_type_id(base_type_id: &'p BaseUrl) -> Self {
         Filter::Equal(
-            Some(FilterExpression::Path {
+            FilterExpression::Path {
                 path: EntityQueryPath::EntityTypeEdge {
                     edge_kind: SharedEdgeKind::IsOfType,
                     path: EntityTypeQueryPath::BaseUrl,
                     inheritance_depth: None,
                 },
-            }),
-            Some(FilterExpression::Parameter {
+            },
+            FilterExpression::Parameter {
                 parameter: Parameter::Text(Cow::Borrowed(base_type_id.as_str())),
                 convert: None,
-            }),
+            },
         )
     }
 
@@ -891,17 +879,17 @@ impl<'p> Filter<'p, Entity> {
         Filter::All(vec![
             Self::for_entity_by_base_type_id(&entity_type_id.base_url),
             Filter::Equal(
-                Some(FilterExpression::Path {
+                FilterExpression::Path {
                     path: EntityQueryPath::EntityTypeEdge {
                         edge_kind: SharedEdgeKind::IsOfType,
                         path: EntityTypeQueryPath::Version,
                         inheritance_depth: None,
                     },
-                }),
-                Some(FilterExpression::Parameter {
+                },
+                FilterExpression::Parameter {
                     parameter: Parameter::OntologyTypeVersion(entity_type_id.version),
                     convert: None,
-                }),
+                },
             ),
         ])
     }
@@ -938,19 +926,19 @@ impl<'p> Filter<'p, Entity> {
                 Self::Not(Box::new(Self::for_resource_filter(filter, actor_id)))
             }
             EntityResourceFilter::CreatedByPrincipal => Self::Equal(
-                Some(FilterExpression::Path {
+                FilterExpression::Path {
                     path: EntityQueryPath::Provenance(Some(JsonPath::from_path_tokens(vec![
                         PathToken::Field(Cow::Borrowed("createdById")),
                     ]))),
-                }),
-                Some(FilterExpression::Parameter {
+                },
+                FilterExpression::Parameter {
                     parameter: Parameter::Any(PropertyValue::String(
                         actor_id
                             .map_or_else(ActorEntityUuid::public_actor, ActorEntityUuid::from)
                             .to_string(),
                     )),
                     convert: None,
-                }),
+                },
             ),
             EntityResourceFilter::IsOfType { entity_type } => {
                 Self::for_entity_by_type_id(entity_type)
@@ -968,33 +956,33 @@ impl<'p> Filter<'p, Entity> {
     ) -> Self {
         match resource_constraint {
             ResourceConstraint::Web { web_id } => Self::Equal(
-                Some(FilterExpression::Path {
+                FilterExpression::Path {
                     path: EntityQueryPath::WebId,
-                }),
-                Some(FilterExpression::Parameter {
+                },
+                FilterExpression::Parameter {
                     parameter: Parameter::Uuid((*web_id).into()),
                     convert: None,
-                }),
+                },
             ),
             ResourceConstraint::Entity(entity_constraint) => match entity_constraint {
                 EntityResourceConstraint::Exact { id } => Self::Equal(
-                    Some(FilterExpression::Path {
+                    FilterExpression::Path {
                         path: EntityQueryPath::Uuid,
-                    }),
-                    Some(FilterExpression::Parameter {
+                    },
+                    FilterExpression::Parameter {
                         parameter: Parameter::Uuid((*id).into()),
                         convert: None,
-                    }),
+                    },
                 ),
                 EntityResourceConstraint::Web { web_id, filter } => Self::All(vec![
                     Self::Equal(
-                        Some(FilterExpression::Path {
+                        FilterExpression::Path {
                             path: EntityQueryPath::WebId,
-                        }),
-                        Some(FilterExpression::Parameter {
+                        },
+                        FilterExpression::Parameter {
                             parameter: Parameter::Uuid((*web_id).into()),
                             convert: None,
-                        }),
+                        },
                     ),
                     Self::for_resource_filter(filter, actor_id),
                 ]),
@@ -1057,13 +1045,13 @@ impl<'p> Filter<'p, Entity> {
             [] => {}
             &[entity_uuid] => {
                 permits.push(Self::Equal(
-                    Some(FilterExpression::Path {
+                    FilterExpression::Path {
                         path: EntityQueryPath::Uuid,
-                    }),
-                    Some(FilterExpression::Parameter {
+                    },
+                    FilterExpression::Parameter {
                         parameter: Parameter::Uuid(entity_uuid.into()),
                         convert: None,
-                    }),
+                    },
                 ));
             }
             entity_uuids => {
@@ -1082,13 +1070,13 @@ impl<'p> Filter<'p, Entity> {
             [] => {}
             &[web_id] => {
                 permits.push(Self::Equal(
-                    Some(FilterExpression::Path {
+                    FilterExpression::Path {
                         path: EntityQueryPath::WebId,
-                    }),
-                    Some(FilterExpression::Parameter {
+                    },
+                    FilterExpression::Parameter {
                         parameter: Parameter::Uuid(web_id.into()),
                         convert: None,
-                    }),
+                    },
                 ));
             }
             web_ids => {
@@ -1152,30 +1140,29 @@ where
             }
             Self::Not(filter) => Box::pin(filter.convert_parameters(data_type_provider)).await?,
             Self::Equal(lhs, rhs) | Self::NotEqual(lhs, rhs) => {
-                if let Some(lhs) = lhs {
-                    lhs.apply_parameter_conversion(data_type_provider).await?;
-                }
-                if let Some(rhs) = rhs {
-                    rhs.apply_parameter_conversion(data_type_provider).await?;
-                }
+                lhs.apply_parameter_conversion(data_type_provider).await?;
+                rhs.apply_parameter_conversion(data_type_provider).await?;
 
                 match (lhs, rhs) {
                     (
-                        Some(FilterExpression::Parameter {
+                        FilterExpression::Parameter {
                             parameter,
                             convert: _,
-                        }),
-                        Some(FilterExpression::Path { path }),
+                        },
+                        FilterExpression::Path { path },
                     )
                     | (
-                        Some(FilterExpression::Path { path }),
-                        Some(FilterExpression::Parameter {
+                        FilterExpression::Path { path },
+                        FilterExpression::Parameter {
                             parameter,
                             convert: _,
-                        }),
+                        },
                     ) => parameter.convert_to_parameter_type(&path.expected_type())?,
                     (..) => {}
                 }
+            }
+            Self::Exists { path: _ } => {
+                // Nothing to convert
             }
             Self::Greater(lhs, rhs)
             | Self::GreaterOrEqual(lhs, rhs)
@@ -1511,27 +1498,6 @@ mod tests {
         test_filter_representation(&Filter::for_entity_by_entity_id(entity_id), &expected).await;
     }
 
-    #[tokio::test]
-    async fn null_check() {
-        let expected = json!({
-          "notEqual": [
-            { "path": ["description"] },
-            null
-          ]
-        });
-
-        test_filter_representation(
-            &Filter::<DataTypeWithMetadata>::NotEqual(
-                Some(FilterExpression::Path {
-                    path: DataTypeQueryPath::Description,
-                }),
-                None,
-            ),
-            &expected,
-        )
-        .await;
-    }
-
     mod policy_conversion {
         use hash_graph_authorization::policies::{
             Effect, OptimizationData, Policy, PolicyId,
@@ -1593,13 +1559,13 @@ mod tests {
                     assert_eq!(permits.len(), 1);
                     match &permits[0] {
                         Filter::Equal(
-                            Some(FilterExpression::Path {
+                            FilterExpression::Path {
                                 path: EntityQueryPath::Uuid,
-                            }),
-                            Some(FilterExpression::Parameter {
+                            },
+                            FilterExpression::Parameter {
                                 parameter: Parameter::Uuid(uuid),
                                 ..
-                            }),
+                            },
                         ) => {
                             assert_eq!(*uuid, Uuid::from(entity_uuid));
                         }
@@ -1687,13 +1653,13 @@ mod tests {
                     for permit in &permits {
                         match permit {
                             Filter::Equal(
-                                Some(FilterExpression::Path {
+                                FilterExpression::Path {
                                     path: EntityQueryPath::Uuid,
-                                }),
-                                Some(FilterExpression::Parameter {
+                                },
+                                FilterExpression::Parameter {
                                     parameter: Parameter::Uuid(uuid),
                                     ..
-                                }),
+                                },
                             ) => {
                                 found_uuids.push(*uuid);
                             }
@@ -1868,12 +1834,9 @@ mod tests {
                     let has_web_permit = permits.iter().any(|permit| {
                         matches!(
                             permit,
-                            Filter::Equal(
-                                Some(FilterExpression::Path {
-                                    path: EntityQueryPath::WebId
-                                }),
-                                _
-                            )
+                            Filter::Exists {
+                                path: EntityQueryPath::WebId
+                            }
                         )
                     });
 

--- a/libs/@local/hash-isomorphic-utils/src/graph-queries.ts
+++ b/libs/@local/hash-isomorphic-utils/src/graph-queries.ts
@@ -258,13 +258,9 @@ const archivedBaseUrl = systemPropertyTypes.archived.propertyTypeBaseUrl;
 export const pageOrNotificationNotArchivedFilter: Filter = {
   any: [
     {
-      equal: [
-        {
-          path: ["properties", archivedBaseUrl],
-        },
-        // @ts-expect-error -- We will update the type definition of `EntityStructuralQuery` to allow this, see H-1207
-        null,
-      ],
+      exists: {
+        path: ["properties", archivedBaseUrl],
+      },
     },
     {
       equal: [

--- a/libs/@local/hashql/eval/src/graph/read/filter.rs
+++ b/libs/@local/hashql/eval/src/graph/read/filter.rs
@@ -108,8 +108,8 @@ impl<'env, 'heap: 'env> GraphReadCompiler<'env, 'heap> {
 
                         return Ok(());
                     }
-                    BinOpKind::Eq => |left, right| Filter::Equal(Some(left), Some(right)),
-                    BinOpKind::Ne => |left, right| Filter::NotEqual(Some(left), Some(right)),
+                    BinOpKind::Eq => |left, right| Filter::Equal(left, right),
+                    BinOpKind::Ne => |left, right| Filter::NotEqual(left, right),
                     BinOpKind::Lt => Filter::Less,
                     BinOpKind::Lte => Filter::LessOrEqual,
                     BinOpKind::Gt => Filter::Greater,
@@ -159,14 +159,12 @@ impl<'env, 'heap: 'env> GraphReadCompiler<'env, 'heap> {
             | NodeKind::Closure(_)
             | NodeKind::Graph(_) => {
                 sink.push(Filter::Equal(
-                    Some(
-                        self.compile_filter_expr(context, node)?
-                            .finish(context, &mut self.diagnostics)?,
-                    ),
-                    Some(FilterExpression::Parameter {
+                    self.compile_filter_expr(context, node)?
+                        .finish(context, &mut self.diagnostics)?,
+                    FilterExpression::Parameter {
                         parameter: Parameter::Boolean(true),
                         convert: None,
-                    }),
+                    },
                 ));
 
                 Ok(())

--- a/libs/@local/hashql/eval/tests/ui/graph/read/entity/boolean-literal.stdout
+++ b/libs/@local/hashql/eval/tests/ui/graph/read/entity/boolean-literal.stdout
@@ -19,21 +19,17 @@ _1«Boolean» ->
 
 [
     Equal(
-        Some(
-            Parameter {
-                parameter: Boolean(
-                    true,
-                ),
-                convert: None,
-            },
-        ),
-        Some(
-            Parameter {
-                parameter: Boolean(
-                    true,
-                ),
-                convert: None,
-            },
-        ),
+        Parameter {
+            parameter: Boolean(
+                true,
+            ),
+            convert: None,
+        },
+        Parameter {
+            parameter: Boolean(
+                true,
+            ),
+            convert: None,
+        },
     ),
 ]

--- a/libs/@local/hashql/eval/tests/ui/graph/read/entity/constructor-call-none.stdout
+++ b/libs/@local/hashql/eval/tests/ui/graph/read/entity/constructor-call-none.stdout
@@ -20,21 +20,17 @@ _1«Boolean» ->
 
 [
     Equal(
-        Some(
-            Parameter {
-                parameter: Any(
-                    Null,
-                ),
-                convert: None,
-            },
-        ),
-        Some(
-            Parameter {
-                parameter: Any(
-                    Null,
-                ),
-                convert: None,
-            },
-        ),
+        Parameter {
+            parameter: Any(
+                Null,
+            ),
+            convert: None,
+        },
+        Parameter {
+            parameter: Any(
+                Null,
+            ),
+            convert: None,
+        },
     ),
 ]

--- a/libs/@local/hashql/eval/tests/ui/graph/read/entity/equality-comparison.stdout
+++ b/libs/@local/hashql/eval/tests/ui/graph/read/entity/equality-comparison.stdout
@@ -21,40 +21,32 @@ _1«Boolean» ->
     Any(
         [
             Equal(
-                Some(
-                    Parameter {
-                        parameter: Boolean(
-                            true,
-                        ),
-                        convert: None,
-                    },
-                ),
-                Some(
-                    Parameter {
-                        parameter: Boolean(
-                            false,
-                        ),
-                        convert: None,
-                    },
-                ),
+                Parameter {
+                    parameter: Boolean(
+                        true,
+                    ),
+                    convert: None,
+                },
+                Parameter {
+                    parameter: Boolean(
+                        false,
+                    ),
+                    convert: None,
+                },
             ),
             NotEqual(
-                Some(
-                    Parameter {
-                        parameter: Boolean(
-                            true,
-                        ),
-                        convert: None,
-                    },
-                ),
-                Some(
-                    Parameter {
-                        parameter: Boolean(
-                            false,
-                        ),
-                        convert: None,
-                    },
-                ),
+                Parameter {
+                    parameter: Boolean(
+                        true,
+                    ),
+                    convert: None,
+                },
+                Parameter {
+                    parameter: Boolean(
+                        false,
+                    ),
+                    convert: None,
+                },
             ),
         ],
     ),

--- a/libs/@local/hashql/eval/tests/ui/graph/read/entity/input-field-access.stdout
+++ b/libs/@local/hashql/eval/tests/ui/graph/read/entity/input-field-access.stdout
@@ -20,18 +20,14 @@ _1«Boolean» ->
 
 [
     Equal(
-        Some(
-            Path {
-                path: Uuid,
-            },
-        ),
-        Some(
-            Parameter {
-                parameter: Text(
-                    "e2851dbb-7376-4959-9bca-f72cafc4448f",
-                ),
-                convert: None,
-            },
-        ),
+        Path {
+            path: Uuid,
+        },
+        Parameter {
+            parameter: Text(
+                "e2851dbb-7376-4959-9bca-f72cafc4448f",
+            ),
+            convert: None,
+        },
     ),
 ]

--- a/libs/@local/hashql/eval/tests/ui/graph/read/entity/input-index-access.stdout
+++ b/libs/@local/hashql/eval/tests/ui/graph/read/entity/input-index-access.stdout
@@ -21,18 +21,14 @@ _1«Boolean» ->
 
 [
     Equal(
-        Some(
-            Path {
-                path: Uuid,
-            },
-        ),
-        Some(
-            Parameter {
-                parameter: Text(
-                    "e2851dbb-7376-4959-9bca-f72cafc4448f",
-                ),
-                convert: None,
-            },
-        ),
+        Path {
+            path: Uuid,
+        },
+        Parameter {
+            parameter: Text(
+                "e2851dbb-7376-4959-9bca-f72cafc4448f",
+            ),
+            convert: None,
+        },
     ),
 ]

--- a/libs/@local/hashql/eval/tests/ui/graph/read/entity/input-parameter.stdout
+++ b/libs/@local/hashql/eval/tests/ui/graph/read/entity/input-parameter.stdout
@@ -20,18 +20,14 @@ _1«Boolean» ->
 
 [
     Equal(
-        Some(
-            Path {
-                path: Uuid,
-            },
-        ),
-        Some(
-            Parameter {
-                parameter: Text(
-                    "e2851dbb-7376-4959-9bca-f72cafc4448f",
-                ),
-                convert: None,
-            },
-        ),
+        Path {
+            path: Uuid,
+        },
+        Parameter {
+            parameter: Text(
+                "e2851dbb-7376-4959-9bca-f72cafc4448f",
+            ),
+            convert: None,
+        },
     ),
 ]

--- a/libs/@local/hashql/eval/tests/ui/graph/read/entity/let-expression.stdout
+++ b/libs/@local/hashql/eval/tests/ui/graph/read/entity/let-expression.stdout
@@ -23,18 +23,14 @@ _1«Boolean» ->
 
 [
     Equal(
-        Some(
-            Path {
-                path: Uuid,
-            },
-        ),
-        Some(
-            Parameter {
-                parameter: Text(
-                    "e2851dbb-7376-4959-9bca-f72cafc4448f",
-                ),
-                convert: None,
-            },
-        ),
+        Path {
+            path: Uuid,
+        },
+        Parameter {
+            parameter: Text(
+                "e2851dbb-7376-4959-9bca-f72cafc4448f",
+            ),
+            convert: None,
+        },
     ),
 ]

--- a/libs/@local/hashql/eval/tests/ui/graph/read/entity/let-propagation.stdout
+++ b/libs/@local/hashql/eval/tests/ui/graph/read/entity/let-propagation.stdout
@@ -23,18 +23,14 @@ _1«Boolean» ->
 
 [
     Equal(
-        Some(
-            Path {
-                path: Uuid,
-            },
-        ),
-        Some(
-            Parameter {
-                parameter: Text(
-                    "e2851dbb-7376-4959-9bca-f72cafc4448f",
-                ),
-                convert: None,
-            },
-        ),
+        Path {
+            path: Uuid,
+        },
+        Parameter {
+            parameter: Text(
+                "e2851dbb-7376-4959-9bca-f72cafc4448f",
+            ),
+            convert: None,
+        },
     ),
 ]

--- a/libs/@local/hashql/eval/tests/ui/graph/read/entity/logical-and-or.stdout
+++ b/libs/@local/hashql/eval/tests/ui/graph/read/entity/logical-and-or.stdout
@@ -19,60 +19,48 @@ _1«Boolean» ->
 
 [
     Equal(
-        Some(
-            Parameter {
-                parameter: Boolean(
-                    true,
-                ),
-                convert: None,
-            },
-        ),
-        Some(
-            Parameter {
-                parameter: Boolean(
-                    true,
-                ),
-                convert: None,
-            },
-        ),
+        Parameter {
+            parameter: Boolean(
+                true,
+            ),
+            convert: None,
+        },
+        Parameter {
+            parameter: Boolean(
+                true,
+            ),
+            convert: None,
+        },
     ),
     Any(
         [
             Equal(
-                Some(
-                    Parameter {
-                        parameter: Boolean(
-                            true,
-                        ),
-                        convert: None,
-                    },
-                ),
-                Some(
-                    Parameter {
-                        parameter: Boolean(
-                            true,
-                        ),
-                        convert: None,
-                    },
-                ),
+                Parameter {
+                    parameter: Boolean(
+                        true,
+                    ),
+                    convert: None,
+                },
+                Parameter {
+                    parameter: Boolean(
+                        true,
+                    ),
+                    convert: None,
+                },
             ),
             Equal(
-                Some(
-                    Parameter {
-                        parameter: Boolean(
-                            false,
-                        ),
-                        convert: None,
-                    },
-                ),
-                Some(
-                    Parameter {
-                        parameter: Boolean(
-                            true,
-                        ),
-                        convert: None,
-                    },
-                ),
+                Parameter {
+                    parameter: Boolean(
+                        false,
+                    ),
+                    convert: None,
+                },
+                Parameter {
+                    parameter: Boolean(
+                        true,
+                    ),
+                    convert: None,
+                },
             ),
         ],
     ),

--- a/libs/@local/hashql/eval/tests/ui/graph/read/entity/logical-or-and.stdout
+++ b/libs/@local/hashql/eval/tests/ui/graph/read/entity/logical-or-and.stdout
@@ -21,60 +21,48 @@ _1«Boolean» ->
     Any(
         [
             Equal(
-                Some(
-                    Parameter {
-                        parameter: Boolean(
-                            true,
-                        ),
-                        convert: None,
-                    },
-                ),
-                Some(
-                    Parameter {
-                        parameter: Boolean(
-                            true,
-                        ),
-                        convert: None,
-                    },
-                ),
+                Parameter {
+                    parameter: Boolean(
+                        true,
+                    ),
+                    convert: None,
+                },
+                Parameter {
+                    parameter: Boolean(
+                        true,
+                    ),
+                    convert: None,
+                },
             ),
             All(
                 [
                     Equal(
-                        Some(
-                            Parameter {
-                                parameter: Boolean(
-                                    true,
-                                ),
-                                convert: None,
-                            },
-                        ),
-                        Some(
-                            Parameter {
-                                parameter: Boolean(
-                                    true,
-                                ),
-                                convert: None,
-                            },
-                        ),
+                        Parameter {
+                            parameter: Boolean(
+                                true,
+                            ),
+                            convert: None,
+                        },
+                        Parameter {
+                            parameter: Boolean(
+                                true,
+                            ),
+                            convert: None,
+                        },
                     ),
                     Equal(
-                        Some(
-                            Parameter {
-                                parameter: Boolean(
-                                    false,
-                                ),
-                                convert: None,
-                            },
-                        ),
-                        Some(
-                            Parameter {
-                                parameter: Boolean(
-                                    true,
-                                ),
-                                convert: None,
-                            },
-                        ),
+                        Parameter {
+                            parameter: Boolean(
+                                false,
+                            ),
+                            convert: None,
+                        },
+                        Parameter {
+                            parameter: Boolean(
+                                true,
+                            ),
+                            convert: None,
+                        },
                     ),
                 ],
             ),

--- a/libs/@local/hashql/eval/tests/ui/graph/read/entity/nested-let-bindings.stdout
+++ b/libs/@local/hashql/eval/tests/ui/graph/read/entity/nested-let-bindings.stdout
@@ -23,18 +23,14 @@ _1«Boolean» ->
 
 [
     Equal(
-        Some(
-            Path {
-                path: Uuid,
-            },
-        ),
-        Some(
-            Parameter {
-                parameter: Text(
-                    "e2851dbb-7376-4959-9bca-f72cafc4448f",
-                ),
-                convert: None,
-            },
-        ),
+        Path {
+            path: Uuid,
+        },
+        Parameter {
+            parameter: Text(
+                "e2851dbb-7376-4959-9bca-f72cafc4448f",
+            ),
+            convert: None,
+        },
     ),
 ]

--- a/libs/@local/hashql/eval/tests/ui/graph/read/entity/scalar-property-filter.stdout
+++ b/libs/@local/hashql/eval/tests/ui/graph/read/entity/scalar-property-filter.stdout
@@ -22,18 +22,14 @@ _1«Boolean» ->
 
 [
     Equal(
-        Some(
-            Path {
-                path: Uuid,
-            },
-        ),
-        Some(
-            Parameter {
-                parameter: Text(
-                    "e2851dbb-7376-4959-9bca-f72cafc4448f",
-                ),
-                convert: None,
-            },
-        ),
+        Path {
+            path: Uuid,
+        },
+        Parameter {
+            parameter: Text(
+                "e2851dbb-7376-4959-9bca-f72cafc4448f",
+            ),
+            convert: None,
+        },
     ),
 ]

--- a/libs/@local/hashql/eval/tests/ui/graph/read/entity/top-level-variable.stdout
+++ b/libs/@local/hashql/eval/tests/ui/graph/read/entity/top-level-variable.stdout
@@ -20,21 +20,17 @@ _1«Boolean» ->
 
 [
     Equal(
-        Some(
-            Parameter {
-                parameter: Boolean(
-                    true,
-                ),
-                convert: None,
-            },
-        ),
-        Some(
-            Parameter {
-                parameter: Boolean(
-                    true,
-                ),
-                convert: None,
-            },
-        ),
+        Parameter {
+            parameter: Boolean(
+                true,
+            ),
+            convert: None,
+        },
+        Parameter {
+            parameter: Boolean(
+                true,
+            ),
+            convert: None,
+        },
     ),
 ]

--- a/libs/@local/hashql/eval/tests/ui/graph/read/entity/top-type-assertion.stdout
+++ b/libs/@local/hashql/eval/tests/ui/graph/read/entity/top-type-assertion.stdout
@@ -19,21 +19,17 @@ _1«Boolean» ->
 
 [
     Equal(
-        Some(
-            Parameter {
-                parameter: Boolean(
-                    true,
-                ),
-                convert: None,
-            },
-        ),
-        Some(
-            Parameter {
-                parameter: Boolean(
-                    true,
-                ),
-                convert: None,
-            },
-        ),
+        Parameter {
+            parameter: Boolean(
+                true,
+            ),
+            convert: None,
+        },
+        Parameter {
+            parameter: Boolean(
+                true,
+            ),
+            convert: None,
+        },
     ),
 ]

--- a/libs/@local/hashql/eval/tests/ui/graph/read/entity/type-assertion-in-comparison.stdout
+++ b/libs/@local/hashql/eval/tests/ui/graph/read/entity/type-assertion-in-comparison.stdout
@@ -22,18 +22,14 @@ _1«Boolean» ->
 
 [
     Equal(
-        Some(
-            Path {
-                path: Uuid,
-            },
-        ),
-        Some(
-            Parameter {
-                parameter: Text(
-                    "e2851dbb-7376-4959-9bca-f72cafc4448f",
-                ),
-                convert: None,
-            },
-        ),
+        Path {
+            path: Uuid,
+        },
+        Parameter {
+            parameter: Text(
+                "e2851dbb-7376-4959-9bca-f72cafc4448f",
+            ),
+            convert: None,
+        },
     ),
 ]

--- a/tests/graph/benches/representative_read/knowledge/entity.rs
+++ b/tests/graph/benches/representative_read/knowledge/entity.rs
@@ -43,13 +43,13 @@ pub fn bench_get_entity_by_id(
                     actor_id,
                     QueryEntitiesParams {
                         filter: Filter::Equal(
-                            Some(FilterExpression::Path {
+                            FilterExpression::Path {
                                 path: EntityQueryPath::Uuid,
-                            }),
-                            Some(FilterExpression::Parameter {
+                            },
+                            FilterExpression::Parameter {
                                 parameter: Parameter::Uuid(entity_uuid.into()),
                                 convert: None,
-                            }),
+                            },
                         ),
                         temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
                             pinned: PinnedTemporalAxisUnresolved::new(None),
@@ -88,17 +88,17 @@ pub fn bench_query_entities_by_property(
 ) {
     bencher.to_async(runtime).iter(|| async move {
         let filter = Filter::Equal(
-            Some(FilterExpression::Path {
+            FilterExpression::Path {
                 path: EntityQueryPath::Properties(Some(JsonPath::from_path_tokens(vec![
                     PathToken::Field(Cow::Borrowed(
                         "https://blockprotocol.org/@alice/types/property-type/name/",
                     )),
                 ]))),
-            }),
-            Some(FilterExpression::Parameter {
+            },
+            FilterExpression::Parameter {
                 parameter: Parameter::Text(Cow::Borrowed("Alice")),
                 convert: None,
-            }),
+            },
         );
         let response = store
             .query_entity_subgraph(
@@ -146,7 +146,7 @@ pub fn bench_get_link_by_target_by_property(
 ) {
     bencher.to_async(runtime).iter(|| async move {
         let filter = Filter::Equal(
-            Some(FilterExpression::Path {
+            FilterExpression::Path {
                 path: EntityQueryPath::EntityEdge {
                     edge_kind: KnowledgeGraphEdgeKind::HasRightEntity,
                     path: Box::new(EntityQueryPath::Properties(Some(
@@ -156,11 +156,11 @@ pub fn bench_get_link_by_target_by_property(
                     ))),
                     direction: EdgeDirection::Outgoing,
                 },
-            }),
-            Some(FilterExpression::Parameter {
+            },
+            FilterExpression::Parameter {
                 parameter: Parameter::Text(Cow::Borrowed("Alice")),
                 convert: None,
-            }),
+            },
         );
         let response = store
             .query_entity_subgraph(

--- a/tests/graph/integration/postgres/links.rs
+++ b/tests/graph/integration/postgres/links.rs
@@ -163,62 +163,62 @@ async fn insert() {
             QueryEntitiesParams {
                 filter: Filter::All(vec![
                     Filter::Equal(
-                        Some(FilterExpression::Path {
+                        FilterExpression::Path {
                             path: EntityQueryPath::EntityEdge {
                                 edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
                                 path: Box::new(EntityQueryPath::Uuid),
                                 direction: EdgeDirection::Outgoing,
                             },
-                        }),
-                        Some(FilterExpression::Parameter {
+                        },
+                        FilterExpression::Parameter {
                             parameter: Parameter::Uuid(
                                 alice_entity.metadata.record_id.entity_id.entity_uuid.into(),
                             ),
                             convert: None,
-                        }),
+                        },
                     ),
                     Filter::Equal(
-                        Some(FilterExpression::Path {
+                        FilterExpression::Path {
                             path: EntityQueryPath::EntityEdge {
                                 edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
                                 path: Box::new(EntityQueryPath::WebId),
                                 direction: EdgeDirection::Outgoing,
                             },
-                        }),
-                        Some(FilterExpression::Parameter {
+                        },
+                        FilterExpression::Parameter {
                             parameter: Parameter::Uuid(
                                 alice_entity.metadata.record_id.entity_id.web_id.into(),
                             ),
                             convert: None,
-                        }),
+                        },
                     ),
                     Filter::Equal(
-                        Some(FilterExpression::Path {
+                        FilterExpression::Path {
                             path: EntityQueryPath::EntityTypeEdge {
                                 edge_kind: SharedEdgeKind::IsOfType,
                                 path: EntityTypeQueryPath::BaseUrl,
                                 inheritance_depth: Some(0),
                             },
-                        }),
-                        Some(FilterExpression::Parameter {
+                        },
+                        FilterExpression::Parameter {
                             parameter: Parameter::Text(Cow::Borrowed(
                                 friend_of_type_id.base_url.as_str(),
                             )),
                             convert: None,
-                        }),
+                        },
                     ),
                     Filter::Equal(
-                        Some(FilterExpression::Path {
+                        FilterExpression::Path {
                             path: EntityQueryPath::EntityTypeEdge {
                                 edge_kind: SharedEdgeKind::IsOfType,
                                 path: EntityTypeQueryPath::Version,
                                 inheritance_depth: Some(0),
                             },
-                        }),
-                        Some(FilterExpression::Parameter {
+                        },
+                        FilterExpression::Parameter {
                             parameter: Parameter::OntologyTypeVersion(friend_of_type_id.version),
                             convert: None,
-                        }),
+                        },
                     ),
                 ]),
                 temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
@@ -459,19 +459,19 @@ async fn get_entity_links() {
             api.account_id,
             QueryEntitiesParams {
                 filter: Filter::Equal(
-                    Some(FilterExpression::Path {
+                    FilterExpression::Path {
                         path: EntityQueryPath::EntityEdge {
                             edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
                             path: Box::new(EntityQueryPath::Uuid),
                             direction: EdgeDirection::Outgoing,
                         },
-                    }),
-                    Some(FilterExpression::Parameter {
+                    },
+                    FilterExpression::Parameter {
                         parameter: Parameter::Uuid(
                             alice_entity.metadata.record_id.entity_id.entity_uuid.into(),
                         ),
                         convert: None,
-                    }),
+                    },
                 ),
                 temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
                     pinned: PinnedTemporalAxisUnresolved::new(None),
@@ -662,28 +662,28 @@ async fn remove_link() {
             CountEntitiesParams {
                 filter: Filter::All(vec![
                     Filter::Equal(
-                        Some(FilterExpression::Path {
+                        FilterExpression::Path {
                             path: EntityQueryPath::EntityEdge {
                                 edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
                                 path: Box::new(EntityQueryPath::Uuid),
                                 direction: EdgeDirection::Outgoing,
                             },
-                        }),
-                        Some(FilterExpression::Parameter {
+                        },
+                        FilterExpression::Parameter {
                             parameter: Parameter::Uuid(
                                 alice_entity.metadata.record_id.entity_id.entity_uuid.into(),
                             ),
                             convert: None,
-                        }),
+                        },
                     ),
                     Filter::Equal(
-                        Some(FilterExpression::Path {
+                        FilterExpression::Path {
                             path: EntityQueryPath::Archived,
-                        }),
-                        Some(FilterExpression::Parameter {
+                        },
+                        FilterExpression::Parameter {
                             parameter: Parameter::Boolean(false),
                             convert: None,
-                        }),
+                        },
                     ),
                 ]),
                 temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
@@ -724,28 +724,28 @@ async fn remove_link() {
             CountEntitiesParams {
                 filter: Filter::All(vec![
                     Filter::Equal(
-                        Some(FilterExpression::Path {
+                        FilterExpression::Path {
                             path: EntityQueryPath::EntityEdge {
                                 edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
                                 path: Box::new(EntityQueryPath::Uuid),
                                 direction: EdgeDirection::Outgoing,
                             },
-                        }),
-                        Some(FilterExpression::Parameter {
+                        },
+                        FilterExpression::Parameter {
                             parameter: Parameter::Uuid(
                                 alice_entity.metadata.record_id.entity_id.entity_uuid.into(),
                             ),
                             convert: None,
-                        }),
+                        },
                     ),
                     Filter::Equal(
-                        Some(FilterExpression::Path {
+                        FilterExpression::Path {
                             path: EntityQueryPath::Archived,
-                        }),
-                        Some(FilterExpression::Parameter {
+                        },
+                        FilterExpression::Parameter {
                             parameter: Parameter::Boolean(false),
                             convert: None,
-                        }),
+                        },
                     ),
                 ]),
                 temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR introduces a dedicated `Exists` filter for queries, replacing the unintuitive pattern of using `Equal` with `None` to check for null values. The implementation also refactors the filter API to use non-optional expressions for `Equal` and `NotEqual` operations, making the query system more ergonomic and type-safe.

The primary motivation is to address codegen issues and improve developer experience when checking for the existence of values in query paths. Previously, developers had to use `Filter::Equal(Some(path), None)` to check if a field was null, which was counterintuitive and caused problems in code generation.

## 🔗 Related links

- Linear issue: [BE-131: Introduce an `exists` filter for queries](https://linear.app/hash/issue/BE-131/introduce-an-exists-filter-for-queries)

## 🔍 What does this change?

- **Adds `Exists` filter variant** to `Filter<'p, R>` enum with a `path` field for checking value existence
- **Refactors `Equal` and `NotEqual` filters** to use non-optional `FilterExpression` parameters instead of `Option<FilterExpression>`
- **Updates SQL transpilation** to handle `Exists` filter as `IS NULL` and `NOT(Exists(...))` as `IS NOT NULL`
- **Migrates existing null-check patterns** across the codebase to use the new `Exists` filter
- **Updates all filter constructors** throughout the graph store, API, and frontend to use the simplified signatures
- **Removes redundant null-handling logic** that was previously required for optional filter expressions
- **Updates OpenAPI specification** to reflect the new filter structure
- **Adds comprehensive test coverage** for the new `Exists` filter functionality

### Key architectural changes:

- **`libs/@local/graph/store/src/filter/mod.rs`**: Core filter enum definition and implementation
- **`libs/@local/graph/postgres-store/src/store/postgres/query/condition.rs`**: SQL transpilation logic for new filter types
- **`libs/@local/hashql/eval/src/graph/read/filter.rs`**: HashQL compilation updates
- **Frontend components**: Updated to use simplified filter constructors
- **Tests**: New test cases for `Exists` filter and updated existing tests

### Migration patterns applied:

```rust
// Before (checking for null/non-existence)
Filter::Equal(Some(FilterExpression::Path { path }), None)

// After (checking for existence)
Filter::Exists { path }

// Before (checking for not-null/existence)  
Filter::NotEqual(Some(FilterExpression::Path { path }), None)

// After (checking for non-existence)
Filter::Not(Box::new(Filter::Exists { path }))

// Before (regular equality)
Filter::Equal(Some(lhs), Some(rhs))

// After (regular equality - simplified)
Filter::Equal(lhs, rhs)
```

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph