### PR TITLE
FE-583: fix transition text wrapping

### DIFF
--- a/libs/@hashintel/petrinaut/src/views/SDCPN/components/classic-place-node.tsx
+++ b/libs/@hashintel/petrinaut/src/views/SDCPN/components/classic-place-node.tsx
@@ -23,8 +23,11 @@ const placeCircleStyle = cva({
     width: "[130px]",
     height: "[130px]",
     display: "flex",
+    flexDirection: "column",
     justifyContent: "center",
     alignItems: "center",
+    gap: "3",
+    minWidth: "0",
     border: "2px solid",
     fontSize: "[15px]",
     boxSizing: "border-box",
@@ -70,14 +73,6 @@ const dynamicsIconStyle = css({
   fontSize: "lg",
 });
 
-const contentWrapperStyle = css({
-  display: "flex",
-  flexDirection: "column",
-  alignItems: "center",
-  gap: "3",
-  minWidth: "0",
-});
-
 const labelContainerStyle = css({
   textAlign: "center",
   display: "flex",
@@ -86,12 +81,8 @@ const labelContainerStyle = css({
   padding: "[12px 0]",
   lineHeight: "[1.1]",
   maxWidth: "[100%]",
-});
-
-const labelSegmentStyle = css({
   overflowWrap: "break-word",
   lineClamp: "3",
-  maxWidth: "[100%]",
 });
 
 const tokenCountBadgeStyle = css({
@@ -167,15 +158,10 @@ export const ClassicPlaceNode: React.FC<NodeProps<PlaceNodeType>> = ({
             <TbMathFunction />
           </div>
         )}
-        <div className={contentWrapperStyle}>
-          <div className={labelContainerStyle}>
-            <span className={labelSegmentStyle}>{label}</span>
-          </div>
-
-          {tokenCount !== null && (
-            <div className={tokenCountBadgeStyle}>{tokenCount}</div>
-          )}
-        </div>
+        <div className={labelContainerStyle}>{label}</div>
+        {tokenCount !== null && (
+          <div className={tokenCountBadgeStyle}>{tokenCount}</div>
+        )}
       </div>
       <Handle
         type="source"

--- a/libs/@hashintel/petrinaut/src/views/SDCPN/components/classic-place-node.tsx
+++ b/libs/@hashintel/petrinaut/src/views/SDCPN/components/classic-place-node.tsx
@@ -75,9 +75,6 @@ const dynamicsIconStyle = css({
 
 const labelContainerStyle = css({
   textAlign: "center",
-  display: "flex",
-  flexWrap: "wrap",
-  justifyContent: "center",
   padding: "[12px 0]",
   lineHeight: "[1.1]",
   maxWidth: "[100%]",

--- a/libs/@hashintel/petrinaut/src/views/SDCPN/components/classic-place-node.tsx
+++ b/libs/@hashintel/petrinaut/src/views/SDCPN/components/classic-place-node.tsx
@@ -158,8 +158,8 @@ export const ClassicPlaceNode: React.FC<NodeProps<PlaceNodeType>> = ({
             ? hexToHsl(data.typeColor).lighten(-10).saturate(-30).css(1)
             : undefined,
           backgroundColor: data.typeColor
-            ? hexToHsl(data.typeColor).lighten(30).css(0.8)
-            : "#FCFCFACC",
+            ? hexToHsl(data.typeColor).lighten(35).css(1)
+            : "#FCFCFA",
         }}
       >
         {data.dynamicsEnabled && (

--- a/libs/@hashintel/petrinaut/src/views/SDCPN/components/classic-transition-node.tsx
+++ b/libs/@hashintel/petrinaut/src/views/SDCPN/components/classic-transition-node.tsx
@@ -17,7 +17,7 @@ const containerStyle = css({
 
 const transitionBoxStyle = cva({
   base: {
-    padding: "4",
+    padding: "2",
     borderRadius: "xl",
     width: "[160px]",
     height: "[80px]",
@@ -70,14 +70,13 @@ const stochasticIconStyle = css({
   fontSize: "lg",
 });
 
-const contentWrapperStyle = css({
-  gap: "3",
-  overflowWrap: "break-word",
-  lineClamp: "2",
-});
-
 const labelStyle = css({
   textAlign: "center",
+  maxWidth: "[100%]",
+  textOverflow: "ellipsis",
+  overflow: "hidden",
+  lineClamp: "2",
+  lineHeight: "[1.25]",
 });
 
 const firingIndicatorStyle = css({
@@ -197,9 +196,7 @@ export const ClassicTransitionNode: React.FC<NodeProps<TransitionNodeType>> = ({
             <TbLambda />
           </div>
         )}
-        <div className={contentWrapperStyle}>
-          <div className={labelStyle}>{label}</div>
-        </div>
+        <div className={labelStyle}>{label}</div>
         <div ref={boltRef} className={firingIndicatorStyle}>
           <TbBolt />
         </div>

--- a/libs/@hashintel/petrinaut/src/views/SDCPN/components/place-node.tsx
+++ b/libs/@hashintel/petrinaut/src/views/SDCPN/components/place-node.tsx
@@ -82,7 +82,7 @@ export const PlaceNode: React.FC<NodeProps<PlaceNodeType>> = ({
     : undefined;
 
   const placeBackgroundColor = data.typeColor
-    ? hexToHsl(data.typeColor).lighten(30).css(0.9)
+    ? hexToHsl(data.typeColor).lighten(30).css(1)
     : "#FFFFFF";
 
   return (


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

- Fixes text wrapping in transition nodes (maxWidth: 100% was missing)
- Also cleans up the styling + html for classic nodes - removing unnecessary extra divs and css.
- Removes opacity from place nodes.

Note I've skipped adding a changeset, as the changeset for the previous PR covering this covers these changes.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

The changes in this PR:

- [x] are internal and do not require a docs change