### PR TITLE
FE-715: Fix petrinaut react-compiler issues in dev build pipeline

### DIFF
--- a/libs/@hashintel/petrinaut/vite.config.ts
+++ b/libs/@hashintel/petrinaut/vite.config.ts
@@ -96,6 +96,15 @@ export default defineConfig(({ command }) => ({
 
     react(),
     babel({
+      // Default excludes node_modules. Also skip workspace `dist/` outputs:
+      // those are pre-bundled JSX → `jsx(tag, { ref, ... })` calls, and
+      // React Compiler flags the inlined `ref` prop as "Passing a ref to a
+      // function" (the rule fires for `jsx()` calls but not raw JSX).
+      exclude: [
+        /[\\/]node_modules[\\/]/,
+        /[\\/]libs[\\/]@hashintel[\\/][^\\/]+[\\/]dist[\\/]/,
+        /^0rolldown\/runtime\.js$/,
+      ],
       presets: [
         reactCompilerPreset({
           target: "19",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

React Compiler's `validateNoRefPassedToFunction` rule was firing on the bundled output of @hashintel/ds-components. The library's source uses standard JSX (<button ref={ref} ... />), which the compiler permits — but tsup (via esbuild) compiles JSX into explicit `jsx("button", { ref, ... })` calls - which causes `validateNoRefPassedToFunction` to fail.

Since Vite follows the workspace symlink from node_modules/@hashintel/ds-components to libs/@hashintel/ds-components/dist/, the default node_modules exclude didn't match and the babel plugin ran the compiler over the bundled output.

This fixes the issue by having react-compiler ignore the pre-built ds-components export.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change