### PR TITLE
H-5837: Add temp/scratch/holding directory ignore patterns (ad-hoc DX)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -177,3 +177,6 @@ out/
 **/_trash/
 **/_scratch/
 **/_holding/
+
+# Jujutsu
+.jj/

--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,6 @@ out/
 **/_trash/
 **/_scratch/
 **/_holding/
+
+# Jujutsu
+.jj/


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR makes small additions to the root `.gitignore` and the `.dockerignore` to allow: 

1. placement of directories matching `_temp/`, `_trash/`, `_scratch/` or `_holding/` anywhere in the file tree to have their contents ignored
2. use of Jujutsu VCS' `.jj/` directory

...without causing false inclusions in other tools.

Background: most repo tools have the behaviour of ignoring whatever is ignored in `.gitignore`, but some do not successfully ignore patterns like `my-directory/.gitignore` where the nested ignore file just contains `*` (which is what Jujutsu does in the `.jj` directory, and what was suggested below in the comments for `_temp` etc. directories).

This is just a DX improvement.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph