### PR TITLE
FE-646: Suppress EDGE_CONFIG warning outside of Vercel

### DIFF
--- a/apps/hash-frontend/src/middleware.page.ts
+++ b/apps/hash-frontend/src/middleware.page.ts
@@ -65,7 +65,7 @@ export const middleware = async (request: NextRequest) => {
         `Error fetching isInMaintenanceMode from edge config: ${error}`,
       );
     }
-  } else {
+  } else if (process.env.VERCEL) {
     // eslint-disable-next-line no-console
     console.warn("EDGE_CONFIG env var is not set");
   }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Stops the `EDGE_CONFIG env var is not set` warning from spamming local dev/test logs. The Edge Config check is Vercel-specific; locally that env var is expected to be unset.

## 🔗 Related links

- [FE-646](https://linear.app/hash/issue/FE-646/disable-edge-config-warning-when-running-frontend-locally)

## 🔍 What does this change?

`apps/hash-frontend/src/middleware.page.ts`: gate the warning behind `process.env.VERCEL`. Still fires on Vercel deploys (where a missing EDGE_CONFIG is a real misconfiguration), silent everywhere else.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

- [x] do not affect the execution graph

## ❓ How to test this?

1. `yarn workspace @apps/hash-frontend run start:test` locally — no `EDGE_CONFIG env var is not set` log line
2. Deploy to Vercel without setting `EDGE_CONFIG` — warning still appears in function logs