### PR TITLE
SRE-415: Fix vercel not building

### DIFF
--- a/apps/hash-frontend/vercel-build.sh
+++ b/apps/hash-frontend/vercel-build.sh
@@ -2,7 +2,6 @@
 
 set -euo pipefail
 
-source "$HOME/.cargo/env"
 eval "$(mise activate bash --shims)"
 
 echo "Changing dir to root"
@@ -13,6 +12,7 @@ cd ../..
 #   `.env` file.
 # See: https://linear.app/hash/issue/H-3213/use-consistent-naming-schema-for-environment-variables
 # See: https://linear.app/hash/issue/H-4202/sort-out-which-environment-variables-are-defined-where
+# See: https://linear.app/hash/issue/H-3212/clean-up-env-files
 rm .env
 
 echo "Building frontend"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Remove the sourcing of Cargo environment variables in the Vercel build script, as it's no longer needed with mise handling environment setup.

## 🔗 Related links

- https://linear.app/hash/issue/H-3212/clean-up-env-files (internal)
- https://linear.app/hash/issue/H-3213/use-consistent-naming-schema-for-environment-variables (internal)
- https://linear.app/hash/issue/H-4202/sort-out-which-environment-variables-are-defined-where (internal)

## 🔍 What does this change?

- Removes `source "$HOME/.cargo/env"` from the Vercel build script
- Adds a reference to H-3212 in the environment variable cleanup comments

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- Vercel build process will validate this change works correctly

## ❓ How to test this?

1. Checkout the branch
2. Verify the Vercel build completes successfully without the Cargo environment sourcing
