### PR TITLE
SRE-260: Disable immutable installs for changeset version script

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "bench": "npm-run-all --continue-on-error \"bench:*\"",
     "bench:integration": "CARGO_TERM_PROGRESS_WHEN=never turbo run bench:integration --env-mode=loose --",
     "bench:unit": "CARGO_TERM_PROGRESS_WHEN=never turbo run bench:unit --env-mode=loose --",
-    "changeset:version": "YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn changeset version && yarn",
+    "changeset:version": "yarn changeset version && YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn",
     "codegen": "turbo codegen",
     "create-block": "yarn workspace @local/repo-chores exe scripts/create-block.ts",
     "dev": "CARGO_TERM_PROGRESS_WHEN=never turbo dev --log-order stream --filter '@apps/hash-api' --filter '@apps/hash-frontend' --",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

#8253 fixed one issue in the Release workflow but it uncovered another, which this PR should fix. The release workflow needs to change `yarn.lock` in CI because converting the changeset files to package bumps should also result in a `yarn.lock` update, but Yarn 4's default behaviour is to error if a `yarn` in CI causes a diff in `yarn.lock`.