### PR TITLE
BE-416: Add Constant::JsonNull, remove Constant::String, add From impls

### DIFF
--- a/libs/@local/graph/postgres-store/src/store/postgres/query/expression/conditional.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/expression/conditional.rs
@@ -173,6 +173,10 @@ impl Transpile for Function {
 pub enum Constant {
     Boolean(bool),
     UnsignedInteger(u32),
+    /// The JSON `null` literal, distinct from SQL `NULL`.
+    ///
+    /// Transpiles to `'null'::jsonb`.
+    JsonNull,
 }
 
 impl From<bool> for Constant {
@@ -192,6 +196,7 @@ impl Transpile for Constant {
         match self {
             Self::Boolean(value) => fmt.write_str(if *value { "TRUE" } else { "FALSE" }),
             Self::UnsignedInteger(number) => fmt::Display::fmt(number, fmt),
+            Self::JsonNull => fmt.write_str("'null'::jsonb"),
         }
     }
 }
@@ -566,6 +571,14 @@ mod tests {
             ),)))
             .transpile_to_string(),
             r#"MIN("ontology_ids_1_2_3"."version")"#
+        );
+    }
+
+    #[test]
+    fn transpile_json_null_constant() {
+        assert_eq!(
+            Expression::Constant(Constant::JsonNull).transpile_to_string(),
+            "'null'::jsonb"
         );
     }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Cleans up the `Constant` enum in the PostgreSQL query expression system by removing the `String` variant (string literals should go through `Parameter` to avoid embedding literals in SQL) and adding ergonomic `From` trait impls for the remaining variants.

## 🔗 Related links

- ...

## 🚫 Blocked by

- [ ] ...

## 🔍 What does this change?

- Removes `Constant::String` — string values must go through `Parameter`
- Implements `From<bool>` and `From<u32>` for ergonomic constant creation
- Improves `UnsignedInteger` transpilation to use `fmt::Display`
- Updates tests to use the new `From` impls

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

## 🐾 Next steps

## 🛡 What tests cover this?

- Existing unit tests for case expressions, array operations, and transpilation functionality

## ❓ How to test this?

1. Checkout the branch
2. Run `cargo nextest run --package hash-graph-postgres-store -E 'test(expression)'`

## 📹 Demo