### PR TITLE
H-6517: Auto-create local Minio bucket on dev external-services up

### DIFF
--- a/apps/hash-external-services/docker-compose.dev.yml
+++ b/apps/hash-external-services/docker-compose.dev.yml
@@ -29,8 +29,6 @@ services:
     depends_on:
       - minio
     restart: "no"
-    profiles:
-      - setup
     security_opt:
       - no-new-privileges:true
     environment:


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Following the documented dev setup (`yarn external-services up -d`) leaves the local Minio bucket uncreated, which silently breaks S3-backed features (file uploads, document-related tests). The bucket-creation job already exists but is gated behind a `setup` profile that isn't mentioned anywhere in the READMEs. This PR removes that gate so the bucket is provisioned automatically.

## 🔗 Related links

- ...

## 🚫 Blocked by

- [ ] ...

## 🔍 What does this change?

- Removes the `profiles: [setup]` gate from the `minio-ensure-bucket-exists` service in `apps/hash-external-services/docker-compose.dev.yml`. The job is idempotent (`mc mb --ignore-existing`) and uses `restart: "no"`, so it runs once and exits cleanly without affecting the rest of the compose stack.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

None.

## 🐾 Next steps

None.

## 🛡 What tests cover this?

No automated tests — this only affects local dev compose orchestration.

## ❓ How to test this?

1. Wipe the local Minio data volume (e.g. `rm -rf var/uploads/s3`) so no bucket exists.
2. Run `yarn external-services up -d`.
3. Confirm the `dev-hash-bucket` bucket exists in the Minio console at http://localhost:9001, or via `mc ls`.
4. Confirm S3-backed features (file uploads) work end-to-end.