### PR TITLE
SRE-64: Switch from exact to caret versioning for Cargo dependencies

### DIFF
--- a/.claude/skills/managing-cargo-dependencies/SKILL.md
+++ b/.claude/skills/managing-cargo-dependencies/SKILL.md
@@ -28,7 +28,7 @@ Automatically activates when:
 ✅ **DO:**
 
 - Add external dependencies to workspace root `[workspace.dependencies]`
-- Use exact versions with `=` prefix (e.g., `version = "=1.0.0"`)
+- Use caret version specifiers (e.g., `version = "1.0.0"` = `^1.0.0`)
 - Set `default-features = false` for all dependencies unless specifically needed
 - Use `workspace = true` in package Cargo.toml
 - Organize dependencies into 4 sections with comment headers
@@ -38,7 +38,7 @@ Automatically activates when:
 ❌ **DON'T:**
 
 - Add version numbers directly in package Cargo.toml
-- Use version ranges or `^` prefixes in workspace root
+- Use exact versions with `=` prefix (e.g., `=1.0.0`) in workspace root
 - Enable `default-features` without considering impact
 - Mix different dependency types without section comments
 - Forget `public = true` for dependencies exposed in public API
@@ -75,7 +75,7 @@ regex       = { workspace = true }
 ### Quick Add Process
 
 1. **Check workspace root** - Is dependency already there?
-2. **Add to workspace if needed** - With exact version `=1.2.3`
+2. **Add to workspace if needed** - With caret version `1.2.3`
 3. **Determine section** - Public workspace/third-party or private?
 4. **Add to package** - Use `workspace = true` (+ `public = true` if needed)
 
@@ -119,10 +119,10 @@ Choose the guide that matches your task:
 
 ### Adding a New External Dependency
 
-```bash
+```toml
 # 1. Add to workspace root Cargo.toml
 [workspace.dependencies]
-my-crate = { version = "=1.2.3", default-features = false }
+my-crate = { version = "1.2.3", default-features = false }
 
 # 2. Add to package Cargo.toml (appropriate section)
 [dependencies]

--- a/.claude/skills/managing-cargo-dependencies/resources/examples-reference.md
+++ b/.claude/skills/managing-cargo-dependencies/resources/examples-reference.md
@@ -199,9 +199,17 @@ my-new-crate = { workspace = true, public = true }
 ### ❌ Version in Package
 
 ```toml
-# WRONG - version should be in workspace root
+# WRONG - version should be in workspace root only
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0.228", features = ["derive"] }
+```
+
+### ❌ Exact Pinning in Workspace
+
+```toml
+# WRONG - use caret versions, let Cargo.lock handle exact pinning
+[workspace.dependencies]
+serde = { version = "=1.0.228", default-features = false }
 ```
 
 ### ❌ Missing Section Comments

--- a/.claude/skills/managing-cargo-dependencies/resources/workspace-setup.md
+++ b/.claude/skills/managing-cargo-dependencies/resources/workspace-setup.md
@@ -29,9 +29,9 @@ All external crates must be defined in workspace root `[workspace.dependencies]`
 ```toml
 [workspace.dependencies]
 # External dependencies
-serde = { version = "=1.0.228", default-features = false }
-tokio = { version = "=1.47.1", default-features = false }
-regex = { version = "=1.11.1", default-features = false }
+serde = { version = "1.0.228", default-features = false }
+tokio = { version = "1.47.1", default-features = false }
+regex = { version = "1.11.1", default-features = false }
 ```
 
 ### With Features (at workspace level)
@@ -39,37 +39,31 @@ regex = { version = "=1.11.1", default-features = false }
 ```toml
 [workspace.dependencies]
 # When you need features enabled everywhere
-derive_more = { version = "=1.0.0", default-features = false, features = ["debug", "from"] }
+derive_more = { version = "1.0.0", default-features = false, features = ["debug", "from"] }
 ```
 
 **Note:** Usually better to enable features at package level for granular control.
 
 ---
 
-## Version Pinning
+## Version Specifiers
 
-HASH uses **exact version pinning** for reproducible builds:
+HASH uses **caret version specifiers** (e.g., `1.0.228` = `^1.0.228`) for reproducible builds with `Cargo.lock`:
 
 ✅ **Correct:**
 
 ```toml
-serde = { version = "=1.0.228", default-features = false }
-tokio = { version = "=1.47.1", default-features = false }
+serde = { version = "1.0.228", default-features = false }
+tokio = { version = "1.47.1", default-features = false }
 ```
 
 ❌ **Wrong:**
 
 ```toml
-serde = { version = "1.0", default-features = false }      # No version range
-serde = { version = "^1.0.228", default-features = false } # No caret
+serde = { version = "=1.0.228", default-features = false } # Exact pinning (not needed)
 tokio = "1.47"                                              # No shorthand
+serde = { version = "1.0", default-features = false }      # Too vague
 ```
-
-### Why Exact Versions?
-
-- **Reproducible builds** - Same code builds identically months later
-- **Predictable CI** - No surprise version updates breaking builds
-- **Explicit updates** - Dependency updates are intentional, reviewed changes
 
 ---
 
@@ -93,6 +87,8 @@ Then enable specific features in package Cargo.toml:
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 serde = { workspace = true, features = ["derive"] }
 ```
+
+**Note:** Workspace root should have `default-features = false`, but package level can override with specific features.
 
 ### Why Disable Defaults?
 
@@ -130,16 +126,16 @@ Group related dependencies with comments:
 error-stack = { path = "libs/error-stack" }
 
 # Async runtime
-tokio = { version = "=1.47.1", default-features = false }
-tokio-util = { version = "=0.7.13", default-features = false }
+tokio = { version = "1.47.1", default-features = false }
+tokio-util = { version = "0.7.13", default-features = false }
 
 # Serialization
-serde = { version = "=1.0.228", default-features = false }
-serde_json = { version = "=1.0.138", default-features = false }
+serde = { version = "1.0.228", default-features = false }
+serde_json = { version = "1.0.138", default-features = false }
 
 # Database
-postgres = { version = "=0.19.9", default-features = false }
-postgres-types = { version = "=0.2.8", default-features = false }
+postgres = { version = "0.19.9", default-features = false }
+postgres-types = { version = "0.2.8", default-features = false }
 ```
 
 ---
@@ -163,7 +159,7 @@ cargo add my-crate --dry-run
 ```toml
 [workspace.dependencies]
 # Add to appropriate section
-tracing = { version = "=0.1.41", default-features = false }
+tracing = { version = "0.1.41", default-features = false }
 ```
 
 ### Adding with Specific Features (workspace-wide)
@@ -171,7 +167,7 @@ tracing = { version = "=0.1.41", default-features = false }
 ```toml
 [workspace.dependencies]
 # When all packages need the same features
-uuid = { version = "=1.11.0", default-features = false, features = ["v4", "serde"] }
+uuid = { version = "1.11.0", default-features = false, features = ["v4", "serde"] }
 ```
 
 ### Adding Workspace Member

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,170 +111,170 @@ bytes-utils       = { version = "=0.1.4", default-features = false }
 camino            = { version = "=1.1.12", default-features = false }
 cargo_metadata    = { version = "=0.22.0", default-features = false }
 # FIXME: Remove `decimal`: https://github.com/cedar-policy/cedar/issues/1700
-cedar-policy-core                  = { version = "=4.5.1", default-features = false, features = ["decimal"] }
-circular-buffer                    = { version = "=1.1.0", default-features = false }
-clap                               = { version = "=4.5.51", features = ["color", "error-context", "help", "std", "suggestions", "usage"] }
-clap_builder                       = { version = "=4.5.51", default-features = false, features = ["std"] }
-clap_complete                      = { version = "=4.5.60", default-features = false }
-console_error_panic_hook           = { version = "=0.1.7", default-features = false }
-convert_case                       = { version = "=0.8.0", default-features = false }
-criterion                          = { version = "=0.7.0" }
-criterion-macro                    = { version = "=0.4.0", default-features = false }
-dashu-base                         = { version = "=0.4.1", default-features = false }
-dashu-float                        = { version = "=0.4.3", default-features = false }
-deadpool                           = { version = "=0.12.3", default-features = false }
-deadpool-postgres                  = { version = "=0.14.1", default-features = false }
-derive-where                       = { version = "=1.6.0", default-features = false, features = ["nightly"] }
-derive_more                        = { version = "=2.0.1", default-features = false }
-dotenv-flow                        = { version = "=0.16.2", default-features = false }
-either                             = { version = "=1.15.0", default-features = false }
-email_address                      = { version = "=0.2.9", default-features = false }
-ena                                = { version = "=0.14.3", default-features = false }
-enum-iterator                      = { version = "=2.1.0", default-features = false }
-enumflags2                         = { version = "=0.7.12", default-features = false }
-expect-test                        = { version = "=1.5.1", default-features = false }
-foldhash                           = { version = "=0.2.0", default-features = false }
-frunk                              = { version = "=0.4.4", default-features = false }
-frunk_core                         = { version = "=0.4.4", default-features = false }
-futures                            = { version = "=0.3.31", default-features = false }
-futures-channel                    = { version = "=0.3.31", default-features = false }
-futures-core                       = { version = "=0.3.31", default-features = false }
-futures-io                         = { version = "=0.3.31", default-features = false }
-futures-sink                       = { version = "=0.3.31", default-features = false }
-futures-util                       = { version = "=0.3.31", default-features = false }
-globset                            = { version = "=0.4.18", default-features = false }
-guppy                              = { version = "=0.17.20", default-features = false }
-hashbrown                          = { version = "=0.16.0", default-features = false, features = ["inline-more", "nightly"] }
-hifijson                           = { version = "=0.2.3", default-features = false }
-http                               = { version = "=1.3.1", default-features = false }
-humansize                          = { version = "=2.1.3", default-features = false }
-hyper                              = { version = "=1.7.0", default-features = false }
-include_dir                        = { version = "=0.7.4", default-features = false }
-include_dir_macros                 = { version = "=0.7.4", default-features = false }
-indexmap                           = { version = "=2.12.0", default-features = false }
-indicatif                          = { version = "=0.18.2", default-features = false }
-indoc                              = { version = "=2.0.7", default-features = false }
-inferno                            = { version = "=0.12.3", default-features = false }
-insta                              = { version = "=1.43.2", default-features = false }
-iso8601-duration                   = { version = "=0.2.0", default-features = false }
-itertools                          = { version = "=0.14.0", default-features = false }
-json-number                        = { version = "=0.4.9", default-features = false }
-jsonptr                            = { version = "=0.7.1", default-features = false }
-lexical                            = { version = "=7.0.5", default-features = false }
-libp2p                             = { version = "=0.56.0", default-features = false }
-libp2p-core                        = { version = "=0.43.1", default-features = false }
-libp2p-identity                    = { version = "=0.2.12", default-features = false }
-libp2p-ping                        = { version = "=0.47.0", default-features = false }
-libp2p-stream                      = { version = "=0.4.0-alpha", default-features = false }
-libp2p-swarm                       = { version = "=0.47.0", default-features = false }
-libp2p-yamux                       = { version = "=0.47.0", default-features = false }
-libtest-mimic                      = { version = "=0.8.1", default-features = false }
-line-index                         = { version = "=0.1.2", default-features = false }
-logos                              = { version = "=0.15.1", default-features = false }
-memchr                             = { version = "=2.7.6", default-features = false }
-mimalloc                           = { version = "=0.1.48", default-features = false }
-mime                               = { version = "=0.3.17", default-features = false }
-multiaddr                          = { version = "=0.18.2", default-features = false }
-multistream-select                 = { version = "=0.13.0", default-features = false }
-napi                               = { version = "=2.16.17", default-features = false }
-napi-build                         = { version = "=2.2.4", default-features = false }
-napi-derive                        = { version = "=2.16.13", default-features = false }
-nextest-filtering                  = { version = "=0.16.0", default-features = false }
-nextest-metadata                   = { version = "=0.12.2", default-features = false }
-opentelemetry                      = { version = "=0.30.0", default-features = false }
-opentelemetry-appender-tracing     = { version = "=0.30.1", default-features = false }
-opentelemetry-otlp                 = { version = "=0.30.0", default-features = false }
-opentelemetry-semantic-conventions = { version = "=0.30.0", default-features = false }
-opentelemetry_sdk                  = { version = "=0.30.0", default-features = false }
-owo-colors                         = { version = "=4.2.3", default-features = false }
-oxc                                = { version = "=0.95.0", default-features = false, features = ["allocator_api"] }
-pin-project                        = { version = "=1.1.10", default-features = false }
-pin-project-lite                   = { version = "=0.2.16", default-features = false }
-postgres-protocol                  = { version = "=0.6.9", default-features = false }
-postgres-types                     = { version = "=0.2.11", default-features = false }
-pretty                             = { version = "=0.12.5", default-features = false }
-pretty_assertions                  = { version = "=1.4.1", default-features = false, features = ["alloc"] }
-proc-macro-error2                  = { version = "=2.0.1", default-features = false }
-proc-macro2                        = { version = "=1.0.103", default-features = false }
-prometheus-client                  = { version = "=0.24.0", default-features = false }
-proptest                           = { version = "=1.7.0", default-features = false, features = ["alloc", "std"] }                                                                                  # `std` or `no_std` are required, `no_std` pulls in `libm`
-quote                              = { version = "=1.0.41", default-features = false }
-radix_trie                         = { version = "=0.2.1", default-features = false }
-rand                               = { version = "=0.9.2", default-features = false }
-rand_distr                         = { version = "=0.5.1", default-features = false }
-rapidfuzz                          = { version = "=0.5.0", default-features = false }
-rayon                              = { version = "=1.11.0", default-features = false }
-refinery                           = { version = "=0.8.16", default-features = false }
-regex                              = { version = "=1.11.2", default-features = false, features = ["perf", "unicode"] }
-reqwest                            = { version = "=0.12.24", default-features = false, features = ["rustls-tls"] }
-reqwest-middleware                 = { version = "=0.4.2", default-features = false }
-reqwest-tracing                    = { version = "=0.5.8", default-features = false }
-roaring                            = { version = "=0.11.2", default-features = false }
-rpds                               = { version = "=1.1.2", default-features = false }
-rstest                             = { version = "=0.26.1", default-features = false }
-rustc_version                      = { version = "=0.4.1", default-features = false }
-scc                                = { version = "=2.4.0", default-features = false }
-semver                             = { version = "=1.0.27", default-features = false }
-sentry                             = { version = "=0.42.0", default-features = false, features = ["backtrace", "contexts", "debug-images", "panic", "reqwest", "rustls", "tower-http", "tracing"] }
-sentry-core                        = { version = "=0.42.0", default-features = false }
-sentry-types                       = { version = "=0.42.0", default-features = false }
-serde                              = { version = "=1.0.228", default-features = false }
-serde_core                         = { version = "=1.0.228", default-features = false }
-serde_json                         = { version = "=1.0.145" }
-serde_plain                        = { version = "=1.0.2", default-features = false }
-sha2                               = { version = "=0.10.9", default-features = false }
-similar-asserts                    = { version = "=1.7.0", default-features = false }
-simple-mermaid                     = { version = "=0.2.0", default-features = false }
-smallvec                           = { version = "=2.0.0-alpha.11", default-features = false }
-smol_str                           = { version = "=0.3.4" }
-specta                             = { version = "=2.0.0-rc.22", default-features = false }
-supports-color                     = { version = "=3.0.2", default-features = false }
-supports-unicode                   = { version = "=3.0.0", default-features = false }
-syn                                = { version = "=2.0.108", default-features = false }
-tachyonix                          = { version = "=0.3.1", default-features = false }
-tarpc                              = { version = "=0.36.0", default-features = false, git = "https://github.com/google/tarpc", rev = "f55f36d2d876b1868cfcf52f41d0456a60cf726c" }
+cedar-policy-core                  = { version = "4.5.1", default-features = false, features = ["decimal"] }
+circular-buffer                    = { version = "1.1.0", default-features = false }
+clap                               = { version = "4.5.51", features = ["color", "error-context", "help", "std", "suggestions", "usage"] }
+clap_builder                       = { version = "4.5.51", default-features = false, features = ["std"] }
+clap_complete                      = { version = "4.5.60", default-features = false }
+console_error_panic_hook           = { version = "0.1.7", default-features = false }
+convert_case                       = { version = "0.8.0", default-features = false }
+criterion                          = { version = "0.7.0" }
+criterion-macro                    = { version = "0.4.0", default-features = false }
+dashu-base                         = { version = "0.4.1", default-features = false }
+dashu-float                        = { version = "0.4.3", default-features = false }
+deadpool                           = { version = "0.12.3", default-features = false }
+deadpool-postgres                  = { version = "0.14.1", default-features = false }
+derive-where                       = { version = "1.6.0", default-features = false, features = ["nightly"] }
+derive_more                        = { version = "2.0.1", default-features = false }
+dotenv-flow                        = { version = "0.16.2", default-features = false }
+either                             = { version = "1.15.0", default-features = false }
+email_address                      = { version = "0.2.9", default-features = false }
+ena                                = { version = "0.14.3", default-features = false }
+enum-iterator                      = { version = "2.1.0", default-features = false }
+enumflags2                         = { version = "0.7.12", default-features = false }
+expect-test                        = { version = "1.5.1", default-features = false }
+foldhash                           = { version = "0.2.0", default-features = false }
+frunk                              = { version = "0.4.4", default-features = false }
+frunk_core                         = { version = "0.4.4", default-features = false }
+futures                            = { version = "0.3.31", default-features = false }
+futures-channel                    = { version = "0.3.31", default-features = false }
+futures-core                       = { version = "0.3.31", default-features = false }
+futures-io                         = { version = "0.3.31", default-features = false }
+futures-sink                       = { version = "0.3.31", default-features = false }
+futures-util                       = { version = "0.3.31", default-features = false }
+globset                            = { version = "0.4.18", default-features = false }
+guppy                              = { version = "0.17.20", default-features = false }
+hashbrown                          = { version = "0.16.0", default-features = false, features = ["inline-more", "nightly"] }
+hifijson                           = { version = "0.2.3", default-features = false }
+http                               = { version = "1.3.1", default-features = false }
+humansize                          = { version = "2.1.3", default-features = false }
+hyper                              = { version = "1.7.0", default-features = false }
+include_dir                        = { version = "0.7.4", default-features = false }
+include_dir_macros                 = { version = "0.7.4", default-features = false }
+indexmap                           = { version = "2.12.0", default-features = false }
+indicatif                          = { version = "0.18.2", default-features = false }
+indoc                              = { version = "2.0.7", default-features = false }
+inferno                            = { version = "0.12.3", default-features = false }
+insta                              = { version = "1.43.2", default-features = false }
+iso8601-duration                   = { version = "0.2.0", default-features = false }
+itertools                          = { version = "0.14.0", default-features = false }
+json-number                        = { version = "0.4.9", default-features = false }
+jsonptr                            = { version = "0.7.1", default-features = false }
+lexical                            = { version = "7.0.5", default-features = false }
+libp2p                             = { version = "0.56.0", default-features = false }
+libp2p-core                        = { version = "0.43.1", default-features = false }
+libp2p-identity                    = { version = "0.2.12", default-features = false }
+libp2p-ping                        = { version = "0.47.0", default-features = false }
+libp2p-stream                      = { version = "0.4.0-alpha", default-features = false }
+libp2p-swarm                       = { version = "0.47.0", default-features = false }
+libp2p-yamux                       = { version = "0.47.0", default-features = false }
+libtest-mimic                      = { version = "0.8.1", default-features = false }
+line-index                         = { version = "0.1.2", default-features = false }
+logos                              = { version = "0.15.1", default-features = false }
+memchr                             = { version = "2.7.6", default-features = false }
+mimalloc                           = { version = "0.1.48", default-features = false }
+mime                               = { version = "0.3.17", default-features = false }
+multiaddr                          = { version = "0.18.2", default-features = false }
+multistream-select                 = { version = "0.13.0", default-features = false }
+napi                               = { version = "2.16.17", default-features = false }
+napi-build                         = { version = "2.2.4", default-features = false }
+napi-derive                        = { version = "2.16.13", default-features = false }
+nextest-filtering                  = { version = "0.16.0", default-features = false }
+nextest-metadata                   = { version = "0.12.2", default-features = false }
+opentelemetry                      = { version = "0.30.0", default-features = false }
+opentelemetry-appender-tracing     = { version = "0.30.1", default-features = false }
+opentelemetry-otlp                 = { version = "0.30.0", default-features = false }
+opentelemetry-semantic-conventions = { version = "0.30.0", default-features = false }
+opentelemetry_sdk                  = { version = "0.30.0", default-features = false }
+owo-colors                         = { version = "4.2.3", default-features = false }
+oxc                                = { version = "0.95.0", default-features = false, features = ["allocator_api"] }
+pin-project                        = { version = "1.1.10", default-features = false }
+pin-project-lite                   = { version = "0.2.16", default-features = false }
+postgres-protocol                  = { version = "0.6.9", default-features = false }
+postgres-types                     = { version = "0.2.11", default-features = false }
+pretty                             = { version = "0.12.5", default-features = false }
+pretty_assertions                  = { version = "1.4.1", default-features = false, features = ["alloc"] }
+proc-macro-error2                  = { version = "2.0.1", default-features = false }
+proc-macro2                        = { version = "1.0.103", default-features = false }
+prometheus-client                  = { version = "0.24.0", default-features = false }
+proptest                           = { version = "1.7.0", default-features = false, features = ["alloc", "std"] }                                                                                  # `std` or `no_std` are required, `no_std` pulls in `libm`
+quote                              = { version = "1.0.41", default-features = false }
+radix_trie                         = { version = "0.2.1", default-features = false }
+rand                               = { version = "0.9.2", default-features = false }
+rand_distr                         = { version = "0.5.1", default-features = false }
+rapidfuzz                          = { version = "0.5.0", default-features = false }
+rayon                              = { version = "1.11.0", default-features = false }
+refinery                           = { version = "0.8.16", default-features = false }
+regex                              = { version = "1.11.2", default-features = false, features = ["perf", "unicode"] }
+reqwest                            = { version = "0.12.24", default-features = false, features = ["rustls-tls"] }
+reqwest-middleware                 = { version = "0.4.2", default-features = false }
+reqwest-tracing                    = { version = "0.5.8", default-features = false }
+roaring                            = { version = "0.11.2", default-features = false }
+rpds                               = { version = "1.1.2", default-features = false }
+rstest                             = { version = "0.26.1", default-features = false }
+rustc_version                      = { version = "0.4.1", default-features = false }
+scc                                = { version = "2.4.0", default-features = false }
+semver                             = { version = "1.0.27", default-features = false }
+sentry                             = { version = "0.42.0", default-features = false, features = ["backtrace", "contexts", "debug-images", "panic", "reqwest", "rustls", "tower-http", "tracing"] }
+sentry-core                        = { version = "0.42.0", default-features = false }
+sentry-types                       = { version = "0.42.0", default-features = false }
+serde                              = { version = "1.0.228", default-features = false }
+serde_core                         = { version = "1.0.228", default-features = false }
+serde_json                         = { version = "1.0.145" }
+serde_plain                        = { version = "1.0.2", default-features = false }
+sha2                               = { version = "0.10.9", default-features = false }
+similar-asserts                    = { version = "1.7.0", default-features = false }
+simple-mermaid                     = { version = "0.2.0", default-features = false }
+smallvec                           = { version = "2.0.0-alpha.11", default-features = false }
+smol_str                           = { version = "0.3.4" }
+specta                             = { version = "2.0.0-rc.22", default-features = false }
+supports-color                     = { version = "3.0.2", default-features = false }
+supports-unicode                   = { version = "3.0.0", default-features = false }
+syn                                = { version = "2.0.108", default-features = false }
+tachyonix                          = { version = "0.3.1", default-features = false }
+tarpc                              = { version = "0.36.0", default-features = false, git = "https://github.com/google/tarpc", rev = "f55f36d2d876b1868cfcf52f41d0456a60cf726c" }
 temporal-client                    = { git = "https://github.com/temporalio/sdk-core", rev = "4a2368d" }
 temporal-sdk-core-protos           = { git = "https://github.com/temporalio/sdk-core", rev = "4a2368d" }
-test-log                           = { version = "=0.2.18", default-features = false }
-test-strategy                      = { version = "=0.4.3", default-features = false }
-text-size                          = { version = "=1.1.1", default-features = false }
-thiserror                          = { version = "=2.0.17", default-features = false }
-time                               = { version = "=0.3.44", default-features = false }
-tokio                              = { version = "=1.47.1", default-features = false }
-tokio-postgres                     = { version = "=0.7.15", default-features = false }
-tokio-stream                       = { version = "=0.1.17", default-features = false }
-tokio-test                         = { version = "=0.4.4", default-features = false }
-tokio-util                         = { version = "=0.7.16", default-features = false }
-toml                               = { version = "=0.9.8", default-features = false }
-tower                              = { version = "=0.5.2", default-features = false }
-tower-http                         = { version = "=0.6.6", features = ["trace"] }
-tower-layer                        = { version = "=0.3.3", default-features = false }
-tower-service                      = { version = "=0.3.3", default-features = false }
-tower-test                         = { version = "=0.4.0", default-features = false }
-tracing                            = { version = "=0.1.41", default-features = false }
-tracing-appender                   = { version = "=0.2.3", default-features = false }
-tracing-core                       = { version = "=0.1.34", default-features = false }
-tracing-error                      = { version = "=0.2.1", default-features = false }
-tracing-flame                      = { version = "=0.2.0", default-features = false }
-tracing-indicatif                  = { version = "=0.3.13", default-features = false }
-tracing-opentelemetry              = { version = "=0.31.0", default-features = false }
-tracing-subscriber                 = { version = "=0.3.20", default-features = false }
-trait-variant                      = { version = "=0.1.2", default-features = false }
-trybuild                           = { version = "=1.0.113", default-features = false }
-tsify-next                         = { version = "=0.5.6", default-features = false }
+test-log                           = { version = "0.2.18", default-features = false }
+test-strategy                      = { version = "0.4.3", default-features = false }
+text-size                          = { version = "1.1.1", default-features = false }
+thiserror                          = { version = "2.0.17", default-features = false }
+time                               = { version = "0.3.44", default-features = false }
+tokio                              = { version = "1.47.1", default-features = false }
+tokio-postgres                     = { version = "0.7.15", default-features = false }
+tokio-stream                       = { version = "0.1.17", default-features = false }
+tokio-test                         = { version = "0.4.4", default-features = false }
+tokio-util                         = { version = "0.7.16", default-features = false }
+toml                               = { version = "0.9.8", default-features = false }
+tower                              = { version = "0.5.2", default-features = false }
+tower-http                         = { version = "0.6.6", features = ["trace"] }
+tower-layer                        = { version = "0.3.3", default-features = false }
+tower-service                      = { version = "0.3.3", default-features = false }
+tower-test                         = { version = "0.4.0", default-features = false }
+tracing                            = { version = "0.1.41", default-features = false }
+tracing-appender                   = { version = "0.2.3", default-features = false }
+tracing-core                       = { version = "0.1.34", default-features = false }
+tracing-error                      = { version = "0.2.1", default-features = false }
+tracing-flame                      = { version = "0.2.0", default-features = false }
+tracing-indicatif                  = { version = "0.3.13", default-features = false }
+tracing-opentelemetry              = { version = "0.31.0", default-features = false }
+tracing-subscriber                 = { version = "0.3.20", default-features = false }
+trait-variant                      = { version = "0.1.2", default-features = false }
+trybuild                           = { version = "1.0.113", default-features = false }
+tsify-next                         = { version = "0.5.6", default-features = false }
 unicase                            = { version = "2.8.1", default-features = false }
-unicode-ident                      = { version = "=1.0.22", default-features = false }
-unicode-normalization              = { version = "=0.1.25", default-features = false }
-unicode-properties                 = { version = "=0.1.4", default-features = false }
-unicode-segmentation               = { version = "=1.12.0", default-features = false }
-url                                = { version = "=2.5.7", default-features = false }
-utoipa                             = { version = "=4.2.3", default-features = false }
-uuid                               = { version = "=1.18.1", default-features = false }
-walkdir                            = { version = "=2.5.0", default-features = false }
-wasm-bindgen                       = { version = "=0.2.100", default-features = false }
-wasm-bindgen-test                  = { version = "=0.3.50", default-features = false }
-winnow                             = { version = "=0.7.13", default-features = false }
-xxhash-rust                        = { version = "=0.8.15", default-features = false }
+unicode-ident                      = { version = "1.0.22", default-features = false }
+unicode-normalization              = { version = "0.1.25", default-features = false }
+unicode-properties                 = { version = "0.1.4", default-features = false }
+unicode-segmentation               = { version = "1.12.0", default-features = false }
+url                                = { version = "2.5.7", default-features = false }
+utoipa                             = { version = "4.2.3", default-features = false }
+uuid                               = { version = "1.18.1", default-features = false }
+walkdir                            = { version = "2.5.0", default-features = false }
+wasm-bindgen                       = { version = "0.2.100", default-features = false }
+wasm-bindgen-test                  = { version = "0.3.50", default-features = false }
+winnow                             = { version = "0.7.13", default-features = false }
+xxhash-rust                        = { version = "0.8.15", default-features = false }
 
 [profile.dev]
 # TODO: Use `codegen-backend = "cranelift"`


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Switch from exact version pinning to caret version specifiers in Cargo dependencies

## 🔗 Related links

- N/A

## 🔍 What does this change?

- Updates the Cargo dependency management skill documentation to recommend caret version specifiers instead of exact pinning
- Removes `=` prefix from all dependency versions in the workspace root Cargo.toml
- Updates examples and guidance in skill documentation to reflect the new approach
- Adds an example of incorrect exact pinning in the examples reference

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- Existing tests should continue to pass as this is a stylistic change to version specification

## ❓ How to test this?

1. Verify that all dependencies still resolve correctly
2. Confirm that builds continue to work as expected
