### PR TITLE
SRE-38: Switch to fork of `dismiss-stale-approvals` action

### DIFF
--- a/.github/workflows/dismiss-stale-approvals.yml
+++ b/.github/workflows/dismiss-stale-approvals.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Dismiss stale pull request approvals
-        uses: withgraphite/dismiss-stale-approvals@36620714c84092b9d1bd5123ab3b5e11c48b5119 # v0.1.2
+        # see: https://github.com/withgraphite/dismiss-stale-approvals/pull/8#issuecomment-3386592574
+        uses: turnage/dismiss-stale-approvals@ff3fc67f2978497c420e446f704b9502dd911fd8 # fork
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Switch from the official `withgraphite/dismiss-stale-approvals` action to a fork (`turnage/dismiss-stale-approvals`) for our stale PR approval dismissal workflow.

## 🔗 Related links

- https://github.com/withgraphite/dismiss-stale-approvals/pull/8#issuecomment-3386592574

## 🔍 What does this change?

- Replaces the GitHub action used in our workflow from `withgraphite/dismiss-stale-approvals@36620714c84092b9d1bd5123ab3b5e11c48b5119` to `turnage/dismiss-stale-approvals@ff3fc67f2978497c420e446f704b9502dd911fd8`
- Adds a comment referencing the reason for using this fork

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- This change affects our GitHub workflow infrastructure, which will be tested when the workflow runs

## ❓ How to test this?

1. Checkout the branch
2. Verify that the GitHub workflow file correctly references the forked action
3. After merging, confirm the workflow runs successfully on PRs
