### PR TITLE
SRE-325: Disable Cargo terminal progress for codegen script

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "bench:integration": "CARGO_TERM_PROGRESS_WHEN=never turbo run bench:integration --env-mode=loose --",
     "bench:unit": "CARGO_TERM_PROGRESS_WHEN=never turbo run bench:unit --env-mode=loose --",
     "changeset:version": "yarn changeset version && YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn",
-    "codegen": "turbo codegen",
+    "codegen": "CARGO_TERM_PROGRESS_WHEN=never turbo codegen",
     "create-block": "yarn workspace @local/repo-chores exe scripts/create-block.ts",
     "dev": "CARGO_TERM_PROGRESS_WHEN=never turbo dev --log-order stream --filter '@apps/hash-api' --filter '@apps/hash-frontend' --",
     "dev:backend": "CARGO_TERM_PROGRESS_WHEN=never turbo dev --log-order stream --filter '@apps/hash-api' --",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR sets the `CARGO_TERM_PROGRESS_WHEN=never` environment variable for the `yarn codegen` command to suppress Cargo progress output during code generation, ensuring consistent and cleaner terminal output.

## 🔗 Related links

- SRE-325

## 🔍 What does this change?

- Updates the `codegen` script in the root `package.json` to include `CARGO_TERM_PROGRESS_WHEN=never`, aligning it with other turbo commands in the repository that already use this environment variable

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- Existing CI/CD pipeline will verify the codegen command continues to work correctly

## ❓ How to test this?

1. Checkout the branch
2. Run `yarn codegen`
3. Confirm that Cargo progress bars are not displayed in the terminal output

---

This PR was created by [Graphite Agent](https://app.graphite.com/background-agents/hashintel/hash/task/bgt_01kfqqhh01esdrb31r0vyy0vv8)
