### PR TITLE
SRE-565: Fix sync-turborepo not removing deleted workspace dependencies

### DIFF
--- a/libs/@local/repo-chores/rust/src/sync_turborepo/mod.rs
+++ b/libs/@local/repo-chores/rust/src/sync_turborepo/mod.rs
@@ -460,7 +460,11 @@ async fn write_package_json_if_changed(
             tracing::debug!("Skipping unchanged package.json: {path}");
             return Ok(());
         }
-        Ok(_) | Err(_) => {}
+        Ok(_) => {}
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(err) => {
+            tracing::warn!("Failed to read {path} for change detection, overwriting: {err}");
+        }
     }
 
     fs::write(path, &output)


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Fix `sync-turborepo` not removing `workspace:*` dependencies from `package.json` when a Rust crate is deleted from the workspace. Also improves error handling and adds documentation.

## 🔗 Related links

- SRE-565

## 🔍 What does this change?

- **Fix stale dependency retention**: The old approach filtered dependencies by querying `yarn workspaces list` for known package names. When a crate's `package.json` was deleted, its dependency entry survived as an apparent "external" package. Now filters by `workspace:*` version protocol instead, which correctly identifies all sync-managed dependencies regardless of whether the target package still exists.
- **Remove yarn/git subprocess calls**: The `get_yarn_workspace_packages()` function (calling `yarn workspaces list` and `git rev-parse`) is no longer needed, making the sync faster and removing two external process dependencies.
- **Fix TOCTOU race in `read_package_json`**: Replace `try_exists` + `read_to_string` with direct `read_to_string` and match on `NotFound`.
- **Improve `write_package_json_if_changed`**: Replace `.ok()` (which swallowed all read errors) with an explicit match.
- **Add documentation**: Module-level docs, struct docs, and `# Errors` sections on all fallible functions.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- Manual verification: `cargo run --package hash-repo-chores --bin repo-chores-cli -- sync-turborepo` (48 packages, 0 failures)
- Verified that removing `hash-graph-test-server` from `hash-graph`'s Cargo.toml correctly removes the `@rust/hash-graph-test-server` entry from `package.json`

## ❓ How to test this?

1. Remove a workspace dependency from any `Cargo.toml`
2. Run `mise run sync-turborepo`
3. Confirm the corresponding `workspace:*` entry is removed from the `package.json`