### PR TITLE
FE-40: Add `vercel.json` for new Storybook instance

### DIFF
--- a/libs/@hashintel/ds-components/vercel.json
+++ b/libs/@hashintel/ds-components/vercel.json
@@ -1,0 +1,8 @@
+{
+  "github": {
+    "silent": true,
+    "autoJobCancelation": true
+  },
+  "buildCommand": "turbo run storybook:build",
+  "outputDirectory": "storybook-static"
+}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Adds Vercel build command for the new Storybook instance.

Already available online at https://hash.design/ – this just puts the custom build command in the repository (rather than entering it in the Vercel UI, which I did to check it worked for deploying the app).