### PR TITLE
BE-386: Mask query params in logs for proxied Kratos requests

### DIFF
--- a/apps/hash-api/src/index.ts
+++ b/apps/hash-api/src/index.ts
@@ -126,6 +126,37 @@ const hydraProxy = createProxyMiddleware<Request, Response>({
   pathRewrite: (_, req) => req.originalUrl,
 });
 
+const redactAuthQueryParams = (value: string): string =>
+  value
+    /**
+     * Fail closed for auth logs by replacing complete query strings.
+     * This avoids relying on an allowlist of sensitive key names.
+     */
+    .replace(/\?[^#\s]*/g, "?[REDACTED_QUERY]");
+
+const sanitizeProxyLogArgs = (args: unknown[]): unknown[] =>
+  args.map((arg) =>
+    typeof arg === "string" ? redactAuthQueryParams(arg) : arg,
+  );
+
+const kratosProxyLogger = {
+  /**
+   * `http-proxy-middleware` logs include request URLs.
+   *
+   * `/auth/*` requests can include Ory self-service query parameters, so we
+   * sanitize all forwarded log levels consistently.
+   */
+  info: (...args: unknown[]) => {
+    logger.info(sanitizeProxyLogArgs(args));
+  },
+  warn: (...args: unknown[]) => {
+    logger.warn(sanitizeProxyLogArgs(args));
+  },
+  error: (...args: unknown[]) => {
+    logger.error(sanitizeProxyLogArgs(args));
+  },
+};
+
 const kratosProxy = createProxyMiddleware<Request, Response>({
   target: kratosPublicUrl,
   pathRewrite: {
@@ -135,6 +166,7 @@ const kratosProxy = createProxyMiddleware<Request, Response>({
      */
     "^/auth": "",
   },
+  logger: kratosProxyLogger,
   selfHandleResponse: true,
   on: {
     proxyReq: fixRequestBody,


### PR DESCRIPTION
This PR addresses something tangentially raised on a security sweep, which is the use of query params related to Kratos login/logout flows.

I don't think there's any real risk here as the relevant values are short-lived ids for specific flows the user is going through rather than secrets which grant any access, but redacting them from server-side logs nonetheless.