### PR TITLE
BE-419: Fix `cargo publish` failures for darwin-kperf crates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
       unit-tests: ${{ steps.packages.outputs.unit-tests }}
       integration-tests: ${{ steps.packages.outputs.integration-tests }}
       system-tests: ${{ steps.packages.outputs.system-tests }}
-      publish: ${{ steps.packages.outputs.publish }}
+      publish-rust: ${{ steps.packages.outputs.publish-rust }}
     steps:
       - name: Checkout source code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -65,7 +65,6 @@ jobs:
             | jq --compact-output '.data.affectedPackages.items | [(.[] | select(.name != "//"))] | { name: [.[].name], include: . }')
 
           PUBLISH_PACKAGES=[]
-          PUBLISH_INCLUDES=[]
           while IFS= read -r file; do
             if [[ -n "$file" ]]; then
               PACKAGE_NAME=$(yq '.package.name' -p toml -oy "$file")
@@ -92,17 +91,13 @@ jobs:
                 continue
               fi
 
-              DIR=$(dirname "$file")
-
               PUBLISH_PACKAGES=$(echo "$PUBLISH_PACKAGES" | jq -c --arg package "$PACKAGE_NAME" '. += [$package]')
-              PUBLISH_INCLUDES=$(echo "$PUBLISH_INCLUDES" | jq -c --arg package "$PACKAGE_NAME" --arg directory "$DIR" '. += [{name: $package, path: $directory}]')
             fi
           done <<< "$(find . -name 'Cargo.toml' -type f | sed 's|\./||')"
-          PUBLISH_PACKAGES=$(jq -c -n --argjson packages "$PUBLISH_PACKAGES" --argjson includes "$PUBLISH_INCLUDES" '{name: $packages, include: $includes}')
 
           echo "unit-tests=$UNIT_TEST_PACKAGES" | tee -a $GITHUB_OUTPUT
           echo "integration-tests=$INTEGRATION_TEST_PACKAGES" | tee -a $GITHUB_OUTPUT
-          echo "publish=$PUBLISH_PACKAGES" | tee -a $GITHUB_OUTPUT
+          echo "publish-rust=$PUBLISH_PACKAGES" | tee -a $GITHUB_OUTPUT
 
   unit-tests:
     name: Unit
@@ -334,13 +329,10 @@ jobs:
             var/api
             var/logs
 
-  publish:
-    name: Publish
+  publish-rust:
+    name: Publish (Rust)
     needs: [setup]
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJSON(needs.setup.outputs.publish) }}
-    if: needs.setup.outputs.publish != '{"name":[],"include":[]}'
+    if: needs.setup.outputs.publish-rust != '[]'
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout source code
@@ -349,11 +341,13 @@ jobs:
       - name: Clean up disk
         uses: ./.github/actions/clean-up-disk
 
-      - name: Find publish jobs to run
-        id: publish
+      - name: Build package flags
+        id: flags
+        env:
+          PUBLISH_PACKAGES: ${{ needs.setup.outputs.publish-rust }}
         run: |
-          HAS_RUST=$([[ -f "${{ matrix.path }}/Cargo.toml" || ${{ matrix.path }} = "apps/hash-graph" ]] && echo 'true' || echo 'false')
-          echo "has-rust=$HAS_RUST" | tee -a $GITHUB_OUTPUT
+          PACKAGES=$(echo "$PUBLISH_PACKAGES" | jq -r '.[]' | while read -r pkg; do echo -n "-p $pkg "; done)
+          echo "packages=$PACKAGES" | tee -a $GITHUB_OUTPUT
 
       - name: Login
         run: |
@@ -361,18 +355,16 @@ jobs:
           cargo login "${{ secrets.CARGO_REGISTRY_TOKEN }}"
 
       - name: Publish (dry run)
-        if: always() && steps.publish.outputs.has-rust == 'true' && github.event_name == 'pull_request' || github.event_name == 'merge_group'
-        working-directory: ${{ matrix.path }}
-        run: cargo publish --all-features --dry-run --no-verify
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        run: cargo publish --all-features --dry-run --no-verify ${{ steps.flags.outputs.packages }}
 
       - name: Publish
-        if: always() && steps.publish.outputs.has-rust == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
-        working-directory: ${{ matrix.path }}
-        run: cargo publish --all-features --no-verify
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: cargo publish --all-features --no-verify ${{ steps.flags.outputs.packages }}
 
   passed:
     name: Tests passed
-    needs: [setup, unit-tests, integration-tests, publish, optimize-ci]
+    needs: [setup, unit-tests, integration-tests, publish-rust, optimize-ci]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -388,7 +380,7 @@ jobs:
           [[ ${{ needs.integration-tests.result }} =~ success|skipped ]]
       - name: Check publish results
         run: |
-          [[ ${{ needs.publish.result }} =~ success|skipped ]]
+          [[ ${{ needs.publish-rust.result }} =~ success|skipped ]]
 
       - name: Notify Slack on failure
         uses: rtCamp/action-slack-notify@c58b60ee33df2229ed2d2eed86eeaf7e6c527c5a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2110,7 +2110,7 @@ dependencies = [
 
 [[package]]
 name = "darwin-kperf"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "darwin-kperf-events",
  "darwin-kperf-sys",
@@ -2118,7 +2118,7 @@ dependencies = [
 
 [[package]]
 name = "darwin-kperf-codegen"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "convert_case 0.11.0",
  "plist",
@@ -2131,7 +2131,7 @@ dependencies = [
 
 [[package]]
 name = "darwin-kperf-criterion"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "codspeed-criterion-compat-walltime",
  "criterion",
@@ -2141,11 +2141,11 @@ dependencies = [
 
 [[package]]
 name = "darwin-kperf-events"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "darwin-kperf-sys"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "dashu-base"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,10 +58,10 @@ version = "0.0.0"
 
 [workspace.dependencies]
 # Workspace members
-darwin-kperf                        = { path = "libs/darwin-kperf", version = "0.1.0" }
-darwin-kperf-criterion              = { path = "libs/darwin-kperf/criterion", version = "0.1.0" }
-darwin-kperf-events                 = { path = "libs/darwin-kperf/events", version = "0.1.0" }
-darwin-kperf-sys                    = { path = "libs/darwin-kperf/sys", version = "0.1.0" }
+darwin-kperf                        = { path = "libs/darwin-kperf", version = "0.1.1" }
+darwin-kperf-criterion              = { path = "libs/darwin-kperf/criterion", version = "0.1.1" }
+darwin-kperf-events                 = { path = "libs/darwin-kperf/events", version = "0.1.1" }
+darwin-kperf-sys                    = { path = "libs/darwin-kperf/sys", version = "0.1.1" }
 error-stack                         = { path = "./libs/error-stack", default-features = false }
 harpc-client.path                   = "libs/@local/harpc/client/rust"
 harpc-codec.path                    = "libs/@local/harpc/codec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,10 +58,10 @@ version = "0.0.0"
 
 [workspace.dependencies]
 # Workspace members
-darwin-kperf.path                   = "libs/darwin-kperf"
-darwin-kperf-criterion.path         = "libs/darwin-kperf/criterion"
-darwin-kperf-events.path            = "libs/darwin-kperf/events"
-darwin-kperf-sys.path               = "libs/darwin-kperf/sys"
+darwin-kperf                        = { path = "libs/darwin-kperf", version = "0.1.0" }
+darwin-kperf-criterion              = { path = "libs/darwin-kperf/criterion", version = "0.1.0" }
+darwin-kperf-events                 = { path = "libs/darwin-kperf/events", version = "0.1.0" }
+darwin-kperf-sys                    = { path = "libs/darwin-kperf/sys", version = "0.1.0" }
 error-stack                         = { path = "./libs/error-stack", default-features = false }
 harpc-client.path                   = "libs/@local/harpc/client/rust"
 harpc-codec.path                    = "libs/@local/harpc/codec"

--- a/libs/darwin-kperf/Cargo.toml
+++ b/libs/darwin-kperf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name              = "darwin-kperf"
-version           = "0.1.0"
+version           = "0.1.1"
 authors.workspace = true
 edition.workspace = true
 license           = "MIT OR Apache-2.0"

--- a/libs/darwin-kperf/README.md
+++ b/libs/darwin-kperf/README.md
@@ -17,12 +17,12 @@
 
 ## Crates
 
-| Crate                                 | Description                                                                      |
-| ------------------------------------- | -------------------------------------------------------------------------------- |
-| [`darwin-kperf`](.)                   | Safe Rust API for configuring and sampling performance counters                  |
-| [`darwin-kperf-sys`](sys)             | Raw FFI bindings to `kperf.framework` and `kperfdata.framework`                  |
-| [`darwin-kperf-events`](events)       | Apple Silicon PMU event definitions (M1-M5), auto-generated from plist databases |
-| [`darwin-kperf-criterion`](criterion) | Criterion.rs measurement plugin for hardware-counter benchmarking                |
+| Crate | Description |
+| --- | --- |
+| [`darwin-kperf`](https://crates.io/crates/darwin-kperf) | Safe Rust API for configuring and sampling performance counters |
+| [`darwin-kperf-sys`](https://crates.io/crates/darwin-kperf-sys) | Raw FFI bindings to `kperf.framework` and `kperfdata.framework` |
+| [`darwin-kperf-events`](https://crates.io/crates/darwin-kperf-events) | Apple Silicon PMU event definitions (M1-M5), auto-generated from plist databases |
+| [`darwin-kperf-criterion`](https://crates.io/crates/darwin-kperf-criterion) | Criterion.rs measurement plugin for hardware-counter benchmarking |
 
 ## Platform support
 

--- a/libs/darwin-kperf/README.md
+++ b/libs/darwin-kperf/README.md
@@ -17,12 +17,12 @@
 
 ## Crates
 
-| Crate | Description |
-| --- | --- |
-| [`darwin-kperf`](https://crates.io/crates/darwin-kperf) | Safe Rust API for configuring and sampling performance counters |
-| [`darwin-kperf-sys`](https://crates.io/crates/darwin-kperf-sys) | Raw FFI bindings to `kperf.framework` and `kperfdata.framework` |
-| [`darwin-kperf-events`](https://crates.io/crates/darwin-kperf-events) | Apple Silicon PMU event definitions (M1-M5), auto-generated from plist databases |
-| [`darwin-kperf-criterion`](https://crates.io/crates/darwin-kperf-criterion) | Criterion.rs measurement plugin for hardware-counter benchmarking |
+| Crate                                                                       | Description                                                                      |
+| --------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| [`darwin-kperf`](https://crates.io/crates/darwin-kperf)                     | Safe Rust API for configuring and sampling performance counters                  |
+| [`darwin-kperf-sys`](https://crates.io/crates/darwin-kperf-sys)             | Raw FFI bindings to `kperf.framework` and `kperfdata.framework`                  |
+| [`darwin-kperf-events`](https://crates.io/crates/darwin-kperf-events)       | Apple Silicon PMU event definitions (M1-M5), auto-generated from plist databases |
+| [`darwin-kperf-criterion`](https://crates.io/crates/darwin-kperf-criterion) | Criterion.rs measurement plugin for hardware-counter benchmarking                |
 
 ## Platform support
 

--- a/libs/darwin-kperf/codegen/Cargo.toml
+++ b/libs/darwin-kperf/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name              = "darwin-kperf-codegen"
-version           = "0.1.0"
+version           = "0.1.1"
 authors.workspace = true
 edition.workspace = true
 license           = "MIT OR Apache-2.0"

--- a/libs/darwin-kperf/codegen/package.json
+++ b/libs/darwin-kperf/codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rust/darwin-kperf-codegen",
-  "version": "0.1.0-private",
+  "version": "0.1.1-private",
   "private": true,
   "license": "MIT OR Apache-2.0"
 }

--- a/libs/darwin-kperf/criterion/Cargo.toml
+++ b/libs/darwin-kperf/criterion/Cargo.toml
@@ -13,7 +13,7 @@ categories        = ["development-tools::profiling"]
 
 [dependencies]
 # Public workspace dependencies
-darwin-kperf-events = { version = "0.1.0", path = "../events", public = true }
+darwin-kperf-events = { workspace = true, public = true }
 
 # Public third-party dependencies
 codspeed-criterion-compat-walltime = { workspace = true, optional = true, public = true, default-features = false }

--- a/libs/darwin-kperf/criterion/Cargo.toml
+++ b/libs/darwin-kperf/criterion/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name              = "darwin-kperf-criterion"
-version           = "0.1.0"
+version           = "0.1.1"
 authors.workspace = true
 edition.workspace = true
 license           = "MIT OR Apache-2.0"

--- a/libs/darwin-kperf/criterion/Cargo.toml
+++ b/libs/darwin-kperf/criterion/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 edition.workspace = true
 license           = "MIT OR Apache-2.0"
 publish           = true
+readme            = "../README.md"
 description       = "Criterion measurement plugin using Apple's hardware performance counters"
 documentation     = "https://docs.rs/darwin-kperf-criterion"
 repository        = "https://github.com/hashintel/hash/tree/main/libs/darwin-kperf/criterion"

--- a/libs/darwin-kperf/criterion/package.json
+++ b/libs/darwin-kperf/criterion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rust/darwin-kperf-criterion",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "Criterion measurement plugin using Apple's hardware performance counters",
   "license": "MIT OR Apache-2.0",

--- a/libs/darwin-kperf/events/Cargo.toml
+++ b/libs/darwin-kperf/events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name              = "darwin-kperf-events"
-version           = "0.1.0"
+version           = "0.1.1"
 authors.workspace = true
 edition.workspace = true
 license           = "MIT OR Apache-2.0"

--- a/libs/darwin-kperf/events/Cargo.toml
+++ b/libs/darwin-kperf/events/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 edition.workspace = true
 license           = "MIT OR Apache-2.0"
 publish           = true
+readme            = "../README.md"
 description       = "Apple Silicon PMU event definitions for darwin-kperf"
 documentation     = "https://docs.rs/darwin-kperf-events"
 repository        = "https://github.com/hashintel/hash/tree/main/libs/darwin-kperf/events"

--- a/libs/darwin-kperf/events/package.json
+++ b/libs/darwin-kperf/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rust/darwin-kperf-events",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "Apple Silicon PMU event definitions for darwin-kperf",
   "license": "MIT OR Apache-2.0"

--- a/libs/darwin-kperf/package.json
+++ b/libs/darwin-kperf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rust/darwin-kperf",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "Safe Rust bindings for Apple's kperf/kpc hardware performance counters",
   "license": "MIT OR Apache-2.0",

--- a/libs/darwin-kperf/sys/Cargo.toml
+++ b/libs/darwin-kperf/sys/Cargo.toml
@@ -5,6 +5,7 @@ authors.workspace = true
 edition.workspace = true
 license           = "MIT OR Apache-2.0"
 publish           = true
+readme            = "../README.md"
 description       = "Raw FFI bindings to Apple's kperf and kperfdata frameworks"
 documentation     = "https://docs.rs/darwin-kperf-sys"
 repository        = "https://github.com/hashintel/hash/tree/main/libs/darwin-kperf/sys"

--- a/libs/darwin-kperf/sys/Cargo.toml
+++ b/libs/darwin-kperf/sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name              = "darwin-kperf-sys"
-version           = "0.1.0"
+version           = "0.1.1"
 authors.workspace = true
 edition.workspace = true
 license           = "MIT OR Apache-2.0"

--- a/libs/darwin-kperf/sys/package.json
+++ b/libs/darwin-kperf/sys/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rust/darwin-kperf-sys",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "Raw FFI bindings to Apple's kperf and kperfdata frameworks",
   "license": "MIT OR Apache-2.0",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR standardizes the dependency declarations for darwin-kperf workspace crates by migrating from path-only dependencies to workspace-managed dependencies with explicit versioning.

## 🔍 What does this change?

- Converts darwin-kperf workspace dependencies from shorthand path syntax to full table syntax with version "0.1.1"
- Updates darwin-kperf-criterion to use `workspace = true` for its darwin-kperf-events dependency instead of explicit path and version

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] modifies a **Cargo**-publishable library and **I have amended the version**

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- Existing cargo build and test processes

## ❓ How to test this?

1. Checkout the branch
2. Run `cargo check` to verify dependency resolution
3. Confirm that all darwin-kperf crates build successfully
