### PR TITLE
SRE-719: Use github-worker App token in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
-## Using MACHINE_USER_TOKEN enables GitHub Workflows in ‘Version Packages’ PRs
+## Uses a GitHub App installation token so that ‘Version Packages’ PRs trigger
+## downstream workflows (GITHUB_TOKEN-created PRs do not).
 ## https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
 
 name: Release
@@ -14,9 +15,27 @@ jobs:
       id-token: write
 
     steps:
+      - name: Authenticate Vault
+        id: secrets
+        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: jwt
+          role: dev
+          secrets: |
+            automation/data/pipelines/hash/dev github_worker_app_id | GITHUB_WORKER_APP_ID ;
+            automation/data/pipelines/hash/dev github_worker_app_private_key | GITHUB_WORKER_APP_PRIVATE_KEY ;
+
+      - name: Get token
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        with:
+          app-id: ${{ steps.secrets.outputs.GITHUB_WORKER_APP_ID }}
+          private-key: ${{ steps.secrets.outputs.GITHUB_WORKER_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          token: ${{ secrets.MACHINE_USER_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Install tools
         uses: ./.github/actions/install-tools
@@ -33,7 +52,7 @@ jobs:
           publish: yarn changeset:publish
           version: yarn changeset:version
         env:
-          GITHUB_TOKEN: ${{ secrets.MACHINE_USER_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_LOGLEVEL: verbose
           TURBO_LOG_LEVEL: debug


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Replaces the `hashdotai` machine-user PAT (`secrets.MACHINE_USER_TOKEN`) in `.github/workflows/release.yml` with a short-lived installation token minted from the `github-worker` GitHub App. The PAT is long-lived, broadly scoped, never rotated, and consumes an org seat under a "human-looking" account; the App pattern is what `hashintel/.github` already uses for Renovate across the org, so this aligns `release.yml` with that pattern.

## 🔗 Related links

- [SRE-719](https://linear.app/hash/issue/SRE-719/replace-machine-user-token-with-github-worker-app-in-release-workflow) _(internal)_
- Pattern source: [`hashintel/.github` housekeeping-dependencies.yml](https://github.com/hashintel/.github/blob/main/.github/workflows/housekeeping-dependencies.yml)

## 🔍 What does this change?

- Adds a `hashicorp/vault-action` step that reads `github_worker_app_id` / `github_worker_app_private_key` from `automation/data/pipelines/hash/dev`
- Adds an `actions/create-github-app-token` step that mints a short-lived installation token from those credentials
- Switches `actions/checkout` and the `GITHUB_TOKEN` env on `changesets/action` to consume `steps.app-token.outputs.token`
- Drops every reference to `secrets.MACHINE_USER_TOKEN` from this workflow
- Same SHA pins as `hashintel/.github` housekeeping-dependencies.yml (`vault-action` v3.4.0 `4c06c5cc…`, `create-github-app-token` v3.0.0 `f8d387b6…`)

Out of scope: `dispatch-fix.yml`, `auto-approve.yml`, `canary-release.yml`, `ai-pr-review.yml` still reference `MACHINE_USER_TOKEN` and/or the literal `hashdotai` login but are either not PR-openers or disabled, so they migrate separately. Decommissioning the `hashdotai` user and the `MACHINE_USER_TOKEN` secret is also out of scope until every consumer has migrated.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

The first release run after merge is the live smoke test — the workflow only fires on `push` to `main`, so there is no way to fully validate end-to-end without merging. If the App is missing `Workflows: write`, the "Version Packages" PR creation will fail the first time a release-eligible changeset touches a workflow file; that failure is recoverable by either widening the App permission or reverting this PR.

## 🐾 Next steps

- Migrate `dispatch-fix.yml` and `auto-approve.yml` to the same App-token pattern (separate tickets)
- Decide whether `canary-release.yml`'s `git config user.name "hashdotai"` push should be reattributed to the App identity or kept as-is
- Once every consumer is migrated, decommission the `hashdotai` user account and remove the `MACHINE_USER_TOKEN` secret

## 🛡 What tests cover this?

No automated tests — this is GitHub Actions configuration that only exercises in the live workflow. Validation happens on the first post-merge release run by checking that (a) the Vault-auth and `create-github-app-token` steps succeed, (b) the "Version Packages" PR (if any) is authored by `hash-worker[bot]`, and (c) downstream workflows trigger on that PR.

## ❓ How to test this?

1. Confirm the Org-Admin / Vault prerequisites in **Blocked by** are met
2. Merge to `main`
3. On the next release-eligible push, watch the `Release` workflow run — both the `Authenticate Vault` and `Get token` steps must succeed
4. If a "Version Packages" PR is opened, confirm it is authored by `hash-worker[bot]` (not `hashdotai`) and that its CI run starts automatically
5. If the run is a publish (not a PR), confirm npm publishing still succeeds — `NPM_TOKEN` is unchanged and orthogonal to this migration

## 📹 Demo

N/A — workflow-config change with no UI surface.