### PR TITLE
SRE-150: Disable incremental builds in CI to improve compilation time

### DIFF
--- a/.github/actions/install-sccache/action.yml
+++ b/.github/actions/install-sccache/action.yml
@@ -47,3 +47,7 @@ runs:
       shell: bash
       run: |
         echo "RUSTC_WRAPPER=${SCCACHE_PATH}" >> $GITHUB_ENV
+        # sccache does not work with incremental builds, we do not need incremental builds in CI anyway,
+        # because we only compile the library once. Therefore not compiling at all when there are no changes
+        # is beneficial as it will lead to less compilation time and faster builds in CI.
+        echo "CARGO_INCREMENTAL=0" >> $GITHUB_ENV


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Disable incremental builds when using sccache in CI to improve build performance.

## 🔍 What does this change?

- Adds `CARGO_INCREMENTAL=0` to the environment when using sccache in CI
- Includes a comment explaining that sccache doesn't work well with incremental builds
- Notes that disabling incremental builds is beneficial for CI since we only compile once, leading to faster builds

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- This change affects CI build performance and will be validated through normal CI runs

## ❓ How to test this?

1. Run CI builds with this change
2. Observe improved build times when using sccache
