### PR TITLE
BE-517: Stop double-stringifying log payloads

### DIFF
--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/answer-question-action.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/answer-question-action.ts
@@ -109,7 +109,7 @@ const runPythonCode = async (code: string, contextToUpload: string | null) => {
 
   const response = await sandbox.runPython(code);
 
-  logger.debug(`Python code execution response: ${stringify(response)}`);
+  logger.debug("Python code execution response", { response });
 
   const { stdout, stderr, artifacts } = response;
 

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/answer-question-action.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/answer-question-action.ts
@@ -34,7 +34,6 @@ import { graphApiClient } from "../shared/graph-api-client.js";
 import { mapActionInputEntitiesToEntities } from "../shared/map-action-input-entities-to-entities.js";
 import { openAiSeed } from "../shared/open-ai-seed.js";
 import type { PermittedOpenAiModel } from "../shared/openai-client.js";
-import { stringify } from "../shared/stringify.js";
 
 const answerTools: LlmToolDefinition[] = [
   {

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/checkpoints.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/checkpoints.ts
@@ -40,7 +40,7 @@ export const heartbeatAndWaitCancellation = async (
     } satisfies ResearchActionCheckpointState);
   }, secondsBetweenHeartbeats * 1000);
 
-  return Context.current().cancelled.catch((error) => {
+  return Context.current().cancelled.catch((error: unknown) => {
     logger.error("Cancellation received", { error });
     clearInterval(heartbeatInterval);
     throw error;

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/checkpoints.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/checkpoints.ts
@@ -40,10 +40,10 @@ export const heartbeatAndWaitCancellation = async (
     } satisfies ResearchActionCheckpointState);
   }, secondsBetweenHeartbeats * 1000);
 
-  return Context.current().cancelled.catch((err) => {
-    logger.error(`Cancellation received: ${err}`);
+  return Context.current().cancelled.catch((error) => {
+    logger.error("Cancellation received", { error });
     clearInterval(heartbeatInterval);
-    throw err;
+    throw error;
   });
 };
 

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/coordinating-agent.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/coordinating-agent.ts
@@ -33,7 +33,6 @@ import {
 import { graphApiClient } from "../../shared/graph-api-client.js";
 import { logProgress } from "../../shared/log-progress.js";
 import { mapActionInputEntitiesToEntities } from "../../shared/map-action-input-entities-to-entities.js";
-import { stringify } from "../../shared/stringify.js";
 import { createCheckpoint } from "./checkpoints.js";
 import { createInitialPlan } from "./coordinating-agent/create-initial-plan.js";
 import { processCompleteToolCall } from "./coordinating-agent/process-complete-tool-call.js";
@@ -583,8 +582,10 @@ export const runCoordinatingAgent: AiFlowActionActivity<
     })),
   );
 
-  logger.debug(`Proposed Entities: ${stringify(allProposedEntities)}`);
-  logger.debug(`File Entities Proposed: ${stringify(fileEntityProposals)}`);
+  logger.debug("Proposed entities", {
+    allProposedEntities,
+    fileEntityProposals,
+  });
 
   logProgress([
     {

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/coordinating-agent/process-complete-tool-call.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/coordinating-agent/process-complete-tool-call.ts
@@ -117,7 +117,7 @@ export const processCompleteToolCall = ({
   }
 
   if (warnings.length > 0) {
-    logger.debug(`Conducting check step with warnings: ${stringify(warnings)}`);
+    logger.debug("Conducting check step with warnings", { warnings });
     return {
       ...toolCall,
       output: dedent(`

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/coordinating-agent/process-complete-tool-call.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/coordinating-agent/process-complete-tool-call.ts
@@ -2,7 +2,6 @@ import dedent from "dedent";
 
 import { logger } from "../../../shared/activity-logger.js";
 import type { ParsedLlmToolCall } from "../../../shared/get-llm-response/types.js";
-import { stringify } from "../../../shared/stringify.js";
 import type { ParsedCoordinatorToolCallMap } from "../shared/coordinator-tools.js";
 import type {
   CoordinatingAgentInput,

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/link-follower-agent.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/link-follower-agent.ts
@@ -666,7 +666,7 @@ export const linkFollowerAgent = async (params: {
     if (nextToolCall.name === "exploreLinks") {
       const { links } = nextToolCall.input;
 
-      logger.debug(`Exploring additional links: ${stringify(links)}`);
+      logger.debug("Exploring additional links", { links });
 
       resourcesToExplore.push(...links);
     } else {

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/link-follower-agent/get-link-follower-next-tool-calls.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/link-follower-agent/get-link-follower-next-tool-calls.ts
@@ -13,7 +13,6 @@ import type {
   LlmToolDefinition,
 } from "../../../shared/get-llm-response/types.js";
 import { graphApiClient } from "../../../shared/graph-api-client.js";
-import { stringify } from "../../../shared/stringify.js";
 import type { Claim } from "../../shared/claims.js";
 import type { LocalEntitySummary } from "../../shared/infer-summaries-then-claims-from-text/get-entity-summaries-from-text.js";
 import { simplifyClaimForLlmConsumption } from "../shared/simplify-for-llm-consumption.js";

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/link-follower-agent/get-link-follower-next-tool-calls.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/link-follower-agent/get-link-follower-next-tool-calls.ts
@@ -373,7 +373,7 @@ export const getLinkFollowerNextToolCalls = async (
     };
   }
 
-  logger.error(`Unsuccessful link follower response: ${stringify(response)}`);
+  logger.error("Unsuccessful link follower response", { response });
 
   await sleep(2_000);
 

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/shared/coordinator-tools.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/shared/coordinator-tools.ts
@@ -570,9 +570,12 @@ const toolCallExceptionHandler = <
   error: unknown;
   toolCall: ToolCall;
 }): CompletedCoordinatorToolCall<ToolCall["name"]> => {
-  logger.error(
-    `Error getting ${agentType} tool call results for tool call ${toolCall.name} with id ${toolCall.id}: ${stringifyError(error)}`,
-  );
+  logger.error("Error getting tool call results", {
+    agentType,
+    toolCallName: toolCall.name,
+    toolCallId: toolCall.id,
+    error,
+  });
 
   const errorForLlm =
     error && typeof error === "object" && "message" in error

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/shared/deduplicate-entities.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/shared/deduplicate-entities.ts
@@ -194,7 +194,9 @@ export const deduplicateEntities = async (params: {
       });
     }
 
-    logger.error(`Error deduplicating entities: ${llmResponse.status}`);
+    logger.error("Error deduplicating entities", {
+      status: llmResponse.status,
+    });
 
     await sleep(2_000);
 

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/web-search-action.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/web-search-action.ts
@@ -2,7 +2,6 @@ import type { Url } from "@blockprotocol/type-system";
 import type { AiFlowActionActivity } from "@local/hash-backend-utils/flows";
 import { internalApiClient } from "@local/hash-backend-utils/internal-api-client";
 import { getSimplifiedAiFlowActionInputs } from "@local/hash-isomorphic-utils/flows/action-definitions";
-import { stringifyError } from "@local/hash-isomorphic-utils/stringify-error";
 import type { GetWebSearchResults200ResponseWebSearchResultsInner } from "@local/internal-api-client";
 import { StatusCode } from "@local/status";
 import { backOff } from "exponential-backoff";
@@ -38,11 +37,7 @@ export const webSearchAction: AiFlowActionActivity<"webSearch"> = async ({
       try {
         return await internalApiClient.getWebSearchResults(query);
       } catch (error) {
-        logger.error(
-          `Error fetching web search results for query "${query}": ${stringifyError(
-            error,
-          )}`,
-        );
+        logger.error("Error fetching web search results", { query, error });
         throw error;
       }
     },

--- a/apps/hash-ai-worker-ts/src/activities/get-web-page-activity.ts
+++ b/apps/hash-ai-worker-ts/src/activities/get-web-page-activity.ts
@@ -214,7 +214,10 @@ const getWebPageFromRemoteBrowser = async (
     };
   } catch (error) {
     const errMessage = stringifyError(error);
-    logger.error(`Failed to load URL ${url} in remote browser: ${errMessage}`);
+    logger.error(`Failed to load URL ${url} in remote browser`, {
+      url,
+      error: errMessage,
+    });
 
     return {
       error: errMessage,

--- a/apps/hash-ai-worker-ts/src/activities/get-web-page-activity.ts
+++ b/apps/hash-ai-worker-ts/src/activities/get-web-page-activity.ts
@@ -213,14 +213,13 @@ const getWebPageFromRemoteBrowser = async (
       url,
     };
   } catch (error) {
-    const errMessage = stringifyError(error);
     logger.error(`Failed to load URL ${url} in remote browser`, {
       url,
-      error: errMessage,
+      error,
     });
 
     return {
-      error: errMessage,
+      error: stringifyError(error),
     };
   } finally {
     await page?.close().catch(() => {});

--- a/apps/hash-ai-worker-ts/src/activities/infer-entities/propose-entities.ts
+++ b/apps/hash-ai-worker-ts/src/activities/infer-entities/propose-entities.ts
@@ -173,7 +173,7 @@ export const proposeEntities = async (params: {
           },
         ];
 
-  logger.debug(`Next messages to model: ${stringify(messages)}`);
+  logger.debug("Next messages to model", { messages });
 
   const { userAuthentication, flowEntityId, stepId, webId } =
     await getFlowContext();

--- a/apps/hash-ai-worker-ts/src/activities/shared/activity-logger.ts
+++ b/apps/hash-ai-worker-ts/src/activities/shared/activity-logger.ts
@@ -24,11 +24,20 @@ const log = (
   meta: LogMeta | undefined,
   level: "debug" | "error" | "info" | "silly" | "warn",
 ) => {
-  let flowWorkflowId = "no-requestId-in-context";
+  // `Context.current()` throws when no Temporal activity context is
+  // active (e.g. when the logger is reached from a unit test or a
+  // non-activity bootstrap path). Falling back to placeholders keeps
+  // the logger working in those cases — particularly important
+  // because most callers reach the logger from `catch` blocks where
+  // a logger crash would swallow the original error.
+  let workflowExecution: { workflowId: string; runId: string } = {
+    workflowId: "no-context",
+    runId: "no-context",
+  };
   try {
-    flowWorkflowId = Context.current().info.workflowExecution.workflowId;
+    workflowExecution = Context.current().info.workflowExecution;
   } catch {
-    // no id in context for some reason
+    // no Temporal context — placeholders above are used
   }
 
   const now = new Date().toISOString();
@@ -36,9 +45,7 @@ const log = (
   /**
    * A special prefix which will appear in the console but be stripped out for other destinations (e.g. DataDog)
    */
-  const consolePrefix = `[Flow ${flowWorkflowId} – ${now}]`;
-
-  const workflowExecution = Context.current().info.workflowExecution;
+  const consolePrefix = `[Flow ${workflowExecution.workflowId} – ${now}]`;
 
   // Spread `meta` FIRST so the helper-owned fields (`message`,
   // `consolePrefix`, `workflowExecution`) always win — otherwise a
@@ -68,7 +75,10 @@ const log = (
       fs.mkdirSync(logFolderPath);
     }
 
-    const logFilePath = path.join(logFolderPath, `${flowWorkflowId}.log`);
+    const logFilePath = path.join(
+      logFolderPath,
+      `${workflowExecution.workflowId}.log`,
+    );
 
     let stringifiedMessage: string;
 

--- a/apps/hash-ai-worker-ts/src/activities/shared/activity-logger.ts
+++ b/apps/hash-ai-worker-ts/src/activities/shared/activity-logger.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { safeStringify } from "@local/hash-backend-utils/logger";
 import { Context } from "@temporalio/activity";
 
 import { logger as baseLogger } from "../../shared/logger.js";
@@ -61,18 +62,15 @@ const log = (
       };
 
       /**
-       * Keep any detailed fields out of the log file.
-       * We create a file per LLM request, so we can inspect the detailed fields there,
-       * and including them in the main log file also makes it harder to inspect and very large.
-       *
-       * The requestId will be included in the main log file, so we can identify the relevant request file.
+       * Detailed fields go into per-request log files; keep them out of the
+       * flow-level log. Error / BigInt / circular handling is provided by
+       * `safeStringify`.
        */
-      const filtered = JSON.stringify(
-        restMeta,
-        (key, value) =>
-          detailedFields?.includes(key) ? undefined : (value as unknown),
-        2,
-      );
+      const filtered = safeStringify(restMeta, {
+        space: 2,
+        replacer: (key, value) =>
+          detailedFields?.includes(key) ? undefined : value,
+      });
 
       /**
        * We don't need the full console prefix because it includes the flow id, which is already in the file name.

--- a/apps/hash-ai-worker-ts/src/activities/shared/activity-logger.ts
+++ b/apps/hash-ai-worker-ts/src/activities/shared/activity-logger.ts
@@ -10,9 +10,18 @@ import { logger as baseLogger } from "../../shared/logger.js";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+/**
+ * Keys this helper owns on the resulting log object. Banning them in
+ * the caller's `meta` shape is the only way to prevent silent collisions
+ * — at runtime, either spread order discards data on overlap.
+ */
+type ReservedLogKeys = "message" | "consolePrefix" | "workflowExecution";
+
+type LogMeta = { [K in ReservedLogKeys]?: never } & Record<string, unknown>;
+
 const log = (
   message: string,
-  meta: object | undefined,
+  meta: LogMeta | undefined,
   level: "debug" | "error" | "info" | "silly" | "warn",
 ) => {
   let flowWorkflowId = "no-requestId-in-context";
@@ -31,13 +40,21 @@ const log = (
 
   const workflowExecution = Context.current().info.workflowExecution;
 
+  // Spread `meta` FIRST so the helper-owned fields (`message`,
+  // `consolePrefix`, `workflowExecution`) always win — otherwise a
+  // caller passing meta with a `message` key (e.g. an HTTP response
+  // body, an LLM error object) would silently overwrite the log
+  // description.
   const logObject: {
     consolePrefix: string;
     message: string | object;
     workflowExecution: { workflowId: string; runId: string };
-  } & Record<string, unknown> = meta
-    ? { consolePrefix, message, workflowExecution, ...meta }
-    : { consolePrefix, message, workflowExecution };
+  } & Record<string, unknown> = {
+    ...meta,
+    consolePrefix,
+    message,
+    workflowExecution,
+  };
 
   baseLogger[level](logObject);
 
@@ -85,9 +102,9 @@ const log = (
  * 2. Writes a file per flow run containing its logs, in development and test environments.
  */
 export const logger = {
-  debug: (message: string, meta?: object) => log(message, meta, "debug"),
-  error: (message: string, meta?: object) => log(message, meta, "error"),
-  info: (message: string, meta?: object) => log(message, meta, "info"),
-  silly: (message: string, meta?: object) => log(message, meta, "silly"),
-  warn: (message: string, meta?: object) => log(message, meta, "warn"),
+  debug: (message: string, meta?: LogMeta) => log(message, meta, "debug"),
+  error: (message: string, meta?: LogMeta) => log(message, meta, "error"),
+  info: (message: string, meta?: LogMeta) => log(message, meta, "info"),
+  silly: (message: string, meta?: LogMeta) => log(message, meta, "silly"),
+  warn: (message: string, meta?: LogMeta) => log(message, meta, "warn"),
 };

--- a/apps/hash-ai-worker-ts/src/activities/shared/activity-logger.ts
+++ b/apps/hash-ai-worker-ts/src/activities/shared/activity-logger.ts
@@ -61,20 +61,15 @@ const log = (
         [key: string]: unknown;
       };
 
-      /**
-       * Detailed fields go into per-request log files; keep them out of the
-       * flow-level log. Error / BigInt / circular handling is provided by
-       * `safeStringify`.
-       */
+      // Detailed fields go into per-request log files; keep them out of
+      // the flow-level log.
       const filtered = safeStringify(restMeta, {
         space: 2,
         replacer: (key, value) =>
           detailedFields?.includes(key) ? undefined : value,
       });
 
-      /**
-       * We don't need the full console prefix because it includes the flow id, which is already in the file name.
-       */
+      // File name already encodes the flow id, so no prefix needed here.
       stringifiedMessage = `[${now}] ${message}: ${filtered}`;
     } else {
       stringifiedMessage = `[${now}] ${message}`;

--- a/apps/hash-ai-worker-ts/src/activities/shared/activity-logger.ts
+++ b/apps/hash-ai-worker-ts/src/activities/shared/activity-logger.ts
@@ -11,6 +11,7 @@ const __dirname = path.dirname(__filename);
 
 const log = (
   message: string,
+  meta: object | undefined,
   level: "debug" | "error" | "info" | "silly" | "warn",
 ) => {
   let flowWorkflowId = "no-requestId-in-context";
@@ -27,46 +28,15 @@ const log = (
    */
   const consolePrefix = `[Flow ${flowWorkflowId} – ${now}]`;
 
-  let logObject: {
-    consolePrefix: string;
-    message: string | object;
-    workflowExecution: {
-      workflowId: string;
-      runId: string;
-    };
-  };
-
   const workflowExecution = Context.current().info.workflowExecution;
 
-  try {
-    const parsedLogMessage = JSON.parse(message) as unknown;
-
-    if (
-      typeof parsedLogMessage !== "object" ||
-      Array.isArray(parsedLogMessage) ||
-      parsedLogMessage === null
-    ) {
-      // not a JSON object
-      logObject = {
-        consolePrefix,
-        message,
-        workflowExecution,
-      };
-    } else {
-      logObject = {
-        consolePrefix,
-        message: parsedLogMessage,
-        workflowExecution,
-      };
-    }
-  } catch {
-    // not valid JSON
-    logObject = {
-      consolePrefix,
-      message,
-      workflowExecution,
-    };
-  }
+  const logObject: {
+    consolePrefix: string;
+    message: string | object;
+    workflowExecution: { workflowId: string; runId: string };
+  } & Record<string, unknown> = meta
+    ? { consolePrefix, message, workflowExecution, ...meta }
+    : { consolePrefix, message, workflowExecution };
 
   baseLogger[level](logObject);
 
@@ -82,35 +52,34 @@ const log = (
 
     const logFilePath = path.join(logFolderPath, `${flowWorkflowId}.log`);
 
-    let stringifiedMessage = logObject.message;
+    let stringifiedMessage: string;
 
-    if (typeof stringifiedMessage === "object") {
-      const { detailedFields, ...restMessage } = logObject.message as {
+    if (meta) {
+      const { detailedFields, ...restMeta } = meta as {
         detailedFields?: string[];
         [key: string]: unknown;
       };
 
       /**
+       * Keep any detailed fields out of the log file.
+       * We create a file per LLM request, so we can inspect the detailed fields there,
+       * and including them in the main log file also makes it harder to inspect and very large.
+       *
+       * The requestId will be included in the main log file, so we can identify the relevant request file.
+       */
+      const filtered = JSON.stringify(
+        restMeta,
+        (key, value) =>
+          detailedFields?.includes(key) ? undefined : (value as unknown),
+        2,
+      );
+
+      /**
        * We don't need the full console prefix because it includes the flow id, which is already in the file name.
        */
-      stringifiedMessage = `[${now}]: ${JSON.stringify(
-        restMessage,
-        (key, value) => {
-          /**
-           * Keep any detailed fields out of the log file.
-           * We create a file per LLM request, so we can inspect the detailed fields there,
-           * and including them in the main log file also makes it harder to inspect and very large.
-           *
-           * The requestId will be included in the main log file, so we can identify the relevant request file.
-           */
-          if (detailedFields?.includes(key)) {
-            return undefined;
-          }
-
-          return value as unknown;
-        },
-        2,
-      )}`;
+      stringifiedMessage = `[${now}] ${message}: ${filtered}`;
+    } else {
+      stringifiedMessage = `[${now}] ${message}`;
     }
 
     fs.appendFileSync(logFilePath, `${stringifiedMessage}\n`);
@@ -123,9 +92,9 @@ const log = (
  * 2. Writes a file per flow run containing its logs, in development and test environments.
  */
 export const logger = {
-  debug: (message: string) => log(message, "debug"),
-  error: (message: string) => log(message, "error"),
-  info: (message: string) => log(message, "info"),
-  silly: (message: string) => log(message, "silly"),
-  warn: (message: string) => log(message, "warn"),
+  debug: (message: string, meta?: object) => log(message, meta, "debug"),
+  error: (message: string, meta?: object) => log(message, meta, "error"),
+  info: (message: string, meta?: object) => log(message, meta, "info"),
+  silly: (message: string, meta?: object) => log(message, meta, "silly"),
+  warn: (message: string, meta?: object) => log(message, meta, "warn"),
 };

--- a/apps/hash-ai-worker-ts/src/activities/shared/get-llm-response/get-anthropic-response.ts
+++ b/apps/hash-ai-worker-ts/src/activities/shared/get-llm-response/get-anthropic-response.ts
@@ -1,6 +1,5 @@
 import type { APIError, RateLimitError } from "@anthropic-ai/sdk/error";
 import type { Tool } from "@anthropic-ai/sdk/resources/messages";
-import { stringifyError } from "@local/hash-isomorphic-utils/stringify-error";
 import dedent from "dedent";
 import { backOff } from "exponential-backoff";
 
@@ -359,9 +358,10 @@ export const getAnthropicResponse = async <ToolName extends string>(
       initialProvider,
     });
   } catch (error) {
-    logger.error(
-      `Anthropic API error for request ${metadata.requestId}: ${stringifyError(error)}`,
-    );
+    logger.error("Anthropic API error", {
+      requestId: metadata.requestId,
+      error,
+    });
 
     if (isActivityCancelled()) {
       return {

--- a/apps/hash-ai-worker-ts/src/activities/shared/get-llm-response/get-google-ai-response.ts
+++ b/apps/hash-ai-worker-ts/src/activities/shared/get-llm-response/get-google-ai-response.ts
@@ -110,7 +110,7 @@ export const getGoogleAiResponse = async <ToolName extends string>(
   try {
     ({ response } = await gemini.generateContent(transformedRequest));
   } catch (error) {
-    logger.error(`Google AI API error: ${stringifyError(error)}`);
+    logger.error("Google AI API error", { error: stringifyError(error) });
 
     if (isActivityCancelled()) {
       return {

--- a/apps/hash-ai-worker-ts/src/activities/shared/get-llm-response/get-google-ai-response.ts
+++ b/apps/hash-ai-worker-ts/src/activities/shared/get-llm-response/get-google-ai-response.ts
@@ -7,7 +7,6 @@ import {
   type Part,
 } from "@google-cloud/vertexai";
 import type { HashEntity } from "@local/hash-graph-sdk/entity";
-import { stringifyError } from "@local/hash-isomorphic-utils/stringify-error";
 import type { File } from "@local/hash-isomorphic-utils/system-types/shared";
 
 import { logger } from "../activity-logger.js";
@@ -110,7 +109,7 @@ export const getGoogleAiResponse = async <ToolName extends string>(
   try {
     ({ response } = await gemini.generateContent(transformedRequest));
   } catch (error) {
-    logger.error("Google AI API error", { error: stringifyError(error) });
+    logger.error("Google AI API error", { error });
 
     if (isActivityCancelled()) {
       return {

--- a/apps/hash-ai-worker-ts/src/activities/shared/get-llm-response/get-openai-reponse.ts
+++ b/apps/hash-ai-worker-ts/src/activities/shared/get-llm-response/get-openai-reponse.ts
@@ -309,7 +309,7 @@ export const getOpenAiResponse = async <ToolName extends string>(
       metadata,
     });
   } catch (error) {
-    logger.error(`OpenAI API error: ${stringifyError(error)}`);
+    logger.error("OpenAI API error", { error: stringifyError(error) });
 
     if (isActivityCancelled()) {
       return {

--- a/apps/hash-ai-worker-ts/src/activities/shared/get-llm-response/get-openai-reponse.ts
+++ b/apps/hash-ai-worker-ts/src/activities/shared/get-llm-response/get-openai-reponse.ts
@@ -1,4 +1,3 @@
-import { stringifyError } from "@local/hash-isomorphic-utils/stringify-error";
 import { Context } from "@temporalio/activity";
 import dedent from "dedent";
 import { backOff } from "exponential-backoff";
@@ -309,7 +308,7 @@ export const getOpenAiResponse = async <ToolName extends string>(
       metadata,
     });
   } catch (error) {
-    logger.error("OpenAI API error", { error: stringifyError(error) });
+    logger.error("OpenAI API error", { error });
 
     if (isActivityCancelled()) {
       return {

--- a/apps/hash-ai-worker-ts/src/activities/shared/get-llm-response/log-llm-request.ts
+++ b/apps/hash-ai-worker-ts/src/activities/shared/get-llm-response/log-llm-request.ts
@@ -10,7 +10,11 @@ import type { LlmLog, LlmServerErrorLog } from "./types.js";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const writeLogToFile = (log: LlmLog | LlmServerErrorLog) => {
+const writeLogToFile = (
+  log: (LlmLog | LlmServerErrorLog) & {
+    workflowExecution?: { workflowId: string; runId: string };
+  },
+) => {
   const logFolderPath = path.join(__dirname, "logs");
 
   if (!existsSync(logFolderPath)) {
@@ -30,9 +34,11 @@ const writeLogToFile = (log: LlmLog | LlmServerErrorLog) => {
 };
 
 export const logLlmServerError = (log: LlmServerErrorLog) => {
+  // `workflowExecution` is owned by the activity-logger — it stamps it
+  // onto every log object from the Temporal context. Add it only for
+  // the per-request file dump, where it's part of the record on disk.
   const orderedLog = {
     requestId: log.requestId,
-    workflowExecution: Context.current().info.workflowExecution,
     provider: log.provider,
     stepId: log.stepId,
     taskName: log.taskName,
@@ -46,7 +52,10 @@ export const logLlmServerError = (log: LlmServerErrorLog) => {
   logger.error(`llm ${log.provider}${taskLabel} server error`, orderedLog);
 
   if (["development", "test"].includes(process.env.NODE_ENV ?? "")) {
-    writeLogToFile(orderedLog);
+    writeLogToFile({
+      ...orderedLog,
+      workflowExecution: Context.current().info.workflowExecution,
+    });
   }
 };
 

--- a/apps/hash-ai-worker-ts/src/activities/shared/get-llm-response/log-llm-request.ts
+++ b/apps/hash-ai-worker-ts/src/activities/shared/get-llm-response/log-llm-request.ts
@@ -42,7 +42,8 @@ export const logLlmServerError = (log: LlmServerErrorLog) => {
     detailedFields: ["response", "request"],
   };
 
-  logger.error(JSON.stringify(orderedLog));
+  const taskLabel = log.taskName ? ` ${log.taskName}` : "";
+  logger.error(`llm ${log.provider}${taskLabel} server error`, orderedLog);
 
   if (["development", "test"].includes(process.env.NODE_ENV ?? "")) {
     writeLogToFile(orderedLog);
@@ -65,10 +66,11 @@ export const logLlmRequest = (
     detailedFields: ["response", "request", "transformedRequest"],
   };
 
+  const taskLabel = log.taskName ? ` ${log.taskName}` : "";
   if (log.response.status === "ok") {
-    logger.debug(JSON.stringify(orderedLog));
+    logger.debug(`llm ${log.provider}${taskLabel}`, orderedLog);
   } else {
-    logger.error(JSON.stringify(orderedLog));
+    logger.error(`llm ${log.provider}${taskLabel} failed`, orderedLog);
   }
 
   if (["development", "test"].includes(process.env.NODE_ENV ?? "")) {

--- a/apps/hash-ai-worker-ts/src/activities/shared/judge-ai-outputs.ts
+++ b/apps/hash-ai-worker-ts/src/activities/shared/judge-ai-outputs.ts
@@ -366,7 +366,7 @@ export const judgeAiOutputs = async ({
   }
 
   if (errors.length) {
-    logger.error(`Errors in judge-ai-outputs: ${errors.join("\n")}`);
+    logger.error("Errors in judge-ai-outputs", { errors });
     return judgeAiOutputs({
       exchangeToReview,
       judgeModel,

--- a/apps/hash-ai-worker-ts/src/main.ts
+++ b/apps/hash-ai-worker-ts/src/main.ts
@@ -175,7 +175,7 @@ process.on("SIGTERM", () => {
   process.exit(1);
 });
 
-run().catch((err) => {
-  logger.error(`Error running worker: ${err}`);
+run().catch((error) => {
+  logger.error("Error running worker", { error });
   process.exit(1);
 });

--- a/apps/hash-ai-worker-ts/src/main.ts
+++ b/apps/hash-ai-worker-ts/src/main.ts
@@ -175,7 +175,7 @@ process.on("SIGTERM", () => {
   process.exit(1);
 });
 
-run().catch((error) => {
+run().catch((error: unknown) => {
   logger.error("Error running worker", { error });
   process.exit(1);
 });

--- a/apps/hash-api/src/auth/create-auth-handlers.ts
+++ b/apps/hash-api/src/auth/create-auth-handlers.ts
@@ -3,7 +3,6 @@ import { getRequiredEnv } from "@local/hash-backend-utils/environment";
 import { getHashInstance } from "@local/hash-backend-utils/hash-instance";
 import type { Logger } from "@local/hash-backend-utils/logger";
 import { publicUserAccountId } from "@local/hash-backend-utils/public-user-account-id";
-import { stringifyError } from "@local/hash-isomorphic-utils/stringify-error";
 import type { Session } from "@ory/kratos-client";
 import * as Sentry from "@sentry/node";
 import type { AxiosError } from "axios";
@@ -75,9 +74,10 @@ const kratosAfterRegistrationHookHandler =
       } catch (error) {
         // The kratos hook can interrupt creation on 4xx and 5xx responses.
 
-        logger.error(
-          `Error creating user with kratos identity id "${kratosIdentityId}": ${stringifyError(error, { prettify: false })}`,
-        );
+        logger.error("Error creating user from kratos identity", {
+          kratosIdentityId,
+          error,
+        });
         Sentry.captureException(error);
 
         res.status(400).send(

--- a/apps/hash-api/src/email/create-email-transporter.ts
+++ b/apps/hash-api/src/email/create-email-transporter.ts
@@ -55,7 +55,7 @@ export const createEmailTransporter = (): EmailTransporter => {
 
   return {
     sendMail: (mail) => {
-      logger.info(`Tried to send mail to ${mail.to}:\n${mail.html}`);
+      logger.info(`Tried to send mail to ${mail.to}`, { html: mail.html });
     },
   } as EmailTransporter;
 };

--- a/apps/hash-api/src/email/transporters/aws-ses-email-transporter.ts
+++ b/apps/hash-api/src/email/transporters/aws-ses-email-transporter.ts
@@ -42,8 +42,8 @@ export class AwsSesEmailTransporter implements EmailTransporter {
         html,
       })
       .then(() => undefined)
-      .catch((err) => {
-        logger.error(`Error sending email: ${err as string}`);
+      .catch((error) => {
+        logger.error("Error sending email", { error });
       });
   }
 }

--- a/apps/hash-api/src/email/transporters/smtp-email-transporter.ts
+++ b/apps/hash-api/src/email/transporters/smtp-email-transporter.ts
@@ -51,8 +51,8 @@ export class SmtpEmailTransporter implements EmailTransporter {
         html,
       })
       .then(() => undefined)
-      .catch((err) => {
-        logger.error(`Error sending email: ${err as string}`);
+      .catch((error) => {
+        logger.error("Error sending email", { error });
       });
   }
 }

--- a/apps/hash-api/src/graph/knowledge/system-types/user.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/user.ts
@@ -140,7 +140,7 @@ const getKratosIdentityIdByEmail = async (
     });
     return identities.length > 0 ? identities[0]!.id : null;
   } catch (error) {
-    logger.warn(`Failed to lookup Kratos identity by email ${email}: ${error}`);
+    logger.warn("Failed to lookup Kratos identity", { email, error });
     return null;
   }
 };

--- a/apps/hash-api/src/graphql/create-apollo-server.ts
+++ b/apps/hash-api/src/graphql/create-apollo-server.ts
@@ -96,8 +96,8 @@ const statsPlugin = ({
         };
         const operationType = ctx.operation?.operation ?? "graphql";
         const operationLabel = `${operationType} ${ctx.operationName ?? "anonymous"}`;
-        // Use the request-scoped logger (carries requestId via logger.child)
-        // so log lines correlate with the rest of the request.
+        // Use the request-scoped logger so log lines correlate with the
+        // rest of the request via the requestId set in the context.
         const reqLogger = ctx.contextValue.logger;
         if (ctx.errors) {
           if (ctx.errors[0]?.extensions.code !== "FORBIDDEN") {

--- a/apps/hash-api/src/graphql/create-apollo-server.ts
+++ b/apps/hash-api/src/graphql/create-apollo-server.ts
@@ -31,10 +31,8 @@ import type { GraphQLContext } from "./context";
 import { resolvers } from "./resolvers";
 
 const statsPlugin = ({
-  logger,
   statsd,
 }: {
-  logger: Logger;
   statsd?: StatsD;
 }): ApolloServerPlugin<GraphQLContext> => ({
   requestDidStart: async () => {
@@ -98,17 +96,20 @@ const statsPlugin = ({
         };
         const operationType = ctx.operation?.operation ?? "graphql";
         const operationLabel = `${operationType} ${ctx.operationName ?? "anonymous"}`;
+        // Use the request-scoped logger (carries requestId via logger.child)
+        // so log lines correlate with the rest of the request.
+        const reqLogger = ctx.contextValue.logger;
         if (ctx.errors) {
           if (ctx.errors[0]?.extensions.code !== "FORBIDDEN") {
             /** Log errors unrelated to auth failures */
-            logger.error(`${operationLabel} failed`, {
+            reqLogger.error(`${operationLabel} failed`, {
               ...msg,
               errors: ctx.errors,
               stack: ctx.errors.map((err) => err.stack),
             });
           }
         } else {
-          logger.info(operationLabel, msg);
+          reqLogger.info(operationLabel, msg);
           if (ctx.operationName) {
             statsd?.timing(ctx.operationName, elapsed, 1, ["graphql"]);
           }
@@ -178,7 +179,7 @@ export const createApolloServer = async ({
   }
 }`,
           }),
-      statsPlugin({ logger, statsd }),
+      statsPlugin({ statsd }),
       ApolloServerPluginDrainHttpServer({ httpServer }),
     ],
   });

--- a/apps/hash-api/src/graphql/create-apollo-server.ts
+++ b/apps/hash-api/src/graphql/create-apollo-server.ts
@@ -31,8 +31,12 @@ import type { GraphQLContext } from "./context";
 import { resolvers } from "./resolvers";
 
 const statsPlugin = ({
+  logger,
   statsd,
-}: { statsd?: StatsD }): ApolloServerPlugin<GraphQLContext> => ({
+}: {
+  logger: Logger;
+  statsd?: StatsD;
+}): ApolloServerPlugin<GraphQLContext> => ({
   requestDidStart: async () => {
     const startTimestamp = performance.now();
 
@@ -92,19 +96,19 @@ const statsPlugin = ({
           },
           userAgent,
         };
+        const operationType = ctx.operation?.operation ?? "graphql";
+        const operationLabel = `${operationType} ${ctx.operationName ?? "anonymous"}`;
         if (ctx.errors) {
           if (ctx.errors[0]?.extensions.code !== "FORBIDDEN") {
             /** Log errors unrelated to auth failures */
-            ctx.logger.error(
-              JSON.stringify({
-                ...msg,
-                errors: ctx.errors,
-                stack: ctx.errors.map((err) => err.stack),
-              }),
-            );
+            logger.error(`${operationLabel} failed`, {
+              ...msg,
+              errors: ctx.errors,
+              stack: ctx.errors.map((err) => err.stack),
+            });
           }
         } else {
-          ctx.logger.info(JSON.stringify(msg));
+          logger.info(operationLabel, msg);
           if (ctx.operationName) {
             statsd?.timing(ctx.operationName, elapsed, 1, ["graphql"]);
           }
@@ -174,7 +178,7 @@ export const createApolloServer = async ({
   }
 }`,
           }),
-      statsPlugin({ statsd }),
+      statsPlugin({ logger, statsd }),
       ApolloServerPluginDrainHttpServer({ httpServer }),
     ],
   });

--- a/apps/hash-api/src/graphql/resolvers/generation/generate-inverse.ts
+++ b/apps/hash-api/src/graphql/resolvers/generation/generate-inverse.ts
@@ -1,4 +1,3 @@
-import { stringifyError } from "@local/hash-isomorphic-utils/stringify-error";
 import { backOff } from "exponential-backoff";
 
 import type { QueryGenerateInverseArgs, ResolverFn } from "../../api-types.gen";
@@ -79,10 +78,11 @@ export const generateInverseResolver: ResolverFn<
     );
 
     return responseMessage;
-  } catch (err) {
-    graphQLContext.logger.error(
-      `Failed to generate inverse relationship for '${relationship}': ${stringifyError(err)}`,
-    );
+  } catch (error) {
+    graphQLContext.logger.error("Failed to generate inverse relationship", {
+      relationship,
+      error,
+    });
     throw Error.internal(
       `Failed to generate inverse relationship for ${relationship}`,
     );

--- a/apps/hash-api/src/graphql/resolvers/generation/generate-plural.ts
+++ b/apps/hash-api/src/graphql/resolvers/generation/generate-plural.ts
@@ -1,4 +1,3 @@
-import { stringifyError } from "@local/hash-isomorphic-utils/stringify-error";
 import { backOff } from "exponential-backoff";
 
 import type { QueryGeneratePluralArgs, ResolverFn } from "../../api-types.gen";
@@ -71,10 +70,11 @@ export const generatePluralResolver: ResolverFn<
     );
 
     return responseMessage;
-  } catch (err) {
-    graphQLContext.logger.error(
-      `Failed to generate plural for '${singular}': ${stringifyError(err)}`,
-    );
+  } catch (error) {
+    graphQLContext.logger.error("Failed to generate plural", {
+      singular,
+      error,
+    });
     throw Error.internal(`Failed to generate plural for '${singular}'`);
   }
 };

--- a/apps/hash-api/src/index.ts
+++ b/apps/hash-api/src/index.ts
@@ -364,19 +364,24 @@ const main = async () => {
     });
   }
 
-  // Add logging of requests
+  // Add logging of requests. /graphql is logged at the operation level
+  // (query/mutation name) by the Apollo plugin in `create-apollo-server.ts`,
+  // so logging it here would be a less informative duplicate.
   app.use((req, res, next) => {
     const requestId = nanoid();
     res.set("x-hash-request-id", requestId);
-    logger.info(`${req.method} ${req.path}`, {
-      requestId,
-      origin: req.headers.origin,
-      ip: req.ip,
-      userAgent: req.headers["user-agent"],
-      graphqlClient:
-        req.headers[hashClientHeaderKey] ??
-        req.headers["apollographql-client-name"],
-    });
+
+    if (req.path !== "/graphql") {
+      logger.info(`${req.method} ${req.path}`, {
+        requestId,
+        origin: req.headers.origin,
+        ip: req.ip,
+        userAgent: req.headers["user-agent"],
+        graphqlClient:
+          req.headers[hashClientHeaderKey] ??
+          req.headers["apollographql-client-name"],
+      });
+    }
 
     next();
   });

--- a/apps/hash-api/src/index.ts
+++ b/apps/hash-api/src/index.ts
@@ -345,8 +345,8 @@ const main = async () => {
         await promisify((statsd as StatsD).close).bind(statsd)();
       });
     }
-  } catch (err) {
-    logger.error(`Could not start StatsD client: ${err}`);
+  } catch (error) {
+    logger.error("Could not start StatsD client", { error });
   }
 
   app.use(cors(CORS_CONFIG));
@@ -368,19 +368,15 @@ const main = async () => {
   app.use((req, res, next) => {
     const requestId = nanoid();
     res.set("x-hash-request-id", requestId);
-    logger.info(
-      JSON.stringify({
-        requestId,
-        method: req.method,
-        origin: req.headers.origin,
-        ip: req.ip,
-        path: req.path,
-        userAgent: req.headers["user-agent"],
-        graphqlClient:
-          req.headers[hashClientHeaderKey] ??
-          req.headers["apollographql-client-name"],
-      }),
-    );
+    logger.info(`${req.method} ${req.path}`, {
+      requestId,
+      origin: req.headers.origin,
+      ip: req.ip,
+      userAgent: req.headers["user-agent"],
+      graphqlClient:
+        req.headers[hashClientHeaderKey] ??
+        req.headers["apollographql-client-name"],
+    });
 
     next();
   });
@@ -746,7 +742,7 @@ const main = async () => {
       const { default: fs } = await import("node:fs/promises");
 
       const servers = dns.getServers();
-      logger.info(`DNS servers: ${servers}`);
+      logger.info("DNS servers", { servers });
 
       try {
         const resolveAny = await dns.resolveAny(rpcHost);

--- a/apps/hash-api/src/integrations/sync-back-watcher.ts
+++ b/apps/hash-api/src/integrations/sync-back-watcher.ts
@@ -115,9 +115,9 @@ export const createIntegrationSyncBackWatcher = async ({
 
         return true;
       })
-      .catch((err) => {
+      .catch((error) => {
         // caught because this function loses ownership of the queue occasionally in dev
-        logger.error(`Could not take message from queue: ${err.message}`);
+        logger.error("Could not take message from queue", { error });
       });
   };
 

--- a/apps/hash-integration-worker/src/activities/linear-activities.ts
+++ b/apps/hash-integration-worker/src/activities/linear-activities.ts
@@ -409,7 +409,7 @@ export const createLinearIntegrationActivities = ({
   }>): Promise<void> {
     const issues = await readLinearIssues({ apiKey, filter });
 
-    logger.info(`Found ${issues.length} issues to sync to ${webId}`);
+    logger.info("Found Linear issues to sync", { count: issues.length, webId });
 
     const batchSize = 100;
 
@@ -424,7 +424,7 @@ export const createLinearIntegrationActivities = ({
       });
     }
 
-    logger.info(`Synced ${issues.length} issues to ${webId}`);
+    logger.info("Synced Linear issues", { count: issues.length, webId });
   },
 
   async readLinearTeams({ apiKey }: ParamsWithApiKey): Promise<Team[]> {

--- a/libs/@local/hash-backend-utils/package.json
+++ b/libs/@local/hash-backend-utils/package.json
@@ -19,7 +19,8 @@
     "build": "rimraf dist && tsc --build tsconfig.build.json",
     "fix:eslint": "eslint --fix .",
     "lint:eslint": "eslint --report-unused-disable-directives .",
-    "lint:tsc": "tsc --noEmit"
+    "lint:tsc": "tsc --noEmit",
+    "test:unit": "vitest run --passWithNoTests"
   },
   "dependencies": {
     "@aws-crypto/sha256-js": "5.2.0",

--- a/libs/@local/hash-backend-utils/src/logger.test.ts
+++ b/libs/@local/hash-backend-utils/src/logger.test.ts
@@ -48,6 +48,27 @@ describe("expandLogValue / Error handling", () => {
     expect(causeOfA.message).toBe("b");
     expect(causeOfA.cause).toBe("[Circular]");
   });
+
+  it("preserves enumerable own properties on Error subclasses", () => {
+    class APIError extends Error {
+      constructor(
+        message: string,
+        public status: number,
+        public code: string,
+      ) {
+        super(message);
+        this.name = "APIError";
+      }
+    }
+    const err = new APIError("rate limit", 429, "rate_limit_exceeded");
+
+    const expanded = expandLogValue(err) as Record<string, unknown>;
+
+    expect(expanded.name).toBe("APIError");
+    expect(expanded.message).toBe("rate limit");
+    expect(expanded.status).toBe(429);
+    expect(expanded.code).toBe("rate_limit_exceeded");
+  });
 });
 
 describe("expandLogValue / cycles in plain objects", () => {

--- a/libs/@local/hash-backend-utils/src/logger.test.ts
+++ b/libs/@local/hash-backend-utils/src/logger.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+
+import { expandLogValue, safeStringify } from "./logger.js";
+
+describe("expandLogValue / Error handling", () => {
+  it("rebuilds Error fields that JSON.stringify would otherwise drop", () => {
+    const err = new Error("boom");
+    const expanded = expandLogValue(err) as Record<string, unknown>;
+
+    expect(expanded.name).toBe("Error");
+    expect(expanded.message).toBe("boom");
+    expect(typeof expanded.stack).toBe("string");
+    expect("cause" in expanded).toBe(false);
+  });
+
+  it("expands nested Error.cause chains", () => {
+    const inner = new Error("inner");
+    const outer = new Error("outer", { cause: inner });
+    const expanded = expandLogValue(outer) as Record<string, unknown>;
+
+    expect(expanded.message).toBe("outer");
+    const cause = expanded.cause as Record<string, unknown>;
+    expect(cause.name).toBe("Error");
+    expect(cause.message).toBe("inner");
+  });
+
+  it("breaks self-referential Error.cause cycles with [Circular]", () => {
+    const err = new Error("self") as Error & { cause: unknown };
+    err.cause = err;
+
+    // Without cycle detection on Error this would blow the stack.
+    const expanded = expandLogValue(err) as Record<string, unknown>;
+
+    expect(expanded.message).toBe("self");
+    expect(expanded.cause).toBe("[Circular]");
+  });
+
+  it("breaks A → B → A Error.cause cycles", () => {
+    const a = new Error("a") as Error & { cause: unknown };
+    const b = new Error("b") as Error & { cause: unknown };
+    a.cause = b;
+    b.cause = a;
+
+    const expanded = expandLogValue(a) as Record<string, unknown>;
+
+    expect(expanded.message).toBe("a");
+    const causeOfA = expanded.cause as Record<string, unknown>;
+    expect(causeOfA.message).toBe("b");
+    expect(causeOfA.cause).toBe("[Circular]");
+  });
+});
+
+describe("expandLogValue / cycles in plain objects", () => {
+  it("collapses self-references in objects", () => {
+    type Loop = { name: string; self?: Loop };
+    const loop: Loop = { name: "x" };
+    loop.self = loop;
+
+    const expanded = expandLogValue(loop) as Record<string, unknown>;
+
+    expect(expanded.name).toBe("x");
+    expect(expanded.self).toBe("[Circular]");
+  });
+
+  it("does not flag legitimate sibling references as circular", () => {
+    const shared = { id: 1 };
+    const payload = { left: shared, right: shared };
+
+    const expanded = expandLogValue(payload) as Record<
+      string,
+      Record<string, unknown>
+    >;
+
+    expect(expanded.left).toEqual({ id: 1 });
+    expect(expanded.right).toEqual({ id: 1 });
+  });
+});
+
+describe("expandLogValue / non-JSON values", () => {
+  it("converts BigInt to its string form", () => {
+    expect(expandLogValue(42n)).toBe("42");
+    expect(expandLogValue({ size: 9007199254740993n })).toEqual({
+      size: "9007199254740993",
+    });
+  });
+
+  it("preserves toJSON values like Date untouched", () => {
+    const date = new Date("2026-01-01T00:00:00.000Z");
+    expect(expandLogValue(date)).toBe(date);
+    // ...so JSON.stringify still calls toJSON on them.
+    expect(safeStringify({ at: date })).toBe(
+      '{"at":"2026-01-01T00:00:00.000Z"}',
+    );
+  });
+});
+
+describe("safeStringify", () => {
+  it("survives Errors with circular cause without throwing", () => {
+    const err = new Error("loop") as Error & { cause: unknown };
+    err.cause = err;
+
+    const out = safeStringify({ error: err });
+
+    expect(out).toContain('"message":"loop"');
+    expect(out).toContain('"[Circular]"');
+  });
+
+  it("falls back to a marker string on unexpected serialisation failure", () => {
+    // BigInts inside `toJSON`-bearing objects bypass `expandLogValue`'s
+    // BigInt branch and would throw inside JSON.stringify; the catch
+    // converts that into the marker rather than propagating.
+    const sneaky = {
+      toJSON() {
+        return { n: 1n };
+      },
+    };
+
+    const out = safeStringify(sneaky);
+
+    expect(out).toMatch(/^\[unserializable: /);
+  });
+});

--- a/libs/@local/hash-backend-utils/src/logger.ts
+++ b/libs/@local/hash-backend-utils/src/logger.ts
@@ -47,8 +47,9 @@ function mapWinstonLevelToOtel(level: string): SeverityNumber {
  * Recursively replace values in a log payload that JSON.stringify cannot
  * usefully serialise on its own:
  *
- * - Errors: their `message`, `stack`, `name`, and `cause` are non-enumerable
- *   so a plain `JSON.stringify(new Error("x"))` produces `{}`.
+ * - Errors: do not implement `toJSON`, and `message` / `stack` / `cause`
+ *   are non-enumerable own or inherited properties, so
+ *   `JSON.stringify(new Error("x"))` returns `{}`.
  * - BigInts: throw `TypeError: Do not know how to serialize a BigInt`.
  *
  * Values that already implement `toJSON` (Date, Buffer, decimal/ID types,
@@ -57,12 +58,14 @@ function mapWinstonLevelToOtel(level: string): SeverityNumber {
  * via `Object.entries` would lose the `toJSON` hook (e.g. `Date` would
  * become `{}`).
  *
- * Cycles are tracked via a `WeakSet` and replaced with `[Circular]` so
- * the function cannot infinite-recurse on a self-referential payload.
+ * Cycles are tracked via a path-scoped `Set` (added before recursion,
+ * removed after) so true self-references collapse to `[Circular]`
+ * without falsely flagging legitimate shared references that appear in
+ * sibling positions.
  */
 export const expandLogValue = (
   value: unknown,
-  seen: WeakSet<object> = new WeakSet(),
+  ancestors: Set<object> = new Set(),
 ): unknown => {
   if (value instanceof Error) {
     return {
@@ -70,40 +73,54 @@ export const expandLogValue = (
       message: value.message,
       stack: value.stack,
       ...(value.cause !== undefined
-        ? { cause: expandLogValue(value.cause, seen) }
+        ? { cause: expandLogValue(value.cause, ancestors) }
         : {}),
     };
   }
   if (typeof value === "bigint") {
     return value.toString();
   }
-  if (value !== null && typeof value === "object") {
-    if (seen.has(value)) {
-      return "[Circular]";
-    }
-    seen.add(value);
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+  if (ancestors.has(value)) {
+    return "[Circular]";
+  }
 
-    // Anything with its own `toJSON` knows how to serialise itself —
-    // pass through and let `JSON.stringify` invoke it.
-    if (typeof (value as { toJSON?: unknown }).toJSON === "function") {
-      return value;
-    }
+  // Anything with its own `toJSON` knows how to serialise itself —
+  // pass through and let `JSON.stringify` invoke it.
+  if (typeof (value as { toJSON?: unknown }).toJSON === "function") {
+    return value;
+  }
+
+  ancestors.add(value);
+  try {
     if (Array.isArray(value)) {
-      return value.map((item) => expandLogValue(item, seen));
+      return value.map((item) => expandLogValue(item, ancestors));
     }
-    const out: Record<string, unknown> = {};
+    const out: Record<string | symbol, unknown> = {};
     for (const [key, nested] of Object.entries(value)) {
-      out[key] = expandLogValue(nested, seen);
+      out[key] = expandLogValue(nested, ancestors);
+    }
+    // Carry symbol-keyed properties through unchanged. Winston attaches
+    // its finalised level/message/splat under `Symbol.for("level")` etc.,
+    // and `Object.entries` only enumerates string keys, so without this
+    // step a recursive rebuild silently strips them.
+    for (const sym of Object.getOwnPropertySymbols(value)) {
+      out[sym] = (value as Record<string | symbol, unknown>)[sym];
     }
     return out;
+  } finally {
+    ancestors.delete(value);
   }
-  return value;
 };
 
 /**
- * `JSON.stringify` that survives Errors, BigInts, circular references,
- * and types with custom `toJSON` (Date, Buffer, etc.). Falls back to a
- * marker string rather than throwing.
+ * `JSON.stringify` that handles values which would otherwise lose
+ * information or throw: Errors, BigInts, types with `toJSON`. Plain-object
+ * cycles are rewritten to `[Circular]` by `expandLogValue`; anything that
+ * still throws inside `JSON.stringify` is caught and replaced with a
+ * marker string rather than propagated.
  */
 export const safeStringify = (
   value: unknown,
@@ -133,7 +150,6 @@ const expandLogValuesFormat = format((info) => {
   try {
     return expandLogValue(info) as winston.Logform.TransformableInfo;
   } catch {
-    // Best-effort: never crash the logger.
     return info;
   }
 });
@@ -213,18 +229,18 @@ const rewriteForConsole = format(
     // from the surrounding metadata before they reach the console
     // formatter, so heavy payloads (request/response blobs) don't get
     // dumped into stdout.
-    const result: winston.Logform.TransformableInfo = {
+    const cleanedInfo: winston.Logform.TransformableInfo = {
       ...original,
       message: `${consolePrefix} ${message}`,
     };
-    delete (result as { consolePrefix?: unknown }).consolePrefix;
-    delete (result as { detailedFields?: unknown }).detailedFields;
+    delete (cleanedInfo as { consolePrefix?: unknown }).consolePrefix;
+    delete (cleanedInfo as { detailedFields?: unknown }).detailedFields;
     if (detailedKeys) {
       for (const key of detailedKeys) {
-        delete (result as Record<string, unknown>)[key];
+        delete (cleanedInfo as Record<string, unknown>)[key];
       }
     }
-    return result;
+    return cleanedInfo;
   },
 );
 

--- a/libs/@local/hash-backend-utils/src/logger.ts
+++ b/libs/@local/hash-backend-utils/src/logger.ts
@@ -51,30 +51,49 @@ function mapWinstonLevelToOtel(level: string): SeverityNumber {
  *   so a plain `JSON.stringify(new Error("x"))` produces `{}`.
  * - BigInts: throw `TypeError: Do not know how to serialize a BigInt`.
  *
- * Returns a value safe to pass to `JSON.stringify` (or a stringifier like
- * winston's `format.json()`) without losing information.
+ * Values that already implement `toJSON` (Date, Buffer, decimal/ID types,
+ * etc.) are passed through unchanged — `JSON.stringify` will call `toJSON`
+ * on them and produce the right representation. Rebuilding their fields
+ * via `Object.entries` would lose the `toJSON` hook (e.g. `Date` would
+ * become `{}`).
+ *
+ * Cycles are tracked via a `WeakSet` and replaced with `[Circular]` so
+ * the function cannot infinite-recurse on a self-referential payload.
  */
-export const expandLogValue = (value: unknown): unknown => {
+export const expandLogValue = (
+  value: unknown,
+  seen: WeakSet<object> = new WeakSet(),
+): unknown => {
   if (value instanceof Error) {
     return {
       name: value.name,
       message: value.message,
       stack: value.stack,
       ...(value.cause !== undefined
-        ? { cause: expandLogValue(value.cause) }
+        ? { cause: expandLogValue(value.cause, seen) }
         : {}),
     };
   }
   if (typeof value === "bigint") {
     return value.toString();
   }
-  if (Array.isArray(value)) {
-    return value.map(expandLogValue);
-  }
-  if (value && typeof value === "object") {
+  if (value !== null && typeof value === "object") {
+    if (seen.has(value)) {
+      return "[Circular]";
+    }
+    seen.add(value);
+
+    // Anything with its own `toJSON` knows how to serialise itself —
+    // pass through and let `JSON.stringify` invoke it.
+    if (typeof (value as { toJSON?: unknown }).toJSON === "function") {
+      return value;
+    }
+    if (Array.isArray(value)) {
+      return value.map((item) => expandLogValue(item, seen));
+    }
     const out: Record<string, unknown> = {};
     for (const [key, nested] of Object.entries(value)) {
-      out[key] = expandLogValue(nested);
+      out[key] = expandLogValue(nested, seen);
     }
     return out;
   }
@@ -82,8 +101,9 @@ export const expandLogValue = (value: unknown): unknown => {
 };
 
 /**
- * `JSON.stringify` that survives Errors, BigInts, and circular references.
- * Falls back to a marker string rather than throwing.
+ * `JSON.stringify` that survives Errors, BigInts, circular references,
+ * and types with custom `toJSON` (Date, Buffer, etc.). Falls back to a
+ * marker string rather than throwing.
  */
 export const safeStringify = (
   value: unknown,
@@ -104,13 +124,19 @@ export const safeStringify = (
 };
 
 /**
- * Winston format that recursively expands non-enumerable Error properties
- * and BigInts in the info object before any later format (notably
- * `format.json`) tries to serialise it.
+ * Winston format that expands Errors / BigInts / cycles in the info
+ * object before any later format (notably `format.json`) tries to
+ * serialise it. Wrapped in try/catch so a malformed payload cannot
+ * throw out of the Winston pipeline.
  */
-const expandLogValuesFormat = format(
-  (info) => expandLogValue(info) as winston.Logform.TransformableInfo,
-);
+const expandLogValuesFormat = format((info) => {
+  try {
+    return expandLogValue(info) as winston.Logform.TransformableInfo;
+  } catch {
+    // Best-effort: never crash the logger.
+    return info;
+  }
+});
 
 function toAnyValue(value: unknown): AnyValue {
   if (value === null || value === undefined) {
@@ -144,37 +170,61 @@ function sanitizeAttributes(obj: Record<string, unknown>): AnyValueMap {
  * This function takes the consolePrefix (if it exists) and prepends the message with it for the console transport.
  * A corresponding format is used to remove the consolePrefix from the message in the Http transport.
  *
- * This also removes any 'detailedFields' from the message if any are specified.
+ * Also removes any `detailedFields` listed in the payload — both from a
+ * legacy object-shaped `message` and from the top-level info metadata
+ * (callers that pass `logger.X("description", { detailedFields, ... })`
+ * spread the field list into the info object directly).
  */
 const rewriteForConsole = format(
   (original: winston.Logform.TransformableInfo & { message: unknown }) => {
-    const { message: fullMessage, ...metadata } = original;
-
-    const { consolePrefix, ...restMetadata } = metadata;
+    const consolePrefix = (original as { consolePrefix?: unknown })
+      .consolePrefix;
 
     if (typeof consolePrefix !== "string" || consolePrefix.length === 0) {
       return original;
     }
 
+    const fullMessage = original.message;
+    const detailedFromMeta = (original as { detailedFields?: unknown })
+      .detailedFields;
+    let detailedKeys: string[] | undefined = Array.isArray(detailedFromMeta)
+      ? (detailedFromMeta as string[])
+      : undefined;
+
     let message: string;
     if (typeof fullMessage === "object" && fullMessage !== null) {
-      const { detailedFields, ...restMessage } = fullMessage as {
-        detailedFields?: string[];
-        [key: string]: unknown;
-      };
+      const { detailedFields: detailedFromMessage, ...restMessage } =
+        fullMessage as {
+          detailedFields?: string[];
+          [key: string]: unknown;
+        };
+
+      detailedKeys = detailedKeys ?? detailedFromMessage;
 
       message = safeStringify(restMessage, {
         replacer: (key, value) =>
-          detailedFields?.includes(key) ? undefined : value,
+          detailedKeys?.includes(key) ? undefined : value,
       });
     } else {
       message = fullMessage as string;
     }
 
-    return {
+    // Strip detailed fields and `consolePrefix`/`detailedFields` markers
+    // from the surrounding metadata before they reach the console
+    // formatter, so heavy payloads (request/response blobs) don't get
+    // dumped into stdout.
+    const result: winston.Logform.TransformableInfo = {
+      ...original,
       message: `${consolePrefix} ${message}`,
-      ...restMetadata,
     };
+    delete (result as { consolePrefix?: unknown }).consolePrefix;
+    delete (result as { detailedFields?: unknown }).detailedFields;
+    if (detailedKeys) {
+      for (const key of detailedKeys) {
+        delete (result as Record<string, unknown>)[key];
+      }
+    }
+    return result;
   },
 );
 

--- a/libs/@local/hash-backend-utils/src/logger.ts
+++ b/libs/@local/hash-backend-utils/src/logger.ts
@@ -136,7 +136,7 @@ export const safeStringify = (
       options?.space,
     );
   } catch (error) {
-    return `[unserialisable: ${(error as Error).message}]`;
+    return `[unserializable: ${(error as Error).message}]`;
   }
 };
 

--- a/libs/@local/hash-backend-utils/src/logger.ts
+++ b/libs/@local/hash-backend-utils/src/logger.ts
@@ -43,6 +43,75 @@ function mapWinstonLevelToOtel(level: string): SeverityNumber {
   }
 }
 
+/**
+ * Recursively replace values in a log payload that JSON.stringify cannot
+ * usefully serialise on its own:
+ *
+ * - Errors: their `message`, `stack`, `name`, and `cause` are non-enumerable
+ *   so a plain `JSON.stringify(new Error("x"))` produces `{}`.
+ * - BigInts: throw `TypeError: Do not know how to serialize a BigInt`.
+ *
+ * Returns a value safe to pass to `JSON.stringify` (or a stringifier like
+ * winston's `format.json()`) without losing information.
+ */
+export const expandLogValue = (value: unknown): unknown => {
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: value.message,
+      stack: value.stack,
+      ...(value.cause !== undefined
+        ? { cause: expandLogValue(value.cause) }
+        : {}),
+    };
+  }
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+  if (Array.isArray(value)) {
+    return value.map(expandLogValue);
+  }
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [key, nested] of Object.entries(value)) {
+      out[key] = expandLogValue(nested);
+    }
+    return out;
+  }
+  return value;
+};
+
+/**
+ * `JSON.stringify` that survives Errors, BigInts, and circular references.
+ * Falls back to a marker string rather than throwing.
+ */
+export const safeStringify = (
+  value: unknown,
+  options?: {
+    space?: number;
+    replacer?: (key: string, value: unknown) => unknown;
+  },
+): string => {
+  try {
+    return JSON.stringify(
+      expandLogValue(value),
+      options?.replacer,
+      options?.space,
+    );
+  } catch (error) {
+    return `[unserialisable: ${(error as Error).message}]`;
+  }
+};
+
+/**
+ * Winston format that recursively expands non-enumerable Error properties
+ * and BigInts in the info object before any later format (notably
+ * `format.json`) tries to serialise it.
+ */
+const expandLogValuesFormat = format(
+  (info) => expandLogValue(info) as winston.Logform.TransformableInfo,
+);
+
 function toAnyValue(value: unknown): AnyValue {
   if (value === null || value === undefined) {
     return undefined;
@@ -55,12 +124,7 @@ function toAnyValue(value: unknown): AnyValue {
   ) {
     return value as AnyValue;
   }
-  try {
-    return JSON.stringify(value);
-  } catch {
-    // eslint-disable-next-line @typescript-eslint/no-base-to-string
-    return String(value);
-  }
+  return safeStringify(value);
 }
 
 function sanitizeAttributes(obj: Record<string, unknown>): AnyValueMap {
@@ -99,12 +163,9 @@ const rewriteForConsole = format(
         [key: string]: unknown;
       };
 
-      message = JSON.stringify(restMessage, (key, value) => {
-        if (detailedFields?.includes(key)) {
-          return undefined;
-        }
-
-        return value as unknown;
+      message = safeStringify(restMessage, {
+        replacer: (key, value) =>
+          detailedFields?.includes(key) ? undefined : value,
       });
     } else {
       message = fullMessage as string;
@@ -173,6 +234,10 @@ export class Logger {
       level,
       format: winston.format.combine(
         winston.format.errors({ stack: true }),
+        // Run before any later format that stringifies the info object
+        // (format.json on each transport) so Errors and BigInts in nested
+        // meta don't serialise to `{}` or throw.
+        expandLogValuesFormat(),
         winston.format.json(),
       ),
       defaultMeta: { service: cfg.serviceName, ...this.cfg.metadata },

--- a/libs/@local/hash-backend-utils/src/logger.ts
+++ b/libs/@local/hash-backend-utils/src/logger.ts
@@ -78,14 +78,25 @@ export const expandLogValue = (
     }
     ancestors.add(value);
     try {
-      return {
+      const out: Record<string, unknown> = {
         name: value.name,
         message: value.message,
         stack: value.stack,
-        ...(value.cause !== undefined
-          ? { cause: expandLogValue(value.cause, ancestors) }
-          : {}),
       };
+      // Preserve enumerable own properties added by Error subclasses
+      // (e.g. `status`, `code`, `headers` on OpenAI.APIError or
+      // AxiosError) — `Object.entries` skips name/message/stack
+      // because those are non-enumerable on the prototype, so we
+      // don't double up on them.
+      for (const [key, nested] of Object.entries(value)) {
+        if (key !== "cause") {
+          out[key] = expandLogValue(nested, ancestors);
+        }
+      }
+      if (value.cause !== undefined) {
+        out.cause = expandLogValue(value.cause, ancestors);
+      }
+      return out;
     } finally {
       ancestors.delete(value);
     }

--- a/libs/@local/hash-backend-utils/src/logger.ts
+++ b/libs/@local/hash-backend-utils/src/logger.ts
@@ -49,7 +49,10 @@ function mapWinstonLevelToOtel(level: string): SeverityNumber {
  *
  * - Errors: do not implement `toJSON`, and `message` / `stack` / `cause`
  *   are non-enumerable own or inherited properties, so
- *   `JSON.stringify(new Error("x"))` returns `{}`.
+ *   `JSON.stringify(new Error("x"))` returns `{}`. This rebuild is the
+ *   canonical handling for log payloads — call sites should pass
+ *   `logger.X("desc", { error })` and rely on this expansion rather
+ *   than pre-stringify the error themselves.
  * - BigInts: throw `TypeError: Do not know how to serialize a BigInt`.
  *
  * Values that already implement `toJSON` (Date, Buffer, decimal/ID types,
@@ -61,21 +64,31 @@ function mapWinstonLevelToOtel(level: string): SeverityNumber {
  * Cycles are tracked via a path-scoped `Set` (added before recursion,
  * removed after) so true self-references collapse to `[Circular]`
  * without falsely flagging legitimate shared references that appear in
- * sibling positions.
+ * sibling positions. Errors are part of this protection — Axios
+ * v1.12+ is known to produce `Error.cause` chains that loop back on
+ * themselves, which would otherwise blow the stack.
  */
 export const expandLogValue = (
   value: unknown,
   ancestors: Set<object> = new Set(),
 ): unknown => {
   if (value instanceof Error) {
-    return {
-      name: value.name,
-      message: value.message,
-      stack: value.stack,
-      ...(value.cause !== undefined
-        ? { cause: expandLogValue(value.cause, ancestors) }
-        : {}),
-    };
+    if (ancestors.has(value)) {
+      return "[Circular]";
+    }
+    ancestors.add(value);
+    try {
+      return {
+        name: value.name,
+        message: value.message,
+        stack: value.stack,
+        ...(value.cause !== undefined
+          ? { cause: expandLogValue(value.cause, ancestors) }
+          : {}),
+      };
+    } finally {
+      ancestors.delete(value);
+    }
   }
   if (typeof value === "bigint") {
     return value.toString();

--- a/libs/@local/hash-backend-utils/src/vault.ts
+++ b/libs/@local/hash-backend-utils/src/vault.ts
@@ -393,9 +393,7 @@ export const createVaultClient = async ({
         secretMountPath,
       });
     } catch (error) {
-      logger.error(
-        `Failed to login to Vault via IAM: ${stringifyError(error)}`,
-      );
+      logger.error("Failed to login to Vault via IAM", { error });
 
       return undefined;
     }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

`logger.X(JSON.stringify(obj))` round-trips through Winston's JSON formatter. The OTLP log record ends up with the entire payload as an escaped string in `body` and an empty `attributes` map — fields cannot be searched in Loki without re-parsing the body. Tim already worked around this on the Grafana ingestion side; this PR removes the workaround at the source.

## 🔗 Related links

- [BE-517](https://linear.app/hash/issue/BE-517)
- Slack thread: https://hashintel.slack.com/archives/C022217GAHF/p1777385776994559
- [BE-518](https://linear.app/hash/issue/BE-518) (followup cleanup)
- [BE-519](https://linear.app/hash/issue/BE-519) (OTEL setup for the workers — without this, none of these log improvements are visible from the workers)

## 🔍 What does this change?

- Replace the antipattern at 6 call sites with `logger.X("description", payload)`. Identifier-rich descriptions:
  - `${req.method} ${req.path}` for Express requests (e.g. `GET /health-check`)
  - `${operationType} ${operationName}` for GraphQL ops (e.g. `query GetMe`, `mutation CreateEntity failed`)
  - `llm ${provider} ${taskName}` for LLM logs (e.g. `llm openai extract-entities`)
- Move error objects, large stringified payloads, and IDs out of the message body and into structured attributes across ~14 other call sites
- Rename `catch (err)` → `catch (error)` so `{ error }` shorthand works
- Skip `/graphql` in the Express request log — Apollo's plugin logs operation-level detail which is more useful than the generic `POST /graphql`. `requestId` is still generated and set on the response header for downstream correlation
- Apollo plugin now uses `ctx.contextValue.logger` (the request-scoped child logger that already carries `requestId`) so each operation log correlates with its request
- `activity-logger.ts`: signature extended to accept an optional meta object. Removed the legacy `JSON.parse(message)` workaround that existed solely to recover from the antipattern this PR removes

Apollo Server's `ctx.logger` is a 1-arg `Logger` interface, so `ctx.contextValue.logger` (typed as our Winston `Logger`) is used in the plugin instead.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

- [x] do not affect the execution graph

## ⚠️ Known issues

- The workers (`hash-ai-worker-ts`, `hash-integration-worker`) still have no OTEL setup, so their structured log calls are invisible in Loki until [BE-519](https://linear.app/hash/issue/BE-519) lands. This PR upgrades the call-site quality regardless — once OTEL is wired up, the value is unlocked without further code changes.
- ~20 lower-value call sites still embed identifiers in the message body (e.g. `Listening on port ${port}`, `Iteration ${count} begun`). Tracked in [BE-518](https://linear.app/hash/issue/BE-518) to keep this PR focused.

## 🐾 Next steps

- [BE-518](https://linear.app/hash/issue/BE-518): cleanup of remaining lower-value call sites + an eslint rule to prevent `logger.X(JSON.stringify(...))` regression and a `no-console` rule for production code (catches `console.info` in `hash-integration-worker/src/main.ts`)
- [BE-519](https://linear.app/hash/issue/BE-519): wire up OTEL for both Temporal workers so log payloads actually reach Loki

## 🛡 What tests cover this?

No new tests — change is to logging shape only, no behavioural change. Verified locally with a Winston harness that the new `logger.X("desc", obj)` pattern produces structured OTLP records (body=description, attributes=payload).

## ❓ How to test this?

1. Check out the branch
2. `yarn dev:backend` and hit a few GraphQL queries / make a recovery / send a test email
3. With a local OTEL collector pointed at the API, confirm log records have `body` set to a short description and `attributes` containing the structured payload (`operation`, `elapsed`, etc.)
4. Without OTEL, just confirm the dev console output is readable (e.g. `info: query GetMe {operation:"GetMe",elapsed:"5ms",...}`)

## 📹 Demo

<img width="848" height="948" alt="image" src="https://github.com/user-attachments/assets/03b3ee22-bb90-4483-846e-d031a44e5eb6" />
<img width="570" height="610" alt="image" src="https://github.com/user-attachments/assets/f0effaff-6408-4437-bf18-b6269e08d3ed" />

```
info: query queryEntities {"clientInfo":{"clientName":"web-app"},"elapsed":"111.39ms","environment":"development","hostname":"localhost","operation":"queryEntities","requestId":"VsXJXwkzBIQT83","service":"api","timestamp":"2026-04-28T16:25:14.425Z","userAgent":"Mozilla/5.0"}
info: query queryEntities {"clientInfo":{"clientName":"web-app"},"elapsed":"59.06ms","environment":"development","hostname":"localhost","operation":"queryEntities","requestId":"cJx2L6jO1GjYCM","service":"api","timestamp":"2026-04-28T16:25:14.570Z","userAgent":"Mozilla/5.0"}
info: query me {"clientInfo":{"clientName":"web-app"},"elapsed":"36.75ms","environment":"development","hostname":"localhost","operation":"me","requestId":"f58b1f8S3CKXy3","service":"api","timestamp":"2026-04-28T16:25:14.675Z","userAgent":"node"}
info: GET /auth/sessions/whoami {"environment":"development","hostname":"localhost","ip":"127.0.0.1","requestId":"eyDq57D5wUohFe","service":"api","timestamp":"2026-04-28T16:25:14.679Z","userAgent":"axios/1.15.1"}
info: [HPM] GET /auth/sessions/whoami -> http://127.0.0.1:4433/sessions/whoami [200] {"environment":"development","hostname":"localhost","service":"api","timestamp":"2026-04-28T16:25:14.684Z"}
info: GET /auth/sessions/whoami {"environment":"development","hostname":"localhost","ip":"127.0.0.1","origin":"http://localhost:3000","requestId":"775bZgpOLOlxcu","service":"api","timestamp":"2026-04-28T16:25:14.691Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.3.1 Safari/605.1.15"}
info: [HPM] GET /auth/sessions/whoami -> http://127.0.0.1:4433/sessions/whoami [200] {"environment":"development","hostname":"localhost","service":"api","timestamp":"2026-04-28T16:25:14.698Z"}
info: query queryEntities {"clientInfo":{"clientName":"web-app"},"elapsed":"32.62ms","environment":"development","hostname":"localhost","operation":"queryEntities","requestId":"o54WGq7IDUrxJx","service":"api","timestamp":"2026-04-28T16:25:14.852Z","userAgent":"Mozilla/5.0"}
(node:82144) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 error listeners added to [Socket]. MaxListeners is 10. Use emitter.setMaxListeners() to increase limit
info: query queryEntities {"clientInfo":{"clientName":"web-app"},"elapsed":"82.29ms","environment":"development","hostname":"localhost","operation":"queryEntities","requestId":"MUiox8YBpvJzhf","service":"api","timestamp":"2026-04-28T16:25:14.899Z","userAgent":"Mozilla/5.0"}
info: query queryEntities {"clientInfo":{"clientName":"web-app"},"elapsed":"91.46ms","environment":"development","hostname":"localhost","operation":"queryEntities","requestId":"JxBVAwNbQEWTn2","service":"api","timestamp":"2026-04-28T16:25:14.915Z","userAgent":"Mozilla/5.0"}
info: query queryEntitySubgraph {"clientInfo":{"clientName":"web-app"},"elapsed":"137.35ms","environment":"development","hostname":"localhost","operation":"queryEntitySubgraph","requestId":"6NaF7V8YJYGJZp","service":"api","timestamp":"2026-04-28T16:25:15.068Z","userAgent":"Mozilla/5.0"}
info: GET /auth/sessions/whoami {"environment":"development","hostname":"localhost","ip":"127.0.0.1","origin":"http://localhost:3000","requestId":"dC7jpb5KXzyXjQ","service":"api","timestamp":"2026-04-28T16:25:15.116Z","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.3.1 Safari/605.1.15"}
info: [HPM] GET /auth/sessions/whoami -> http://127.0.0.1:4433/sessions/whoami [200] {"environment":"development","hostname":"localhost","service":"api","timestamp":"2026-04-28T16:25:15.122Z"}
info: query countEntities {"clientInfo":{"clientName":"web-app"},"elapsed":"21.65ms","environment":"development","hostname":"localhost","operation":"countEntities","requestId":"UrJPY0T3sG8vVV","service":"api","timestamp":"2026-04-28T16:25:21.336Z","userAgent":"Mozilla/5.0"}
info: query countEntities {"clientInfo":{"clientName":"web-app"},"elapsed":"28.31ms","environment":"development","hostname":"localhost","operation":"countEntities","requestId":"Bmnm90N8My5C0A","service":"api","timestamp":"2026-04-28T16:25:21.340Z","userAgent":"Mozilla/5.0"}
info: query getMyPendingInvitations {"clientInfo":{"clientName":"web-app"},"elapsed":"73.88ms","environment":"development","hostname":"localhost","operation":"getMyPendingInvitations","requestId":"9jVHrBNBZRn3J5","service":"api","timestamp":"2026-04-28T16:25:21.391Z","userAgent":"Mozilla/5.0"}
```