### PR TITLE
BE-578: Gate `sink` imports behind `cfg(nightly)`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2645,7 +2645,7 @@ dependencies = [
 
 [[package]]
 name = "error-stack"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "ansi-to-html",
  "anyhow",

--- a/libs/error-stack/CHANGELOG.md
+++ b/libs/error-stack/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to `error-stack` will be documented in this file.
 - Support for [`defmt`](https://defmt.ferrous-systems.com).
 - Better support for serialization and deserialization of `Report`.
 
+## [0.7.1](https://github.com/hashintel/hash/tree/error-stack%400.7.1/libs/error-stack) - 2026-05-27
+
+### Fixes
+
+- Gate `sink` imports behind `cfg(nightly)` so `error-stack` compiles on stable Rust with the `unstable` feature enabled. ([#8768](https://github.com/hashintel/hash/pull/8768))
+
 ## [0.7.0](https://github.com/hashintel/hash/tree/error-stack%400.7.0/libs/error-stack) - 2026-03-26
 
 ### Features

--- a/libs/error-stack/Cargo.toml
+++ b/libs/error-stack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "error-stack"
-version       = "0.7.0"
+version       = "0.7.1"
 authors       = { workspace = true }
 edition       = "2021"
 rust-version  = "1.83.0"

--- a/libs/error-stack/package.json
+++ b/libs/error-stack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rust/error-stack",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": true,
   "description": "A context-aware error-handling library that supports arbitrary attached user data",
   "license": "MIT OR Apache-2.0",

--- a/libs/error-stack/src/sink.rs
+++ b/libs/error-stack/src/sink.rs
@@ -1,5 +1,6 @@
 #[cfg(any(all(not(target_arch = "wasm32"), feature = "std"), feature = "tracing"))]
 use core::panic::Location;
+#[cfg(nightly)]
 use core::{
     convert::Infallible,
     ops::{FromResidual, Try},


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

`error-stack` with the `unstable` feature failed to compile on **stable** Rust. `sink.rs` imported `core::ops::{FromResidual, Try}` unconditionally, but those traits require the nightly-only `try_trait_v2` feature — which (along with their `impl`s) was already gated behind `cfg(nightly)`. The unconditional import therefore broke stable builds with `E0658`.

This gates the import to match, and bumps the crate to **0.7.1** for release.

## 🔗 Related links

- Fixes #8766

## 🔍 What does this change?

- Gate `use core::{convert::Infallible, ops::{FromResidual, Try}}` in `sink.rs` behind `#[cfg(nightly)]`, mirroring the existing `#![cfg_attr(all(nightly, feature = "unstable"), feature(try_trait_v2))]` gate in `lib.rs` and the already-gated `Try`/`FromResidual` impls.
- `ReportSink`'s core API (`new`/`append`/`capture`/`finish`) and the multi-error `bail![…]` macro remain available on stable; only the `?`-operator support (the `Try`/`FromResidual` impls) stays nightly-only — i.e. status quo.
- Bump `error-stack` to `0.7.1` (`Cargo.toml`, `package.json`, `Cargo.lock`) and add the `0.7.1` changelog entry.

This is the minimal fix the issue author and branch name describe — gating just the import — rather than gating the whole `sink` module, which would have removed `ReportSink` from stable and broken multi-error `bail!`.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] modifies a **Cargo**-publishable library and **I have amended the version**

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

None.

## 🐾 Next steps

- Publish `error-stack` 0.7.1 to crates.io (releasing today).

## 🛡 What tests cover this?

- Existing `sink.rs` unit tests cover `ReportSink`'s stable API (`add_*`, `capture_*`); the `?`-operator tests stay `#[cfg(nightly)]`.
- Verified locally: `cargo check -p error-stack --features unstable` on nightly compiles, and a stable-emulated check (nightly `cfg` disabled via a temporary `build.rs` patch) also compiles with no remaining `try_trait_v2` reference. A true `cargo +stable` build cannot run from the workspace root because the manifest uses the nightly-only `codegen-backend` Cargo feature.

## ❓ How to test this?

1. On a stable toolchain, add the dependency: `cargo add -F unstable error-stack` (or path-depend on this branch).
2. Run `cargo check`.
3. Confirm it compiles — previously it failed with `error[E0658]: use of unstable library feature 'try_trait_v2'`.
