### PR TITLE
SRE-571: Deploy graph admin endpoint

### DIFF
--- a/.github/workflows/hash-backend-cd.yml
+++ b/.github/workflows/hash-backend-cd.yml
@@ -25,7 +25,7 @@ env:
   APP_CLUSTER_NAME: h-stage-euc1-app
   APP_DEPLOY_ROLE_ARN: arn:aws:iam::054238437032:role/h-stage-euc1-app-deploy
   APP_GRAPH_SERVICE_NAME: h-stage-euc1-app-graph
-  APP_GRAPH_TEST_SERVICE_NAME: h-stage-euc1-app-graph-test
+  APP_GRAPH_ADMIN_SERVICE_NAME: h-stage-euc1-app-graph-admin
   APP_TYPE_FETCHER_SERVICE_NAME: h-stage-euc1-app-type-fetcher
   APP_API_SERVICE_NAME: h-stage-euc1-app-api
   WORKER_CLUSTER_NAME: h-stage-euc1-worker
@@ -320,7 +320,7 @@ jobs:
           ECS_SERVICE_NAME: ${{ env.APP_GRAPH_SERVICE_NAME }}
           ROLE_ARN: ${{ env.APP_DEPLOY_ROLE_ARN }}
 
-      - name: Redeploy graph-test staging service
+      - name: Redeploy graph-admin staging service
         uses: ./.github/actions/redeploy-ecs-service
         with:
           AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
@@ -328,7 +328,7 @@ jobs:
           AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
           AWS_REGION: ${{ env.AWS_REGION }}
           ECS_CLUSTER_NAME: ${{ env.APP_CLUSTER_NAME }}
-          ECS_SERVICE_NAME: ${{ env.APP_GRAPH_TEST_SERVICE_NAME }}
+          ECS_SERVICE_NAME: ${{ env.APP_GRAPH_ADMIN_SERVICE_NAME }}
           ROLE_ARN: ${{ env.APP_DEPLOY_ROLE_ARN }}
 
       - name: Redeploy type-fetcher staging service


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Rename the `graph-test` ECS service references to `graph-admin` in the backend CD workflow, aligning the deployment pipeline with the admin endpoint introduced in BE-426.

## 🔗 Related links

- [SRE-571: Deploy admin endpoint](https://linear.app/hash/issue/SRE-571/deploy-admin-endpoint)
- [BE-426: Merge graph test-server into admin endpoint in main binary](https://linear.app/hash/issue/BE-426/merge-graph-test-server-into-main-binary-as-admin-endpoint)
- [BE-423: Add JWT authentication and actor resolution for Graph admin API](https://linear.app/hash/issue/BE-423/decide-auth-approach-for-graph-admin-api-login)

## 🔍 What does this change?

- Rename `APP_GRAPH_TEST_SERVICE_NAME` → `APP_GRAPH_ADMIN_SERVICE_NAME` (env variable)
- Update ECS service name from `h-stage-euc1-app-graph-test` → `h-stage-euc1-app-graph-admin`
- Update step name from "Redeploy graph-test staging service" → "Redeploy graph-admin staging service"

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

## 🐾 Next steps

## 🛡 What tests cover this?

- CD workflow will be validated on merge by deploying the admin service

## ❓ How to test this?

1. Merge and observe the CD workflow run
2. Confirm the `graph-admin` ECS service is redeployed successfully