### PR TITLE
FE-645: Disable update password button until Kratos flow loads

### DIFF
--- a/apps/hash-frontend/src/pages/settings/security.page.tsx
+++ b/apps/hash-frontend/src/pages/settings/security.page.tsx
@@ -533,7 +533,10 @@ const SecurityPage: NextPageWithLayout = () => {
               />
             </Box>
             <Box mt={1.5}>
-              <Button type="submit" disabled={!password || updatingPassword}>
+              <Button
+                type="submit"
+                disabled={!flow || !password || updatingPassword}
+              >
                 {updatingPassword ? "Updating password..." : "Update password"}
               </Button>
             </Box>

--- a/tests/hash-playwright/tests/account/password.spec.ts
+++ b/tests/hash-playwright/tests/account/password.spec.ts
@@ -78,10 +78,21 @@ test("user can recover account and set a new password", async ({ page }) => {
     recoveryTimestamp,
   );
 
+  // Kratos redirects to settings/security after successful recovery, and the
+  // page then fetches the settings flow from Kratos. Wait for that fetch
+  // before interacting — without it, the submit handler silently returns
+  // because `flow` is still undefined in component state.
+  const settingsFlowReady = page.waitForResponse(
+    (response) =>
+      response.request().method() === "GET" &&
+      response.url().includes("/auth/self-service/settings/flows"),
+    { timeout: 10_000 },
+  );
+
   await page.fill('[placeholder="Enter your verification code"]', recoveryCode);
 
-  // Kratos redirects to settings/security after successful recovery
   await page.waitForURL("**/settings/security**", { timeout: 5_000 });
+  await settingsFlowReady;
 
   // Recovery session is privileged — password change must work without re-auth
   await page.fill('[placeholder="Enter your new password"]', newPassword);


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Closes a race on `/settings/security` where the "Update password" button was clickable before the Kratos `SettingsFlow` had been loaded into component state. Clicking in that window hit a silent early return in the submit handler — no network call, no success or error UI. Surfaced as a flake on the recovery test.

## 🔗 Related links

- [FE-645](https://linear.app/hash/issue/FE-645/settingssecurity-update-password-button-submits-silently-when-kratos)

## 🔍 What does this change?

- `security.page.tsx`: include `!flow` in the submit button's `disabled` prop
- `password.spec.ts` (recovery test): wait for the `/auth/self-service/settings/flows` GET before filling the new password, mirroring the existing `waitForResponse` pattern in the same test

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

- [x] do not affect the execution graph

## 🛡 What tests cover this?

`tests/hash-playwright/tests/account/password.spec.ts › user can recover account and set a new password` — the test that exposed the bug.

## ❓ How to test this?

1. Check out the branch
2. Run `yarn workspace @tests/hash-playwright run test:integration -g "user can recover account"`
3. 30 sequential local runs were green on this branch (6.2s–7.5s each)