### PR TITLE
SRE-29: Run `yarn` in `changeset` release PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
         uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1.5.3
         with:
           publish: yarn changeset publish
+          version: yarn changeset version && yarn
         env:
           GITHUB_TOKEN: ${{ secrets.MACHINE_USER_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We need to run `yarn` after Changesets turns changeset files into version updates, otherwise `yarn.lock` is out of sync with the version numbers in the repo.