### PR TITLE
H-6339: Better pagination handling for `getFlowRuns` queries to Graph

### DIFF
--- a/apps/hash-api/src/graphql/resolvers/flows/get-flow-runs.ts
+++ b/apps/hash-api/src/graphql/resolvers/flows/get-flow-runs.ts
@@ -10,7 +10,11 @@ import type { GraphQLContext } from "../../context";
 import { wereDetailedFieldsRequested } from "./shared/were-detailed-fields-requested";
 
 export const getFlowRunsResolver: ResolverFn<
-  { flowRuns: FlowRun[] | SparseFlowRun[]; totalCount: number },
+  {
+    flowRuns: FlowRun[] | SparseFlowRun[];
+    totalCount: number;
+    nextCursor: string | null;
+  },
   Record<string, never>,
   Pick<GraphQLContext, "authentication" | "dataSources" | "temporal">,
   QueryGetFlowRunsArgs
@@ -19,14 +23,14 @@ export const getFlowRunsResolver: ResolverFn<
 
   const { authentication, dataSources, temporal } = context;
 
-  const { flowDefinitionIds, executionStatus, offset, limit } = args;
+  const { flowDefinitionIds, executionStatus, cursor, limit } = args;
 
   return await getFlowRuns({
     authentication,
     filters: {
       flowDefinitionIds,
       executionStatus,
-      offset,
+      cursor,
       limit,
     },
     graphApiClient: dataSources.graphApi,

--- a/apps/hash-frontend/src/pages/shared/flow-runs-context.tsx
+++ b/apps/hash-frontend/src/pages/shared/flow-runs-context.tsx
@@ -19,15 +19,17 @@ import type {
 import { FlowRunStatus, FlowStepStatus } from "../../graphql/api-types.gen";
 
 export type FlowRunsPaginationState = {
-  page: number;
+  currentCursor: string | null;
+  previousCursors: string[];
   rowsPerPage: number;
-  onPageChange: (newPage: number) => void;
-  onRowsPerPageChange: (newRowsPerPage: number) => void;
+  onNextPage: (nextCursor: string) => void;
+  onPreviousPage: () => void;
 };
 
 export type FlowRunsContextType = {
   flowRuns: GetFlowRunsQuery["getFlowRuns"]["flowRuns"];
   totalCount: number;
+  nextCursor: string | null;
   loading: boolean;
   pagination: FlowRunsPaginationState | null;
   selectedFlowRun: FlowRun | null;
@@ -46,10 +48,10 @@ export const FlowRunsContextProvider = ({
 }>) => {
   const variables: GetFlowRunsQueryVariables = pagination
     ? {
-        offset: pagination.page * pagination.rowsPerPage,
+        cursor: pagination.currentCursor,
         limit: pagination.rowsPerPage,
       }
-    : { offset: 0, limit: flowRunsQueryMaxLimit };
+    : { limit: flowRunsQueryMaxLimit };
 
   const { data: flowRunsData, loading: flowRunsLoading } = useQuery<
     GetFlowRunsQuery,
@@ -79,6 +81,7 @@ export const FlowRunsContextProvider = ({
   }, [flowRunsData]);
 
   const totalCount = flowRunsData?.getFlowRuns.totalCount ?? 0;
+  const nextCursor = flowRunsData?.getFlowRuns.nextCursor ?? null;
 
   const selectedFlowRun = useMemo(() => {
     if (selectedFlowRunData) {
@@ -91,6 +94,7 @@ export const FlowRunsContextProvider = ({
     () => ({
       flowRuns,
       totalCount,
+      nextCursor,
       loading: selectedFlowRunLoading || flowRunsLoading,
       pagination: pagination ?? null,
       selectedFlowRun,
@@ -99,6 +103,7 @@ export const FlowRunsContextProvider = ({
     [
       flowRuns,
       totalCount,
+      nextCursor,
       flowRunsLoading,
       pagination,
       selectedFlowRunLoading,

--- a/apps/hash-frontend/src/pages/workers.page.tsx
+++ b/apps/hash-frontend/src/pages/workers.page.tsx
@@ -63,26 +63,35 @@ const WorkersPageContent = () => {
 };
 
 const WorkersPage: NextPageWithLayout = () => {
-  const [page, setPage] = useState(0);
-  const [rowsPerPage, setRowsPerPage] = useState(defaultRowsPerPage);
+  const [currentCursor, setCurrentCursor] = useState<string | null>(null);
+  const [previousCursors, setPreviousCursors] = useState<string[]>([]);
 
-  const handlePageChange = useCallback((newPage: number) => {
-    setPage(newPage);
-  }, []);
+  const handleNextPage = useCallback(
+    (nextCursor: string) => {
+      setPreviousCursors((prev) => [...prev, currentCursor ?? ""]);
+      setCurrentCursor(nextCursor);
+    },
+    [currentCursor],
+  );
 
-  const handleRowsPerPageChange = useCallback((newRowsPerPage: number) => {
-    setRowsPerPage(newRowsPerPage);
-    setPage(0);
+  const handlePreviousPage = useCallback(() => {
+    setPreviousCursors((prev) => {
+      const newStack = [...prev];
+      const prevCursor = newStack.pop();
+      setCurrentCursor(prevCursor === "" ? null : (prevCursor ?? null));
+      return newStack;
+    });
   }, []);
 
   const pagination = useMemo(
     () => ({
-      page,
-      rowsPerPage,
-      onPageChange: handlePageChange,
-      onRowsPerPageChange: handleRowsPerPageChange,
+      currentCursor,
+      previousCursors,
+      rowsPerPage: defaultRowsPerPage,
+      onNextPage: handleNextPage,
+      onPreviousPage: handlePreviousPage,
     }),
-    [page, rowsPerPage, handlePageChange, handleRowsPerPageChange],
+    [currentCursor, previousCursors, handleNextPage, handlePreviousPage],
   );
 
   return (

--- a/apps/hash-frontend/src/pages/workers.page/flow-run-table.tsx
+++ b/apps/hash-frontend/src/pages/workers.page/flow-run-table.tsx
@@ -283,6 +283,7 @@ export const FlowRunTable = ({ flowDefinitionIdFilter }: FlowRunTableProps) => {
   const {
     flowRuns: unfilteredFlowRuns,
     totalCount,
+    nextCursor,
     loading,
     pagination,
   } = useFlowRunsContext();
@@ -447,70 +448,70 @@ export const FlowRunTable = ({ flowDefinitionIdFilter }: FlowRunTableProps) => {
           setSort={setSort}
         />
       </Box>
-      {pagination && totalCount > 0 && (
-        <Stack
-          direction="row"
-          alignItems="center"
-          justifyContent="space-between"
-          sx={{ px: 1, py: 1.5 }}
-        >
-          <Typography
-            sx={{ fontSize: 13, color: ({ palette }) => palette.gray[70] }}
+      {pagination &&
+        (flowRunRows.length > 0 || pagination.previousCursors.length > 0) && (
+          <Stack
+            direction="row"
+            alignItems="center"
+            justifyContent="space-between"
+            sx={{ px: 1, py: 1.5 }}
           >
-            Showing{" "}
-            <strong>{pagination.page * pagination.rowsPerPage + 1}</strong> to{" "}
-            <strong>
-              {Math.min(
-                (pagination.page + 1) * pagination.rowsPerPage,
-                totalCount,
+            <Typography
+              sx={{ fontSize: 13, color: ({ palette }) => palette.gray[70] }}
+            >
+              Showing <strong>{flowRunRows.length}</strong> result
+              {flowRunRows.length !== 1 ? "s" : ""}
+              {totalCount > 0 && (
+                <>
+                  {" "}
+                  of ~<strong>{totalCount}</strong> total
+                </>
               )}
-            </strong>{" "}
-            of <strong>{totalCount}</strong>
-          </Typography>
-          <Stack direction="row" gap={2}>
-            {pagination.page > 0 && (
-              <Typography
-                component="button"
-                onClick={() => pagination.onPageChange(pagination.page - 1)}
-                sx={{
-                  fontSize: 13,
-                  fontWeight: 600,
-                  color: ({ palette }) => palette.blue[70],
-                  cursor: "pointer",
-                  background: "none",
-                  border: "none",
-                  padding: 0,
-                  "&:hover": {
-                    textDecoration: "underline",
-                  },
-                }}
-              >
-                Previous page
-              </Typography>
-            )}
-            {(pagination.page + 1) * pagination.rowsPerPage < totalCount && (
-              <Typography
-                component="button"
-                onClick={() => pagination.onPageChange(pagination.page + 1)}
-                sx={{
-                  fontSize: 13,
-                  fontWeight: 600,
-                  color: ({ palette }) => palette.blue[70],
-                  cursor: "pointer",
-                  background: "none",
-                  border: "none",
-                  padding: 0,
-                  "&:hover": {
-                    textDecoration: "underline",
-                  },
-                }}
-              >
-                Next page
-              </Typography>
-            )}
+            </Typography>
+            <Stack direction="row" gap={2}>
+              {pagination.previousCursors.length > 0 && (
+                <Typography
+                  component="button"
+                  onClick={() => pagination.onPreviousPage()}
+                  sx={{
+                    fontSize: 13,
+                    fontWeight: 600,
+                    color: ({ palette }) => palette.blue[70],
+                    cursor: "pointer",
+                    background: "none",
+                    border: "none",
+                    padding: 0,
+                    "&:hover": {
+                      textDecoration: "underline",
+                    },
+                  }}
+                >
+                  Previous page
+                </Typography>
+              )}
+              {nextCursor && (
+                <Typography
+                  component="button"
+                  onClick={() => pagination.onNextPage(nextCursor)}
+                  sx={{
+                    fontSize: 13,
+                    fontWeight: 600,
+                    color: ({ palette }) => palette.blue[70],
+                    cursor: "pointer",
+                    background: "none",
+                    border: "none",
+                    padding: 0,
+                    "&:hover": {
+                      textDecoration: "underline",
+                    },
+                  }}
+                >
+                  Next page
+                </Typography>
+              )}
+            </Stack>
           </Stack>
-        </Stack>
-      )}
+        )}
     </Box>
   );
 };

--- a/libs/@local/hash-backend-utils/src/flows.ts
+++ b/libs/@local/hash-backend-utils/src/flows.ts
@@ -135,7 +135,7 @@ const convertScreamingSnakeToPascalCase = (str: string) =>
 type GetFlowRunsFilters = {
   executionStatus?: FlowRunStatus | null;
   flowDefinitionIds?: string[] | null;
-  offset?: number | null;
+  cursor?: string | null;
   limit?: number | null;
 };
 
@@ -158,6 +158,7 @@ type MinimalFlowMetadata = {
 type PaginatedFlowRuns<T> = {
   flowRuns: T[];
   totalCount: number;
+  nextCursor: string | null;
 };
 
 export async function getFlowRuns(
@@ -184,7 +185,12 @@ export async function getFlowRuns({
 }: GetFlowRunsFnArgs<boolean>): Promise<
   PaginatedFlowRuns<SparseFlowRun | FlowRun>
 > {
-  const temporalWorkflowIdToFlowDetails = await queryEntities<FlowRunEntity>(
+  const effectiveLimit = Math.min(
+    Math.max(filters.limit ?? flowRunsQueryMaxLimit, 0),
+    flowRunsQueryMaxLimit,
+  );
+
+  const queryResult = await queryEntities<FlowRunEntity>(
     { graphApi: graphApiClient },
     authentication,
     {
@@ -217,39 +223,47 @@ export async function getFlowRuns({
       temporalAxes: currentTimeInstantTemporalAxes,
       includeDrafts: false,
       includePermissions: false,
+      limit: effectiveLimit,
+      ...(filters.cursor
+        ? { cursor: JSON.parse(filters.cursor) as object[] }
+        : {}),
+      includeCount: true,
     },
-  ).then(({ entities }) => {
-    const result: Record<string, MinimalFlowMetadata> = {};
+  );
 
-    for (const entity of entities) {
-      const [webId, entityUuid] = splitEntityId(
-        entity.metadata.recordId.entityId,
-      );
+  const temporalWorkflowIdToFlowDetails: Record<string, MinimalFlowMetadata> =
+    {};
 
-      const name =
-        entity.properties[
-          "https://blockprotocol.org/@blockprotocol/types/property-type/name/"
-        ];
+  for (const entity of queryResult.entities) {
+    const [webId, entityUuid] = splitEntityId(
+      entity.metadata.recordId.entityId,
+    );
 
-      const temporalWorkflowId =
-        entity.properties[
-          "https://hash.ai/@h/types/property-type/workflow-id/"
-        ];
+    const name =
+      entity.properties[
+        "https://blockprotocol.org/@blockprotocol/types/property-type/name/"
+      ];
 
-      result[temporalWorkflowId] = {
-        flowRunId: entityUuid,
-        name,
-        temporalWorkflowId,
-        webId,
-      };
-    }
-    return result;
-  });
+    const temporalWorkflowId =
+      entity.properties["https://hash.ai/@h/types/property-type/workflow-id/"];
+
+    temporalWorkflowIdToFlowDetails[temporalWorkflowId] = {
+      flowRunId: entityUuid,
+      name,
+      temporalWorkflowId,
+      webId,
+    };
+  }
 
   const temporalWorkflowIds = typedKeys(temporalWorkflowIdToFlowDetails);
 
+  const nextCursor = queryResult.cursor
+    ? JSON.stringify(queryResult.cursor)
+    : null;
+  const totalCount = queryResult.count ?? 0;
+
   if (!temporalWorkflowIds.length) {
-    return { flowRuns: [], totalCount: 0 };
+    return { flowRuns: [], totalCount, nextCursor };
   }
 
   /** @see https://docs.temporal.io/develop/typescript/observability#search-attributes */
@@ -296,19 +310,10 @@ export async function getFlowRuns({
     deduplicatedWorkflowIds.push(temporalWorkflowId);
   }
 
-  const totalCount = deduplicatedWorkflowIds.length;
-
-  const offset = Math.max(filters.offset ?? 0, 0);
-  const limit = Math.min(
-    Math.max(filters.limit ?? flowRunsQueryMaxLimit, 0),
-    flowRunsQueryMaxLimit,
-  );
-  const paginatedIds = deduplicatedWorkflowIds.slice(offset, offset + limit);
-
   if (includeDetails) {
     const workflows: FlowRun[] = [];
 
-    for (const temporalWorkflowId of paginatedIds) {
+    for (const temporalWorkflowId of deduplicatedWorkflowIds) {
       const flowDetails = temporalWorkflowIdToFlowDetails[temporalWorkflowId]!;
 
       const runInfo = await getFlowRunFromTemporalWorkflowId({
@@ -322,11 +327,11 @@ export async function getFlowRuns({
       workflows.push(runInfo);
     }
 
-    return { flowRuns: workflows, totalCount };
+    return { flowRuns: workflows, totalCount, nextCursor };
   } else {
     const workflows: SparseFlowRun[] = [];
 
-    for (const temporalWorkflowId of paginatedIds) {
+    for (const temporalWorkflowId of deduplicatedWorkflowIds) {
       const flowDetails = temporalWorkflowIdToFlowDetails[temporalWorkflowId]!;
 
       const runInfo = await getSparseFlowRunFromTemporalWorkflowId({
@@ -339,6 +344,6 @@ export async function getFlowRuns({
       workflows.push(runInfo);
     }
 
-    return { flowRuns: workflows, totalCount };
+    return { flowRuns: workflows, totalCount, nextCursor };
   }
 }

--- a/libs/@local/hash-isomorphic-utils/src/graphql/queries/flow.queries.ts
+++ b/libs/@local/hash-isomorphic-utils/src/graphql/queries/flow.queries.ts
@@ -1,9 +1,10 @@
 import { gql } from "@apollo/client";
 
 export const getFlowRunsQuery = gql`
-  query getFlowRuns($offset: Int, $limit: Int) {
-    getFlowRuns(offset: $offset, limit: $limit) {
+  query getFlowRuns($cursor: String, $limit: Int) {
+    getFlowRuns(cursor: $cursor, limit: $limit) {
       totalCount
+      nextCursor
       flowRuns {
         name
         flowDefinitionId

--- a/libs/@local/hash-isomorphic-utils/src/graphql/type-defs/knowledge/flow.typedef.ts
+++ b/libs/@local/hash-isomorphic-utils/src/graphql/type-defs/knowledge/flow.typedef.ts
@@ -193,9 +193,15 @@ export const flowTypedef = gql`
     """
     flowRuns: [FlowRun!]!
     """
-    The total number of flow runs matching the filters (before pagination)
+    The total number of flow run entities matching the filters.
+    Note: this count comes from the graph query and may not reflect
+    Temporal-side filtering (e.g. by executionStatus).
     """
     totalCount: Int!
+    """
+    An opaque cursor for fetching the next page. Null when there are no more results.
+    """
+    nextCursor: String
   }
 
   extend type Query {
@@ -209,12 +215,11 @@ export const flowTypedef = gql`
       """
       executionStatus: FlowRunStatus
       """
-      Number of flow runs to skip (for offset-based pagination).
-      Defaults to 0. Negative values are clamped to 0.
+      An opaque cursor returned from a previous query, used to fetch the next page.
       """
-      offset: Int
+      cursor: String
       """
-      Maximum number of flow runs to return (for offset-based pagination).
+      Maximum number of flow runs to return per page.
       Defaults to 100 and is capped at that value.
       Negative values are clamped to 0.
       """


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

#8547 enforced a page size limit for requests for Flow Runs to Temporal, but didn't limit the request size to the Graph API. 

This PR implements that.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->
<!-- Libraries inside of the `@local` directory are always internal libraries which have no need for publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

H-6264: This limit needs better handling in the Flow Runs context in the frontend.
