### PR TITLE
FE-496: Refactor account recovery page with shared auth components

### DIFF
--- a/apps/hash-frontend/src/pages/recovery.page.tsx
+++ b/apps/hash-frontend/src/pages/recovery.page.tsx
@@ -1,5 +1,5 @@
 import { TextField } from "@hashintel/design-system";
-import { Box, Collapse, Container, Typography } from "@mui/material";
+import { Box, Collapse, Typography } from "@mui/material";
 import type { RecoveryFlow } from "@ory/client";
 import { isUiNodeInputAttributes } from "@ory/integrations/ui";
 import { useRouter } from "next/router";
@@ -9,6 +9,9 @@ import { useEffect, useState } from "react";
 import type { NextPageWithLayout } from "../shared/layout";
 import { getPlainLayout } from "../shared/layout";
 import { Button } from "../shared/ui";
+import { AuthHeading } from "./shared/auth-heading";
+import { AuthLayout } from "./shared/auth-layout";
+import { AuthPaper } from "./shared/auth-paper";
 import {
   gatherUiNodeValuesFromFlow,
   oryKratosClient,
@@ -166,91 +169,100 @@ const RecoveryPage: NextPageWithLayout = () => {
   const hasSubmittedEmail = flow && flow.state !== "choose_method";
 
   return (
-    <Container sx={{ pt: 10 }}>
-      <Typography variant="h1" gutterBottom>
-        Account Recovery
-      </Typography>
-      <Box
-        component="form"
-        onSubmit={handleSubmitEmail}
+    <AuthLayout>
+      <AuthPaper
         sx={{
-          display: "flex",
-          flexDirection: "column",
-          maxWidth: 500,
-          "> *:not(:first-child)": {
-            marginTop: 1,
-          },
+          maxWidth: 600,
         }}
       >
-        <TextField
-          label="Email"
-          type="email"
-          autoComplete="email"
-          placeholder="Enter your email address"
-          value={email}
-          onChange={({ target }) => setEmail(target.value)}
-          error={
-            !!emailInputUiNode?.messages.find(({ type }) => type === "error")
-          }
-          helperText={emailInputUiNode?.messages.map(({ id, text }) => (
-            <Typography key={id}>{text}</Typography>
-          ))}
-          disabled={hasSubmittedEmail}
-          required
-        />
-        <Collapse in={!hasSubmittedEmail} sx={{ width: "100%" }}>
-          <Button
-            type="submit"
-            disabled={hasSubmittedEmail}
-            sx={{ width: "100%" }}
-          >
-            Recover account
-          </Button>
-        </Collapse>
-      </Box>
-      <Collapse in={hasSubmittedEmail}>
+        <AuthHeading>Account Recovery</AuthHeading>
         <Box
           component="form"
-          onSubmit={handleSubmitCode}
+          onSubmit={handleSubmitEmail}
           sx={{
             display: "flex",
             flexDirection: "column",
             maxWidth: 500,
-            "> *:not(:first-child)": {
-              marginTop: 1,
-            },
+            gap: 1,
           }}
         >
           <TextField
-            label="Verification code"
-            type="text"
-            autoComplete="off"
-            placeholder="Enter your verification code"
-            value={code}
-            onChange={({ target }) => setCode(target.value)}
+            label="Email address"
+            type="email"
+            autoComplete="email"
+            autoFocus
+            placeholder="Enter your email address"
+            value={email}
+            onChange={({ target }) => setEmail(target.value)}
             error={
-              !!codeInputUiNode?.messages.find(({ type }) => type === "error")
+              !!emailInputUiNode?.messages.find(({ type }) => type === "error")
             }
-            helperText={codeInputUiNode?.messages.map(({ id, text }) => (
+            helperText={emailInputUiNode?.messages.map(({ id, text }) => (
               <Typography key={id}>{text}</Typography>
             ))}
+            disabled={hasSubmittedEmail}
             required
           />
-          <Button type="submit" disabled={!code}>
-            Submit Code
-          </Button>
-          <Button variant="secondary" onClick={resetFlow}>
-            Change Email Address
-          </Button>
+          <Collapse in={!hasSubmittedEmail} sx={{ width: "100%" }}>
+            <Button
+              type="submit"
+              disabled={hasSubmittedEmail}
+              sx={{ width: "100%" }}
+            >
+              Recover account
+            </Button>
+          </Collapse>
         </Box>
-      </Collapse>
-      <Box maxWidth={500} mt={1}>
+        <Collapse in={hasSubmittedEmail}>
+          <Box
+            component="form"
+            onSubmit={handleSubmitCode}
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              maxWidth: 500,
+              gap: 1,
+            }}
+          >
+            <TextField
+              label="Verification code"
+              type="text"
+              autoComplete="off"
+              autoFocus
+              placeholder="Enter your verification code"
+              value={code}
+              onChange={({ target }) => setCode(target.value)}
+              error={
+                !!codeInputUiNode?.messages.find(({ type }) => type === "error")
+              }
+              helperText={codeInputUiNode?.messages.map(({ id, text }) => (
+                <Typography key={id}>{text}</Typography>
+              ))}
+              required
+            />
+            <Button type="submit" disabled={!code}>
+              Submit code
+            </Button>
+            <Button variant="secondary" onClick={resetFlow}>
+              Change email address
+            </Button>
+          </Box>
+        </Collapse>
+        {errorMessage ? (
+          <Typography
+            sx={{ color: ({ palette }) => palette.red[70], mt: 1 }}
+            variant="smallTextParagraphs"
+          >
+            {errorMessage}
+          </Typography>
+        ) : null}
         {flow?.ui.messages?.map(({ text, id }) => (
-          <Typography key={id}>{text}</Typography>
+          <Typography key={id} sx={{ mt: 1 }}>
+            {text}
+          </Typography>
         ))}
-        {errorMessage ? <Typography>{errorMessage}</Typography> : null}
-      </Box>
-    </Container>
+      </AuthPaper>
+    </AuthLayout>
   );
 };
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR refactors the account recovery page to use shared authentication layout components (`AuthLayout`, `AuthPaper`, and `AuthHeading`) for consistency with other authentication pages. It also improves the styling and user experience with better spacing and focus management.

## 🔗 Related links

- N/A

## 🚫 Blocked by

- N/A

## 🔍 What does this change?

- **Replaced layout structure**: Replaced `Container` with `AuthLayout` and `AuthPaper` components for consistent styling across authentication pages
- **Improved spacing**: Changed from manual margin management (`"> *:not(:first-child)": { marginTop: 1 }`) to `gap: 1` for cleaner spacing between form elements
- **Added heading component**: Used `AuthHeading` component for the "Account Recovery" title instead of raw `Typography`
- **Enhanced UX**: Added `autoFocus` attributes to email and verification code inputs for better keyboard navigation
- **Improved messaging**: Updated button and label text for consistency ("Submit Code" → "Submit code", "Change Email Address" → "Change email address", "Email" → "Email address")
- **Better error styling**: Moved error message styling to use palette colors with proper typography variant
- **Removed unused import**: Removed `Container` from Material-UI imports as it's no longer needed

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:
- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:
- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:
- [x] do not affect the execution graph

## ⚠️ Known issues

None

## 🐾 Next steps

None

## 🛡 What tests cover this?

Existing tests should cover this refactoring as it maintains the same functionality while improving the presentation layer.

## ❓ How to test this?

1. Navigate to the account recovery page
2. Verify the layout matches other authentication pages (login, signup, etc.)
3. Test the email submission flow
4. Test the verification code submission flow
5. Verify error messages display correctly with proper styling
6. Confirm focus is automatically set on input fields when they become visible

## 📷  Demo

Before:
<img width="550" height="261" alt="image" src="https://github.com/user-attachments/assets/76698820-e7f8-476c-ac22-07b85adeaf67" />
After:
<img width="546" height="425" alt="image" src="https://github.com/user-attachments/assets/7d06f0e7-df13-40a0-8671-8db5b5c1caa8" />


https://claude.ai/code/session_01S4ybFcAXDrX3HXV6w1mwpc