### PR TITLE
BE-111: Replace usages of subgraph if not needed

### DIFF
--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/answer-question-action.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/answer-question-action.ts
@@ -7,10 +7,7 @@ import type {
   StepOutput,
 } from "@local/hash-isomorphic-utils/flows/types";
 import { textFormats } from "@local/hash-isomorphic-utils/flows/types";
-import {
-  currentTimeInstantTemporalAxes,
-  zeroedGraphResolveDepths,
-} from "@local/hash-isomorphic-utils/graph-queries";
+import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import type { Status } from "@local/status";
 import { StatusCode } from "@local/status";
 import { Context } from "@temporalio/activity";
@@ -444,7 +441,6 @@ export const answerQuestionAction: FlowActionActivity = async ({ inputs }) => {
           })),
         },
         graphResolveDepths: {
-          ...zeroedGraphResolveDepths,
           constrainsValuesOn: { outgoing: 255 },
           constrainsPropertiesOn: { outgoing: 255 },
           constrainsLinksOn: { outgoing: 1 },

--- a/apps/hash-api/src/graphql/resolvers/index.ts
+++ b/apps/hash-api/src/graphql/resolvers/index.ts
@@ -40,6 +40,7 @@ import {
   countEntitiesResolver,
   createEntityResolver,
   isEntityPublicResolver,
+  queryEntitiesResolver,
   queryEntitySubgraphResolver,
   removeEntityViewerResolver,
   updateEntitiesResolver,
@@ -143,6 +144,7 @@ export const resolvers: Omit<Resolvers, "Query" | "Mutation"> & {
       );
     }),
     countEntities: countEntitiesResolver,
+    queryEntities: queryEntitiesResolver,
     queryEntitySubgraph: queryEntitySubgraphResolver,
     hashInstanceSettings: hashInstanceSettingsResolver,
     getMyPendingInvitations: loggedInAndSignedUpMiddleware(

--- a/apps/hash-api/src/graphql/resolvers/knowledge/entity/entity.ts
+++ b/apps/hash-api/src/graphql/resolvers/knowledge/entity/entity.ts
@@ -6,6 +6,7 @@ import {
 import { publicUserAccountId } from "@local/hash-backend-utils/public-user-account-id";
 import {
   HashEntity,
+  queryEntities,
   queryEntitySubgraph,
   serializeQueryEntitySubgraphResponse,
 } from "@local/hash-graph-sdk/entity";
@@ -15,7 +16,6 @@ import {
   queryPolicies,
 } from "@local/hash-graph-sdk/policy";
 import type { EntityValidationReport } from "@local/hash-graph-sdk/validation";
-import type { MutationArchiveEntitiesArgs } from "@local/hash-isomorphic-utils/graphql/api-types.gen";
 import {
   ApolloError,
   ForbiddenError,
@@ -37,6 +37,7 @@ import {
 } from "../../../../graph/knowledge/primitive/link-entity";
 import type {
   MutationAddEntityViewerArgs,
+  MutationArchiveEntitiesArgs,
   MutationArchiveEntityArgs,
   MutationCreateEntityArgs,
   MutationRemoveEntityViewerArgs,
@@ -45,6 +46,7 @@ import type {
   Query,
   QueryCountEntitiesArgs,
   QueryIsEntityPublicArgs,
+  QueryQueryEntitiesArgs,
   QueryQueryEntitySubgraphArgs,
   QueryValidateEntityArgs,
   ResolverFn,
@@ -118,6 +120,18 @@ export const countEntitiesResolver: ResolverFn<
   QueryCountEntitiesArgs
 > = async (_, { request }, graphQLContext) =>
   countEntities(
+    graphQLContextToImpureGraphContext(graphQLContext),
+    graphQLContext.authentication,
+    request,
+  );
+
+export const queryEntitiesResolver: ResolverFn<
+  Query["queryEntities"],
+  Record<string, never>,
+  GraphQLContext,
+  QueryQueryEntitiesArgs
+> = async (_, { request }, graphQLContext) =>
+  queryEntities(
     graphQLContextToImpureGraphContext(graphQLContext),
     graphQLContext.authentication,
     request,

--- a/apps/hash-frontend/src/components/hooks/use-entity-by-id.ts
+++ b/apps/hash-frontend/src/components/hooks/use-entity-by-id.ts
@@ -60,10 +60,7 @@ export const useEntityById = ({
               : []),
           ],
         },
-        graphResolveDepths: {
-          ...zeroedGraphResolveDepths,
-          ...graphResolveDepths,
-        },
+        graphResolveDepths: graphResolveDepths ?? zeroedGraphResolveDepths,
         temporalAxes: currentTimeInstantTemporalAxes,
         includeDrafts: !!draftId,
         includePermissions,

--- a/apps/hash-frontend/src/components/hooks/use-orgs.ts
+++ b/apps/hash-frontend/src/components/hooks/use-orgs.ts
@@ -1,19 +1,14 @@
 import type { ApolloQueryResult } from "@apollo/client";
 import { useQuery } from "@apollo/client";
-import { getRoots } from "@blockprotocol/graph/stdlib";
-import { deserializeQueryEntitySubgraphResponse } from "@local/hash-graph-sdk/entity";
 import { convertBpFilterToGraphFilter } from "@local/hash-graph-sdk/filter";
-import {
-  currentTimeInstantTemporalAxes,
-  zeroedGraphResolveDepths,
-} from "@local/hash-isomorphic-utils/graph-queries";
+import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import { systemEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 
 import type {
-  QueryEntitySubgraphQuery,
-  QueryEntitySubgraphQueryVariables,
+  QueryEntitiesQuery,
+  QueryEntitiesQueryVariables,
 } from "../../graphql/api-types.gen";
-import { queryEntitySubgraphQuery } from "../../graphql/queries/knowledge/entity.queries";
+import { queryEntitiesQuery } from "../../graphql/queries/knowledge/entity.queries";
 import type { MinimalOrg } from "../../lib/user-and-org";
 import { constructMinimalOrg, isEntityOrgEntity } from "../../lib/user-and-org";
 import { entityHasEntityTypeByVersionedUrlFilter } from "../../shared/filters";
@@ -25,12 +20,12 @@ import { useMemoCompare } from "../../shared/use-memo-compare";
 export const useOrgs = (): {
   loading: boolean;
   orgs?: MinimalOrg[];
-  refetch: () => Promise<ApolloQueryResult<QueryEntitySubgraphQuery>>;
+  refetch: () => Promise<ApolloQueryResult<QueryEntitiesQuery>>;
 } => {
   const { data, loading, refetch } = useQuery<
-    QueryEntitySubgraphQuery,
-    QueryEntitySubgraphQueryVariables
-  >(queryEntitySubgraphQuery, {
+    QueryEntitiesQuery,
+    QueryEntitiesQueryVariables
+  >(queryEntitiesQuery, {
     variables: {
       request: {
         filter: convertBpFilterToGraphFilter({
@@ -41,7 +36,6 @@ export const useOrgs = (): {
           ],
           operator: "AND",
         }),
-        graphResolveDepths: zeroedGraphResolveDepths,
         temporalAxes: currentTimeInstantTemporalAxes,
         includeDrafts: false,
         includePermissions: false,
@@ -50,18 +44,15 @@ export const useOrgs = (): {
     fetchPolicy: "cache-and-network",
   });
 
-  const { queryEntitySubgraph } = data ?? {};
+  const { queryEntities } = data ?? {};
 
   const orgs = useMemoCompare(
     () => {
-      if (!queryEntitySubgraph) {
+      if (!queryEntities) {
         return undefined;
       }
 
-      const subgraph =
-        deserializeQueryEntitySubgraphResponse(queryEntitySubgraph).subgraph;
-
-      return getRoots(subgraph).map((orgEntity) => {
+      return queryEntities.entities.map((orgEntity) => {
         if (!isEntityOrgEntity(orgEntity)) {
           throw new Error(
             `Entity with type(s) ${orgEntity.metadata.entityTypeIds.join(", ")} is not an org entity`,
@@ -70,7 +61,7 @@ export const useOrgs = (): {
         return constructMinimalOrg({ orgEntity });
       });
     },
-    [queryEntitySubgraph],
+    [queryEntities],
     /**
      * Check if the previous and new orgs are the same.
      * If they are, the return value from the hook won't change, avoiding unnecessary re-renders.

--- a/apps/hash-frontend/src/graphql/queries/knowledge/entity.queries.ts
+++ b/apps/hash-frontend/src/graphql/queries/knowledge/entity.queries.ts
@@ -21,6 +21,12 @@ export const createEntityMutation = gql`
   }
 `;
 
+export const queryEntitiesQuery = gql`
+  query queryEntities($request: QueryEntitiesRequest!) {
+    queryEntities(request: $request)
+  }
+`;
+
 export const queryEntitySubgraphQuery = gql`
   query queryEntitySubgraph($request: QueryEntitySubgraphRequest!) {
     queryEntitySubgraph(request: $request)

--- a/apps/hash-frontend/src/middleware/return-types-as-json/generate-query-args.ts
+++ b/apps/hash-frontend/src/middleware/return-types-as-json/generate-query-args.ts
@@ -1,14 +1,11 @@
 import type { VersionedUrl } from "@blockprotocol/type-system";
-import {
-  fullTransactionTimeAxis,
-  zeroedGraphResolveDepths,
-} from "@local/hash-isomorphic-utils/graph-queries";
+import { fullTransactionTimeAxis } from "@local/hash-isomorphic-utils/graph-queries";
 import type { DocumentNode } from "graphql";
 
 import type {
-  QueryDataTypeSubgraphQueryVariables,
-  QueryEntityTypeSubgraphQueryVariables,
-  QueryPropertyTypeSubgraphQueryVariables,
+  QueryDataTypesQueryVariables,
+  QueryEntityTypesQueryVariables,
+  QueryPropertyTypesQueryVariables,
 } from "../../graphql/api-types.gen";
 import { queryDataTypeSubgraphQuery } from "../../graphql/queries/ontology/data-type.queries";
 import { queryEntityTypeSubgraphQuery } from "../../graphql/queries/ontology/entity-type.queries";
@@ -35,9 +32,9 @@ export const generateQueryArgs = (
 ): {
   query: string;
   variables:
-    | QueryDataTypeSubgraphQueryVariables
-    | QueryEntityTypeSubgraphQueryVariables
-    | QueryPropertyTypeSubgraphQueryVariables;
+    | QueryDataTypesQueryVariables
+    | QueryEntityTypesQueryVariables
+    | QueryPropertyTypesQueryVariables;
 } => {
   switch (ontologyType) {
     case "data-type":
@@ -48,7 +45,6 @@ export const generateQueryArgs = (
             filter: {
               equal: [{ path: ["versionedUrl"] }, { parameter: versionedUrl }],
             },
-            graphResolveDepths: zeroedGraphResolveDepths,
             temporalAxes: fullTransactionTimeAxis,
           },
         },
@@ -61,7 +57,6 @@ export const generateQueryArgs = (
             filter: {
               equal: [{ path: ["versionedUrl"] }, { parameter: versionedUrl }],
             },
-            graphResolveDepths: zeroedGraphResolveDepths,
             temporalAxes: fullTransactionTimeAxis,
           },
         },
@@ -74,7 +69,6 @@ export const generateQueryArgs = (
             filter: {
               equal: [{ path: ["versionedUrl"] }, { parameter: versionedUrl }],
             },
-            graphResolveDepths: zeroedGraphResolveDepths,
             temporalAxes: fullTransactionTimeAxis,
           },
         },

--- a/apps/hash-frontend/src/middleware/return-types-as-json/generate-query-args.ts
+++ b/apps/hash-frontend/src/middleware/return-types-as-json/generate-query-args.ts
@@ -7,9 +7,9 @@ import type {
   QueryEntityTypesQueryVariables,
   QueryPropertyTypesQueryVariables,
 } from "../../graphql/api-types.gen";
-import { queryDataTypeSubgraphQuery } from "../../graphql/queries/ontology/data-type.queries";
-import { queryEntityTypeSubgraphQuery } from "../../graphql/queries/ontology/entity-type.queries";
-import { queryPropertyTypeSubgraphQuery } from "../../graphql/queries/ontology/property-type.queries";
+import { queryDataTypesQuery } from "../../graphql/queries/ontology/data-type.queries";
+import { queryEntityTypesQuery } from "../../graphql/queries/ontology/entity-type.queries";
+import { queryPropertyTypesQuery } from "../../graphql/queries/ontology/property-type.queries";
 
 /**
  * Return the internal query string from a gql-tagged query, i.e. gql`string` -> string
@@ -39,7 +39,7 @@ export const generateQueryArgs = (
   switch (ontologyType) {
     case "data-type":
       return {
-        query: queryStringFromNode(queryDataTypeSubgraphQuery),
+        query: queryStringFromNode(queryDataTypesQuery),
         variables: {
           request: {
             filter: {
@@ -51,7 +51,7 @@ export const generateQueryArgs = (
       };
     case "entity-type":
       return {
-        query: queryStringFromNode(queryEntityTypeSubgraphQuery),
+        query: queryStringFromNode(queryEntityTypesQuery),
         variables: {
           request: {
             filter: {
@@ -63,7 +63,7 @@ export const generateQueryArgs = (
       };
     case "property-type":
       return {
-        query: queryStringFromNode(queryPropertyTypeSubgraphQuery),
+        query: queryStringFromNode(queryPropertyTypesQuery),
         variables: {
           request: {
             filter: {

--- a/apps/hash-frontend/src/pages/@/[shortname].page.tsx
+++ b/apps/hash-frontend/src/pages/@/[shortname].page.tsx
@@ -1,9 +1,4 @@
 import { useQuery } from "@apollo/client";
-import type {
-  DataTypeRootType,
-  EntityTypeRootType,
-  PropertyTypeRootType,
-} from "@blockprotocol/graph";
 import {
   getEntityTypeAndDescendantsById,
   getRoots,
@@ -15,10 +10,7 @@ import type {
   PropertyTypeWithMetadata,
 } from "@blockprotocol/type-system";
 import { extractBaseUrl } from "@blockprotocol/type-system";
-import { deserializeQueryDataTypeSubgraphResponse } from "@local/hash-graph-sdk/data-type";
 import { deserializeQueryEntitySubgraphResponse } from "@local/hash-graph-sdk/entity";
-import { deserializeQueryEntityTypeSubgraphResponse } from "@local/hash-graph-sdk/entity-type";
-import { deserializeQueryPropertyTypeSubgraphResponse } from "@local/hash-graph-sdk/property-type";
 import {
   currentTimeInstantTemporalAxes,
   fullTransactionTimeAxis,
@@ -31,19 +23,19 @@ import { useRouter } from "next/router";
 import { useCallback, useMemo, useState } from "react";
 
 import type {
-  QueryDataTypeSubgraphQuery,
-  QueryDataTypeSubgraphQueryVariables,
+  QueryDataTypesQuery,
+  QueryDataTypesQueryVariables,
   QueryEntitySubgraphQuery,
   QueryEntitySubgraphQueryVariables,
-  QueryEntityTypeSubgraphQuery,
-  QueryEntityTypeSubgraphQueryVariables,
-  QueryPropertyTypeSubgraphQuery,
-  QueryPropertyTypeSubgraphQueryVariables,
+  QueryEntityTypesQuery,
+  QueryEntityTypesQueryVariables,
+  QueryPropertyTypesQuery,
+  QueryPropertyTypesQueryVariables,
 } from "../../graphql/api-types.gen";
 import { queryEntitySubgraphQuery } from "../../graphql/queries/knowledge/entity.queries";
-import { queryDataTypeSubgraphQuery } from "../../graphql/queries/ontology/data-type.queries";
-import { queryEntityTypeSubgraphQuery } from "../../graphql/queries/ontology/entity-type.queries";
-import { queryPropertyTypeSubgraphQuery } from "../../graphql/queries/ontology/property-type.queries";
+import { queryDataTypesQuery } from "../../graphql/queries/ontology/data-type.queries";
+import { queryEntityTypesQuery } from "../../graphql/queries/ontology/entity-type.queries";
+import { queryPropertyTypesQuery } from "../../graphql/queries/ontology/property-type.queries";
 import {
   constructOrg,
   constructUser,
@@ -105,9 +97,9 @@ const ProfilePage: NextPageWithLayout = () => {
     profile?.kind === "org" ? profile.webId : profile?.accountId;
 
   const { data: entityTypesData, loading: entityTypesLoading } = useQuery<
-    QueryEntityTypeSubgraphQuery,
-    QueryEntityTypeSubgraphQueryVariables
-  >(queryEntityTypeSubgraphQuery, {
+    QueryEntityTypesQuery,
+    QueryEntityTypesQueryVariables
+  >(queryEntityTypesQuery, {
     fetchPolicy: "cache-and-network",
     variables: {
       request: {
@@ -131,7 +123,6 @@ const ProfilePage: NextPageWithLayout = () => {
             },
           ],
         },
-        graphResolveDepths: zeroedGraphResolveDepths,
         temporalAxes: fullTransactionTimeAxis,
       },
     },
@@ -139,9 +130,9 @@ const ProfilePage: NextPageWithLayout = () => {
   });
 
   const { data: propertyTypesData, loading: propertyTypesLoading } = useQuery<
-    QueryPropertyTypeSubgraphQuery,
-    QueryPropertyTypeSubgraphQueryVariables
-  >(queryPropertyTypeSubgraphQuery, {
+    QueryPropertyTypesQuery,
+    QueryPropertyTypesQueryVariables
+  >(queryPropertyTypesQuery, {
     fetchPolicy: "cache-and-network",
     variables: {
       request: {
@@ -165,7 +156,6 @@ const ProfilePage: NextPageWithLayout = () => {
             },
           ],
         },
-        graphResolveDepths: zeroedGraphResolveDepths,
         temporalAxes: fullTransactionTimeAxis,
       },
     },
@@ -173,9 +163,9 @@ const ProfilePage: NextPageWithLayout = () => {
   });
 
   const { data: dataTypesData, loading: dataTypesLoading } = useQuery<
-    QueryDataTypeSubgraphQuery,
-    QueryDataTypeSubgraphQueryVariables
-  >(queryDataTypeSubgraphQuery, {
+    QueryDataTypesQuery,
+    QueryDataTypesQueryVariables
+  >(queryDataTypesQuery, {
     fetchPolicy: "cache-and-network",
     variables: {
       request: {
@@ -199,7 +189,6 @@ const ProfilePage: NextPageWithLayout = () => {
             },
           ],
         },
-        graphResolveDepths: zeroedGraphResolveDepths,
         temporalAxes: fullTransactionTimeAxis,
       },
     },
@@ -214,33 +203,15 @@ const ProfilePage: NextPageWithLayout = () => {
     )[] = [];
 
     if (propertyTypesData) {
-      const propertyTypes = getRoots<PropertyTypeRootType>(
-        deserializeQueryPropertyTypeSubgraphResponse(
-          propertyTypesData.queryPropertyTypeSubgraph,
-        ).subgraph,
-      );
-
-      types.push(...propertyTypes);
+      types.push(...propertyTypesData.queryPropertyTypes.propertyTypes);
     }
 
     if (entityTypesData) {
-      const entityTypes = getRoots<EntityTypeRootType>(
-        deserializeQueryEntityTypeSubgraphResponse(
-          entityTypesData.queryEntityTypeSubgraph,
-        ).subgraph,
-      );
-
-      types.push(...entityTypes);
+      types.push(...entityTypesData.queryEntityTypes.entityTypes);
     }
 
     if (dataTypesData) {
-      const dataTypes = getRoots<DataTypeRootType>(
-        deserializeQueryDataTypeSubgraphResponse(
-          dataTypesData.queryDataTypeSubgraph,
-        ).subgraph,
-      );
-
-      types.push(...dataTypes);
+      types.push(...dataTypesData.queryDataTypes.dataTypes);
     }
 
     return types;

--- a/apps/hash-frontend/src/pages/index.page/waitlisted.tsx
+++ b/apps/hash-frontend/src/pages/index.page/waitlisted.tsx
@@ -8,7 +8,6 @@ import {
 import {
   currentTimeInstantTemporalAxes,
   generateVersionedUrlMatchingFilter,
-  zeroedGraphResolveDepths,
 } from "@local/hash-isomorphic-utils/graph-queries";
 import { isSelfHostedInstance } from "@local/hash-isomorphic-utils/instance";
 import { systemEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
@@ -17,13 +16,13 @@ import { Box } from "@mui/material";
 import { useCallback, useState } from "react";
 
 import type {
+  CountEntitiesQuery,
+  CountEntitiesQueryVariables,
   GetWaitlistPositionQuery,
-  QueryEntitySubgraphQuery,
-  QueryEntitySubgraphQueryVariables,
   SubmitEarlyAccessFormMutation,
   SubmitEarlyAccessFormMutationVariables,
 } from "../../graphql/api-types.gen";
-import { queryEntitySubgraphQuery } from "../../graphql/queries/knowledge/entity.queries";
+import { countEntitiesQuery } from "../../graphql/queries/knowledge/entity.queries";
 import {
   getWaitlistPositionQuery,
   submitEarlyAccessFormMutation,
@@ -64,23 +63,21 @@ export const Waitlisted = () => {
     "closed" | "open" | "submitted"
   >("closed");
 
-  useQuery<QueryEntitySubgraphQuery, QueryEntitySubgraphQueryVariables>(
-    queryEntitySubgraphQuery,
+  useQuery<CountEntitiesQuery, CountEntitiesQueryVariables>(
+    countEntitiesQuery,
     {
       variables: {
         request: {
           filter: generateVersionedUrlMatchingFilter(
             systemEntityTypes.prospectiveUser.entityTypeId,
           ),
-          graphResolveDepths: zeroedGraphResolveDepths,
           includeDrafts: false,
           temporalAxes: currentTimeInstantTemporalAxes,
-          includePermissions: false,
         },
       },
       fetchPolicy: "cache-and-network",
       onCompleted: (data) => {
-        if (data.queryEntitySubgraph.subgraph.roots.length) {
+        if (data.countEntities > 0) {
           setEarlyAccessFormState("submitted");
         }
       },

--- a/apps/hash-frontend/src/pages/settings/organizations/[shortname]/integrations.page.tsx
+++ b/apps/hash-frontend/src/pages/settings/organizations/[shortname]/integrations.page.tsx
@@ -1,13 +1,9 @@
 import { useQuery } from "@apollo/client";
-import { getRoots } from "@blockprotocol/graph/stdlib";
-import { deserializeQueryEntitySubgraphResponse } from "@local/hash-graph-sdk/entity";
 import {
   currentTimeInstantTemporalAxes,
   generateVersionedUrlMatchingFilter,
-  zeroedGraphResolveDepths,
 } from "@local/hash-isomorphic-utils/graph-queries";
 import { systemLinkEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
-import type { SyncLinearDataWith } from "@local/hash-isomorphic-utils/system-types/linearintegration";
 import {
   Box,
   Skeleton,
@@ -22,10 +18,10 @@ import { NextSeo } from "next-seo";
 import { useMemo } from "react";
 
 import type {
-  QueryEntitySubgraphQuery,
-  QueryEntitySubgraphQueryVariables,
+  QueryEntitiesQuery,
+  QueryEntitiesQueryVariables,
 } from "../../../../graphql/api-types.gen";
-import { queryEntitySubgraphQuery } from "../../../../graphql/queries/knowledge/entity.queries";
+import { queryEntitiesQuery } from "../../../../graphql/queries/knowledge/entity.queries";
 import { LinearLogo } from "../../../../shared/icons/linear-logo";
 import type { NextPageWithLayout } from "../../../../shared/layout";
 import { Link } from "../../../../shared/ui";
@@ -52,8 +48,8 @@ const OrgIntegrationsPage: NextPageWithLayout = () => {
     data: linearIntegrationSyncLinksData,
     loading,
     refetch,
-  } = useQuery<QueryEntitySubgraphQuery, QueryEntitySubgraphQueryVariables>(
-    queryEntitySubgraphQuery,
+  } = useQuery<QueryEntitiesQuery, QueryEntitiesQueryVariables>(
+    queryEntitiesQuery,
     {
       variables: {
         request: {
@@ -82,7 +78,6 @@ const OrgIntegrationsPage: NextPageWithLayout = () => {
               },
             ],
           },
-          graphResolveDepths: zeroedGraphResolveDepths,
           includeDrafts: false,
           temporalAxes: currentTimeInstantTemporalAxes,
           includePermissions: true,
@@ -98,15 +93,11 @@ const OrgIntegrationsPage: NextPageWithLayout = () => {
       return [];
     }
 
-    const { entityPermissions, subgraph } =
-      deserializeQueryEntitySubgraphResponse<SyncLinearDataWith>(
-        linearIntegrationSyncLinksData.queryEntitySubgraph,
-      );
-
-    const links = getRoots(subgraph);
+    const { permissions, entities: links } =
+      linearIntegrationSyncLinksData.queryEntities;
 
     return links.map(({ metadata, entityId }) => {
-      const canEdit = !!entityPermissions?.[entityId]?.update;
+      const canEdit = !!permissions?.[entityId]?.update;
 
       return {
         createdById: metadata.provenance.createdById,

--- a/apps/hash-frontend/src/pages/settings/organizations/[shortname]/members.page/add-member-form.tsx
+++ b/apps/hash-frontend/src/pages/settings/organizations/[shortname]/members.page/add-member-form.tsx
@@ -1,12 +1,7 @@
 import { useLazyQuery, useMutation } from "@apollo/client";
-import { getRoots } from "@blockprotocol/graph/stdlib";
 import { TextField } from "@hashintel/design-system";
-import { deserializeQueryEntitySubgraphResponse } from "@local/hash-graph-sdk/entity";
 import { convertBpFilterToGraphFilter } from "@local/hash-graph-sdk/filter";
-import {
-  currentTimeInstantTemporalAxes,
-  zeroedGraphResolveDepths,
-} from "@local/hash-isomorphic-utils/graph-queries";
+import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import { systemPropertyTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 import { Stack } from "@mui/material";
 import type { FormEvent } from "react";
@@ -15,10 +10,10 @@ import { useEffect, useRef, useState } from "react";
 import type {
   InviteUserToOrgMutation,
   InviteUserToOrgMutationVariables,
-  QueryEntitySubgraphQuery,
-  QueryEntitySubgraphQueryVariables,
+  QueryEntitiesQuery,
+  QueryEntitiesQueryVariables,
 } from "../../../../../graphql/api-types.gen";
-import { queryEntitySubgraphQuery } from "../../../../../graphql/queries/knowledge/entity.queries";
+import { queryEntitiesQuery } from "../../../../../graphql/queries/knowledge/entity.queries";
 import { inviteUserToOrgMutation } from "../../../../../graphql/queries/knowledge/org.queries";
 import type { Org } from "../../../../../lib/user-and-org";
 import { Button } from "../../../../../shared/ui/button";
@@ -35,10 +30,10 @@ export const AddMemberForm = ({ org }: { org: Org }) => {
     InviteUserToOrgMutationVariables
   >(inviteUserToOrgMutation);
 
-  const [queryEntitySubgraph] = useLazyQuery<
-    QueryEntitySubgraphQuery,
-    QueryEntitySubgraphQueryVariables
-  >(queryEntitySubgraphQuery);
+  const [queryEntities] = useLazyQuery<
+    QueryEntitiesQuery,
+    QueryEntitiesQueryVariables
+  >(queryEntitiesQuery);
 
   const { refetch: refetchAuthenticatedUser } = useAuthenticatedUser();
 
@@ -67,7 +62,7 @@ export const AddMemberForm = ({ org }: { org: Org }) => {
       return;
     }
 
-    const { data } = await queryEntitySubgraph({
+    const { data } = await queryEntities({
       variables: {
         request: {
           filter: convertBpFilterToGraphFilter({
@@ -85,7 +80,6 @@ export const AddMemberForm = ({ org }: { org: Org }) => {
             ],
             operator: "AND",
           }),
-          graphResolveDepths: zeroedGraphResolveDepths,
           temporalAxes: currentTimeInstantTemporalAxes,
           includeDrafts: false,
           includePermissions: false,
@@ -99,11 +93,7 @@ export const AddMemberForm = ({ org }: { org: Org }) => {
       return;
     }
 
-    const subgraph = deserializeQueryEntitySubgraphResponse(
-      data.queryEntitySubgraph,
-    ).subgraph;
-
-    const user = getRoots(subgraph)[0];
+    const user = data.queryEntities.entities[0];
 
     if (!user && !isEmail) {
       setError(`User with shortname ${shortnameOrEmail} not found`);

--- a/apps/hash-frontend/src/pages/shared/block-collection/block-context-menu/block-select-data-modal.tsx
+++ b/apps/hash-frontend/src/pages/shared/block-collection/block-context-menu/block-select-data-modal.tsx
@@ -187,7 +187,6 @@ export const BlockSelectDataModal: FunctionComponent<
   //     const res = await queryEntities({
   //       data: {
   //         operation: { multiFilter },
-  //         graphResolveDepths: zeroedGraphResolveDepths,
   //       },
   //     });
 

--- a/apps/hash-frontend/src/pages/shared/create-data-type-form.tsx
+++ b/apps/hash-frontend/src/pages/shared/create-data-type-form.tsx
@@ -5,10 +5,7 @@ import {
   makeOntologyTypeVersion,
 } from "@blockprotocol/type-system";
 import { Callout, TextField } from "@hashintel/design-system";
-import {
-  currentTimeInstantTemporalAxes,
-  zeroedGraphResolveDepths,
-} from "@local/hash-isomorphic-utils/graph-queries";
+import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import { Box, Stack } from "@mui/material";
 import { Buffer } from "buffer/";
 import { useRouter } from "next/router";
@@ -16,10 +13,10 @@ import { useContext } from "react";
 import { useForm } from "react-hook-form";
 
 import type {
-  QueryDataTypeSubgraphQuery,
-  QueryDataTypeSubgraphQueryVariables,
+  QueryDataTypesQuery,
+  QueryDataTypesQueryVariables,
 } from "../../graphql/api-types.gen";
-import { queryDataTypeSubgraphQuery } from "../../graphql/queries/ontology/data-type.queries";
+import { queryDataTypesQuery } from "../../graphql/queries/ontology/data-type.queries";
 import { Button } from "../../shared/ui/button";
 import { useAuthenticatedUser } from "./auth-info-context";
 import { useDataTypesContext } from "./data-types-context";
@@ -54,10 +51,10 @@ export const CreateDataTypeForm = ({
 }: CreateDataTypeFormProps) => {
   const router = useRouter();
 
-  const [queryDataTypeSubgraph] = useLazyQuery<
-    QueryDataTypeSubgraphQuery,
-    QueryDataTypeSubgraphQueryVariables
-  >(queryDataTypeSubgraphQuery);
+  const [queryDataTypes] = useLazyQuery<
+    QueryDataTypesQuery,
+    QueryDataTypesQueryVariables
+  >(queryDataTypesQuery);
 
   const {
     handleSubmit,
@@ -208,7 +205,7 @@ export const CreateDataTypeForm = ({
                 clearErrors("title");
               },
               async validate(titleToValidate) {
-                const res = await queryDataTypeSubgraph({
+                const res = await queryDataTypes({
                   variables: {
                     request: {
                       filter: {
@@ -226,12 +223,11 @@ export const CreateDataTypeForm = ({
                         ],
                       },
                       temporalAxes: currentTimeInstantTemporalAxes,
-                      graphResolveDepths: zeroedGraphResolveDepths,
                     },
                   },
                 });
 
-                return res.data?.queryDataTypeSubgraph.subgraph.roots.length
+                return res.data?.queryDataTypes.dataTypes.length
                   ? "Data type name must be unique"
                   : true;
               },

--- a/apps/hash-frontend/src/pages/shared/entity-selector.tsx
+++ b/apps/hash-frontend/src/pages/shared/entity-selector.tsx
@@ -1,5 +1,4 @@
 import { useQuery } from "@apollo/client";
-import { getRoots } from "@blockprotocol/graph/stdlib";
 import type { EntityId, EntityType } from "@blockprotocol/type-system";
 import {
   entityIdFromComponents,
@@ -14,7 +13,6 @@ import type {
 import { Chip, SelectorAutocomplete } from "@hashintel/design-system";
 import type { HashEntity } from "@local/hash-graph-sdk/entity";
 import {
-  deserializeQueryEntitySubgraphResponse,
   getClosedMultiEntityTypeFromMap,
   getDisplayFieldsForClosedEntityType,
 } from "@local/hash-graph-sdk/entity";
@@ -23,15 +21,14 @@ import { generateEntityLabel } from "@local/hash-isomorphic-utils/generate-entit
 import {
   currentTimeInstantTemporalAxes,
   generateVersionedUrlMatchingFilter,
-  zeroedGraphResolveDepths,
 } from "@local/hash-isomorphic-utils/graph-queries";
 import { useMemo, useState } from "react";
 
 import type {
-  QueryEntitySubgraphQuery,
-  QueryEntitySubgraphQueryVariables,
+  QueryEntitiesQuery,
+  QueryEntitiesQueryVariables,
 } from "../../graphql/api-types.gen";
-import { queryEntitySubgraphQuery } from "../../graphql/queries/knowledge/entity.queries";
+import { queryEntitiesQuery } from "../../graphql/queries/knowledge/entity.queries";
 
 type EntitySelectorProps<Multiple extends boolean = false> = Omit<
   SelectorAutocompleteProps<HashEntity, Multiple>,
@@ -65,9 +62,9 @@ export const EntitySelector = <Multiple extends boolean>({
   const [query, setQuery] = useState("");
 
   const { data: entitiesData, loading } = useQuery<
-    QueryEntitySubgraphQuery,
-    QueryEntitySubgraphQueryVariables
-  >(queryEntitySubgraphQuery, {
+    QueryEntitiesQuery,
+    QueryEntitiesQueryVariables
+  >(queryEntitiesQuery, {
     variables: {
       request: {
         filter:
@@ -81,7 +78,6 @@ export const EntitySelector = <Multiple extends boolean>({
                 ),
               },
         temporalAxes: currentTimeInstantTemporalAxes,
-        graphResolveDepths: zeroedGraphResolveDepths,
         includeDrafts,
         includeEntityTypes: "resolved",
         includePermissions: false,
@@ -90,23 +86,21 @@ export const EntitySelector = <Multiple extends boolean>({
     fetchPolicy: "cache-and-network",
   });
 
-  const entitiesSubgraph = entitiesData
-    ? deserializeQueryEntitySubgraphResponse(entitiesData.queryEntitySubgraph)
-        .subgraph
+  const entities = entitiesData
+    ? entitiesData.queryEntities.entities
     : undefined;
 
   const closedMultiEntityTypesRootMap =
-    entitiesData?.queryEntitySubgraph.closedMultiEntityTypes;
+    entitiesData?.queryEntities.closedMultiEntityTypes;
 
   const sortedAndFilteredEntities = useMemo(() => {
-    if (!entitiesSubgraph) {
+    if (!entities) {
       return [];
     }
-    const subgraphRoots = getRoots(entitiesSubgraph);
 
     const hasLiveVersion: Record<EntityId, boolean> = {};
 
-    return subgraphRoots
+    return entities
       .filter((entity) => {
         const rootEntityId = entity.metadata.recordId.entityId;
 
@@ -143,7 +137,7 @@ export const EntitySelector = <Multiple extends boolean>({
             return false;
           }
           if (
-            subgraphRoots.some(
+            entities.some(
               (possiblyLiveEntity) =>
                 possiblyLiveEntity.metadata.recordId.entityId === liveEntityId,
             )
@@ -164,7 +158,7 @@ export const EntitySelector = <Multiple extends boolean>({
           b.metadata.temporalVersioning.decisionTime.start.limit,
         ),
       );
-  }, [entitiesSubgraph, entityIdsToFilterOut, includeDrafts]);
+  }, [entities, entityIdsToFilterOut, includeDrafts]);
 
   return (
     <SelectorAutocomplete<HashEntity, Multiple>
@@ -185,8 +179,7 @@ export const EntitySelector = <Multiple extends boolean>({
       onInputChange={(_, value) => setQuery(value)}
       options={sortedAndFilteredEntities}
       optionToRenderData={(entity) => {
-        const typesMap =
-          entitiesData?.queryEntitySubgraph.closedMultiEntityTypes;
+        const typesMap = entitiesData?.queryEntities.closedMultiEntityTypes;
 
         if (!typesMap) {
           throw new Error(
@@ -230,8 +223,7 @@ export const EntitySelector = <Multiple extends boolean>({
       inputPlaceholder="Search for an entity"
       renderTags={(tagValue, getTagProps) =>
         tagValue.map((option, index) => {
-          const typesMap =
-            entitiesData?.queryEntitySubgraph.closedMultiEntityTypes;
+          const typesMap = entitiesData?.queryEntities.closedMultiEntityTypes;
 
           if (!typesMap) {
             throw new Error(

--- a/apps/hash-frontend/src/pages/shared/entity/query-editor.tsx
+++ b/apps/hash-frontend/src/pages/shared/entity/query-editor.tsx
@@ -2,7 +2,6 @@ import type { MultiFilter } from "@blockprotocol/graph";
 import { getRoots } from "@blockprotocol/graph/stdlib";
 import type { Entity as EntityBp } from "@blockprotocol/type-system";
 import { EntityQueryEditor } from "@hashintel/query-editor";
-import { zeroedGraphResolveDepths } from "@local/hash-isomorphic-utils/graph-queries";
 import { blockProtocolPropertyTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 import { Box, Stack, Typography } from "@mui/material";
 import { NextSeo } from "next-seo";
@@ -64,7 +63,6 @@ export const QueryEditor = (props: QueryEditorProps) => {
       const res = await queryEntities({
         data: {
           operation: { multiFilter },
-          graphResolveDepths: zeroedGraphResolveDepths,
         },
       });
 

--- a/apps/hash-frontend/src/pages/shared/integrations/google/google-auth-context/use-google-accounts.ts
+++ b/apps/hash-frontend/src/pages/shared/integrations/google/google-auth-context/use-google-accounts.ts
@@ -1,21 +1,18 @@
 import { useQuery } from "@apollo/client";
-import { getRoots } from "@blockprotocol/graph/stdlib";
 import type { HashEntity } from "@local/hash-graph-sdk/entity";
-import { deserializeQueryEntitySubgraphResponse } from "@local/hash-graph-sdk/entity";
 import {
   currentTimeInstantTemporalAxes,
   generateVersionedUrlMatchingFilter,
-  zeroedGraphResolveDepths,
 } from "@local/hash-isomorphic-utils/graph-queries";
 import { googleEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 import type { Account as GoogleAccount } from "@local/hash-isomorphic-utils/system-types/google/account";
 import { useMemo } from "react";
 
 import type {
-  QueryEntitySubgraphQuery,
-  QueryEntitySubgraphQueryVariables,
+  QueryEntitiesQuery,
+  QueryEntitiesQueryVariables,
 } from "../../../../../graphql/api-types.gen";
-import { queryEntitySubgraphQuery } from "../../../../../graphql/queries/knowledge/entity.queries";
+import { queryEntitiesQuery } from "../../../../../graphql/queries/knowledge/entity.queries";
 import { useAuthenticatedUser } from "../../../auth-info-context";
 
 type UseGoogleAccountsResult = {
@@ -28,9 +25,9 @@ export const useGoogleAccounts = (): UseGoogleAccountsResult => {
   const { authenticatedUser } = useAuthenticatedUser();
 
   const { data, loading, refetch } = useQuery<
-    QueryEntitySubgraphQuery,
-    QueryEntitySubgraphQueryVariables
-  >(queryEntitySubgraphQuery, {
+    QueryEntitiesQuery,
+    QueryEntitiesQueryVariables
+  >(queryEntitiesQuery, {
     variables: {
       request: {
         filter: {
@@ -48,7 +45,6 @@ export const useGoogleAccounts = (): UseGoogleAccountsResult => {
             { equal: [{ path: ["archived"] }, { parameter: false }] },
           ],
         },
-        graphResolveDepths: zeroedGraphResolveDepths,
         temporalAxes: currentTimeInstantTemporalAxes,
         includeDrafts: false,
         includePermissions: false,
@@ -59,16 +55,10 @@ export const useGoogleAccounts = (): UseGoogleAccountsResult => {
   });
 
   return useMemo(() => {
-    const subgraph = data
-      ? deserializeQueryEntitySubgraphResponse<GoogleAccount>(
-          data.queryEntitySubgraph,
-        ).subgraph
-      : undefined;
-
-    const accounts = subgraph ? getRoots(subgraph) : [];
+    const accounts = data ? data.queryEntities.entities : [];
 
     return {
-      accounts,
+      accounts: accounts as HashEntity<GoogleAccount>[],
       loading,
       refetch,
     };

--- a/apps/hash-frontend/src/shared/layout/layout-with-header/search-bar.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-header/search-bar.tsx
@@ -13,7 +13,6 @@ import {
 import { Chip, IconButton } from "@hashintel/design-system";
 import type { Filter } from "@local/hash-graph-client";
 import type { HashEntity } from "@local/hash-graph-sdk/entity";
-import { deserializeQueryEntityTypeSubgraphResponse } from "@local/hash-graph-sdk/entity-type";
 import { deserializeSubgraph } from "@local/hash-graph-sdk/subgraph";
 import { generateEntityLabel } from "@local/hash-isomorphic-utils/generate-entity-label";
 import {
@@ -30,11 +29,11 @@ import { useUserOrOrgShortnameByWebId } from "../../../components/hooks/use-user
 import type {
   QueryEntitySubgraphQuery,
   QueryEntitySubgraphQueryVariables,
-  QueryEntityTypeSubgraphQuery,
-  QueryEntityTypeSubgraphQueryVariables,
+  QueryEntityTypesQuery,
+  QueryEntityTypesQueryVariables,
 } from "../../../graphql/api-types.gen";
 import { queryEntitySubgraphQuery } from "../../../graphql/queries/knowledge/entity.queries";
-import { queryEntityTypeSubgraphQuery } from "../../../graphql/queries/ontology/entity-type.queries";
+import { queryEntityTypesQuery } from "../../../graphql/queries/ontology/entity-type.queries";
 import { generateLinkParameters } from "../../generate-link-parameters";
 import { SearchIcon } from "../../icons";
 import { Button, Link } from "../../ui";
@@ -274,14 +273,13 @@ export const SearchBar: FunctionComponent = () => {
   });
 
   const { data: entityTypeResultData, loading: entityTypesLoading } = useQuery<
-    QueryEntityTypeSubgraphQuery,
-    QueryEntityTypeSubgraphQueryVariables
-  >(queryEntityTypeSubgraphQuery, {
+    QueryEntityTypesQuery,
+    QueryEntityTypesQueryVariables
+  >(queryEntityTypesQuery, {
     variables: {
       request: {
         filter: queryFilter,
         temporalAxes: currentTimeInstantTemporalAxes,
-        graphResolveDepths: zeroedGraphResolveDepths,
       },
     },
     skip: !submittedQuery,
@@ -300,21 +298,10 @@ export const SearchBar: FunctionComponent = () => {
       : undefined;
   const entityResults = entitySubgraph ? getRoots(entitySubgraph) : [];
 
-  const entityTypeSubgraph =
-    entityTypeResultData &&
-    /**
-     * Ideally we would use {@link isEntityTypeRootedSubgraph} here, but we cannot because one of the checks it makes
-     * is that the root's revisionId is a stringified integer. In HASH, the revisionId for a type root is a number.
-     * Either the types in @blockprotocol/graph or the value delivered by HASH needs to change
-     * H-2489
-     */
-    deserializeQueryEntityTypeSubgraphResponse(
-      entityTypeResultData.queryEntityTypeSubgraph,
-    ).subgraph;
-
-  const entityTypeResults = entityTypeSubgraph
-    ? getRoots(entityTypeSubgraph)
-    : [];
+  const entityTypeResults =
+    (entityTypeResultData &&
+      entityTypeResultData.queryEntityTypes.entityTypes) ??
+    [];
 
   useKey(["Escape"], () => setResultListVisible(false));
 

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar/account-entities-list.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar/account-entities-list.tsx
@@ -16,10 +16,10 @@ import { TransitionGroup } from "react-transition-group";
 
 import { useUpdateAuthenticatedUser } from "../../../../components/hooks/use-update-authenticated-user";
 import type {
-  QueryEntitySubgraphQuery,
-  QueryEntitySubgraphQueryVariables,
+  QueryEntitiesQuery,
+  QueryEntitiesQueryVariables,
 } from "../../../../graphql/api-types.gen";
-import { queryEntitySubgraphQuery } from "../../../../graphql/queries/knowledge/entity.queries";
+import { queryEntitiesQuery } from "../../../../graphql/queries/knowledge/entity.queries";
 import { hiddenEntityTypeIds } from "../../../../pages/shared/hidden-types";
 import { useActiveWorkspace } from "../../../../pages/shared/workspace-context";
 import { useLatestEntityTypesOptional } from "../../../entity-types-context/hooks";
@@ -83,9 +83,9 @@ export const AccountEntitiesList: FunctionComponent<
   } = useLatestEntityTypesOptional();
 
   const { data: userEntitiesData, loading: userEntitiesLoading } = useQuery<
-    QueryEntitySubgraphQuery,
-    QueryEntitySubgraphQueryVariables
-  >(queryEntitySubgraphQuery, {
+    QueryEntitiesQuery,
+    QueryEntitiesQueryVariables
+  >(queryEntitiesQuery, {
     variables: generateSidebarEntityTypeEntitiesQueryVariables({
       webId,
     }),
@@ -110,9 +110,9 @@ export const AccountEntitiesList: FunctionComponent<
         (root) =>
           ((isOwnedOntologyElementMetadata(root.metadata) &&
             root.metadata.webId === webId) ||
-            Object.keys(
-              userEntitiesData?.queryEntitySubgraph.typeIds ?? {},
-            ).includes(root.schema.$id)) &&
+            Object.keys(userEntitiesData?.queryEntities.typeIds ?? {}).includes(
+              root.schema.$id,
+            )) &&
           // Filter out external types from blockprotocol.org, except the Address type.
           (!root.schema.$id.startsWith(blockProtocolHubOrigin) ||
             root.schema.$id.includes("/address/")) &&

--- a/apps/hash-frontend/src/shared/use-entity-type-entities.tsx
+++ b/apps/hash-frontend/src/shared/use-entity-type-entities.tsx
@@ -21,6 +21,7 @@ import { systemPropertyTypes } from "@local/hash-isomorphic-utils/ontology-type-
 import { useMemo } from "react";
 
 import type {
+  QueryEntitiesQueryVariables,
   QueryEntitySubgraphQuery,
   QueryEntitySubgraphQueryVariables,
 } from "../graphql/api-types.gen";
@@ -142,7 +143,7 @@ export const generateSidebarEntityTypeEntitiesQueryVariables = ({
   webId,
 }: {
   webId: WebId;
-}): QueryEntitySubgraphQueryVariables => {
+}): QueryEntitiesQueryVariables => {
   return {
     request: {
       /**
@@ -158,7 +159,6 @@ export const generateSidebarEntityTypeEntitiesQueryVariables = ({
         webIds: [webId],
         includeArchived: false,
       }),
-      graphResolveDepths: zeroedGraphResolveDepths,
       temporalAxes: currentTimeInstantTemporalAxes,
       includeDrafts: false,
       includePermissions: false,

--- a/apps/plugin-browser/src/graphql/queries/entity.queries.ts
+++ b/apps/plugin-browser/src/graphql/queries/entity.queries.ts
@@ -18,6 +18,12 @@ export const updateEntityMutation = /* GraphQL */ `
   }
 `;
 
+export const queryEntitiesQuery = /* GraphQL */ `
+  query queryEntities($request: QueryEntitiesRequest!) {
+    queryEntities(request: $request)
+  }
+`;
+
 export const queryEntitySubgraphQuery = /* GraphQL */ `
   query queryEntitySubgraph($request: QueryEntitySubgraphRequest!) {
     queryEntitySubgraph(request: $request)

--- a/apps/plugin-browser/src/pages/popup/popup-contents/action-center/history/shared/history-row/flow-metadata-cell-contents.tsx
+++ b/apps/plugin-browser/src/pages/popup/popup-contents/action-center/history/shared/history-row/flow-metadata-cell-contents.tsx
@@ -1,15 +1,12 @@
-import { getRoots } from "@blockprotocol/graph/stdlib";
 import {
   ArrowDownRegularIcon,
   ArrowRightRegularIcon,
   AsteriskRegularIcon,
   ClockRegularIcon,
 } from "@hashintel/design-system";
-import { deserializeQueryEntitySubgraphResponse } from "@local/hash-graph-sdk/entity";
 import {
   currentTimeInstantTemporalAxes,
   generateVersionedUrlMatchingFilter,
-  zeroedGraphResolveDepths,
 } from "@local/hash-isomorphic-utils/graph-queries";
 import { systemEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 import { simplifyProperties } from "@local/hash-isomorphic-utils/simplify-properties";
@@ -21,10 +18,10 @@ import type { FunctionComponent } from "react";
 import { useEffect, useState } from "react";
 
 import type {
-  QueryEntitySubgraphQuery,
-  QueryEntitySubgraphQueryVariables,
+  QueryEntitiesQuery,
+  QueryEntitiesQueryVariables,
 } from "../../../../../../../graphql/api-types.gen";
-import { queryEntitySubgraphQuery } from "../../../../../../../graphql/queries/entity.queries";
+import { queryEntitiesQuery } from "../../../../../../../graphql/queries/entity.queries";
 import { queryGraphQlApi } from "../../../../../../../shared/query-graphql-api";
 import type { MinimalFlowRun } from "../../../../../../../shared/storage";
 import { iconSx } from "./styles";
@@ -50,8 +47,8 @@ type TotalUsage = {
 };
 
 const getTotalUsage = ({ flowRunId }: { flowRunId: string }) =>
-  queryGraphQlApi<QueryEntitySubgraphQuery, QueryEntitySubgraphQueryVariables>(
-    queryEntitySubgraphQuery,
+  queryGraphQlApi<QueryEntitiesQuery, QueryEntitiesQueryVariables>(
+    queryEntitiesQuery,
     {
       request: {
         filter: {
@@ -70,18 +67,13 @@ const getTotalUsage = ({ flowRunId }: { flowRunId: string }) =>
             },
           ],
         },
-        graphResolveDepths: zeroedGraphResolveDepths,
         temporalAxes: currentTimeInstantTemporalAxes,
         includeDrafts: false,
         includePermissions: false,
       },
     },
   ).then(({ data }) => {
-    const subgraph = deserializeQueryEntitySubgraphResponse(
-      data.queryEntitySubgraph,
-    ).subgraph;
-
-    const usageRecords = getRoots(subgraph);
+    const usageRecords = data.queryEntities.entities;
 
     let inputTokens = 0;
     let outputTokens = 0;

--- a/libs/@local/hash-backend-utils/src/google.ts
+++ b/libs/@local/hash-backend-utils/src/google.ts
@@ -1,14 +1,9 @@
-import { getRoots } from "@blockprotocol/graph/stdlib";
 import type { ActorEntityUuid, EntityId } from "@blockprotocol/type-system";
 import type { GraphApi } from "@local/hash-graph-client";
-import {
-  type HashEntity,
-  queryEntitySubgraph,
-} from "@local/hash-graph-sdk/entity";
+import { type HashEntity, queryEntities } from "@local/hash-graph-sdk/entity";
 import {
   currentTimeInstantTemporalAxes,
   generateVersionedUrlMatchingFilter,
-  zeroedGraphResolveDepths,
 } from "@local/hash-isomorphic-utils/graph-queries";
 import { googleEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 import type { Account as GoogleAccount } from "@local/hash-isomorphic-utils/system-types/google/account";
@@ -52,7 +47,7 @@ export const getGoogleAccountById = async ({
   googleAccountId: string;
   graphApiClient: GraphApi;
 }): Promise<HashEntity<GoogleAccount> | undefined> => {
-  const entities = await queryEntitySubgraph(
+  const { entities } = await queryEntities(
     { graphApi: graphApiClient },
     { actorId: userAccountId },
     {
@@ -79,14 +74,11 @@ export const getGoogleAccountById = async ({
           },
         ],
       },
-      graphResolveDepths: zeroedGraphResolveDepths,
       temporalAxes: currentTimeInstantTemporalAxes,
       includeDrafts: false,
       includePermissions: false,
     },
-  ).then(({ subgraph }) => {
-    return getRoots(subgraph);
-  });
+  );
 
   if (entities.length > 1) {
     throw new Error(

--- a/libs/@local/hash-isomorphic-utils/src/graphql/queries/entity.queries.ts
+++ b/libs/@local/hash-isomorphic-utils/src/graphql/queries/entity.queries.ts
@@ -1,5 +1,11 @@
 import { gql } from "@apollo/client";
 
+export const queryEntitiesQuery = gql`
+  query queryEntities($request: QueryEntitiesRequest!) {
+    queryEntities(request: $request)
+  }
+`;
+
 export const queryEntitySubgraphQuery = gql`
   query queryEntitySubgraph($request: QueryEntitySubgraphRequest!) {
     queryEntitySubgraph(request: $request)

--- a/libs/@local/hash-isomorphic-utils/src/graphql/type-defs/knowledge/entity.typedef.ts
+++ b/libs/@local/hash-isomorphic-utils/src/graphql/type-defs/knowledge/entity.typedef.ts
@@ -112,6 +112,10 @@ export const entityTypedef = gql`
   extend type Query {
     countEntities(request: CountEntitiesParams!): Int!
 
+    queryEntities(
+      request: QueryEntitiesRequest!
+    ): QueryEntitiesResponse!
+
     queryEntitySubgraph(
       request: QueryEntitySubgraphRequest!
     ): QueryEntitySubgraphResponse!

--- a/tests/hash-backend-integration/src/tests/graph/ontology/primitive/entity-type.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/ontology/primitive/entity-type.test.ts
@@ -29,7 +29,6 @@ import { getClosedMultiEntityTypeFromMap } from "@local/hash-graph-sdk/entity";
 import {
   getClosedMultiEntityTypes,
   getEntityTypeById,
-  getEntityTypeSubgraphById,
   hasPermissionForEntityTypes,
   queryEntityTypes,
   queryEntityTypeSubgraph,
@@ -569,9 +568,8 @@ describe("Entity type CRU", () => {
     ).toBeNull();
 
     expect(
-      await getEntityTypeSubgraphById(graphContext.graphApi, authentication, {
+      await getEntityTypeById(graphContext.graphApi, authentication, {
         entityTypeId,
-        graphResolveDepths: zeroedGraphResolveDepths,
         temporalAxes: currentTimeInstantTemporalAxes,
       }),
     ).not.toBeNull();

--- a/tests/hash-backend-integration/src/tests/graph/ontology/primitive/property-type.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/ontology/primitive/property-type.test.ts
@@ -14,14 +14,10 @@ import { isOwnedOntologyElementMetadata } from "@blockprotocol/type-system";
 import { Logger } from "@local/hash-backend-utils/logger";
 import { publicUserAccountId } from "@local/hash-backend-utils/public-user-account-id";
 import type { ConstructPropertyTypeParams } from "@local/hash-graph-sdk/ontology";
-import {
-  getPropertyTypeById,
-  getPropertyTypeSubgraphById,
-} from "@local/hash-graph-sdk/property-type";
+import { getPropertyTypeById } from "@local/hash-graph-sdk/property-type";
 import {
   currentTimeInstantTemporalAxes,
   fullTransactionTimeAxis,
-  zeroedGraphResolveDepths,
 } from "@local/hash-isomorphic-utils/graph-queries";
 import { beforeAll, describe, expect, it } from "vitest";
 
@@ -214,9 +210,8 @@ describe("Property type CRU", () => {
     ).toBeNull();
 
     expect(
-      await getPropertyTypeSubgraphById(graphContext.graphApi, authentication, {
+      await getPropertyTypeById(graphContext.graphApi, authentication, {
         propertyTypeId,
-        graphResolveDepths: zeroedGraphResolveDepths,
         temporalAxes: currentTimeInstantTemporalAxes,
       }),
     ).not.toBeNull();


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Replace `queryEntitySubgraph` with `queryEntities` where appropriate to simplify entity retrieval operations.

## 🔍 What does this change?

- Introduces a new `queryEntities` GraphQL query that returns entities directly without the subgraph structure
- Removes unnecessary `zeroedGraphResolveDepths` parameter from queries where it's not needed
- Updates frontend components to use the new query pattern instead of having to extract entities from subgraphs
- Simplifies entity retrieval code by eliminating the need to call `getRoots` and `deserializeQueryEntitySubgraphResponse`
- Updates similar patterns for data types, property types, and entity types

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

Existing tests have been updated to use the new query pattern.

## ❓ How to test this?

1. Checkout the branch
2. Verify that all entity retrieval operations work as expected
3. Confirm that UI components display entities correctly