### PR TITLE
H-6363: Add /ingest route to HASH frontend

### DIFF
--- a/.codex/.gitignore
+++ b/.codex/.gitignore
@@ -1,0 +1,1 @@
+environments/

--- a/apps/hash-frontend/.gitignore
+++ b/apps/hash-frontend/.gitignore
@@ -1,0 +1,2 @@
+# AI-generated working documents (roadmaps, plans, research notes)
+memory/

--- a/apps/hash-frontend/next.config.js
+++ b/apps/hash-frontend/next.config.js
@@ -64,6 +64,10 @@ const apiUrl = process.env.NEXT_PUBLIC_API_ORIGIN ?? "http://localhost:5001";
 
 const apiDomain = new URL(apiUrl).hostname;
 
+// Mastra API origin for ingest pipeline proxy (local dev: port 4111)
+const mastraApiOrigin =
+  process.env.MASTRA_API_ORIGIN ?? "http://localhost:4111";
+
 /**
  * @todo: import the page `entityTypeId` from `@local/hash-isomorphic-utils/ontology-types`
  * when the `next.config.js` supports imports from modules
@@ -81,6 +85,19 @@ export default withSentryConfig(
     {
       async rewrites() {
         return [
+          // Ingest pipeline proxy → Mastra API
+          {
+            source: "/api/ingest",
+            destination: `${mastraApiOrigin}/discovery-runs`,
+          },
+          {
+            source: "/api/ingest/:path*",
+            destination: `${mastraApiOrigin}/discovery-runs/:path*`,
+          },
+          {
+            source: "/api/ingest-fixtures/:path*",
+            destination: `${mastraApiOrigin}/discovery-fixtures/:path*`,
+          },
           {
             source: "/pages",
             destination: `/entities?entityTypeIdOrBaseUrl=${pageEntityTypeBaseUrl}`,

--- a/apps/hash-frontend/package.json
+++ b/apps/hash-frontend/package.json
@@ -11,6 +11,7 @@
     "codegen": "rimraf './src/**/*.gen.*'; graphql-codegen --config codegen.config.ts",
     "dev": "next dev",
     "fix:eslint": "eslint --fix .",
+    "fix:format": "biome format --write",
     "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit",
     "start": "next start",
@@ -20,6 +21,7 @@
   },
   "dependencies": {
     "@apollo/client": "3.10.5",
+    "@ark-ui/react": "5.26.2",
     "@blockprotocol/core": "0.1.4",
     "@blockprotocol/graph": "workspace:*",
     "@blockprotocol/hook": "0.1.8",

--- a/apps/hash-frontend/src/pages/ingest.page.tsx
+++ b/apps/hash-frontend/src/pages/ingest.page.tsx
@@ -1,0 +1,65 @@
+import { InfinityLightIcon } from "@hashintel/design-system";
+import { Box, Container } from "@mui/material";
+import { useRouter } from "next/router";
+import { useEffect } from "react";
+
+import type { NextPageWithLayout } from "../shared/layout";
+import { getLayoutWithSidebar } from "../shared/layout";
+import { WorkersHeader } from "../shared/workers-header";
+import { getIngestResultsPath } from "./ingest.page/routing";
+import { UploadPanel } from "./ingest.page/upload-panel";
+import { shouldFetchResults, useIngestRun } from "./ingest.page/use-ingest-run";
+
+const IngestPage: NextPageWithLayout = () => {
+  const router = useRouter();
+  const { state, upload, reset } = useIngestRun();
+
+  useEffect(() => {
+    if (!shouldFetchResults(state)) {
+      return;
+    }
+    void router.push(
+      getIngestResultsPath({
+        kind: "run",
+        runId: state.runStatus.runId,
+      }),
+    );
+  }, [router, state]);
+
+  return (
+    <>
+      <WorkersHeader
+        crumbs={[
+          {
+            title: "Ingest",
+            href: "/ingest",
+            id: "ingest",
+          },
+        ]}
+        title={{
+          Icon: InfinityLightIcon,
+          text: "Ingest",
+        }}
+        subtitle="Upload a PDF to extract entities, claims, and evidence."
+      />
+      <Container>
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            minHeight: 400,
+            py: 4,
+          }}
+        >
+          <UploadPanel state={state} onUpload={upload} onReset={reset} />
+        </Box>
+      </Container>
+    </>
+  );
+};
+
+IngestPage.getLayout = (page) =>
+  getLayoutWithSidebar(page, { fullWidth: true });
+
+export default IngestPage;

--- a/apps/hash-frontend/src/pages/ingest.page/bbox-transform.ts
+++ b/apps/hash-frontend/src/pages/ingest.page/bbox-transform.ts
@@ -1,0 +1,38 @@
+/**
+ * Coordinate transform: PDF-point bbox → CSS percentage positioning.
+ *
+ * Overlays are absolutely-positioned <div>s inside a container wrapping the
+ * page <img>. Percentage-based positioning keeps them responsive.
+ */
+
+export interface BboxInput {
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+}
+
+export interface BboxPercentage {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+export function bboxToPercentage(
+  bbox: BboxInput,
+  pdfPageWidth: number,
+  pdfPageHeight: number,
+  origin: "BOTTOMLEFT" | "TOPLEFT",
+): BboxPercentage {
+  const left = (bbox.x1 / pdfPageWidth) * 100;
+  const width = ((bbox.x2 - bbox.x1) / pdfPageWidth) * 100;
+  const height = ((bbox.y2 - bbox.y1) / pdfPageHeight) * 100;
+
+  const top =
+    origin === "BOTTOMLEFT"
+      ? ((pdfPageHeight - bbox.y2) / pdfPageHeight) * 100
+      : (bbox.y1 / pdfPageHeight) * 100;
+
+  return { left, top, width, height };
+}

--- a/apps/hash-frontend/src/pages/ingest.page/evidence-resolver.ts
+++ b/apps/hash-frontend/src/pages/ingest.page/evidence-resolver.ts
@@ -1,0 +1,51 @@
+/**
+ * Evidence resolver: selection → highlighted block IDs + target page.
+ *
+ * Pure function. No I/O, no React.
+ */
+import type { Block, ExtractedClaim, RosterEntry } from "./types";
+
+export type Selection =
+  | { kind: "roster"; entry: RosterEntry }
+  | { kind: "claim"; claim: ExtractedClaim }
+  | null;
+
+export interface EvidenceResult {
+  blockIds: string[];
+  targetPage: number | null;
+}
+
+export function resolveEvidence(
+  selection: Selection,
+  blocks: Block[],
+): EvidenceResult {
+  if (!selection) {
+    return { blockIds: [], targetPage: null };
+  }
+
+  const blockIds =
+    selection.kind === "roster"
+      ? [...new Set(selection.entry.mentions.map((mention) => mention.blockId))]
+      : [
+          ...new Set(
+            selection.claim.evidenceRefs.flatMap((ref) => ref.blockIds),
+          ),
+        ];
+
+  let targetPage: number | null = null;
+  for (const block of blocks) {
+    if (!blockIds.includes(block.blockId)) {
+      continue;
+    }
+    for (const anchor of block.anchors) {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Anchor union may expand
+      if (anchor.kind === "file_page_bbox") {
+        if (targetPage === null || anchor.page < targetPage) {
+          targetPage = anchor.page;
+        }
+      }
+    }
+  }
+
+  return { blockIds, targetPage };
+}

--- a/apps/hash-frontend/src/pages/ingest.page/page-viewer.tsx
+++ b/apps/hash-frontend/src/pages/ingest.page/page-viewer.tsx
@@ -1,0 +1,129 @@
+/**
+ * Page viewer: PDF page image with bbox overlay highlights.
+ */
+import { Box, Stack, Typography } from "@mui/material";
+import type { FunctionComponent } from "react";
+
+import { Button } from "../../shared/ui/button";
+import { bboxToPercentage } from "./bbox-transform";
+import type { Block, PageImageManifest } from "./types";
+
+interface PageViewerProps {
+  pageImages: PageImageManifest[];
+  blocks: Block[];
+  highlightedBlockIds: string[];
+  currentPage: number;
+  onPageChange: (page: number) => void;
+}
+
+export const PageViewer: FunctionComponent<PageViewerProps> = ({
+  pageImages,
+  blocks,
+  highlightedBlockIds,
+  currentPage,
+  onPageChange,
+}) => {
+  const totalPages = pageImages.length;
+  const pageImage = pageImages.find((img) => img.pageNumber === currentPage);
+  if (!pageImage) {
+    return null;
+  }
+
+  const visibleBlocks =
+    highlightedBlockIds.length > 0
+      ? blocks.filter(
+          (block) =>
+            highlightedBlockIds.includes(block.blockId) &&
+            block.anchors.some((anchor) => anchor.page === currentPage),
+        )
+      : [];
+
+  return (
+    <Box>
+      {/* Page navigation */}
+      <Stack
+        direction="row"
+        spacing={1}
+        alignItems="center"
+        sx={{ mb: 1, fontSize: "0.875rem" }}
+      >
+        <Button
+          size="small"
+          variant="secondary"
+          onClick={() => onPageChange(Math.max(1, currentPage - 1))}
+          disabled={currentPage <= 1}
+        >
+          ← Prev
+        </Button>
+        <Typography variant="smallTextLabels">
+          Page {currentPage} / {totalPages}
+        </Typography>
+        <Button
+          size="small"
+          variant="secondary"
+          onClick={() => onPageChange(Math.min(totalPages, currentPage + 1))}
+          disabled={currentPage >= totalPages}
+        >
+          Next →
+        </Button>
+        {visibleBlocks.length > 0 && (
+          <Typography
+            variant="smallTextLabels"
+            sx={{ color: "blue.70", ml: 1 }}
+          >
+            {visibleBlocks.length} highlighted
+          </Typography>
+        )}
+      </Stack>
+
+      {/* Page image with bbox overlays */}
+      <Box
+        sx={{ position: "relative", display: "inline-block", lineHeight: 0 }}
+      >
+        <img
+          src={pageImage.imageUrl}
+          alt={`Page ${currentPage}`}
+          style={{
+            maxWidth: "100%",
+            height: "auto",
+            border: "1px solid",
+            borderColor: "rgba(0, 0, 0, 0.12)",
+          }}
+        />
+
+        {visibleBlocks.map((block) => {
+          const anchor = block.anchors.find((anc) => anc.page === currentPage);
+          if (!anchor) {
+            return null;
+          }
+
+          const pct = bboxToPercentage(
+            anchor.bbox,
+            pageImage.pdfPageWidth,
+            pageImage.pdfPageHeight,
+            pageImage.bboxOrigin,
+          );
+
+          return (
+            <Box
+              key={block.blockId}
+              title={`[${block.kind}] ${block.text.substring(0, 80)}`}
+              sx={{
+                position: "absolute",
+                left: `${pct.left}%`,
+                top: `${pct.top}%`,
+                width: `${pct.width}%`,
+                height: `${pct.height}%`,
+                border: "2px solid rgba(59, 130, 246, 0.7)",
+                backgroundColor: "rgba(59, 130, 246, 0.12)",
+                pointerEvents: "none",
+                boxSizing: "border-box",
+                borderRadius: "2px",
+              }}
+            />
+          );
+        })}
+      </Box>
+    </Box>
+  );
+};

--- a/apps/hash-frontend/src/pages/ingest.page/results-panel.tsx
+++ b/apps/hash-frontend/src/pages/ingest.page/results-panel.tsx
@@ -39,7 +39,7 @@ export const ResultsPanel: FunctionComponent<ResultsPanelProps> = ({
 }) => {
   const isRosterSelected = (entry: RosterEntry) =>
     selection?.kind === "roster" &&
-    selection.entry.canonicalName === entry.canonicalName;
+    selection.entry.rosterEntryId === entry.rosterEntryId;
 
   const isClaimSelected = (claim: ExtractedClaim) =>
     selection?.kind === "claim" && selection.claim.claimId === claim.claimId;
@@ -75,7 +75,7 @@ export const ResultsPanel: FunctionComponent<ResultsPanelProps> = ({
           const selected = isRosterSelected(entry);
           return (
             <ButtonBase
-              key={entry.canonicalName}
+              key={entry.rosterEntryId}
               onClick={() =>
                 onSelect(selected ? null : { kind: "roster", entry })
               }
@@ -155,6 +155,10 @@ export const ResultsPanel: FunctionComponent<ResultsPanelProps> = ({
               </Box>
               {entryClaims.map((claim) => {
                 const selected = isClaimSelected(claim);
+                const firstEvidenceRef = claim.evidenceRefs.at(0);
+                const quote = firstEvidenceRef
+                  ? firstEvidenceRef.quote.substring(0, 60)
+                  : undefined;
                 return (
                   <ButtonBase
                     key={claim.claimId}
@@ -182,17 +186,18 @@ export const ResultsPanel: FunctionComponent<ResultsPanelProps> = ({
                     >
                       {claim.claimText}
                     </Typography>
-                    <Typography
-                      variant="microText"
-                      sx={{
-                        color: "gray.50",
-                        mt: 0.5,
-                        fontStyle: "italic",
-                      }}
-                    >
-                      &quot;{claim.evidenceRefs[0]?.quote.substring(0, 60)}
-                      …&quot;
-                    </Typography>
+                    {quote && (
+                      <Typography
+                        variant="microText"
+                        sx={{
+                          color: "gray.50",
+                          mt: 0.5,
+                          fontStyle: "italic",
+                        }}
+                      >
+                        &quot;{quote}…&quot;
+                      </Typography>
+                    )}
                   </ButtonBase>
                 );
               })}

--- a/apps/hash-frontend/src/pages/ingest.page/results-panel.tsx
+++ b/apps/hash-frontend/src/pages/ingest.page/results-panel.tsx
@@ -1,0 +1,205 @@
+/**
+ * Results panel: roster entries + claims list with click-to-highlight.
+ *
+ * Left-side panel in the ingest results view.
+ */
+import {
+  Box,
+  ButtonBase,
+  List,
+  ListSubheader,
+  Typography,
+} from "@mui/material";
+import type { FunctionComponent } from "react";
+
+import type { Selection } from "./evidence-resolver";
+import type { ExtractedClaim, RosterEntry } from "./types";
+
+interface ResultsPanelProps {
+  rosterEntries: RosterEntry[];
+  claims: ExtractedClaim[];
+  selection: Selection;
+  onSelect: (selection: Selection) => void;
+}
+
+const CATEGORY_ICONS: Record<string, string> = {
+  person: "👤",
+  organization: "🏢",
+  place: "📍",
+  artifact: "📄",
+  event: "📅",
+  other: "◽",
+};
+
+export const ResultsPanel: FunctionComponent<ResultsPanelProps> = ({
+  rosterEntries,
+  claims,
+  selection,
+  onSelect,
+}) => {
+  const isRosterSelected = (entry: RosterEntry) =>
+    selection?.kind === "roster" &&
+    selection.entry.canonicalName === entry.canonicalName;
+
+  const isClaimSelected = (claim: ExtractedClaim) =>
+    selection?.kind === "claim" && selection.claim.claimId === claim.claimId;
+
+  return (
+    <Box
+      sx={{
+        width: 360,
+        minWidth: 360,
+        borderRight: ({ palette }) => `1px solid ${palette.gray[30]}`,
+        overflowY: "auto",
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      {/* Roster section */}
+      <ListSubheader
+        sx={{
+          px: 2,
+          py: 1.5,
+          borderBottom: ({ palette }) => `1px solid ${palette.gray[30]}`,
+          fontSize: "0.75rem",
+          fontWeight: 600,
+          textTransform: "uppercase",
+          letterSpacing: "0.05em",
+          lineHeight: 1,
+        }}
+      >
+        Roster ({rosterEntries.length})
+      </ListSubheader>
+      <List disablePadding sx={{ flex: "0 0 auto" }}>
+        {rosterEntries.map((entry) => {
+          const selected = isRosterSelected(entry);
+          return (
+            <ButtonBase
+              key={entry.canonicalName}
+              onClick={() =>
+                onSelect(selected ? null : { kind: "roster", entry })
+              }
+              sx={{
+                display: "block",
+                width: "100%",
+                px: 2,
+                py: 1,
+                textAlign: "left",
+                borderBottom: ({ palette }) => `1px solid ${palette.gray[20]}`,
+                bgcolor: selected ? "rgba(59, 130, 246, 0.08)" : "transparent",
+                "&:hover": { bgcolor: "rgba(59, 130, 246, 0.04)" },
+              }}
+            >
+              <Typography variant="smallTextLabels" component="span">
+                <span style={{ marginRight: "0.5rem" }}>
+                  {CATEGORY_ICONS[entry.category ?? "other"] ?? "◽"}
+                </span>
+                <span style={{ fontWeight: selected ? 600 : 400 }}>
+                  {entry.canonicalName}
+                </span>
+              </Typography>
+              <Typography
+                variant="microText"
+                component="div"
+                sx={{ color: "gray.60", mt: 0.25, pl: 3 }}
+              >
+                {entry.mentions.length} mention
+                {entry.mentions.length !== 1 ? "s" : ""}
+              </Typography>
+            </ButtonBase>
+          );
+        })}
+      </List>
+
+      {/* Claims section */}
+      <ListSubheader
+        sx={{
+          px: 2,
+          py: 1.5,
+          borderTop: ({ palette }) => `1px solid ${palette.gray[30]}`,
+          borderBottom: ({ palette }) => `1px solid ${palette.gray[30]}`,
+          mt: 1,
+          fontSize: "0.75rem",
+          fontWeight: 600,
+          textTransform: "uppercase",
+          letterSpacing: "0.05em",
+          lineHeight: 1,
+        }}
+      >
+        Claims ({claims.length})
+      </ListSubheader>
+      <Box sx={{ flex: 1, overflowY: "auto" }}>
+        {rosterEntries.map((entry) => {
+          const entryClaims = claims.filter(
+            (claim) => claim.rosterEntryId === entry.rosterEntryId,
+          );
+          if (entryClaims.length === 0) {
+            return null;
+          }
+          return (
+            <Box key={`claims-${entry.rosterEntryId}`}>
+              <Box
+                sx={{
+                  px: 2,
+                  py: 0.75,
+                  fontSize: "0.6875rem",
+                  fontWeight: 600,
+                  color: "gray.60",
+                  borderBottom: ({ palette }) =>
+                    `1px solid ${palette.gray[20]}`,
+                  bgcolor: "rgba(0, 0, 0, 0.02)",
+                }}
+              >
+                {CATEGORY_ICONS[entry.category ?? "other"] ?? "◽"}{" "}
+                {entry.canonicalName} ({entryClaims.length})
+              </Box>
+              {entryClaims.map((claim) => {
+                const selected = isClaimSelected(claim);
+                return (
+                  <ButtonBase
+                    key={claim.claimId}
+                    onClick={() =>
+                      onSelect(selected ? null : { kind: "claim", claim })
+                    }
+                    sx={{
+                      display: "block",
+                      width: "100%",
+                      px: 2,
+                      py: 1,
+                      pl: 3,
+                      textAlign: "left",
+                      borderBottom: ({ palette }) =>
+                        `1px solid ${palette.gray[20]}`,
+                      bgcolor: selected
+                        ? "rgba(59, 130, 246, 0.08)"
+                        : "transparent",
+                      "&:hover": { bgcolor: "rgba(59, 130, 246, 0.04)" },
+                    }}
+                  >
+                    <Typography
+                      variant="smallTextLabels"
+                      sx={{ fontWeight: selected ? 600 : 400 }}
+                    >
+                      {claim.claimText}
+                    </Typography>
+                    <Typography
+                      variant="microText"
+                      sx={{
+                        color: "gray.50",
+                        mt: 0.5,
+                        fontStyle: "italic",
+                      }}
+                    >
+                      &quot;{claim.evidenceRefs[0]?.quote.substring(0, 60)}
+                      …&quot;
+                    </Typography>
+                  </ButtonBase>
+                );
+              })}
+            </Box>
+          );
+        })}
+      </Box>
+    </Box>
+  );
+};

--- a/apps/hash-frontend/src/pages/ingest.page/routing.ts
+++ b/apps/hash-frontend/src/pages/ingest.page/routing.ts
@@ -1,0 +1,52 @@
+export const INGEST_FIXTURES = [
+  { id: "uk-practice-direction-51zh", label: "UK Practice Direction" },
+  { id: "gao-25-107546", label: "GAO Report" },
+] as const;
+
+export type IngestResultsSource =
+  | { kind: "fixture"; fixtureId: string }
+  | { kind: "run"; runId: string };
+
+const DEFAULT_FIXTURE_ID = INGEST_FIXTURES[0].id;
+const INGEST_FIXTURE_IDS = new Set<string>(
+  INGEST_FIXTURES.map((fixture) => fixture.id),
+);
+
+/**
+ * Derive the results source from Next.js query params.
+ */
+export function getIngestResultsSource(query: {
+  runId?: string;
+  fixture?: string;
+}): IngestResultsSource {
+  const runId = query.runId?.trim();
+  if (runId) {
+    return { kind: "run", runId };
+  }
+
+  const fixtureId = query.fixture?.trim();
+  if (fixtureId && INGEST_FIXTURE_IDS.has(fixtureId)) {
+    return { kind: "fixture", fixtureId };
+  }
+
+  return { kind: "fixture", fixtureId: DEFAULT_FIXTURE_ID };
+}
+
+export function getIngestResultsPath(source: IngestResultsSource): string {
+  const params = new URLSearchParams();
+
+  if (source.kind === "fixture") {
+    params.set("fixture", source.fixtureId);
+  } else {
+    params.set("runId", source.runId);
+  }
+
+  return `/ingest/results?${params.toString()}`;
+}
+
+export function getDefaultIngestResultsPath(): string {
+  return getIngestResultsPath({
+    kind: "fixture",
+    fixtureId: DEFAULT_FIXTURE_ID,
+  });
+}

--- a/apps/hash-frontend/src/pages/ingest.page/routing.ts
+++ b/apps/hash-frontend/src/pages/ingest.page/routing.ts
@@ -43,10 +43,3 @@ export function getIngestResultsPath(source: IngestResultsSource): string {
 
   return `/ingest/results?${params.toString()}`;
 }
-
-export function getDefaultIngestResultsPath(): string {
-  return getIngestResultsPath({
-    kind: "fixture",
-    fixtureId: DEFAULT_FIXTURE_ID,
-  });
-}

--- a/apps/hash-frontend/src/pages/ingest.page/types.ts
+++ b/apps/hash-frontend/src/pages/ingest.page/types.ts
@@ -1,0 +1,169 @@
+/**
+ * Contract types for the ingest pipeline UI.
+ *
+ * These mirror the Zod schemas in the internal repo's pipeline contracts
+ * but as plain TypeScript types — the Mastra API validates; the frontend
+ * just consumes the JSON.
+ */
+
+// ---------------------------------------------------------------------------
+//  Anchors & blocks
+// ---------------------------------------------------------------------------
+
+export interface PdfBbox {
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+  unit: "pt";
+}
+
+export interface FilePageBboxAnchor {
+  kind: "file_page_bbox";
+  page: number;
+  bbox: PdfBbox;
+}
+
+export type Anchor = FilePageBboxAnchor;
+
+export interface Block {
+  blockId: string;
+  sourceId: string;
+  kind: string;
+  text: string;
+  anchors: Anchor[];
+  confidence?: number;
+  attributes?: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+//  Evidence refs
+// ---------------------------------------------------------------------------
+
+export interface BlockSpan {
+  blockId: string;
+  start: number;
+  end: number;
+}
+
+export interface EvidenceRef {
+  sourceId: string;
+  blockIds: string[];
+  blockSpans: BlockSpan[];
+  quote: string;
+}
+
+// ---------------------------------------------------------------------------
+//  Corpus
+// ---------------------------------------------------------------------------
+
+export interface Source {
+  sourceId: string;
+  kind: "file" | "web" | "audio" | "video";
+  mimeType: string;
+  stableRef: {
+    contentHash: string;
+    fileEntityId?: string;
+    snapshotId?: string;
+  };
+}
+
+export interface ExtractedCorpus {
+  version: "v0";
+  parser: string;
+  sources: Source[];
+  blocks: Block[];
+  metadata: {
+    language?: string;
+    createdAt?: string;
+  };
+}
+
+// ---------------------------------------------------------------------------
+//  Discovery domain
+// ---------------------------------------------------------------------------
+
+export type MentionCategory =
+  | "person"
+  | "organization"
+  | "place"
+  | "artifact"
+  | "event"
+  | "other";
+
+export interface EntityMention {
+  chunkId: string;
+  blockId: string;
+  start: number;
+  end: number;
+  surface: string;
+}
+
+export interface RosterEntry {
+  rosterEntryId: string;
+  canonicalName: string;
+  category?: MentionCategory;
+  discoveredTypeId: string;
+  resolvedTypeId: string;
+  summary: string;
+  mentions: EntityMention[];
+  chunkIds: string[];
+  mergedLocalIds: string[];
+}
+
+export interface ExtractedClaim {
+  claimId: string;
+  rosterEntryId: string;
+  claimText: string;
+  subject: string;
+  predicate: string;
+  object: string;
+  evidenceRefs: EvidenceRef[];
+}
+
+// ---------------------------------------------------------------------------
+//  Page images
+// ---------------------------------------------------------------------------
+
+export interface PageImageManifest {
+  contentHash: string;
+  pageNumber: number;
+  imageUrl: string;
+  pdfPageWidth: number;
+  pdfPageHeight: number;
+  bboxOrigin: "BOTTOMLEFT" | "TOPLEFT";
+}
+
+// ---------------------------------------------------------------------------
+//  Run status & view
+// ---------------------------------------------------------------------------
+
+export interface RunStatus {
+  runId: string;
+  status: "queued" | "running" | "succeeded" | "failed";
+  phase?: string;
+  step?: string;
+  contentHash?: string;
+  counts?: {
+    pages?: number;
+    chunks?: number;
+    mentions?: number;
+    claims?: number;
+  };
+  startedAt?: string;
+  updatedAt?: string;
+  error?: string;
+}
+
+export interface IngestRunView {
+  runId: string;
+  sourceMetadata: {
+    filename: string;
+    contentHash: string;
+    mimeType: string;
+  };
+  pageImages: PageImageManifest[];
+  roster: { entries: RosterEntry[] };
+  claims: ExtractedClaim[];
+  corpus: ExtractedCorpus;
+}

--- a/apps/hash-frontend/src/pages/ingest.page/upload-panel.tsx
+++ b/apps/hash-frontend/src/pages/ingest.page/upload-panel.tsx
@@ -1,0 +1,211 @@
+/**
+ * Upload panel: drag-and-drop PDF upload with progress display.
+ *
+ * Uses Ark UI FileUpload for accessible drag-and-drop, and MUI for layout.
+ */
+import { FileUpload } from "@ark-ui/react";
+import { Box, CircularProgress, Typography } from "@mui/material";
+import type { FunctionComponent } from "react";
+
+import { Button } from "../../shared/ui/button";
+import type { RunStatus } from "./types";
+import type { IngestRunState } from "./use-ingest-run";
+
+// ---------------------------------------------------------------------------
+// Sub-components (defined first to satisfy no-use-before-define)
+// ---------------------------------------------------------------------------
+
+const StatusCard: FunctionComponent<{ children: React.ReactNode }> = ({
+  children,
+}) => (
+  <Box
+    sx={{
+      border: ({ palette }) => `1px solid ${palette.gray[30]}`,
+      borderRadius: 2,
+      p: 4,
+      textAlign: "center",
+      maxWidth: 400,
+      mx: "auto",
+    }}
+  >
+    {children}
+  </Box>
+);
+
+const RunCounts: FunctionComponent<{ status: RunStatus }> = ({ status }) => {
+  if (!status.counts) {
+    return null;
+  }
+  const { pages, chunks, mentions, claims } = status.counts;
+  const items = [
+    pages && `${pages} pages`,
+    chunks && `${chunks} chunks`,
+    mentions && `${mentions} mentions`,
+    claims && `${claims} claims`,
+  ].filter(Boolean);
+  if (items.length === 0) {
+    return null;
+  }
+  return (
+    <Typography variant="smallTextLabels" sx={{ color: "gray.60", mt: 0.5 }}>
+      {items.join(" · ")}
+    </Typography>
+  );
+};
+
+const RunProgress: FunctionComponent<{ status: RunStatus }> = ({ status }) => (
+  <Box>
+    <Typography fontWeight={600} sx={{ mb: 0.25 }}>
+      {status.phase && (
+        <span style={{ textTransform: "capitalize" }}>{status.phase}</span>
+      )}
+      {status.step && (
+        <Typography
+          component="span"
+          variant="smallTextLabels"
+          sx={{ color: "gray.60", ml: 0.5 }}
+        >
+          → {status.step}
+        </Typography>
+      )}
+    </Typography>
+    <RunCounts status={status} />
+    <Typography variant="microText" sx={{ color: "gray.50", mt: 1 }}>
+      Run: {status.runId.slice(0, 8)}…
+    </Typography>
+  </Box>
+);
+
+const DropZone: FunctionComponent<{ onUpload: (file: File) => void }> = ({
+  onUpload,
+}) => (
+  <FileUpload.Root
+    accept={{ "application/pdf": [".pdf"] }}
+    maxFiles={1}
+    onFileAccept={(details: { files: File[] }) => {
+      const file = details.files[0];
+      if (file) {
+        onUpload(file);
+      }
+    }}
+  >
+    <FileUpload.Dropzone
+      style={{
+        border: "2px dashed",
+        borderColor: "rgba(0, 0, 0, 0.23)",
+        borderRadius: "8px",
+        padding: "3rem 2rem",
+        textAlign: "center",
+        cursor: "pointer",
+        transition: "border-color 0.15s",
+      }}
+    >
+      <Typography sx={{ fontSize: "1.125rem", fontWeight: 600, mb: 1 }}>
+        Drop a PDF here
+      </Typography>
+      <Typography variant="smallTextLabels" sx={{ color: "gray.60", mb: 2 }}>
+        or click to browse
+      </Typography>
+      <FileUpload.Trigger asChild>
+        <Button variant="secondary" size="small">
+          Choose File
+        </Button>
+      </FileUpload.Trigger>
+    </FileUpload.Dropzone>
+    <FileUpload.HiddenInput />
+  </FileUpload.Root>
+);
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+interface UploadPanelProps {
+  state: IngestRunState;
+  onUpload: (file: File) => void;
+  onReset: () => void;
+}
+
+export const UploadPanel: FunctionComponent<UploadPanelProps> = ({
+  state,
+  onUpload,
+  onReset,
+}) => {
+  if (state.phase === "idle") {
+    return <DropZone onUpload={onUpload} />;
+  }
+
+  if (state.phase === "uploading") {
+    return (
+      <StatusCard>
+        <CircularProgress size={32} sx={{ mb: 1.5 }} />
+        <Typography fontWeight={600}>Uploading PDF…</Typography>
+      </StatusCard>
+    );
+  }
+
+  if (state.phase === "streaming") {
+    return (
+      <StatusCard>
+        <CircularProgress size={32} sx={{ mb: 1.5 }} />
+        <RunProgress status={state.runStatus} />
+      </StatusCard>
+    );
+  }
+
+  if (state.phase === "done") {
+    const succeeded = state.runStatus.status === "succeeded";
+    return (
+      <StatusCard>
+        {succeeded ? (
+          <>
+            <Typography fontWeight={600} sx={{ mb: 0.5 }}>
+              Pipeline complete!
+            </Typography>
+            <RunCounts status={state.runStatus} />
+            <Typography
+              variant="smallTextLabels"
+              sx={{ color: "gray.60", mt: 2 }}
+            >
+              Opening results…
+            </Typography>
+          </>
+        ) : (
+          <>
+            <Typography fontWeight={600} sx={{ mb: 0.5 }}>
+              Pipeline failed
+            </Typography>
+            {state.runStatus.error && (
+              <Typography variant="smallTextLabels" sx={{ color: "red.70" }}>
+                {state.runStatus.error}
+              </Typography>
+            )}
+            <Button
+              variant="secondary"
+              size="small"
+              onClick={onReset}
+              sx={{ mt: 2 }}
+            >
+              Try Again
+            </Button>
+          </>
+        )}
+      </StatusCard>
+    );
+  }
+
+  // error phase
+  return (
+    <StatusCard>
+      <Typography fontWeight={600} sx={{ mb: 0.5 }}>
+        Error
+      </Typography>
+      <Typography variant="smallTextLabels" sx={{ color: "red.70" }}>
+        {state.message}
+      </Typography>
+      <Button variant="secondary" size="small" onClick={onReset} sx={{ mt: 2 }}>
+        Try Again
+      </Button>
+    </StatusCard>
+  );
+};

--- a/apps/hash-frontend/src/pages/ingest.page/use-ingest-run.ts
+++ b/apps/hash-frontend/src/pages/ingest.page/use-ingest-run.ts
@@ -1,0 +1,187 @@
+/**
+ * Ingest run hook: upload PDF → stream SSE progress → terminal state.
+ *
+ * Pure functions (isPdfFile, isTerminalStatus) are exported for testing.
+ * The hook (useIngestRun) wires them to React state + SSE side effects.
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type { RunStatus } from "./types";
+
+// ---------------------------------------------------------------------------
+// Pure functions (functional core)
+// ---------------------------------------------------------------------------
+
+export function isPdfFile(file: File): boolean {
+  return (
+    file.type === "application/pdf" || file.name.toLowerCase().endsWith(".pdf")
+  );
+}
+
+export function isTerminalStatus(
+  status: RunStatus["status"],
+): status is "succeeded" | "failed" {
+  return status === "succeeded" || status === "failed";
+}
+
+export function shouldFetchResults(
+  state: IngestRunState,
+): state is Extract<IngestRunState, { phase: "done" }> {
+  return state.phase === "done" && state.runStatus.status === "succeeded";
+}
+
+/** Map an SSE event payload to a RunStatus shape for the UI. */
+export function statusFromEvent(
+  runId: string,
+  eventKind: string,
+  payload: Record<string, unknown>,
+): RunStatus {
+  const status: RunStatus["status"] =
+    eventKind === "run-succeeded"
+      ? "succeeded"
+      : eventKind === "run-failed"
+        ? "failed"
+        : ((payload.status as RunStatus["status"] | undefined) ?? "running");
+  return {
+    runId,
+    status,
+    phase: payload.phase as string | undefined,
+    step: payload.step as string | undefined,
+    counts: payload.counts as RunStatus["counts"],
+    error: payload.error ? (payload.error as string) : undefined,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// State machine
+// ---------------------------------------------------------------------------
+
+export type IngestRunState =
+  | { phase: "idle" }
+  | { phase: "uploading" }
+  | { phase: "streaming"; runStatus: RunStatus }
+  | { phase: "done"; runStatus: RunStatus }
+  | { phase: "error"; message: string };
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useIngestRun() {
+  const [state, setState] = useState<IngestRunState>({ phase: "idle" });
+  const esRef = useRef<EventSource | null>(null);
+
+  useEffect(() => {
+    return () => {
+      esRef.current?.close();
+    };
+  }, []);
+
+  const stopStream = useCallback(() => {
+    if (esRef.current) {
+      esRef.current.close();
+      esRef.current = null;
+    }
+  }, []);
+
+  const startStream = useCallback(
+    (runId: string) => {
+      stopStream();
+
+      const es = new EventSource(`/api/ingest/${runId}/events`);
+      esRef.current = es;
+
+      const handleEvent = (event: MessageEvent) => {
+        try {
+          const payload = JSON.parse(event.data) as Record<string, unknown>;
+          const runStatus = statusFromEvent(runId, event.type, payload);
+
+          if (isTerminalStatus(runStatus.status)) {
+            stopStream();
+            setState({ phase: "done", runStatus });
+          } else {
+            setState({ phase: "streaming", runStatus });
+          }
+        } catch {
+          // Malformed event — ignore
+        }
+      };
+
+      for (const kind of [
+        "run-queued",
+        "phase-start",
+        "phase-complete",
+        "step-start",
+        "step-complete",
+        "run-succeeded",
+        "run-failed",
+      ]) {
+        es.addEventListener(kind, handleEvent);
+      }
+
+      es.onerror = () => {
+        if (!esRef.current) {
+          return;
+        }
+        stopStream();
+        setState({
+          phase: "error",
+          message: "Lost connection to progress stream",
+        });
+      };
+    },
+    [stopStream],
+  );
+
+  const upload = useCallback(
+    async (file: File) => {
+      if (!isPdfFile(file)) {
+        setState({ phase: "error", message: "Only PDF files are accepted" });
+        return;
+      }
+
+      setState({ phase: "uploading" });
+
+      try {
+        const formData = new FormData();
+        formData.append("file", file);
+
+        const res = await fetch("/api/ingest", {
+          method: "POST",
+          body: formData,
+        });
+
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error(
+            (body as { error?: string }).error ??
+              `Upload failed with status ${res.status}`,
+          );
+        }
+
+        const status: RunStatus = (await res.json()) as RunStatus;
+
+        if (isTerminalStatus(status.status)) {
+          setState({ phase: "done", runStatus: status });
+        } else {
+          setState({ phase: "streaming", runStatus: status });
+          startStream(status.runId);
+        }
+      } catch (err) {
+        setState({
+          phase: "error",
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+    },
+    [startStream],
+  );
+
+  const reset = useCallback(() => {
+    stopStream();
+    setState({ phase: "idle" });
+  }, [stopStream]);
+
+  return { state, upload, reset };
+}

--- a/apps/hash-frontend/src/pages/ingest/results.page.tsx
+++ b/apps/hash-frontend/src/pages/ingest/results.page.tsx
@@ -1,0 +1,194 @@
+import { InfinityLightIcon } from "@hashintel/design-system";
+import { Box, Container, Typography } from "@mui/material";
+import { useRouter } from "next/router";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import type { NextPageWithLayout } from "../../shared/layout";
+import { getLayoutWithSidebar } from "../../shared/layout";
+import { Button } from "../../shared/ui/button";
+import { WorkersHeader } from "../../shared/workers-header";
+import type { Selection } from "../ingest.page/evidence-resolver";
+import { resolveEvidence } from "../ingest.page/evidence-resolver";
+import { PageViewer } from "../ingest.page/page-viewer";
+import { ResultsPanel } from "../ingest.page/results-panel";
+import {
+  getIngestResultsPath,
+  getIngestResultsSource,
+  INGEST_FIXTURES,
+} from "../ingest.page/routing";
+import type { IngestRunView } from "../ingest.page/types";
+
+const IngestResultsPage: NextPageWithLayout = () => {
+  const router = useRouter();
+  const source = useMemo(
+    () =>
+      getIngestResultsSource({
+        runId: router.query.runId as string | undefined,
+        fixture: router.query.fixture as string | undefined,
+      }),
+    [router.query.runId, router.query.fixture],
+  );
+
+  const [view, setView] = useState<IngestRunView | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [selection, setSelection] = useState<Selection>(null);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [loading, setLoading] = useState(false);
+
+  const fetchResults = useCallback(async () => {
+    setView(null);
+    setError(null);
+    setSelection(null);
+    setCurrentPage(1);
+    setLoading(true);
+
+    const endpoint =
+      source.kind === "fixture"
+        ? `/api/ingest-fixtures/${source.fixtureId}/view`
+        : `/api/ingest/${source.runId}/view`;
+
+    try {
+      const response = await fetch(endpoint);
+      if (!response.ok) {
+        throw new Error(`Failed to load results: ${response.status}`);
+      }
+      const data = (await response.json()) as IngestRunView;
+      setView(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, [source]);
+
+  useEffect(() => {
+    void fetchResults();
+  }, [fetchResults]);
+
+  useEffect(() => {
+    if (!view || !selection) {
+      return;
+    }
+    const { targetPage } = resolveEvidence(selection, view.corpus.blocks);
+    if (targetPage !== null) {
+      setCurrentPage(targetPage);
+    }
+  }, [selection, view]);
+
+  const handleFixtureChange = (fixtureId: string) => {
+    void router.push(getIngestResultsPath({ kind: "fixture", fixtureId }));
+  };
+
+  const handleNewUpload = () => {
+    void router.push("/ingest");
+  };
+
+  return (
+    <>
+      <WorkersHeader
+        crumbs={[
+          { title: "Ingest", href: "/ingest", id: "ingest" },
+          { title: "Results", href: "#", id: "results" },
+        ]}
+        title={{
+          Icon: InfinityLightIcon,
+          text: "Ingest Results",
+        }}
+        hideDivider
+        endElement={
+          <Box sx={{ display: "flex", gap: 1.5, alignItems: "center" }}>
+            {source.kind === "fixture" && (
+              <select
+                value={source.fixtureId}
+                onChange={(ev) => handleFixtureChange(ev.target.value)}
+                style={{
+                  background: "white",
+                  border: "1px solid rgba(0, 0, 0, 0.23)",
+                  borderRadius: "4px",
+                  padding: "4px 8px",
+                  fontSize: "0.8125rem",
+                }}
+              >
+                {INGEST_FIXTURES.map((fixture) => (
+                  <option key={fixture.id} value={fixture.id}>
+                    {fixture.label}
+                  </option>
+                ))}
+              </select>
+            )}
+            {view && (
+              <Typography variant="smallTextLabels" sx={{ color: "gray.60" }}>
+                {view.sourceMetadata.filename} · {view.pageImages.length} pages
+                · {view.roster.entries.length} entities · {view.claims.length}{" "}
+                claims
+              </Typography>
+            )}
+          </Box>
+        }
+      />
+
+      {error && (
+        <Container sx={{ py: 4 }}>
+          <Typography variant="h5" sx={{ color: "red.70", mb: 1 }}>
+            Error loading results
+          </Typography>
+          <Typography variant="smallTextLabels" sx={{ mb: 2 }}>
+            {error}
+          </Typography>
+          {source.kind === "run" && (
+            <Button variant="secondary" size="small" onClick={handleNewUpload}>
+              New Upload
+            </Button>
+          )}
+        </Container>
+      )}
+
+      {!error && !view && (
+        <Container sx={{ py: 4 }}>
+          <Typography variant="smallTextLabels" sx={{ color: "gray.60" }}>
+            {loading ? "Loading results…" : "Preparing view…"}
+          </Typography>
+        </Container>
+      )}
+
+      {view && (
+        <Box sx={{ display: "flex", flex: 1, overflow: "hidden" }}>
+          <ResultsPanel
+            rosterEntries={view.roster.entries}
+            claims={view.claims}
+            selection={selection}
+            onSelect={setSelection}
+          />
+          <Box sx={{ flex: 1, overflow: "auto", p: 2 }}>
+            <PageViewer
+              pageImages={view.pageImages}
+              blocks={view.corpus.blocks}
+              highlightedBlockIds={
+                selection
+                  ? resolveEvidence(selection, view.corpus.blocks).blockIds
+                  : []
+              }
+              currentPage={currentPage}
+              onPageChange={setCurrentPage}
+            />
+            {source.kind === "run" && (
+              <Button
+                variant="tertiary_quiet"
+                size="small"
+                onClick={handleNewUpload}
+                sx={{ mt: 2, color: "gray.60" }}
+              >
+                ← New Upload
+              </Button>
+            )}
+          </Box>
+        </Box>
+      )}
+    </>
+  );
+};
+
+IngestResultsPage.getLayout = (page) =>
+  getLayoutWithSidebar(page, { fullWidth: true });
+
+export default IngestResultsPage;

--- a/apps/hash-frontend/src/pages/ingest/results.page.tsx
+++ b/apps/hash-frontend/src/pages/ingest/results.page.tsx
@@ -1,7 +1,7 @@
 import { InfinityLightIcon } from "@hashintel/design-system";
 import { Box, Container, Typography } from "@mui/material";
 import { useRouter } from "next/router";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import type { NextPageWithLayout } from "../../shared/layout";
 import { getLayoutWithSidebar } from "../../shared/layout";
@@ -18,13 +18,17 @@ import {
 } from "../ingest.page/routing";
 import type { IngestRunView } from "../ingest.page/types";
 
+const normalizeQueryParam = (
+  value: string | string[] | undefined,
+): string | undefined => (typeof value === "string" ? value : value?.[0]);
+
 const IngestResultsPage: NextPageWithLayout = () => {
   const router = useRouter();
   const source = useMemo(
     () =>
       getIngestResultsSource({
-        runId: router.query.runId as string | undefined,
-        fixture: router.query.fixture as string | undefined,
+        runId: normalizeQueryParam(router.query.runId),
+        fixture: normalizeQueryParam(router.query.fixture),
       }),
     [router.query.runId, router.query.fixture],
   );
@@ -35,7 +39,9 @@ const IngestResultsPage: NextPageWithLayout = () => {
   const [currentPage, setCurrentPage] = useState(1);
   const [loading, setLoading] = useState(false);
 
-  const fetchResults = useCallback(async () => {
+  useEffect(() => {
+    const abortController = new AbortController();
+
     setView(null);
     setError(null);
     setSelection(null);
@@ -44,36 +50,55 @@ const IngestResultsPage: NextPageWithLayout = () => {
 
     const endpoint =
       source.kind === "fixture"
-        ? `/api/ingest-fixtures/${source.fixtureId}/view`
-        : `/api/ingest/${source.runId}/view`;
+        ? `/api/ingest-fixtures/${encodeURIComponent(source.fixtureId)}/view`
+        : `/api/ingest/${encodeURIComponent(source.runId)}/view`;
 
-    try {
-      const response = await fetch(endpoint);
-      if (!response.ok) {
-        throw new Error(`Failed to load results: ${response.status}`);
+    void (async () => {
+      try {
+        const response = await fetch(endpoint, {
+          signal: abortController.signal,
+        });
+        if (!response.ok) {
+          throw new Error(`Failed to load results: ${response.status}`);
+        }
+        const data = (await response.json()) as IngestRunView;
+        if (!abortController.signal.aborted) {
+          setView(data);
+        }
+      } catch (err) {
+        if (
+          abortController.signal.aborted ||
+          (err instanceof Error && err.name === "AbortError")
+        ) {
+          return;
+        }
+
+        setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        if (!abortController.signal.aborted) {
+          setLoading(false);
+        }
       }
-      const data = (await response.json()) as IngestRunView;
-      setView(data);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setLoading(false);
-    }
+    })();
+
+    return () => {
+      abortController.abort();
+    };
   }, [source]);
 
-  useEffect(() => {
-    void fetchResults();
-  }, [fetchResults]);
+  const evidence = useMemo(
+    () =>
+      view && selection
+        ? resolveEvidence(selection, view.corpus.blocks)
+        : { blockIds: [], targetPage: null },
+    [selection, view],
+  );
 
   useEffect(() => {
-    if (!view || !selection) {
-      return;
+    if (evidence.targetPage !== null) {
+      setCurrentPage(evidence.targetPage);
     }
-    const { targetPage } = resolveEvidence(selection, view.corpus.blocks);
-    if (targetPage !== null) {
-      setCurrentPage(targetPage);
-    }
-  }, [selection, view]);
+  }, [evidence]);
 
   const handleFixtureChange = (fixtureId: string) => {
     void router.push(getIngestResultsPath({ kind: "fixture", fixtureId }));
@@ -163,11 +188,7 @@ const IngestResultsPage: NextPageWithLayout = () => {
             <PageViewer
               pageImages={view.pageImages}
               blocks={view.corpus.blocks}
-              highlightedBlockIds={
-                selection
-                  ? resolveEvidence(selection, view.corpus.blocks).blockIds
-                  : []
-              }
+              highlightedBlockIds={evidence.blockIds}
               currentPage={currentPage}
               onPageChange={setCurrentPage}
             />

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar.tsx
@@ -108,6 +108,11 @@ export const PageSidebar: FunctionComponent = () => {
                   path: "/workers",
                   activeIfPathMatches: /^\/@([^/]+)\/workers\//,
                 },
+                {
+                  title: "Ingest",
+                  path: "/ingest",
+                  activeIfPathMatches: /^\/ingest/,
+                },
               ],
             },
           ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -527,6 +527,7 @@ __metadata:
   resolution: "@apps/hash-frontend@workspace:apps/hash-frontend"
   dependencies:
     "@apollo/client": "npm:3.10.5"
+    "@ark-ui/react": "npm:5.26.2"
     "@blockprotocol/core": "npm:0.1.4"
     "@blockprotocol/graph": "workspace:*"
     "@blockprotocol/hook": "npm:0.1.8"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Add an `/ingest` route to the HASH frontend that proxies to the Mastra API from the internal repo, enabling PDF upload and discovery pipeline results viewing.

## 🔗 Related links

- [H-6363](https://linear.app/hash/issue/H-6363) — Add a route to HASH app for current prototype
- [H-6290](https://linear.app/hash/issue/H-6290) — End-to-end MVP atop HASH of unstructured ingest _(parent)_

## 🚫 Blocked by

- [ ] Nothing

## 🔍 What does this change?

- Add `/ingest` upload page with Ark UI `FileUpload` drag-and-drop zone and SSE progress display
- Add `/ingest/results` page with roster/claims sidebar and PDF page viewer with bbox overlays
- Add Next.js rewrites to proxy `/api/ingest/*` → `localhost:4111/discovery-runs/*` (Mastra API)
- Add `/api/ingest-fixtures/*` rewrite for fixture data
- Add "Ingest" sidebar link under Agents section, gated on `workers` feature flag
- Add `@ark-ui/react` dependency (version-aligned at 5.26.2 with `ds-components` and `petrinaut`)
- Add `useIngestRun` hook for upload + SSE `EventSource` progress streaming
- Add contract types mirroring internal repo's pipeline schemas (`RunStatus`, `IngestRunView`, etc.)
- Add `.gitignore` for `memory/` directory (AI-generated working docs)

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are in a state where docs changes are not _yet_ required but will be

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

- Components are a first pass ported from the internal repo prototype — data shapes and design will evolve
- Requires Mastra API (port 4111) from internal repo to be running for upload/results to work

## 🐾 Next steps

- H-6364: Temporal wiring + UI redesign (stacked PR)
- Ingest UI redesign with assertion-centric entity cards (per design reference)
- hash-api GraphQL integration (pending team discussion)

## 🛡 What tests cover this?

- `turbo lint:tsc --filter=@apps/hash-frontend` — type checking
- `yarn fix:eslint` — zero lint errors
- `yarn fix:format` — formatting clean

## ❓ How to test this?

1. Start HASH external services: `yarn external-services up -d`
2. Start graph + API + frontend: `yarn start:graph`, `yarn dev:backend`, `yarn dev:frontend`
3. Start Mastra API from internal repo: `TEMPORAL_NAMESPACE=HASH yarn dev:api`
4. Log in as `alice@example.com` / `password`
5. Navigate to `/ingest` — upload panel renders within sidebar layout
6. Upload a PDF — progress streaming appears (requires Temporal workers running)

## 📹 Demo

<!-- Screenshots to be added after visual verification -->
