### PR TITLE
SRE-89: Update Cloudflare provider to version 5.12

### DIFF
--- a/infra/terraform/hash/.terraform.lock.hcl
+++ b/infra/terraform/hash/.terraform.lock.hcl
@@ -2,19 +2,19 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/cloudflare/cloudflare" {
-  version     = "5.8.4"
-  constraints = "~> 5.0"
+  version     = "5.12.0"
+  constraints = "~> 5.0, ~> 5.12"
   hashes = [
-    "h1:ihbA9kw+RRkVjCts0NLwt+eQhrJloCH4JDfXYYCkNlA=",
-    "zh:0e3ffc026d07699189406d7471f6a65e66a35065ee26b7cded6dfff0f5c22fba",
-    "zh:2819e632d8f5437ee8cafbd35a0b44b9ea685aabae95536da345f012b2cbd193",
-    "zh:3ec56bd9e5bcc8bb2012651fa3ad837934603aacdbbb06c2d579681398e993b2",
-    "zh:56f4acef08aee4ba0fca8830b341d46658c6b4f83e55a8badbf4324156d6edd7",
-    "zh:5a8481a1b1b756f5d13c44ae1c89fd04e24e00e85a1e182a80c593130e4061a5",
-    "zh:af2e89d30aed52d0f0477a782303605f58b9868ce6868449c0a2ee1cb1ff825b",
-    "zh:d2622f857b37386e9d58fe9bd8391f9ef5930e3bf78b6e8b1b2b888e3dcc7be2",
-    "zh:e8dd942e2252c52dc68aa75eaeac43053e2d04b768ac9ea191b8da79b9ec4472",
+    "h1:vrbI9qWFMZPA47W+OLnqcBT7+3gk24vfqj5kzoOAyMU=",
+    "zh:06166a72e69eb712ad2c8b49c1ed060223b0d57bb95ce5f6c8440ce19253913e",
+    "zh:484c32dc4fbe1f7baaf00f8d0d1774d259e1a602aebf60b8dea8c6dd122c1d27",
+    "zh:914b4796a5f2c5914cb94864a7541ce132c0e287bf49a5328706d50152117bc4",
+    "zh:bbcf3effe11ad44988c2aa4482c3fd0089ca86527463a9a873cecda1a4a022bc",
+    "zh:c2a59f29b4b4c0344dbb9ab3d78ebcc1d32153f1fd7e919eba7edf7d825119c2",
+    "zh:d6900b39b9c58743e6b1f05b2db7c39276c94f74d501f23bebb88d413266c57c",
+    "zh:f000d33075c30e616df8e58e341614e958eed4a51f3427d2e1a18ea1b7e0c6c6",
     "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+    "zh:ff4fd5b3b0327f8f41fc65d909839288fb98ecfe32a9aff11d2e2638f2109302",
   ]
 }
 
@@ -37,25 +37,6 @@ provider "registry.terraform.io/cyrilgdn/postgresql" {
     "zh:ec864a068eeab48899d99405f5606379478df8e48c005844d63a5360c23d5e15",
     "zh:fda709d1cabde236b79c98c9abb80f2c1591fdea751afadc546073056be6e6ba",
     "zh:ff08607ab25d1c5b55c3794b67a4ee2c9ac5023962c196ce587df34f0e201ca6",
-  ]
-}
-
-provider "registry.terraform.io/hashicorp/archive" {
-  version = "2.7.1"
-  hashes = [
-    "h1:A7EnRBVm4h9ryO9LwxYnKr4fy7ExPMwD5a1DsY7m1Y0=",
-    "zh:19881bb356a4a656a865f48aee70c0b8a03c35951b7799b6113883f67f196e8e",
-    "zh:2fcfbf6318dd514863268b09bbe19bfc958339c636bcbcc3664b45f2b8bf5cc6",
-    "zh:3323ab9a504ce0a115c28e64d0739369fe85151291a2ce480d51ccbb0c381ac5",
-    "zh:362674746fb3da3ab9bd4e70c75a3cdd9801a6cf258991102e2c46669cf68e19",
-    "zh:7140a46d748fdd12212161445c46bbbf30a3f4586c6ac97dd497f0c2565fe949",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:875e6ce78b10f73b1efc849bfcc7af3a28c83a52f878f503bb22776f71d79521",
-    "zh:b872c6ed24e38428d817ebfb214da69ea7eefc2c38e5a774db2ccd58e54d3a22",
-    "zh:cd6a44f731c1633ae5d37662af86e7b01ae4c96eb8b04144255824c3f350392d",
-    "zh:e0600f5e8da12710b0c52d6df0ba147a5486427c1a2cc78f31eea37a47ee1b07",
-    "zh:f21b2e2563bbb1e44e73557bcd6cdbc1ceb369d471049c40eb56cb84b6317a60",
-    "zh:f752829eba1cc04a479cf7ae7271526b402e206d5bcf1fcce9f535de5ff9e4e6",
   ]
 }
 

--- a/infra/terraform/hash/hash_application/main.tf
+++ b/infra/terraform/hash/hash_application/main.tf
@@ -70,7 +70,7 @@ terraform {
   required_providers {
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 5.0"
+      version = "~> 5.12"
     }
   }
 }

--- a/infra/terraform/hash/observability/terraform.tf
+++ b/infra/terraform/hash/observability/terraform.tf
@@ -6,7 +6,7 @@ terraform {
     }
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 5.0"
+      version = "~> 5.12"
     }
   }
 }

--- a/infra/terraform/hash/observability/tls.tf
+++ b/infra/terraform/hash/observability/tls.tf
@@ -36,8 +36,8 @@ resource "cloudflare_dns_record" "otlp_cert_validation" {
   }
 
   zone_id = data.cloudflare_zones.hash_ai.result[0].id
-  name    = each.value.name
-  content = each.value.record
+  name    = trimsuffix(each.value.name, ".")
+  content = trimsuffix(each.value.record, ".")
   type    = each.value.type
   ttl     = 1
 
@@ -87,8 +87,8 @@ resource "cloudflare_dns_record" "profile_cert_validation" {
   }
 
   zone_id = data.cloudflare_zones.hash_ai.result[0].id
-  name    = each.value.name
-  content = each.value.record
+  name    = trimsuffix(each.value.name, ".")
+  content = trimsuffix(each.value.record, ".")
   type    = each.value.type
   ttl     = 1
 

--- a/infra/terraform/hash/terraform.tf
+++ b/infra/terraform/hash/terraform.tf
@@ -6,7 +6,7 @@ terraform {
     }
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 5.0"
+      version = "~> 5.12"
     }
     postgresql = {
       source  = "cyrilgdn/postgresql"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Update Cloudflare Terraform provider to version 5.12.0 and fix DNS record validation issues by trimming trailing dots from DNS record names and content.

## 🔍 What does this change?

- Updates Cloudflare provider constraint from `~> 5.0` to `~> 5.12` across multiple Terraform files
- Updates Cloudflare provider version from 5.8.4 to 5.12.0 in lock file
- Removes unused HashiCorp Archive provider from lock file
- Fixes DNS validation records by adding `trimsuffix()` to remove trailing dots from DNS record names and content

## 🛡 What tests cover this?

- Terraform plan validation would verify these changes work as expected

## ❓ How to test this?

1. Run `terraform plan` to verify the changes don't cause any unexpected modifications
2. Verify that DNS validation records are properly created without trailing dots

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph
