### PR TITLE
SRE-88: Enable AWS GuardDuty with PagerDuty notifications

### DIFF
--- a/infra/terraform/hash/security.tf
+++ b/infra/terraform/hash/security.tf
@@ -28,3 +28,65 @@ resource "aws_guardduty_detector" "main" {
     Purpose = "Threat detection and intrusion monitoring"
   }
 }
+
+# SNS Topic for GuardDuty findings
+resource "aws_sns_topic" "guardduty_findings" {
+  name = "${local.prefix}-guardduty-findings"
+
+  tags = {
+    Name    = "${local.prefix}-guardduty-findings"
+    Service = "security"
+    Purpose = "GuardDuty findings notifications"
+  }
+}
+
+# PagerDuty subscription for GuardDuty findings
+resource "aws_sns_topic_subscription" "guardduty_pagerduty" {
+  topic_arn = aws_sns_topic.guardduty_findings.arn
+  protocol  = "https"
+  endpoint  = "https://events.pagerduty.com/integration/${sensitive(data.vault_kv_secret_v2.secrets.data["pagerduty_infrastructure_security_aws_integration_key"])}/enqueue"
+}
+
+# EventBridge rule to capture GuardDuty findings
+resource "aws_cloudwatch_event_rule" "guardduty_findings" {
+  name        = "${local.prefix}-guardduty-findings"
+  description = "Capture all GuardDuty findings"
+
+  event_pattern = jsonencode({
+    source      = ["aws.guardduty"]
+    detail-type = ["GuardDuty Finding"]
+  })
+
+  tags = {
+    Name    = "${local.prefix}-guardduty-findings-rule"
+    Service = "security"
+    Purpose = "Route GuardDuty findings to SNS"
+  }
+}
+
+# EventBridge target to send findings to SNS
+resource "aws_cloudwatch_event_target" "guardduty_sns" {
+  rule      = aws_cloudwatch_event_rule.guardduty_findings.name
+  target_id = "SendToSNS"
+  arn       = aws_sns_topic.guardduty_findings.arn
+}
+
+# SNS topic policy to allow EventBridge to publish
+resource "aws_sns_topic_policy" "guardduty_findings" {
+  arn = aws_sns_topic.guardduty_findings.arn
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowEventBridgeToPublish"
+        Effect = "Allow"
+        Principal = {
+          Service = "events.amazonaws.com"
+        }
+        Action   = "SNS:Publish"
+        Resource = aws_sns_topic.guardduty_findings.arn
+      }
+    ]
+  })
+}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Add GuardDuty findings integration with PagerDuty to enhance security alerting capabilities. This creates a notification pipeline that routes AWS GuardDuty security findings to PagerDuty for immediate response.

## 🔗 Related links

- AWS GuardDuty documentation: https://docs.aws.amazon.com/guardduty/latest/ug/what-is-guardduty.html
- PagerDuty integration documentation: https://support.pagerduty.com/docs/aws-cloudwatch-integration-guide

## 🔍 What does this change?

- Creates an SNS topic for GuardDuty findings
- Configures a PagerDuty subscription to the SNS topic using a Vault-stored integration key
- Sets up an EventBridge rule to capture all GuardDuty findings
- Configures an EventBridge target to send findings to the SNS topic
- Implements an SNS topic policy to allow EventBridge to publish messages

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- Infrastructure changes will be validated through Terraform plan/apply

## ❓ How to test this?

1. Apply the Terraform changes
2. Generate a test GuardDuty finding
3. Verify the alert appears in PagerDuty
