### PR TITLE
SRE-159: Enable sccache caching in turbo commands

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -123,5 +123,9 @@
     // External services
     "apps/hash-external-services/**"
   ],
-  "globalPassThroughEnv": ["CARGO_TERM_PROGRESS_WHEN"]
+  "globalPassThroughEnv": [
+    "CARGO_TERM_PROGRESS_WHEN",
+    "RUSTC_WRAPPER",
+    "CARGO_INCREMENTAL"
+  ]
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Add `RUSTC_WRAPPER` to the list of environment variables that are passed through to Turborepo tasks. This allows for the use of tools like `sccache` to speed up Rust compilation.

## 🔍 What does this change?

- Adds `RUSTC_WRAPPER` to the `globalPassThroughEnv` array in `turbo.json`, allowing this environment variable to be passed through to all Turborepo tasks.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- This is a configuration change that doesn't require specific tests

## ❓ How to test this?

1. Set the `RUSTC_WRAPPER` environment variable (e.g., to `sccache`)
2. Run a Turborepo task that involves Rust compilation
3. Confirm that the wrapper is being used (e.g., by seeing cache hits in sccache stats)
