### PR TITLE
SRE-525: Skip sccache install for forks without Vault secrets

### DIFF
--- a/.github/actions/install-tools/action.yml
+++ b/.github/actions/install-tools/action.yml
@@ -47,7 +47,8 @@ runs:
         command: ${{ github.action_path }}/install-rust.sh
 
     - name: "Install sccache"
-      if: ${{ (inputs.rust == true || inputs.rust == 'true') && (inputs.sccache == true || inputs.sccache == 'true') }}
+      # Forked pull requests do not receive repository secrets, so `vault_address` is empty there.
+      if: ${{ (inputs.rust == true || inputs.rust == 'true') && (inputs.sccache == true || inputs.sccache == 'true') && inputs.vault_address != '' }}
       uses: ./.github/actions/install-sccache
       with:
         vault_address: ${{ inputs.vault_address }}


### PR DESCRIPTION
### Motivation
- Prevent invoking `install-sccache` in forked PRs that don't have repository secrets (so `vault_address` is empty) to avoid Vault-backed sccache setup failures and broken CI for forks.

### Description
- Add an inline comment and tighten the `if` condition in `.github/actions/install-tools/action.yml` so `install-sccache` is only used when `inputs.vault_address != ''`, preserving the existing Rust/sccache guards.

### Testing
- Ran `git diff -- .github/actions/install-tools/action.yml && git diff --check` and `git show --stat --oneline -1`, both completed successfully (commit succeeded; pre-commit hook printed `biome: not found` in this environment but did not block the commit).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699655bbf8308328b80267fa52d5664d)