### PR TITLE
BE-516: Upgrade rustls-webpki to 0.103.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2024,7 +2024,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -7927,9 +7927,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Resolves the Dependabot security alert by upgrading `rustls-webpki` from `0.103.9` to `0.103.12`.

## 🔗 Related links

- [Linear issue BE-516](https://linear.app/hash/issue/BE-516/upgrade-rustls-webpki-to-version-010312-or-later)
- [Dependabot Alert #780](https://github.com/hashintel/hash/security/dependabot/780) _(internal)_

## 🔍 What does this change?

- Updates `rustls-webpki` in `Cargo.lock` from `0.103.9` to `0.103.12` via `cargo update -p rustls-webpki --precise 0.103.12 --ignore-rust-version`.
- Incidentally realigns `data-encoding-macro-internal`'s `syn` dependency from `2.0.117` to `1.0.109`, which matches the crate's actual manifest (`syn 1.0.109` was already present in the lockfile, so no new dependency is introduced).

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- Existing CI suite covers the affected transitive TLS paths.

## ❓ How to test this?

1. Check out the branch.
2. Run `cargo +nightly check --all-features` and verify the workspace builds.
3. Confirm `Cargo.lock` reports `rustls-webpki v0.103.12`.