### PR TITLE
SRE-731: Add commitMode option to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,7 @@ jobs:
         with:
           publish: yarn changeset:publish
           version: yarn changeset:version
+          commitMode: github-api
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This pull request introduces a configuration change to the release workflow. The most important update is the addition of the `commitMode: github-api` setting, which changes how commits are made during the release process.