### PR TITLE
FE-594: Fix PDFDocumentProxy type mismatch in pdf-preview

### DIFF
--- a/apps/hash-frontend/src/pages/shared/pdf-preview.tsx
+++ b/apps/hash-frontend/src/pages/shared/pdf-preview.tsx
@@ -11,12 +11,12 @@ import {
 import { Box, Stack, Typography } from "@mui/material";
 import { debounce } from "lodash";
 import dynamic from "next/dynamic";
-import type { PDFDocumentProxy } from "pdfjs-dist";
 import { useCallback, useEffect, useState } from "react";
 import { FullScreen, useFullScreenHandle } from "react-full-screen";
 import { Document, Page, pdfjs } from "react-pdf";
 import type {
   CustomTextRenderer,
+  DocumentCallback,
   OnDocumentLoadSuccess,
 } from "react-pdf/dist/cjs/shared/types";
 
@@ -134,7 +134,7 @@ export const PdfPreview = ({
       });
   }, [initialUrl]);
 
-  const [documentProxy, setDocumentProxy] = useState<PDFDocumentProxy | null>(
+  const [documentProxy, setDocumentProxy] = useState<DocumentCallback | null>(
     null,
   );
   const [scale, setScale] = useState(1);

--- a/apps/hash-frontend/src/pages/shared/pdf-preview/pdf-search.tsx
+++ b/apps/hash-frontend/src/pages/shared/pdf-preview/pdf-search.tsx
@@ -16,9 +16,9 @@ import {
   Typography,
 } from "@mui/material";
 import debounce from "lodash/debounce";
-import type { PDFDocumentProxy } from "pdfjs-dist";
 import type { TextItem } from "pdfjs-dist/types/src/display/api";
 import { useEffect, useRef, useState } from "react";
+import type { DocumentCallback } from "react-pdf/dist/cjs/shared/types";
 
 import { FontCaseRegularIcon } from "../../../shared/icons/font-case-regular-icon";
 import { GrayToBlueIconButton } from "../gray-to-blue-icon-button";
@@ -144,7 +144,7 @@ const findStringInPages = ({
 
 type PdfSearchProps = {
   closeSearch: () => void;
-  document: PDFDocumentProxy | null;
+  document: DocumentCallback | null;
   searchHits: SearchHits;
   setSearchHits: (hits: SearchHits) => void;
   selectedSearchHit: SearchHit | null;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Fix a `tsc` error in `pdf-preview.tsx` / `pdf-search.tsx` caused by `PDFDocumentProxy` type divergence between the hoisted `pdfjs-dist` and the version bundled inside `react-pdf`.

## 🔗 Related links

- [FE-594](https://linear.app/hash/issue/FE-594/fix-tsc-error-on-main-in-pdf-preview)

## 🚫 Blocked by

_Nothing._

## 🔍 What does this change?

- Replaces `import type { PDFDocumentProxy } from "pdfjs-dist"` with `DocumentCallback` from `react-pdf/dist/cjs/shared/types` in both `pdf-preview.tsx` and `pdf-search.tsx`.
- `DocumentCallback` is react-pdf's own alias for `PDFDocumentProxy`, guaranteed to match its bundled pdfjs-dist version.
- `pdfjs-dist` was never a declared dependency of `@apps/hash-frontend` — the import only resolved via yarn hoisting. `import/no-extraneous-dependencies` didn't catch it because the rule is only scoped to test/storybook/config files in the base eslint config.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

- `pdfjs-dist` is still not a declared dependency — `TextItem` in `pdf-search.tsx` still imports from `pdfjs-dist/types/src/display/api` (react-pdf v9 doesn't re-export it). Adding it explicitly or bumping to react-pdf v10 (which does re-export `TextItem`) are follow-up options.
- `import/no-extraneous-dependencies` is not active for regular source files in the base eslint config — only for tests, storybooks, and config files. This allowed the undeclared import to go unnoticed.

## 🐾 Next steps

- Consider adding `pdfjs-dist` as an explicit dependency pinned to react-pdf's version.
- Consider enabling `import/no-extraneous-dependencies` globally in the eslint base config.

## 🛡 What tests cover this?

- `tsc --noEmit` (the build would have failed without this fix)

## ❓ How to test this?

1. `cd apps/hash-frontend && yarn lint:tsc`
2. Confirm no errors in `pdf-preview.tsx` or `pdf-search.tsx`.