### PR TITLE
SRE-613: Disable BuildKit provenance attestation to fix Inspector scanning

### DIFF
--- a/.github/actions/build-docker-images/action.yml
+++ b/.github/actions/build-docker-images/action.yml
@@ -75,6 +75,7 @@ runs:
         tags: |
           hash-graph
           hash-graph:test
+        provenance: false
         cache-from: |
           type=registry,ref=ghcr.io/hashintel/hash-graph${{ env.IMAGE_TAG }}
           type=registry,ref=ghcr.io/hashintel/hash-graph
@@ -99,6 +100,7 @@ runs:
         tags: |
           hash-graph
           hash-graph:test
+        provenance: false
         cache-from: |
           type=registry,ref=ghcr.io/hashintel/hash-graph
         secrets: |
@@ -114,6 +116,7 @@ runs:
         context: .
         file: apps/hash-ai-worker-ts/docker/Dockerfile
         tags: hash-ai-worker-ts
+        provenance: false
         cache-from: |
           type=registry,ref=ghcr.io/hashintel/hash-ai-worker-ts${{ env.IMAGE_TAG }}
           type=registry,ref=ghcr.io/hashintel/hash-ai-worker-ts
@@ -135,6 +138,7 @@ runs:
         context: .
         file: apps/hash-ai-worker-ts/docker/Dockerfile
         tags: hash-ai-worker-ts
+        provenance: false
         cache-from: |
           type=registry,ref=ghcr.io/hashintel/hash-ai-worker-ts
         secrets: |
@@ -149,6 +153,7 @@ runs:
         context: .
         file: apps/hash-integration-worker/docker/Dockerfile
         tags: hash-integration-worker
+        provenance: false
         cache-from: |
           type=registry,ref=ghcr.io/hashintel/hash-integration-worker${{ env.IMAGE_TAG }}
           type=registry,ref=ghcr.io/hashintel/hash-integration-worker
@@ -168,6 +173,7 @@ runs:
         context: .
         file: apps/hash-integration-worker/docker/Dockerfile
         tags: hash-integration-worker
+        provenance: false
         cache-from: |
           type=registry,ref=ghcr.io/hashintel/hash-integration-worker
         secrets: |
@@ -180,6 +186,7 @@ runs:
         context: .
         file: infra/docker/api/prod/Dockerfile
         tags: hash-api
+        provenance: false
         cache-from: |
           type=registry,ref=ghcr.io/hashintel/hash-api${{ env.IMAGE_TAG }}
           type=registry,ref=ghcr.io/hashintel/hash-api
@@ -199,6 +206,7 @@ runs:
         context: .
         file: infra/docker/api/prod/Dockerfile
         tags: hash-api
+        provenance: false
         cache-from: |
           type=registry,ref=ghcr.io/hashintel/hash-api
         secrets: |
@@ -211,6 +219,7 @@ runs:
         context: .
         file: infra/docker/frontend/prod/Dockerfile
         tags: hash-frontend
+        provenance: false
         cache-from: |
           type=registry,ref=ghcr.io/hashintel/hash-frontend${{ env.IMAGE_TAG }}
           type=registry,ref=ghcr.io/hashintel/hash-frontend
@@ -233,6 +242,7 @@ runs:
         context: .
         file: infra/docker/frontend/prod/Dockerfile
         tags: hash-frontend
+        provenance: false
         cache-from: |
           type=registry,ref=ghcr.io/hashintel/hash-frontend
         secrets: |

--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -84,6 +84,7 @@ runs:
           ${{ inputs.AWS_ECR_URL }}/${{ inputs.IMAGE_NAME }}:${{ inputs.IMAGE_TAG }}
           ${{ inputs.AWS_ECR_URL }}/${{ inputs.IMAGE_NAME }}:sha-${{ github.sha }}
           ${{ inputs.AWS_ECR_URL }}/${{ inputs.IMAGE_NAME }}:run-${{ env.GH_RUN_ID }}
+        provenance: false
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

BuildKit's default provenance attestation wraps single-platform images in OCI Image Indexes. AWS Inspector scans child manifests but tags (`production`, `staging`) and usage tracking (`inUseCount`) sit on the Image Index — not on the scanned children. This makes it impossible to correlate CVE findings with deployed images, rendering alerting unusable.

Setting `provenance: false` produces plain single-platform manifests that Inspector can fully scan with tag and deployment context.

## 🔗 Related links

- [SRE-613](https://linear.app/hash/issue/SRE-613/replace-buildkit-provenance-embedding-with-aws-signer-for-container) _(internal)_
- [SRE-614: Image signing evaluation](https://linear.app/hash/issue/SRE-614) _(internal)_ — follow-up for proper signing/provenance
- [moby/buildkit#3499](https://github.com/moby/buildkit/issues/3499) — BuildKit provenance breaks ECR scanning
- [aws/containers-roadmap#1683](https://github.com/aws/containers-roadmap/issues/1683) — Inspector doesn't support OCI Image Index

## 🔍 What does this change?

- Adds `provenance: false` to the CD build action (`.github/actions/docker-build-push/action.yml`) — this is the critical change affecting ECR images scanned by Inspector
- Adds `provenance: false` to all CI build steps (`.github/actions/build-docker-images/action.yml`) for consistency

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🐾 Next steps

- SRE-614: Evaluate and implement proper image signing (AWS Signer / Cosign) as a separate concern from manifest format

## 🛡 What tests cover this?

- The next CD run on `main` will produce plain manifests — verifiable by inspecting the ECR image manifest type
- No unit tests applicable (GitHub Actions workflow config)

## ❓ How to test this?

1. Merge to `main` and wait for the backend CD workflow to run
2. In ECR, inspect any newly pushed image manifest — it should be a plain image manifest, not an OCI Image Index
3. Verify Inspector findings now show tags and `inUseCount` on the scanned images