### PR TITLE
SRE-191: Add workflow to check for @todo comments with ticket IDs

### DIFF
--- a/.github/workflows/check-todo-linear-tickets.yml
+++ b/.github/workflows/check-todo-linear-tickets.yml
@@ -72,16 +72,29 @@ jobs:
             #   // see: https://linear.app/hash/issue/H-1234
 
             # Single-line: any line with both "todo" and the ticket ID
-            SINGLE_LINE=$(rg -in "todo.*${TICKET}|${TICKET}.*todo" . 2>/dev/null || true)
+            # rg exits with 0 if matches found, 1 if no matches, 2+ on error
+            SINGLE_LINE=$(rg -in "todo.*${TICKET}|${TICKET}.*todo" .) || {
+              rc=$?
+              if [[ $rc -ne 1 ]]; then
+                echo "::error::ripgrep failed with exit code $rc"
+                exit $rc
+              fi
+            }
 
             # Multiline: TODO within ~5 lines of Linear URL containing the ticket
             MULTILINE=$(rg -inU \
               -e "todo[\s\S]{0,300}linear\.app/[^/]+/issue/${TICKET}" \
               -e "linear\.app/[^/]+/issue/${TICKET}[\s\S]{0,300}todo" \
-              . 2>/dev/null || true)
+              .) || {
+              rc=$?
+              if [[ $rc -ne 1 ]]; then
+                echo "::error::ripgrep failed with exit code $rc"
+                exit $rc
+              fi
+            }
 
             # Combine and deduplicate results
-            MATCHES=$(echo -e "${SINGLE_LINE}\n${MULTILINE}" | grep -v '^$' | sort -u || true)
+            MATCHES=$(echo -e "${SINGLE_LINE}\n${MULTILINE}" | grep -v '^$' | sort -u) || true
 
             if [[ -n "$MATCHES" ]]; then
               echo "::error::Found TODO comments or Linear URLs referencing $TICKET:"


### PR DESCRIPTION
This PR adds a new GitHub Action workflow that scans the codebase for TODO comments containing Linear ticket IDs referenced in the PR title. The workflow:

1. Extracts ticket IDs from the PR title (e.g., "H-1234", "BE-123, FE-456")
2. Searches the codebase for TODO comments containing these ticket IDs
3. Fails the check if any TODOs with these ticket IDs are found

The action supports various TODO formats:

- `TODO: H-1234`
- `@todo H-1234`
- `todo!(H-1234)`
- Linear URLs containing the ticket ID

This prevents PRs from being merged when they would close Linear tickets that still have associated TODOs in the codebase, ensuring that all work referenced in a ticket is properly completed before the ticket is marked as done.