### PR TITLE
FE-728: Fix toast styling in petrinaut website

### DIFF
--- a/libs/@hashintel/petrinaut/src/ui/petrinaut.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/petrinaut.tsx
@@ -3,8 +3,10 @@ import "@fontsource-variable/inter-tight";
 import "@fontsource-variable/jetbrains-mono";
 import "@xyflow/react/dist/style.css";
 import "./index.css";
-import { type FunctionComponent, useEffect, useMemo } from "react";
+import { type FunctionComponent, useEffect, useMemo, useRef } from "react";
 
+import { PortalContainerContext } from "@hashintel/ds-components";
+import { css, cx } from "@hashintel/ds-helpers/css";
 import {
   createPetrinaut,
   type PetrinautDocHandle,
@@ -16,8 +18,26 @@ import {
 } from "@hashintel/petrinaut-core";
 
 import { PetrinautProvider } from "../react/petrinaut-provider";
+import { Stack } from "./components/stack";
 import { MonacoProvider } from "./monaco/provider";
 import { EditorView } from "./views/Editor/editor-view";
+
+const editorRootStyle = css({
+  position: "relative",
+  height: "full",
+  overflow: "hidden",
+  backgroundColor: "neutral.s25",
+});
+
+const portalContainerStyle = css({
+  position: "absolute",
+  top: "0",
+  left: "0",
+  width: "full",
+  height: "full",
+  zIndex: "99999",
+  pointerEvents: "none",
+});
 
 import type {
   PetrinautAiMessage,
@@ -95,6 +115,7 @@ export const Petrinaut: FunctionComponent<PetrinautProps> = ({
   monteCarloWorkerFactory,
   lspWorkerFactory,
 }) => {
+  const portalContainerRef = useRef<HTMLDivElement>(null);
   const instance = useMemo<Instance>(
     () => createPetrinaut({ document: handle, readonly }),
     [handle, readonly],
@@ -111,20 +132,25 @@ export const Petrinaut: FunctionComponent<PetrinautProps> = ({
   };
 
   return (
-    <PetrinautProvider
-      instance={instance}
-      netManagement={netManagement}
-      simulationWorkerFactory={simulationWorkerFactory}
-      monteCarloWorkerFactory={monteCarloWorkerFactory}
-      lspWorkerFactory={lspWorkerFactory}
-    >
-      <MonacoProvider>
-        <EditorView
-          aiAssistant={aiAssistant}
-          hideNetManagementControls={hideNetManagementControls}
-          viewportActions={viewportActions}
-        />
-      </MonacoProvider>
-    </PetrinautProvider>
+    <PortalContainerContext value={portalContainerRef}>
+      <PetrinautProvider
+        instance={instance}
+        netManagement={netManagement}
+        simulationWorkerFactory={simulationWorkerFactory}
+        monteCarloWorkerFactory={monteCarloWorkerFactory}
+        lspWorkerFactory={lspWorkerFactory}
+      >
+        <MonacoProvider>
+          <Stack className={cx(editorRootStyle, "petrinaut-root")}>
+            <div ref={portalContainerRef} className={portalContainerStyle} />
+            <EditorView
+              aiAssistant={aiAssistant}
+              hideNetManagementControls={hideNetManagementControls}
+              viewportActions={viewportActions}
+            />
+          </Stack>
+        </MonacoProvider>
+      </PetrinautProvider>
+    </PortalContainerContext>
   );
 };

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/editor-view.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/editor-view.tsx
@@ -1,7 +1,6 @@
-import { use, useRef, useState } from "react";
+import { use, useState } from "react";
 
-import { PortalContainerContext } from "@hashintel/ds-components";
-import { css, cx } from "@hashintel/ds-helpers/css";
+import { css } from "@hashintel/ds-helpers/css";
 import { calculateGraphLayout, type SDCPN } from "@hashintel/petrinaut-core";
 import {
   deploymentPipelineSDCPN,
@@ -76,23 +75,6 @@ const canvasContainerStyle = css({
   width: "full",
   position: "relative",
   flexGrow: 1,
-});
-
-const editorRootStyle = css({
-  position: "relative",
-  height: "full",
-  overflow: "hidden",
-  backgroundColor: "neutral.s25",
-});
-
-const portalContainerStyle = css({
-  position: "absolute",
-  top: "0",
-  left: "0",
-  width: "full",
-  height: "full",
-  zIndex: "99999",
-  pointerEvents: "none",
 });
 
 const isEmptySDCPN = (sdcpn: SDCPN) =>
@@ -372,8 +354,6 @@ export const EditorView = ({
     },
   ];
 
-  const portalContainerRef = useRef<HTMLDivElement>(null);
-
   const showEmptyAiHero =
     aiAssistant !== undefined &&
     !isAiAssistantOpen &&
@@ -381,86 +361,82 @@ export const EditorView = ({
     isEmptySDCPN(petriNetDefinition);
 
   return (
-    <PortalContainerContext value={portalContainerRef}>
-      <Stack className={cx(editorRootStyle, "petrinaut-root")}>
-        <div ref={portalContainerRef} className={portalContainerStyle} />
-
-        <ImportErrorDialog
-          open={importError !== null}
-          onOpenChange={({ open }) => {
-            if (!open) {
-              setImportError(null);
-            }
-          }}
-          errorMessage={importError ?? ""}
-          onCreateEmpty={handleCreateEmpty}
-        />
-
-        {/* Top Bar - always visible */}
-        <TopBar
-          menuItems={menuItems}
-          title={title}
-          onTitleChange={setTitle}
-          hideNetManagementControls={hideNetManagementControls}
-          mode={mode}
-          onModeChange={setGlobalMode}
-          onRunningExperimentClick={(experiment) =>
-            handleRunningExperimentClick(experiment.id)
+    <>
+      <ImportErrorDialog
+        open={importError !== null}
+        onOpenChange={({ open }) => {
+          if (!open) {
+            setImportError(null);
           }
-        />
+        }}
+        errorMessage={importError ?? ""}
+        onCreateEmpty={handleCreateEmpty}
+      />
 
-        <Stack direction="row" className={rowContainerStyle}>
-          {mode === "simulate" ? (
-            <SimulateView />
-          ) : (
-            <Box className={canvasContainerStyle}>
-              {/* Left Sidebar - Tools and content panels */}
-              <LeftSideBar />
+      {/* Top Bar - always visible */}
+      <TopBar
+        menuItems={menuItems}
+        title={title}
+        onTitleChange={setTitle}
+        hideNetManagementControls={hideNetManagementControls}
+        mode={mode}
+        onModeChange={setGlobalMode}
+        onRunningExperimentClick={(experiment) =>
+          handleRunningExperimentClick(experiment.id)
+        }
+      />
 
-              {/* Properties Panel - Right Side */}
-              <PropertiesPanel />
+      <Stack direction="row" className={rowContainerStyle}>
+        {mode === "simulate" ? (
+          <SimulateView />
+        ) : (
+          <Box className={canvasContainerStyle}>
+            {/* Left Sidebar - Tools and content panels */}
+            <LeftSideBar />
 
-              {/* SDCPN Visualization */}
-              <SDCPNView viewportActions={viewportActions} />
+            {/* Properties Panel - Right Side */}
+            <PropertiesPanel />
 
-              {showEmptyAiHero && (
-                <AiCtaModal
-                  bottomClearance={isBottomPanelOpen ? bottomPanelHeight : 0}
-                  onDismiss={() => setIsAiCtaDismissed(true)}
-                  onSubmit={(message) => {
-                    setPendingAiAssistantMessage(message);
-                    setAiAssistantOpen(true);
-                  }}
-                />
-              )}
+            {/* SDCPN Visualization */}
+            <SDCPNView viewportActions={viewportActions} />
 
-              {/* Bottom Panel - Diagnostics, Simulation Settings */}
-              <BottomPanel />
-
-              <BottomBar
-                mode={mode}
-                editionMode={editionMode}
-                onEditionModeChange={setEditionMode}
-                cursorMode={cursorMode}
-                onCursorModeChange={setCursorMode}
-                hasAiAssistant={aiAssistant !== undefined}
+            {showEmptyAiHero && (
+              <AiCtaModal
+                bottomClearance={isBottomPanelOpen ? bottomPanelHeight : 0}
+                onDismiss={() => setIsAiCtaDismissed(true)}
+                onSubmit={(message) => {
+                  setPendingAiAssistantMessage(message);
+                  setAiAssistantOpen(true);
+                }}
               />
+            )}
 
-              {aiAssistant && (
-                <AiAssistantPanel
-                  /** Reset state (e.g. initial messages) when the active net changes */
-                  key={petriNetId ?? "no-net"}
-                  aiAssistant={aiAssistant}
-                  initialMessage={pendingAiAssistantMessage}
-                  onInitialMessageConsumed={() =>
-                    setPendingAiAssistantMessage(null)
-                  }
-                />
-              )}
-            </Box>
-          )}
-        </Stack>
+            {/* Bottom Panel - Diagnostics, Simulation Settings */}
+            <BottomPanel />
+
+            <BottomBar
+              mode={mode}
+              editionMode={editionMode}
+              onEditionModeChange={setEditionMode}
+              cursorMode={cursorMode}
+              onCursorModeChange={setCursorMode}
+              hasAiAssistant={aiAssistant !== undefined}
+            />
+
+            {aiAssistant && (
+              <AiAssistantPanel
+                /** Reset state (e.g. initial messages) when the active net changes */
+                key={petriNetId ?? "no-net"}
+                aiAssistant={aiAssistant}
+                initialMessage={pendingAiAssistantMessage}
+                onInitialMessageConsumed={() =>
+                  setPendingAiAssistantMessage(null)
+                }
+              />
+            )}
+          </Box>
+        )}
       </Stack>
-    </PortalContainerContext>
+    </>
   );
 };


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Due to the fact that panda css styling gets scoped to a specific dom subtree, any elements that open portals (dialogs, popovers, toasts etc) need to be portaled into that subtree or else the scoped styles won't be applied. The way that this has been implemented is to add a `<PortalContextProvider>` element that scopes all portals beneath it to the portal context element instead of the root html element.

Since `<PetrinautProvider>` was recently updated to call toasts during some operations, it needs to sit underneath this `<PortalContextProvider>` or else the toasts it triggers won't get styled. This PR moves the PortalContextProvider to now be at the app root to fix the issue.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change