### PR TITLE
H-6450: Reduce space around entity headers

### DIFF
--- a/apps/hash-frontend/src/pages/entities.page.tsx
+++ b/apps/hash-frontend/src/pages/entities.page.tsx
@@ -341,7 +341,7 @@ const EntitiesPage: NextPageWithLayout = () => {
                   }
                 />
               )}
-              <Typography variant="h1" fontWeight="bold" my={3}>
+              <Typography variant="h1" fontWeight="bold">
                 {pageTitle}
               </Typography>
             </Stack>

--- a/apps/hash-frontend/src/pages/shared/entity/entity-header.tsx
+++ b/apps/hash-frontend/src/pages/shared/entity/entity-header.tsx
@@ -197,7 +197,7 @@ export const EntityHeader = ({
             </Box>
           </Stack>
           {showTabs && entityPath && (
-            <Box mt={7.5}>
+            <Box mt={3}>
               <EntityEditorTabs entityPath={entityPath} isInSlide={isInSlide} />
             </Box>
           )}

--- a/apps/hash-frontend/src/pages/shared/slide-stack.tsx
+++ b/apps/hash-frontend/src/pages/shared/slide-stack.tsx
@@ -78,20 +78,22 @@ const StackSlide = ({
           onClose={onClose}
         />
 
-        {item.kind === "dataType" && (
-          <DataTypeSlide dataTypeId={item.itemId} replaceItem={replaceItem} />
-        )}
-        {item.kind === "entityType" && (
-          <EntityTypeSlide replaceItem={replaceItem} typeUrl={item.itemId} />
-        )}
-        {item.kind === "entity" && (
-          <EntitySlide
-            {...item}
-            entityId={item.itemId}
-            removeItem={removeItem}
-            replaceItem={replaceItem}
-          />
-        )}
+        <Box sx={{ pt: 1, background: ({ palette }) => palette.common.white }}>
+          {item.kind === "dataType" && (
+            <DataTypeSlide dataTypeId={item.itemId} replaceItem={replaceItem} />
+          )}
+          {item.kind === "entityType" && (
+            <EntityTypeSlide replaceItem={replaceItem} typeUrl={item.itemId} />
+          )}
+          {item.kind === "entity" && (
+            <EntitySlide
+              {...item}
+              entityId={item.itemId}
+              removeItem={removeItem}
+              replaceItem={replaceItem}
+            />
+          )}
+        </Box>
       </Box>
     </Slide>
   );

--- a/apps/hash-frontend/src/pages/shared/slide-stack/slide-back-forward-close-bar.tsx
+++ b/apps/hash-frontend/src/pages/shared/slide-stack/slide-back-forward-close-bar.tsx
@@ -29,6 +29,7 @@ export const SlideBackForwardCloseBar = ({
         pointerEvents: "auto",
         pt: 1.5,
         pr: 3,
+        zIndex: 2,
       }}
     >
       <Box display="flex" justifyContent="space-between" gap={1}>

--- a/apps/hash-frontend/src/pages/shared/slide-stack/slide-back-forward-close-bar.tsx
+++ b/apps/hash-frontend/src/pages/shared/slide-stack/slide-back-forward-close-bar.tsx
@@ -22,29 +22,30 @@ export const SlideBackForwardCloseBar = ({
     <Box
       sx={{
         width: "100%",
-        position: "sticky",
+        position: "absolute",
         top: 0,
-        background: ({ palette }) => palette.common.white,
-        zIndex: 2,
+        display: "flex",
+        justifyContent: "flex-end",
+        pointerEvents: "auto",
+        pt: 1.5,
+        pr: 3,
       }}
     >
-      <Box pl={3} pr={4} py={1.5} display="flex" justifyContent="space-between">
-        <Box display="flex" justifyContent="space-between" gap={1}>
-          {(onBack ?? onForward) ? (
+      <Box display="flex" justifyContent="space-between" gap={1}>
+        {(onBack ?? onForward) ? (
+          <>
             <Tooltip title="Back" placement="bottom">
               <IconButton disabled={!onBack} onClick={onBack}>
                 <ArrowLeftIcon />
               </IconButton>
             </Tooltip>
-          ) : null}
-          {onForward ? (
             <Tooltip title="Forward" placement="bottom">
-              <IconButton onClick={onForward}>
+              <IconButton disabled={!onForward} onClick={onForward}>
                 <ArrowRightRegularIcon />
               </IconButton>
             </Tooltip>
-          ) : null}
-        </Box>
+          </>
+        ) : null}
         <Tooltip title="Close" placement="bottom">
           <IconButton onClick={onClose}>
             <CloseIcon />


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

There's a lot of white space around the header on both the entities page and on individual entity views.

I don't know how long this has been here but it takes up a lot of screen real estate at the expense of meaningful content. 

This PR reduces it (see difference below).

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->
<!-- Libraries inside of the `@local` directory are always internal libraries which have no need for publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 📹 Demo

### Previous

<img width="1540" height="859" alt="Screenshot 2026-05-07 at 18 35 23" src="https://github.com/user-attachments/assets/2013a266-94fc-426f-8681-3484a5397662" />

<img width="1540" height="861" alt="Screenshot 2026-05-07 at 18 35 30" src="https://github.com/user-attachments/assets/e15c5044-8866-4aa2-a78c-bf4a4c724865" />


### Now


<img width="1544" height="863" alt="Screenshot 2026-05-07 at 18 31 16" src="https://github.com/user-attachments/assets/be5fbc55-b43c-48ab-9730-e0142a5d8fe6" />


<img width="1541" height="867" alt="Screenshot 2026-05-07 at 18 31 39" src="https://github.com/user-attachments/assets/ee17ecd0-ffa3-4a3d-9c6f-9f766eacd433" />



<!-- Add a screenshot or video showcasing your work -->
