### PR TITLE
BE-150: Remove unused edge direction enums

### DIFF
--- a/libs/@local/graph/api/openapi/openapi.json
+++ b/libs/@local/graph/api/openapi/openapi.json
@@ -4344,6 +4344,13 @@
         },
         "additionalProperties": false
       },
+      "EdgeDirection": {
+        "type": "string",
+        "enum": [
+          "incoming",
+          "outgoing"
+        ]
+      },
       "Edges": {
         "type": "object",
         "additionalProperties": {
@@ -4723,7 +4730,7 @@
             ],
             "properties": {
               "direction": {
-                "$ref": "#/components/schemas/EntityTraversalEdgeDirection"
+                "$ref": "#/components/schemas/EdgeDirection"
               },
               "kind": {
                 "type": "string",
@@ -4742,7 +4749,7 @@
             ],
             "properties": {
               "direction": {
-                "$ref": "#/components/schemas/EntityTraversalEdgeDirection"
+                "$ref": "#/components/schemas/EdgeDirection"
               },
               "kind": {
                 "type": "string",
@@ -4756,13 +4763,6 @@
         "discriminator": {
           "propertyName": "kind"
         }
-      },
-      "EntityTraversalEdgeDirection": {
-        "type": "string",
-        "enum": [
-          "incoming",
-          "outgoing"
-        ]
       },
       "EntityTraversalPath": {
         "type": "object",
@@ -6530,12 +6530,6 @@
           }
         },
         "additionalProperties": false
-      },
-      "OntologyTraversalEdgeDirection": {
-        "type": "string",
-        "enum": [
-          "outgoing"
-        ]
       },
       "OntologyTypeRecordId": {
         "type": "object",
@@ -9041,7 +9035,7 @@
             ],
             "properties": {
               "direction": {
-                "$ref": "#/components/schemas/EntityTraversalEdgeDirection"
+                "$ref": "#/components/schemas/EdgeDirection"
               },
               "kind": {
                 "type": "string",
@@ -9060,7 +9054,7 @@
             ],
             "properties": {
               "direction": {
-                "$ref": "#/components/schemas/EntityTraversalEdgeDirection"
+                "$ref": "#/components/schemas/EdgeDirection"
               },
               "kind": {
                 "type": "string",

--- a/libs/@local/graph/api/src/rest/mod.rs
+++ b/libs/@local/graph/api/src/rest/mod.rs
@@ -48,9 +48,8 @@ use hash_graph_store::{
     property_type::PropertyTypeStore,
     subgraph::{
         edges::{
-            EntityTraversalEdge, EntityTraversalEdgeDirection, EntityTraversalPath,
-            GraphResolveDepths, KnowledgeGraphEdgeKind, OntologyEdgeKind,
-            OntologyTraversalEdgeDirection, SharedEdgeKind, TraversalEdge, TraversalPath,
+            EdgeDirection, EntityTraversalEdge, EntityTraversalPath, GraphResolveDepths,
+            KnowledgeGraphEdgeKind, OntologyEdgeKind, SharedEdgeKind, TraversalEdge, TraversalPath,
         },
         identifier::{
             DataTypeVertexId, EntityIdWithInterval, EntityTypeVertexId, EntityVertexId,
@@ -464,8 +463,7 @@ async fn serve_static_schema(Path(path): Path<String>) -> Result<Response, Statu
             TraversalPath,
             EntityTraversalEdge,
             EntityTraversalPath,
-            EntityTraversalEdgeDirection,
-            OntologyTraversalEdgeDirection,
+            EdgeDirection,
 
             DecisionTime,
             TransactionTime,

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
@@ -183,19 +183,13 @@ where
                             }
                             TraversalEdge::HasLeftEntity { direction } => {
                                 knowledge_edges_to_traverse
-                                    .entry((
-                                        KnowledgeGraphEdgeKind::HasLeftEntity,
-                                        EdgeDirection::from(*direction),
-                                    ))
+                                    .entry((KnowledgeGraphEdgeKind::HasLeftEntity, *direction))
                                     .or_insert_with(default_traversal_data)
                                     .push(entity_vertex_id, traversal_interval, traversal_params);
                             }
                             TraversalEdge::HasRightEntity { direction } => {
                                 knowledge_edges_to_traverse
-                                    .entry((
-                                        KnowledgeGraphEdgeKind::HasRightEntity,
-                                        EdgeDirection::from(*direction),
-                                    ))
+                                    .entry((KnowledgeGraphEdgeKind::HasRightEntity, *direction))
                                     .or_insert_with(default_traversal_data)
                                     .push(entity_vertex_id, traversal_interval, traversal_params);
                             }
@@ -249,19 +243,13 @@ where
                         match edge {
                             EntityTraversalEdge::HasLeftEntity { direction } => {
                                 knowledge_edges_to_traverse
-                                    .entry((
-                                        KnowledgeGraphEdgeKind::HasLeftEntity,
-                                        EdgeDirection::from(*direction),
-                                    ))
+                                    .entry((KnowledgeGraphEdgeKind::HasLeftEntity, *direction))
                                     .or_insert_with(default_traversal_data)
                                     .push(entity_vertex_id, traversal_interval, traversal_params);
                             }
                             EntityTraversalEdge::HasRightEntity { direction } => {
                                 knowledge_edges_to_traverse
-                                    .entry((
-                                        KnowledgeGraphEdgeKind::HasRightEntity,
-                                        EdgeDirection::from(*direction),
-                                    ))
+                                    .entry((KnowledgeGraphEdgeKind::HasRightEntity, *direction))
                                     .or_insert_with(default_traversal_data)
                                     .push(entity_vertex_id, traversal_interval, traversal_params);
                             }

--- a/libs/@local/graph/store/src/subgraph/edges/edge.rs
+++ b/libs/@local/graph/store/src/subgraph/edges/edge.rs
@@ -2,8 +2,6 @@ use serde::{Serialize, Serializer, ser::SerializeStruct as _};
 #[cfg(feature = "utoipa")]
 use utoipa::{ToSchema, openapi};
 
-use super::{EntityTraversalEdgeDirection, OntologyTraversalEdgeDirection};
-
 #[derive(Debug, Hash, PartialEq, Eq)]
 pub struct OutwardEdge<K, E> {
     pub kind: K,
@@ -28,13 +26,15 @@ where
     }
 }
 
-/// The direction of an edge in a graph.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "codegen", derive(specta::Type))]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde(rename_all = "kebab-case")]
 pub enum EdgeDirection {
-    /// Represents an edge that points from the left endpoint to the right endpoint.
-    Outgoing,
     /// Represents a reversed edge that points from the right endpoint to the left endpoint.
     Incoming,
+    /// Represents an edge that points from the left endpoint to the right endpoint.
+    Outgoing,
 }
 
 impl EdgeDirection {
@@ -43,23 +43,6 @@ impl EdgeDirection {
         match self {
             Self::Outgoing => Self::Incoming,
             Self::Incoming => Self::Outgoing,
-        }
-    }
-}
-
-impl From<OntologyTraversalEdgeDirection> for EdgeDirection {
-    fn from(direction: OntologyTraversalEdgeDirection) -> Self {
-        match direction {
-            OntologyTraversalEdgeDirection::Outgoing => Self::Outgoing,
-        }
-    }
-}
-
-impl From<EntityTraversalEdgeDirection> for EdgeDirection {
-    fn from(direction: EntityTraversalEdgeDirection) -> Self {
-        match direction {
-            EntityTraversalEdgeDirection::Outgoing => Self::Outgoing,
-            EntityTraversalEdgeDirection::Incoming => Self::Incoming,
         }
     }
 }

--- a/libs/@local/graph/store/src/subgraph/edges/mod.rs
+++ b/libs/@local/graph/store/src/subgraph/edges/mod.rs
@@ -16,8 +16,7 @@ pub use self::{
         EdgeKind, GraphResolveDepths, KnowledgeGraphEdgeKind, OntologyEdgeKind, SharedEdgeKind,
     },
     traversal::{
-        BorrowedTraversalParams, EntityTraversalEdge, EntityTraversalEdgeDirection,
-        EntityTraversalEdgeKind, EntityTraversalPath, OntologyTraversalEdgeDirection,
+        BorrowedTraversalParams, EntityTraversalEdge, EntityTraversalEdgeKind, EntityTraversalPath,
         SubgraphTraversalParams, TraversalEdge, TraversalEdgeKind, TraversalPath,
         TraversalPathConversionError,
     },

--- a/libs/@local/graph/store/src/subgraph/edges/traversal.rs
+++ b/libs/@local/graph/store/src/subgraph/edges/traversal.rs
@@ -1,23 +1,6 @@
 use core::error::Error;
 
-use super::GraphResolveDepths;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(feature = "codegen", derive(specta::Type))]
-#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[serde(rename_all = "kebab-case")]
-pub enum EntityTraversalEdgeDirection {
-    Incoming,
-    Outgoing,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(feature = "codegen", derive(specta::Type))]
-#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[serde(rename_all = "kebab-case")]
-pub enum OntologyTraversalEdgeDirection {
-    Outgoing,
-}
+use super::{EdgeDirection, GraphResolveDepths};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "codegen", derive(specta::Type))]
@@ -25,13 +8,9 @@ pub enum OntologyTraversalEdgeDirection {
 #[serde(rename_all = "kebab-case", tag = "kind")]
 pub enum EntityTraversalEdge {
     #[cfg_attr(feature = "utoipa", schema(title = "HasLeftEntityEdge"))]
-    HasLeftEntity {
-        direction: EntityTraversalEdgeDirection,
-    },
+    HasLeftEntity { direction: EdgeDirection },
     #[cfg_attr(feature = "utoipa", schema(title = "HasRightEntityEdge"))]
-    HasRightEntity {
-        direction: EntityTraversalEdgeDirection,
-    },
+    HasRightEntity { direction: EdgeDirection },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
@@ -52,13 +31,9 @@ pub enum TraversalEdge {
     #[cfg_attr(feature = "utoipa", schema(title = "IsOfTypeEdge"))]
     IsOfType,
     #[cfg_attr(feature = "utoipa", schema(title = "HasLeftEntityEdge"))]
-    HasLeftEntity {
-        direction: EntityTraversalEdgeDirection,
-    },
+    HasLeftEntity { direction: EdgeDirection },
     #[cfg_attr(feature = "utoipa", schema(title = "HasRightEntityEdge"))]
-    HasRightEntity {
-        direction: EntityTraversalEdgeDirection,
-    },
+    HasRightEntity { direction: EdgeDirection },
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]

--- a/libs/@local/graph/store/types/index.snap.d.ts
+++ b/libs/@local/graph/store/types/index.snap.d.ts
@@ -11,6 +11,7 @@ export interface CreateEntityPolicyParams {
 export interface EntityPermissions {
 	update?: [EntityEditionId, ...EntityEditionId[]];
 }
+export type EdgeDirection = "incoming" | "outgoing";
 export interface GraphResolveDepths {
 	inheritsFrom?: number;
 	constrainsValuesOn?: number;
@@ -21,12 +22,11 @@ export interface GraphResolveDepths {
 }
 export type EntityTraversalEdge = {
 	kind: "has-left-entity"
-	direction: EntityTraversalEdgeDirection
+	direction: EdgeDirection
 } | {
 	kind: "has-right-entity"
-	direction: EntityTraversalEdgeDirection
+	direction: EdgeDirection
 };
-export type EntityTraversalEdgeDirection = "incoming" | "outgoing";
 export type EntityTraversalEdgeKind = {
 	kind: "has-left-entity"
 } | {
@@ -35,7 +35,6 @@ export type EntityTraversalEdgeKind = {
 export interface EntityTraversalPath {
 	edges: EntityTraversalEdge[];
 }
-export type OntologyTraversalEdgeDirection = "outgoing";
 export type TraversalEdge = {
 	kind: "inherits-from"
 } | {
@@ -50,10 +49,10 @@ export type TraversalEdge = {
 	kind: "is-of-type"
 } | {
 	kind: "has-left-entity"
-	direction: EntityTraversalEdgeDirection
+	direction: EdgeDirection
 } | {
 	kind: "has-right-entity"
-	direction: EntityTraversalEdgeDirection
+	direction: EdgeDirection
 };
 export type TraversalEdgeKind = {
 	kind: "inherits-from"

--- a/tests/graph/benches/read_scaling/knowledge/complete/entity.rs
+++ b/tests/graph/benches/read_scaling/knowledge/complete/entity.rs
@@ -13,9 +13,7 @@ use hash_graph_store::{
     },
     filter::Filter,
     subgraph::{
-        edges::{
-            EntityTraversalEdgeDirection, SubgraphTraversalParams, TraversalEdge, TraversalPath,
-        },
+        edges::{EdgeDirection, SubgraphTraversalParams, TraversalEdge, TraversalPath},
         temporal_axes::{
             PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved,
             VariableTemporalAxisUnresolved,
@@ -328,31 +326,31 @@ fn bench_scaling_read_entity_zero_depths(crit: &mut Criterion) {
                             TraversalPath {
                                 edges: vec![
                                     TraversalEdge::HasLeftEntity {
-                                        direction: EntityTraversalEdgeDirection::Incoming,
+                                        direction: EdgeDirection::Incoming,
                                     },
                                     TraversalEdge::HasRightEntity {
-                                        direction: EntityTraversalEdgeDirection::Outgoing,
+                                        direction: EdgeDirection::Outgoing,
                                     },
                                 ],
                             },
                             TraversalPath {
                                 edges: vec![
                                     TraversalEdge::HasRightEntity {
-                                        direction: EntityTraversalEdgeDirection::Incoming,
+                                        direction: EdgeDirection::Incoming,
                                     },
                                     TraversalEdge::HasLeftEntity {
-                                        direction: EntityTraversalEdgeDirection::Outgoing,
+                                        direction: EdgeDirection::Outgoing,
                                     },
                                 ],
                             },
                             TraversalPath {
                                 edges: vec![TraversalEdge::HasLeftEntity {
-                                    direction: EntityTraversalEdgeDirection::Outgoing,
+                                    direction: EdgeDirection::Outgoing,
                                 }],
                             },
                             TraversalPath {
                                 edges: vec![TraversalEdge::HasLeftEntity {
-                                    direction: EntityTraversalEdgeDirection::Outgoing,
+                                    direction: EdgeDirection::Outgoing,
                                 }],
                             },
                         ],
@@ -405,31 +403,31 @@ fn bench_scaling_read_entity_one_depth(crit: &mut Criterion) {
                             TraversalPath {
                                 edges: vec![
                                     TraversalEdge::HasLeftEntity {
-                                        direction: EntityTraversalEdgeDirection::Incoming,
+                                        direction: EdgeDirection::Incoming,
                                     },
                                     TraversalEdge::HasRightEntity {
-                                        direction: EntityTraversalEdgeDirection::Outgoing,
+                                        direction: EdgeDirection::Outgoing,
                                     },
                                 ],
                             },
                             TraversalPath {
                                 edges: vec![
                                     TraversalEdge::HasRightEntity {
-                                        direction: EntityTraversalEdgeDirection::Incoming,
+                                        direction: EdgeDirection::Incoming,
                                     },
                                     TraversalEdge::HasLeftEntity {
-                                        direction: EntityTraversalEdgeDirection::Outgoing,
+                                        direction: EdgeDirection::Outgoing,
                                     },
                                 ],
                             },
                             TraversalPath {
                                 edges: vec![TraversalEdge::HasLeftEntity {
-                                    direction: EntityTraversalEdgeDirection::Outgoing,
+                                    direction: EdgeDirection::Outgoing,
                                 }],
                             },
                             TraversalPath {
                                 edges: vec![TraversalEdge::HasLeftEntity {
-                                    direction: EntityTraversalEdgeDirection::Outgoing,
+                                    direction: EdgeDirection::Outgoing,
                                 }],
                             },
                         ],

--- a/tests/graph/benches/representative_read/lib.rs
+++ b/tests/graph/benches/representative_read/lib.rs
@@ -48,7 +48,7 @@ use core::{iter, str::FromStr as _};
 use criterion::{BenchmarkId, Criterion};
 use criterion_macro::criterion;
 use hash_graph_store::subgraph::edges::{
-    EntityTraversalEdge, EntityTraversalEdgeDirection, EntityTraversalPath, GraphResolveDepths,
+    EdgeDirection, EntityTraversalEdge, EntityTraversalPath, GraphResolveDepths,
     SubgraphTraversalParams,
 };
 use type_system::principal::actor::ActorEntityUuid;
@@ -119,10 +119,10 @@ fn bench_representative_read_multiple_entities(crit: &mut Criterion) {
             traversal_paths: vec![EntityTraversalPath {
                 edges: vec![
                     EntityTraversalEdge::HasLeftEntity {
-                        direction: EntityTraversalEdgeDirection::Incoming,
+                        direction: EdgeDirection::Incoming,
                     },
                     EntityTraversalEdge::HasRightEntity {
-                        direction: EntityTraversalEdgeDirection::Outgoing,
+                        direction: EdgeDirection::Outgoing,
                     },
                 ],
             }],
@@ -136,10 +136,10 @@ fn bench_representative_read_multiple_entities(crit: &mut Criterion) {
             traversal_paths: vec![EntityTraversalPath {
                 edges: vec![
                     EntityTraversalEdge::HasLeftEntity {
-                        direction: EntityTraversalEdgeDirection::Incoming,
+                        direction: EdgeDirection::Incoming,
                     },
                     EntityTraversalEdge::HasRightEntity {
-                        direction: EntityTraversalEdgeDirection::Outgoing,
+                        direction: EdgeDirection::Outgoing,
                     },
                 ],
             }],
@@ -154,10 +154,10 @@ fn bench_representative_read_multiple_entities(crit: &mut Criterion) {
             traversal_paths: vec![EntityTraversalPath {
                 edges: vec![
                     EntityTraversalEdge::HasLeftEntity {
-                        direction: EntityTraversalEdgeDirection::Incoming,
+                        direction: EdgeDirection::Incoming,
                     },
                     EntityTraversalEdge::HasRightEntity {
-                        direction: EntityTraversalEdgeDirection::Outgoing,
+                        direction: EdgeDirection::Outgoing,
                     },
                 ],
             }],
@@ -173,10 +173,10 @@ fn bench_representative_read_multiple_entities(crit: &mut Criterion) {
             traversal_paths: vec![EntityTraversalPath {
                 edges: vec![
                     EntityTraversalEdge::HasLeftEntity {
-                        direction: EntityTraversalEdgeDirection::Incoming,
+                        direction: EdgeDirection::Incoming,
                     },
                     EntityTraversalEdge::HasRightEntity {
-                        direction: EntityTraversalEdgeDirection::Outgoing,
+                        direction: EdgeDirection::Outgoing,
                     },
                 ],
             }],
@@ -193,10 +193,10 @@ fn bench_representative_read_multiple_entities(crit: &mut Criterion) {
             traversal_paths: vec![EntityTraversalPath {
                 edges: iter::repeat([
                     EntityTraversalEdge::HasLeftEntity {
-                        direction: EntityTraversalEdgeDirection::Incoming,
+                        direction: EdgeDirection::Incoming,
                     },
                     EntityTraversalEdge::HasRightEntity {
-                        direction: EntityTraversalEdgeDirection::Outgoing,
+                        direction: EdgeDirection::Outgoing,
                     },
                 ])
                 .flatten()


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Consolidate edge direction enums into a single `EdgeDirection` type to simplify the API and reduce duplication.

## 🔍 What does this change?

- Replaces `EntityTraversalEdgeDirection` and `OntologyTraversalEdgeDirection` with a single `EdgeDirection` enum
- Updates all references to use the consolidated enum
- Removes unnecessary conversions between direction types
- Updates OpenAPI schema to reflect the consolidated type
- Updates TypeScript type definitions

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- do not affect the execution graph

## 🛡 What tests cover this?

- Existing tests cover this change as the functionality remains the same

## ❓ How to test this?

1. Checkout the branch
2. Run the test suite to ensure all tests pass
3. Verify that entity traversal functionality works as expected

