### PR TITLE
H-5727: Add note about @local libraries not requiring publishing in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -31,6 +31,7 @@
 
 <!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
 <!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->
+<!-- Libraries inside of the `@local` directory are always internal libraries which have no need for publishing -->
 
 This PR:
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Add a note to the PR template clarifying that libraries in the `@local` directory are internal and don't need publishing.

This is primarily needed for graphite (and other tools) that create a PR template message, and always get this setting wrong. Hopefully being explicit about the nature of the `@local` directory helps here.

## 🔍 What does this change?

- Adds a comment in the PR template explaining that libraries inside the `@local` directory are always internal libraries which have no need for publishing.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- N/A - Documentation change only

## ❓ How to test this?

1. Review the updated PR template to confirm the added note is clear and helpful
