### PR TITLE
BE-480: Fix feature gate conditions for backtrace and int_from_ascii

### DIFF
--- a/libs/@local/hashql/diagnostics/src/lib.rs
+++ b/libs/@local/hashql/diagnostics/src/lib.rs
@@ -11,8 +11,11 @@
 
     // Library Features
     variant_count,
-    int_from_ascii,
 )]
+#![cfg_attr(feature = "serde", feature(
+    // Library Features
+    int_from_ascii,
+))]
 
 extern crate alloc;
 

--- a/libs/error-stack/src/lib.rs
+++ b/libs/error-stack/src/lib.rs
@@ -478,7 +478,7 @@
 #![cfg_attr(nightly, feature(error_generic_member_access))]
 #![cfg_attr(all(nightly, feature = "unstable"), feature(try_trait_v2))]
 #![cfg_attr(all(doc, nightly), feature(doc_cfg))]
-#![cfg_attr(all(nightly, feature = "std"), feature(backtrace_frames))]
+#![cfg_attr(all(nightly, feature = "backtrace"), feature(backtrace_frames))]
 #![cfg_attr(
     not(miri),
     doc(test(attr(

--- a/libs/error-stack/tests/test_compatibility.rs
+++ b/libs/error-stack/tests/test_compatibility.rs
@@ -1,7 +1,7 @@
 #![cfg(any(feature = "eyre", feature = "anyhow"))]
 #![cfg_attr(nightly, feature(error_generic_member_access))]
 #![cfg_attr(nightly, allow(clippy::incompatible_msrv))]
-#![cfg_attr(all(nightly, feature = "std"), feature(backtrace_frames))]
+#![cfg_attr(all(nightly, feature = "backtrace"), feature(backtrace_frames))]
 
 mod common;
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR refines feature gate conditions to improve conditional compilation accuracy. The changes ensure that unstable Rust features are only enabled when the appropriate feature flags are set, preventing unnecessary feature activation.

## 🔗 Related links

- ...

## 🚫 Blocked by

- [ ] ...

## 🔍 What does this change?

- Moves `int_from_ascii` feature gate to only activate when the `serde` feature is enabled in the hashql diagnostics library
- Changes the condition for enabling `backtrace_frames` from `feature = "std"` to `feature = "backtrace"` in both the error-stack library and its compatibility tests

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

## 🐾 Next steps

## 🛡 What tests cover this?

- Existing compilation tests will verify that feature gates work correctly

## ❓ How to test this?

1. Checkout the branch
2. Build with different feature flag combinations
3. Confirm that features are only enabled when their corresponding flags are set

## 📹 Demo
