### PR TITLE
BE-398: Remove hardcoded database names from environment files

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -2,11 +2,6 @@
 # The values contained within this dotfile are provided to development instances of HASH
 # These variables can be locally overridden by re-specifying them in a `.env.development.local` file
 
-HASH_KRATOS_PG_DATABASE=dev_kratos
-HASH_TEMPORAL_PG_DATABASE=dev_temporal
-HASH_TEMPORAL_VISIBILITY_PG_DATABASE=dev_temporal_visibility
-HASH_GRAPH_PG_DATABASE=dev_graph
-
 HASH_GRAPH_RPC_ENABLED=true
 HASH_RPC_ENABLED=true
 

--- a/.env.test
+++ b/.env.test
@@ -2,10 +2,6 @@
 # The values contained within this dotfile are provided to test instances of HASH
 # These variables can be locally overridden by re-specifying them in a `.env.test.local` file
 
-HASH_KRATOS_PG_DATABASE=test_kratos
-HASH_TEMPORAL_PG_DATABASE=test_temporal
-HASH_TEMPORAL_VISIBILITY_PG_DATABASE=test_temporal_visibility
-HASH_GRAPH_PG_DATABASE=test_graph
 HASH_GRAPH_ALLOWED_URL_DOMAIN_PATTERN="(?:http://localhost:3000|https://hash\\.ai)/@(?P<shortname>[\\w-]+)/types/(?P<kind>(?:data-type)|(?:property-type)|(?:entity-type))/[\\w\\-_%]+/"
 
 # For locally-running minio instance

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -194,8 +194,6 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.setup.outputs.integration) }}
       fail-fast: false
-    env:
-      HASH_GRAPH_PG_DATABASE: graph
     if: needs.setup.outputs.integration != '{"name":[],"include":[]}'
     runs-on: ubuntu-24.04
     steps:
@@ -236,9 +234,6 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           touch .env.local
-
-          echo 'HASH_GRAPH_PG_DATABASE=graph' > .env.local
-
           cp .env.local .env.test.local
           yarn external-services:test up --wait
 
@@ -316,9 +311,6 @@ jobs:
       - name: Launch external services
         run: |
           touch .env.local
-
-          echo 'HASH_GRAPH_PG_DATABASE=graph' > .env.local
-
           cp .env.local .env.test.local
           yarn external-services:test up --wait
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -303,9 +303,6 @@ jobs:
           echo 'ANTHROPIC_API_KEY=dummy' >> .env.local
           echo 'HASH_TEMPORAL_WORKER_AI_AWS_ACCESS_KEY_ID=dummy' >> .env.local
           echo 'HASH_TEMPORAL_WORKER_AI_AWS_SECRET_ACCESS_KEY=dummy' >> .env.local
-
-          echo 'HASH_GRAPH_PG_DATABASE=graph' >> .env.local
-
           cp .env.local .env.test.local
           yarn external-services:test up --wait
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Remove hardcoded database name environment variables from configuration files

## 🔍 What does this change?

- Removes database name environment variables from `.env.development` and `.env.test`
- Removes database name overrides from GitHub workflow files

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- Existing CI workflows will validate the changes

## ❓ How to test this?

1. Checkout the branch
2. Run the application in development mode
3. Confirm that database connections work correctly without the hardcoded database names
