### PR TITLE
FE-765: Remove line-height on tooltip wrapper

### DIFF
--- a/libs/@hashintel/ds-components/src/components/Tooltip/tooltip.recipe.ts
+++ b/libs/@hashintel/ds-components/src/components/Tooltip/tooltip.recipe.ts
@@ -1,6 +1,8 @@
 import { css, cva } from "@hashintel/ds-helpers/css";
 
 export const triggerStyles = css({
+  lineHeight: "[0]",
+
   "&:focus-visible": {
     outline: "[2px solid]",
     outlineColor: "neutral.s30",

--- a/libs/@hashintel/ds-components/src/components/Tooltip/tooltip.stories.tsx
+++ b/libs/@hashintel/ds-components/src/components/Tooltip/tooltip.stories.tsx
@@ -28,7 +28,7 @@ export const Default: Story = () => (
         <h3 style={{ marginBottom: 12 }}>
           {variant.charAt(0).toUpperCase() + variant.slice(1)} variant
         </h3>
-        <div style={{ display: "flex", gap: 24, alignItems: "center" }}>
+        <div className={css({ "& > *": { marginX: "3" } })}>
           <Tooltip content="Button tooltip" variant={variant}>
             <Button size="sm" onClick={() => {}}>
               Hover me
@@ -87,7 +87,7 @@ export const AllPositions: Story = () => (
       ) : (
         <Tooltip key={position} content={position} position={position}>
           <Button
-            size="lg"
+            size="xxs"
             className={css({ width: "[100%]" })}
             onClick={() => {}}
           >


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Sets the line-height on tooltip wrappers to 0 so that small items inside tooltips are properly aligned. This is safe to do, because the internal size/line-height of an element is still used to set the min height of the line-box, so it doesn't change the alignment/height of items at all.

## 🔗 Related links
- https://drafts.csswg.org/css-inline-3/

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change
