### PR TITLE
SRE-86: Add `FreeableMemory` CloudWatch alert for RDS

### DIFF
--- a/infra/terraform/hash/postgres/alerts.tf
+++ b/infra/terraform/hash/postgres/alerts.tf
@@ -29,7 +29,8 @@ resource "aws_cloudwatch_metric_alarm" "rds_free_storage_space" {
   namespace           = "AWS/RDS"
   statistic           = "Minimum"
   period              = 300                     # 5 minutes
-  evaluation_periods  = 2                       # Must be low for 10 minutes total
+  evaluation_periods  = 2                       # 10 minutes total
+  datapoints_to_alarm = 2                       # Both datapoints must be low
   threshold           = 10 * 1024 * 1024 * 1024 # 10GB in bytes
   comparison_operator = "LessThanThreshold"
   treat_missing_data  = "breaching"
@@ -58,7 +59,8 @@ resource "aws_cloudwatch_metric_alarm" "rds_cpu_utilization_high" {
   namespace           = "AWS/RDS"
   statistic           = "Average"
   period              = 300 # 5 minutes
-  evaluation_periods  = 2   # Must be high for 10 minutes total
+  evaluation_periods  = 5   # 25 minutes total
+  datapoints_to_alarm = 3   # 3 of 5 datapoints must be high (grace for spikes)
   threshold           = 80  # 80%
   comparison_operator = "GreaterThanThreshold"
   treat_missing_data  = "notBreaching"
@@ -87,7 +89,8 @@ resource "aws_cloudwatch_metric_alarm" "rds_freeable_memory_low" {
   namespace           = "AWS/RDS"
   statistic           = "Minimum"
   period              = 300               # 5 minutes
-  evaluation_periods  = 2                 # Must be low for 10 minutes total
+  evaluation_periods  = 3                 # 15 minutes total
+  datapoints_to_alarm = 2                 # 2 of 3 datapoints must be low (moderate grace)
   threshold           = 256 * 1024 * 1024 # 256MB in bytes
   comparison_operator = "LessThanThreshold"
   treat_missing_data  = "breaching"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Add a CloudWatch alarm to monitor RDS freeable memory and alert when it drops below a critical threshold.

## 🔍 What does this change?

- Adds a new CloudWatch metric alarm `rds_freeable_memory_low` that triggers when the database instance has less than 1GB of freeable memory for 10 minutes
- Configures the alarm to send notifications to the existing database alerts SNS topic
- Sets appropriate tags for severity and purpose tracking

## 🛡 What tests cover this?

- Existing Terraform validation tests

## ❓ How to test this?

1. Apply the Terraform changes
2. Verify the new CloudWatch alarm appears in the AWS console
3. Confirm the alarm is properly linked to the SNS topic for notifications

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph
