### PR TITLE
FE-597: Show SSO provider buttons on signup page

### DIFF
--- a/apps/hash-frontend/src/pages/shared/sso-provider-buttons.tsx
+++ b/apps/hash-frontend/src/pages/shared/sso-provider-buttons.tsx
@@ -73,16 +73,21 @@ export const SsoProviderButtons: FunctionComponent<
             },
           });
 
-    void updateFlow.catch((err: AxiosError) => {
-      const data = err.response?.data as
-        | { redirect_browser_to?: string }
-        | undefined;
-      if (err.response?.status === 422 && data?.redirect_browser_to) {
-        window.location.href = data.redirect_browser_to;
-        return;
-      }
-      void onFlowError(err);
-    });
+    void updateFlow
+      .catch((err: AxiosError) => {
+        const data = err.response?.data as
+          | { redirect_browser_to?: string }
+          | undefined;
+        if (err.response?.status === 422 && data?.redirect_browser_to) {
+          window.location.href = data.redirect_browser_to;
+          return;
+        }
+        return onFlowError(err);
+      })
+      .catch(() => {
+        // onFlowError already handles navigation/state — swallow any
+        // rejection so it doesn't surface as an unhandled promise.
+      });
   };
 
   return (

--- a/apps/hash-frontend/src/pages/shared/sso-provider-buttons.tsx
+++ b/apps/hash-frontend/src/pages/shared/sso-provider-buttons.tsx
@@ -1,6 +1,6 @@
 import type { SvgIconProps } from "@mui/material";
 import { Box, Typography } from "@mui/material";
-import type { LoginFlow } from "@ory/client";
+import type { LoginFlow, RegistrationFlow } from "@ory/client";
 import { isUiNodeInputAttributes } from "@ory/integrations/ui";
 import type { AxiosError } from "axios";
 import type { FunctionComponent } from "react";
@@ -43,10 +43,13 @@ const ssoButtonSx = {
 
 type FlowErrorHandler = (err: AxiosError) => void | Promise<void>;
 
-export const SsoProviderButtons: FunctionComponent<{
-  flow: LoginFlow;
-  onFlowError: FlowErrorHandler;
-}> = ({ flow, onFlowError }) => {
+type SsoFlow =
+  | { kind: "login"; flow: LoginFlow }
+  | { kind: "registration"; flow: RegistrationFlow };
+
+export const SsoProviderButtons: FunctionComponent<
+  SsoFlow & { onFlowError: FlowErrorHandler }
+> = ({ kind, flow, onFlowError }) => {
   const oidcNodes = flow.ui.nodes.filter(({ group }) => group === "oidc");
 
   if (oidcNodes.length === 0) {
@@ -55,25 +58,31 @@ export const SsoProviderButtons: FunctionComponent<{
 
   const handleProviderClick = (provider: string) => {
     const csrf_token = mustGetCsrfTokenFromFlow(flow);
-    void oryKratosClient
-      .updateLoginFlow({
-        flow: flow.id,
-        updateLoginFlowBody: {
-          method: "oidc",
-          provider,
-          csrf_token,
-        },
-      })
-      .catch((err: AxiosError) => {
-        const data = err.response?.data as
-          | { redirect_browser_to?: string }
-          | undefined;
-        if (err.response?.status === 422 && data?.redirect_browser_to) {
-          window.location.href = data.redirect_browser_to;
-          return;
-        }
-        void onFlowError(err);
-      });
+    const updateFlow =
+      kind === "login"
+        ? oryKratosClient.updateLoginFlow({
+            flow: flow.id,
+            updateLoginFlowBody: { method: "oidc", provider, csrf_token },
+          })
+        : oryKratosClient.updateRegistrationFlow({
+            flow: flow.id,
+            updateRegistrationFlowBody: {
+              method: "oidc",
+              provider,
+              csrf_token,
+            },
+          });
+
+    void updateFlow.catch((err: AxiosError) => {
+      const data = err.response?.data as
+        | { redirect_browser_to?: string }
+        | undefined;
+      if (err.response?.status === 422 && data?.redirect_browser_to) {
+        window.location.href = data.redirect_browser_to;
+        return;
+      }
+      void onFlowError(err);
+    });
   };
 
   return (
@@ -85,8 +94,9 @@ export const SsoProviderButtons: FunctionComponent<{
           mb: 2,
         }}
       >
-        If you use SSO, or have previously linked your account to another
-        service, sign in with them below
+        {kind === "login"
+          ? "If you use SSO, or have previously linked your account to another service, sign in with them below"
+          : "Or sign up with"}
       </Typography>
       <Box
         sx={{

--- a/apps/hash-frontend/src/pages/signin.page.tsx
+++ b/apps/hash-frontend/src/pages/signin.page.tsx
@@ -605,7 +605,11 @@ const SigninPage: NextPageWithLayout = () => {
             Create a free account
           </Button>
           {flow ? (
-            <SsoProviderButtons flow={flow} onFlowError={handleFlowError} />
+            <SsoProviderButtons
+              kind="login"
+              flow={flow}
+              onFlowError={handleFlowError}
+            />
           ) : null}
         </Box>
       </Box>

--- a/apps/hash-frontend/src/pages/signup.page/signup-registration-form.tsx
+++ b/apps/hash-frontend/src/pages/signup.page/signup-registration-form.tsx
@@ -18,6 +18,7 @@ import {
   mustGetCsrfTokenFromFlow,
   oryKratosClient,
 } from "../shared/ory-kratos";
+import { SsoProviderButtons } from "../shared/sso-provider-buttons";
 import { useKratosErrorHandler } from "../shared/use-kratos-flow-error-handler";
 
 export const SignupRegistrationForm: FunctionComponent = () => {
@@ -249,6 +250,13 @@ export const SignupRegistrationForm: FunctionComponent = () => {
           ))}
           {errorMessage ? <Typography>{errorMessage}</Typography> : null}
         </Box>
+        {flow ? (
+          <SsoProviderButtons
+            kind="registration"
+            flow={flow}
+            onFlowError={handleFlowError}
+          />
+        ) : null}
         <Box sx={{ width: "100%", display: "flex", justifyContent: "center" }}>
           <Typography
             sx={{


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Users who navigate directly to `/signup` see only email+password registration. SSO buttons (Google, Microsoft) were only shown on `/signin`. This adds the same buttons to the signup page.

## 🔗 Related links

- [FE-597](https://linear.app/hash/issue/FE-597)

## 🔍 What does this change?

- Generalize `SsoProviderButtons` to accept both `LoginFlow` and `RegistrationFlow` via a discriminated `kind` prop.
- `kind: "login"` calls `updateLoginFlow` (existing signin behavior, unchanged).
- `kind: "registration"` calls `updateRegistrationFlow` with `method: "oidc"`.
- Description text adapts per kind ("sign in with them below" vs "Or sign up with").
- Render `SsoProviderButtons` in `SignupRegistrationForm`.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- Manual verification: SSO buttons visible on `/signup`, clicking Google triggers OIDC registration flow.

## ❓ How to test this?

1. `yarn dev`
2. Navigate to `/signup`
3. Confirm Google + Microsoft buttons appear below the form
4. Click one — should redirect to the OIDC provider and complete registration

## 📹 Demo

<img width="654" height="642" alt="image" src="https://github.com/user-attachments/assets/ef784753-7c05-4570-abac-bb9bfa99c1b5" />
