### PR TITLE
BE-132: Add support for non-empty lists in codegen system

### DIFF
--- a/libs/@local/codegen/src/definitions/type.rs
+++ b/libs/@local/codegen/src/definitions/type.rs
@@ -29,6 +29,7 @@ pub enum Type {
     Struct(Struct),
     Tuple(Tuple),
     List(List),
+    NonEmptyList(List),
     Map(Map),
     Nullable(Box<Self>),
 }

--- a/libs/@local/codegen/tests/standalone-types/lists.rs
+++ b/libs/@local/codegen/tests/standalone-types/lists.rs
@@ -30,6 +30,9 @@ pub(crate) struct ListPrimitives {
     // LinkedList collections
     linked_string_list: LinkedList<String>,
     linked_integer_list: LinkedList<i32>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    non_empty_list: Vec<i32>,
 }
 
 // List of optional items

--- a/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__ListPrimitives::Typescript.snap
+++ b/libs/@local/codegen/tests/standalone-types/snapshots/standalone_types__ListPrimitives::Typescript.snap
@@ -16,4 +16,5 @@ export interface ListPrimitives {
 	btree_integer_set: number[];
 	linked_string_list: string[];
 	linked_integer_list: number[];
+	non_empty_list?: [number, ...number[]];
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR adds support for non-empty lists in the codegen system by introducing a new `NonEmptyList` type variant that generates TypeScript tuples with at least one element. This enables stronger type safety for collections that must contain at least one item.

The implementation detects optional list fields with `#[serde(default, skip_serializing_if = "Vec::is_empty")]` and converts them to `NonEmptyList` types, which generate as TypeScript tuples like `[T, ...T[]]` instead of `T[]`.

## 🔗 Related links

- Linear issue: BE-132 (internal)

## 🚫 Blocked by

- [ ] N/A

## 🔍 What does this change?

- **Add `NonEmptyList` type variant** in `libs/@local/codegen/src/definitions/type.rs`
  - New enum variant to distinguish non-empty lists from regular lists
  
- **Implement non-empty list detection** in `libs/@local/codegen/src/definitions/fields.rs` 
  - Logic to detect optional list fields with empty-skipping serde attributes
  - Converts detected fields from `List` to `NonEmptyList` type
  
- **Add TypeScript tuple generation** in `libs/@local/codegen/src/typescript.rs`
  - New `visit_non_empty_list` method that generates `[T, ...T[]]` tuples
  - Updated pattern matching to handle `NonEmptyList` variant throughout
  - Renamed `visit_optional` to `visit_nullable` for clarity
  
- **Add test case and update snapshot** in `libs/@local/codegen/tests/standalone-types/`
  - New `non_empty_list` field in `ListPrimitives` test struct
  - Updated snapshot showing generated TypeScript: `non_empty_list?: [number, ...number[]]`

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

- The detection logic currently only works for fields which `specta` marks as `optional`
- More complex serde configurations might not be detected properly
- The implementation assumes the non-empty constraint is always desired when these attributes are present (which is a good heuristic but not necessarily true all the time)

## 🛡 What tests cover this?

- **Existing snapshot tests** in `libs/@local/codegen/tests/standalone-types/` continue to pass
- **New test case** `ListPrimitives::non_empty_list` validates the TypeScript generation
- **Updated snapshot** confirms the correct tuple syntax `[T, ...T[]]` is generated

## ❓ How to test this?

1. Checkout the branch
2. Navigate to `libs/@local/codegen`
3. Run `cargo test` to verify all tests pass
4. Check the snapshot file at `tests/standalone-types/snapshots/standalone_types__ListPrimitives::Typescript.snap`
5. Confirm that `non_empty_list?: [number, ...number[]]` appears in the generated TypeScript interface
6. Test with custom structs having `#[serde(default, skip_serializing_if = "Vec::is_empty")]` fields

## 📹 Demo

The generated TypeScript interface now includes:

```typescript
export interface ListPrimitives {
    // ... existing fields
    non_empty_list?: [number, ...number[]]; // <- New non-empty list type
}
```

This provides compile-time assurance that if `non_empty_list` is present, it contains at least one element, while maintaining compatibility with the optional nature of the field.