### PR TITLE
H-6070: Enable idiomatic version file for Rust in mise config

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -1,6 +1,9 @@
 [env]
 _.file = [".env", ".env.local"]
 
+[settings]
+idiomatic_version_file_enable_tools = ["rust"]
+
 [tools]
 # Basic tools
 node        = { version = "22.21.1", postinstall = "corepack enable" }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Enable idiomatic version file support for Rust in mise configuration.

## 🔍 What does this change?

- Adds a new `[settings]` section to the mise config
- Enables idiomatic version file support specifically for Rust tools via the `idiomatic_version_file_enable_tools` setting

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- Manual testing of Rust version detection via mise

## ❓ How to test this?

1. Checkout the branch
2. Create a project with a `rust-toolchain.toml` file
3. Confirm that mise correctly detects and uses the specified Rust version
