### PR TITLE
BE-210: HashQL: Implement WorkQueue data structure

### DIFF
--- a/libs/@local/hashql/core/src/collections/mod.rs
+++ b/libs/@local/hashql/core/src/collections/mod.rs
@@ -1,12 +1,13 @@
 mod hash_map;
 pub mod pool;
+mod work_queue;
 
 use alloc::alloc::Global;
 use core::alloc::Allocator;
 
 use hashbrown::{HashMap, HashSet};
 
-pub use self::hash_map::HashMapExt;
+pub use self::{hash_map::HashMapExt, work_queue::WorkQueue};
 
 pub type ConcurrentHashMap<K, V> = scc::HashMap<K, V, foldhash::fast::RandomState>;
 pub type ConcurrentHashSet<T> = scc::HashSet<T, foldhash::fast::RandomState>;

--- a/libs/@local/hashql/core/src/collections/work_queue.rs
+++ b/libs/@local/hashql/core/src/collections/work_queue.rs
@@ -1,0 +1,146 @@
+use alloc::{alloc::Global, collections::VecDeque};
+use core::alloc::Allocator;
+
+use crate::id::{Id, bit_vec::DenseBitSet};
+
+/// A work queue that prevents duplicate items from being enqueued simultaneously.
+///
+/// This queue automatically deduplicates items: no item will be in the queue multiple times at any
+/// given time. Attempting to enqueue an item that is already in the queue will be rejected.
+///
+/// This makes it ideal for work scheduling where fixed-point iteration is required.
+///
+/// Items are dequeued in FIFO order (first in, first out) and the implementation assumes dense
+/// indices.
+///
+/// # Examples
+///
+/// ```
+/// use hashql_core::collections::WorkQueue;
+/// # hashql_core::id::newtype!(pub struct MyId(u32 is 0..=100));
+///
+/// let mut queue = WorkQueue::new(100);
+///
+/// assert!(queue.enqueue(MyId::new(5)));
+/// assert!(queue.enqueue(MyId::new(10)));
+///
+/// // Duplicate enqueue fails
+/// assert!(!queue.enqueue(MyId::new(5)));
+///
+/// // Items are dequeued in FIFO order
+/// assert_eq!(queue.dequeue(), Some(MyId::new(5)));
+/// assert_eq!(queue.dequeue(), Some(MyId::new(10)));
+/// assert_eq!(queue.dequeue(), None);
+/// ```
+pub struct WorkQueue<I, A: Allocator = Global> {
+    queue: VecDeque<I, A>,
+    set: DenseBitSet<I>,
+}
+
+impl<I> WorkQueue<I>
+where
+    I: Id,
+{
+    /// Creates a new empty work queue.
+    ///
+    /// The `domain_size` specifies the maximum number of unique items that can be enqueued.
+    /// All item IDs must be in the range `0..domain_size`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hashql_core::collections::WorkQueue;
+    /// # hashql_core::id::newtype!(pub struct MyId(u32 is 0..=100));
+    ///
+    /// // Create a queue supporting up to 100 unique items
+    /// let queue = WorkQueue::new(100);
+    /// # let _: WorkQueue<MyId> = queue;
+    /// ```
+    #[must_use]
+    pub fn new(domain_size: usize) -> Self {
+        Self::new_in(domain_size, Global)
+    }
+}
+
+impl<I, A: Allocator> WorkQueue<I, A>
+where
+    I: Id,
+{
+    /// Creates a new empty work queue with a custom allocator.
+    ///
+    /// The `domain_size` specifies the maximum number of unique items that can be enqueued.
+    /// All item IDs must be in the range `0..domain_size`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hashql_core::collections::WorkQueue;
+    /// # use hashql_core::heap::Heap;
+    /// # hashql_core::id::newtype!(pub struct MyId(u32 is 0..=100));
+    /// # let heap = Heap::new();
+    ///
+    /// let queue = WorkQueue::new_in(100, &heap);
+    /// # let _: WorkQueue<MyId, _> = queue;
+    /// ```
+    #[must_use]
+    pub fn new_in(domain_size: usize, alloc: A) -> Self {
+        Self {
+            queue: VecDeque::new_in(alloc),
+            set: DenseBitSet::new_empty(domain_size),
+        }
+    }
+
+    /// Attempts to enqueue an item if it's not already in the queue.
+    ///
+    /// Returns `true` if the `item` was successfully added, or `false` if the item
+    /// is already present in the queue.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hashql_core::collections::WorkQueue;
+    /// # hashql_core::id::newtype!(pub struct MyId(u32 is 0..=100));
+    ///
+    /// let mut queue = WorkQueue::new(100);
+    ///
+    /// assert!(queue.enqueue(MyId::new(1))); // Added
+    /// assert!(!queue.enqueue(MyId::new(1))); // Already in queue - rejected
+    ///
+    /// assert_eq!(queue.dequeue(), Some(MyId::new(1))); // Remove item 1
+    /// assert!(queue.enqueue(MyId::new(1))); // Can be added again
+    /// ```
+    pub fn enqueue(&mut self, item: I) -> bool {
+        if self.set.insert(item) {
+            self.queue.push_back(item);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Removes and returns the next item from the queue.
+    ///
+    /// Returns [`None`] if the queue is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use hashql_core::collections::WorkQueue;
+    /// # hashql_core::id::newtype!(pub struct MyId(u32 is 0..=100));
+    ///
+    /// let mut queue = WorkQueue::new(100);
+    ///
+    /// queue.enqueue(MyId::new(1));
+    /// queue.enqueue(MyId::new(2));
+    ///
+    /// assert_eq!(queue.dequeue(), Some(MyId::new(1)));
+    /// assert_eq!(queue.dequeue(), Some(MyId::new(2)));
+    /// assert_eq!(queue.dequeue(), None);
+    /// ```
+    pub fn dequeue(&mut self) -> Option<I> {
+        let element = self.queue.pop_front()?;
+        self.set.remove(element);
+
+        Some(element)
+    }
+}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Adds a new `WorkQueue` data structure that prevents duplicate items from being enqueued simultaneously, making it ideal for work scheduling where fixed-point iteration is required.

## 🔍 What does this change?

- Implements a new `WorkQueue` collection that automatically deduplicates items in a FIFO queue
- Adds comprehensive documentation with usage examples
- Exposes the new collection through the module's public API

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- The implementation includes doc tests that verify the core functionality

## ❓ How to test this?

1. Checkout the branch
2. Run the doc tests to verify the `WorkQueue` functionality
3. Confirm that the queue properly handles item deduplication and FIFO ordering
