### PR TITLE
H-6392: Use centralized dependency review workflow

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -14,4 +14,4 @@ permissions:
 jobs:
   dependency-review:
     name: Dependency Review
-    uses: hashintel/.github/.github/workflows/dependency-review.yml@8f5593ef032fa7797bc4d70b6c7b5c02549fc862
+    uses: hashintel/.github/.github/workflows/dependency-review.yml@5ba4cedb756d32b66f2c628967e57fad88aeb717


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Replaces the inline `dependency-review` workflow with a call to a centralized reusable workflow in the `hashintel/.github` org repo. This ensures the action version and configuration are maintained in a single place across all repos.

## 🔗 Related links

- [H-6392](https://linear.app/hash/issue/H-6392)

## 🚫 Blocked by

- [ ] Reusable workflow in `hashintel/.github` must be merged first

## 🔍 What does this change?

- Removes inline dependency-review action and comments from `.github/workflows/dependency-review.yml`
- Calls `hashintel/.github/.github/workflows/dependency-review.yml` as a reusable workflow
- Adds `merge_group` trigger for merge queue support

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- The dependency review workflow will run on this PR itself, validating the reusable workflow call works

## ❓ How to test this?

1. Check that the "Dependency Review" check appears and passes on this PR
2. Verify it calls the reusable workflow from `.github` org repo