### PR TITLE
FE-757: Fix OOM error in hash frontend docker build

### DIFF
--- a/apps/hash-frontend/next.config.js
+++ b/apps/hash-frontend/next.config.js
@@ -192,7 +192,15 @@ export default withSentryConfig(
         ],
       },
 
-      webpack: (webpackConfig, { isServer }) => {
+      webpack: (webpackConfig, { isServer, dev }) => {
+        if (!dev) {
+          // Production builds disable webpack's filesystem cache to avoid a
+          // "No serializer registered for ConstDependency" failure caused by
+          // Yarn PnP loading multiple virtual instances of webpack in the
+          // pruned Docker install.
+          webpackConfig.cache = false;
+        }
+
         webpackConfig.module.rules.push({
           test: /\.svg$/,
           use: ["@svgr/webpack"],


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Splitting this out into its own PR from https://github.com/hashintel/hash/pull/8757 as discussion is blocking the upgrade to tsdown.

Disables the nextjs webpack build cache in production for apps/hash-frontend - which fixes docker builds that were breaking in scenarios where the webpack build cache was already populated during other tasks.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change