### PR TITLE
H-6426: Fix measuring entities table size

### DIFF
--- a/apps/hash-frontend/src/pages/shared/entities-visualizer.tsx
+++ b/apps/hash-frontend/src/pages/shared/entities-visualizer.tsx
@@ -484,12 +484,33 @@ export const EntitiesVisualizer: FunctionComponent<{
   const currentlyDisplayedColumnsRef = useRef<SizedGridColumn[] | null>(null);
   const currentlyDisplayedRowsRef = useRef<EntitiesTableRow[] | null>(null);
 
+  const contentTopRef = useRef<HTMLDivElement>(null);
+  const [contentTop, setContentTop] = useState<number | null>(null);
+
+  useEffect(() => {
+    const el = contentTopRef.current;
+    if (!el) {
+      return;
+    }
+
+    const measure = () => {
+      setContentTop(el.getBoundingClientRect().top);
+    };
+
+    measure();
+
+    const observer = new ResizeObserver(measure);
+    observer.observe(document.documentElement);
+    return () => observer.disconnect();
+  }, []);
+
   const tableHeight =
     maxHeight ??
-    `min(600px, calc(100vh - (${
-      // The magic number accounts for the page header
-      HEADER_HEIGHT + TOP_CONTEXT_BAR_HEIGHT + 230 + tableHeaderHeight
-    }px + ${theme.spacing(5)} + ${theme.spacing(5)})))`;
+    `min(600px, calc(100vh - ${
+      contentTop != null
+        ? `${contentTop}px - ${theme.spacing(5)}`
+        : `(${HEADER_HEIGHT + TOP_CONTEXT_BAR_HEIGHT + 230 + tableHeaderHeight}px + ${theme.spacing(5)} + ${theme.spacing(5)})`
+    }))`;
 
   const isPrimaryEntity = useCallback(
     (entity: { metadata: Pick<HashEntity["metadata"], "entityTypeIds"> }) =>
@@ -562,6 +583,7 @@ export const EntitiesVisualizer: FunctionComponent<{
             : undefined
         }
       />
+      <Box ref={contentTopRef} />
       {!subgraph || !closedMultiEntityTypesRootMap ? (
         <Stack
           alignItems="center"

--- a/apps/hash-frontend/src/shared/table-header.tsx
+++ b/apps/hash-frontend/src/shared/table-header.tsx
@@ -49,7 +49,7 @@ import type { GenerateCsvFileFunction } from "./table-header/export-to-csv-butto
 import { ExportToCsvButton } from "./table-header/export-to-csv-button";
 import { TableHeaderButton } from "./table-header/table-header-button";
 
-export const tableHeaderHeight = 50;
+export const tableHeaderHeight = 52;
 
 const CheckboxFilter: FunctionComponent<{
   label: string;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The page on `/entities` adjusts the size of the entities table to keep it in the viewport (with a minimum height). It previously relied on a series of magic numbers, one of which had become inaccurate, causing a tiny bit of overflow.

This PR fixes the magic number and also introduces measuring the actual DOM once available so that future drift only matters on the first render.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->
<!-- Libraries inside of the `@local` directory are always internal libraries which have no need for publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph


## ❓ How to test this?

Visit `/entities` path on the preview deployment and confirm there is no vertical scroll bar.