### PR TITLE
SRE-715: Add PR-title preflight workflow + bump SHA pins

### DIFF
--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -62,7 +62,7 @@ jobs:
 
   renovate:
     name: Dependencies
-    uses: hashintel/.github/.github/workflows/housekeeping-dependencies.yml@8d021823fbe2e8dbe0c8054ae50a7ed758172aa7
+    uses: hashintel/.github/.github/workflows/housekeeping-dependencies.yml@e12e306a03b1939c357d92c55b48d539d4286bd6
     with:
       repoCache: ${{ inputs.repoCache || 'enabled' }}
       logLevel: ${{ inputs.logLevel || 'info' }}

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -21,14 +21,14 @@ jobs:
       # see: https://github.com/orgs/community/discussions/26245#discussioncomment-15601440
       id-token: write
       pull-requests: write
-    uses: hashintel/.github/.github/workflows/preflight-stale-approvals.yml@8d021823fbe2e8dbe0c8054ae50a7ed758172aa7
+    uses: hashintel/.github/.github/workflows/preflight-stale-approvals.yml@e12e306a03b1939c357d92c55b48d539d4286bd6
 
   dependencies:
     name: Dependencies
     permissions:
       contents: read
       pull-requests: write
-    uses: hashintel/.github/.github/workflows/preflight-dependencies.yml@8d021823fbe2e8dbe0c8054ae50a7ed758172aa7
+    uses: hashintel/.github/.github/workflows/preflight-dependencies.yml@e12e306a03b1939c357d92c55b48d539d4286bd6
 
   labeler:
     name: Labeler
@@ -47,4 +47,10 @@ jobs:
     name: Todo comments
     permissions:
       contents: read
-    uses: hashintel/.github/.github/workflows/preflight-todo-comments.yml@8d021823fbe2e8dbe0c8054ae50a7ed758172aa7
+    uses: hashintel/.github/.github/workflows/preflight-todo-comments.yml@e12e306a03b1939c357d92c55b48d539d4286bd6
+
+  pr-title:
+    name: PR title
+    permissions:
+      contents: read
+    uses: hashintel/.github/.github/workflows/preflight-pr-title.yml@e12e306a03b1939c357d92c55b48d539d4286bd6


### PR DESCRIPTION
## Summary

- Wires the new reusable `preflight-pr-title.yml` workflow into this repo's preflight chain.
- Bumps every `hashintel/.github` reusable-workflow SHA pin (preflight + housekeeping) to `e12e306` in one atomic change — Renovate would have done the bump on its next pass; doing it here keeps the change reviewable as a single PR.

The new check enforces that human-authored PR titles include a Linear issue ID (e.g. `H-1234`, `BE-5678`) in the prefix segment. Bot-authored PRs (`hash-worker[bot]`, `dependabot[bot]`, …) are skipped automatically.

Related: [SRE-715](https://linear.app/hash/issue/SRE-715), follow-up of the source change in [hashintel/.github#65](https://github.com/hashintel/.github/pull/65) (H-6402 was the original rollout of the preflight chain).

## Test plan

- [ ] Preflight `PR title` job runs and passes on this PR (title contains `SRE-715`)
- [ ] Other preflight jobs (stale-approvals, dependencies, todo-comments) still pass after the SHA bump
- [ ] Housekeeping workflow continues to function with the new pin