### PR TITLE
SRE-528: fix dismiss-stale-approvals workflow for forks

### DIFF
--- a/.github/workflows/dismiss-stale-approvals.yml
+++ b/.github/workflows/dismiss-stale-approvals.yml
@@ -1,7 +1,7 @@
 name: Dismiss stale pull request approvals
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
   merge_group:
 
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Dismiss stale pull request approvals
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request_target'
         # see: https://github.com/withgraphite/dismiss-stale-approvals/pull/8#issuecomment-3386592574
         uses: turnage/dismiss-stale-approvals@ff3fc67f2978497c420e446f704b9502dd911fd8 # fork
         with:


### PR DESCRIPTION
### Motivation
- Allow the stale-approval dismissal action to run with base-repo context for pull requests opened from forks by using the safer `pull_request_target` event.

### Description
- Switch the trigger and step guard in `/.github/workflows/dismiss-stale-approvals.yml` from `pull_request` to `pull_request_target` so the action can perform write operations (dismiss approvals) on forked PRs.

### Testing
- Ran `git diff --check` which succeeded, and attempted local YAML parsing and helper tooling (`PyYAML`/`ruby`/`yq`) and an external lookup to validate behavior, but those attempts failed due to missing tools or network restrictions in the execution environment; the workflow file change is a small, syntactic update applied to `/.github/workflows/dismiss-stale-approvals.yml` and committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699707bae1548328a5ded34f6f6a515e)