### PR TITLE
BE-377: Replace unmaintained `tsify-next` with `tsify`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9248,23 +9248,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "tsify-next"
+name = "tsify"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d0f2208feeb5f7a6edb15a2389c14cd42480ef6417318316bb866da5806a61d"
+checksum = "8ec5505497c87f1c050b4392d3f11b49a04537fcb9dc0da57bc0af168a6331f2"
 dependencies = [
  "gloo-utils",
  "serde",
  "serde_json",
- "tsify-next-macros",
+ "tsify-macros",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "tsify-next-macros"
+name = "tsify-macros"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81253930d0d388a3ab8fa4ae56da9973ab171ef833d1be2e9080fc3ce502bd6"
+checksum = "9fc2c44dc9fe4baf55b88e032621b7a11b215a1f0a7de8d0aa04367207d915bc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9300,7 +9300,7 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "tokio",
- "tsify-next",
+ "tsify",
  "url",
  "utoipa",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -268,7 +268,7 @@ tracing-opentelemetry              = { version = "0.31.0", default-features = fa
 tracing-subscriber                 = { version = "0.3.20", default-features = false }
 trait-variant                      = { version = "0.1.2", default-features = false }
 trybuild                           = { version = "1.0.113", default-features = false }
-tsify-next                         = { version = "0.5.6", default-features = false }
+tsify                              = { version = "0.5.6", default-features = false }
 unicase                            = { version = "2.8.1", default-features = false }
 unicode-ident                      = { version = "1.0.22", default-features = false }
 unicode-normalization              = { version = "0.1.25", default-features = false }

--- a/libs/@blockprotocol/type-system/rust/Cargo.toml
+++ b/libs/@blockprotocol/type-system/rust/Cargo.toml
@@ -67,7 +67,7 @@ workspace = true
 # all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
 # code size when deploying.
 console_error_panic_hook = { workspace = true }
-tsify-next               = { workspace = true, features = ["json"] }
+tsify                    = { workspace = true, features = ["json"] }
 wasm-bindgen             = { workspace = true, features = ["serde-serialize"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]

--- a/libs/@blockprotocol/type-system/rust/src/knowledge/confidence.rs
+++ b/libs/@blockprotocol/type-system/rust/src/knowledge/confidence.rs
@@ -8,7 +8,7 @@ use utoipa::{
 };
 
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Serialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[cfg_attr(feature = "postgres", derive(FromSql, ToSql), postgres(transparent))]
 #[repr(transparent)]
 pub struct Confidence(

--- a/libs/@blockprotocol/type-system/rust/src/knowledge/entity/id.rs
+++ b/libs/@blockprotocol/type-system/rust/src/knowledge/entity/id.rs
@@ -155,7 +155,7 @@ impl ToSchema<'_> for EntityId {
 #[cfg(target_arch = "wasm32")]
 #[expect(dead_code, reason = "Used in the generated TypeScript types")]
 mod patch {
-    #[derive(tsify_next::Tsify)]
+    #[derive(tsify::Tsify)]
     pub struct EntityId(#[tsify(type = "Brand<string, \"EntityId\">")] String);
 }
 
@@ -186,7 +186,7 @@ impl EntityEditionId {
 }
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(ToSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct EntityRecordId {

--- a/libs/@blockprotocol/type-system/rust/src/knowledge/entity/link.rs
+++ b/libs/@blockprotocol/type-system/rust/src/knowledge/entity/link.rs
@@ -6,7 +6,7 @@ use crate::knowledge::{Confidence, property::metadata::PropertyProvenance};
 /// The associated information for 'Link' entities.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct LinkData {
     pub left_entity_id: EntityId,

--- a/libs/@blockprotocol/type-system/rust/src/knowledge/entity/metadata/diff.rs
+++ b/libs/@blockprotocol/type-system/rust/src/knowledge/entity/metadata/diff.rs
@@ -6,7 +6,7 @@ use crate::ontology::VersionedUrl;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase", tag = "op")]
 pub enum EntityTypeIdDiff<'e> {
     Added { added: Cow<'e, VersionedUrl> },

--- a/libs/@blockprotocol/type-system/rust/src/knowledge/entity/metadata/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/knowledge/entity/metadata/mod.rs
@@ -30,7 +30,7 @@ use crate::{
 /// This metadata provides context for interpreting and validating the entity's properties.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct EntityMetadata {
     /// Unique identifier for this entity record.
@@ -87,7 +87,7 @@ pub struct EntityMetadata {
 /// versus when it was recorded, enabling accurate historical queries.
 #[derive(Debug, Clone, Hash, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct EntityTemporalMetadata {
     /// The interval during which this entity version was decided to be inserted or considered

--- a/libs/@blockprotocol/type-system/rust/src/knowledge/entity/provenance.rs
+++ b/libs/@blockprotocol/type-system/rust/src/knowledge/entity/provenance.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct EntityEditionProvenance {
@@ -53,7 +53,7 @@ impl ToSql for EntityEditionProvenance {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct ProvidedEntityEditionProvenance {
@@ -64,7 +64,7 @@ pub struct ProvidedEntityEditionProvenance {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct InferredEntityProvenance {
@@ -111,7 +111,7 @@ impl ToSql for InferredEntityProvenance {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct EntityProvenance {

--- a/libs/@blockprotocol/type-system/rust/src/knowledge/property/array.rs
+++ b/libs/@blockprotocol/type-system/rust/src/knowledge/property/array.rs
@@ -1,7 +1,7 @@
 use super::{PropertyWithMetadata, metadata::ArrayMetadata};
 
 #[derive(Debug, Default, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct PropertyArrayWithMetadata {

--- a/libs/@blockprotocol/type-system/rust/src/knowledge/property/diff.rs
+++ b/libs/@blockprotocol/type-system/rust/src/knowledge/property/diff.rs
@@ -21,7 +21,7 @@ use crate::knowledge::property::{Property, PropertyPath};
 /// particular path.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase", tag = "op")]
 pub enum PropertyDiff<'e> {
     /// A property was added at the specified path.

--- a/libs/@blockprotocol/type-system/rust/src/knowledge/property/metadata/array.rs
+++ b/libs/@blockprotocol/type-system/rust/src/knowledge/property/metadata/array.rs
@@ -3,7 +3,7 @@ use crate::knowledge::Confidence;
 
 #[derive(Debug, Default, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ArrayMetadata {
     #[serde(default, skip_serializing_if = "PropertyProvenance::is_empty")]
@@ -22,7 +22,7 @@ impl ArrayMetadata {
 
 #[derive(Debug, Default, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct PropertyArrayMetadata {
     /// Metadata for each item in the array.

--- a/libs/@blockprotocol/type-system/rust/src/knowledge/property/metadata/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/knowledge/property/metadata/mod.rs
@@ -34,7 +34,7 @@ use serde::{Deserialize, Serialize};
 /// [`Property`]: crate::knowledge::property::Property
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(untagged)]
 pub enum PropertyMetadata {
     /// Metadata for an array property, containing element-level and array-level metadata.

--- a/libs/@blockprotocol/type-system/rust/src/knowledge/property/metadata/object.rs
+++ b/libs/@blockprotocol/type-system/rust/src/knowledge/property/metadata/object.rs
@@ -12,7 +12,7 @@ use crate::{knowledge::Confidence, ontology::BaseUrl};
 
 #[derive(Debug, Default, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ObjectMetadata {
     #[serde(default, skip_serializing_if = "PropertyProvenance::is_empty")]
@@ -31,7 +31,7 @@ impl ObjectMetadata {
 
 #[derive(Debug, Default, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct PropertyObjectMetadata {
     /// Metadata for each field in the object.

--- a/libs/@blockprotocol/type-system/rust/src/knowledge/property/metadata/provenance.rs
+++ b/libs/@blockprotocol/type-system/rust/src/knowledge/property/metadata/provenance.rs
@@ -10,7 +10,7 @@ use crate::provenance::SourceProvenance;
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct PropertyProvenance {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/libs/@blockprotocol/type-system/rust/src/knowledge/property/metadata/value.rs
+++ b/libs/@blockprotocol/type-system/rust/src/knowledge/property/metadata/value.rs
@@ -2,7 +2,7 @@ use crate::knowledge::value::ValueMetadata;
 
 #[derive(Debug, Default, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct PropertyValueMetadata {
     /// Comprehensive metadata for a primitive value, including provenance,

--- a/libs/@blockprotocol/type-system/rust/src/knowledge/property/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/knowledge/property/mod.rs
@@ -60,7 +60,7 @@ use crate::ontology::{
 ///
 /// [`PropertyType`]: crate::ontology::property_type::PropertyType
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(untagged)]
 pub enum Property {
@@ -94,7 +94,7 @@ pub enum Property {
 /// The structure mirrors the [`Property`] enum, with specialized types for arrays, objects,
 /// and values that maintain metadata at each level of the hierarchy.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(untagged)]
 pub enum PropertyWithMetadata {

--- a/libs/@blockprotocol/type-system/rust/src/knowledge/property/object.rs
+++ b/libs/@blockprotocol/type-system/rust/src/knowledge/property/object.rs
@@ -17,7 +17,7 @@ use crate::{knowledge::PropertyValue, ontology::BaseUrl};
 
 #[derive(Debug, Default, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 pub struct PropertyObject(HashMap<BaseUrl, Property>);
 
 impl PropertyObject {
@@ -143,7 +143,7 @@ impl<'a> FromSql<'a> for PropertyObject {
 
 #[derive(Debug, Default, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct PropertyObjectWithMetadata {
     pub value: HashMap<BaseUrl, PropertyWithMetadata>,

--- a/libs/@blockprotocol/type-system/rust/src/knowledge/property/patch.rs
+++ b/libs/@blockprotocol/type-system/rust/src/knowledge/property/patch.rs
@@ -5,7 +5,7 @@ use crate::knowledge::property::{PropertyPath, PropertyWithMetadata};
 
 #[derive(Debug, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase", tag = "op")]
 pub enum PropertyPatchOperation {
     Add {

--- a/libs/@blockprotocol/type-system/rust/src/knowledge/property/path.rs
+++ b/libs/@blockprotocol/type-system/rust/src/knowledge/property/path.rs
@@ -22,7 +22,7 @@ use crate::ontology::BaseUrl;
 /// deeply nested properties within the property hierarchy.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(untagged)]
 pub enum PropertyPathElement<'k> {
     /// A property key that addresses a specific field in an object property.
@@ -79,7 +79,7 @@ impl PropertyPathElement<'_> {
 /// A path can be empty (representing the root property) or contain any number of elements
 /// representing navigation through objects and arrays.
 #[derive(Debug, Default, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(transparent)]
 pub struct PropertyPath<'k> {
     /// The sequence of path elements that make up this property path.

--- a/libs/@blockprotocol/type-system/rust/src/knowledge/property/value.rs
+++ b/libs/@blockprotocol/type-system/rust/src/knowledge/property/value.rs
@@ -16,7 +16,7 @@ use crate::knowledge::value::{PropertyValue, ValueMetadata};
 /// [`PropertyWithMetadata`]: crate::knowledge::property::PropertyWithMetadata
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct PropertyValueWithMetadata {
     /// The primitive value data, such as a string, number, or boolean.

--- a/libs/@blockprotocol/type-system/rust/src/knowledge/value/metadata/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/knowledge/value/metadata/mod.rs
@@ -11,7 +11,7 @@ use crate::{
 
 #[derive(Debug, Default, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ValueMetadata {
     #[serde(default, skip_serializing_if = "ValueProvenance::is_empty")]

--- a/libs/@blockprotocol/type-system/rust/src/knowledge/value/metadata/provenance.rs
+++ b/libs/@blockprotocol/type-system/rust/src/knowledge/value/metadata/provenance.rs
@@ -9,7 +9,7 @@ use postgres_types::{FromSql, IsNull, Json, ToSql, Type};
 use crate::provenance::SourceProvenance;
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ValueProvenance {

--- a/libs/@blockprotocol/type-system/rust/src/ontology/data_type/conversion.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/data_type/conversion.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use utoipa::openapi;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Conversions {
@@ -21,7 +21,7 @@ pub struct Conversions {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ConversionDefinition {
@@ -56,7 +56,7 @@ impl ToSql for ConversionDefinition {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub enum Variable {
     #[serde(rename = "self")]
@@ -107,7 +107,7 @@ impl utoipa::ToSchema<'_> for ConversionValue {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub enum Operator {
     #[serde(rename = "+")]
@@ -197,7 +197,7 @@ mod codec {
     use crate::ontology::json_schema::NumberTypeTag;
 
     #[derive(Serialize, Deserialize)]
-    #[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+    #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
     #[serde(untagged, rename = "ConversionValue")]
     pub(super) enum ConversionValue {
         Variable(Variable),
@@ -259,7 +259,7 @@ mod codec {
 
     #[derive(Serialize, Deserialize)]
     #[serde(rename = "ConversionExpression")]
-    #[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+    #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
     pub(super) struct ConversionExpression(
         Operator,
         super::ConversionValue,

--- a/libs/@blockprotocol/type-system/rust/src/ontology/data_type/metadata.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/data_type/metadata.rs
@@ -30,7 +30,7 @@ pub struct DataTypeMetadata {
 mod metadata_patch {
     use super::*;
 
-    #[derive(tsify_next::Tsify)]
+    #[derive(tsify::Tsify)]
     #[serde(untagged)]
     enum DataTypeMetadata {
         #[serde(rename_all = "camelCase")]
@@ -111,7 +111,7 @@ pub type DataTypeWithMetadata = OntologyTypeWithMetadata<DataType>;
 mod with_metadata_patch {
     use super::*;
 
-    #[derive(tsify_next::Tsify)]
+    #[derive(tsify::Tsify)]
     struct DataTypeWithMetadata {
         schema: DataType,
         metadata: DataTypeMetadata,

--- a/libs/@blockprotocol/type-system/rust/src/ontology/data_type/schema/closed.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/data_type/schema/closed.rs
@@ -22,7 +22,7 @@ use crate::{
 /// data types (via `allOf` references). It represents the complete set of constraints
 /// and metadata that apply to a particular data type after resolution.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ClosedDataType {
     #[serde(rename = "$id")]

--- a/libs/@blockprotocol/type-system/rust/src/ontology/data_type/schema/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/data_type/schema/mod.rs
@@ -13,7 +13,7 @@ use crate::ontology::{
 };
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase")]
 pub struct ValueLabel {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -30,14 +30,14 @@ impl ValueLabel {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase")]
 pub enum DataTypeTag {
     DataType,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase")]
 pub enum DataTypeSchemaTag {
     #[serde(rename = "https://blockprotocol.org/types/modules/graph/0.3/schema/data-type")]
@@ -45,7 +45,7 @@ pub enum DataTypeSchemaTag {
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ValueSchemaMetadata {
     pub description: String,
@@ -71,7 +71,7 @@ mod raw {
     };
 
     #[derive(serde::Serialize, serde::Deserialize)]
-    #[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+    #[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
     #[serde(rename_all = "camelCase", deny_unknown_fields)]
     pub struct DataTypeBase {
         #[serde(rename = "$schema")]
@@ -185,7 +185,7 @@ mod raw {
     mod wasm {
         use super::*;
 
-        #[derive(tsify_next::Tsify)]
+        #[derive(tsify::Tsify)]
         #[serde(untagged)]
         enum DataType {
             Schema {
@@ -560,7 +560,7 @@ impl OntologyTypeSchema for DataType {
 #[derive(
     Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
 )]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(deny_unknown_fields)]
 #[repr(transparent)]
 pub struct DataTypeReference {

--- a/libs/@blockprotocol/type-system/rust/src/ontology/entity_type/metadata.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/entity_type/metadata.rs
@@ -26,7 +26,7 @@ pub struct EntityTypeMetadata {
 mod metadata_patch {
     use super::*;
 
-    #[derive(tsify_next::Tsify)]
+    #[derive(tsify::Tsify)]
     #[serde(untagged)]
     enum EntityTypeMetadata {
         #[serde(rename_all = "camelCase")]
@@ -95,7 +95,7 @@ pub type ClosedEntityTypeWithMetadata = OntologyTypeWithMetadata<ClosedEntityTyp
 mod with_metadata_patch {
     use super::*;
 
-    #[derive(tsify_next::Tsify)]
+    #[derive(tsify::Tsify)]
     struct EntityTypeWithMetadata {
         schema: EntityType,
         metadata: EntityTypeMetadata,

--- a/libs/@blockprotocol/type-system/rust/src/ontology/entity_type/schema/closed.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/entity_type/schema/closed.rs
@@ -16,7 +16,7 @@ use crate::ontology::{
 };
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ClosedEntityTypeMetadata {
     #[serde(rename = "$id")]
@@ -49,7 +49,7 @@ impl ClosedEntityTypeMetadata {
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ClosedEntityType {
     #[serde(rename = "$id")]
@@ -160,7 +160,7 @@ impl ClosedEntityType {
 /// multiple types together to provide a single schema, which represents the shape of the entity
 /// with those types (e.g. valid properties, links, etc).
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ClosedMultiEntityType {
     /// The merged constraints for all the types in this type.

--- a/libs/@blockprotocol/type-system/rust/src/ontology/entity_type/schema/constraints.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/entity_type/schema/constraints.rs
@@ -8,7 +8,7 @@ use crate::ontology::{
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct EntityConstraints {
     pub properties: HashMap<BaseUrl, ValueOrArray<PropertyTypeReference>>,

--- a/libs/@blockprotocol/type-system/rust/src/ontology/entity_type/schema/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/entity_type/schema/mod.rs
@@ -21,7 +21,7 @@ use crate::ontology::{
 };
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct InverseEntityTypeMetadata {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -38,14 +38,14 @@ impl InverseEntityTypeMetadata {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase")]
 pub enum EntityTypeKindTag {
     EntityType,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase")]
 pub enum EntityTypeSchemaTag {
     #[serde(rename = "https://blockprotocol.org/types/modules/graph/0.3/schema/entity-type")]
@@ -53,7 +53,7 @@ pub enum EntityTypeSchemaTag {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct EntityTypeSchemaMetadata {
     pub title: String,
@@ -65,7 +65,7 @@ pub struct EntityTypeSchemaMetadata {
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct EntityTypeDisplayMetadata {
     #[serde(rename = "$id")]
@@ -194,7 +194,7 @@ pub struct EntityTypeDisplayMetadata {
 /// assert_eq!(links.len(), 1, "Should have exactly one link type");
 /// ```
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct EntityType {
     #[serde(rename = "$schema")]
@@ -224,7 +224,7 @@ pub struct EntityType {
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct PartialEntityType {
     #[serde(rename = "$id")]
@@ -522,7 +522,7 @@ impl OntologyTypeSchema for ClosedEntityType {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(deny_unknown_fields)]
 #[repr(transparent)]
 pub struct EntityTypeReference {

--- a/libs/@blockprotocol/type-system/rust/src/ontology/id/error.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/id/error.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 #[cfg(target_arch = "wasm32")]
-use tsify_next::Tsify;
+use tsify::Tsify;
 
 // TODO: Use error-stack
 //   see https://linear.app/hash/issue/BE-160/simplify-error-handling-in-type-system-package

--- a/libs/@blockprotocol/type-system/rust/src/ontology/id/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/id/mod.rs
@@ -540,7 +540,7 @@ pub struct VersionedUrl {
 
 #[cfg(target_arch = "wasm32")]
 mod patch {
-    #[derive(tsify_next::Tsify)]
+    #[derive(tsify::Tsify)]
     #[expect(dead_code, reason = "Used in the generated TypeScript types")]
     struct VersionedUrl(#[tsify(type = "`${string}v/${string}`")] String);
 }
@@ -688,7 +688,7 @@ impl ToSchema<'_> for VersionedUrl {
 /// # Ok::<(), Box<dyn core::error::Error>>(())
 /// ```
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase")]
 pub struct OntologyTypeRecordId {

--- a/libs/@blockprotocol/type-system/rust/src/ontology/id/wasm.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/id/wasm.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use tsify_next::Tsify;
+use tsify::Tsify;
 use wasm_bindgen::{JsValue, prelude::wasm_bindgen};
 
 use crate::ontology::{BaseUrl, VersionedUrl};

--- a/libs/@blockprotocol/type-system/rust/src/ontology/json_schema/constraint/any_of.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/json_schema/constraint/any_of.rs
@@ -8,7 +8,7 @@ use super::{
 use crate::{knowledge::PropertyValue, ontology::data_type::schema::ResolveClosedDataTypeError};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct AnyOfConstraints {
     #[cfg_attr(

--- a/libs/@blockprotocol/type-system/rust/src/ontology/json_schema/constraint/array.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/json_schema/constraint/array.rs
@@ -34,14 +34,14 @@ pub enum ArrayValidationError {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase")]
 pub enum ArrayTypeTag {
     Array,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(tag = "type", rename_all = "camelCase")]
 pub enum ArrayItemConstraints {
     Boolean,
@@ -133,7 +133,7 @@ impl Constraint for ArrayItemsSchema {
 mod wasm {
     use super::*;
 
-    #[derive(tsify_next::Tsify)]
+    #[derive(tsify::Tsify)]
     #[serde(untagged)]
     enum ArrayItemsSchema {
         Schema {
@@ -148,7 +148,7 @@ mod wasm {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(untagged, rename_all = "camelCase")]
 pub enum ArraySchema {
     Constrained(Box<ArrayConstraints>),
@@ -231,7 +231,7 @@ impl ConstraintValidator<[PropertyValue]> for ArraySchema {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct ArrayConstraints {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -292,7 +292,7 @@ impl ConstraintValidator<[PropertyValue]> for ArrayConstraints {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct TupleConstraints {
     #[cfg_attr(target_arch = "wasm32", tsify(type = "false"))]

--- a/libs/@blockprotocol/type-system/rust/src/ontology/json_schema/constraint/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/json_schema/constraint/mod.rs
@@ -73,7 +73,7 @@ pub trait ConstraintValidator<V: ?Sized>: Constraint {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(untagged, rename_all = "camelCase")]
 pub enum ValueConstraints {
     Typed(Box<SingleValueConstraints>),
@@ -186,7 +186,7 @@ impl ConstraintValidator<PropertyValue> for ValueConstraints {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "kebab-case")]
 pub enum JsonSchemaValueType {
@@ -212,7 +212,7 @@ impl fmt::Display for JsonSchemaValueType {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(tag = "type", rename_all = "camelCase")]
 pub enum SingleValueConstraints {
     Null,
@@ -331,7 +331,7 @@ impl Constraint for SingleValueSchema {
 mod wasm {
     use super::*;
 
-    #[derive(tsify_next::Tsify)]
+    #[derive(tsify::Tsify)]
     #[serde(untagged)]
     enum SingleValueSchema {
         Schema {

--- a/libs/@blockprotocol/type-system/rust/src/ontology/json_schema/constraint/number.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/json_schema/constraint/number.rs
@@ -46,14 +46,14 @@ pub enum NumberValidationError {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase")]
 pub enum NumberTypeTag {
     Number,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(untagged, rename_all = "camelCase", deny_unknown_fields)]
 pub enum NumberSchema {
     Constrained(NumberConstraints),
@@ -208,7 +208,7 @@ impl ConstraintValidator<Real> for NumberSchema {
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct NumberConstraints {
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/libs/@blockprotocol/type-system/rust/src/ontology/json_schema/constraint/object.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/json_schema/constraint/object.rs
@@ -11,7 +11,7 @@ use crate::{knowledge::PropertyValue, ontology::data_type::schema::ResolveClosed
 pub enum ObjectValidationError {}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase")]
 pub enum ObjectTypeTag {
     Object,

--- a/libs/@blockprotocol/type-system/rust/src/ontology/json_schema/constraint/string.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/json_schema/constraint/string.rs
@@ -23,7 +23,7 @@ use crate::{
 };
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "kebab-case")]
 pub enum StringFormat {
     Uri,
@@ -214,7 +214,7 @@ pub enum StringTypeTag {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(untagged, rename_all = "camelCase", deny_unknown_fields)]
 pub enum StringSchema {
     Constrained(StringConstraints),
@@ -358,7 +358,7 @@ impl ConstraintValidator<str> for StringSchema {
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct StringConstraints {
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/libs/@blockprotocol/type-system/rust/src/ontology/json_schema/one_of/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/json_schema/one_of/mod.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 pub use self::validation::{OneOfSchemaValidationError, OneOfSchemaValidator};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct OneOfSchema<T> {
     #[serde(rename = "oneOf")]

--- a/libs/@blockprotocol/type-system/rust/src/ontology/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/mod.rs
@@ -73,7 +73,7 @@ pub struct OntologyTypeWithMetadata<S: OntologyTypeSchema> {
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct OntologyTemporalMetadata {

--- a/libs/@blockprotocol/type-system/rust/src/ontology/property_type/metadata.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/property_type/metadata.rs
@@ -26,7 +26,7 @@ pub struct PropertyTypeMetadata {
 mod metadata_patch {
     use super::*;
 
-    #[derive(tsify_next::Tsify)]
+    #[derive(tsify::Tsify)]
     #[serde(untagged)]
     enum PropertyTypeMetadata {
         #[serde(rename_all = "camelCase")]
@@ -93,7 +93,7 @@ pub type PropertyTypeWithMetadata = OntologyTypeWithMetadata<PropertyType>;
 mod with_metadata_patch {
     use super::*;
 
-    #[derive(tsify_next::Tsify)]
+    #[derive(tsify::Tsify)]
     struct PropertyTypeWithMetadata {
         schema: PropertyType,
         metadata: PropertyTypeMetadata,

--- a/libs/@blockprotocol/type-system/rust/src/ontology/property_type/schema/array/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/property_type/schema/array/mod.rs
@@ -29,7 +29,7 @@ where
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(untagged)]
 pub enum ValueOrArray<T> {
     Value(T),

--- a/libs/@blockprotocol/type-system/rust/src/ontology/property_type/schema/array/raw.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/property_type/schema/array/raw.rs
@@ -1,7 +1,7 @@
 use crate::ontology::json_schema::ArrayTypeTag;
 
 #[derive(serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub(super) struct PropertyValueArray<T> {
     #[serde(rename = "type")]

--- a/libs/@blockprotocol/type-system/rust/src/ontology/property_type/schema/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/property_type/schema/mod.rs
@@ -248,7 +248,7 @@ impl Serialize for PropertyType {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(deny_unknown_fields)]
 #[repr(transparent)]
 pub struct PropertyTypeReference {
@@ -264,7 +264,7 @@ impl From<&VersionedUrl> for &PropertyTypeReference {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(
     untagged,
     expecting = "Expected a data type reference, a property type object, or an array of property \

--- a/libs/@blockprotocol/type-system/rust/src/ontology/property_type/schema/object/raw.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/property_type/schema/object/raw.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use crate::ontology::{BaseUrl, json_schema::ObjectTypeTag};
 
 #[derive(serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub(super) struct PropertyValueObject<T> {
     #[serde(rename = "type")]

--- a/libs/@blockprotocol/type-system/rust/src/ontology/property_type/schema/raw.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/property_type/schema/raw.rs
@@ -6,7 +6,7 @@ use super::PropertyValues;
 use crate::ontology::VersionedUrl;
 
 #[derive(Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase")]
 enum PropertyTypeSchemaTag {
     #[serde(rename = "https://blockprotocol.org/types/modules/graph/0.3/schema/property-type")]
@@ -14,14 +14,14 @@ enum PropertyTypeSchemaTag {
 }
 
 #[derive(Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase")]
 enum PropertyTypeTag {
     PropertyType,
 }
 
 #[derive(Serialize, Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct PropertyType<'a> {
     #[serde(rename = "$schema")]

--- a/libs/@blockprotocol/type-system/rust/src/ontology/provenance/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/ontology/provenance/mod.rs
@@ -33,7 +33,7 @@ use crate::{
 /// - Types that are created and owned by the local system
 /// - Types that have been fetched from external sources
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(untagged)]
 pub enum OntologyOwnership {
@@ -57,7 +57,7 @@ pub enum OntologyOwnership {
 ///
 /// Contains tracking information about the creation, modification, and origin of an ontology type.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct OntologyProvenance {
@@ -70,7 +70,7 @@ pub struct OntologyProvenance {
 /// Contains information provided by the client about the creation context,
 /// including the acting entity's type and the origin of the creation action.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct ProvidedOntologyEditionProvenance {
@@ -85,7 +85,7 @@ pub struct ProvidedOntologyEditionProvenance {
 /// Contains comprehensive tracking of who created and potentially archived this
 /// edition, along with user-provided context about the creation process.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct OntologyEditionProvenance {

--- a/libs/@blockprotocol/type-system/rust/src/provenance/origin.rs
+++ b/libs/@blockprotocol/type-system/rust/src/provenance/origin.rs
@@ -7,7 +7,7 @@ use utoipa::{
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[serde(deny_unknown_fields, tag = "type", rename_all = "kebab-case")]
 pub enum OriginType {
     WebApp,
@@ -70,7 +70,7 @@ impl OriginProvenance {
 mod patch {
     use super::*;
 
-    #[derive(tsify_next::Tsify)]
+    #[derive(tsify::Tsify)]
     #[serde(untagged)]
     pub enum OriginProvenance {
         #[serde(rename_all = "camelCase")]

--- a/libs/@blockprotocol/type-system/rust/src/provenance/source.rs
+++ b/libs/@blockprotocol/type-system/rust/src/provenance/source.rs
@@ -7,7 +7,7 @@ use crate::knowledge::entity::EntityId;
 // This enumeration is expected to grow over time, thus it's marked as non-exhaustive.
 // To generate the OpenAPI specs pass `--write-openapi-specs` when running the HASH Graph server.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 #[non_exhaustive]
@@ -19,7 +19,7 @@ pub enum SourceType {
 
 /// A location where the source material can be found.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct Location {
@@ -42,7 +42,7 @@ pub struct Location {
 
 /// The source material used in producing a value.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(target_arch = "wasm32", derive(tsify_next::Tsify))]
+#[cfg_attr(target_arch = "wasm32", derive(tsify::Tsify))]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SourceProvenance {

--- a/libs/@blockprotocol/type-system/rust/src/utils.rs
+++ b/libs/@blockprotocol/type-system/rust/src/utils.rs
@@ -1,7 +1,7 @@
 #[cfg(target_arch = "wasm32")]
 mod wasm {
     use serde::{Deserialize, Serialize};
-    use tsify_next::Tsify;
+    use tsify::Tsify;
     use wasm_bindgen::prelude::wasm_bindgen;
 
     #[wasm_bindgen(typescript_custom_section)]
@@ -42,15 +42,15 @@ export type Brand<Base, Kind extends string> = Base extends BrandedBase<
 
     // Common types
 
-    #[derive(tsify_next::Tsify)]
+    #[derive(tsify::Tsify)]
     #[expect(dead_code, reason = "Used in the generated TypeScript types")]
     struct Url(#[tsify(type = "Brand<string, \"Url\">")] String);
 
-    #[derive(tsify_next::Tsify)]
+    #[derive(tsify::Tsify)]
     #[expect(dead_code, reason = "Used in the generated TypeScript types")]
     struct Timestamp(#[tsify(type = "Brand<string, \"Timestamp\">")] String);
 
-    #[derive(tsify_next::Tsify)]
+    #[derive(tsify::Tsify)]
     #[serde(rename_all = "camelCase", tag = "kind", content = "limit")]
     #[expect(dead_code, reason = "Used in the generated TypeScript types")]
     enum TemporalBound {
@@ -58,20 +58,20 @@ export type Brand<Base, Kind extends string> = Base extends BrandedBase<
         Inclusive(Timestamp),
         Exclusive(Timestamp),
     }
-    #[derive(tsify_next::Tsify)]
+    #[derive(tsify::Tsify)]
     #[serde(rename_all = "camelCase", tag = "kind", content = "limit")]
     #[expect(dead_code, reason = "Used in the generated TypeScript types")]
     enum LimitedTemporalBound {
         Inclusive(Timestamp),
         Exclusive(Timestamp),
     }
-    #[derive(tsify_next::Tsify)]
+    #[derive(tsify::Tsify)]
     #[serde(rename_all = "camelCase", tag = "kind", content = "limit")]
     #[expect(dead_code, reason = "Used in the generated TypeScript types")]
     enum ClosedTemporalBound {
         Inclusive(Timestamp),
     }
-    #[derive(tsify_next::Tsify)]
+    #[derive(tsify::Tsify)]
     #[serde(rename_all = "camelCase", tag = "kind", content = "limit")]
     #[expect(dead_code, reason = "Used in the generated TypeScript types")]
     enum OpenTemporalBound {
@@ -79,19 +79,19 @@ export type Brand<Base, Kind extends string> = Base extends BrandedBase<
         Unbounded,
     }
 
-    #[derive(tsify_next::Tsify)]
+    #[derive(tsify::Tsify)]
     #[expect(dead_code, reason = "Used in the generated TypeScript types")]
     struct TemporalInterval<Start, End> {
         start: Start,
         end: End,
     }
-    #[derive(tsify_next::Tsify)]
+    #[derive(tsify::Tsify)]
     #[expect(dead_code, reason = "Used in the generated TypeScript types")]
     struct RightBoundedTemporalInterval {
         start: TemporalBound,
         end: LimitedTemporalBound,
     }
-    #[derive(tsify_next::Tsify)]
+    #[derive(tsify::Tsify)]
     #[expect(dead_code, reason = "Used in the generated TypeScript types")]
     struct LeftClosedTemporalInterval {
         start: ClosedTemporalBound,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Update the `tsify` dependency from `tsify-next` to `tsify` in the Block Protocol type system Rust package.

## 🔗 Related links

- The `tsify-next` package has been renamed to `tsify` in the latest version

## 🔍 What does this change?

- Updates all imports and derive macros from `tsify-next` to `tsify`
- Updates the dependency in Cargo.lock and Cargo.toml files
- Maintains the same functionality while using the renamed package

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- modifies a **Cargo**-publishable library and **I have amended the version**

### 📜 Does this require a change to the docs?

The changes in this PR:

- are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- do not affect the execution graph

## 🛡 What tests cover this?

- Existing tests should continue to pass with the renamed dependency

## ❓ How to test this?

1. Checkout the branch
2. Run the tests for the Block Protocol type system Rust package
3. Confirm that all tests pass and TypeScript types are correctly generated
