### PR TITLE
SRE-80: Add `CPUUtilization` CloudWatch alert for RDS

### DIFF
--- a/infra/terraform/hash/postgres/alerts.tf
+++ b/infra/terraform/hash/postgres/alerts.tf
@@ -47,3 +47,32 @@ resource "aws_cloudwatch_metric_alarm" "rds_free_storage_space" {
     Purpose  = "Alert when RDS free storage space is critically low"
   }
 }
+
+# CloudWatch Alarm for RDS CPU utilization
+resource "aws_cloudwatch_metric_alarm" "rds_cpu_utilization_high" {
+  alarm_name        = "${var.prefix}-rds-cpu-utilization-high"
+  alarm_description = "WARNING: RDS instance ${aws_db_instance.postgres.identifier} has high CPU utilization."
+
+  # RDS CPU metrics
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/RDS"
+  statistic           = "Average"
+  period              = 300 # 5 minutes
+  evaluation_periods  = 2   # Must be high for 10 minutes total
+  threshold           = 80  # 80%
+  comparison_operator = "GreaterThanThreshold"
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    DBInstanceIdentifier = aws_db_instance.postgres.identifier
+  }
+
+  alarm_actions = [aws_sns_topic.database_alerts.arn]
+  ok_actions    = [aws_sns_topic.database_alerts.arn]
+
+  tags = {
+    Name     = "${var.prefix}-rds-cpu-utilization-high-alarm"
+    Severity = "WARNING"
+    Purpose  = "Alert when RDS CPU utilization is consistently high"
+  }
+}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Add a CloudWatch alarm for high CPU utilization on RDS PostgreSQL instances to improve monitoring and alerting capabilities.

## 🔍 What does this change?

- Adds a new CloudWatch metric alarm that triggers when RDS CPU utilization exceeds 80% for 10 minutes
- Configures the alarm to send notifications to the existing database alerts SNS topic
- Sets appropriate tags for severity (WARNING) and purpose documentation

## 🛡 What tests cover this?

- Terraform plan validation will verify the resource configuration

## ❓ How to test this?

1. Apply the Terraform changes
2. Verify the new alarm appears in CloudWatch
3. Optionally, simulate high CPU load to confirm the alert triggers correctly

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph
