### PR TITLE
SRE-516: Add TURBO_GLOBAL_WARNING_DISABLED env var to Mise config

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -1,5 +1,6 @@
 [env]
-_.file = [".env", ".env.local"]
+TURBO_GLOBAL_WARNING_DISABLED = 1
+_.file                        = [".env", ".env.local"]
 
 [settings]
 idiomatic_version_file_enable_tools = ["rust"]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Removes the warning displayed when running Turborepo commands (e.g. `turbo build`, `turbo lint`), which appears because `turbo` is not defined as a dependency in `package.json` — it is installed globally via Mise instead.

## 🔍 What does this change?

- Adds `TURBO_GLOBAL_WARNING_DISABLED=1` to the Mise environment config (`.config/mise/config.toml`)

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph