### PR TITLE
FE-498: Apply Next.js build memory optimizations

### DIFF
--- a/apps/hash-frontend/next.config.js
+++ b/apps/hash-frontend/next.config.js
@@ -149,6 +149,11 @@ export default withSentryConfig(
       eslint: { ignoreDuringBuilds: true },
       typescript: { ignoreBuildErrors: true },
 
+      experimental: {
+        webpackBuildWorker: true,
+        webpackMemoryOptimizations: true,
+      },
+
       transpilePackages: [
         "@blockprotocol/service",
         "@blockprotocol/core",

--- a/apps/hash-frontend/vercel-build.sh
+++ b/apps/hash-frontend/vercel-build.sh
@@ -16,4 +16,4 @@ cd ../..
 rm .env
 
 echo "Building frontend"
-turbo build --filter='@apps/hash-frontend' --env-mode=loose
+NODE_OPTIONS="--max-old-space-size=6144" turbo build --filter='@apps/hash-frontend' --env-mode=loose


### PR DESCRIPTION
### Motivation
- Reduce memory pressure and OOMs during frontend builds by enabling Next.js build-time memory optimizations and increasing Node's heap for CI/Vercel builds.

### Description
- Enabled `experimental.webpackBuildWorker` and `experimental.webpackMemoryOptimizations` in `apps/hash-frontend/next.config.js`.
- Prefixed the frontend build command in `apps/hash-frontend/vercel-build.sh` with `NODE_OPTIONS="--max-old-space-size=6144"` so the build runs with a larger V8 heap.
- Changes target only the frontend build configuration and the Vercel build script.

### Testing
- Verified shell syntax for the build script with `bash -n apps/hash-frontend/vercel-build.sh`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a6db94dff88332a04326bd6dffbbfd)