### PR TITLE
SRE-465: Add gitleaks CI workflow with SARIF upload

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,36 @@
+name: Gitleaks
+
+on:
+  pull_request: {}
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "42 10 * * 1"
+
+jobs:
+  gitleaks:
+    name: Scan
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Run Gitleaks
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196e88e9c30 # v2.3.9
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: true
+          GITLEAKS_ENABLE_SUMMARY: true
+
+      - name: Upload SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@cf1bb45a277cb3c205638b2cd5c984db1c46a412 # v4.31.7
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -15,19 +15,30 @@ jobs:
       contents: read
       security-events: write
 
+    if: (github.actor != 'dependabot[bot]')
+
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
+      - name: Mark workspace as safe for Docker
+        run: git config --global --add safe.directory /github/workspace
+
       - name: Run Gitleaks
         uses: docker://zricethezav/gitleaks:v8.30.0
         with:
           args: detect --source /github/workspace --log-opts="${{ github.event.pull_request.base.sha || github.event.before }}..HEAD" --report-format sarif --report-path /github/workspace/results.sarif
-        continue-on-error: true
+
+      - name: Check SARIF file exists
+        id: sarif_file_check
+        if: always()
+        uses: andstor/file-existence-action@076e0072799f4942c8bc574a82233e1e4d13e9d6 # v3.0.0
+        with:
+          files: "results.sarif"
 
       - name: Upload SARIF
-        if: always() && github.event.pull_request.head.repo.full_name == github.repository
+        if: always() && steps.sarif_file_check.outputs.files_exists == 'true' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
         uses: github/codeql-action/upload-sarif@cf1bb45a277cb3c205638b2cd5c984db1c46a412 # v4.31.7
         with:
           sarif_file: results.sarif

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -5,8 +5,6 @@ on:
   push:
     branches:
       - main
-  schedule:
-    - cron: "42 10 * * 1"
 
 jobs:
   gitleaks:
@@ -23,14 +21,13 @@ jobs:
           fetch-depth: 0
 
       - name: Run Gitleaks
-        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196e88e9c30 # v2.3.9
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: true
-          GITLEAKS_ENABLE_SUMMARY: true
+        uses: docker://zricethezav/gitleaks:v8.30.0
+        with:
+          args: detect --source /github/workspace --log-opts="${{ github.event.pull_request.base.sha || github.event.before }}..HEAD" --report-format sarif --report-path /github/workspace/results.sarif
+        continue-on-error: true
 
       - name: Upload SARIF
-        if: always()
+        if: always() && github.event.pull_request.head.repo.full_name == github.repository
         uses: github/codeql-action/upload-sarif@cf1bb45a277cb3c205638b2cd5c984db1c46a412 # v4.31.7
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Add Gitleaks GitHub Action to scan for secrets in the codebase. This workflow will run on pull requests, pushes to main, and weekly on Mondays to detect potential credential leaks.

## 🔍 What does this change?

- Adds a new GitHub workflow file `.github/workflows/gitleaks.yml` that configures Gitleaks scanning
- Sets up Gitleaks to run on pull requests, pushes to main branch, and on a weekly schedule
- Configures the workflow to upload scan results as SARIF files for GitHub security analysis
- Includes appropriate permissions for security events writing

## 🛡 What tests cover this?

- The workflow will automatically run on the specified events to validate its functionality

## ❓ How to test this?

1. Checkout the branch
2. Create a PR to trigger the workflow
3. Confirm that the Gitleaks scan runs successfully and reports any findings

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph
