### PR TITLE
FE-689: Add tooltip component to DS

### DIFF
--- a/.changeset/fiery-tigers-kick.md
+++ b/.changeset/fiery-tigers-kick.md
@@ -1,0 +1,5 @@
+---
+"@hashintel/ds-components": patch
+---
+
+Add tooltip component to DS

--- a/libs/@hashintel/ds-components/eslint.config.js
+++ b/libs/@hashintel/ds-components/eslint.config.js
@@ -1,4 +1,5 @@
 import typescriptEslint from "@typescript-eslint/eslint-plugin";
+import reactHooks from "eslint-plugin-react-hooks";
 
 import { createBase, disableRules } from "@local/eslint/deprecated";
 
@@ -17,6 +18,7 @@ export default [
       "src/stories/Intro.mdx",
     ],
   },
+  reactHooks.configs.flat["recommended-latest"],
   ...createBase(import.meta.dirname),
   ...disableRules([]),
   {

--- a/libs/@hashintel/ds-components/src/beta/scroll-area/infinite-scroll.story.tsx
+++ b/libs/@hashintel/ds-components/src/beta/scroll-area/infinite-scroll.story.tsx
@@ -15,6 +15,7 @@ export const App = () => {
 
   const hasMore = items.length < 200;
 
+  // eslint-disable-next-line react-hooks/incompatible-library
   const rowVirtualizer = useVirtualizer({
     count: hasMore ? items.length + 1 : items.length,
     getScrollElement: () => scrollRef.current,

--- a/libs/@hashintel/ds-components/src/beta/scroll-area/virtualization.story.tsx
+++ b/libs/@hashintel/ds-components/src/beta/scroll-area/virtualization.story.tsx
@@ -9,6 +9,7 @@ import * as ScrollArea from "./scroll-area";
 export const App = () => {
   const scrollRef = useRef<HTMLDivElement>(null);
 
+  // eslint-disable-next-line react-hooks/incompatible-library
   const rowVirtualizer = useVirtualizer({
     count: 200,
     getScrollElement: () => scrollRef.current,

--- a/libs/@hashintel/ds-components/src/components/Tooltip/tooltip.recipe.ts
+++ b/libs/@hashintel/ds-components/src/components/Tooltip/tooltip.recipe.ts
@@ -1,7 +1,16 @@
 import { css, cva } from "@hashintel/ds-helpers/css";
 
+export const triggerStyles = css({
+  "&:focus-visible": {
+    outline: "[2px solid]",
+    outlineColor: "neutral.s30",
+    outlineOffset: "[2px]",
+    borderRadius: "md",
+  },
+});
+
 export const positionerStyles = css({
-  zIndex: "[1500]",
+  zIndex: "zIndex.tooltip",
 });
 
 export const contentStyles = cva({

--- a/libs/@hashintel/ds-components/src/components/Tooltip/tooltip.recipe.ts
+++ b/libs/@hashintel/ds-components/src/components/Tooltip/tooltip.recipe.ts
@@ -1,0 +1,32 @@
+import { css, cva } from "@hashintel/ds-helpers/css";
+
+export const positionerStyles = css({
+  zIndex: "[1500]",
+});
+
+export const contentStyles = cva({
+  base: {
+    borderRadius: "md",
+    paddingX: "2",
+    paddingY: "1",
+    textStyle: "sm",
+    maxWidth: "[300px]",
+    wordWrap: "break-word",
+  },
+  variants: {
+    variant: {
+      dark: {
+        backgroundColor: "neutral.s120/94",
+        color: "white",
+      },
+      light: {
+        backgroundColor: "white",
+        color: "fg.body",
+        boxShadow: "[0 2px 8px rgba(0, 0, 0, 0.15)]",
+      },
+    },
+  },
+  defaultVariants: {
+    variant: "dark",
+  },
+});

--- a/libs/@hashintel/ds-components/src/components/Tooltip/tooltip.stories.tsx
+++ b/libs/@hashintel/ds-components/src/components/Tooltip/tooltip.stories.tsx
@@ -33,23 +33,11 @@ export const Default: Story = () => (
           variant="light"
           describeChild={false}
         >
-          <button
-            type="button"
-            style={{
-              background: "none",
-              border: "none",
-              cursor: "pointer",
-              padding: 4,
-            }}
-          >
-            <Icon name="info" />
-          </button>
+          <Icon name="info" />
         </Tooltip>
 
         <Tooltip content={richContent} variant="light" describeChild={false}>
-          <Button variant="ghost" colorScheme="neutral" size="sm">
-            Rich content
-          </Button>
+          Rich content
         </Tooltip>
       </div>
     </div>
@@ -68,23 +56,11 @@ export const Default: Story = () => (
           variant="dark"
           describeChild={false}
         >
-          <button
-            type="button"
-            style={{
-              background: "none",
-              border: "none",
-              cursor: "pointer",
-              padding: 4,
-            }}
-          >
-            <Icon name="info" />
-          </button>
+          <Icon name="info" />
         </Tooltip>
 
         <Tooltip content={richContent} variant="dark" describeChild={false}>
-          <Button variant="ghost" colorScheme="neutral" size="sm">
-            Rich content
-          </Button>
+          Rich content
         </Tooltip>
       </div>
     </div>

--- a/libs/@hashintel/ds-components/src/components/Tooltip/tooltip.stories.tsx
+++ b/libs/@hashintel/ds-components/src/components/Tooltip/tooltip.stories.tsx
@@ -17,45 +17,32 @@ const richContent = (
   </div>
 );
 
+const variants = ["light", "dark"] as const;
+
 export const Default: Story = () => (
   <div style={{ display: "flex", flexDirection: "column", gap: 40 }}>
-    <div>
-      <h3 style={{ marginBottom: 12 }}>Light variant</h3>
-      <div style={{ display: "flex", gap: 24, alignItems: "center" }}>
-        <Tooltip content="Button tooltip" variant="light">
-          <Button variant="secondary" colorScheme="neutral" size="sm">
-            Hover me
-          </Button>
-        </Tooltip>
+    {variants.map((variant) => (
+      <div key={variant}>
+        <h3 style={{ marginBottom: 12 }}>
+          {variant.charAt(0).toUpperCase() + variant.slice(1)} variant
+        </h3>
+        <div style={{ display: "flex", gap: 24, alignItems: "center" }}>
+          <Tooltip content="Button tooltip" variant={variant}>
+            <Button variant="secondary" colorScheme="neutral" size="sm">
+              Hover me
+            </Button>
+          </Tooltip>
 
-        <Tooltip content="More information" variant="light">
-          <Icon name="info" />
-        </Tooltip>
+          <Tooltip content="More information" variant={variant}>
+            <Icon name="info" />
+          </Tooltip>
 
-        <Tooltip content={richContent} variant="light">
-          Rich content
-        </Tooltip>
+          <Tooltip content={richContent} variant={variant}>
+            Rich content
+          </Tooltip>
+        </div>
       </div>
-    </div>
-
-    <div>
-      <h3 style={{ marginBottom: 12 }}>Dark variant</h3>
-      <div style={{ display: "flex", gap: 24, alignItems: "center" }}>
-        <Tooltip content="Button tooltip" variant="dark">
-          <Button variant="secondary" colorScheme="neutral" size="sm">
-            Hover me
-          </Button>
-        </Tooltip>
-
-        <Tooltip content="More information" variant="dark">
-          <Icon name="info" />
-        </Tooltip>
-
-        <Tooltip content={richContent} variant="dark">
-          Rich content
-        </Tooltip>
-      </div>
-    </div>
+    ))}
   </div>
 );
 Default.parameters = {

--- a/libs/@hashintel/ds-components/src/components/Tooltip/tooltip.stories.tsx
+++ b/libs/@hashintel/ds-components/src/components/Tooltip/tooltip.stories.tsx
@@ -22,21 +22,17 @@ export const Default: Story = () => (
     <div>
       <h3 style={{ marginBottom: 12 }}>Light variant</h3>
       <div style={{ display: "flex", gap: 24, alignItems: "center" }}>
-        <Tooltip content="Button tooltip" variant="light" describeChild={false}>
+        <Tooltip content="Button tooltip" variant="light">
           <Button variant="secondary" colorScheme="neutral" size="sm">
             Hover me
           </Button>
         </Tooltip>
 
-        <Tooltip
-          content="More information"
-          variant="light"
-          describeChild={false}
-        >
+        <Tooltip content="More information" variant="light">
           <Icon name="info" />
         </Tooltip>
 
-        <Tooltip content={richContent} variant="light" describeChild={false}>
+        <Tooltip content={richContent} variant="light">
           Rich content
         </Tooltip>
       </div>
@@ -45,21 +41,17 @@ export const Default: Story = () => (
     <div>
       <h3 style={{ marginBottom: 12 }}>Dark variant</h3>
       <div style={{ display: "flex", gap: 24, alignItems: "center" }}>
-        <Tooltip content="Button tooltip" variant="dark" describeChild={false}>
+        <Tooltip content="Button tooltip" variant="dark">
           <Button variant="secondary" colorScheme="neutral" size="sm">
             Hover me
           </Button>
         </Tooltip>
 
-        <Tooltip
-          content="More information"
-          variant="dark"
-          describeChild={false}
-        >
+        <Tooltip content="More information" variant="dark">
           <Icon name="info" />
         </Tooltip>
 
-        <Tooltip content={richContent} variant="dark" describeChild={false}>
+        <Tooltip content={richContent} variant="dark">
           Rich content
         </Tooltip>
       </div>
@@ -104,12 +96,7 @@ export const AllPositions: Story = () => (
         // eslint-disable-next-line react/jsx-key
         <div />
       ) : (
-        <Tooltip
-          key={position}
-          content={position}
-          position={position}
-          describeChild={false}
-        >
+        <Tooltip key={position} content={position} position={position}>
           <Button
             variant="secondary"
             colorScheme="neutral"

--- a/libs/@hashintel/ds-components/src/components/Tooltip/tooltip.stories.tsx
+++ b/libs/@hashintel/ds-components/src/components/Tooltip/tooltip.stories.tsx
@@ -1,0 +1,152 @@
+import type { Story, StoryDefault } from "@ladle/react";
+
+import { Button } from "../Button/button";
+import { Icon } from "../Icon/icon";
+import { Tooltip } from "./tooltip";
+
+export default {
+  title: "Components/Tooltip",
+} satisfies StoryDefault;
+
+const richContent = (
+  <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+    <strong>Rich tooltip</strong>
+    <span>
+      This tooltip contains structured content with multiple elements.
+    </span>
+  </div>
+);
+
+export const Default: Story = () => (
+  <div style={{ display: "flex", flexDirection: "column", gap: 40 }}>
+    <div>
+      <h3 style={{ marginBottom: 12 }}>Light variant</h3>
+      <div style={{ display: "flex", gap: 24, alignItems: "center" }}>
+        <Tooltip content="Button tooltip" variant="light" describeChild={false}>
+          <Button variant="secondary" colorScheme="neutral" size="sm">
+            Hover me
+          </Button>
+        </Tooltip>
+
+        <Tooltip
+          content="More information"
+          variant="light"
+          describeChild={false}
+        >
+          <button
+            type="button"
+            style={{
+              background: "none",
+              border: "none",
+              cursor: "pointer",
+              padding: 4,
+            }}
+          >
+            <Icon name="info" />
+          </button>
+        </Tooltip>
+
+        <Tooltip content={richContent} variant="light" describeChild={false}>
+          <Button variant="ghost" colorScheme="neutral" size="sm">
+            Rich content
+          </Button>
+        </Tooltip>
+      </div>
+    </div>
+
+    <div>
+      <h3 style={{ marginBottom: 12 }}>Dark variant</h3>
+      <div style={{ display: "flex", gap: 24, alignItems: "center" }}>
+        <Tooltip content="Button tooltip" variant="dark" describeChild={false}>
+          <Button variant="secondary" colorScheme="neutral" size="sm">
+            Hover me
+          </Button>
+        </Tooltip>
+
+        <Tooltip
+          content="More information"
+          variant="dark"
+          describeChild={false}
+        >
+          <button
+            type="button"
+            style={{
+              background: "none",
+              border: "none",
+              cursor: "pointer",
+              padding: 4,
+            }}
+          >
+            <Icon name="info" />
+          </button>
+        </Tooltip>
+
+        <Tooltip content={richContent} variant="dark" describeChild={false}>
+          <Button variant="ghost" colorScheme="neutral" size="sm">
+            Rich content
+          </Button>
+        </Tooltip>
+      </div>
+    </div>
+  </div>
+);
+Default.parameters = {
+  controls: { disable: true },
+};
+
+const positions = [
+  "top-start",
+  "top",
+  "top-end",
+  "left-start",
+  "empty",
+  "right-start",
+  "left",
+  "empty",
+  "right",
+  "left-end",
+  "empty",
+  "right-end",
+  "bottom-start",
+  "bottom",
+  "bottom-end",
+] as const;
+
+export const AllPositions: Story = () => (
+  <div
+    style={{
+      display: "grid",
+      gridTemplateColumns: "repeat(3, 1fr)",
+      gap: 12,
+      padding: 80,
+      maxWidth: 500,
+      margin: "0 auto",
+    }}
+  >
+    {positions.map((position) =>
+      position === "empty" ? (
+        // eslint-disable-next-line react/jsx-key
+        <div />
+      ) : (
+        <Tooltip
+          key={position}
+          content={position}
+          position={position}
+          describeChild={false}
+        >
+          <Button
+            variant="secondary"
+            colorScheme="neutral"
+            size="lg"
+            style={{ width: "100%" }}
+          >
+            {position}
+          </Button>
+        </Tooltip>
+      ),
+    )}
+  </div>
+);
+AllPositions.parameters = {
+  controls: { disable: true },
+};

--- a/libs/@hashintel/ds-components/src/components/Tooltip/tooltip.tsx
+++ b/libs/@hashintel/ds-components/src/components/Tooltip/tooltip.tsx
@@ -1,0 +1,38 @@
+import type { RequireExactlyOne } from "type-fest";
+
+type Direction = "bottom" | "top" | "left" | "right";
+type Position = Direction | `${Direction}-${'start' | 'end'}`;
+
+export const Tooltip = ({
+  ...props,
+}: {
+  className?: string;
+  /** The tooltip trigger */
+  children: React.ReactNode;
+  /** The content that triggers the tooltip */
+  content: React.ReactNode;
+  /** The preferred position of the tooltip - depending on the viewport, trigger and content another position may be chosen for better fit */
+  position?: Position;
+  /** Whether to display a light or dark tooltip */
+  variant?: 'light' | 'dark';
+  /** Whether to disable the tooltip */
+  disableTooltip?: boolean;
+  /** How long before the the tooltip is opened on hover/focus */
+  openDelayMs?: number;
+  /** How long before the the tooltip is opened when leaving hover/focus */
+  closeDelayMs?: number;
+  /** The X distance the tooltip will be from the trigger in px */
+  offsetX?: number;
+  /** The Y distance the tooltip will be from the trigger in px */
+  offsetY?: number;
+  onOpen?: () => void;
+  onClose?: () => void;
+} & RequireExactlyOne<{
+  content: string;
+  /** Whether the tooltip content should act as the accessible description for the content */
+  describeChild: true;
+} | {
+  describeChild?: false;
+}>) => {
+  return <></>;
+}

--- a/libs/@hashintel/ds-components/src/components/Tooltip/tooltip.tsx
+++ b/libs/@hashintel/ds-components/src/components/Tooltip/tooltip.tsx
@@ -2,7 +2,6 @@ import { Portal } from "@ark-ui/react/portal";
 import { Tooltip as ArkTooltip } from "@ark-ui/react/tooltip";
 import { cx } from "@hashintel/ds-helpers/css";
 import { useEffect, useRef } from "react";
-import type { RequireExactlyOne } from "type-fest";
 
 import {
   contentStyles,
@@ -82,16 +81,7 @@ export const Tooltip = ({
   gapY?: number;
   onOpen?: () => void;
   onClose?: () => void;
-} & RequireExactlyOne<
-  | {
-      content: string;
-      /** Whether the tooltip content should act as the accessible description for the content */
-      describeChild: true;
-    }
-  | {
-      describeChild?: false;
-    }
->) => {
+}) => {
   const triggerRef = useRef<HTMLSpanElement>(null);
 
   // If the child is not focusable, add a tabindex to the wrapper element to focus it.

--- a/libs/@hashintel/ds-components/src/components/Tooltip/tooltip.tsx
+++ b/libs/@hashintel/ds-components/src/components/Tooltip/tooltip.tsx
@@ -106,14 +106,8 @@ export const Tooltip = ({
     }
   }, [children, disableTooltip]);
 
-  const wrappedChildren = (
-    <span ref={triggerRef} className={cx(triggerStyles, className)}>
-      {children}
-    </span>
-  );
-
   if (disableTooltip) {
-    return wrappedChildren;
+    return <span className={cx(triggerStyles, className)}>{children}</span>;
   }
 
   const offset = getPositioningOffset(position, gapX, gapY);
@@ -137,7 +131,11 @@ export const Tooltip = ({
       unmountOnExit
       lazyMount
     >
-      <ArkTooltip.Trigger asChild>{wrappedChildren}</ArkTooltip.Trigger>
+      <ArkTooltip.Trigger asChild>
+        <span ref={triggerRef} className={cx(triggerStyles, className)}>
+          {children}
+        </span>
+      </ArkTooltip.Trigger>
       <Portal>
         <ArkTooltip.Positioner className={positionerStyles}>
           <ArkTooltip.Content className={contentStyles({ variant })}>

--- a/libs/@hashintel/ds-components/src/components/Tooltip/tooltip.tsx
+++ b/libs/@hashintel/ds-components/src/components/Tooltip/tooltip.tsx
@@ -94,22 +94,25 @@ export const Tooltip = ({
 >) => {
   const triggerRef = useRef<HTMLSpanElement>(null);
 
-  // If the child is not focusable, add a tabindex to the wrapper element to focus it
+  // If the child is not focusable, add a tabindex to the wrapper element to focus it.
+  // When the child becomes focusable or the tooltip is disabled, clean up so the
+  // wrapper doesn't remain an unexpected tab stop.
   useEffect(() => {
-    if (disableTooltip) {
+    const wrapper = triggerRef.current;
+    if (!wrapper) {
       return;
     }
 
-    const triggerEl = triggerRef.current
-      ?.firstElementChild as HTMLElement | null;
+    const triggerEl = wrapper.firstElementChild as HTMLElement | null;
+    const needsFocus =
+      !disableTooltip &&
+      ((!triggerEl && wrapper.textContent) ||
+        (triggerEl && !isDomFocusable(triggerEl)));
 
-    // If the trigger element is plain text
-    if (triggerRef.current && !triggerEl && triggerRef.current.textContent) {
-      triggerRef.current.tabIndex = 0;
-      // Or if the trigger element is not focusable
-    } else if (triggerRef.current && triggerEl && !isDomFocusable(triggerEl)) {
-      triggerRef.current.tabIndex = 0;
-      triggerRef.current.role = "button";
+    if (needsFocus) {
+      wrapper.tabIndex = 0;
+    } else {
+      wrapper.removeAttribute("tabindex");
     }
   }, [children, disableTooltip]);
 

--- a/libs/@hashintel/ds-components/src/components/Tooltip/tooltip.tsx
+++ b/libs/@hashintel/ds-components/src/components/Tooltip/tooltip.tsx
@@ -1,12 +1,27 @@
 import { Portal } from "@ark-ui/react/portal";
 import { Tooltip as ArkTooltip } from "@ark-ui/react/tooltip";
 import { cx } from "@hashintel/ds-helpers/css";
+import { useEffect, useRef } from "react";
 import type { RequireExactlyOne } from "type-fest";
 
-import { contentStyles, positionerStyles } from "./tooltip.recipe";
+import {
+  contentStyles,
+  positionerStyles,
+  triggerStyles,
+} from "./tooltip.recipe";
 
 type Direction = "bottom" | "top" | "left" | "right";
 type Position = Direction | `${Direction}-${"start" | "end"}`;
+
+function isDomFocusable(el: HTMLElement): boolean {
+  if (el.tabIndex < 0) {
+    return false;
+  }
+  if ("disabled" in el && (el as HTMLButtonElement).disabled) {
+    return false;
+  }
+  return true;
+}
 
 function getPositioningOffset(position: Position, gapX: number, gapY: number) {
   const direction = position.split("-")[0] ?? "bottom";
@@ -62,20 +77,38 @@ export const Tooltip = ({
       describeChild?: false;
     }
 >) => {
+  const triggerRef = useRef<HTMLSpanElement>(null);
+
+  // If the child is not focusable, add a tabindex to the wrapper element to focus it
+  useEffect(() => {
+    if (disableTooltip) {
+      return;
+    }
+
+    const triggerEl = triggerRef.current
+      ?.firstElementChild as HTMLElement | null;
+
+    // If the trigger element is plain text
+    if (triggerRef.current && !triggerEl && triggerRef.current.textContent) {
+      triggerRef.current.tabIndex = 0;
+      // Or if the trigger element is not focusable
+    } else if (triggerRef.current && triggerEl && !isDomFocusable(triggerEl)) {
+      triggerRef.current.tabIndex = 0;
+      triggerRef.current.role = "button";
+    }
+  }, [children, disableTooltip]);
+
+  const wrappedChildren = (
+    <span ref={triggerRef} className={cx(triggerStyles, className)}>
+      {children}
+    </span>
+  );
+
   if (disableTooltip) {
-    return children;
+    return wrappedChildren;
   }
 
   const offset = getPositioningOffset(position, gapX, gapY);
-  const wrappedChildren =
-    typeof children === "string" ||
-    typeof children === "number" ||
-    typeof children === "boolean" ||
-    typeof children === "bigint" ? (
-      <span>{children}</span>
-    ) : (
-      children
-    );
 
   return (
     <ArkTooltip.Root
@@ -99,9 +132,7 @@ export const Tooltip = ({
       <ArkTooltip.Trigger asChild>{wrappedChildren}</ArkTooltip.Trigger>
       <Portal>
         <ArkTooltip.Positioner className={positionerStyles}>
-          <ArkTooltip.Content
-            className={cx(contentStyles({ variant }), className)}
-          >
+          <ArkTooltip.Content className={contentStyles({ variant })}>
             {content}
           </ArkTooltip.Content>
         </ArkTooltip.Positioner>

--- a/libs/@hashintel/ds-components/src/components/Tooltip/tooltip.tsx
+++ b/libs/@hashintel/ds-components/src/components/Tooltip/tooltip.tsx
@@ -1,10 +1,67 @@
+import { Portal } from "@ark-ui/react/portal";
+import { Tooltip as ArkTooltip } from "@ark-ui/react/tooltip";
+import { css, cx } from "@hashintel/ds-helpers/css";
 import type { RequireExactlyOne } from "type-fest";
 
 type Direction = "bottom" | "top" | "left" | "right";
-type Position = Direction | `${Direction}-${'start' | 'end'}`;
+type Position = Direction | `${Direction}-${"start" | "end"}`;
+
+const positionerStyles = css({
+  zIndex: "[1500]",
+});
+
+const contentBaseStyles = css({
+  borderRadius: "[6px]",
+  px: "[8px]",
+  py: "[4px]",
+  fontSize: "[13px]",
+  lineHeight: "[1.4]",
+  maxWidth: "[300px]",
+  wordWrap: "break-word",
+});
+
+const darkContentStyles = css({
+  backgroundColor: "[rgba(33, 33, 33, 0.92)]",
+  color: "[#fff]",
+});
+
+const lightContentStyles = css({
+  backgroundColor: "[#fff]",
+  color: "[rgba(0, 0, 0, 0.87)]",
+  boxShadow: "[0 2px 8px rgba(0, 0, 0, 0.15)]",
+});
+
+function getPositioningOffset(
+  position: Position | undefined,
+  offsetX: number | undefined,
+  offsetY: number | undefined,
+) {
+  if (offsetX === undefined && offsetY === undefined) {
+    return undefined;
+  }
+
+  const direction = position?.split("-")[0] ?? "bottom";
+  const isVertical = direction === "top" || direction === "bottom";
+
+  return {
+    mainAxis: isVertical ? offsetY : offsetX,
+    crossAxis: isVertical ? offsetX : offsetY,
+  };
+}
 
 export const Tooltip = ({
-  ...props,
+  className,
+  children,
+  content,
+  position,
+  variant = "dark",
+  disableTooltip,
+  openDelayMs,
+  closeDelayMs,
+  offsetX,
+  offsetY,
+  onOpen,
+  onClose,
 }: {
   className?: string;
   /** The tooltip trigger */
@@ -14,7 +71,7 @@ export const Tooltip = ({
   /** The preferred position of the tooltip - depending on the viewport, trigger and content another position may be chosen for better fit */
   position?: Position;
   /** Whether to display a light or dark tooltip */
-  variant?: 'light' | 'dark';
+  variant?: "light" | "dark";
   /** Whether to disable the tooltip */
   disableTooltip?: boolean;
   /** How long before the the tooltip is opened on hover/focus */
@@ -27,12 +84,58 @@ export const Tooltip = ({
   offsetY?: number;
   onOpen?: () => void;
   onClose?: () => void;
-} & RequireExactlyOne<{
-  content: string;
-  /** Whether the tooltip content should act as the accessible description for the content */
-  describeChild: true;
-} | {
-  describeChild?: false;
-}>) => {
-  return <></>;
-}
+} & RequireExactlyOne<
+  | {
+      content: string;
+      /** Whether the tooltip content should act as the accessible description for the content */
+      describeChild: true;
+    }
+  | {
+      describeChild?: false;
+    }
+>) => {
+  if (disableTooltip) {
+    return children;
+  }
+
+  const offset = getPositioningOffset(position, offsetX, offsetY);
+
+  return (
+    <ArkTooltip.Root
+      openDelay={openDelayMs}
+      closeDelay={closeDelayMs}
+      positioning={{
+        placement: position,
+        ...(offset && { offset }),
+      }}
+      onOpenChange={
+        onOpen || onClose
+          ? ({ open }) => {
+              if (open) {
+                onOpen?.();
+              } else {
+                onClose?.();
+              }
+            }
+          : undefined
+      }
+      unmountOnExit
+      lazyMount
+    >
+      <ArkTooltip.Trigger asChild>{children}</ArkTooltip.Trigger>
+      <Portal>
+        <ArkTooltip.Positioner className={positionerStyles}>
+          <ArkTooltip.Content
+            className={cx(
+              contentBaseStyles,
+              variant === "dark" ? darkContentStyles : lightContentStyles,
+              className,
+            )}
+          >
+            {content}
+          </ArkTooltip.Content>
+        </ArkTooltip.Positioner>
+      </Portal>
+    </ArkTooltip.Root>
+  );
+};

--- a/libs/@hashintel/ds-components/src/components/Tooltip/tooltip.tsx
+++ b/libs/@hashintel/ds-components/src/components/Tooltip/tooltip.tsx
@@ -67,6 +67,15 @@ export const Tooltip = ({
   }
 
   const offset = getPositioningOffset(position, gapX, gapY);
+  const wrappedChildren =
+    typeof children === "string" ||
+    typeof children === "number" ||
+    typeof children === "boolean" ||
+    typeof children === "bigint" ? (
+      <span>{children}</span>
+    ) : (
+      children
+    );
 
   return (
     <ArkTooltip.Root
@@ -87,7 +96,7 @@ export const Tooltip = ({
       unmountOnExit
       lazyMount
     >
-      <ArkTooltip.Trigger asChild>{children}</ArkTooltip.Trigger>
+      <ArkTooltip.Trigger asChild>{wrappedChildren}</ArkTooltip.Trigger>
       <Portal>
         <ArkTooltip.Positioner className={positionerStyles}>
           <ArkTooltip.Content

--- a/libs/@hashintel/ds-components/src/components/Tooltip/tooltip.tsx
+++ b/libs/@hashintel/ds-components/src/components/Tooltip/tooltip.tsx
@@ -8,21 +8,12 @@ import { contentStyles, positionerStyles } from "./tooltip.recipe";
 type Direction = "bottom" | "top" | "left" | "right";
 type Position = Direction | `${Direction}-${"start" | "end"}`;
 
-function getPositioningOffset(
-  position: Position | undefined,
-  offsetX: number | undefined,
-  offsetY: number | undefined,
-) {
-  if (offsetX === undefined && offsetY === undefined) {
-    return undefined;
-  }
-
-  const direction = position?.split("-")[0] ?? "bottom";
+function getPositioningOffset(position: Position, gapX: number, gapY: number) {
+  const direction = position.split("-")[0] ?? "bottom";
   const isVertical = direction === "top" || direction === "bottom";
 
   return {
-    mainAxis: isVertical ? offsetY : offsetX,
-    crossAxis: isVertical ? offsetX : offsetY,
+    mainAxis: isVertical ? gapY : gapX,
   };
 }
 
@@ -35,8 +26,8 @@ export const Tooltip = ({
   disableTooltip,
   openDelayMs = 300,
   closeDelayMs = 150,
-  offsetX,
-  offsetY,
+  gapX = 8,
+  gapY = 8,
   onOpen,
   onClose,
 }: {
@@ -56,9 +47,9 @@ export const Tooltip = ({
   /** How long before the the tooltip is opened when leaving hover/focus */
   closeDelayMs?: number;
   /** The X distance the tooltip will be from the trigger in px */
-  offsetX?: number;
+  gapX?: number;
   /** The Y distance the tooltip will be from the trigger in px */
-  offsetY?: number;
+  gapY?: number;
   onOpen?: () => void;
   onClose?: () => void;
 } & RequireExactlyOne<
@@ -75,13 +66,13 @@ export const Tooltip = ({
     return children;
   }
 
-  const offset = getPositioningOffset(position, offsetX, offsetY);
+  const offset = getPositioningOffset(position, gapX, gapY);
 
   return (
     <ArkTooltip.Root
       openDelay={openDelayMs}
       closeDelay={closeDelayMs}
-      positioning={{ placement: position, ...(offset && { offset }) }}
+      positioning={{ placement: position, offset }}
       onOpenChange={
         onOpen || onClose
           ? ({ open }) => {

--- a/libs/@hashintel/ds-components/src/components/Tooltip/tooltip.tsx
+++ b/libs/@hashintel/ds-components/src/components/Tooltip/tooltip.tsx
@@ -1,7 +1,7 @@
 import { Portal } from "@ark-ui/react/portal";
 import { Tooltip as ArkTooltip } from "@ark-ui/react/tooltip";
 import { cx } from "@hashintel/ds-helpers/css";
-import { useEffect, useRef } from "react";
+import { useCallback } from "react";
 
 import {
   contentStyles,
@@ -82,32 +82,47 @@ export const Tooltip = ({
   onOpen?: () => void;
   onClose?: () => void;
 }) => {
-  const triggerRef = useRef<HTMLSpanElement>(null);
-
   // If the child is not focusable, add a tabindex to the wrapper element to focus it.
   // When the child becomes focusable or the tooltip is disabled, clean up so the
   // wrapper doesn't remain an unexpected tab stop.
-  useEffect(() => {
-    const wrapper = triggerRef.current;
-    if (!wrapper) {
-      return;
-    }
+  //
+  // Uses a callback ref so DOM mutations happen during commit without reading
+  // ref.current during render (which the React Compiler forbids) since ark-ui seems to
+  // try and read triggerRef.current when rendering it as the trigger element.
+  const triggerRef = useCallback(
+    (node: HTMLSpanElement | null) => {
+      // Intentionally capture `children` — the callback must re-run whenever
+      // children changes because the focusability check inspects the DOM.
+      void children;
 
-    const triggerEl = wrapper.firstElementChild as HTMLElement | null;
-    const needsFocus =
-      !disableTooltip &&
-      ((!triggerEl && wrapper.textContent) ||
-        (triggerEl && !isDomFocusable(triggerEl)));
+      if (!node) {
+        return;
+      }
 
-    if (needsFocus) {
-      wrapper.tabIndex = 0;
-    } else {
-      wrapper.removeAttribute("tabindex");
-    }
-  }, [children, disableTooltip]);
+      const wrapper = node;
+      const triggerEl = wrapper.firstElementChild as HTMLElement | null;
+      const needsFocus =
+        !disableTooltip &&
+        ((!triggerEl && wrapper.textContent) ||
+          (triggerEl && !isDomFocusable(triggerEl)));
+
+      if (needsFocus) {
+        wrapper.tabIndex = 0;
+      } else {
+        wrapper.removeAttribute("tabindex");
+      }
+    },
+    [children, disableTooltip],
+  );
+
+  const wrappedChildren = (
+    <span ref={triggerRef} className={cx(triggerStyles, className)}>
+      {children}
+    </span>
+  );
 
   if (disableTooltip) {
-    return <span className={cx(triggerStyles, className)}>{children}</span>;
+    return wrappedChildren;
   }
 
   const offset = getPositioningOffset(position, gapX, gapY);
@@ -131,11 +146,7 @@ export const Tooltip = ({
       unmountOnExit
       lazyMount
     >
-      <ArkTooltip.Trigger asChild>
-        <span ref={triggerRef} className={cx(triggerStyles, className)}>
-          {children}
-        </span>
-      </ArkTooltip.Trigger>
+      <ArkTooltip.Trigger asChild>{wrappedChildren}</ArkTooltip.Trigger>
       <Portal>
         <ArkTooltip.Positioner className={positionerStyles}>
           <ArkTooltip.Content className={contentStyles({ variant })}>

--- a/libs/@hashintel/ds-components/src/components/Tooltip/tooltip.tsx
+++ b/libs/@hashintel/ds-components/src/components/Tooltip/tooltip.tsx
@@ -1,35 +1,12 @@
 import { Portal } from "@ark-ui/react/portal";
 import { Tooltip as ArkTooltip } from "@ark-ui/react/tooltip";
-import { css, cx } from "@hashintel/ds-helpers/css";
+import { cx } from "@hashintel/ds-helpers/css";
 import type { RequireExactlyOne } from "type-fest";
+
+import { contentStyles, positionerStyles } from "./tooltip.recipe";
 
 type Direction = "bottom" | "top" | "left" | "right";
 type Position = Direction | `${Direction}-${"start" | "end"}`;
-
-const positionerStyles = css({
-  zIndex: "[1500]",
-});
-
-const contentBaseStyles = css({
-  borderRadius: "[6px]",
-  px: "[8px]",
-  py: "[4px]",
-  fontSize: "[13px]",
-  lineHeight: "[1.4]",
-  maxWidth: "[300px]",
-  wordWrap: "break-word",
-});
-
-const darkContentStyles = css({
-  backgroundColor: "[rgba(33, 33, 33, 0.92)]",
-  color: "[#fff]",
-});
-
-const lightContentStyles = css({
-  backgroundColor: "[#fff]",
-  color: "[rgba(0, 0, 0, 0.87)]",
-  boxShadow: "[0 2px 8px rgba(0, 0, 0, 0.15)]",
-});
 
 function getPositioningOffset(
   position: Position | undefined,
@@ -53,11 +30,11 @@ export const Tooltip = ({
   className,
   children,
   content,
-  position,
+  position = "bottom",
   variant = "dark",
   disableTooltip,
-  openDelayMs,
-  closeDelayMs,
+  openDelayMs = 300,
+  closeDelayMs = 150,
   offsetX,
   offsetY,
   onOpen,
@@ -104,10 +81,7 @@ export const Tooltip = ({
     <ArkTooltip.Root
       openDelay={openDelayMs}
       closeDelay={closeDelayMs}
-      positioning={{
-        placement: position,
-        ...(offset && { offset }),
-      }}
+      positioning={{ placement: position, ...(offset && { offset }) }}
       onOpenChange={
         onOpen || onClose
           ? ({ open }) => {
@@ -126,11 +100,7 @@ export const Tooltip = ({
       <Portal>
         <ArkTooltip.Positioner className={positionerStyles}>
           <ArkTooltip.Content
-            className={cx(
-              contentBaseStyles,
-              variant === "dark" ? darkContentStyles : lightContentStyles,
-              className,
-            )}
+            className={cx(contentStyles({ variant }), className)}
           >
             {content}
           </ArkTooltip.Content>

--- a/libs/@hashintel/ds-components/src/components/Tooltip/tooltip.tsx
+++ b/libs/@hashintel/ds-components/src/components/Tooltip/tooltip.tsx
@@ -12,6 +12,21 @@ import {
 
 type Direction = "bottom" | "top" | "left" | "right";
 type Position = Direction | `${Direction}-${"start" | "end"}`;
+type Delay = "fast" | "medium" | "slow" | "none";
+
+const openDelayMsMap = {
+  none: 0,
+  fast: 200,
+  medium: 500,
+  slow: 1000,
+};
+
+const closeDelayMsMap = {
+  none: 0,
+  fast: 100,
+  medium: 200,
+  slow: 300,
+};
 
 function isDomFocusable(el: HTMLElement): boolean {
   if (el.tabIndex < 0) {
@@ -39,8 +54,8 @@ export const Tooltip = ({
   position = "bottom",
   variant = "dark",
   disableTooltip,
-  openDelayMs = 300,
-  closeDelayMs = 150,
+  openDelay = "medium",
+  closeDelay = "medium",
   gapX = 8,
   gapY = 8,
   onOpen,
@@ -58,9 +73,9 @@ export const Tooltip = ({
   /** Whether to disable the tooltip */
   disableTooltip?: boolean;
   /** How long before the the tooltip is opened on hover/focus */
-  openDelayMs?: number;
+  openDelay?: Delay;
   /** How long before the the tooltip is opened when leaving hover/focus */
-  closeDelayMs?: number;
+  closeDelay?: Delay;
   /** The X distance the tooltip will be from the trigger in px */
   gapX?: number;
   /** The Y distance the tooltip will be from the trigger in px */
@@ -112,8 +127,8 @@ export const Tooltip = ({
 
   return (
     <ArkTooltip.Root
-      openDelay={openDelayMs}
-      closeDelay={closeDelayMs}
+      openDelay={openDelayMsMap[openDelay]}
+      closeDelay={closeDelayMsMap[closeDelay]}
       positioning={{ placement: position, offset }}
       onOpenChange={
         onOpen || onClose

--- a/libs/@hashintel/ds-components/src/main.ts
+++ b/libs/@hashintel/ds-components/src/main.ts
@@ -15,3 +15,4 @@ export {
 } from "./components/SegmentedControl/segmented-control";
 export { Slider, type SliderProps } from "./components/Slider/slider";
 export { Switch, type SwitchProps } from "./components/Switch/switch";
+export { Tooltip } from "./components/Tooltip/tooltip";


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Adds a tooltip component to the DS based on ark-ui. In addition to the tooltip features provided by ark-ui we also add logic to handle when a tooltip wraps both focusable and non-focusable elements - adding focus handlers when wrapping non-focusable content.

## Pre-Merge Checklist 🚀

This PR:

- [x] modifies an **npm**-publishable library and **I have added a changeset file(s)**

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change
