### PR TITLE
BE-225: Add `IF NOT EXISTS` to vector extension creation

### DIFF
--- a/libs/@local/graph/postgres-store/postgres_migrations/V12__similarity_search.sql
+++ b/libs/@local/graph/postgres-store/postgres_migrations/V12__similarity_search.sql
@@ -1,4 +1,4 @@
-CREATE EXTENSION "vector";
+CREATE EXTENSION IF NOT EXISTS "vector";
 
 CREATE TABLE "entity_embeddings" (
     "web_id"      UUID NOT NULL,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Add `IF NOT EXISTS` clause to the vector extension creation in the similarity search migration to prevent errors when the extension is already installed.

## 🔍 What does this change?

- Modifies the SQL migration script to use `CREATE EXTENSION IF NOT EXISTS "vector"` instead of `CREATE EXTENSION "vector"` to make the migration more robust when running against databases where the vector extension is already installed.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- Existing database migration tests

## ❓ How to test this?

1. Checkout the branch
2. Run the migrations against a database where the vector extension is already installed
3. Confirm that the migration completes without errors
