### PR TITLE
FE-759: Fix SimulationTimeline and ViewportControls buttons sizes

### DIFF
--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/BottomPanel/subviews/simulation-timeline.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/BottomPanel/subviews/simulation-timeline.tsx
@@ -246,7 +246,7 @@ const TimelineViewPicker: React.FC = () => {
       <div style={{ display: "flex" }}>
         {selectedMetric && (
           <Button
-            size="sm"
+            size="xs"
             variant="ghost"
             aria-label="Edit metric"
             tooltip="Edit Metric"
@@ -255,7 +255,7 @@ const TimelineViewPicker: React.FC = () => {
           />
         )}
         <Button
-          size="sm"
+          size="xs"
           variant="ghost"
           aria-label="Create metric"
           tooltip="Create Metric"
@@ -263,7 +263,7 @@ const TimelineViewPicker: React.FC = () => {
           onClick={() => setIsCreateOpen(true)}
         />
         <Button
-          size="sm"
+          size="xs"
           variant="ghost"
           aria-label="Manage metrics"
           tooltip="Manage Metrics"
@@ -328,7 +328,7 @@ function createEmptyStore(places: PlaceMeta[]): StreamingStore {
  */
 type SeriesExtractor = (
   frame: SimulationFrameReader,
-  seriesIdx: number,
+  seriesIdx: number
 ) => number;
 
 const UNTYPED_COLOR = "#94a3b8"; // slate-400
@@ -358,9 +358,9 @@ function useStreamingData(): {
   const selectedMetric = useMemo(
     () =>
       timelineView.kind === "metric"
-        ? (metrics.find((m) => m.id === timelineView.metricId) ?? null)
+        ? metrics.find((m) => m.id === timelineView.metricId) ?? null
         : null,
-    [timelineView, metrics],
+    [timelineView, metrics]
   );
 
   // Compile the selected metric. Recompiles only when its code changes.
@@ -608,12 +608,12 @@ function useStreamingData(): {
   ]);
 
   const [streamingStore] = useState(() =>
-    createValueStore<StreamingStore>(createEmptyStore(seriesConfig.series)),
+    createValueStore<StreamingStore>(createEmptyStore(seriesConfig.series))
   );
   const store = useSyncExternalStore(
     (listener) => streamingStore.subscribe(listener),
     () => streamingStore.getSnapshot(),
-    () => streamingStore.getSnapshot(),
+    () => streamingStore.getSnapshot()
   );
   const processedRef = useRef(0);
   const [, setRevision] = useState(0);
@@ -699,7 +699,7 @@ function useStreamingData(): {
 function buildRunData(
   store: StreamingStore,
   hiddenPlaces: Set<string>,
-  length = store.length,
+  length = store.length
 ): uPlot.AlignedData {
   const result: (number | null | undefined)[][] = [store.columns[0]!];
   for (let i = 0; i < store.places.length; i++) {
@@ -717,7 +717,7 @@ function buildRunData(
 function buildStackedData(
   store: StreamingStore,
   hiddenPlaces: Set<string>,
-  length = store.length,
+  length = store.length
 ): uPlot.AlignedData {
   const visible = store.places
     .map((p, i) => ({ ...p, colIdx: i + 1 }))
@@ -790,7 +790,7 @@ function hitTestStackedBand(
   store: StreamingStore,
   hiddenPlaces: Set<string>,
   idx: number,
-  yVal: number,
+  yVal: number
 ): { placeIdx: number; value: number } | null {
   if (yVal < 0) {
     return null;
@@ -827,7 +827,7 @@ function resolveHoverTarget(
   store: StreamingStore,
   chartType: TimelineChartType,
   hiddenPlaces: Set<string>,
-  focusedSeriesIdx: number,
+  focusedSeriesIdx: number
 ): HoverHit | null {
   const idx = u.cursor.idx;
   if (idx == null || idx < 0 || store.length === 0) {
@@ -846,7 +846,7 @@ function resolveHoverTarget(
       store,
       hiddenPlaces,
       idx,
-      u.posToVal(top, "y"),
+      u.posToVal(top, "y")
     );
     if (!hit) {
       return null;
@@ -1005,7 +1005,7 @@ function buildUPlotOptions(opts: ChartOptions): uPlot.Options {
       currentStore,
       chartType,
       hiddenPlaces,
-      focused,
+      focused
     );
     if (!hit) {
       t.root.style.display = "none";
@@ -1143,7 +1143,7 @@ function buildUPlotOptions(opts: ChartOptions): uPlot.Options {
  */
 function attachRulerScrubbing(
   u: uPlot,
-  onScrub: (frameIndex: number) => void,
+  onScrub: (frameIndex: number) => void
 ): () => void {
   let dragging = false;
   let overRect: DOMRect | null = null;
@@ -1166,7 +1166,7 @@ function attachRulerScrubbing(
     if (dragging && overRect) {
       const x = Math.max(
         0,
-        Math.min(e.clientX - overRect.left, overRect.width),
+        Math.min(e.clientX - overRect.left, overRect.width)
       );
       onScrub(u.posToIdx(x));
     }
@@ -1241,7 +1241,7 @@ const UPlotChart: React.FC<{
       chartType === "stacked"
         ? buildStackedData(store, hiddenPlaces, dataLength)
         : buildRunData(store, hiddenPlaces, dataLength),
-    [store, dataLength, chartType, hiddenPlaces],
+    [store, dataLength, chartType, hiddenPlaces]
   );
 
   // -- Effect 1: create/destroy uPlot on structural changes -------------------

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/BottomPanel/subviews/simulation-timeline.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/BottomPanel/subviews/simulation-timeline.tsx
@@ -328,7 +328,7 @@ function createEmptyStore(places: PlaceMeta[]): StreamingStore {
  */
 type SeriesExtractor = (
   frame: SimulationFrameReader,
-  seriesIdx: number
+  seriesIdx: number,
 ) => number;
 
 const UNTYPED_COLOR = "#94a3b8"; // slate-400
@@ -358,9 +358,9 @@ function useStreamingData(): {
   const selectedMetric = useMemo(
     () =>
       timelineView.kind === "metric"
-        ? metrics.find((m) => m.id === timelineView.metricId) ?? null
+        ? (metrics.find((m) => m.id === timelineView.metricId) ?? null)
         : null,
-    [timelineView, metrics]
+    [timelineView, metrics],
   );
 
   // Compile the selected metric. Recompiles only when its code changes.
@@ -608,12 +608,12 @@ function useStreamingData(): {
   ]);
 
   const [streamingStore] = useState(() =>
-    createValueStore<StreamingStore>(createEmptyStore(seriesConfig.series))
+    createValueStore<StreamingStore>(createEmptyStore(seriesConfig.series)),
   );
   const store = useSyncExternalStore(
     (listener) => streamingStore.subscribe(listener),
     () => streamingStore.getSnapshot(),
-    () => streamingStore.getSnapshot()
+    () => streamingStore.getSnapshot(),
   );
   const processedRef = useRef(0);
   const [, setRevision] = useState(0);
@@ -699,7 +699,7 @@ function useStreamingData(): {
 function buildRunData(
   store: StreamingStore,
   hiddenPlaces: Set<string>,
-  length = store.length
+  length = store.length,
 ): uPlot.AlignedData {
   const result: (number | null | undefined)[][] = [store.columns[0]!];
   for (let i = 0; i < store.places.length; i++) {
@@ -717,7 +717,7 @@ function buildRunData(
 function buildStackedData(
   store: StreamingStore,
   hiddenPlaces: Set<string>,
-  length = store.length
+  length = store.length,
 ): uPlot.AlignedData {
   const visible = store.places
     .map((p, i) => ({ ...p, colIdx: i + 1 }))
@@ -790,7 +790,7 @@ function hitTestStackedBand(
   store: StreamingStore,
   hiddenPlaces: Set<string>,
   idx: number,
-  yVal: number
+  yVal: number,
 ): { placeIdx: number; value: number } | null {
   if (yVal < 0) {
     return null;
@@ -827,7 +827,7 @@ function resolveHoverTarget(
   store: StreamingStore,
   chartType: TimelineChartType,
   hiddenPlaces: Set<string>,
-  focusedSeriesIdx: number
+  focusedSeriesIdx: number,
 ): HoverHit | null {
   const idx = u.cursor.idx;
   if (idx == null || idx < 0 || store.length === 0) {
@@ -846,7 +846,7 @@ function resolveHoverTarget(
       store,
       hiddenPlaces,
       idx,
-      u.posToVal(top, "y")
+      u.posToVal(top, "y"),
     );
     if (!hit) {
       return null;
@@ -1005,7 +1005,7 @@ function buildUPlotOptions(opts: ChartOptions): uPlot.Options {
       currentStore,
       chartType,
       hiddenPlaces,
-      focused
+      focused,
     );
     if (!hit) {
       t.root.style.display = "none";
@@ -1143,7 +1143,7 @@ function buildUPlotOptions(opts: ChartOptions): uPlot.Options {
  */
 function attachRulerScrubbing(
   u: uPlot,
-  onScrub: (frameIndex: number) => void
+  onScrub: (frameIndex: number) => void,
 ): () => void {
   let dragging = false;
   let overRect: DOMRect | null = null;
@@ -1166,7 +1166,7 @@ function attachRulerScrubbing(
     if (dragging && overRect) {
       const x = Math.max(
         0,
-        Math.min(e.clientX - overRect.left, overRect.width)
+        Math.min(e.clientX - overRect.left, overRect.width),
       );
       onScrub(u.posToIdx(x));
     }
@@ -1241,7 +1241,7 @@ const UPlotChart: React.FC<{
       chartType === "stacked"
         ? buildStackedData(store, hiddenPlaces, dataLength)
         : buildRunData(store, hiddenPlaces, dataLength),
-    [store, dataLength, chartType, hiddenPlaces]
+    [store, dataLength, chartType, hiddenPlaces],
   );
 
   // -- Effect 1: create/destroy uPlot on structural changes -------------------

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/components/viewport-controls.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/components/viewport-controls.tsx
@@ -54,11 +54,13 @@ export const ViewportControls: React.FC<{
 
   return (
     <div
-      className={`${containerStyle} ${animatingStyle({ animating: isPanelAnimating })}`}
+      className={`${containerStyle} ${animatingStyle({
+        animating: isPanelAnimating,
+      })}`}
       style={{ right: rightOffset, bottom: bottomOffset }}
     >
       <Button
-        size="sm"
+        size="xs"
         variant="subtle"
         aria-label="Zoom in"
         tooltip="Zoom in"
@@ -68,7 +70,7 @@ export const ViewportControls: React.FC<{
         onClick={() => zoomIn()}
       />
       <Button
-        size="sm"
+        size="xs"
         variant="subtle"
         aria-label="Zoom out"
         tooltip="Zoom out"
@@ -78,7 +80,7 @@ export const ViewportControls: React.FC<{
         onClick={() => zoomOut()}
       />
       <Button
-        size="sm"
+        size="xs"
         variant="subtle"
         aria-label="Fullscreen"
         tooltip="Fullscreen"
@@ -87,7 +89,7 @@ export const ViewportControls: React.FC<{
         onClick={collapseAllPanels}
       />
       <Button
-        size="sm"
+        size="xs"
         variant="subtle"
         aria-label="Lock view"
         tooltip="Lock view"
@@ -98,7 +100,7 @@ export const ViewportControls: React.FC<{
         }}
       />
       <Button
-        size="sm"
+        size="xs"
         variant="subtle"
         aria-label="Settings"
         tooltip="Settings"
@@ -114,7 +116,7 @@ export const ViewportControls: React.FC<{
         <Button
           key={action.key}
           ref={action.ref}
-          size="sm"
+          size="xs"
           variant="subtle"
           aria-label={action.label}
           tooltip={action.tooltip}

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/components/viewport-controls.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/components/viewport-controls.tsx
@@ -16,7 +16,7 @@ const containerStyle = css({
   position: "absolute",
   display: "flex",
   flexDirection: "column",
-  gap: "0.5",
+  gap: "[2px]",
   zIndex: "[900]",
 });
 

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/components/viewport-controls.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/components/viewport-controls.tsx
@@ -16,7 +16,7 @@ const containerStyle = css({
   position: "absolute",
   display: "flex",
   flexDirection: "column",
-  gap: "1",
+  gap: "0.5",
   zIndex: "[900]",
 });
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

- Fixes an issue with Metrics buttons in SimulationTimeline that break the layout as bigger than the container.
- Align ViewportControls sizes with the Figma designs.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->
<!-- Libraries inside of the `@local` directory are always internal libraries which have no need for publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
