### PR TITLE
Add MiniMap colours, tweak size/ratio

### DIFF
--- a/libs/@hashintel/petrinaut/src/views/SDCPN/components/mini-map.tsx
+++ b/libs/@hashintel/petrinaut/src/views/SDCPN/components/mini-map.tsx
@@ -32,6 +32,7 @@ const MiniMapNode: React.FC<MiniMapNodeProps> = ({
   width,
   height,
 }) => {
+  // MiniMapNodeProps doesn't include node data, so we look it up from the store
   const node = useStore(
     (state) => state.nodeInternals.get(id) as NodeType | undefined,
   );


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Some suggestions to make the MiniMap look a bit nicer:
1. Add colours based on place type
2. Make it bigger
3. Make the aspect ratio the same as standard widescreen (so it will fill it if the user has their window maximised)

<img width="1665" height="929" alt="Screenshot 2026-01-28 at 17 51 11" src="https://github.com/user-attachments/assets/b85a86c9-af5c-40d7-ba8a-9fe161ffa1cd" />
