### PR TITLE
BE-153: HashQL: Implement `IntoIterator` for `&Labels` and `&Messages`

### DIFF
--- a/libs/@local/hashql/diagnostics/src/diagnostic/label.rs
+++ b/libs/@local/hashql/diagnostics/src/diagnostic/label.rs
@@ -1,5 +1,5 @@
 use alloc::borrow::Cow;
-use core::borrow::Borrow;
+use core::{borrow::Borrow, slice};
 
 #[cfg(feature = "render")]
 use annotate_snippets::{Annotation, AnnotationKind};
@@ -309,5 +309,14 @@ impl<S> Labels<S> {
         Labels {
             labels: self.labels.into_iter().map(func).collect(),
         }
+    }
+}
+
+impl<'this, S> IntoIterator for &'this Labels<S> {
+    type IntoIter = slice::Iter<'this, Label<S>>;
+    type Item = &'this Label<S>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.labels.iter()
     }
 }

--- a/libs/@local/hashql/diagnostics/src/diagnostic/message.rs
+++ b/libs/@local/hashql/diagnostics/src/diagnostic/message.rs
@@ -1,5 +1,5 @@
 use alloc::borrow::Cow;
-use core::borrow::Borrow;
+use core::{borrow::Borrow, slice};
 
 #[cfg(feature = "render")]
 use annotate_snippets::{Group, Level};
@@ -361,5 +361,14 @@ impl<S> Messages<S> {
 impl<S> const Default for Messages<S> {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl<'this, S> IntoIterator for &'this Messages<S> {
+    type IntoIter = slice::Iter<'this, Message<S>>;
+    type Item = &'this Message<S>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.messages.iter()
     }
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Implement `IntoIterator` trait for `&Labels<S>` and `&Messages<S>` to enable more ergonomic iteration over these collections.

## 🔍 What does this change?

- Added `IntoIterator` implementation for `&Labels<S>` that returns an iterator over `&Label<S>`
- Added `IntoIterator` implementation for `&Messages<S>` that returns an iterator over `&Message<S>`

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

Existing tests should cover this functionality as it's a convenience implementation that doesn't change behavior.

## ❓ How to test this?

1. Checkout the branch
2. Verify that code that iterates over `Labels` and `Messages` can now use the `for` loop syntax directly
