### PR TITLE
BE-507: Update cargo package `aws-lc-sys` to v0.39.1 [SECURITY]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2024,7 +2024,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,9 +497,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -508,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
 dependencies = [
  "cc",
  "cmake",
@@ -2024,7 +2024,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Updates `aws-lc-sys` from 0.38.0 to 0.39.1 (and `aws-lc-rs` from 1.16.1 to 1.16.2) to resolve a high-severity security vulnerability.

### Vulnerability: [GHSA-394x-vwmw-crm3](https://github.com/advisories/GHSA-394x-vwmw-crm3) — X.509 Name Constraints Bypass via Wildcard/Unicode CN

- **Severity:** High (CVSS 8.2)
- **Affected versions:** `aws-lc-sys` >= 0.32.0, < 0.39.0
- **Patched version:** 0.39.0
- **Impact:** Certificates containing wildcard or raw UTF-8 Unicode CN values can bypass name constraints enforcement, potentially enabling unauthorized access or man-in-the-middle attacks.

## 🔗 Related links

- [Dependabot alert #667](https://github.com/hashintel/hash/security/dependabot/667) _(internal)_
- [GHSA-394x-vwmw-crm3](https://github.com/advisories/GHSA-394x-vwmw-crm3)
- [Slack thread](https://hashintel.slack.com/archives/C03F7V6DU9M/p1776156419313629?thread_ts=1776156258.519279&cid=C03F7V6DU9M) _(internal)_

## 🚫 Blocked by

_Nothing_

## 🔍 What does this change?

- Updates `aws-lc-sys` 0.38.0 → 0.39.1
- Updates `aws-lc-rs` 1.16.1 → 1.16.2 (transitive parent dependency)
- Only `Cargo.lock` is modified — no source code changes

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

_None_

## 🐾 Next steps

_None_

## 🛡 What tests cover this?

- Existing CI test suite — this is a lockfile-only update to a transitive dependency

## ❓ How to test this?

1. Verify `Cargo.lock` contains `aws-lc-sys` version 0.39.1
2. Run `cargo build` to confirm compilation succeeds
3. Run existing test suites to confirm no regressions

## 📹 Demo

_N/A — lockfile-only change_