### PR TITLE
BE-487: Make Kratos/Hydra admin URLs optional when not embedding admin server

### DIFF
--- a/apps/hash-graph/src/subcommand/admin_server.rs
+++ b/apps/hash-graph/src/subcommand/admin_server.rs
@@ -57,10 +57,10 @@ fn parse_jwt_algorithm(name: &str) -> Result<Algorithm, String> {
 ///
 /// Operational parameters (cache TTL, refresh cooldown, HTTP timeout, algorithms) have sensible
 /// defaults and only take effect when JWT authentication is enabled.
-///
-/// Ideally this would be `Option<JwtConfig>` with required fields in `AdminConfig`, but clap does
-/// not support optional flattened structs with required fields. See
-/// <https://github.com/clap-rs/clap/issues/5092>.
+//
+// Ideally this would have required fields and be used as `Option<JwtConfig>` in `AdminConfig`, but
+// clap does not support optional flattened structs with required fields.
+// See <https://github.com/clap-rs/clap/issues/5092>.
 #[derive(Debug, Clone, Parser)]
 pub struct JwtConfig {
     /// JWKS endpoint URL for JWT signature validation.
@@ -139,18 +139,23 @@ pub struct JwtConfig {
 
 /// Configuration for external identity services (Kratos, Hydra, Mailchimp).
 ///
-/// Kratos and Hydra URLs are required — the admin server cannot function correctly without access
-/// to both identity and OAuth2 services. Mailchimp settings are optional and only needed when
-/// email subscription cleanup is desired during user deletion.
+/// All fields are optional at the CLI/env level so that `AdminConfig` can be flattened into
+/// `ServerArgs` without forcing callers to provide Kratos/Hydra URLs when `--embed-admin` is not
+/// set. When the admin server actually starts, [`run_admin_server`] validates that the required
+/// URLs are present.
+//
+// Ideally these would be required fields and `AdminConfig` would be used as
+// `Option<AdminConfig>` in `ServerArgs`, but clap does not support optional flattened structs
+// with required fields. See <https://github.com/clap-rs/clap/issues/5092>.
 #[derive(Debug, Clone, Parser)]
 pub struct ExternalServicesConfig {
     /// Kratos admin API URL for identity management.
     #[clap(long, env = "HASH_KRATOS_ADMIN_URL")]
-    pub kratos_admin_url: Url,
+    pub kratos_admin_url: Option<Url>,
 
     /// Hydra admin API URL for OAuth2 session management.
     #[clap(long, env = "HASH_HYDRA_ADMIN_URL")]
-    pub hydra_admin_url: Url,
+    pub hydra_admin_url: Option<Url>,
 
     /// Mailchimp API key for email subscription management.
     ///
@@ -263,12 +268,23 @@ pub(crate) async fn run_admin_server(
         }
     };
 
+    let kratos_admin_url = config.external_services.kratos_admin_url.ok_or_else(|| {
+        Report::new(GraphError).attach(
+            "--kratos-admin-url (HASH_KRATOS_ADMIN_URL) is required when running the admin server",
+        )
+    })?;
+    let hydra_admin_url = config.external_services.hydra_admin_url.ok_or_else(|| {
+        Report::new(GraphError).attach(
+            "--hydra-admin-url (HASH_HYDRA_ADMIN_URL) is required when running the admin server",
+        )
+    })?;
+
     let router = hash_graph_api::rest::admin::routes(
         pool,
         jwt_validator,
         hash_graph_api::rest::admin::ExternalServicesConfig {
-            kratos_admin_url: config.external_services.kratos_admin_url,
-            hydra_admin_url: config.external_services.hydra_admin_url,
+            kratos_admin_url,
+            hydra_admin_url,
             mailchimp_api_key: config.external_services.mailchimp_api_key,
             mailchimp_list_id: config.external_services.mailchimp_list_id,
         },

--- a/apps/hash-graph/src/subcommand/server.rs
+++ b/apps/hash-graph/src/subcommand/server.rs
@@ -193,6 +193,9 @@ pub struct ServerArgs {
     #[clap(long, default_value_t = false, env = "HASH_GRAPH_EMBED_ADMIN")]
     pub embed_admin: bool,
 
+    // Ideally this would be `Option<AdminConfig>` and required if `embed_admin` is true, but clap
+    // does not support optional flattened structs with required fields.
+    // See <https://github.com/clap-rs/clap/issues/5092>.
     #[clap(flatten)]
     pub admin: AdminConfig,
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

`HASH_KRATOS_ADMIN_URL` and `HASH_HYDRA_ADMIN_URL` were always required CLI/env arguments, even when running the regular `server` subcommand without `--embed-admin`. This made local development and deployment harder than necessary.

## 🔗 Related links

- [BE-487](https://linear.app/hash/issue/BE-487)

## 🔍 What does this change?

- Makes `kratos_admin_url` and `hydra_admin_url` `Option<Url>` in `ExternalServicesConfig`
- Adds runtime validation in `run_admin_server` that produces clear error messages when the URLs are missing
- Adds `//` comments explaining the clap limitation (`clap#5092`) that prevents using `Option<AdminConfig>` in `ServerArgs`
- Updates the equivalent comment on `JwtConfig`

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- Manual testing: `cargo run -- server` without `HASH_KRATOS_ADMIN_URL`/`HASH_HYDRA_ADMIN_URL` no longer fails at startup
- Manual testing: `cargo run -- admin-server` without the URLs fails with a clear runtime error

## ❓ How to test this?

1. Unset `HASH_KRATOS_ADMIN_URL` and `HASH_HYDRA_ADMIN_URL`
2. Run `cargo run -- server` — should start without error
3. Run `cargo run -- server --embed-admin` — should fail with a clear message about missing URLs
4. Run `cargo run -- admin-server` — should fail with same clear message