### PR TITLE
H-6219: Restore TOTP MFA and fix AAL2 login redirect

### DIFF
--- a/apps/hash-api/src/index.ts
+++ b/apps/hash-api/src/index.ts
@@ -108,9 +108,56 @@ const baseRateLimitOptions: Partial<RateLimitOptions> = {
 };
 
 /**
+ * Key the rate limiter by remote IP. Mirrors the default `express-rate-limit`
+ * behaviour but falls back to a literal "unknown" bucket when `req.ip` is
+ * undefined (which can happen behind certain proxy configurations) so the
+ * default keyGenerator's IP-undefined validation doesn't reject the request.
+ */
+const ipKey: RateLimitOptions["keyGenerator"] = (req) =>
+  req.ip ? ipKeyGenerator(req.ip) : "ip-unavailable";
+
+/**
  * A rate limiter for routes which grant authentication or authorization credentials
  */
 const authRouteRateLimiter = rateLimit(baseRateLimitOptions);
+
+/**
+ * Rate limit for state-changing Kratos proxy requests (POST login/registration/
+ * settings/recovery/verification submissions).
+ *
+ * These are the endpoints where credential brute-force or stuffing attacks
+ * are meaningful, but the limit is loose enough to cover legitimate bursty
+ * interactions (fat-finger password retries, signup + verify + MFA-setup
+ * in quick succession). Per-identifier brute-force is additionally bounded
+ * by {@link userIdentifierRateLimiter}. GETs on the same proxy are handled
+ * separately by {@link kratosProxyReadRateLimiter}.
+ */
+const kratosProxyMutationRateLimiter = rateLimit({
+  ...baseRateLimitOptions,
+  limit: 30,
+  keyGenerator: ipKey,
+  skip: (req) => req.method !== "POST",
+});
+
+/**
+ * Rate limit for Kratos proxy GET reads other than `/sessions/whoami`.
+ *
+ * Flow-creation GETs such as `/self-service/settings/browser` persist a row
+ * in Kratos's DB, so we keep a bound to prevent trivial DB-bloat abuse. The
+ * budget is generous (relative to the credential limit) because a single
+ * user's interaction with an auth flow can legitimately involve several
+ * flow fetches in quick succession.
+ *
+ * `/sessions/whoami` is exempted entirely: it is a cheap session lookup with
+ * no brute-forceable value, and several components in the frontend call it
+ * independently during navigation.
+ */
+const kratosProxyReadRateLimiter = rateLimit({
+  ...baseRateLimitOptions,
+  limit: 60,
+  keyGenerator: ipKey,
+  skip: (req) => req.method !== "GET" || req.path === "/sessions/whoami",
+});
 
 /**
  * A rate limiter for the GraphQL endpoint.
@@ -145,20 +192,17 @@ const graphqlRateLimiter = rateLimit({
 });
 
 /**
- * A rate limit which throttles requests based on the user identifier rather than the IP address.
+ * A rate limit which throttles signin attempts per user identifier rather than
+ * per IP address, to mitigate brute-force attempts spread across many IPs.
+ *
+ * Applied only when the request body carries an `identifier` field (i.e. an
+ * actual signin submission). Requests without an identifier are not limited
+ * here — the per-IP {@link kratosProxyMutationRateLimiter} handles those.
  */
 const userIdentifierRateLimiter = rateLimit({
   ...baseRateLimitOptions,
-  keyGenerator: (req) => {
-    if (req.body?.identifier) {
-      /**
-       * 'identifier' is the field which identifies the user on a signin attempt.
-       * We use this as a rate limiting key if present to mitigate brute force signin attempts spread across multiple IPs.
-       */
-      return req.body.identifier as string;
-    }
-    return ipKeyGenerator(req.ip!);
-  },
+  keyGenerator: (req) => req.body?.identifier as string,
+  skip: (req) => typeof req.body?.identifier !== "string",
 });
 
 /**
@@ -534,7 +578,8 @@ const main = async () => {
    */
   app.use(
     "/auth",
-    authRouteRateLimiter,
+    kratosProxyMutationRateLimiter,
+    kratosProxyReadRateLimiter,
     userIdentifierRateLimiter,
     cors(CORS_CONFIG),
     kratosProxy,

--- a/apps/hash-api/src/index.ts
+++ b/apps/hash-api/src/index.ts
@@ -109,9 +109,10 @@ const baseRateLimitOptions: Partial<RateLimitOptions> = {
 
 /**
  * Key the rate limiter by remote IP. Mirrors the default `express-rate-limit`
- * behaviour but falls back to a literal "unknown" bucket when `req.ip` is
- * undefined (which can happen behind certain proxy configurations) so the
- * default keyGenerator's IP-undefined validation doesn't reject the request.
+ * behaviour but falls back to a literal `"ip-unavailable"` bucket when
+ * `req.ip` is undefined (which can happen behind certain proxy configurations)
+ * so the default keyGenerator's IP-undefined validation doesn't reject the
+ * request.
  */
 const ipKey: RateLimitOptions["keyGenerator"] = (req) =>
   req.ip ? ipKeyGenerator(req.ip) : "ip-unavailable";
@@ -136,7 +137,10 @@ const kratosProxyMutationRateLimiter = rateLimit({
   ...baseRateLimitOptions,
   limit: 30,
   keyGenerator: ipKey,
-  skip: (req) => req.method !== "POST",
+  // Apply to anything that isn't a GET — POST is the credential-bearing
+  // method on the Kratos self-service endpoints, but PUT/PATCH/DELETE
+  // would also count as state-changing if they ever appear.
+  skip: (req) => req.method === "GET",
 });
 
 /**

--- a/apps/hash-frontend/src/pages/settings/security.page.tsx
+++ b/apps/hash-frontend/src/pages/settings/security.page.tsx
@@ -102,7 +102,6 @@ const SecurityPage: NextPageWithLayout = () => {
   const [isRecoveryFlow, setIsRecoveryFlow] = useState(false);
   const [currentPasswordError, setCurrentPasswordError] = useState<string>();
   const [totpCode, setTotpCode] = useState("");
-  const [disableTotpCode, setDisableTotpCode] = useState("");
   const [showTotpSetupForm, setShowTotpSetupForm] = useState(false);
   const [showTotpDisableForm, setShowTotpDisableForm] = useState(false);
   const [backupCodes, setBackupCodes] = useState<string[]>([]);
@@ -384,7 +383,7 @@ const SecurityPage: NextPageWithLayout = () => {
   ) => {
     event.preventDefault();
 
-    if (!flow || !disableTotpCode) {
+    if (!flow) {
       return;
     }
 
@@ -399,53 +398,43 @@ const SecurityPage: NextPageWithLayout = () => {
     //   SSO, passkey), then resume the change on return. Must work for
     //   SSO-only users, so a password-reentry shim alone is not enough.
 
-    // Step 1: Validate the TOTP code to prove the user has authenticator access
-    void submitSettingsUpdate(flow, {
-      method: "totp",
-      totp_code: disableTotpCode,
-      csrf_token: mustGetCsrfTokenFromFlow(flow),
-    })
-      .then(async (verifiedFlow) => {
-        if (!verifiedFlow) {
-          return;
-        }
+    const disableSequence = async () => {
+      // Step 1: Unlink TOTP.
+      const unlinkedFlow = await submitSettingsUpdate(flow, {
+        method: "totp",
+        totp_unlink: true,
+        csrf_token: mustGetCsrfTokenFromFlow(flow),
+      });
 
-        // Step 2: Code was valid, now unlink TOTP
-        const unlinkedFlow = await submitSettingsUpdate(verifiedFlow, {
-          method: "totp",
-          totp_unlink: true,
-          csrf_token: mustGetCsrfTokenFromFlow(verifiedFlow),
-        });
+      if (!unlinkedFlow) {
+        return;
+      }
 
-        if (!unlinkedFlow) {
-          return;
-        }
+      // Step 2: Unlink the `lookup_secret` credential.
+      // `required_aal: highest_available` treats any enrolled second
+      // factor (including backup codes) as enforcing AAL2, so leaving
+      // them behind after removing TOTP would force the user through an
+      // AAL2 prompt with no TOTP to answer it. If this step fails, TOTP
+      // is already gone — surface an error so the user can retry rather
+      // than silently landing in the orphan-AAL2 state.
+      const clearedFlow = await submitSettingsUpdate(unlinkedFlow, {
+        method: "lookup_secret",
+        lookup_secret_disable: true,
+        csrf_token: mustGetCsrfTokenFromFlow(unlinkedFlow),
+      });
 
-        // Step 3: Unlink the `lookup_secret` credential.
-        // `required_aal: highest_available` treats any enrolled second
-        // factor (including backup codes) as enforcing AAL2, so leaving
-        // them behind after removing TOTP would force the user through an
-        // AAL2 prompt with no TOTP to answer it. If this step fails, TOTP
-        // is already gone — surface an error so the user can retry rather
-        // than silently landing in the orphan-AAL2 state.
-        const clearedFlow = await submitSettingsUpdate(unlinkedFlow, {
-          method: "lookup_secret",
-          lookup_secret_disable: true,
-          csrf_token: mustGetCsrfTokenFromFlow(unlinkedFlow),
-        });
+      if (!clearedFlow) {
+        setErrorMessage(
+          "TOTP was disabled, but backup codes could not be removed. " +
+            "Please reload the page and try again to avoid being locked out.",
+        );
+        return;
+      }
 
-        if (!clearedFlow) {
-          setErrorMessage(
-            "TOTP was disabled, but backup codes could not be removed. " +
-              "Please reload the page and try again to avoid being locked out.",
-          );
-          return;
-        }
+      setShowTotpDisableForm(false);
+    };
 
-        setDisableTotpCode("");
-        setShowTotpDisableForm(false);
-      })
-      .finally(() => setDisablingTotp(false));
+    void disableSequence().finally(() => setDisablingTotp(false));
   };
 
   const handleRegenerateBackupCodes = () => {
@@ -614,43 +603,29 @@ const SecurityPage: NextPageWithLayout = () => {
                       gap: 1.5,
                     }}
                   >
-                    <TextField
-                      label="Authentication code"
-                      type="text"
-                      autoComplete="one-time-code"
-                      placeholder="Enter a current code to disable"
-                      value={disableTotpCode}
-                      onChange={({ target }) =>
-                        setDisableTotpCode(target.value)
-                      }
-                      error={
-                        !!totpCodeUiNode?.messages.find(
-                          ({ type }) => type === "error",
-                        )
-                      }
-                      helperText={totpCodeUiNode?.messages.map(
-                        ({ id, text }) => (
-                          <Typography key={id}>{text}</Typography>
-                        ),
-                      )}
-                      required
-                      inputProps={{ inputMode: "numeric" }}
-                    />
+                    <Typography
+                      sx={{ color: ({ palette }) => palette.gray[80] }}
+                    >
+                      Disabling TOTP will also remove your backup codes. You
+                      will sign in with just your password until you enable a
+                      second factor again.
+                    </Typography>
                     <Box sx={{ display: "flex", gap: 1.5, flexWrap: "wrap" }}>
                       <Button
                         type="submit"
                         variant="secondary"
                         data-testid="confirm-disable-totp-button"
-                        disabled={!disableTotpCode || disablingTotp}
+                        disabled={disablingTotp}
                       >
-                        {disablingTotp ? "Disabling..." : "Confirm disable"}
+                        {disablingTotp
+                          ? "Disabling..."
+                          : "Yes, disable two-factor authentication"}
                       </Button>
                       <Button
                         type="button"
                         variant="tertiary"
                         data-testid="cancel-disable-totp-button"
                         onClick={() => {
-                          setDisableTotpCode("");
                           setShowTotpDisableForm(false);
                           setErrorMessage(undefined);
                         }}

--- a/apps/hash-frontend/src/pages/settings/security.page.tsx
+++ b/apps/hash-frontend/src/pages/settings/security.page.tsx
@@ -61,7 +61,15 @@ const extractBackupCodesFromFlow = (flow: SettingsFlow): string[] => {
   // Extract backup codes directly by pattern rather than stripping HTML first.
   // Kratos may return codes in an HTML-formatted string (with <br> tags, etc.),
   // but we only care about the alphanumeric code values themselves.
-  const regexMatches = codesText.match(/[A-Z0-9]{4}(?:-[A-Z0-9]{4})+/gi);
+  //
+  // Two formats have been observed across Kratos versions:
+  // - Older releases: groups of four alphanumeric characters separated by
+  //   hyphens, e.g. `ABCD-EFGH`.
+  // - v26+: a single run of eight alphanumeric characters with no separator,
+  //   e.g. `5ne3l4ll`.
+  //
+  // The optional hyphen makes the pattern match both variants.
+  const regexMatches = codesText.match(/[A-Z0-9]{4}(?:-?[A-Z0-9]{4})+/gi);
   if (regexMatches?.length) {
     return regexMatches;
   }
@@ -369,6 +377,11 @@ const SecurityPage: NextPageWithLayout = () => {
     setDisablingTotp(true);
     persistFlowIdInUrl(flow);
 
+    // @todo H-6417 forcibly refresh the session before a sensitive change
+    //   like this, rather than relying solely on Kratos's
+    //   `privileged_session_max_age`. Needs to work for SSO-only users —
+    //   see the ticket for the redirect-to-refresh-login design.
+
     // Step 1: Validate the TOTP code to prove the user has authenticator access
     void submitSettingsUpdate(flow, {
       method: "totp",
@@ -387,10 +400,23 @@ const SecurityPage: NextPageWithLayout = () => {
           csrf_token: mustGetCsrfTokenFromFlow(verifiedFlow),
         });
 
-        if (unlinkedFlow) {
-          setDisableTotpCode("");
-          setShowTotpDisableForm(false);
+        if (!unlinkedFlow) {
+          return;
         }
+
+        // Step 3: Clear backup codes. `required_aal: highest_available`
+        // treats any second-factor credential (including lookup secrets)
+        // as enforcing AAL2 — leaving orphan backup codes behind after
+        // removing TOTP would force the user through an AAL2 prompt with
+        // no TOTP to answer it.
+        await submitSettingsUpdate(unlinkedFlow, {
+          method: "lookup_secret",
+          lookup_secret_disable: true,
+          csrf_token: mustGetCsrfTokenFromFlow(unlinkedFlow),
+        });
+
+        setDisableTotpCode("");
+        setShowTotpDisableForm(false);
       })
       .finally(() => setDisablingTotp(false));
   };
@@ -537,222 +563,214 @@ const SecurityPage: NextPageWithLayout = () => {
 
           <Divider />
 
-          {/* eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- @todo H-6219 restore this */}
-          {false && (
-            <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
-              <Typography variant="regularTextLabels" sx={{ display: "block" }}>
-                Two-factor authentication
-              </Typography>
+          <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+            <Typography variant="regularTextLabels" sx={{ display: "block" }}>
+              Two-factor authentication
+            </Typography>
 
-              {isTotpEnabled ? (
-                <Box
-                  sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}
-                >
-                  <Typography sx={{ color: ({ palette }) => palette.gray[80] }}>
-                    TOTP is enabled for your account.
-                  </Typography>
-                  {showTotpDisableForm ? (
-                    <Box
-                      component="form"
-                      onSubmit={handleDisableTotpSubmit}
-                      sx={{
-                        display: "flex",
-                        flexDirection: "column",
-                        gap: 1.5,
-                      }}
-                    >
-                      <TextField
-                        label="Authentication code"
-                        type="text"
-                        autoComplete="one-time-code"
-                        placeholder="Enter a current code to disable"
-                        value={disableTotpCode}
-                        onChange={({ target }) =>
-                          setDisableTotpCode(target.value)
-                        }
-                        error={
-                          !!totpCodeUiNode?.messages.find(
-                            ({ type }) => type === "error",
-                          )
-                        }
-                        helperText={totpCodeUiNode?.messages.map(
-                          ({ id, text }) => (
-                            <Typography key={id}>{text}</Typography>
-                          ),
-                        )}
-                        required
-                        inputProps={{ inputMode: "numeric" }}
-                      />
-                      <Box sx={{ display: "flex", gap: 1.5, flexWrap: "wrap" }}>
-                        <Button
-                          type="submit"
-                          variant="secondary"
-                          data-testid="confirm-disable-totp-button"
-                          disabled={!disableTotpCode || disablingTotp}
-                        >
-                          {disablingTotp ? "Disabling..." : "Confirm disable"}
-                        </Button>
-                        <Button
-                          type="button"
-                          variant="tertiary"
-                          data-testid="cancel-disable-totp-button"
-                          onClick={() => {
-                            setDisableTotpCode("");
-                            setShowTotpDisableForm(false);
-                            setErrorMessage(undefined);
-                          }}
-                        >
-                          Cancel
-                        </Button>
-                      </Box>
-                    </Box>
-                  ) : (
+            {isTotpEnabled ? (
+              <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+                <Typography sx={{ color: ({ palette }) => palette.gray[80] }}>
+                  TOTP is enabled for your account.
+                </Typography>
+                {showTotpDisableForm ? (
+                  <Box
+                    component="form"
+                    onSubmit={handleDisableTotpSubmit}
+                    sx={{
+                      display: "flex",
+                      flexDirection: "column",
+                      gap: 1.5,
+                    }}
+                  >
+                    <TextField
+                      label="Authentication code"
+                      type="text"
+                      autoComplete="one-time-code"
+                      placeholder="Enter a current code to disable"
+                      value={disableTotpCode}
+                      onChange={({ target }) =>
+                        setDisableTotpCode(target.value)
+                      }
+                      error={
+                        !!totpCodeUiNode?.messages.find(
+                          ({ type }) => type === "error",
+                        )
+                      }
+                      helperText={totpCodeUiNode?.messages.map(
+                        ({ id, text }) => (
+                          <Typography key={id}>{text}</Typography>
+                        ),
+                      )}
+                      required
+                      inputProps={{ inputMode: "numeric" }}
+                    />
                     <Box sx={{ display: "flex", gap: 1.5, flexWrap: "wrap" }}>
                       <Button
-                        type="button"
+                        type="submit"
                         variant="secondary"
-                        data-testid="disable-totp-button"
+                        data-testid="confirm-disable-totp-button"
+                        disabled={!disableTotpCode || disablingTotp}
+                      >
+                        {disablingTotp ? "Disabling..." : "Confirm disable"}
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="tertiary"
+                        data-testid="cancel-disable-totp-button"
                         onClick={() => {
-                          setShowTotpDisableForm(true);
+                          setDisableTotpCode("");
+                          setShowTotpDisableForm(false);
                           setErrorMessage(undefined);
                         }}
                       >
-                        Disable TOTP
-                      </Button>
-                      <Button
-                        type="button"
-                        data-testid="regenerate-backup-codes-button"
-                        onClick={handleRegenerateBackupCodes}
-                        disabled={regeneratingBackupCodes}
-                      >
-                        {regeneratingBackupCodes
-                          ? "Regenerating backup codes..."
-                          : "Regenerate backup codes"}
+                        Cancel
                       </Button>
                     </Box>
-                  )}
-                </Box>
-              ) : showTotpSetupForm ? (
-                <Box
-                  component="form"
-                  onSubmit={handleEnableTotpSubmit}
-                  sx={{ display: "flex", flexDirection: "column", gap: 2 }}
-                >
-                  <Typography
-                    variant="smallTextParagraphs"
-                    sx={{ color: ({ palette }) => palette.gray[80] }}
-                  >
-                    Scan the QR code with your authenticator app, then enter the
-                    6-digit code to enable TOTP.
-                  </Typography>
-                  {totpQrCodeDataUri ? (
-                    <Box
-                      component="img"
-                      src={totpQrCodeDataUri}
-                      alt="TOTP QR code"
-                      data-testid="totp-qr-code"
-                      sx={{
-                        width: 180,
-                        height: 180,
-                        borderRadius: 1,
-                        border: ({ palette }) =>
-                          `1px solid ${palette.gray[30]}`,
-                      }}
-                    />
-                  ) : null}
-                  {totpSecretKey ? (
-                    <Box>
-                      <Typography
-                        variant="smallTextParagraphs"
-                        sx={({ palette }) => ({
-                          color: palette.gray[80],
-                          mb: 0.75,
-                          display: "block",
-                        })}
-                      >
-                        {totpQrCodeDataUri
-                          ? "Alternatively, use the secret key below for manual setup."
-                          : "QR code unavailable. Use the secret key below for manual setup."}
-                      </Typography>
-                      <Typography
-                        component="code"
-                        data-testid="totp-secret-key"
-                        sx={{
-                          display: "inline-block",
-                          py: 1,
-                          px: 2,
-                          borderRadius: 1,
-                          background: ({ palette }) => palette.gray[20],
-                          fontFamily: "monospace",
-                        }}
-                      >
-                        {totpSecretKey}
-                      </Typography>
-                    </Box>
-                  ) : null}
-                  <TextField
-                    label="Authenticator code"
-                    type="text"
-                    autoComplete="one-time-code"
-                    placeholder="Enter your 6-digit code"
-                    value={totpCode}
-                    onChange={({ target }) => setTotpCode(target.value)}
-                    error={
-                      !!totpCodeUiNode?.messages.find(
-                        ({ type }) => type === "error",
-                      )
-                    }
-                    helperText={totpCodeUiNode?.messages.map(({ id, text }) => (
-                      <Typography key={id}>{text}</Typography>
-                    ))}
-                    required
-                    inputProps={{ inputMode: "numeric" }}
-                  />
+                  </Box>
+                ) : (
                   <Box sx={{ display: "flex", gap: 1.5, flexWrap: "wrap" }}>
                     <Button
-                      type="submit"
-                      data-testid="enable-totp-button"
-                      disabled={!totpCode || enablingTotp}
-                    >
-                      {enablingTotp ? "Enabling..." : "Confirm and enable TOTP"}
-                    </Button>
-                    <Button
                       type="button"
-                      variant="tertiary"
-                      data-testid="cancel-enable-totp-button"
+                      variant="secondary"
+                      data-testid="disable-totp-button"
                       onClick={() => {
-                        setTotpCode("");
-                        setShowTotpSetupForm(false);
+                        setShowTotpDisableForm(true);
                         setErrorMessage(undefined);
                       }}
                     >
-                      Cancel
+                      Disable TOTP
+                    </Button>
+                    <Button
+                      type="button"
+                      data-testid="regenerate-backup-codes-button"
+                      onClick={handleRegenerateBackupCodes}
+                      disabled={regeneratingBackupCodes}
+                    >
+                      {regeneratingBackupCodes
+                        ? "Regenerating backup codes..."
+                        : "Regenerate backup codes"}
                     </Button>
                   </Box>
-                </Box>
-              ) : (
-                <Box
-                  sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}
+                )}
+              </Box>
+            ) : showTotpSetupForm ? (
+              <Box
+                component="form"
+                onSubmit={handleEnableTotpSubmit}
+                sx={{ display: "flex", flexDirection: "column", gap: 2 }}
+              >
+                <Typography
+                  variant="smallTextParagraphs"
+                  sx={{ color: ({ palette }) => palette.gray[80] }}
                 >
-                  <Typography sx={{ color: ({ palette }) => palette.gray[80] }}>
-                    TOTP is currently disabled for your account.
-                  </Typography>
+                  Scan the QR code with your authenticator app, then enter the
+                  6-digit code to enable TOTP.
+                </Typography>
+                {totpQrCodeDataUri ? (
+                  <Box
+                    component="img"
+                    src={totpQrCodeDataUri}
+                    alt="TOTP QR code"
+                    data-testid="totp-qr-code"
+                    sx={{
+                      width: 180,
+                      height: 180,
+                      borderRadius: 1,
+                      border: ({ palette }) => `1px solid ${palette.gray[30]}`,
+                    }}
+                  />
+                ) : null}
+                {totpSecretKey ? (
                   <Box>
-                    <Button
-                      type="button"
-                      data-testid="show-enable-totp-form-button"
-                      onClick={() => {
-                        setShowTotpSetupForm(true);
-                        setErrorMessage(undefined);
+                    <Typography
+                      variant="smallTextParagraphs"
+                      sx={({ palette }) => ({
+                        color: palette.gray[80],
+                        mb: 0.75,
+                        display: "block",
+                      })}
+                    >
+                      {totpQrCodeDataUri
+                        ? "Alternatively, use the secret key below for manual setup."
+                        : "QR code unavailable. Use the secret key below for manual setup."}
+                    </Typography>
+                    <Typography
+                      component="code"
+                      data-testid="totp-secret-key"
+                      sx={{
+                        display: "inline-block",
+                        py: 1,
+                        px: 2,
+                        borderRadius: 1,
+                        background: ({ palette }) => palette.gray[20],
+                        fontFamily: "monospace",
                       }}
                     >
-                      Enable TOTP
-                    </Button>
+                      {totpSecretKey}
+                    </Typography>
                   </Box>
+                ) : null}
+                <TextField
+                  label="Authenticator code"
+                  type="text"
+                  autoComplete="one-time-code"
+                  placeholder="Enter your 6-digit code"
+                  value={totpCode}
+                  onChange={({ target }) => setTotpCode(target.value)}
+                  error={
+                    !!totpCodeUiNode?.messages.find(
+                      ({ type }) => type === "error",
+                    )
+                  }
+                  helperText={totpCodeUiNode?.messages.map(({ id, text }) => (
+                    <Typography key={id}>{text}</Typography>
+                  ))}
+                  required
+                  inputProps={{ inputMode: "numeric" }}
+                />
+                <Box sx={{ display: "flex", gap: 1.5, flexWrap: "wrap" }}>
+                  <Button
+                    type="submit"
+                    data-testid="enable-totp-button"
+                    disabled={!totpCode || enablingTotp}
+                  >
+                    {enablingTotp ? "Enabling..." : "Confirm and enable TOTP"}
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="tertiary"
+                    data-testid="cancel-enable-totp-button"
+                    onClick={() => {
+                      setTotpCode("");
+                      setShowTotpSetupForm(false);
+                      setErrorMessage(undefined);
+                    }}
+                  >
+                    Cancel
+                  </Button>
                 </Box>
-              )}
-            </Box>
-          )}
+              </Box>
+            ) : (
+              <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
+                <Typography sx={{ color: ({ palette }) => palette.gray[80] }}>
+                  TOTP is currently disabled for your account.
+                </Typography>
+                <Box>
+                  <Button
+                    type="button"
+                    data-testid="show-enable-totp-form-button"
+                    onClick={() => {
+                      setShowTotpSetupForm(true);
+                      setErrorMessage(undefined);
+                    }}
+                  >
+                    Enable TOTP
+                  </Button>
+                </Box>
+              </Box>
+            )}
+          </Box>
 
           {flow?.ui.messages?.map((message) => (
             <Typography key={message.id}>

--- a/apps/hash-frontend/src/pages/settings/security.page.tsx
+++ b/apps/hash-frontend/src/pages/settings/security.page.tsx
@@ -351,16 +351,30 @@ const SecurityPage: NextPageWithLayout = () => {
         );
 
         if (!flowWithBackupCodes) {
+          // Step 2 of enrolment failed. TOTP is active but there are no
+          // backup codes. Don't leave the user thinking everything is
+          // fine — without codes they have no recovery path if they lose
+          // their authenticator device.
+          setErrorMessage(
+            "TOTP was enabled, but backup codes could not be generated. " +
+              "Please use the “Regenerate backup codes” button to try again.",
+          );
           return;
         }
 
         const regeneratedCodes =
           extractBackupCodesFromFlow(flowWithBackupCodes);
 
-        if (regeneratedCodes.length > 0) {
-          setBackupCodes(regeneratedCodes);
-          setShowBackupCodesModal(true);
+        if (regeneratedCodes.length === 0) {
+          setErrorMessage(
+            "TOTP was enabled, but no backup codes were returned. " +
+              "Please use the “Regenerate backup codes” button to try again.",
+          );
+          return;
         }
+
+        setBackupCodes(regeneratedCodes);
+        setShowBackupCodesModal(true);
       })
       .finally(() => setEnablingTotp(false));
   };
@@ -377,10 +391,13 @@ const SecurityPage: NextPageWithLayout = () => {
     setDisablingTotp(true);
     persistFlowIdInUrl(flow);
 
-    // @todo H-6417 forcibly refresh the session before a sensitive change
-    //   like this, rather than relying solely on Kratos's
-    //   `privileged_session_max_age`. Needs to work for SSO-only users —
-    //   see the ticket for the redirect-to-refresh-login design.
+    // @todo H-6417 force a session refresh before a security-sensitive
+    //   change like this, rather than relying solely on Kratos's
+    //   `privileged_session_max_age` window. The shape: queue the pending
+    //   change, redirect to `/signin?refresh=true&return_to=…`, let the
+    //   user reauthenticate via whichever credential they have (password,
+    //   SSO, passkey), then resume the change on return. Must work for
+    //   SSO-only users, so a password-reentry shim alone is not enough.
 
     // Step 1: Validate the TOTP code to prove the user has authenticator access
     void submitSettingsUpdate(flow, {
@@ -404,16 +421,26 @@ const SecurityPage: NextPageWithLayout = () => {
           return;
         }
 
-        // Step 3: Clear backup codes. `required_aal: highest_available`
-        // treats any second-factor credential (including lookup secrets)
-        // as enforcing AAL2 — leaving orphan backup codes behind after
-        // removing TOTP would force the user through an AAL2 prompt with
-        // no TOTP to answer it.
-        await submitSettingsUpdate(unlinkedFlow, {
+        // Step 3: Unlink the `lookup_secret` credential.
+        // `required_aal: highest_available` treats any enrolled second
+        // factor (including backup codes) as enforcing AAL2, so leaving
+        // them behind after removing TOTP would force the user through an
+        // AAL2 prompt with no TOTP to answer it. If this step fails, TOTP
+        // is already gone — surface an error so the user can retry rather
+        // than silently landing in the orphan-AAL2 state.
+        const clearedFlow = await submitSettingsUpdate(unlinkedFlow, {
           method: "lookup_secret",
           lookup_secret_disable: true,
           csrf_token: mustGetCsrfTokenFromFlow(unlinkedFlow),
         });
+
+        if (!clearedFlow) {
+          setErrorMessage(
+            "TOTP was disabled, but backup codes could not be removed. " +
+              "Please reload the page and try again to avoid being locked out.",
+          );
+          return;
+        }
 
         setDisableTotpCode("");
         setShowTotpDisableForm(false);
@@ -465,6 +492,10 @@ const SecurityPage: NextPageWithLayout = () => {
       .then((nextFlow) => {
         if (nextFlow) {
           setShowBackupCodesModal(false);
+        } else {
+          setErrorMessage(
+            "We couldn't record that you've saved your backup codes. Please try again.",
+          );
         }
       })
       .finally(() => setConfirmingBackupCodes(false));
@@ -819,7 +850,15 @@ const SecurityPage: NextPageWithLayout = () => {
               onClick={() => {
                 navigator.clipboard
                   .writeText(backupCodes.join("\n"))
-                  .catch(() => undefined);
+                  .catch(() => {
+                    // Surface the failure rather than silently swallowing
+                    // it — losing backup codes leads to account lockout if
+                    // the user later loses their authenticator.
+                    setErrorMessage(
+                      "We couldn't copy your backup codes to the clipboard. " +
+                        "Please copy them manually before closing this dialog.",
+                    );
+                  });
               }}
               disabled={backupCodes.length === 0}
             >

--- a/apps/hash-frontend/src/pages/settings/security.page.tsx
+++ b/apps/hash-frontend/src/pages/settings/security.page.tsx
@@ -272,6 +272,12 @@ const SecurityPage: NextPageWithLayout = () => {
     setCurrentPasswordError(undefined);
     persistFlowIdInUrl(flow);
 
+    // @todo H-6417 the password-reentry step below only works for users
+    //   who actually have a password credential — SSO-only users can't
+    //   change their password today. The SSO-compatible forced session
+    //   refresh being designed under H-6417 is the path to fixing this
+    //   (tracked separately as H-6418 for the password-setup UI itself).
+
     const updatePassword = async () => {
       if (!isRecoveryFlow) {
         // Verify the current password by creating and submitting a refresh

--- a/apps/hash-frontend/src/pages/shared/ory-kratos.ts
+++ b/apps/hash-frontend/src/pages/shared/ory-kratos.ts
@@ -44,6 +44,72 @@ export type Flows = {
 export type FlowNames = keyof Flows;
 export type FlowValues = Flows[FlowNames][0];
 
+/**
+ * Static metadata for each self-service flow:
+ *
+ * - `uiPath`: the frontend route that renders the flow. Pushing to this path
+ *   when a flow expires, was intended for a different identity, etc. drops
+ *   the user back into a fresh flow of the right type.
+ * - `kratosBrowserPath`: the Kratos-native `/self-service/<flow>/browser`
+ *   endpoint Kratos embeds in `redirect_browser_to` URLs (via the
+ *   `SERVE_PUBLIC_BASE_URL` setting).
+ *   Because that base URL points at the frontend origin but the frontend
+ *   does not serve these paths, redirects need to be rewritten to the
+ *   matching `uiPath` to avoid dead-ending on a 404.
+ */
+export const flowMetadata = {
+  login: {
+    uiPath: "/signin",
+    kratosBrowserPath: "/self-service/login/browser",
+  },
+  recovery: {
+    uiPath: "/recovery",
+    kratosBrowserPath: "/self-service/recovery/browser",
+  },
+  registration: {
+    uiPath: "/signup",
+    kratosBrowserPath: "/self-service/registration/browser",
+  },
+  settings: {
+    uiPath: "/settings/security",
+    kratosBrowserPath: "/self-service/settings/browser",
+  },
+  settingsWithPassword: {
+    uiPath: "/settings/security",
+    kratosBrowserPath: "/self-service/settings/browser",
+  },
+  verification: {
+    uiPath: "/verification",
+    kratosBrowserPath: "/self-service/verification/browser",
+  },
+} as const satisfies Record<
+  FlowNames,
+  { uiPath: string; kratosBrowserPath: string }
+>;
+
+/**
+ * Look up the UI route for a `redirect_browser_to` URL that points at a
+ * Kratos self-service browser endpoint. Returns `undefined` if the URL is
+ * not a known Kratos browser path, letting the caller fall through to
+ * following the redirect as-is.
+ */
+export const uiPathForKratosBrowserRedirect = (
+  redirectUrl: string,
+): string | undefined => {
+  let parsed: URL;
+  try {
+    parsed = new URL(redirectUrl);
+  } catch {
+    return undefined;
+  }
+
+  const match = Object.values(flowMetadata).find(
+    ({ kratosBrowserPath }) => kratosBrowserPath === parsed.pathname,
+  );
+
+  return match ? `${match.uiPath}${parsed.search}` : undefined;
+};
+
 export const gatherUiNodeValuesFromFlow = <T extends FlowNames>(
   flow: FlowValues,
 ): Flows[T][1] =>

--- a/apps/hash-frontend/src/pages/shared/ory-kratos.ts
+++ b/apps/hash-frontend/src/pages/shared/ory-kratos.ts
@@ -74,6 +74,9 @@ export const flowMetadata = {
     uiPath: "/settings/security",
     kratosBrowserPath: "/self-service/settings/browser",
   },
+  // `settingsWithPassword` shares its UI route and Kratos endpoint with
+  // `settings`. The split is purely a TypeScript-level distinction over the
+  // submit-body shape (see `Flows[settingsWithPassword]`), not over routing.
   settingsWithPassword: {
     uiPath: "/settings/security",
     kratosBrowserPath: "/self-service/settings/browser",
@@ -92,6 +95,9 @@ export const flowMetadata = {
  * Kratos self-service browser endpoint. Returns `undefined` if the URL is
  * not a known Kratos browser path, letting the caller fall through to
  * following the redirect as-is.
+ *
+ * Query parameters are forwarded to the UI route; URL fragments are not
+ * (Kratos doesn't use them, and the frontend routes don't read them).
  */
 export const uiPathForKratosBrowserRedirect = (
   redirectUrl: string,
@@ -100,6 +106,7 @@ export const uiPathForKratosBrowserRedirect = (
   try {
     parsed = new URL(redirectUrl);
   } catch {
+    // Malformed URL — caller will fall back to the raw redirect string.
     return undefined;
   }
 

--- a/apps/hash-frontend/src/pages/shared/use-kratos-flow-error-handler.ts
+++ b/apps/hash-frontend/src/pages/shared/use-kratos-flow-error-handler.ts
@@ -10,6 +10,7 @@ import { useCallback } from "react";
 
 import { useAuthInfo } from "./auth-info-context";
 import type { Flows } from "./ory-kratos";
+import { flowMetadata, uiPathForKratosBrowserRedirect } from "./ory-kratos";
 
 export const useKratosErrorHandler = <S>(props: {
   flowType: keyof Flows;
@@ -26,6 +27,19 @@ export const useKratosErrorHandler = <S>(props: {
     async (err: AxiosError<any>) => {
       const kratosError = err.response?.data;
 
+      // Kratos embeds `redirect_browser_to` URLs using `SERVE_PUBLIC_BASE_URL`,
+      // which points at the frontend origin in our deployments — but the
+      // frontend does not serve Kratos's `*/browser` paths. Following the
+      // redirect as-is dead-ends on a 404, so rewrite to the matching UI
+      // route when we recognise the path; otherwise fall through and follow
+      // whatever Kratos asked for.
+      const followKratosRedirect = async (redirectUrl: string) => {
+        const uiPath = uiPathForKratosBrowserRedirect(redirectUrl);
+        await router.replace(uiPath ?? redirectUrl);
+      };
+
+      const flowUiPath = flowMetadata[flowType].uiPath;
+
       if (kratosError) {
         switch (kratosError.error?.id) {
           case "session_aal2_required": {
@@ -34,7 +48,7 @@ export const useKratosErrorHandler = <S>(props: {
               kratosError as ErrorAuthenticatorAssuranceLevelNotSatisfied;
 
             if (redirect_browser_to) {
-              await router.replace(redirect_browser_to);
+              await followKratosRedirect(redirect_browser_to);
             }
             return;
           }
@@ -55,7 +69,7 @@ export const useKratosErrorHandler = <S>(props: {
               kratosError as NeedsPrivilegedSessionError;
 
             if (redirect_browser_to) {
-              await router.replace(redirect_browser_to);
+              await followKratosRedirect(redirect_browser_to);
             }
             return;
           }
@@ -63,7 +77,7 @@ export const useKratosErrorHandler = <S>(props: {
             // If flow has expired, request a new one
             setErrorMessage("The return_to address is not allowed.");
             setFlow(undefined);
-            await router.push(`/${flowType}`);
+            await router.push(flowUiPath);
             return;
           case "self_service_flow_expired":
             // If flow has expired, request a new one
@@ -71,7 +85,7 @@ export const useKratosErrorHandler = <S>(props: {
               "Your interaction expired, please fill out the form again.",
             );
             setFlow(undefined);
-            await router.push(`/${flowType}`);
+            await router.push(flowUiPath);
             return;
           case "security_csrf_violation":
             // A CSRF violation occurred. Best to just refresh the flow!
@@ -79,12 +93,12 @@ export const useKratosErrorHandler = <S>(props: {
               "A security violation was detected, please fill out the form again.",
             );
             setFlow(undefined);
-            await router.push(`/${flowType}`);
+            await router.push(flowUiPath);
             return;
           case "security_identity_mismatch":
             // The requested item was intended for someone else. Let's request a new flow...
             setFlow(undefined);
-            await router.push(`/${flowType}`);
+            await router.push(flowUiPath);
             return;
           case "browser_location_change_required": {
             // Ory Kratos asked us to point the user to this URL
@@ -92,7 +106,7 @@ export const useKratosErrorHandler = <S>(props: {
               kratosError as ErrorBrowserLocationChangeRequired;
 
             if (redirect_browser_to) {
-              await router.replace(redirect_browser_to);
+              await followKratosRedirect(redirect_browser_to);
             }
             return;
           }
@@ -107,14 +121,14 @@ export const useKratosErrorHandler = <S>(props: {
              * the database. Let's handle this gracefully by resetting the flow.
              */
             setFlow(undefined);
-            await router.push(`/${flowType}`);
+            await router.push(flowUiPath);
             return;
           }
           break;
         case 410:
           // The flow expired, let's request a new one.
           setFlow(undefined);
-          await router.push(`/${flowType}`);
+          await router.push(flowUiPath);
           return;
       }
 

--- a/apps/hash-frontend/src/pages/signin.page.tsx
+++ b/apps/hash-frontend/src/pages/signin.page.tsx
@@ -119,13 +119,24 @@ const SigninPage: NextPageWithLayout = () => {
   });
 
   useEffect(() => {
-    // If the router is not ready yet, or we already have a flow, do nothing.
-    if (!router.isReady || flow) {
+    if (!router.isReady) {
       return;
     }
 
-    // If ?flow=.. was in the URL, we fetch it
-    if (flowId) {
+    // Keep the current flow as long as it matches the AAL requested via the
+    // URL. After Kratos prompts for an AAL upgrade we navigate from `/signin`
+    // to `/signin?aal=aal2` without remounting — the loaded AAL1 flow would
+    // otherwise persist and the AAL2 form would never render.
+    const expectedAal = aal === "aal2" ? "aal2" : "aal1";
+    if (flow && flow.requested_aal === expectedAal) {
+      return;
+    }
+
+    // Fetch by `?flow=…` only on the first attempt (no flow loaded yet).
+    // Once we've loaded a flow and it turned out to be at the wrong AAL,
+    // the stale flow id must not be re-fetched in a loop — we fall through
+    // to creating a fresh flow at the correct AAL.
+    if (flowId && !flow) {
       oryKratosClient
         .getLoginFlow({ id: String(flowId) })
         .then(({ data }) => setFlow(data))
@@ -133,7 +144,6 @@ const SigninPage: NextPageWithLayout = () => {
       return;
     }
 
-    // Otherwise we initialize it
     oryKratosClient
       .createBrowserLoginFlow({
         refresh: Boolean(refresh),

--- a/apps/hash-frontend/src/pages/signin.page.tsx
+++ b/apps/hash-frontend/src/pages/signin.page.tsx
@@ -21,7 +21,11 @@ import { useAuthInfo } from "./shared/auth-info-context";
 import { AuthLayout } from "./shared/auth-layout";
 import { AuthPaper } from "./shared/auth-paper";
 import { formatKratosMessage } from "./shared/format-kratos-message";
-import { mustGetCsrfTokenFromFlow, oryKratosClient } from "./shared/ory-kratos";
+import {
+  mustGetCsrfTokenFromFlow,
+  oryKratosClient,
+  uiPathForKratosBrowserRedirect,
+} from "./shared/ory-kratos";
 import { SsoProviderButtons } from "./shared/sso-provider-buttons";
 import { useKratosErrorHandler } from "./shared/use-kratos-flow-error-handler";
 import { WorkspaceContext } from "./shared/workspace-context";
@@ -315,7 +319,16 @@ const SigninPage: NextPageWithLayout = () => {
               );
 
               if (redirectAction?.redirect_browser_to) {
-                void router.push(redirectAction.redirect_browser_to);
+                // Kratos's `redirect_browser_to` is built from
+                // `SERVE_PUBLIC_BASE_URL` and can point at a
+                // `/self-service/*/browser` path that no frontend route
+                // serves. Rewrite to the matching UI route when possible,
+                // otherwise fall through to whatever Kratos asked for.
+                const redirectTo =
+                  uiPathForKratosBrowserRedirect(
+                    redirectAction.redirect_browser_to,
+                  ) ?? redirectAction.redirect_browser_to;
+                void router.push(redirectTo);
                 return;
               }
 
@@ -327,9 +340,12 @@ const SigninPage: NextPageWithLayout = () => {
                 }>;
 
                 if (maybeAal2Error.response?.status === 403) {
-                  const redirectTo =
-                    maybeAal2Error.response.data.redirect_browser_to ??
-                    "/signin?aal=aal2";
+                  const kratosRedirect =
+                    maybeAal2Error.response.data.redirect_browser_to;
+                  const redirectTo = kratosRedirect
+                    ? (uiPathForKratosBrowserRedirect(kratosRedirect) ??
+                      kratosRedirect)
+                    : "/signin?aal=aal2";
 
                   void router.push(redirectTo);
                   return;

--- a/apps/hash-frontend/src/pages/signin.page.tsx
+++ b/apps/hash-frontend/src/pages/signin.page.tsx
@@ -131,8 +131,9 @@ const SigninPage: NextPageWithLayout = () => {
     // URL. After Kratos prompts for an AAL upgrade we navigate from `/signin`
     // to `/signin?aal=aal2` without remounting — the loaded AAL1 flow would
     // otherwise persist and the AAL2 form would never render.
-    const expectedAal = aal === "aal2" ? "aal2" : "aal1";
-    if (flow && flow.requested_aal === expectedAal) {
+    const wantsAal2 = aal === "aal2";
+    const flowIsAal2 = flow?.requested_aal === "aal2";
+    if (flow && wantsAal2 === flowIsAal2) {
       return;
     }
 

--- a/tests/hash-playwright/tests/mfa.spec.ts
+++ b/tests/hash-playwright/tests/mfa.spec.ts
@@ -56,10 +56,7 @@ test.beforeEach(async () => {
   await resetDb();
 });
 
-/**
- * @todo H-6219 restore these tests when restoring TOTP functionality
- */
-test.skip("user can enable TOTP", async ({ page }) => {
+test("user can enable TOTP", async ({ page }) => {
   await createUserAndCompleteSignup(page, {
     email: "mfa-enable-totp@example.com",
     shortname: "mfa-enable-totp",
@@ -70,7 +67,7 @@ test.skip("user can enable TOTP", async ({ page }) => {
   expect(backupCodes.length).toBeGreaterThan(0);
 });
 
-test.skip("user with TOTP is prompted for code at login", async ({ page }) => {
+test("user with TOTP is prompted for code at login", async ({ page }) => {
   const credentials = await createUserAndCompleteSignup(page, {
     email: "mfa-totp-login@example.com",
     shortname: "mfa-totp-login",
@@ -95,7 +92,7 @@ test.skip("user with TOTP is prompted for code at login", async ({ page }) => {
   await expect(page.locator("text=Get support")).toBeVisible();
 });
 
-test.skip("user can use backup code instead of TOTP", async ({ page }) => {
+test("user can use backup code instead of TOTP", async ({ page }) => {
   const credentials = await createUserAndCompleteSignup(page, {
     email: "mfa-backup-code@example.com",
     shortname: "mfa-backup-code",
@@ -118,7 +115,7 @@ test.skip("user can use backup code instead of TOTP", async ({ page }) => {
   await expect(page.locator("text=Get support")).toBeVisible();
 });
 
-test.skip("user can disable TOTP", async ({ page }) => {
+test("user can disable TOTP", async ({ page }) => {
   const credentials = await createUserAndCompleteSignup(page, {
     email: "mfa-disable-totp@example.com",
     shortname: "mfa-disable-totp",
@@ -148,7 +145,7 @@ test.skip("user can disable TOTP", async ({ page }) => {
   ).not.toBeVisible();
 });
 
-test.skip("wrong TOTP code shows error at login", async ({ page }) => {
+test("wrong TOTP code shows error at login", async ({ page }) => {
   const credentials = await createUserAndCompleteSignup(page, {
     email: "mfa-wrong-code@example.com",
     shortname: "mfa-wrong-code",

--- a/tests/hash-playwright/tests/mfa.spec.ts
+++ b/tests/hash-playwright/tests/mfa.spec.ts
@@ -120,15 +120,10 @@ test("user can disable TOTP", async ({ page }) => {
     email: "mfa-disable-totp@example.com",
     shortname: "mfa-disable-totp",
   });
-  const { secret } = await enableTotpForCurrentUser(page);
+  await enableTotpForCurrentUser(page);
 
   await page.goto("/settings/security");
   await page.click('[data-testid="disable-totp-button"]');
-  await waitForFreshTotpWindow();
-  await page.fill(
-    '[placeholder="Enter a current code to disable"]',
-    generateTotpCode(secret),
-  );
   await page.click('[data-testid="confirm-disable-totp-button"]');
 
   await expect(

--- a/tests/hash-playwright/tests/mfa.spec.ts
+++ b/tests/hash-playwright/tests/mfa.spec.ts
@@ -135,6 +135,19 @@ test("user can disable TOTP", async ({ page }) => {
     page.locator('[data-testid="show-enable-totp-form-button"]'),
   ).toBeVisible();
 
+  // Backup codes should also be cleared as part of the disable flow.
+  // Without `lookup_secret_disable: true` the user would be left at a
+  // permanently-required AAL2 with only orphan backup codes — so re-loading
+  // the security page should not surface the "Regenerate backup codes"
+  // button (which only appears while a `lookup_secret` credential exists).
+  await page.reload();
+  await expect(
+    page.locator('[data-testid="show-enable-totp-form-button"]'),
+  ).toBeVisible();
+  await expect(
+    page.locator('[data-testid="regenerate-backup-codes-button"]'),
+  ).not.toBeVisible();
+
   await page.context().clearCookies();
 
   await signInWithPassword(page, credentials);

--- a/tests/hash-playwright/tests/shared/delete-user.ts
+++ b/tests/hash-playwright/tests/shared/delete-user.ts
@@ -1,0 +1,37 @@
+const graphAdminPort = process.env.HASH_GRAPH_ADMIN_PORT ?? "4001";
+const systemActorId = "00000000-0000-0000-0000-000000000000";
+
+/**
+ * Delete a user (Kratos identity + owned Graph entities + Hydra sessions)
+ * via the Graph admin endpoint.
+ *
+ * Resolves silently when the user does not exist, so it is safe to call as
+ * a pre-test cleanup step. Any other error is rethrown.
+ *
+ * Note: the endpoint intentionally preserves the user's web principal
+ * (entity types may be referenced from other webs). Tests that need a
+ * fresh shortname should randomise it per run in addition to calling
+ * this.
+ */
+export const deleteUserByEmail = async (email: string): Promise<void> => {
+  const response = await fetch(
+    `http://127.0.0.1:${graphAdminPort}/users/delete`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Authenticated-User-Actor-Id": systemActorId,
+      },
+      body: JSON.stringify({ email }),
+    },
+  );
+
+  if (response.ok || response.status === 404) {
+    return;
+  }
+
+  const body = await response.text();
+  throw new Error(
+    `Failed to delete user ${email}: HTTP ${response.status} ${body}`,
+  );
+};

--- a/tests/hash-playwright/tests/shared/get-kratos-verification-code.ts
+++ b/tests/hash-playwright/tests/shared/get-kratos-verification-code.ts
@@ -29,6 +29,27 @@ const extractVerificationCode = (emailBody: string): string | undefined =>
   emailBody.match(/\b(\d{6})\b/)?.[1];
 
 /**
+ * Mailslurper returns `dateSent` in its local time (UTC in our container) but
+ * without any timezone indicator, e.g. `"2026-04-13 09:53:47"`. Parsing that
+ * with `new Date(...)` treats it as *host* local time, which breaks the
+ * timestamp filter on any developer machine not running in UTC. Normalise to
+ * UTC by appending `Z` when no timezone is present.
+ */
+const parseMailslurperDate = (dateSent?: string): number | undefined => {
+  if (!dateSent) {
+    return undefined;
+  }
+
+  const hasTimezone = /[Zz]|[+-]\d{2}:?\d{2}$/.test(dateSent);
+  const isoCandidate = hasTimezone
+    ? dateSent
+    : `${dateSent.replace(" ", "T")}Z`;
+
+  const parsed = Date.parse(isoCandidate);
+  return Number.isNaN(parsed) ? undefined : parsed;
+};
+
+/**
  * Matches the email subject for verification emails.
  * Handles both the Kratos default subject and the custom HASH template subject.
  */
@@ -72,9 +93,7 @@ export const getKratosVerificationCode = async (
       const matchingMailItems =
         data.mailItems
           ?.filter((mailItem) => {
-            const sentTimestamp = mailItem.dateSent
-              ? new Date(mailItem.dateSent).getTime()
-              : undefined;
+            const sentTimestamp = parseMailslurperDate(mailItem.dateSent);
 
             return (
               isVerificationSubject(mailItem.subject) &&
@@ -85,8 +104,8 @@ export const getKratosVerificationCode = async (
             );
           })
           .sort((a, b) => {
-            const aTimestamp = a.dateSent ? new Date(a.dateSent).getTime() : 0;
-            const bTimestamp = b.dateSent ? new Date(b.dateSent).getTime() : 0;
+            const aTimestamp = parseMailslurperDate(a.dateSent) ?? 0;
+            const bTimestamp = parseMailslurperDate(b.dateSent) ?? 0;
 
             return bTimestamp - aTimestamp;
           }) ?? [];
@@ -122,9 +141,7 @@ export const getKratosVerificationCode = async (
   const timestampFilteredOut =
     afterTimestamp !== undefined
       ? verificationToTarget.filter((item) => {
-          const sent = item.dateSent
-            ? new Date(item.dateSent).getTime()
-            : undefined;
+          const sent = parseMailslurperDate(item.dateSent);
           return (
             typeof sent === "number" &&
             sent < afterTimestamp - timestampBufferMs

--- a/tests/hash-playwright/tests/shared/get-kratos-verification-code.ts
+++ b/tests/hash-playwright/tests/shared/get-kratos-verification-code.ts
@@ -30,7 +30,7 @@ const extractVerificationCode = (emailBody: string): string | undefined =>
 
 /**
  * Mailslurper returns `dateSent` in its local time (UTC in our container) but
- * without any timezone indicator, e.g. `"2026-04-13 09:53:47"`. Parsing that
+ * without any timezone indicator (format: `YYYY-MM-DD HH:MM:SS`). Parsing that
  * with `new Date(...)` treats it as *host* local time, which breaks the
  * timestamp filter on any developer machine not running in UTC. Normalise to
  * UTC by appending `Z` when no timezone is present.

--- a/tests/hash-playwright/tests/shared/runtime.ts
+++ b/tests/hash-playwright/tests/shared/runtime.ts
@@ -9,8 +9,26 @@ const tolerableConsoleMessageMatches: RegExp[] = [
   /^Build: commit-.*-local-dev$/, // Sentry build id
 
   // You can add temporarily add more RegExps, but please track their removal
-  /Failed to load resource: the server responded with a status of 401 \(Unauthorized\)/,
   /No validator provided for shape type bpBlock/, // canvas page warning from TLDraw
+];
+
+/**
+ * HTTP 4xx responses that are a normal part of some flow and should not
+ * cause a test to fail. The browser automatically emits a "Failed to load
+ * resource" console error for any 4xx response, so these entries silence
+ * that console noise — scoped by URL so a real 4xx from an unrelated
+ * endpoint still flags the test.
+ */
+const tolerableResponseErrors: Array<{ status: number; urlPattern: RegExp }> = [
+  // Whoami check before the user is authenticated.
+  { status: 401, urlPattern: /\/auth\/sessions\/whoami$/ },
+  // Kratos signals an AAL upgrade via `browser_location_change_required`
+  // when a TOTP-enabled user submits password-only login.
+  { status: 422, urlPattern: /\/auth\/self-service\/login(\?|$)/ },
+  // Kratos rejects expected self-service conditions: invalid TOTP/backup
+  // codes, `session_already_available` when hitting the login browser
+  // endpoint with an active session, expired flows, ...
+  { status: 400, urlPattern: /\/auth\/self-service\// },
 ];
 
 export * from "@playwright/test";
@@ -23,10 +41,45 @@ export const test = base.extend<Page>({
   page: async ({ page }, use) => {
     const messages: string[] = [];
 
+    // Browser "Failed to load resource" console messages only carry the
+    // status code, not the URL. We correlate them with the actual
+    // responses (which do have URLs) by counting credits: each tolerated
+    // 4xx response grants one matching console-error suppression.
+    const toleratedFailuresByStatus = new Map<number, number>();
+
+    page.on("response", (res) => {
+      const status = res.status();
+      if (status < 400) {
+        return;
+      }
+      const ok = tolerableResponseErrors.some(
+        ({ status: s, urlPattern }) =>
+          s === status && urlPattern.test(res.url()),
+      );
+      if (ok) {
+        toleratedFailuresByStatus.set(
+          status,
+          (toleratedFailuresByStatus.get(status) ?? 0) + 1,
+        );
+      }
+    });
+
     page.on("console", (msg) => {
       const text = msg.text();
       if (tolerableConsoleMessageMatches.some((match) => match.test(text))) {
         return;
+      }
+
+      const resourceFailure = text.match(
+        /Failed to load resource: the server responded with a status of (\d+)/,
+      );
+      if (resourceFailure) {
+        const status = Number(resourceFailure[1]);
+        const remaining = toleratedFailuresByStatus.get(status) ?? 0;
+        if (remaining > 0) {
+          toleratedFailuresByStatus.set(status, remaining - 1);
+          return;
+        }
       }
 
       messages.push(`[${msg.type()}] ${msg.text()}`);

--- a/tests/hash-playwright/tests/shared/runtime.ts
+++ b/tests/hash-playwright/tests/shared/runtime.ts
@@ -22,8 +22,9 @@ const tolerableConsoleMessageMatches: RegExp[] = [
 const tolerableResponseErrors: Array<{ status: number; urlPattern: RegExp }> = [
   // Whoami check before the user is authenticated.
   { status: 401, urlPattern: /\/auth\/sessions\/whoami$/ },
-  // Kratos signals an AAL upgrade via `browser_location_change_required`
-  // when a TOTP-enabled user submits password-only login.
+  // Kratos returns 422 with `browser_location_change_required` to signal
+  // that the current login flow needs to upgrade (e.g. AAL2 required for
+  // a TOTP-enabled user submitting password-only login).
   { status: 422, urlPattern: /\/auth\/self-service\/login(\?|$)/ },
   // Kratos rejects expected self-service conditions: invalid TOTP/backup
   // codes, `session_already_available` when hitting the login browser
@@ -53,8 +54,7 @@ export const test = base.extend<Page>({
         return;
       }
       const ok = tolerableResponseErrors.some(
-        ({ status: s, urlPattern }) =>
-          s === status && urlPattern.test(res.url()),
+        (entry) => entry.status === status && entry.urlPattern.test(res.url()),
       );
       if (ok) {
         toleratedFailuresByStatus.set(

--- a/tests/hash-playwright/tests/shared/signup-utils.ts
+++ b/tests/hash-playwright/tests/shared/signup-utils.ts
@@ -1,16 +1,21 @@
 import type { Page } from "@playwright/test";
 import { expect } from "@playwright/test";
 
+import { deleteUserByEmail } from "./delete-user";
 import { getKratosVerificationCode } from "./get-kratos-verification-code";
 
 const defaultPassword = "some-complex-pw-1ab2";
 
-// NOTE: re-running these tests twice against the same persistent dev stack
-// will fail with `Shortname X is already taken` because `POST /users/delete`
-// is a soft-delete that preserves the user's web principal (intentional — so
-// entity types created under the web stay referenceable). CI starts with a
-// fresh database and isn't affected; locally, re-seed the stack between runs
-// (`docker compose down -v` + restart).
+/**
+ * Generate a unique shortname suffix per test run so that the web principal
+ * left behind by a previous run (see `deleteUserByEmail`) doesn't cause a
+ * "Shortname already taken" error. The suffix keeps the base name readable
+ * while guaranteeing uniqueness.
+ */
+const uniqueShortname = (base: string): string => {
+  const suffix = `${Date.now()}${Math.floor(Math.random() * 1_000)}`;
+  return `${base}${suffix}`.slice(0, 24);
+};
 
 /**
  * Fill in the signup form and submit it.
@@ -92,13 +97,18 @@ export const completeSignup = async (
 
 /**
  * Full flow: register a user, verify email, and complete signup.
+ *
+ * Before registering, deletes any Kratos identity left over from a previous
+ * run via the Graph admin API. The shortname is randomised per call to avoid
+ * colliding with the orphan web principal that `POST /users/delete`
+ * intentionally preserves.
  */
 export const createUserAndCompleteSignup = async (
   page: Page,
   {
     email,
     shortname,
-    displayName = shortname,
+    displayName,
     password = defaultPassword,
   }: {
     email: string;
@@ -107,6 +117,12 @@ export const createUserAndCompleteSignup = async (
     password?: string;
   },
 ) => {
+  // Clean up any leftover Kratos identity from a previous run so the
+  // registration doesn't fail with "identifier already exists".
+  await deleteUserByEmail(email);
+
+  const runShortname = uniqueShortname(shortname);
+
   const { emailDispatchTimestamp } = await registerUser(page, {
     email,
     password,
@@ -117,7 +133,10 @@ export const createUserAndCompleteSignup = async (
     afterTimestamp: emailDispatchTimestamp,
   });
 
-  await completeSignup(page, { shortname, displayName });
+  await completeSignup(page, {
+    shortname: runShortname,
+    displayName: displayName ?? runShortname,
+  });
 
   return { email, password };
 };

--- a/tests/hash-playwright/tests/shared/signup-utils.ts
+++ b/tests/hash-playwright/tests/shared/signup-utils.ts
@@ -1,5 +1,3 @@
-import { randomBytes } from "node:crypto";
-
 import type { Page } from "@playwright/test";
 import { expect } from "@playwright/test";
 
@@ -7,31 +5,12 @@ import { getKratosVerificationCode } from "./get-kratos-verification-code";
 
 const defaultPassword = "some-complex-pw-1ab2";
 
-/**
- * Suffix applied to test emails and shortnames so identifiers don't collide
- * across test runs.
- *
- * `POST /users/delete` is a soft-delete — the user's web principal (which
- * owns the shortname) survives by design so entity types created under it
- * remain referenceable. That means re-running a test with a shortname from
- * a prior run fails with `Shortname X is already taken`. Scoping every
- * identifier to a unique per-process id makes signup idempotent without
- * requiring a hard reset of the graph.
- */
-const TEST_RUN_ID = randomBytes(3).toString("hex");
-
-const scopeEmail = (email: string): string => {
-  const atIndex = email.lastIndexOf("@");
-  if (atIndex === -1) {
-    throw new Error(`Test email "${email}" is missing an @-segment`);
-  }
-  const local = email.slice(0, atIndex);
-  const domain = email.slice(atIndex);
-  return `${local}-${TEST_RUN_ID}${domain}`;
-};
-
-const scopeShortname = (shortname: string): string =>
-  `${shortname}-${TEST_RUN_ID}`;
+// NOTE: re-running these tests twice against the same persistent dev stack
+// will fail with `Shortname X is already taken` because `POST /users/delete`
+// is a soft-delete that preserves the user's web principal (intentional — so
+// entity types created under the web stay referenceable). CI starts with a
+// fresh database and isn't affected; locally, re-seed the stack between runs
+// (`docker compose down -v` + restart).
 
 /**
  * Fill in the signup form and submit it.
@@ -119,7 +98,7 @@ export const createUserAndCompleteSignup = async (
   {
     email,
     shortname,
-    displayName,
+    displayName = shortname,
     password = defaultPassword,
   }: {
     email: string;
@@ -128,24 +107,17 @@ export const createUserAndCompleteSignup = async (
     password?: string;
   },
 ) => {
-  const scopedEmail = scopeEmail(email);
-  const scopedShortname = scopeShortname(shortname);
-  const scopedDisplayName = displayName ?? scopedShortname;
-
   const { emailDispatchTimestamp } = await registerUser(page, {
-    email: scopedEmail,
+    email,
     password,
   });
 
   await verifyEmailOnPage(page, {
-    email: scopedEmail,
+    email,
     afterTimestamp: emailDispatchTimestamp,
   });
 
-  await completeSignup(page, {
-    shortname: scopedShortname,
-    displayName: scopedDisplayName,
-  });
+  await completeSignup(page, { shortname, displayName });
 
-  return { email: scopedEmail, password };
+  return { email, password };
 };

--- a/tests/hash-playwright/tests/shared/signup-utils.ts
+++ b/tests/hash-playwright/tests/shared/signup-utils.ts
@@ -14,7 +14,8 @@ const defaultPassword = "some-complex-pw-1ab2";
  */
 const uniqueShortname = (base: string): string => {
   const suffix = `${Date.now()}${Math.floor(Math.random() * 1_000)}`;
-  return `${base}${suffix}`.slice(0, 24);
+  const maxBaseLength = 24 - suffix.length;
+  return `${base.slice(0, maxBaseLength)}${suffix}`;
 };
 
 /**

--- a/tests/hash-playwright/tests/shared/signup-utils.ts
+++ b/tests/hash-playwright/tests/shared/signup-utils.ts
@@ -1,9 +1,37 @@
+import { randomBytes } from "node:crypto";
+
 import type { Page } from "@playwright/test";
 import { expect } from "@playwright/test";
 
 import { getKratosVerificationCode } from "./get-kratos-verification-code";
 
 const defaultPassword = "some-complex-pw-1ab2";
+
+/**
+ * Suffix applied to test emails and shortnames so identifiers don't collide
+ * across test runs.
+ *
+ * `POST /users/delete` is a soft-delete — the user's web principal (which
+ * owns the shortname) survives by design so entity types created under it
+ * remain referenceable. That means re-running a test with a shortname from
+ * a prior run fails with `Shortname X is already taken`. Scoping every
+ * identifier to a unique per-process id makes signup idempotent without
+ * requiring a hard reset of the graph.
+ */
+const TEST_RUN_ID = randomBytes(3).toString("hex");
+
+const scopeEmail = (email: string): string => {
+  const atIndex = email.lastIndexOf("@");
+  if (atIndex === -1) {
+    throw new Error(`Test email "${email}" is missing an @-segment`);
+  }
+  const local = email.slice(0, atIndex);
+  const domain = email.slice(atIndex);
+  return `${local}-${TEST_RUN_ID}${domain}`;
+};
+
+const scopeShortname = (shortname: string): string =>
+  `${shortname}-${TEST_RUN_ID}`;
 
 /**
  * Fill in the signup form and submit it.
@@ -91,7 +119,7 @@ export const createUserAndCompleteSignup = async (
   {
     email,
     shortname,
-    displayName = shortname,
+    displayName,
     password = defaultPassword,
   }: {
     email: string;
@@ -100,17 +128,24 @@ export const createUserAndCompleteSignup = async (
     password?: string;
   },
 ) => {
+  const scopedEmail = scopeEmail(email);
+  const scopedShortname = scopeShortname(shortname);
+  const scopedDisplayName = displayName ?? scopedShortname;
+
   const { emailDispatchTimestamp } = await registerUser(page, {
-    email,
+    email: scopedEmail,
     password,
   });
 
   await verifyEmailOnPage(page, {
-    email,
+    email: scopedEmail,
     afterTimestamp: emailDispatchTimestamp,
   });
 
-  await completeSignup(page, { shortname, displayName });
+  await completeSignup(page, {
+    shortname: scopedShortname,
+    displayName: scopedDisplayName,
+  });
 
-  return { email, password };
+  return { email: scopedEmail, password };
 };

--- a/tests/hash-playwright/tests/shared/totp-utils.ts
+++ b/tests/hash-playwright/tests/shared/totp-utils.ts
@@ -2,15 +2,22 @@ import { createHmac } from "node:crypto";
 
 const base32Alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
 
+/**
+ * RFC 4648 base32 decoder. The accumulator is reduced to the remaining
+ * low bits after every emitted byte so it never exceeds 13 bits — this
+ * matters because a naive `value = value * 32 + index` accumulator loses
+ * precision past 53 bits (JavaScript `Number`) and produces a truncated
+ * key whose trailing bytes collapse to zero.
+ */
 const decodeBase32 = (encodedSecret: string): Buffer => {
   const normalizedSecret = encodedSecret
     .replace(/\s/g, "")
     .replace(/=+$/, "")
     .toUpperCase();
 
-  let bits = 0;
-  let value = 0;
   const bytes: number[] = [];
+  let accumulator = 0;
+  let bits = 0;
 
   for (const character of normalizedSecret) {
     const index = base32Alphabet.indexOf(character);
@@ -19,12 +26,13 @@ const decodeBase32 = (encodedSecret: string): Buffer => {
       continue;
     }
 
-    value = value * 32 + index;
+    accumulator = (accumulator << 5) | index;
     bits += 5;
 
     if (bits >= 8) {
-      bytes.push(Math.floor(value / 2 ** (bits - 8)) % 256);
       bits -= 8;
+      bytes.push((accumulator >> bits) & 0xff);
+      accumulator &= (1 << bits) - 1;
     }
   }
 

--- a/tests/hash-playwright/tests/shared/totp-utils.ts
+++ b/tests/hash-playwright/tests/shared/totp-utils.ts
@@ -8,6 +8,10 @@ const base32Alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
  * matters because a naive `value = value * 32 + index` accumulator loses
  * precision past 53 bits (JavaScript `Number`) and produces a truncated
  * key whose trailing bytes collapse to zero.
+ *
+ * Implementation uses arithmetic rather than bitwise operators to match
+ * the rest of this module's style (and the project ESLint config which
+ * forbids bitwise operators).
  */
 const decodeBase32 = (encodedSecret: string): Buffer => {
   const normalizedSecret = encodedSecret
@@ -26,13 +30,14 @@ const decodeBase32 = (encodedSecret: string): Buffer => {
       continue;
     }
 
-    accumulator = (accumulator << 5) | index;
+    accumulator = accumulator * 32 + index;
     bits += 5;
 
     if (bits >= 8) {
       bits -= 8;
-      bytes.push((accumulator >> bits) & 0xff);
-      accumulator &= (1 << bits) - 1;
+      const divisor = 2 ** bits;
+      bytes.push(Math.floor(accumulator / divisor) % 256);
+      accumulator %= divisor;
     }
   }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Re-enables the TOTP MFA settings UI that was shipped disabled in H-2421 (hidden behind `{false && …}` with a `@todo H-6219 restore this` note) and fixes the underlying issue that had broken it on staging.

The blocker was Kratos emitting `redirect_browser_to: app.hash.ai/self-service/login/browser?aal=aal2` after a password-only login from a TOTP-enabled user. Kratos builds that URL from `SERVE_PUBLIC_BASE_URL` (set to the frontend origin) but no route on the frontend actually serves Kratos-native paths, so following it verbatim dead-ended on 404. The AAL2 form was never shown.

## 🔗 Related links

- https://linear.app/hash/issue/H-6219 _(internal)_

## 🚫 Blocked by

_None._

## 🔍 What does this change?

### Frontend
- `apps/hash-frontend/src/pages/settings/security.page.tsx`
  - Reactivates the TOTP enrolment / disable / backup-code UI block.
  - TOTP disable now also submits `lookup_secret_disable: true`. With `required_aal: highest_available` a leftover backup-code credential kept forcing AAL2 at next login with no TOTP to answer it.
  - Removes the pre-existing placebo "enter a current TOTP code to disable" step — Kratos v26 ignores `totp_code` for an already-enrolled identity, so it gated nothing. The disable form now shows a plain "yes, disable 2FA" confirmation and a warning that backup codes will also be removed.
  - Surfaces previously-silent failures on the clipboard-copy, backup-code regeneration, and "I've saved my codes" paths so the user sees an error instead of getting a half-broken account.
  - Backup-code extraction regex now accepts Kratos v26's no-dash 8-char codes (`XXXXXXXX`) in addition to the old `XXXX-XXXX` layout. Without this the UI rendered all 12 codes as one block and the AAL2-login test submitted the whole comma-separated string.
- `apps/hash-frontend/src/pages/shared/ory-kratos.ts`
  - New `flowMetadata` record mapping each Kratos self-service flow to `uiPath` + `kratosBrowserPath`.
  - New `uiPathForKratosBrowserRedirect` helper that rewrites Kratos-native `/self-service/*/browser` URLs to the matching frontend route.
- `apps/hash-frontend/src/pages/shared/use-kratos-flow-error-handler.ts`
  - `session_aal2_required`, `session_refresh_required`, `browser_location_change_required` now route through the rewriter before calling `router.replace`.
  - The old ad-hoc `router.push(\`/${flowType}\`)` fallbacks use `flowMetadata[flowType].uiPath`. Fixes a latent bug where `flowType: "registration"` would have pushed to a non-existent `/registration` route.
- `apps/hash-frontend/src/pages/signin.page.tsx`
  - Flow-reuse guard compares `flow.requested_aal` against the URL `?aal` param. Without this, the AAL1 flow loaded at `/signin` persisted through the client-side navigation to `/signin?aal=aal2` and the AAL2 form never rendered.
  - The two remaining raw `redirect_browser_to` follows (login-success `continue_with` branch, toSession 403 fallback) now go through `uiPathForKratosBrowserRedirect` too.

### Backend (API proxy)
- `apps/hash-api/src/index.ts`
  - Replaces the single `authRouteRateLimiter` on the Kratos `/auth/*` proxy with tiered limiters: non-GET credentials (30/10s), GETs other than whoami (60/10s), whoami exempted. The redundant whoamis the frontend emits during MFA flows were consuming the old 12/10s IP budget and surfacing as 429s.
  - `userIdentifierRateLimiter` only applies when `body.identifier` is actually present (its documented purpose), instead of falling back to IP.
  - Safe `ipKey` keyGenerator replaces the `req.ip!` assertion used by the previous default generator.

### Test harness
- `tests/hash-playwright/tests/shared/totp-utils.ts`: rewrites `decodeBase32` so the accumulator is truncated after every emitted byte. The old implementation overflowed JavaScript number precision past 53 bits and silently produced a half-zero key, so generated TOTP codes were rejected by Kratos.
- `tests/hash-playwright/tests/shared/get-kratos-verification-code.ts`: parses Mailslurper's timezone-less `dateSent` strings as UTC (they were being interpreted as local time, causing the 5-second window filter to drop every legitimate email on CEST machines).
- `tests/hash-playwright/tests/shared/signup-utils.ts`: adds a per-process suffix to test emails and shortnames. `resetDb()` is still a no-op and `POST /users/delete` intentionally preserves the user's web principal (so shortnames survive), which broke re-runs with the static names.
- `tests/hash-playwright/tests/shared/runtime.ts`: replaces the blanket status-code regex for the 401 tolerance with a URL-aware credit-counter. Each tolerated 4xx response on a specific Kratos path grants exactly one `Failed to load resource` console suppression, so real failures from other endpoints still flag.
- `tests/hash-playwright/tests/mfa.spec.ts`: unskips all five TOTP tests; the disable test additionally asserts the `regenerate-backup-codes-button` is gone so a regression in the `lookup_secret_disable` step would fail the assertion.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

- The `SERVE_PUBLIC_BASE_URL` misconfiguration that caused the redirect mismatch is worked around in the frontend rather than corrected at the source. Proper config fix tracked in H-6419.
- Disabling 2FA currently relies only on the logged-in privileged session — no explicit re-authentication. A proper SSO-compatible session-refresh step is tracked in H-6417 (same note applies to the password-change flow).
- SSO-only users cannot change their password today (pre-existing limitation of `handlePasswordSubmit`). Documented and tracked in H-6418.
- The test runtime's URL-aware 4xx tolerance consumes suppression credits by status code only, so a rare interleaving of a real and an expected failure at the same status can mask the real one. Acceptable trade-off against blanket global tolerance.

## 🐾 Next steps

- H-6417 — Forcible session refresh for sensitive settings changes (SSO-compatible)
- H-6418 — Password setup / reset flow for SSO-only users
- H-6419 — Fix Kratos \`SERVE_PUBLIC_BASE_URL\` / frontend-proxy mismatch

## 🛡 What tests cover this?

- `tests/hash-playwright/tests/mfa.spec.ts` — five E2E tests covering: enable TOTP, AAL2 login with TOTP, AAL2 login with backup code, disable TOTP, rejection of wrong code. All green locally.

## ❓ How to test this?

1. Check out the branch, deploy FE + BE together.
2. Sign in with an existing user, go to `/settings/security`, click "Enable TOTP".
3. Scan the QR code, enter the 6-digit code, save the generated backup codes.
4. Log out, log back in with password alone — confirm the AAL2 form appears, enter a TOTP code or toggle to backup-code mode.
5. From `/settings/security`, click "Disable TOTP" and confirm — log out, log back in with password; no AAL2 prompt should appear.

## 📹 Demo

_To add once manual staging verification is done._