### PR TITLE
BE-572: User email management improvements

### DIFF
--- a/apps/hash-api/src/auth/create-auth-handlers.ts
+++ b/apps/hash-api/src/auth/create-auth-handlers.ts
@@ -163,7 +163,10 @@ export const getUserAndSession = async ({
         ({ value }) => value === primaryEmailAddress,
       )?.verified === true;
 
-    let user = await getUser(context, authentication, { kratosIdentityId });
+    let user = await getUser(context, authentication, {
+      kratosIdentityId,
+      emails: traits.emails,
+    });
 
     if (!user) {
       const hashInstance = await getHashInstance(context, authentication);

--- a/apps/hash-api/src/auth/create-auth-handlers.ts
+++ b/apps/hash-api/src/auth/create-auth-handlers.ts
@@ -163,10 +163,7 @@ export const getUserAndSession = async ({
         ({ value }) => value === primaryEmailAddress,
       )?.verified === true;
 
-    let user = await getUser(context, authentication, {
-      kratosIdentityId,
-      emails: traits.emails,
-    });
+    let user = await getUser(context, authentication, { kratosIdentityId });
 
     if (!user) {
       const hashInstance = await getHashInstance(context, authentication);

--- a/apps/hash-api/src/auth/ory-kratos.ts
+++ b/apps/hash-api/src/auth/ory-kratos.ts
@@ -24,6 +24,13 @@ export type KratosUserIdentity = Omit<Identity, "traits"> & {
   traits: KratosUserIdentityTraits;
 };
 
+export const getVerifiedEmailsFromKratosIdentity = (
+  identity: Pick<Identity, "verifiable_addresses">,
+): string[] =>
+  (identity.verifiable_addresses ?? [])
+    .filter((address) => address.verified === true)
+    .map(({ value }) => value);
+
 export const createKratosIdentity = async (
   params: Omit<CreateIdentityBody, "schema_id" | "traits"> & {
     traits: KratosUserIdentityTraits;
@@ -76,9 +83,7 @@ export const isUserEmailVerified = async (
     id: kratosIdentityId,
   });
 
-  return (
-    identity.verifiable_addresses?.some(({ verified }) => verified) ?? false
-  );
+  return getVerifiedEmailsFromKratosIdentity(identity).length > 0;
 };
 
 /**

--- a/apps/hash-api/src/graph/knowledge/primitive/entity/before-update-entity-hooks/user-before-update-entity-hook-callback.ts
+++ b/apps/hash-api/src/graph/knowledge/primitive/entity/before-update-entity-hooks/user-before-update-entity-hook-callback.ts
@@ -213,9 +213,9 @@ export const userBeforeEntityUpdateHookCallback: BeforeUpdateEntityHookCallback 
         );
       }
 
-      const allowedEmails = accessResult.allowedEmails ?? [];
+      const onlyForEmails = accessResult.onlyForEmails ?? [];
 
-      if (allowedEmails.length > 0) {
+      if (onlyForEmails.length > 0) {
         const verifiedEmails = await getUserVerifiedEmails(
           context,
           authentication,
@@ -224,7 +224,7 @@ export const userBeforeEntityUpdateHookCallback: BeforeUpdateEntityHookCallback 
           },
         );
 
-        if (!allowedEmails.some((email) => verifiedEmails.includes(email))) {
+        if (!onlyForEmails.some((email) => verifiedEmails.includes(email))) {
           throw Error.forbidden(
             "You must verify your email address before completing account setup.",
           );

--- a/apps/hash-api/src/graph/knowledge/primitive/entity/before-update-entity-hooks/user-before-update-entity-hook-callback.ts
+++ b/apps/hash-api/src/graph/knowledge/primitive/entity/before-update-entity-hooks/user-before-update-entity-hook-callback.ts
@@ -20,7 +20,6 @@ import {
 import type { UserProperties } from "@local/hash-isomorphic-utils/system-types/user";
 import { GraphQLError } from "graphql";
 
-import { isUserEmailVerified } from "../../../../../auth/ory-kratos";
 import * as Error from "../../../../../graphql/error";
 import { userHasAccessToHash } from "../../../../../shared/user-has-access-to-hash";
 import type { ImpureGraphContext } from "../../../../context-types";
@@ -32,7 +31,10 @@ import {
   shortnameMaximumLength,
   shortnameMinimumLength,
 } from "../../../system-types/account.fields";
-import { getUserFromEntity } from "../../../system-types/user";
+import {
+  getUserFromEntity,
+  getUserVerifiedEmails,
+} from "../../../system-types/user";
 import type { BeforeUpdateEntityHookCallback } from "../update-entity-hooks";
 
 /**
@@ -199,16 +201,34 @@ export const userBeforeEntityUpdateHookCallback: BeforeUpdateEntityHookCallback 
        * we need to forbid them from completing account signup
        * and prevent them from receiving ownership of the web.
        */
-      if (!(await userHasAccessToHash(context, authentication, user))) {
+      const accessResult = await userHasAccessToHash(
+        context,
+        authentication,
+        user,
+      );
+
+      if (!accessResult.allowed) {
         throw Error.forbidden(
           "The user does not have access to the HASH instance, and therefore cannot complete account signup.",
         );
       }
 
-      if (!(await isUserEmailVerified(user.kratosIdentityId))) {
-        throw Error.forbidden(
-          "You must verify your email address before completing account setup.",
+      const allowedEmails = accessResult.allowedEmails ?? [];
+
+      if (allowedEmails.length > 0) {
+        const verifiedEmails = await getUserVerifiedEmails(
+          context,
+          authentication,
+          {
+            user,
+          },
         );
+
+        if (!allowedEmails.some((email) => verifiedEmails.includes(email))) {
+          throw Error.forbidden(
+            "You must verify your email address before completing account setup.",
+          );
+        }
       }
 
       if (!updatedShortname || !updatedDisplayName) {

--- a/apps/hash-api/src/graph/knowledge/primitive/entity/before-update-entity-hooks/user-before-update-entity-hook-callback.ts
+++ b/apps/hash-api/src/graph/knowledge/primitive/entity/before-update-entity-hooks/user-before-update-entity-hook-callback.ts
@@ -20,6 +20,7 @@ import {
 import type { UserProperties } from "@local/hash-isomorphic-utils/system-types/user";
 import { GraphQLError } from "graphql";
 
+import { isUserEmailVerified } from "../../../../../auth/ory-kratos";
 import * as Error from "../../../../../graphql/error";
 import { userHasAccessToHash } from "../../../../../shared/user-has-access-to-hash";
 import type { ImpureGraphContext } from "../../../../context-types";
@@ -229,6 +230,10 @@ export const userBeforeEntityUpdateHookCallback: BeforeUpdateEntityHookCallback 
             "You must verify your email address before completing account setup.",
           );
         }
+      } else if (!(await isUserEmailVerified(user.kratosIdentityId))) {
+        throw Error.forbidden(
+          "You must verify your email address before completing account setup.",
+        );
       }
 
       if (!updatedShortname || !updatedDisplayName) {

--- a/apps/hash-api/src/graph/knowledge/system-types/user.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/user.ts
@@ -42,7 +42,10 @@ import type {
   KratosUserIdentity,
   KratosUserIdentityTraits,
 } from "../../../auth/ory-kratos";
-import { kratosIdentityApi } from "../../../auth/ory-kratos";
+import {
+  getVerifiedEmailsFromKratosIdentity,
+  kratosIdentityApi,
+} from "../../../auth/ory-kratos";
 import { getPendingOrgInvitationsFromSubgraph } from "../../../graphql/resolvers/knowledge/org/shared";
 import { logger } from "../../../logger";
 import type {
@@ -127,21 +130,46 @@ const getEmailsFromKratos = async (
   }
 };
 
+export const getUserVerifiedEmails: ImpureGraphFunction<
+  { user: User },
+  Promise<string[]>
+> = async (_, __, { user }) => {
+  const { data: identity } = await kratosIdentityApi.getIdentity({
+    id: user.kratosIdentityId,
+  });
+
+  return getVerifiedEmailsFromKratosIdentity(identity);
+};
+
 /**
- * Lookup a Kratos identity by email address.
- * Returns the kratosIdentityId if found, null otherwise.
+ * For a given email address, check if it is associated with a Kratos identity,
+ * and if so if it is verified.
  */
-const getKratosIdentityIdByEmail = async (
+export const checkEmailVerificationAndUsageStatus = async (
   email: string,
-): Promise<string | null> => {
+): Promise<
+  | { status: "email-not-found" }
+  | { status: "verified"; kratosIdentityId: string }
+  | { status: "not-verified"; kratosIdentityId: string }
+> => {
   try {
     const { data: identities } = await kratosIdentityApi.listIdentities({
       credentialsIdentifier: email,
     });
-    return identities.length > 0 ? identities[0]!.id : null;
+
+    if (identities.length === 0) {
+      return { status: "email-not-found" };
+    }
+
+    const verifiedEmails = getVerifiedEmailsFromKratosIdentity(identities[0]!);
+    if (verifiedEmails.includes(email)) {
+      return { status: "verified", kratosIdentityId: identities[0]!.id };
+    } else {
+      return { status: "not-verified", kratosIdentityId: identities[0]!.id };
+    }
   } catch (error) {
     logger.warn("Failed to lookup Kratos identity", { email, error });
-    return null;
+    return { status: "email-not-found" };
   }
 };
 
@@ -180,41 +208,29 @@ export const getUserFromEntity: PureGraphFunction<
 };
 
 /**
- * Get a user by any available identifier.
+ * Get a user by a stable identifier.
  * Emails are always fetched from Kratos (the source of truth) since DB-level
  * masking hides them from non-owners.
  *
  * @param params.entityId - the entity id of the user
  * @param params.shortname - the shortname of the user
  * @param params.kratosIdentityId - the kratos identity id of the user
- * @param params.emails - the emails of the user
  */
 export const getUser: ImpureGraphFunction<
   | {
       entityId: EntityId;
-      emails?: [string, ...string[]];
     }
   | {
       shortname: string;
-      emails?: [string, ...string[]];
-      includeDrafts?: boolean;
     }
   | {
       kratosIdentityId: string;
-      emails?: [string, ...string[]];
-      includeDrafts?: boolean;
-    }
-  | {
-      emails: [string, ...string[]];
-      kratosIdentityId?: string;
-      includeDrafts?: boolean;
     },
   Promise<User | null>
 > = async (context, authentication, params) => {
   const knownShortname = "shortname" in params ? params.shortname : null;
 
-  let emails = params.emails;
-  let kratosIdentityId =
+  const kratosIdentityId =
     "kratosIdentityId" in params ? params.kratosIdentityId : null;
 
   let entity: HashEntity<UserEntity>;
@@ -234,14 +250,6 @@ export const getUser: ImpureGraphFunction<
     }
   } else {
     let queryFilter: Filter;
-
-    if (emails && !kratosIdentityId && !knownShortname) {
-      // If we would have the shortname, we could use it to find the user, but we don't have it so we use the email to find the kratos Identity ID.
-      kratosIdentityId = await getKratosIdentityIdByEmail(emails[0]);
-      if (!kratosIdentityId) {
-        return null;
-      }
-    }
 
     if (kratosIdentityId) {
       queryFilter = {
@@ -284,7 +292,7 @@ export const getUser: ImpureGraphFunction<
         ],
       },
       temporalAxes: currentTimeInstantTemporalAxes,
-      includeDrafts: !!params.includeDrafts,
+      includeDrafts: false,
       includePermissions: false,
     });
 
@@ -301,7 +309,7 @@ export const getUser: ImpureGraphFunction<
     entity = userEntity;
   }
 
-  emails ??= atLeastOne(
+  const emails = atLeastOne(
     await getEmailsFromKratos(
       entity.properties[
         "https://hash.ai/@h/types/property-type/kratos-identity-id/"
@@ -369,7 +377,6 @@ export const createUser: ImpureGraphFunction<
 
   const existingUserWithKratosIdentityId = await getUser(ctx, authentication, {
     kratosIdentityId,
-    emails,
   });
 
   if (existingUserWithKratosIdentityId) {
@@ -625,7 +632,7 @@ export const isUserMemberOfOrg: ImpureGraphFunction<
 export const getUserPendingInvitations: ImpureGraphFunction<
   { user: User },
   Promise<PendingOrgInvitation[]>
-> = async (context, _authentication, { user }) => {
+> = async (context, authentication, { user }) => {
   /**
    * The system account is used to manage invitations on behalf of the user,
    * because the user does not have permissions on them,
@@ -636,6 +643,13 @@ export const getUserPendingInvitations: ImpureGraphFunction<
   const systemAccountAuthentication = {
     actorId: systemAccountId,
   };
+  const verifiedEmails = await getUserVerifiedEmails(context, authentication, {
+    user,
+  });
+
+  if (verifiedEmails.length === 0 && !user.shortname) {
+    return [];
+  }
 
   const { subgraph: invitationSubgraph } = await queryEntitySubgraph(
     context,
@@ -657,20 +671,17 @@ export const getUserPendingInvitations: ImpureGraphFunction<
           },
           {
             any: [
-              {
+              ...verifiedEmails.map((email) => ({
                 equal: [
                   {
-                    /**
-                     * @todo H-4936 update when users can have more than one email
-                     */
                     path: [
                       "properties",
                       systemPropertyTypes.email.propertyTypeBaseUrl,
                     ],
                   },
-                  { parameter: user.emails[0] },
+                  { parameter: email },
                 ],
-              },
+              })),
               ...(user.shortname
                 ? [
                     {

--- a/apps/hash-api/src/graph/knowledge/system-types/user.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/user.ts
@@ -634,7 +634,7 @@ export const isUserMemberOfOrg: ImpureGraphFunction<
 export const getUserPendingInvitations: ImpureGraphFunction<
   { user: User },
   Promise<PendingOrgInvitation[]>
-> = async (context, authentication, { user }) => {
+> = async (context, _authentication, { user }) => {
   /**
    * The system account is used to manage invitations on behalf of the user,
    * because the user does not have permissions on them,
@@ -645,13 +645,6 @@ export const getUserPendingInvitations: ImpureGraphFunction<
   const systemAccountAuthentication = {
     actorId: systemAccountId,
   };
-  const verifiedEmails = await getUserVerifiedEmails(context, authentication, {
-    user,
-  });
-
-  if (verifiedEmails.length === 0 && !user.shortname) {
-    return [];
-  }
 
   const { subgraph: invitationSubgraph } = await queryEntitySubgraph(
     context,
@@ -673,7 +666,7 @@ export const getUserPendingInvitations: ImpureGraphFunction<
           },
           {
             any: [
-              ...verifiedEmails.map((email) => ({
+              ...user.emails.map((email) => ({
                 equal: [
                   {
                     path: [

--- a/apps/hash-api/src/graph/knowledge/system-types/user.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/user.ts
@@ -225,11 +225,13 @@ export const getUser: ImpureGraphFunction<
     }
   | {
       kratosIdentityId: string;
+      emails?: [string, ...string[]];
     },
   Promise<User | null>
 > = async (context, authentication, params) => {
   const knownShortname = "shortname" in params ? params.shortname : null;
 
+  let emails = "emails" in params ? params.emails : undefined;
   const kratosIdentityId =
     "kratosIdentityId" in params ? params.kratosIdentityId : null;
 
@@ -309,7 +311,7 @@ export const getUser: ImpureGraphFunction<
     entity = userEntity;
   }
 
-  const emails = atLeastOne(
+  emails ??= atLeastOne(
     await getEmailsFromKratos(
       entity.properties[
         "https://hash.ai/@h/types/property-type/kratos-identity-id/"

--- a/apps/hash-api/src/graphql/resolvers/knowledge/org/accept-org-invitation.ts
+++ b/apps/hash-api/src/graphql/resolvers/knowledge/org/accept-org-invitation.ts
@@ -17,6 +17,7 @@ import {
   type Org,
 } from "../../../../graph/knowledge/system-types/org";
 import {
+  getUserVerifiedEmails,
   isUserMemberOfOrg,
   joinOrg,
 } from "../../../../graph/knowledge/system-types/user";
@@ -65,7 +66,15 @@ export const acceptOrgInvitationResolver: ResolverFn<
   let isForUser: boolean;
 
   if (isInvitationByEmail(invitation)) {
-    isForUser = user.emails.includes(
+    const verifiedEmails = await getUserVerifiedEmails(
+      context,
+      graphQLContext.authentication,
+      {
+        user,
+      },
+    );
+
+    isForUser = verifiedEmails.includes(
       invitation.properties["https://hash.ai/@h/types/property-type/email/"],
     );
   } else if (isInvitationByShortname(invitation)) {

--- a/apps/hash-api/src/graphql/resolvers/knowledge/org/decline-org-invitation.ts
+++ b/apps/hash-api/src/graphql/resolvers/knowledge/org/decline-org-invitation.ts
@@ -1,6 +1,7 @@
 import type { MutationDeclineOrgInvitationArgs } from "@local/hash-isomorphic-utils/graphql/api-types.gen";
 
 import { getLatestEntityRootedSubgraph } from "../../../../graph/knowledge/primitive/entity";
+import { getUserVerifiedEmails } from "../../../../graph/knowledge/system-types/user";
 import { systemAccountId } from "../../../../graph/system-account";
 import type { ResolverFn } from "../../../api-types.gen";
 import type { LoggedInGraphQLContext } from "../../../context";
@@ -63,7 +64,15 @@ export const declineOrgInvitationResolver: ResolverFn<
   }
 
   if ("email" in invitation) {
-    if (!user.emails.includes(invitation.email)) {
+    const verifiedEmails = await getUserVerifiedEmails(
+      context,
+      graphQLContext.authentication,
+      {
+        user,
+      },
+    );
+
+    if (!verifiedEmails.includes(invitation.email)) {
       throw Error.notFound("Invitation for user not found");
     }
   } else if ("shortname" in invitation) {

--- a/apps/hash-api/src/graphql/resolvers/knowledge/org/invite-user-to-org.ts
+++ b/apps/hash-api/src/graphql/resolvers/knowledge/org/invite-user-to-org.ts
@@ -37,6 +37,7 @@ import {
   type Org,
 } from "../../../../graph/knowledge/system-types/org";
 import {
+  checkEmailVerificationAndUsageStatus,
   getUser,
   isUserMemberOfOrg,
   type User,
@@ -166,9 +167,22 @@ export const inviteUserToOrgResolver: ResolverFn<
   let existingUserToInvite: User | null = null;
 
   if (userEmail) {
-    existingUserToInvite = await getUser(context, authentication, {
-      emails: [userEmail],
-    });
+    const emailCheckResult =
+      await checkEmailVerificationAndUsageStatus(userEmail);
+
+    if (emailCheckResult.status === "verified") {
+      const existingUser = await getUser(context, authentication, {
+        kratosIdentityId: emailCheckResult.kratosIdentityId,
+      });
+
+      if (existingUser) {
+        existingUserToInvite = existingUser;
+      } else {
+        throw Error.notFound(`User with email ${userEmail} not found`);
+      }
+    } else if (emailCheckResult.status === "not-verified") {
+      throw Error.badRequest("User must verify their email address first.");
+    }
   } else if (userShortname) {
     existingUserToInvite = await getUser(context, authentication, {
       shortname: userShortname,

--- a/apps/hash-api/src/graphql/resolvers/knowledge/org/invite-user-to-org.ts
+++ b/apps/hash-api/src/graphql/resolvers/knowledge/org/invite-user-to-org.ts
@@ -159,12 +159,20 @@ export const inviteUserToOrgResolver: ResolverFn<
   Record<string, never>,
   LoggedInGraphQLContext,
   MutationInviteUserToOrgArgs
-> = async (_, { userEmail, userShortname, orgWebId }, graphQLContext) => {
+> = async (
+  _,
+  { userEmail: unnormalisedUserEmail, userShortname, orgWebId },
+  graphQLContext,
+) => {
   const { authentication } = graphQLContext;
 
   const context = graphQLContextToImpureGraphContext(graphQLContext);
 
   let existingUserToInvite: User | null = null;
+
+  const userEmail = unnormalisedUserEmail
+    ? unnormalisedUserEmail.trim().toLowerCase()
+    : null;
 
   if (userEmail) {
     const emailCheckResult =

--- a/apps/hash-api/src/graphql/resolvers/knowledge/org/invite-user-to-org.ts
+++ b/apps/hash-api/src/graphql/resolvers/knowledge/org/invite-user-to-org.ts
@@ -170,7 +170,7 @@ export const inviteUserToOrgResolver: ResolverFn<
     const emailCheckResult =
       await checkEmailVerificationAndUsageStatus(userEmail);
 
-    if (emailCheckResult.status === "verified") {
+    if (emailCheckResult.status !== "email-not-found") {
       const existingUser = await getUser(context, authentication, {
         kratosIdentityId: emailCheckResult.kratosIdentityId,
       });
@@ -180,8 +180,6 @@ export const inviteUserToOrgResolver: ResolverFn<
       } else {
         throw Error.notFound(`User with email ${userEmail} not found`);
       }
-    } else if (emailCheckResult.status === "not-verified") {
-      throw Error.badRequest("User must verify their email address first.");
     }
   } else if (userShortname) {
     existingUserToInvite = await getUser(context, authentication, {

--- a/apps/hash-api/src/graphql/resolvers/knowledge/user/has-access-to-hash.ts
+++ b/apps/hash-api/src/graphql/resolvers/knowledge/user/has-access-to-hash.ts
@@ -9,9 +9,11 @@ export const hasAccessToHashResolver: ResolverFn<
   GraphQLContext,
   Record<string, never>
 > = async (_, __, context) => {
-  return userHasAccessToHash(
-    graphQLContextToImpureGraphContext(context),
-    context.authentication,
-    context.user ?? null,
-  );
+  return (
+    await userHasAccessToHash(
+      graphQLContextToImpureGraphContext(context),
+      context.authentication,
+      context.user ?? null,
+    )
+  ).allowed;
 };

--- a/apps/hash-api/src/shared/user-has-access-to-hash.ts
+++ b/apps/hash-api/src/shared/user-has-access-to-hash.ts
@@ -47,7 +47,11 @@ export const userHasAccessToHash = async (
   context: ImpureGraphContext,
   authentication: AuthenticationContext,
   user: User | null,
-): Promise<{ allowed: boolean; allowedEmails?: string[] }> => {
+): Promise<{
+  allowed: boolean;
+  /** If present, the user is allowed access only with respect to these emails */
+  onlyForEmails?: string[];
+}> => {
   if (!user) {
     return { allowed: false };
   }
@@ -68,7 +72,7 @@ export const userHasAccessToHash = async (
   );
 
   if (allowedEmails.length > 0) {
-    return { allowed: true, allowedEmails };
+    return { allowed: true, onlyForEmails: allowedEmails };
   }
 
   const pendingInvitations = await getUserPendingInvitations(

--- a/apps/hash-api/src/shared/user-has-access-to-hash.ts
+++ b/apps/hash-api/src/shared/user-has-access-to-hash.ts
@@ -47,24 +47,28 @@ export const userHasAccessToHash = async (
   context: ImpureGraphContext,
   authentication: AuthenticationContext,
   user: User | null,
-) => {
+): Promise<{ allowed: boolean; allowedEmails?: string[] }> => {
   if (!user) {
-    return false;
+    return { allowed: false };
   }
 
   if (!userEmailAllowList) {
-    return true;
+    return { allowed: true };
   }
 
   if (user.isAccountSignupComplete) {
     /**
      * If the user has completed account registration, they are allowed access.
      */
-    return true;
+    return { allowed: true };
   }
 
-  if (user.emails.some((email) => userEmailAllowList.includes(email))) {
-    return true;
+  const allowedEmails = user.emails.filter((email) =>
+    userEmailAllowList.includes(email),
+  );
+
+  if (allowedEmails.length > 0) {
+    return { allowed: true, allowedEmails };
   }
 
   const pendingInvitations = await getUserPendingInvitations(
@@ -73,5 +77,5 @@ export const userHasAccessToHash = async (
     { user },
   );
 
-  return pendingInvitations.length > 0;
+  return { allowed: pendingInvitations.length > 0 };
 };

--- a/apps/hash-external-services/kratos/kratos.yml
+++ b/apps/hash-external-services/kratos/kratos.yml
@@ -24,6 +24,11 @@ selfservice:
     password:
       enabled: true
 
+    profile:
+      # HASH treats email ownership as a verified authorization signal.
+      # Do not let users mutate identity traits through Kratos settings flows.
+      enabled: false
+
     link:
       config:
         # The link method is disabled (we use the code method instead).

--- a/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/user.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/user.test.ts
@@ -1,5 +1,7 @@
 import {
   createKratosIdentity,
+  deleteKratosIdentity,
+  kratosFrontendApi,
   kratosIdentityApi,
 } from "@apps/hash-api/src/auth/ory-kratos";
 import { ensureSystemGraphIsInitialized } from "@apps/hash-api/src/graph/ensure-system-graph-is-initialized";
@@ -195,6 +197,78 @@ describe("User model class", () => {
     expect(fetchedUser).not.toBeNull();
 
     expect(fetchedUser).toEqual(createdUser);
+  });
+
+  it("prevents users from amending Kratos profile traits directly", async () => {
+    const email = "kratos-profile-update@example.com";
+    const injectedEmail = "injected-profile-update@example.com";
+    const password = "password";
+
+    const identity = await createKratosIdentity({
+      traits: {
+        emails: [email],
+      },
+      credentials: {
+        password: {
+          config: {
+            password,
+          },
+        },
+      },
+    });
+
+    try {
+      const { data: loginFlow } = await kratosFrontendApi.createNativeLoginFlow(
+        {},
+      );
+
+      const { data: login } = await kratosFrontendApi.updateLoginFlow({
+        flow: loginFlow.id,
+        updateLoginFlowBody: {
+          identifier: email,
+          method: "password",
+          password,
+        },
+      });
+
+      const sessionToken = login.session_token;
+
+      if (!sessionToken) {
+        throw new Error("Expected Kratos to return a native session token.");
+      }
+
+      const { data: settingsFlow } =
+        await kratosFrontendApi.createNativeSettingsFlow({
+          xSessionToken: sessionToken,
+        });
+
+      await expect(
+        kratosFrontendApi.updateSettingsFlow({
+          flow: settingsFlow.id,
+          updateSettingsFlowBody: {
+            method: "profile",
+            traits: {
+              emails: [email, injectedEmail],
+            },
+          },
+          xSessionToken: sessionToken,
+        }),
+      ).rejects.toMatchObject({
+        response: {
+          status: 400,
+        },
+      });
+
+      const { data: updatedIdentity } = await kratosIdentityApi.getIdentity({
+        id: identity.id,
+      });
+
+      expect(updatedIdentity.traits).toMatchObject({
+        emails: [email],
+      });
+    } finally {
+      await deleteKratosIdentity({ kratosIdentityId: identity.id });
+    }
   });
 
   it("can join an org", async () => {

--- a/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/user.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/user.test.ts
@@ -255,7 +255,7 @@ describe("User model class", () => {
         }),
       ).rejects.toMatchObject({
         response: {
-          status: 400,
+          status: 404,
         },
       });
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Security hardening:
1. Disable Kratos self-service profile updates (stop users updating their own traits, which should be managed via our API)
2. Check for email verification status when taking actions that should require it (e.g. to do with org invites)

Plus cleaning up some function arguments that weren't being used.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->
<!-- Libraries inside of the `@local` directory are always internal libraries which have no need for publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- Existing tests to do with signing up / in.
- Additional test added to check users cannot update traits via Kratos selfservice.
