### PR TITLE
H-6368: Fix release process after rewriting `workspace:` identifiers

### DIFF
--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -32,7 +32,7 @@ jobs:
           EOF
 
           yarn changeset:resolve-workspace-ranges
-          yarn changeset publish --tag canary
+          YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn changeset publish --tag canary
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "bench:integration": "CARGO_TERM_PROGRESS_WHEN=never turbo run bench:integration --env-mode=loose --",
     "bench:unit": "CARGO_TERM_PROGRESS_WHEN=never turbo run bench:unit --env-mode=loose --",
     "changeset:resolve-workspace-ranges": "node scripts/resolve-workspace-ranges.mjs",
-    "changeset:publish": "yarn changeset:resolve-workspace-ranges && yarn changeset publish",
+    "changeset:publish": "yarn changeset:resolve-workspace-ranges && YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn changeset publish",
     "changeset:version": "yarn changeset version && YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn",
     "codegen": "CARGO_TERM_PROGRESS_WHEN=never turbo codegen",
     "create-block": "yarn workspace @local/repo-chores exe scripts/create-block.ts",

--- a/scripts/resolve-workspace-ranges.mjs
+++ b/scripts/resolve-workspace-ranges.mjs
@@ -25,13 +25,15 @@ const output = execSync("yarn workspaces list --json", {
 
 const workspaces = output.split("\n").filter(Boolean).map(JSON.parse);
 
-const versionMap = new Map();
+console.log("Rewriting 'workspace:' dependency ranges in packages...");
+
+const packageMap = new Map();
 for (const { location } of workspaces) {
   const pkg = JSON.parse(
     readFileSync(resolve(rootDir, location, "package.json"), "utf-8"),
   );
   if (pkg.name && pkg.version) {
-    versionMap.set(pkg.name, pkg.version);
+    packageMap.set(pkg.name, { version: pkg.version, private: !!pkg.private });
   }
 }
 
@@ -42,6 +44,11 @@ for (const { location, name } of workspaces) {
   const pkgPath = resolve(rootDir, location, "package.json");
   const raw = readFileSync(pkgPath, "utf-8");
   const pkg = JSON.parse(raw);
+
+  if (pkg.private) {
+    continue;
+  }
+
   let modified = false;
 
   for (const field of DEP_FIELDS) {
@@ -53,13 +60,19 @@ for (const { location, name } of workspaces) {
         continue;
       }
 
-      const version = versionMap.get(dep);
-      if (!version) {
+      const depInfo = packageMap.get(dep);
+      if (!depInfo) {
         console.warn(
-          `  ⚠ ${name}: ${dep} has ${range} but no workspace version found`,
+          `  ⚠ ${name}: ${dep} has ${range} but no workspace package found`,
         );
         continue;
       }
+
+      if (depInfo.private) {
+        continue;
+      }
+
+      const { version } = depInfo;
 
       const specifier = range.slice("workspace:".length);
       let resolved;
@@ -90,4 +103,6 @@ for (const { location, name } of workspaces) {
   }
 }
 
-console.log(`Resolved ${totalResolved} workspace: ranges`);
+console.log(
+  `Rewrote ${totalResolved} 'workspace:' dependency ranges in ${workspaces.length} packages`,
+);


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Follow-up to #8570 – release process errored, I think it might be because of yarn immutable installs in CI, this might fix it.

Also adds a log and avoids rewriting identifiers for packages not being published.