### PR TITLE
H-5774: Hide Panel if selected item does not exist

### DIFF
--- a/libs/@hashintel/petrinaut/src/views/Editor/panels/PropertiesPanel/panel.tsx
+++ b/libs/@hashintel/petrinaut/src/views/Editor/panels/PropertiesPanel/panel.tsx
@@ -16,13 +16,6 @@ import { PlaceProperties } from "./place-properties";
 import { TransitionProperties } from "./transition-properties";
 import { TypeProperties } from "./type-properties";
 
-const unknownItemStyle = css({
-  padding: "[16px]",
-  textAlign: "center",
-  color: "[#999]",
-  fontSize: "[14px]",
-});
-
 const positionContainerStyle = css({
   display: "flex",
   position: "fixed",
@@ -95,7 +88,8 @@ export const PropertiesPanel: React.FC = () => {
   const itemType = getItemType(selectedId);
 
   // Don't show panel for arcs - they can only be deleted, not edited
-  if (itemType === "arc") {
+  // Don't show panel if the selected item doesn't exist (e.g. after switching documents)
+  if (itemType === "arc" || itemType === null) {
     return null;
   }
 
@@ -178,10 +172,6 @@ export const PropertiesPanel: React.FC = () => {
       }
       break;
     }
-
-    default:
-      // Unknown item type
-      content = <div className={unknownItemStyle}>Unknown item selected</div>;
   }
 
   // Calculate bottom offset based on bottom panel visibility


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

In some circumstances (e.g. deleting items) the panel could show an error because the item could not be found.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->
<!-- Libraries inside of the `@local` directory are always internal libraries which have no need for publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

