### PR TITLE
SRE-137: Remove rustfmt transformer from DeepSource config

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -7,7 +7,6 @@ test_patterns    = ["**/*.test.ts", "**/*.spec.ts"]
 meta = { environment = ["vitest", "nodejs", "browser"], plugins = ["react"] }
 name = "javascript"
 
-
 [[analyzers]]
 name = "secrets"
 
@@ -27,6 +26,3 @@ name = "shell"
 [[analyzers]]
 meta = { dockerfile_paths = ["**/Dockerfile", "**/*.Dockerfile"] }
 name = "docker"
-
-[[transformers]]
-name = "rustfmt"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Remove the `rustfmt` transformer from DeepSource configuration and clean up whitespace.

The transformer does not take our configuration into consideration, resulting in wrong PRs.

## 🔍 What does this change?

- Removes the `rustfmt` transformer from `.deepsource.toml`
- Removes unnecessary blank lines in the configuration file

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- Configuration change only, no tests required

## ❓ How to test this?

1. Checkout the branch
2. Verify DeepSource analysis runs correctly without the rustfmt transformer
