### PR TITLE
BE-149: Refactor HIR lowering pipeline into reusable components

### DIFF
--- a/libs/@local/hashql/compiletest/src/suite/hir_lower_alias_replacement.rs
+++ b/libs/@local/hashql/compiletest/src/suite/hir_lower_alias_replacement.rs
@@ -1,6 +1,6 @@
 use core::fmt::Write as _;
 
-use hashql_ast::{lowering::lower, node::expr::Expr};
+use hashql_ast::{lowering::ExtractedTypes, node::expr::Expr};
 use hashql_core::{
     heap::Heap,
     module::ModuleRegistry,
@@ -14,8 +14,47 @@ use hashql_hir::{
     node::Node, pretty::PrettyPrintEnvironment,
 };
 
-use super::{Suite, SuiteDiagnostic};
-use crate::suite::common::{Header, process_issues, process_status};
+use super::{Suite, SuiteDiagnostic, hir_reify::hir_reify};
+use crate::suite::common::{Header, process_issues};
+
+pub(crate) struct TestOptions<'data> {
+    pub skip_alias_replacement: bool,
+    pub output: &'data mut String,
+    pub diagnostics: &'data mut Vec<SuiteDiagnostic>,
+}
+
+pub(crate) fn hir_lower_alias_replacement<'heap>(
+    heap: &'heap Heap,
+    expr: Expr<'heap>,
+    environment: &Environment<'heap>,
+    context: &mut HirContext<'_, 'heap>,
+    options: &mut TestOptions,
+) -> Result<(Node<'heap>, ExtractedTypes<'heap>), SuiteDiagnostic> {
+    let (mut node, types) = hir_reify(heap, expr, environment, context, options.diagnostics)?;
+
+    let _ = writeln!(
+        options.output,
+        "{}\n\n{}",
+        Header::new("Initial HIR"),
+        node.pretty_print(
+            &PrettyPrintEnvironment {
+                env: environment,
+                symbols: &context.symbols,
+            },
+            PrettyOptions::default().without_color()
+        )
+    );
+
+    if !options.skip_alias_replacement {
+        let mut issues = DiagnosticIssues::new();
+        let mut replacement = AliasReplacement::new(context, &mut issues);
+        Ok(node) = replacement.fold_node(node);
+
+        process_issues(options.diagnostics, issues)?;
+    }
+
+    Ok((node, types))
+}
 
 pub(crate) struct HirLowerAliasReplacementSuite;
 
@@ -27,7 +66,7 @@ impl Suite for HirLowerAliasReplacementSuite {
     fn run<'heap>(
         &self,
         heap: &'heap Heap,
-        mut expr: Expr<'heap>,
+        expr: Expr<'heap>,
         diagnostics: &mut Vec<SuiteDiagnostic>,
     ) -> Result<String, SuiteDiagnostic> {
         let environment = Environment::new(SpanId::SYNTHETIC, heap);
@@ -37,34 +76,17 @@ impl Suite for HirLowerAliasReplacementSuite {
 
         let mut output = String::new();
 
-        let result = lower(
-            heap.intern_symbol("::main"),
-            &mut expr,
+        let (node, _) = hir_lower_alias_replacement(
+            heap,
+            expr,
             &environment,
-            &registry,
-        );
-        let types = process_status(diagnostics, result)?;
-
-        let node = process_status(diagnostics, Node::from_ast(expr, &mut context, &types))?;
-
-        let _ = writeln!(
-            output,
-            "{}\n\n{}",
-            Header::new("Initial HIR"),
-            node.pretty_print(
-                &PrettyPrintEnvironment {
-                    env: &environment,
-                    symbols: &context.symbols,
-                },
-                PrettyOptions::default().without_color()
-            )
-        );
-
-        let mut issues = DiagnosticIssues::new();
-        let mut replacement = AliasReplacement::new(&context, &mut issues);
-        let Ok(node) = replacement.fold_node(node);
-
-        process_issues(diagnostics, issues)?;
+            &mut context,
+            &mut TestOptions {
+                skip_alias_replacement: false,
+                output: &mut output,
+                diagnostics,
+            },
+        )?;
 
         let _ = writeln!(
             output,

--- a/libs/@local/hashql/compiletest/src/suite/hir_lower_ctor.rs
+++ b/libs/@local/hashql/compiletest/src/suite/hir_lower_ctor.rs
@@ -1,6 +1,6 @@
 use core::fmt::Write as _;
 
-use hashql_ast::{lowering::lower, node::expr::Expr};
+use hashql_ast::node::expr::Expr;
 use hashql_core::{
     heap::Heap,
     module::ModuleRegistry,
@@ -10,16 +10,35 @@ use hashql_core::{
 };
 use hashql_diagnostics::DiagnosticIssues;
 use hashql_hir::{
-    context::HirContext,
-    fold::Fold as _,
-    intern::Interner,
-    lower::{alias::AliasReplacement, ctor::ConvertTypeConstructor},
-    node::Node,
-    pretty::PrettyPrintEnvironment,
+    context::HirContext, fold::Fold as _, intern::Interner, lower::ctor::ConvertTypeConstructor,
+    node::Node, pretty::PrettyPrintEnvironment,
 };
 
-use super::{Suite, SuiteDiagnostic, common::Header};
-use crate::suite::common::{process_issues, process_status};
+use super::{
+    Suite, SuiteDiagnostic,
+    common::Header,
+    hir_lower_alias_replacement::{TestOptions, hir_lower_alias_replacement},
+};
+use crate::suite::common::process_issues;
+
+pub(crate) fn hir_lower_ctor<'heap>(
+    heap: &'heap Heap,
+    expr: Expr<'heap>,
+    environment: &Environment<'heap>,
+    context: &mut HirContext<'_, 'heap>,
+    options: &mut TestOptions,
+) -> Result<Node<'heap>, SuiteDiagnostic> {
+    let (node, types) = hir_lower_alias_replacement(heap, expr, environment, context, options)?;
+
+    let mut issues = DiagnosticIssues::new();
+
+    let mut converter =
+        ConvertTypeConstructor::new(context, &types.locals, environment, &mut issues);
+    let Ok(node) = converter.fold_node(node);
+
+    process_issues(options.diagnostics, issues)?;
+    Ok(node)
+}
 
 pub(crate) struct HirLowerCtorSuite;
 
@@ -31,7 +50,7 @@ impl Suite for HirLowerCtorSuite {
     fn run<'heap>(
         &self,
         heap: &'heap Heap,
-        mut expr: Expr<'heap>,
+        expr: Expr<'heap>,
         diagnostics: &mut Vec<SuiteDiagnostic>,
     ) -> Result<String, SuiteDiagnostic> {
         let environment = Environment::new(SpanId::SYNTHETIC, heap);
@@ -41,38 +60,17 @@ impl Suite for HirLowerCtorSuite {
 
         let mut output = String::new();
 
-        let result = lower(
-            heap.intern_symbol("::main"),
-            &mut expr,
+        let node = hir_lower_ctor(
+            heap,
+            expr,
             &environment,
-            &registry,
-        );
-        let types = process_status(diagnostics, result)?;
-
-        let node = process_status(diagnostics, Node::from_ast(expr, &mut context, &types))?;
-
-        let _ = writeln!(
-            output,
-            "{}\n\n{}",
-            Header::new("Initial HIR"),
-            node.pretty_print(
-                &PrettyPrintEnvironment {
-                    env: &environment,
-                    symbols: &context.symbols,
-                },
-                PrettyOptions::default().without_color()
-            )
-        );
-
-        let mut issues = DiagnosticIssues::new();
-        let mut replacement = AliasReplacement::new(&context, &mut issues);
-        let Ok(node) = replacement.fold_node(node);
-
-        let mut converter =
-            ConvertTypeConstructor::new(&context, &types.locals, &environment, &mut issues);
-        let Ok(node) = converter.fold_node(node);
-
-        process_issues(diagnostics, issues)?;
+            &mut context,
+            &mut TestOptions {
+                skip_alias_replacement: false,
+                output: &mut output,
+                diagnostics,
+            },
+        )?;
 
         let _ = writeln!(
             output,

--- a/libs/@local/hashql/compiletest/src/suite/hir_lower_inference_intrinsics.rs
+++ b/libs/@local/hashql/compiletest/src/suite/hir_lower_inference_intrinsics.rs
@@ -1,28 +1,22 @@
 use core::fmt::Write as _;
 
-use hashql_ast::{lowering::lower, node::expr::Expr};
+use hashql_ast::node::expr::Expr;
 use hashql_core::{
     heap::Heap,
     module::ModuleRegistry,
     pretty::{PrettyOptions, PrettyPrint as _},
     r#type::environment::Environment,
 };
-use hashql_diagnostics::DiagnosticIssues;
-use hashql_hir::{
-    context::HirContext,
-    fold::Fold as _,
-    intern::Interner,
-    lower::{ctor::ConvertTypeConstructor, inference::TypeInference},
-    node::Node,
-    pretty::PrettyPrintEnvironment,
-    visit::Visitor as _,
-};
+use hashql_hir::{context::HirContext, intern::Interner, pretty::PrettyPrintEnvironment};
 
 use super::{
     Suite, SuiteDiagnostic,
     common::{Annotated, Header},
 };
-use crate::suite::common::{process_issues, process_status};
+use crate::suite::{
+    common::process_status, hir_lower_alias_replacement::TestOptions,
+    hir_lower_inference::hir_lower_inference,
+};
 
 pub(crate) struct HirLowerTypeInferenceIntrinsicsSuite;
 
@@ -34,7 +28,7 @@ impl Suite for HirLowerTypeInferenceIntrinsicsSuite {
     fn run<'heap>(
         &self,
         heap: &'heap Heap,
-        mut expr: Expr<'heap>,
+        expr: Expr<'heap>,
         diagnostics: &mut Vec<SuiteDiagnostic>,
     ) -> Result<String, SuiteDiagnostic> {
         let mut environment = Environment::new(expr.span, heap);
@@ -44,42 +38,17 @@ impl Suite for HirLowerTypeInferenceIntrinsicsSuite {
 
         let mut output = String::new();
 
-        let result = lower(
-            heap.intern_symbol("::main"),
-            &mut expr,
+        let (node, solver, inference_residual) = hir_lower_inference(
+            heap,
+            expr,
             &environment,
-            &registry,
-        );
-        let types = process_status(diagnostics, result)?;
-
-        let node = process_status(diagnostics, Node::from_ast(expr, &mut context, &types))?;
-
-        let _ = writeln!(
-            output,
-            "{}\n\n{}",
-            Header::new("Initial HIR"),
-            node.pretty_print(
-                &PrettyPrintEnvironment {
-                    env: &environment,
-                    symbols: &context.symbols,
-                },
-                PrettyOptions::default().without_color()
-            )
-        );
-
-        let mut issues = DiagnosticIssues::new();
-
-        let mut converter =
-            ConvertTypeConstructor::new(&context, &types.locals, &environment, &mut issues);
-        let Ok(node) = converter.fold_node(node);
-
-        process_issues(diagnostics, issues)?;
-
-        let mut inference = TypeInference::new(&environment, &context);
-        inference.visit_node(&node);
-
-        let (solver, inference_residual, inference_diagnostics) = inference.finish();
-        process_issues(diagnostics, inference_diagnostics)?;
+            &mut context,
+            &mut TestOptions {
+                skip_alias_replacement: true,
+                output: &mut output,
+                diagnostics,
+            },
+        )?;
 
         // We sort so that the output is deterministic
         let mut inference_intrinsics: Vec<_> = inference_residual

--- a/libs/@local/hashql/compiletest/src/suite/hir_lower_specialization.rs
+++ b/libs/@local/hashql/compiletest/src/suite/hir_lower_specialization.rs
@@ -1,6 +1,6 @@
 use core::fmt::Write as _;
 
-use hashql_ast::{lowering::lower, node::expr::Expr};
+use hashql_ast::node::expr::Expr;
 use hashql_core::{
     heap::Heap,
     module::ModuleRegistry,
@@ -9,20 +9,39 @@ use hashql_core::{
 };
 use hashql_diagnostics::DiagnosticIssues;
 use hashql_hir::{
-    context::HirContext,
-    fold::Fold as _,
-    intern::Interner,
-    lower::{
-        alias::AliasReplacement, checking::TypeChecking, ctor::ConvertTypeConstructor,
-        inference::TypeInference, specialization::Specialization,
-    },
-    node::Node,
-    pretty::PrettyPrintEnvironment,
-    visit::Visitor as _,
+    context::HirContext, fold::Fold as _, intern::Interner, lower::specialization::Specialization,
+    node::Node, pretty::PrettyPrintEnvironment,
 };
 
-use super::{Suite, SuiteDiagnostic, common::Header};
-use crate::suite::common::{process_issues, process_status};
+use super::{
+    Suite, SuiteDiagnostic, common::Header, hir_lower_alias_replacement::TestOptions,
+    hir_lower_checking::hir_lower_checking,
+};
+use crate::suite::common::process_issues;
+
+pub(crate) fn hir_lower_specialization<'heap>(
+    heap: &'heap Heap,
+    expr: Expr<'heap>,
+    environment: &mut Environment<'heap>,
+    context: &mut HirContext<'_, 'heap>,
+    options: &mut TestOptions,
+) -> Result<Node<'heap>, SuiteDiagnostic> {
+    let (node, mut residual) = hir_lower_checking(heap, expr, environment, context, options)?;
+
+    let mut issues = DiagnosticIssues::new();
+    let mut specialisation = Specialization::new(
+        environment,
+        context,
+        &mut residual.types,
+        residual.intrinsics,
+        &mut issues,
+    );
+    let Ok(node) = specialisation.fold_node(node);
+
+    process_issues(options.diagnostics, issues)?;
+
+    Ok(node)
+}
 
 pub(crate) struct HirLowerSpecializationSuite;
 
@@ -34,7 +53,7 @@ impl Suite for HirLowerSpecializationSuite {
     fn run<'heap>(
         &self,
         heap: &'heap Heap,
-        mut expr: Expr<'heap>,
+        expr: Expr<'heap>,
         diagnostics: &mut Vec<SuiteDiagnostic>,
     ) -> Result<String, SuiteDiagnostic> {
         let mut environment = Environment::new(expr.span, heap);
@@ -44,65 +63,17 @@ impl Suite for HirLowerSpecializationSuite {
 
         let mut output = String::new();
 
-        let result = lower(
-            heap.intern_symbol("::main"),
-            &mut expr,
-            &environment,
-            &registry,
-        );
-        let types = process_status(diagnostics, result)?;
-
-        let node = process_status(diagnostics, Node::from_ast(expr, &mut context, &types))?;
-
-        let _ = writeln!(
-            output,
-            "{}\n\n{}",
-            Header::new("Initial HIR"),
-            node.pretty_print(
-                &PrettyPrintEnvironment {
-                    env: &environment,
-                    symbols: &context.symbols,
-                },
-                PrettyOptions::default().without_color()
-            )
-        );
-
-        let mut issues = DiagnosticIssues::new();
-        let mut replacement = AliasReplacement::new(&context, &mut issues);
-        let Ok(node) = replacement.fold_node(node);
-
-        let mut converter =
-            ConvertTypeConstructor::new(&context, &types.locals, &environment, &mut issues);
-        let Ok(node) = converter.fold_node(node);
-
-        process_issues(diagnostics, issues)?;
-
-        let mut inference = TypeInference::new(&environment, &context);
-        inference.visit_node(&node);
-
-        let (solver, inference_residual, inference_diagnostics) = inference.finish();
-        process_issues(diagnostics, inference_diagnostics)?;
-
-        let substitution = process_status(diagnostics, solver.solve())?;
-
-        environment.substitution = substitution;
-
-        let mut checking = TypeChecking::new(&environment, &context, inference_residual);
-        checking.visit_node(&node);
-
-        let mut residual = process_status(diagnostics, checking.finish())?;
-
-        let mut issues = DiagnosticIssues::new();
-        let mut specialisation = Specialization::new(
-            &environment,
-            &context,
-            &mut residual.types,
-            residual.intrinsics,
-            &mut issues,
-        );
-        let Ok(node) = specialisation.fold_node(node);
-
-        process_issues(diagnostics, issues)?;
+        let node = hir_lower_specialization(
+            heap,
+            expr,
+            &mut environment,
+            &mut context,
+            &mut TestOptions {
+                skip_alias_replacement: false,
+                output: &mut output,
+                diagnostics,
+            },
+        )?;
 
         let _ = writeln!(
             output,

--- a/libs/@local/hashql/hir/src/lower/inference.rs
+++ b/libs/@local/hashql/hir/src/lower/inference.rs
@@ -53,9 +53,9 @@ pub struct TypeInferenceResidual<'heap> {
     pub types: FastHashMap<HirId, TypeId>,
 }
 
-pub struct TypeInference<'env, 'heap> {
+pub struct TypeInference<'env, 'ctx, 'heap> {
     env: &'env Environment<'heap>,
-    context: &'env HirContext<'env, 'heap>,
+    context: &'ctx HirContext<'ctx, 'heap>,
 
     inference: InferenceEnvironment<'env, 'heap>,
     collector: VariableCollector<'env, 'heap>,
@@ -70,8 +70,8 @@ pub struct TypeInference<'env, 'heap> {
     intrinsics: FastHashMap<HirId, &'static str>,
 }
 
-impl<'env, 'heap> TypeInference<'env, 'heap> {
-    pub fn new(env: &'env Environment<'heap>, context: &'env HirContext<'env, 'heap>) -> Self {
+impl<'env, 'ctx, 'heap> TypeInference<'env, 'ctx, 'heap> {
+    pub fn new(env: &'env Environment<'heap>, context: &'ctx HirContext<'ctx, 'heap>) -> Self {
         Self {
             env,
             context,
@@ -146,7 +146,7 @@ impl<'env, 'heap> TypeInference<'env, 'heap> {
     }
 }
 
-impl<'heap> Visitor<'heap> for TypeInference<'_, 'heap> {
+impl<'heap> Visitor<'heap> for TypeInference<'_, '_, 'heap> {
     fn visit_type_id(&mut self, id: TypeId) {
         self.collector.visit_id(id);
     }

--- a/libs/@local/hashql/hir/src/reify/mod.rs
+++ b/libs/@local/hashql/hir/src/reify/mod.rs
@@ -54,16 +54,16 @@ enum Fold<'heap> {
 // TODO: we might want to contemplate moving this into a separate crate, to completely separate
 // HashQL's AST and HIR. (like done in rustc)
 #[derive(Debug)]
-struct ReificationContext<'ctx, 'env, 'heap> {
+struct ReificationContext<'ctx, 'types, 'env, 'heap> {
     context: &'ctx mut HirContext<'env, 'heap>,
-    types: &'env ExtractedTypes<'heap>,
+    types: &'types ExtractedTypes<'heap>,
     diagnostics: ReificationDiagnosticIssues,
     binder_scope: FastHashMap<Symbol<'heap>, VarId>,
 
     scratch_ident: Vec<Ident<'heap>>,
 }
 
-impl<'heap> ReificationContext<'_, '_, 'heap> {
+impl<'heap> ReificationContext<'_, '_, '_, 'heap> {
     fn call_arguments(
         &mut self,
         args: heap::Vec<'heap, Argument<'heap>>,
@@ -802,7 +802,7 @@ impl<'heap> Node<'heap> {
     pub fn from_ast<'env>(
         expr: Expr<'heap>,
         context: &mut HirContext<'env, 'heap>,
-        types: &'env ExtractedTypes<'heap>,
+        types: &ExtractedTypes<'heap>,
     ) -> ReificationStatus<Self> {
         // pre-populate the binder_scope and symbol table with types, as ctor might reference them
         // once `ConvertTypeConstructor` is run, these variables are no longer referenced inside the


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Refactor HIR lowering phases to improve code organization and reusability by extracting common functionality into dedicated helper functions.

## 🔍 What does this change?

- Extracts HIR lowering phases into reusable functions that can be composed together
- Creates a `TestOptions` struct to standardize option passing between lowering phases
- Refactors the HIR lowering pipeline to use these new helper functions
- Fixes function signatures to properly handle ownership and lifetimes
- Removes duplicated code across test suites

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- Existing tests continue to work with the refactored code

## ❓ How to test this?

1. Run the existing test suite to verify that all tests still pass
2. Verify that the HIR lowering phases work correctly with the new helper functions
