### PR TITLE
FE-494: Fix scroll lock ref to prevent overflow hidden from persisting

### DIFF
--- a/apps/hash-frontend/src/shared/use-scroll-lock.ts
+++ b/apps/hash-frontend/src/shared/use-scroll-lock.ts
@@ -58,6 +58,17 @@ export const useScrollLock = (
 ) => {
   const scrollbarSize = useLastScrollbarSize(elementToLock);
 
+  // Store the last positive scrollbar size in a ref so that it survives the
+  // ResizeObserver-driven update that resets `scrollbarSize` to 0 after we
+  // hide overflow (the scrollbar disappears, so the measured size drops to 0).
+  // Using a ref also keeps `scrollbarSize` out of the effect dependency array,
+  // preventing a cleanup/re-apply cycle that left `overflow: hidden` stuck on
+  // the body when the slide-over was closed.
+  const scrollbarSizeRef = useRef(scrollbarSize);
+  if (scrollbarSize > 0) {
+    scrollbarSizeRef.current = scrollbarSize;
+  }
+
   const madeChangesRequiringRemoval = useRef(false);
 
   useLayoutEffect(() => {
@@ -65,8 +76,13 @@ export const useScrollLock = (
 
     const overflowWasAlreadyHidden = overflow === "hidden";
 
-    if (active && scrollbarSize && !overflowWasAlreadyHidden) {
-      elementToLock.style.setProperty("padding-right", `${scrollbarSize}px`);
+    if (active && !overflowWasAlreadyHidden) {
+      if (scrollbarSizeRef.current) {
+        elementToLock.style.setProperty(
+          "padding-right",
+          `${scrollbarSizeRef.current}px`,
+        );
+      }
       elementToLock.style.setProperty("overflow", `hidden`);
       madeChangesRequiringRemoval.current = true;
     }
@@ -77,5 +93,5 @@ export const useScrollLock = (
         madeChangesRequiringRemoval.current = false;
       }
     };
-  }, [active, scrollbarSize, elementToLock]);
+  }, [active, elementToLock]);
 };


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR fixes a bug in the `useScrollLock` hook where `overflow: hidden` would remain stuck on the body element after closing a slide-over. The issue was caused by the effect dependency array including `scrollbarSize`, which changes to 0 after the scrollbar disappears, triggering a cleanup/re-apply cycle that left the overflow property in an incorrect state.

## 🔗 Related links

- N/A

## 🔍 What does this change?

- **Added `scrollbarSizeRef`**: Stores the last positive scrollbar size in a ref so it persists across ResizeObserver-driven updates that reset `scrollbarSize` to 0
- **Updated effect logic**: Changed the condition from checking `scrollbarSize` directly to checking `scrollbarSizeRef.current`, allowing the padding to be applied with the correct value even after the scrollbar disappears
- **Removed `scrollbarSize` from dependency array**: Removed `scrollbarSize` from the `useLayoutEffect` dependency array to prevent unnecessary cleanup/re-apply cycles that were causing the overflow property to get stuck

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

- [x] do not affect the execution graph

## 🛡 What tests cover this?

Existing tests for the `useScrollLock` hook should cover this change. The fix is a refactoring of internal state management without changing the public API or behavior.

## ❓ How to test this?

1. Open a slide-over or modal that uses `useScrollLock`
2. Verify that the body element has `overflow: hidden` applied while the modal is open
3. Close the modal
4. Confirm that `overflow: hidden` is properly removed from the body element (not stuck)
5. Verify that the page is scrollable again after closing

https://claude.ai/code/session_017nvssXtqwMfVW1Ecpoo2yh