### PR TITLE
Revert "Update npm package `nodemailer` to v7"

### DIFF
--- a/apps/hash-api/package.json
+++ b/apps/hash-api/package.json
@@ -100,7 +100,7 @@
     "md5": "2.3.0",
     "mime-types": "2.1.35",
     "nanoid": "3.3.11",
-    "nodemailer": "7.0.7",
+    "nodemailer": "6.10.1",
     "oembed-providers": "1.0.20250715",
     "openai": "4.104.0",
     "ts-json-schema-generator": "1.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -437,7 +437,7 @@ __metadata:
     md5: "npm:2.3.0"
     mime-types: "npm:2.1.35"
     nanoid: "npm:3.3.11"
-    nodemailer: "npm:7.0.7"
+    nodemailer: "npm:6.10.1"
     oembed-providers: "npm:1.0.20250715"
     openai: "npm:4.104.0"
     rimraf: "npm:6.0.1"
@@ -37940,10 +37940,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nodemailer@npm:7.0.7":
-  version: 7.0.7
-  resolution: "nodemailer@npm:7.0.7"
-  checksum: 10c0/9f7215f3c76b0db3e76a9a6a10fa4fdca3e3ea907fa82430498b6598b40700df287efd586e1d5bc56fe4b903144e5d70413e01f621106e4417e7af7eb1dccaee
+"nodemailer@npm:6.10.1":
+  version: 6.10.1
+  resolution: "nodemailer@npm:6.10.1"
+  checksum: 10c0/e81fde258ea4f4e5646e9e3eebe89294d007939999d2d1a8c96c5488fa00bf659e46cf76fccb2697e9aa6ef9807a1ed47ff2aef6ad30b795e3849b6997066d16
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Reverts hashintel/hash#7843

We currently encounter issues and need to fix the configurations