### PR TITLE
FE-720(Refractive): Fix SSR issues by delaying rendering until dimensions available

### DIFF
--- a/.changeset/refractive-ssr-filter.md
+++ b/.changeset/refractive-ssr-filter.md
@@ -1,0 +1,5 @@
+---
+"@hashintel/refractive": patch
+---
+
+Fix SSR issues by only rendering browser-dependent Refractive filters on the client.

--- a/libs/@hashintel/refractive/src/hoc/refractive.tsx
+++ b/libs/@hashintel/refractive/src/hoc/refractive.tsx
@@ -41,6 +41,7 @@ function createRefractiveComponent<
     const internalRef = useRef<HTMLElement>(null);
     const [width, setWidth] = useState(0);
     const [height, setHeight] = useState(0);
+    const hasMeasuredElement = width > 0 && height > 0;
 
     // If a ref is passed in props, use it; otherwise, use internalRef.
     // If the passed ref is updated later, it will trigger a re-render.
@@ -77,21 +78,23 @@ function createRefractiveComponent<
 
     return (
       <>
-        <Filter
-          id={filterId}
-          scaleRatio={1} // Always 1 for now, could be animatable in the future
-          pixelRatio={6} // Always 6 for now, could be configurable in the future
-          width={width}
-          height={height}
-          radius={refraction.radius}
-          blur={refraction.blur ?? 0}
-          glassThickness={refraction.glassThickness ?? 70}
-          bezelWidth={refraction.bezelWidth ?? 0}
-          refractiveIndex={refraction.refractiveIndex ?? 1.5}
-          specularOpacity={refraction.specularOpacity ?? 0}
-          specularAngle={refraction.specularAngle ?? 0}
-          bezelHeightFn={refraction.bezelHeightFn ?? convex}
-        />
+        {hasMeasuredElement ? (
+          <Filter
+            id={filterId}
+            scaleRatio={1} // Always 1 for now, could be animatable in the future
+            pixelRatio={6} // Always 6 for now, could be configurable in the future
+            width={width}
+            height={height}
+            radius={refraction.radius}
+            blur={refraction.blur ?? 0}
+            glassThickness={refraction.glassThickness ?? 70}
+            bezelWidth={refraction.bezelWidth ?? 0}
+            refractiveIndex={refraction.refractiveIndex ?? 1.5}
+            specularOpacity={refraction.specularOpacity ?? 0}
+            specularAngle={refraction.specularAngle ?? 0}
+            bezelHeightFn={refraction.bezelHeightFn ?? convex}
+          />
+        ) : null}
 
         {/* @ts-expect-error Need to fix types in this file */}
         <Component
@@ -99,7 +102,9 @@ function createRefractiveComponent<
           ref={elementRef}
           style={{
             ...componentProps.style,
-            backdropFilter: `url(#${filterId})`,
+            ...(hasMeasuredElement
+              ? { backdropFilter: `url(#${filterId})` }
+              : undefined),
             borderRadius: refraction.radius,
           }}
         />


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Fix `@hashintel/refractive` SSR crashes in Next.js by avoiding browser-only SVG filter rendering until the component has mounted on the client and its element dimensions are known.

## 🔗 Related links

- Fixes https://github.com/hashintel/hash/issues/8612

## 🔍 What does this change?

- Defers Refractive filter generation until client-side element measurement reports non-zero dimensions.
- Avoids applying the SVG `backdrop-filter` URL until the corresponding filter exists.
- Adds a patch changeset for `@hashintel/refractive`.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] modifies an **npm**-publishable library and **I have added a changeset file(s)**

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- `yarn workspace @hashintel/refractive lint:tsc`
- `yarn workspace @hashintel/refractive build`
- SSR smoke test with `react-dom/server`

## ❓ How to test this?

1. Render a Refractive component in a Next.js SSR route.
2. Confirm the server render does not throw `ImageData is not defined`.
3. Confirm the refractive filter appears after client hydration and measurement.
