### PR TITLE
SRE-418: Add wasm32-unknown-unknown target to Vercel build

### DIFF
--- a/apps/hash-frontend/vercel-install.sh
+++ b/apps/hash-frontend/vercel-install.sh
@@ -14,10 +14,13 @@ yum-config-manager --add-repo https://mise.jdx.dev/rpm/mise.repo
 yum install -y mise
 eval "$(mise activate bash --shims)"
 
-echo "Installing Rust toolchain: $(yq '.toolchain.channel' rust-toolchain.toml)"
 mise install yq
+echo "Installing Rust toolchain: $(yq '.toolchain.channel' rust-toolchain.toml)"
 export RUSTUP_AUTO_INSTALL=0
 mise use --global rust[profile=minimal]@$(yq '.toolchain.channel' rust-toolchain.toml)
+
+echo "Adding wasm32-unknown-unknown target"
+rustup target add wasm32-unknown-unknown
 
 echo "Installing prerequisites"
 mise install node npm:turbo java biome npm:@redocly/cli cargo-binstall cargo:wasm-pack cargo:wasm-opt protoc


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Add the wasm32-unknown-unknown target to the Rust toolchain installation in the Vercel build process.

## 🔍 What does this change?

- Reorders the installation steps to ensure `yq` is installed before using it
- Adds explicit installation of the wasm32-unknown-unknown target using rustup
- This ensures WebAssembly compilation will work properly during the build process

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- This change will be tested during the Vercel build process

## ❓ How to test this?

1. Checkout the branch
2. Verify that Vercel builds complete successfully
3. Confirm that any WebAssembly components are properly compiled
