### PR TITLE
SRE-710: Migrate AWS auth from Vault to GitHub OIDC

### DIFF
--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -1,28 +1,13 @@
 name: Build Docker image
-description: Build and push Docker image
+description: Build and push Docker image. AWS credentials must be configured upstream.
 
 inputs:
   GITHUB_TOKEN:
     description: GitHub token for API access
     required: true
-  AWS_ACCESS_KEY_ID:
-    description: AWS access key id
-    required: true
-  AWS_SECRET_ACCESS_KEY:
-    description: AWS secret access key
-    required: true
-  AWS_SESSION_TOKEN:
-    description: AWS session token
-    required: true
-  AWS_REGION:
-    description: AWS region
-    required: true
   AWS_ECR_URL:
     description: AWS ECR url
     required: true
-  ROLE_ARN:
-    description: IAM role ARN to assume for ECR access (cross-account)
-    required: false
   SHORTNAME:
     description: Name of the thing that is being built. Keep path-friendly, please don't use special characters or spaces.
     required: true
@@ -47,14 +32,7 @@ inputs:
 runs:
   using: composite
   steps:
-    # Set up AWS ECR login
     - uses: ./.github/actions/docker-ecr-login
-      with:
-        AWS_ACCESS_KEY_ID: ${{ inputs.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ inputs.AWS_SECRET_ACCESS_KEY }}
-        AWS_SESSION_TOKEN: ${{ inputs.AWS_SESSION_TOKEN }}
-        AWS_REGION: ${{ inputs.AWS_REGION }}
-        ROLE_ARN: ${{ inputs.ROLE_ARN }}
 
     - name: Cache Docker layers
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0

--- a/.github/actions/docker-ecr-login/action.yml
+++ b/.github/actions/docker-ecr-login/action.yml
@@ -1,41 +1,12 @@
 name: Docker ECR login
-description: Authenticate with AWS, sigh Docker into ECR
-
-inputs:
-  AWS_ACCESS_KEY_ID:
-    description: AWS access key id
-    required: true
-  AWS_SECRET_ACCESS_KEY:
-    description: AWS secret access key
-    required: true
-  AWS_SESSION_TOKEN:
-    description: AWS session token
-    required: true
-  AWS_REGION:
-    description: AWS region
-    required: true
-  ROLE_ARN:
-    description: IAM role ARN to assume for ECR access (cross-account)
-    required: false
+description: Log Docker into ECR and set up Buildx. AWS credentials must be configured upstream.
 
 runs:
   using: composite
   steps:
-    # Set up AWS ECR login
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
-      with:
-        aws-access-key-id: ${{ inputs.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ inputs.AWS_SECRET_ACCESS_KEY }}
-        aws-session-token: ${{ inputs.AWS_SESSION_TOKEN }}
-        aws-region: ${{ inputs.AWS_REGION }}
-        role-to-assume: ${{ inputs.ROLE_ARN }}
-        role-duration-seconds: 900
-
     - name: Login to Amazon ECR
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
 
-    # Configure Docker with Buildx
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1

--- a/.github/actions/redeploy-ecs-service/action.yml
+++ b/.github/actions/redeploy-ecs-service/action.yml
@@ -1,41 +1,17 @@
 name: Redeploy ECS service
-description: Force a new ECS service deployment with optional role assumption
+description: Force a new ECS service deployment. AWS credentials must be configured upstream.
 
 inputs:
-  AWS_ACCESS_KEY_ID:
-    description: AWS access key id
-    required: true
-  AWS_SECRET_ACCESS_KEY:
-    description: AWS secret access key
-    required: true
-  AWS_SESSION_TOKEN:
-    description: AWS session token
-    required: true
-  AWS_REGION:
-    description: AWS region
-    required: true
   ECS_CLUSTER_NAME:
     description: ECS cluster name
     required: true
   ECS_SERVICE_NAME:
     description: ECS service name
     required: true
-  ROLE_ARN:
-    description: IAM role ARN to assume for deployment (cross-account)
-    required: false
 
 runs:
   using: composite
   steps:
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
-      with:
-        aws-access-key-id: ${{ inputs.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ inputs.AWS_SECRET_ACCESS_KEY }}
-        aws-session-token: ${{ inputs.AWS_SESSION_TOKEN }}
-        aws-region: ${{ inputs.AWS_REGION }}
-        role-to-assume: ${{ inputs.ROLE_ARN }}
-
     - name: Redeploy ECS service
       env:
         ECS_CLUSTER_NAME: ${{ inputs.ECS_CLUSTER_NAME }}

--- a/.github/workflows/hash-backend-cd.yml
+++ b/.github/workflows/hash-backend-cd.yml
@@ -17,23 +17,21 @@ on:
       - "infra/docker/api/prod/**"
 
 env:
-  ARTIFACTS_ECR_URL: 469596578827.dkr.ecr.eu-central-1.amazonaws.com
-  ARTIFACTS_ECR_ROLE_ARN: arn:aws:iam::469596578827:role/h-artifacts-euc1-ecr-push
-  ARTIFACTS_AWS_REGION: eu-central-1
-
   AWS_REGION: eu-central-1
+
+  ARTIFACTS_ECR_URL: 469596578827.dkr.ecr.eu-central-1.amazonaws.com
+  OIDC_HASH_CD_PUSH_ROLE: arn:aws:iam::469596578827:role/github-oidc-hash-cd-push
+  OIDC_HASH_CD_DEPLOY_ROLE: arn:aws:iam::054238437032:role/github-oidc-hash-cd-deploy
+
   APP_CLUSTER_NAME: h-stage-euc1-app
-  APP_DEPLOY_ROLE_ARN: arn:aws:iam::054238437032:role/h-stage-euc1-app-deploy
   APP_GRAPH_SERVICE_NAME: h-stage-euc1-app-graph
   APP_GRAPH_ADMIN_SERVICE_NAME: h-stage-euc1-app-graph-admin
   APP_TYPE_FETCHER_SERVICE_NAME: h-stage-euc1-app-type-fetcher
   APP_API_SERVICE_NAME: h-stage-euc1-app-api
   WORKER_CLUSTER_NAME: h-stage-euc1-worker
-  WORKER_DEPLOY_ROLE_ARN: arn:aws:iam::054238437032:role/h-stage-euc1-worker-deploy
   WORKER_AI_TS_SERVICE_NAME: h-stage-euc1-worker-ai-ts
   WORKER_INTEGRATION_SERVICE_NAME: h-stage-euc1-worker-integration
   AUTH_CLUSTER_NAME: h-stage-euc1-auth
-  AUTH_DEPLOY_ROLE_ARN: arn:aws:iam::054238437032:role/h-stage-euc1-auth-deploy
   AUTH_KRATOS_SERVICE_NAME: h-stage-euc1-auth-kratos
   AUTH_HYDRA_SERVICE_NAME: h-stage-euc1-auth-hydra
 
@@ -48,20 +46,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Authenticate Vault
-        id: secrets
-        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+      - name: Configure AWS credentials (ECR push)
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
-          exportToken: true
-          url: ${{ secrets.VAULT_ADDR }}
-          method: jwt
-          role: prod
-          # Even though it could look like separate calls to fetch the secrets
-          # the responses here are cached, so we're only issuing a single set of credentials
-          secrets: |
-            aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
-            aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
-            aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
+          role-to-assume: ${{ env.OIDC_HASH_CD_PUSH_ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Push to artifacts ECR
         uses: ./.github/actions/docker-build-push
@@ -69,12 +58,7 @@ jobs:
           SHORTNAME: "graph"
           CONTEXT_PATH: ${{ github.workspace }}/
           DOCKERFILE_LOCATION: ${{ github.workspace }}/apps/hash-graph/docker/Dockerfile
-          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
-          AWS_REGION: ${{ env.ARTIFACTS_AWS_REGION }}
           AWS_ECR_URL: ${{ env.ARTIFACTS_ECR_URL }}
-          ROLE_ARN: ${{ env.ARTIFACTS_ECR_ROLE_ARN }}
           IMAGE_NAME: ${{ github.repository }}/graph
           IMAGE_TAG: staging
           GITHUB_TOKEN: ${{ github.token }}
@@ -88,20 +72,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Authenticate Vault
-        id: secrets
-        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+      - name: Configure AWS credentials (ECR push)
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
-          exportToken: true
-          url: ${{ secrets.VAULT_ADDR }}
-          method: jwt
-          role: prod
-          # Even though it could look like separate calls to fetch the secrets
-          # the responses here are cached, so we're only issuing a single set of credentials
-          secrets: |
-            aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
-            aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
-            aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
+          role-to-assume: ${{ env.OIDC_HASH_CD_PUSH_ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Push to artifacts ECR
         uses: ./.github/actions/docker-build-push
@@ -109,12 +84,7 @@ jobs:
           SHORTNAME: "api"
           CONTEXT_PATH: ${{ github.workspace }}
           DOCKERFILE_LOCATION: ${{ github.workspace }}/infra/docker/api/prod/Dockerfile
-          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
-          AWS_REGION: ${{ env.ARTIFACTS_AWS_REGION }}
           AWS_ECR_URL: ${{ env.ARTIFACTS_ECR_URL }}
-          ROLE_ARN: ${{ env.ARTIFACTS_ECR_ROLE_ARN }}
           IMAGE_NAME: ${{ github.repository }}/api
           IMAGE_TAG: staging
           GITHUB_TOKEN: ${{ github.token }}
@@ -128,20 +98,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Authenticate Vault
-        id: secrets
-        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+      - name: Configure AWS credentials (ECR push)
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
-          exportToken: true
-          url: ${{ secrets.VAULT_ADDR }}
-          method: jwt
-          role: prod
-          # Even though it could look like separate calls to fetch the secrets
-          # the responses here are cached, so we're only issuing a single set of credentials
-          secrets: |
-            aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
-            aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
-            aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
+          role-to-assume: ${{ env.OIDC_HASH_CD_PUSH_ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Push to artifacts ECR
         uses: ./.github/actions/docker-build-push
@@ -149,12 +110,7 @@ jobs:
           SHORTNAME: "kratos"
           CONTEXT_PATH: ${{ github.workspace }}/apps/hash-external-services/kratos
           DOCKERFILE_LOCATION: ${{ github.workspace }}/apps/hash-external-services/kratos/Dockerfile
-          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
-          AWS_REGION: ${{ env.ARTIFACTS_AWS_REGION }}
           AWS_ECR_URL: ${{ env.ARTIFACTS_ECR_URL }}
-          ROLE_ARN: ${{ env.ARTIFACTS_ECR_ROLE_ARN }}
           IMAGE_NAME: ${{ github.repository }}/kratos
           IMAGE_TAG: staging
           GITHUB_TOKEN: ${{ github.token }}
@@ -168,20 +124,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Authenticate Vault
-        id: secrets
-        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+      - name: Configure AWS credentials (ECR push)
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
-          exportToken: true
-          url: ${{ secrets.VAULT_ADDR }}
-          method: jwt
-          role: prod
-          # Even though it could look like separate calls to fetch the secrets
-          # the responses here are cached, so we're only issuing a single set of credentials
-          secrets: |
-            aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
-            aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
-            aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
+          role-to-assume: ${{ env.OIDC_HASH_CD_PUSH_ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Push to artifacts ECR
         uses: ./.github/actions/docker-build-push
@@ -189,12 +136,7 @@ jobs:
           SHORTNAME: "hydra"
           CONTEXT_PATH: ${{ github.workspace }}/apps/hash-external-services/hydra
           DOCKERFILE_LOCATION: ${{ github.workspace }}/apps/hash-external-services/hydra/Dockerfile
-          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
-          AWS_REGION: ${{ env.ARTIFACTS_AWS_REGION }}
           AWS_ECR_URL: ${{ env.ARTIFACTS_ECR_URL }}
-          ROLE_ARN: ${{ env.ARTIFACTS_ECR_ROLE_ARN }}
           IMAGE_NAME: ${{ github.repository }}/hydra
           IMAGE_TAG: staging
           GITHUB_TOKEN: ${{ github.token }}
@@ -210,20 +152,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Authenticate Vault
-        id: secrets
-        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+      - name: Configure AWS credentials (ECR push)
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
-          exportToken: true
-          url: ${{ secrets.VAULT_ADDR }}
-          method: jwt
-          role: prod
-          # Even though it could look like separate calls to fetch the secrets
-          # the responses here are cached, so we're only issuing a single set of credentials
-          secrets: |
-            aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
-            aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
-            aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
+          role-to-assume: ${{ env.OIDC_HASH_CD_PUSH_ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Push to artifacts ECR
         uses: ./.github/actions/docker-build-push
@@ -231,12 +164,7 @@ jobs:
           SHORTNAME: "temporal-worker-ai-ts"
           CONTEXT_PATH: ${{ github.workspace }}
           DOCKERFILE_LOCATION: ${{ github.workspace }}/apps/hash-ai-worker-ts/docker/Dockerfile
-          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
-          AWS_REGION: ${{ env.ARTIFACTS_AWS_REGION }}
           AWS_ECR_URL: ${{ env.ARTIFACTS_ECR_URL }}
-          ROLE_ARN: ${{ env.ARTIFACTS_ECR_ROLE_ARN }}
           IMAGE_NAME: ${{ github.repository }}/ai-worker-ts
           IMAGE_TAG: staging
           GITHUB_TOKEN: ${{ github.token }}
@@ -252,20 +180,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Authenticate Vault
-        id: secrets
-        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+      - name: Configure AWS credentials (ECR push)
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
-          exportToken: true
-          url: ${{ secrets.VAULT_ADDR }}
-          method: jwt
-          role: prod
-          # Even though it could look like separate calls to fetch the secrets
-          # the responses here are cached, so we're only issuing a single set of credentials
-          secrets: |
-            aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
-            aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
-            aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
+          role-to-assume: ${{ env.OIDC_HASH_CD_PUSH_ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Push to artifacts ECR
         uses: ./.github/actions/docker-build-push
@@ -273,12 +192,7 @@ jobs:
           SHORTNAME: "temporal-integration-worker"
           CONTEXT_PATH: ${{ github.workspace }}
           DOCKERFILE_LOCATION: ${{ github.workspace }}/apps/hash-integration-worker/docker/Dockerfile
-          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
-          AWS_REGION: ${{ env.ARTIFACTS_AWS_REGION }}
           AWS_ECR_URL: ${{ env.ARTIFACTS_ECR_URL }}
-          ROLE_ARN: ${{ env.ARTIFACTS_ECR_ROLE_ARN }}
           IMAGE_NAME: ${{ github.repository }}/integration-worker
           IMAGE_TAG: staging
           GITHUB_TOKEN: ${{ github.token }}
@@ -294,53 +208,29 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Authenticate Vault
-        id: secrets
-        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+      - name: Configure AWS credentials (ECS deploy)
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
-          exportToken: true
-          url: ${{ secrets.VAULT_ADDR }}
-          method: jwt
-          role: prod
-          # Even though it could look like separate calls to fetch the secrets
-          # the responses here are cached, so we're only issuing a single set of credentials
-          secrets: |
-            aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
-            aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
-            aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
+          role-to-assume: ${{ env.OIDC_HASH_CD_DEPLOY_ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Redeploy graph staging service
         uses: ./.github/actions/redeploy-ecs-service
         with:
-          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
-          AWS_REGION: ${{ env.AWS_REGION }}
           ECS_CLUSTER_NAME: ${{ env.APP_CLUSTER_NAME }}
           ECS_SERVICE_NAME: ${{ env.APP_GRAPH_SERVICE_NAME }}
-          ROLE_ARN: ${{ env.APP_DEPLOY_ROLE_ARN }}
 
       - name: Redeploy graph-admin staging service
         uses: ./.github/actions/redeploy-ecs-service
         with:
-          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
-          AWS_REGION: ${{ env.AWS_REGION }}
           ECS_CLUSTER_NAME: ${{ env.APP_CLUSTER_NAME }}
           ECS_SERVICE_NAME: ${{ env.APP_GRAPH_ADMIN_SERVICE_NAME }}
-          ROLE_ARN: ${{ env.APP_DEPLOY_ROLE_ARN }}
 
       - name: Redeploy type-fetcher staging service
         uses: ./.github/actions/redeploy-ecs-service
         with:
-          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
-          AWS_REGION: ${{ env.AWS_REGION }}
           ECS_CLUSTER_NAME: ${{ env.APP_CLUSTER_NAME }}
           ECS_SERVICE_NAME: ${{ env.APP_TYPE_FETCHER_SERVICE_NAME }}
-          ROLE_ARN: ${{ env.APP_DEPLOY_ROLE_ARN }}
 
   deploy-app:
     name: Deploy HASH app images
@@ -357,53 +247,29 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Authenticate Vault
-        id: secrets
-        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+      - name: Configure AWS credentials (ECS deploy)
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
-          exportToken: true
-          url: ${{ secrets.VAULT_ADDR }}
-          method: jwt
-          role: prod
-          # Even though it could look like separate calls to fetch the secrets
-          # the responses here are cached, so we're only issuing a single set of credentials
-          secrets: |
-            aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
-            aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
-            aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
+          role-to-assume: ${{ env.OIDC_HASH_CD_DEPLOY_ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Redeploy API staging service
         uses: ./.github/actions/redeploy-ecs-service
         with:
-          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
-          AWS_REGION: ${{ env.AWS_REGION }}
           ECS_CLUSTER_NAME: ${{ env.APP_CLUSTER_NAME }}
           ECS_SERVICE_NAME: ${{ env.APP_API_SERVICE_NAME }}
-          ROLE_ARN: ${{ env.APP_DEPLOY_ROLE_ARN }}
 
       - name: Redeploy kratos staging service
         uses: ./.github/actions/redeploy-ecs-service
         with:
-          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
-          AWS_REGION: ${{ env.AWS_REGION }}
           ECS_CLUSTER_NAME: ${{ env.AUTH_CLUSTER_NAME }}
           ECS_SERVICE_NAME: ${{ env.AUTH_KRATOS_SERVICE_NAME }}
-          ROLE_ARN: ${{ env.AUTH_DEPLOY_ROLE_ARN }}
 
       - name: Redeploy hydra staging service
         uses: ./.github/actions/redeploy-ecs-service
         with:
-          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
-          AWS_REGION: ${{ env.AWS_REGION }}
           ECS_CLUSTER_NAME: ${{ env.AUTH_CLUSTER_NAME }}
           ECS_SERVICE_NAME: ${{ env.AUTH_HYDRA_SERVICE_NAME }}
-          ROLE_ARN: ${{ env.AUTH_DEPLOY_ROLE_ARN }}
 
   deploy-workers:
     name: Deploy HASH worker images
@@ -419,42 +285,23 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Authenticate Vault
-        id: secrets
-        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+      - name: Configure AWS credentials (ECS deploy)
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
-          exportToken: true
-          url: ${{ secrets.VAULT_ADDR }}
-          method: jwt
-          role: prod
-          # Even though it could look like separate calls to fetch the secrets
-          # the responses here are cached, so we're only issuing a single set of credentials
-          secrets: |
-            aws/creds/prod-deploy access_key | AWS_ACCESS_KEY_ID ;
-            aws/creds/prod-deploy secret_key | AWS_SECRET_ACCESS_KEY ;
-            aws/creds/prod-deploy security_token | AWS_SESSION_TOKEN
+          role-to-assume: ${{ env.OIDC_HASH_CD_DEPLOY_ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
 
       - name: Redeploy AI-TS staging service
         uses: ./.github/actions/redeploy-ecs-service
         with:
-          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
-          AWS_REGION: ${{ env.AWS_REGION }}
           ECS_CLUSTER_NAME: ${{ env.WORKER_CLUSTER_NAME }}
           ECS_SERVICE_NAME: ${{ env.WORKER_AI_TS_SERVICE_NAME }}
-          ROLE_ARN: ${{ env.WORKER_DEPLOY_ROLE_ARN }}
 
       - name: Redeploy Integration staging service
         uses: ./.github/actions/redeploy-ecs-service
         with:
-          AWS_ACCESS_KEY_ID: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ steps.secrets.outputs.AWS_SESSION_TOKEN }}
-          AWS_REGION: ${{ env.AWS_REGION }}
           ECS_CLUSTER_NAME: ${{ env.WORKER_CLUSTER_NAME }}
           ECS_SERVICE_NAME: ${{ env.WORKER_INTEGRATION_SERVICE_NAME }}
-          ROLE_ARN: ${{ env.WORKER_DEPLOY_ROLE_ARN }}
 
   notify-slack:
     name: Notify Slack on failure


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Replace Vault-based AWS authentication (`hashicorp/vault-action` + `aws/creds/prod-deploy` → 2-stage assume) with direct GitHub OIDC `AssumeRoleWithWebIdentity` for the hash backend CD workflow. Removes Vault as the central CI credential broker; OIDC sessions are scoped per-account, per-workflow, and per-branch.

## 🔗 Related links

- Linear: [SRE-710](https://linear.app/hashintel/issue/SRE-710) _(internal)_
- Companion infra PR creating the OIDC roles + policies: `hashintel/internal-infra` SRE-710 (must merge first) _(internal)_

## 🚫 Blocked by

- [x] Companion `hashintel/internal-infra` PR — creates the `github-oidc-hash-cd-push` (artifacts account) and `github-oidc-hash-cd-deploy` (staging account) OIDC roles this workflow assumes

## 🔍 What does this change?

- `hash-backend-cd.yml`: each job replaces the Vault auth + manual `aws sts assume-role` chain with a single `aws-actions/configure-aws-credentials` step using OIDC `role-to-assume`
- Build jobs assume `github-oidc-hash-cd-push` (artifacts account, full ECR push)
- Deploy jobs assume `github-oidc-hash-cd-deploy` (staging account, ECS UpdateService)
- Composite actions `docker-ecr-login`, `docker-build-push`, `redeploy-ecs-service` no longer take AWS credential inputs or `ROLE_ARN` — callers configure credentials upstream
- Operational role ARNs (`h-artifacts-euc1-ecr-push`, `h-stage-euc1-*-deploy`) removed from the workflow env section

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

- [x] do not affect the execution graph

## ⚠️ Known issues

The workflow_ref trust pin requires the OIDC roles to exist in the target AWS accounts — merging the infra PR first is required.

## 🐾 Next steps

- After successful runs are verified, drop Vault `aws/creds/prod-deploy` trust from the operational ECR/ECS roles in `internal-infra` (separate SRE-710 follow-up PR)
- Decommission the legacy Vault account `982704398867`

## 🛡 What tests cover this?

No automated tests cover CI workflow auth. Verified via `workflow_dispatch` from this branch against staging — 5 build jobs and 4 deploy jobs succeeded end-to-end.

## ❓ How to test this?

1. After the infra PR merges and the workflow_refs trust is tightened back to `@refs/heads/main`, dispatch `hash-backend-cd.yml` from `main`
2. Confirm all 9 jobs succeed (5 builds + 4 deploys)
3. Verify ECR shows new image digests for the staging tags and staging ECS services have rolled

## 📹 Demo

_n/a — CI auth change_