### PR TITLE
FE-583: better petrinaut text wrapping

### DIFF
--- a/.changeset/nice-numbers-boil.md
+++ b/.changeset/nice-numbers-boil.md
@@ -1,0 +1,5 @@
+---
+"@hashintel/petrinaut": patch
+---
+
+Improve text wrapping for long text in nodes

--- a/libs/@hashintel/petrinaut/src/lib/split-pascal-case.ts
+++ b/libs/@hashintel/petrinaut/src/lib/split-pascal-case.ts
@@ -31,7 +31,3 @@ export const splitPascalCase = (pascalCaseString: string): string[] => {
 
   return segments;
 };
-
-export const addPascalCaseBreakPoints = (str: string) => {
-  return splitPascalCase(str).join("\u200B");
-};

--- a/libs/@hashintel/petrinaut/src/lib/split-pascal-case.ts
+++ b/libs/@hashintel/petrinaut/src/lib/split-pascal-case.ts
@@ -31,3 +31,7 @@ export const splitPascalCase = (pascalCaseString: string): string[] => {
 
   return segments;
 };
+
+export const addPascalCaseBreakPoints = (str: string) => {
+  return str.slice(0, 1) + str.slice(1).replaceAll(/[A-Z]/g, "\u200B$&");
+};

--- a/libs/@hashintel/petrinaut/src/lib/split-pascal-case.ts
+++ b/libs/@hashintel/petrinaut/src/lib/split-pascal-case.ts
@@ -33,5 +33,5 @@ export const splitPascalCase = (pascalCaseString: string): string[] => {
 };
 
 export const addPascalCaseBreakPoints = (str: string) => {
-  return str.slice(0, 1) + str.slice(1).replaceAll(/[A-Z]/g, "\u200B$&");
+  return splitPascalCase(str).join("\u200B");
 };

--- a/libs/@hashintel/petrinaut/src/views/SDCPN/components/classic-place-node.tsx
+++ b/libs/@hashintel/petrinaut/src/views/SDCPN/components/classic-place-node.tsx
@@ -4,7 +4,7 @@ import { use } from "react";
 import { TbMathFunction } from "react-icons/tb";
 
 import { hexToHsl } from "../../../lib/hsl-color";
-import { addPascalCaseBreakPoints } from "../../../lib/split-pascal-case";
+import { splitPascalCase } from "../../../lib/split-pascal-case";
 import { PlaybackContext } from "../../../playback/context";
 import { SimulationContext } from "../../../simulation/context";
 import { EditorContext } from "../../../state/editor-context";
@@ -89,7 +89,6 @@ const labelContainerStyle = css({
 });
 
 const labelSegmentStyle = css({
-  display: "inline-block",
   overflowWrap: "break-word",
   lineClamp: "3",
   maxWidth: "[100%]",
@@ -133,8 +132,8 @@ export const ClassicPlaceNode: React.FC<NodeProps<PlaceNodeType>> = ({
     tokenCount = marking?.count ?? 0;
   }
 
-  // Add breakpoints to labels to split on pascal case
-  const label = addPascalCaseBreakPoints(data.label);
+  // Add zero width space to labels between pascal case points as text-wrapping breakpoints
+  const label = splitPascalCase(data.label).join("\u200B");
 
   // Determine selection state
   const isInSelection = isSelected(id);

--- a/libs/@hashintel/petrinaut/src/views/SDCPN/components/classic-place-node.tsx
+++ b/libs/@hashintel/petrinaut/src/views/SDCPN/components/classic-place-node.tsx
@@ -74,6 +74,8 @@ const contentWrapperStyle = css({
   flexDirection: "column",
   alignItems: "center",
   gap: "3",
+  overflowWrap: "break-word",
+  minWidth: "0",
 });
 
 const labelContainerStyle = css({
@@ -81,13 +83,17 @@ const labelContainerStyle = css({
   display: "flex",
   flexWrap: "wrap",
   justifyContent: "center",
-  padding: "[12px]",
+  padding: "[12px 0]",
   lineHeight: "[1.1]",
+  maxWidth: "[100%]",
 });
 
 const labelSegmentStyle = css({
   display: "inline-block",
   whiteSpace: "nowrap",
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  maxWidth: "[100%]",
 });
 
 const tokenCountBadgeStyle = css({

--- a/libs/@hashintel/petrinaut/src/views/SDCPN/components/classic-place-node.tsx
+++ b/libs/@hashintel/petrinaut/src/views/SDCPN/components/classic-place-node.tsx
@@ -4,7 +4,7 @@ import { use } from "react";
 import { TbMathFunction } from "react-icons/tb";
 
 import { hexToHsl } from "../../../lib/hsl-color";
-import { splitPascalCase } from "../../../lib/split-pascal-case";
+import { addPascalCaseBreakPoints } from "../../../lib/split-pascal-case";
 import { PlaybackContext } from "../../../playback/context";
 import { SimulationContext } from "../../../simulation/context";
 import { EditorContext } from "../../../state/editor-context";
@@ -17,7 +17,8 @@ const containerStyle = css({
 
 const placeCircleStyle = cva({
   base: {
-    padding: "4",
+    paddingY: "4",
+    paddingX: "2",
     borderRadius: "[50%]",
     width: "[130px]",
     height: "[130px]",
@@ -74,7 +75,6 @@ const contentWrapperStyle = css({
   flexDirection: "column",
   alignItems: "center",
   gap: "3",
-  overflowWrap: "break-word",
   minWidth: "0",
 });
 
@@ -90,9 +90,8 @@ const labelContainerStyle = css({
 
 const labelSegmentStyle = css({
   display: "inline-block",
-  whiteSpace: "nowrap",
-  overflow: "hidden",
-  textOverflow: "ellipsis",
+  overflowWrap: "break-word",
+  lineClamp: "3",
   maxWidth: "[100%]",
 });
 
@@ -134,17 +133,8 @@ export const ClassicPlaceNode: React.FC<NodeProps<PlaceNodeType>> = ({
     tokenCount = marking?.count ?? 0;
   }
 
-  // Split label into segments with unique keys (handles duplicate segments)
-  const labelSegments = splitPascalCase(data.label).reduce<
-    { key: string; text: string }[]
-  >((acc, segment) => {
-    const count = acc.filter((entry) => entry.text === segment).length;
-    acc.push({
-      key: count > 0 ? `${segment}-${String(count)}` : segment,
-      text: segment,
-    });
-    return acc;
-  }, []);
+  // Add breakpoints to labels to split on pascal case
+  const label = addPascalCaseBreakPoints(data.label);
 
   // Determine selection state
   const isInSelection = isSelected(id);
@@ -180,11 +170,7 @@ export const ClassicPlaceNode: React.FC<NodeProps<PlaceNodeType>> = ({
         )}
         <div className={contentWrapperStyle}>
           <div className={labelContainerStyle}>
-            {labelSegments.map(({ key, text }) => (
-              <span key={key} className={labelSegmentStyle}>
-                {text}
-              </span>
-            ))}
+            <span className={labelSegmentStyle}>{label}</span>
           </div>
 
           {tokenCount !== null && (

--- a/libs/@hashintel/petrinaut/src/views/SDCPN/components/classic-transition-node.tsx
+++ b/libs/@hashintel/petrinaut/src/views/SDCPN/components/classic-transition-node.tsx
@@ -71,9 +71,6 @@ const stochasticIconStyle = css({
 });
 
 const contentWrapperStyle = css({
-  display: "flex",
-  flexDirection: "column",
-  alignItems: "center",
   gap: "3",
   overflowWrap: "break-word",
   lineClamp: "2",

--- a/libs/@hashintel/petrinaut/src/views/SDCPN/components/classic-transition-node.tsx
+++ b/libs/@hashintel/petrinaut/src/views/SDCPN/components/classic-transition-node.tsx
@@ -75,6 +75,8 @@ const contentWrapperStyle = css({
   flexDirection: "column",
   alignItems: "center",
   gap: "3",
+  overflowWrap: "break-word",
+  lineClamp: "2",
 });
 
 const labelStyle = css({


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Improves the text-wrapping functionality in petrinaut nodes.
I've broken this PR into 2 commits. The first is what I think are uncontroversial css changes that simply handles multi-line overflows + ellipsis better in the classic nodes.
The second is a new approach of handling the pascal case splitting that behaves slightly differently to the current implementations and I'm open to throwing away if its not liked. I'll explain the implementation + differences with some examples below:


<img width="119" height="111" alt="Screenshot 2026-04-13 at 5 13 25 pm" src="https://github.com/user-attachments/assets/9ec2a0b1-d729-480d-a03d-673acaeb3170" />
<img width="140" height="159" alt="Screenshot 2026-04-13 at 5 12 50 pm" src="https://github.com/user-attachments/assets/086ba4d3-eddd-4ace-88e6-5fa0d3f96a18" />

In the original version, we manually split pascal case into 2 lines. This means that if we have text that is too long, each individual line will ellipsify as in the first image. It also means that if we have a short pascal case it still splits into multiple lines.

In my new version, instead I add a zero width space between every pascal case character, which will then only break between pascal case characters if they do not fit on one line. If a very long word without a new pascal case section appears it uses overflow wrap to break anyway. Then uses line-clamp to keep the total max lines at 3 before ellipsifying.

The behaviour in most cases is identical, but how it handles very long words is slightly different.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->
<!-- Libraries inside of the `@local` directory are always internal libraries which have no need for publishing -->

This PR:

- [x] modifies an **npm**-publishable library and **I have added a changeset file(s)**

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph