### PR TITLE
BE-562: Bundle CA certificates in `hash-graph` Docker image

### DIFF
--- a/apps/hash-graph/docker/Dockerfile
+++ b/apps/hash-graph/docker/Dockerfile
@@ -93,8 +93,9 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     fi && \
     rustup target add "$(uname -m)-unknown-linux-musl" && \
     cargo install --target "$(uname -m)-unknown-linux-musl" --path apps/hash-graph --root /tmp --profile $PROFILE --locked && \
-    mkdir -p /out/etc && \
+    mkdir -p /out/etc/ssl/certs && \
     cp /tmp/bin/hash-graph /out/hash-graph && \
+    cp /etc/ssl/certs/ca-certificates.crt /out/etc/ssl/certs/ca-certificates.crt && \
     echo 'graph:x:61000:60000:hash-graph:/:' > /out/etc/passwd && \
     echo 'hash:x:60000:' > /out/etc/group && \
     install -d -m 0775 -o 61000 -g 60000 /out/logs


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Fix a runtime panic in the `hash-graph` Docker image in AWS where Sentry initialisation fails because the `FROM scratch` runner image lacks a system CA trust store. After the recent `reqwest` 0.13 upgrade, `rustls-platform-verifier` is the only trust source available for the `rustls` feature, and it requires `/etc/ssl/certs/ca-certificates.crt` to exist on disk at runtime.

## 🔗 Related links

- Linear: BE-562 _(internal)_
- Trigger: #8672 (`reqwest` 0.13 upgrade)
- Underlying: `reqwest` 0.13 removed `rustls-tls-native-roots` / `rustls-tls-webpki-roots` features. `rustls-platform-verifier` is now a mandatory dep on every `rustls*` feature flag of `reqwest`; there is no opt-out.

## 🚫 Blocked by

- [ ] none

## 🔍 What does this change?

- Copy `/etc/ssl/certs/ca-certificates.crt` from the Debian-based builder stage into `/out/etc/ssl/certs/` so the final `FROM scratch` image has a system trust store available for `rustls-platform-verifier`.
- Image size grows by ~220 KB (the size of the CA bundle).
- Only `hash-graph` is affected — all other workload images (`hash-api`, `hash-frontend`, AI/integration workers) are based on full Debian images and already have `ca-certificates` installed.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

The panic message emitted by `sentry-0.47`'s reqwest transport is misleading — it claims a TLS backend feature is missing (`Enable either the native-tls or the rustls feature of the sentry crate`), but the actual cause is a missing system trust store. The features are correctly enabled; only the CA bundle is absent. Nothing to fix on our end.

## 🐾 Next steps

None planned. If future Rust workloads adopt the `FROM scratch` pattern, they will need the same two-line `COPY`.

## 🛡 What tests cover this?

No automated tests — Docker image content is not part of any CI test suite. Verified manually:

1. Built `hash-graph:repro` locally with this fix using `yarn build:docker:dev`.
2. Confirmed `/etc/ssl/certs/ca-certificates.crt` is present in the image (`docker export | tar -tv`).
3. Reproduced the original AWS panic on the fixed image by simulating the unfixed state via `docker run --tmpfs /etc/ssl/certs:size=1m ...` with `HASH_GRAPH_SENTRY_DSN` set — got the exact `Failed to build reqwest client ... No CA certificates were loaded from the system` panic.
4. Without the tmpfs override, Sentry transport builds successfully and the TLS handshake to `o0.ingest.sentry.io:443` completes (verified via `h2` debug logs); failure happens later on Postgres connect, which is expected.

## ❓ How to test this?

1. Check out the branch.
2. From `apps/hash-graph`, run `yarn build:docker:dev` (or `yarn build:docker` for release).
3. `docker run --rm -e HASH_GRAPH_SENTRY_DSN='https://aaa@o0.ingest.sentry.io/1' --entrypoint=/hash-graph hash-graph server` — should fail later on Postgres connect, **not** on the Sentry TLS panic.

## 📹 Demo

n/a