### PR TITLE
H-6168: Remove Cargo env source from Petrinaut Vercel build script

### DIFF
--- a/libs/@hashintel/petrinaut/vercel-build.sh
+++ b/libs/@hashintel/petrinaut/vercel-build.sh
@@ -2,7 +2,6 @@
 
 set -euo pipefail
 
-source "$HOME/.cargo/env"
 eval "$(mise activate bash --shims)"
 
 echo "Changing dir to root"
@@ -13,6 +12,7 @@ cd ../../..
 #   `.env` file.
 # See: https://linear.app/hash/issue/H-3213/use-consistent-naming-schema-for-environment-variables
 # See: https://linear.app/hash/issue/H-4202/sort-out-which-environment-variables-are-defined-where
+# See: https://linear.app/hash/issue/H-3212/clean-up-env-files
 rm .env
 
 echo "Building Petrinaut"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Remove the unnecessary sourcing of Cargo environment in the Petrinaut Vercel build script and add a reference to an additional Linear issue.

## 🔗 Related links

- https://linear.app/hash/issue/H-3213/use-consistent-naming-schema-for-environment-variables (internal)
- https://linear.app/hash/issue/H-4202/sort-out-which-environment-variables-are-defined-where (internal)
- https://linear.app/hash/issue/H-3212/clean-up-env-files (internal)

## 🔍 What does this change?

- Removes `source "$HOME/.cargo/env"` from the Vercel build script as it's no longer needed
- Adds a reference to Linear issue H-3212 about cleaning up env files

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- Vercel build process will validate this change works correctly

## ❓ How to test this?

1. Checkout the branch
2. Verify the Vercel build completes successfully without the Cargo environment sourcing
