### PR TITLE
FE-726: generate ds-helpers styled-system before publishing

### DIFF
--- a/.changeset/clean-pumas-help.md
+++ b/.changeset/clean-pumas-help.md
@@ -1,0 +1,5 @@
+---
+"@hashintel/ds-helpers": patch
+---
+
+Publish the generated `styled-system` files in the package tarball.

--- a/libs/@hashintel/ds-helpers/AGENTS.md
+++ b/libs/@hashintel/ds-helpers/AGENTS.md
@@ -34,7 +34,8 @@ css(), cva(), token(), jsx runtime for consumers
 
 Boundary rules:
 
-- never add a dependency edge from `ds-helpers` back to `ds-components`
+- never add a runtime or package-manager dependency edge from `ds-helpers` back to `ds-components`
+- build orchestration may invoke `ds-components` codegen to materialize `styled-system/**`, but `ds-components` remains the source owner
 - never move source-of-truth token or preset code into this package
 - if you need to regenerate this package, run `yarn workspace @hashintel/ds-components codegen`
 

--- a/libs/@hashintel/ds-helpers/package.json
+++ b/libs/@hashintel/ds-helpers/package.json
@@ -52,5 +52,9 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "codegen": "true",
+    "prepack": "turbo run codegen --filter @hashintel/ds-helpers >&2"
   }
 }

--- a/libs/@hashintel/ds-helpers/package.json
+++ b/libs/@hashintel/ds-helpers/package.json
@@ -54,7 +54,7 @@
     "access": "public"
   },
   "scripts": {
-    "codegen": "node -e \"process.exit(0)\"",
+    "codegen": "true",
     "prepack": "turbo run codegen --filter @hashintel/ds-helpers"
   }
 }

--- a/libs/@hashintel/ds-helpers/package.json
+++ b/libs/@hashintel/ds-helpers/package.json
@@ -55,6 +55,6 @@
   },
   "scripts": {
     "codegen": "node -e \"process.exit(0)\"",
-    "prepack": "node -e \"const { spawnSync } = require('node:child_process'); const result = spawnSync('turbo', ['run', 'codegen', '--filter', '@hashintel/ds-helpers'], { shell: process.platform === 'win32', stdio: ['ignore', 'pipe', 'inherit'] }); if (result.stdout) process.stderr.write(result.stdout); process.exit(result.status ?? 1);\""
+    "prepack": "turbo run codegen --filter @hashintel/ds-helpers"
   }
 }

--- a/libs/@hashintel/ds-helpers/package.json
+++ b/libs/@hashintel/ds-helpers/package.json
@@ -54,7 +54,7 @@
     "access": "public"
   },
   "scripts": {
-    "codegen": "true",
+    "codegen": "node -e \"process.exit(0)\"",
     "prepack": "turbo run codegen --filter @hashintel/ds-helpers"
   }
 }

--- a/libs/@hashintel/ds-helpers/package.json
+++ b/libs/@hashintel/ds-helpers/package.json
@@ -54,7 +54,7 @@
     "access": "public"
   },
   "scripts": {
-    "codegen": "true",
-    "prepack": "turbo run codegen --filter @hashintel/ds-helpers >&2"
+    "codegen": "node -e \"process.exit(0)\"",
+    "prepack": "node -e \"const { spawnSync } = require('node:child_process'); const result = spawnSync('turbo', ['run', 'codegen', '--filter', '@hashintel/ds-helpers'], { shell: process.platform === 'win32', stdio: ['ignore', 'pipe', 'inherit'] }); if (result.stdout) process.stderr.write(result.stdout); process.exit(result.status ?? 1);\""
   }
 }

--- a/libs/@hashintel/ds-helpers/turbo.json
+++ b/libs/@hashintel/ds-helpers/turbo.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://turborepo.org/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "dependsOn": []
+    },
+    "codegen": {
+      "cache": false,
+      "dependsOn": ["@hashintel/ds-components#codegen"],
+      "outputs": ["styled-system/**"]
+    }
+  }
+}

--- a/libs/@hashintel/ds-helpers/turbo.json
+++ b/libs/@hashintel/ds-helpers/turbo.json
@@ -6,8 +6,13 @@
       "dependsOn": []
     },
     "codegen": {
-      "cache": false,
       "dependsOn": ["@hashintel/ds-components#codegen"],
+      "inputs": [
+        "package.json",
+        "turbo.json",
+        "../ds-components/panda.config.ts",
+        "../ds-components/src/**"
+      ],
       "outputs": ["styled-system/**"]
     }
   }

--- a/libs/@hashintel/ds-helpers/turbo.json
+++ b/libs/@hashintel/ds-helpers/turbo.json
@@ -2,6 +2,10 @@
   "$schema": "https://turborepo.org/schema.json",
   "extends": ["//"],
   "tasks": {
+    // Override the root `build -> codegen` dependency for this generated
+    // artifact package. Without this, `ds-helpers#codegen ->
+    // ds-components#codegen -> ds-helpers#build -> ds-helpers#codegen`
+    // forms a cycle, because `ds-components#codegen` depends on `^build`.
     "build": {
       "dependsOn": []
     },

--- a/libs/@hashintel/ds-helpers/turbo.json
+++ b/libs/@hashintel/ds-helpers/turbo.json
@@ -10,13 +10,22 @@
       "dependsOn": []
     },
     "codegen": {
+      // `ds-helpers` owns no source codegen; `ds-components` is the source
+      // package whose Panda config writes `../ds-helpers/styled-system`.
+      // This edge makes `turbo run codegen --filter @hashintel/ds-helpers`
+      // materialize the publishable generated artifact before packing.
       "dependsOn": ["@hashintel/ds-components#codegen"],
+      // Cache key inputs are the package metadata plus the source package files
+      // that control generated styled-system output. The generated output itself
+      // remains ignored by git and is restored by Turbo from `outputs` below.
       "inputs": [
         "package.json",
         "turbo.json",
         "../ds-components/panda.config.ts",
         "../ds-components/src/**"
       ],
+      // `styled-system/**` is the only publishable artifact this package needs
+      // to regenerate before `npm pack`/`npm publish`.
       "outputs": ["styled-system/**"]
     }
   }

--- a/libs/@hashintel/ds-helpers/turbo.json
+++ b/libs/@hashintel/ds-helpers/turbo.json
@@ -16,12 +16,15 @@
       // materialize the publishable generated artifact before packing.
       "dependsOn": ["@hashintel/ds-components#codegen"],
       // Cache key inputs are the package metadata plus the source package files
-      // that control generated styled-system output. The generated output itself
-      // remains ignored by git and is restored by Turbo from `outputs` below.
+      // and scripts that control generated styled-system output. The generated
+      // output itself remains ignored by git and is restored by Turbo from
+      // `outputs` below.
       "inputs": [
         "package.json",
         "turbo.json",
+        "../ds-components/package.json",
         "../ds-components/panda.config.ts",
+        "../ds-components/scripts/**",
         "../ds-components/src/**"
       ],
       // `styled-system/**` is the only publishable artifact this package needs


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Ensure the generated Panda `styled-system/` files are present in the `@hashintel/ds-helpers` npm tarball when the package is packed/published, without committing that generated output to git.

This fixes the broken `@hashintel/ds-helpers@0.2.0` package shape reported in FE-726, where the published tarball included export paths pointing at `styled-system/` but omitted the generated directory itself.

## 🔗 Related links

- Fixes https://github.com/hashintel/hash/issues/8719
- https://linear.app/hash/issue/FE-726/user-report-hashintelds-helpers020-published-tarball-is-missing-the _(internal)_

## 🚫 Blocked by

- Not blocked

## 🔍 What does this change?

- Adds a `prepack` script to `@hashintel/ds-helpers` so packaging runs Turbo codegen before npm assembles the tarball.
- Adds a no-op `codegen` script for `@hashintel/ds-helpers`, making it addressable in the Turbo graph.
- Adds `libs/@hashintel/ds-helpers/turbo.json` so `ds-helpers#codegen` depends on `@hashintel/ds-components#codegen`, which is the source-owned generator that writes `../ds-helpers/styled-system`.
- Overrides `ds-helpers#build` locally to avoid a Turbo dependency cycle while preserving `styled-system/` as generated, gitignored output.
- Adds a patch changeset for `@hashintel/ds-helpers`.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] modifies an **npm**-publishable library and **I have added a changeset file(s)**

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] affected the execution graph, and the `turbo.json`'s have been updated to reflect this

## ⚠️ Known issues

The already-published `@hashintel/ds-helpers@0.2.0` tarball cannot be changed in place; this will publish a patched package version with the generated files included.

## 🐾 Next steps

After merge, publish the changeset release for `@hashintel/ds-helpers` so consumers can upgrade to the fixed package version.

## 🛡 What tests cover this?

- Manual package verification with `npm pack --dry-run --json` from `libs/@hashintel/ds-helpers`, after deleting local `styled-system/`.
- Manual Turbo verification with `turbo run codegen --filter @hashintel/ds-helpers`.

## ❓ How to test this?

1. Remove any local generated output: `rm -rf libs/@hashintel/ds-helpers/styled-system`
2. Run: `cd libs/@hashintel/ds-helpers && npm pack --dry-run --json`
3. Confirm `prepack` runs `turbo run codegen --filter @hashintel/ds-helpers`.
4. Confirm the pack output includes `styled-system/` files, e.g. `styled-system/css/index.mjs` and `styled-system/tokens/index.mjs`.

## 📹 Demo

N/A — packaging fix only.
