### PR TITLE
BE-212: HashQL: Add dominators algorithm for control flow graph analysis

### DIFF
--- a/libs/@local/hashql/ast/src/lib.rs
+++ b/libs/@local/hashql/ast/src/lib.rs
@@ -56,7 +56,6 @@
     allocator_api,
     formatting_options,
     iter_intersperse,
-    step_trait,
 )]
 #![cfg_attr(test, feature(assert_matches))]
 

--- a/libs/@local/hashql/core/src/graph/algorithms/dominators/mod.rs
+++ b/libs/@local/hashql/core/src/graph/algorithms/dominators/mod.rs
@@ -49,7 +49,10 @@ struct PreOrderFrame<Iter> {
     iter: Iter,
 }
 
-newtype!(struct PreorderIndex(u32 is 0..=u32::MAX));
+newtype!(
+    #[steppable]
+    struct PreorderIndex(u32 is 0..=u32::MAX)
+);
 
 #[derive(Clone, Debug)]
 pub struct Dominators<N> {

--- a/libs/@local/hashql/hir/src/lib.rs
+++ b/libs/@local/hashql/hir/src/lib.rs
@@ -14,7 +14,6 @@
     // Library Features
     allocator_api,
     iter_intersperse,
-    step_trait,
     try_trait_v2,
     unwrap_infallible,
 )]

--- a/libs/@local/hashql/mir/src/lib.rs
+++ b/libs/@local/hashql/mir/src/lib.rs
@@ -17,7 +17,6 @@
     formatting_options,
     iter_array_chunks,
     iter_collect_into,
-    step_trait,
     try_trait_v2,
 )]
 #![expect(clippy::indexing_slicing)]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Add a dominators algorithm implementation for directed graphs, which allows determining if one node dominates another in a control flow graph.

## 🔗 Related links

- Adapted from Rust compiler source code: https://github.com/rust-lang/rust/blob/42ec52babac2cbf2bb2b9d794f980cbcb3ebe413/compiler/rustc_data_structures/src/graph/mod.rs

## 🔍 What does this change?

- Adds a dominators algorithm implementation in `libs/@local/hashql/core/src/graph/algorithms/dominators/`
- Adds tests for the dominators algorithm
- Extends the `Id` trait with additional methods like `decrement_by` and `minus`
- Implements `Step` trait for newtype IDs to support range operations
- Adds utility methods to `IdVec` like `from_elem` and `from_domain`

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- The implementation includes a comprehensive test suite in `dominators/tests.rs`