### PR TITLE
SRE-66: Disable SSH access to Bastion host

### DIFF
--- a/infra/terraform/modules/bastion/bastion.tf
+++ b/infra/terraform/modules/bastion/bastion.tf
@@ -59,27 +59,48 @@ resource "aws_security_group" "bastion" {
   name   = "${local.prefix}ssh"
   vpc_id = var.vpc_id
 
-  ingress {
-    from_port        = var.ssh_port
-    to_port          = var.ssh_port
-    protocol         = "tcp"
-    cidr_blocks      = var.ingress_cidr_blocks
-    ipv6_cidr_blocks = var.ingress_ipv6_cidr_blocks
-  }
-
-  egress {
-    from_port        = 0
-    to_port          = 0
-    protocol         = "-1"
-    cidr_blocks      = var.egress_cidr_blocks
-    ipv6_cidr_blocks = var.egress_ipv6_cidr_blocks
-  }
-
   revoke_rules_on_delete = true
 
   lifecycle {
     create_before_destroy = true
   }
+}
+
+# resource "aws_vpc_security_group_ingress_rule" "bastion_ssh_ipv4" {
+#   for_each = toset(var.ingress_cidr_blocks)
+
+#   security_group_id = aws_security_group.bastion.id
+#   cidr_ipv4         = each.value
+#   from_port         = var.ssh_port
+#   to_port           = var.ssh_port
+#   ip_protocol       = tcp
+# }
+
+# resource "aws_vpc_security_group_ingress_rule" "bastion_ssh_ipv6" {
+#   for_each = toset(var.ingress_ipv6_cidr_blocks)
+
+#   security_group_id = aws_security_group.bastion.id
+#   cidr_ipv6         = each.value
+#   from_port         = var.ssh_port
+#   to_port           = var.ssh_port
+#   ip_protocol       = tcp
+# }
+
+
+resource "aws_vpc_security_group_egress_rule" "bastion_ssh_ipv4" {
+  for_each = toset(var.egress_cidr_blocks)
+
+  security_group_id = aws_security_group.bastion.id
+  cidr_ipv4         = each.value
+  ip_protocol       = "-1"
+}
+
+resource "aws_vpc_security_group_egress_rule" "bastion_ssh_ipv6" {
+  for_each = toset(var.egress_ipv6_cidr_blocks)
+
+  security_group_id = aws_security_group.bastion.id
+  cidr_ipv6         = each.value
+  ip_protocol       = "-1"
 }
 
 resource "aws_iam_role" "bastion" {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We don't use SSH anymore to access the Bastion host but the SSM session manager, so we don't need the SSH port but use IAM based authentication instead.

## 🔍 What does this change?

- Removes inline ingress/egress rules from the `aws_security_group.bastion` resource
- Adds new `aws_vpc_security_group_egress_rule` resources for both IPv4 and IPv6 CIDR blocks
- Comments out the ingress rule implementation using the new resource format for future implementation (in case we need to enable it again)

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- Existing infrastructure tests

## ❓ How to test this?

1. Apply the Terraform changes
2. Verify that the bastion host can still make outbound connections
3. Confirm that security group rules are correctly applied in the AWS console
