### PR TITLE
H-6373: Change publishing lifecycle scripts; add changeset for `@hashintel/refractive`

### DIFF
--- a/.changeset/green-wombats-try.md
+++ b/.changeset/green-wombats-try.md
@@ -1,0 +1,5 @@
+---
+"@hashintel/refractive": patch
+---
+
+change equation export casing, e.g. LIP -> lip

--- a/.changeset/yellow-badgers-grin.md
+++ b/.changeset/yellow-badgers-grin.md
@@ -1,0 +1,5 @@
+---
+"@hashintel/ds-helpers": patch
+---
+
+fix publishing process

--- a/libs/@hashintel/ds-components/package.json
+++ b/libs/@hashintel/ds-components/package.json
@@ -45,7 +45,7 @@
     "lint": "npm-run-all --continue-on-error \"lint:*\"",
     "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit",
-    "prepare": "turbo run build",
+    "prepublishOnly": "turbo run build",
     "storybook": "storybook dev -p 6006",
     "storybook:build": "storybook build"
   },

--- a/libs/@hashintel/ds-helpers/README.md
+++ b/libs/@hashintel/ds-helpers/README.md
@@ -1,0 +1,5 @@
+# @hashintel/ds-helpers
+
+This packages contains PandaCSS helper functions and utilities for the HASH design system.
+
+In PandaCSS's terminology, this is the "styled-system" layer of the design system.

--- a/libs/@hashintel/ds-helpers/package.json
+++ b/libs/@hashintel/ds-helpers/package.json
@@ -60,7 +60,7 @@
     "lint": "npm-run-all --continue-on-error \"lint:*\"",
     "lint:tsc": "tsc --noEmit",
     "preflight:ladle": "ladle build && ladle preview",
-    "prepare": "turbo run build",
+    "prepublishOnly": "turbo run build",
     "test:snapshots": "ladle build && playwright test",
     "test:update": "ladle build && playwright test --update-snapshots"
   },

--- a/libs/@hashintel/ds-theme/package.json
+++ b/libs/@hashintel/ds-theme/package.json
@@ -45,7 +45,7 @@
     "fix:format": "biome format --write",
     "lint": "npm-run-all --continue-on-error \"lint:*\"",
     "lint:tsc": "tsc --noEmit && tsc --noEmit -p scripts/tsconfig.json",
-    "prepare": "turbo run build",
+    "prepublishOnly": "turbo run build",
     "test:unit": "vitest run"
   },
   "devDependencies": {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Fixes to published packages / publishing process:

1. Switch the lifecycle script for pre-publishing build to `prepublishOnly` consistently: a few packages had `prepare`, and somehow `@hashintel/ds-helpers` ended up being published without its built `styled-system` folder. I'm not sure this will fix it but it's worth a try.
2. Add a changeset for `@hashintel/refractive` to get a new version published – the export names were changed but the published version still has the old exports, meaning using `@hashintel/petrinaut` in other repos fails (because it refers to the new, unpublished function names).
3. Adds a `README` for `ds-helpers`