### PR TITLE
H-6541: Update Petrinaut user docs, make available to AI assistant

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,6 +15,9 @@
 **/*.md
 !**/README*.md
 !**/LICENSE*.md
+# Petrinaut bundles its user-facing docs into the build via `?raw` imports,
+# so they must be present in the Docker context (not just README.md).
+!libs/@hashintel/petrinaut/docs/*.md
 
 ########################
 ## Same as in .gitignore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,22 @@ cargo clippy --all-features --package <package-name>
 
 For Rust packages, you can add features as needed with `--all-features`, specific features like `--features=foo,bar`, or use `cargo-hack` with `--feature-powerset` for comprehensive feature testing.
 
+## Documentation Maintenance
+
+### Petrinaut user-facing docs
+
+The Petrinaut user guide lives at `libs/@hashintel/petrinaut/docs/*.md` and is the source of truth for end-user behaviour. The in-app AI assistant reads these pages at runtime via the `readPetrinautDoc` tool, so stale docs lead directly to wrong advice in the product.
+
+When you change UI or behaviour in the petrinaut packages (`libs/@hashintel/petrinaut`, `libs/@hashintel/petrinaut-core`), you MUST:
+
+1. Review the user-facing docs that mention the affected feature and update them in the same change.
+2. If you add a brand-new user-facing surface (panel, view, mode, tool, settings dialog, ...), add a corresponding page and link it from `libs/@hashintel/petrinaut/docs/README.md`.
+3. When you add a new doc page, also register it in `petrinautDocNames` and `petrinautDocSummaries` in `libs/@hashintel/petrinaut-core/src/ai.ts`, and add a `?raw` import in `libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel/petrinaut-docs-content.ts`. The tests in `libs/@hashintel/petrinaut-core/src/ai.test.ts` and `petrinaut-docs-content.test.ts` enforce that every enum value has a summary and a content entry.
+4. Keep the docs end-user-focused: describe what the user sees, what they click, what happens. Do not document Storybook, internal modules, or test setup in the user guide.
+5. If UI are changes that may make screenshots in the docs outdated, you MUST prompt your user to replace the screenshots.
+
+If a change ships without doc updates, call that out in your summary so the user can decide whether to follow up.
+
 ## Contextual Rules
 
 CRITICAL: For the files referenced below, use your Read tool to load it on a need-to-know basis, ONLY when relevant to the SPECIFIC task at hand:

--- a/libs/@hashintel/petrinaut-core/src/ai.ts
+++ b/libs/@hashintel/petrinaut-core/src/ai.ts
@@ -80,6 +80,42 @@ function createToolBundle<const InputSchemas extends Record<string, z.ZodType>>(
 export const getLatestNetDefinitionToolName = "getLatestNetDefinition";
 export const getNetCompilationErrorsToolName = "getNetCompilationErrors";
 export const setNetTitleToolName = "setNetTitle";
+export const readPetrinautDocToolName = "readPetrinautDoc";
+
+export const petrinautDocNames = [
+  "drawing-a-net",
+  "petri-net-extensions",
+  "useful-patterns",
+  "simulation",
+  "scenarios",
+  "experiments",
+  "ai-assistant",
+  "visual-settings",
+  "examples",
+] as const;
+
+export type PetrinautDocName = (typeof petrinautDocNames)[number];
+
+export const petrinautDocSummaries: Record<PetrinautDocName, string> = {
+  "drawing-a-net":
+    "Top bar (mode selector, menu, version history, active experiments), canvas, sidebars, adding nodes, arcs, selection, keyboard shortcuts, import/export, auto-layout.",
+  "petri-net-extensions":
+    "Token types, parameters, differential equations, visualizers, transition kernels, distributions, firing rate vs predicate, inhibitor arcs, diagnostics.",
+  "useful-patterns":
+    "Duration modelling (exponential / non-exponential), resource pools, mutual exclusion, source / sink transitions, competing/routing transitions, multi-token arcs.",
+  simulation:
+    "Single-run simulation: initial state, simulation settings (scenario picker, dt, ODE solver, parameters), running, frame computation, deadlock, playback controls, timeline, locked editing.",
+  scenarios:
+    "Named simulation configurations: scenario parameters, parameter bindings, per-place vs code-mode initial state, running and switching scenarios.",
+  experiments:
+    "Monte Carlo batches: configuration (runs, seed, dt, max time, scenario), lifecycle/statuses, cancel/remove, results (median/mean/p10/p90), active-experiments popover.",
+  "ai-assistant":
+    "In-app AI assistant: opening the panel, conversation surface, prompt chips, tool cards, read-only/simulate-mode rules, host configuration.",
+  "visual-settings":
+    "Animations, keep-panels-mounted, minimap, snap-to-grid, compact vs classic nodes, partial selection, tree view, arc rendering style.",
+  examples:
+    "Walkthroughs of the built-in examples and the scenarios/metrics each ships with: SIR, Supply Chain, Deployment Pipeline, Production Machines, Satellites in Orbit, Probabilistic Satellites Launcher.",
+};
 
 const getLatestNetDefinitionToolInputSchema = z
   .strictObject({})
@@ -104,12 +140,24 @@ export const setNetTitleToolInputSchema = z
     "Set the human-readable title shown for the current Petrinaut net.",
   );
 
+export const readPetrinautDocToolInputSchema = z
+  .strictObject({
+    doc: z.enum(petrinautDocNames).meta({
+      description:
+        "Which Petrinaut user-guide page to read. Pick the one whose summary best matches the user's question or what you need to verify before acting.",
+    }),
+  })
+  .describe(
+    "Read one page of the Petrinaut user guide. Use this when the user asks how a UI workflow works (panels, simulation controls, settings, examples), or when you need to confirm a UI detail before instructing them.",
+  );
+
 export const petrinautAiToolInputSchemas = {
   ...mutationActionInputSchemas,
   ...aiCommandActionInputSchemas,
   [getLatestNetDefinitionToolName]: getLatestNetDefinitionToolInputSchema,
   [getNetCompilationErrorsToolName]: getNetCompilationErrorsToolInputSchema,
   [setNetTitleToolName]: setNetTitleToolInputSchema,
+  [readPetrinautDocToolName]: readPetrinautDocToolInputSchema,
 };
 
 export const petrinautAiMutationTools = createToolBundle(
@@ -134,6 +182,10 @@ export const petrinautAiTools = {
   [setNetTitleToolName]: {
     description: getSchemaDescription(setNetTitleToolInputSchema),
     inputSchema: setNetTitleToolInputSchema,
+  },
+  [readPetrinautDocToolName]: {
+    description: getSchemaDescription(readPetrinautDocToolInputSchema),
+    inputSchema: readPetrinautDocToolInputSchema,
   },
 } satisfies PetrinautAiTools;
 
@@ -167,12 +219,19 @@ export function createPetrinautAiWritableCallbacks(
   return writable;
 }
 
+const petrinautDocIndex = petrinautDocNames
+  .map((name) => `- \`${name}\` — ${petrinautDocSummaries[name]}`)
+  .join("\n");
+
 export const petrinautAiPrompt = `You are an expert assistant for building Stochastic Dynamic Coloured Petri Nets (SDCPNs) in Petrinaut.
 
 Use the provided tools to directly modify the current net. The tools use Petrinaut's raw mutation interfaces, so include stable IDs, full entity objects where required, and canvas positions for places and transitions.
 You can check the current net state at any point using the ${getLatestNetDefinitionToolName} tool, which returns \`{ title, definition }\` — the user-visible net title plus the complete SDCPN. Use it before making changes that depend on existing places, transitions, arcs, scenarios, metrics, parameters, or types, and consult the \`title\` when deciding whether the net could use a more descriptive name.
 You can check current TypeScript compilation diagnostics at any point using the ${getNetCompilationErrorsToolName} tool.
 You can rename the net at any point using the ${setNetTitleToolName} tool.
+You can read pages of the Petrinaut user guide at any point using the ${readPetrinautDocToolName} tool. Reach for it when the user asks how a UI workflow works (panels, simulation controls, visual settings, the built-in examples), or when you need to confirm a UI detail before instructing them. The available pages and what they cover:
+
+${petrinautDocIndex}
 
 Interview first, build second. Before creating a new net (or adding a substantial new subsystem to an existing one), do NOT jump straight to tool calls. Run a brief, focused interview to establish:
 

--- a/libs/@hashintel/petrinaut-core/src/index.ts
+++ b/libs/@hashintel/petrinaut-core/src/index.ts
@@ -65,7 +65,11 @@ export {
   petrinautAiMutationTools,
   petrinautAiPrompt,
   petrinautAiTools,
+  petrinautDocNames,
+  petrinautDocSummaries,
   placeSchema,
+  readPetrinautDocToolInputSchema,
+  readPetrinautDocToolName,
   scenarioSchema,
   setNetTitleToolInputSchema,
   setNetTitleToolName,
@@ -81,6 +85,7 @@ export type {
   PetrinautAiMutationToolName,
   PetrinautAiToolName,
   PetrinautAiTools,
+  PetrinautDocName,
 } from "./ai";
 
 // --- Simulation ---

--- a/libs/@hashintel/petrinaut/docs/README.md
+++ b/libs/@hashintel/petrinaut/docs/README.md
@@ -10,11 +10,28 @@ Petrinaut is available at [demo.petrinaut.org](https://demo.petrinaut.org).
 
 Net data will be stored in local browser storage. You can also export and import nets as JSON files for transfer between devices and browsers.
 
+## Concepts
+
+A quick map of the things you'll encounter:
+
+- **Net** -- the document you're editing: places, transitions, arcs, types, parameters, differential equations.
+- **Scenario** -- a saved, named configuration for running the net (initial markings, scenario parameters, parameter overrides). Optional.
+- **Metric** -- a built-in or user-authored function over simulation state that returns a number to plot on the Timeline.
+- **Experiment** -- a Monte Carlo batch: many independent simulation runs of the current net, optionally against one scenario, aggregated as distributions over time.
+
+Petrinaut has two global modes you switch between in the top bar:
+
+- **Edit** -- the drawing/configuration workspace plus single-run simulation playback.
+- **Simulate** -- a separate management surface for scenarios, metrics, and experiments.
+
 ## Contents
 
-- [Drawing a Net](drawing-a-net.md) -- Add nodes (places and transitions), connect them with arcs, and navigate the editor.
-- [Petri Net Extensions](petri-net-extensions.md) -- Add types, dynamics, transition kernels, firing rules, and inhibitor arcs, as well as parameters and state visualizers.
+- [Drawing a Net](drawing-a-net.md) -- Top bar, canvas, sidebars, adding nodes and connecting arcs, selection, keyboard shortcuts, import/export, auto-layout.
+- [Petri Net Extensions](petri-net-extensions.md) -- Types, dynamics, transition kernels, firing rules, and inhibitor arcs, as well as parameters and state visualizers.
 - [Useful Patterns](useful-patterns.md) -- Common modelling techniques, including duration and resource pools.
-- [Simulation](simulation.md) -- Set initial state, run the simulation, use the timeline, and control playback.
+- [Simulation](simulation.md) -- Set initial state, run a single simulation, use the timeline, control playback.
+- [Scenarios](scenarios.md) -- Save and switch between named simulation configurations.
+- [Experiments](experiments.md) -- Run Monte Carlo batches and inspect token-count distributions over time.
+- [AI Assistant](ai-assistant.md) -- Build, review, and revise nets using natural language.
 - [Visual Settings](visual-settings.md) -- Configure the editor appearance and behavior.
 - [Examples](examples.md) -- Walkthrough of the built-in example nets.

--- a/libs/@hashintel/petrinaut/docs/ai-assistant.md
+++ b/libs/@hashintel/petrinaut/docs/ai-assistant.md
@@ -1,0 +1,52 @@
+# AI Assistant
+
+Petrinaut has an in-app AI assistant that can build a net from a natural-language description, review or revise an existing one, read TypeScript compilation diagnostics, and consult its own user-guide pages to answer "how do I ..." questions. The host application controls whether the assistant is available -- it is enabled on [demo.petrinaut.org](https://demo.petrinaut.org) and in [HASH](https://hash.ai) and may or may not be enabled in other Petrinaut embeds.
+
+## Opening the panel
+
+There are two entry points:
+
+1. **AI button** in the bottom toolbar (Edit mode only). Click it to open the panel; click again to close. The tooltip is "Show AI assistant" / "Hide AI assistant".
+2. **First-run prompt**. When you load Petrinaut against an empty net, a centred prompt appears. Type a description, press send, and the panel opens with your message already in flight. Dismiss the prompt with the **X**, by clicking outside it, or by pressing **Escape**; it is hidden for the rest of the session once dismissed.
+
+The assistant panel only renders in **Edit** mode. Switching to **Simulate** mode hides it; switch back to **Edit** to continue the conversation. The panel resizes by dragging its left edge.
+
+## The conversation
+
+While a response is streaming you can:
+
+- Watch the model's text and reasoning appear live. The **Reasoning** block is collapsible; while it is streaming, it auto-opens, shows a shimmer effect, and (once attached timing information arrives) an elapsed timer.
+- Press **Stop AI response** (the send button turns into a stop icon) to halt the current response.
+- Type your next message in the composer -- it is queued for after the current response ends.
+
+**Clear AI chat** via the delete button in the top right of the panel: wipes the conversation, stops any in-flight stream, and tells the host app to forget the messages (if the host persists them).
+
+## What the assistant can do
+
+The assistant has tools for inspecting and modifying the current net. You'll see one card per tool call inline in the conversation:
+
+- **Read tools** (neutral, expandable) –– for checking the current net state at any point, for compilation errors, and for reading the user guide.
+- **Mutation tools** (green for additions/updates, red for deletions) -- "Added place X", "Updated transition Y", "Removed metric Z", and so on. Multiple successive mutations group under a collapsible "N changes" header.
+- **`setNetTitle`** -- renames the net.
+- **`applyAutoLayout`** -- rearranges places and transitions on the canvas. If the assistant calls this on a net you've already arranged, it asks you first via an inline widget with **Yes, auto-layout** / **No, keep current layout** buttons. Otherwise it'll run it without asking.
+
+Clicking a mutation card usually selects the entity it touched (place, transition, scenario, metric, etc.) so you can inspect what changed.
+
+After applying changes, the assistant may automatically check TypeScript compile diagnostics (you'll see a **Checked net compilation errors** card) and fix problems on its own before continuing.
+
+## Read-only behaviour
+
+Whether the assistant can change the net depends on the editor state:
+
+- **Application marks the document read-only (e.g. you don't have permissions)** -- no mutations at all.
+- **Simulation running, paused, or completed** -- the same rule applies (reset the simulation to mutate the structure again).
+
+The composer stays open in all of these cases, so you can still ask questions, request a review, or have the assistant read documentation -- it just won't be able to write changes back until you reset.
+
+## Diagnostics integration
+
+When the assistant edits code surfaces (lambdas, kernels, dynamics, visualizers, metric/scenario code), it sees the resulting TypeScript diagnostics on the next turn and can iteratively fix them. You don't have to relay errors manually -- the post-edit re-check happens automatically. The same diagnostics also appear in the bottom **Diagnostics** tab as usual; the assistant just sees them in addition.
+
+## Host configuration
+
+Whether the assistant is available, where the conversation is stored (in-memory, in your host app's database, or anywhere else), and the model behind it are all controlled by the host application that embeds Petrinaut. Read-only documents and the simulate-mode restrictions described above always apply when applicable.

--- a/libs/@hashintel/petrinaut/docs/drawing-a-net.md
+++ b/libs/@hashintel/petrinaut/docs/drawing-a-net.md
@@ -4,13 +4,48 @@
 
 The editor is organized around a central canvas where you build your net:
 
+- **Top bar** -- net management menu, optional title field, **Edit / Simulate** mode switcher, active-experiments indicator, recent-changes history. See [Top bar](#top-bar).
 - **Canvas** (center) -- the main workspace where places and transitions are displayed and connected.
 - **Left sidebar** -- lists of entities organized into tabs: Nodes, Types, Differential Equations, Parameters.
 - **Properties panel** (right) -- opens when you select an entity, showing its configurable properties.
 - **Bottom panel** -- tabs for Diagnostics (code errors), Simulation Settings, and Timeline (during simulation).
-- **Bottom toolbar** -- editing mode buttons and simulation controls (+ show/hide toggle for bottom panel).
+- **Bottom toolbar** -- editing mode buttons, simulation controls, the AI assistant toggle, and a show/hide button for the bottom panel.
 
 <img width="1793" height="1175" alt="full-editor" src="https://github.com/user-attachments/assets/ea41efe8-9056-479b-a936-e0d5e4196b11" />
+
+## Top bar
+
+Spans the full editor width and has three sections.
+
+**Left**
+
+- **Sidebar toggle** -- collapses or expands the left sidebar.
+- **Menu** (hamburger icon) -- file operations: **Export** (JSON / JSON without visual info / TikZ), **Layout** (apply auto-layout), and **Docs**. A standalone embed of Petrinaut may additionally show **New**, **Open**, **Import**, and **Load example**.
+- **Net title** -- editable inline title for the current net. Whether the title field is shown depends on the host application; the demo site shows it, but a Petrinaut embedded in another product may hide it.
+
+**Center**
+
+- **Edit / Simulate / Actual** mode switcher. See [Edit vs Simulate mode](#edit-vs-simulate-mode) below.
+
+**Right**
+
+- **Active experiments** -- a flask icon with a count (e.g. "2 active") that appears only when [Monte Carlo experiments](experiments.md) are initializing or running. Clicking it opens a popover; clicking a row jumps to that experiment in Simulate mode.
+- **Recent changes** (clock icon) -- a dropdown listing your recent undo/redo checkpoints with timestamps. Click any entry to jump to that state. This is the same history you walk via Cmd/Ctrl+Z and Cmd/Ctrl+Shift+Z.
+- The host application may add additional buttons here (login, share, ...).
+
+## Edit vs Simulate mode
+
+Petrinaut has two global modes, switched via the centre control in the top bar.
+
+| Mode         | Workspace                                                                                                                                                                                 |
+| ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Edit**     | Canvas + left sidebar + properties panel + bottom panel + bottom toolbar (with AI assistant). This is where you draw the net, configure entities, write code, and run single simulations. |
+| **Simulate** | Replaces the workspace with the [Scenarios](scenarios.md), [Metrics](metrics.md), and [Experiments](experiments.md) management views.                                                     |
+| **Actual**   | Reserved for a future live-data mode.                                                                                                                                                     |
+
+In Simulate mode the net structure becomes read-only -- you can still create, edit, and delete scenarios and metrics, but you cannot change places, transitions, arcs, types, or parameters. Switch back to Edit mode to modify the net.
+
+Switching modes does not stop background experiments. The active-experiments indicator remains visible in the top bar from either mode.
 
 ## Adding places and transitions
 
@@ -110,12 +145,13 @@ When enabled, node positions snap to a grid when placing or dragging. Toggle thi
 
 ## Import and export
 
-From the hamburger menu (top-left):
+From the top-bar menu (hamburger icon), under **Export**:
 
-- **Export as JSON** -- saves the full net definition including positions and visual styling.
-- **Export as JSON without visual info** -- strips node positions and type display colours. Useful for sharing the logical structure only.
-- **Export as TikZ** -- generates a `.tex` file with a structural diagram. This is a simplified view: no colours, inhibitor arcs, dynamics, or token types are encoded. Intended for papers and presentations.
-- **Import from JSON** -- loads a net from a `.json` file. If node positions are missing, an automatic layout is applied.
+- **JSON** -- the full SDCPN: places, transitions, arcs, types, dynamics, parameters, scenarios, metrics, **and** canvas positions / display colours. The format other Petrinaut instances can re-import faithfully.
+- **JSON without visual info** -- the same payload minus node positions and type display colours. Useful when only the logical structure matters (sharing for review, embedding in another tool, comparing two nets without layout noise). On import, the receiving editor applies auto-layout to fill in positions.
+- **TikZ** -- a `.tex` file with a structural diagram. This is a simplified view: only the place / transition / arc structure is included. Token types, dynamics, inhibitor arcs, scenarios, and metrics are **not** encoded. Intended for papers and presentations.
+
+**Import**: loads a net from a `.json` file. If node positions are missing, an automatic layout is applied on load.
 
 ## Auto-layout
 

--- a/libs/@hashintel/petrinaut/docs/drawing-a-net.md
+++ b/libs/@hashintel/petrinaut/docs/drawing-a-net.md
@@ -40,7 +40,7 @@ Petrinaut has two global modes, switched via the centre control in the top bar.
 | Mode         | Workspace                                                                                                                                                                                 |
 | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Edit**     | Canvas + left sidebar + properties panel + bottom panel + bottom toolbar (with AI assistant). This is where you draw the net, configure entities, write code, and run single simulations. |
-| **Simulate** | Replaces the workspace with the [Scenarios](scenarios.md), [Metrics](metrics.md), and [Experiments](experiments.md) management views.                                                     |
+| **Simulate** | Replaces the workspace with the [Scenarios](scenarios.md) and [Experiments](experiments.md) management views.                                                                             |
 | **Actual**   | Reserved for a future live-data mode.                                                                                                                                                     |
 
 In Simulate mode the net structure becomes read-only -- you can still create, edit, and delete scenarios and metrics, but you cannot change places, transitions, arcs, types, or parameters. Switch back to Edit mode to modify the net.

--- a/libs/@hashintel/petrinaut/docs/examples.md
+++ b/libs/@hashintel/petrinaut/docs/examples.md
@@ -16,7 +16,7 @@ The classic Susceptible-Infected-Recovered compartmental model from epidemiology
 
 **Bundled extras:** two scenarios -- **Seasonal Flu** (R₀ ≈ 1.5) and **High Virulence Outbreak** (R₀ ≈ 6) -- driven by `population` and `infected_ratio` scenario parameters. One metric, **Infected Fraction**, plots the share of the population currently infected.
 
-**Key concepts:** [stochastic firing](petri-net-extensions.md#stochastic-rate), [parameters](petri-net-extensions.md#global-parameters), [arc weight](useful-patterns.md#arc-weight-for-multi-token-operations), [scenarios](scenarios.md), [metrics](metrics.md).
+**Key concepts:** [stochastic firing](petri-net-extensions.md#stochastic-rate), [parameters](petri-net-extensions.md#global-parameters), [arc weight](useful-patterns.md#arc-weight-for-multi-token-operations), [scenarios](scenarios.md).
 
 <img width="1104" height="412" alt="SIR" src="https://github.com/user-attachments/assets/b8ad69cb-687c-452a-8394-d5100db3e198" />
 

--- a/libs/@hashintel/petrinaut/docs/examples.md
+++ b/libs/@hashintel/petrinaut/docs/examples.md
@@ -14,7 +14,9 @@ The classic Susceptible-Infected-Recovered compartmental model from epidemiology
 
 **Suggested initial state:** set Susceptible to **100** tokens, Infected to **1**, Recovered to **0**. All places are untyped, so you just set token counts. Press Play and watch the epidemic curve in the timeline.
 
-**Key concepts:** [stochastic firing](petri-net-extensions.md#stochastic-rate), [parameters](petri-net-extensions.md#global-parameters), [arc weight](useful-patterns.md#arc-weight-for-multi-token-operations).
+**Bundled extras:** two scenarios -- **Seasonal Flu** (R₀ ≈ 1.5) and **High Virulence Outbreak** (R₀ ≈ 6) -- driven by `population` and `infected_ratio` scenario parameters. One metric, **Infected Fraction**, plots the share of the population currently infected.
+
+**Key concepts:** [stochastic firing](petri-net-extensions.md#stochastic-rate), [parameters](petri-net-extensions.md#global-parameters), [arc weight](useful-patterns.md#arc-weight-for-multi-token-operations), [scenarios](scenarios.md), [metrics](metrics.md).
 
 <img width="1104" height="412" alt="SIR" src="https://github.com/user-attachments/assets/b8ad69cb-687c-452a-8394-d5100db3e198" />
 
@@ -71,7 +73,9 @@ A manufacturing system where machines produce goods, accumulate damage, break do
 
 All other places start empty. "Start Production" will immediately consume a raw material and an available machine to begin.
 
-**Key concepts:** [dynamics](petri-net-extensions.md#differential-equations-dynamics), [resource pools](useful-patterns.md#resource-pools), predicate vs stochastic on competing transitions.
+**Bundled extras:** one scenario, **Default Production**, with scenario parameters `raw_material`, `machines_count`, and `initial_machine_damage`. Use it to compare runs without retyping the initial marking.
+
+**Key concepts:** [dynamics](petri-net-extensions.md#differential-equations-dynamics), [resource pools](useful-patterns.md#resource-pools), predicate vs stochastic on competing transitions, [scenarios](scenarios.md).
 
 <img width="1223" height="611" alt="production-machines" src="https://github.com/user-attachments/assets/f9b058a2-6eef-4b0f-880b-09ae45921729" />
 
@@ -113,6 +117,8 @@ Extends the Satellites example with ongoing satellite launches at a stochastic r
 
 **Suggested initial state:** no initial tokens needed -- start with all places empty. The "LaunchSatellite" source transition fires at a rate of 1 per second, creating satellites with randomized orbital positions and velocities. Just press Play and watch the Space visualizer fill up.
 
-**Key concepts:** [source transitions](useful-patterns.md#source-transitions-exogenous-arrivals), [distributions and `.map()`](petri-net-extensions.md#distributions).
+**Bundled extras:** four scenarios -- **Moon Orbit**, **Earth Orbit**, **Mars Orbit**, and **Solar Orbit** -- that tune the physical constants for very different orbital regimes. Switch between them in Simulation Settings to compare.
+
+**Key concepts:** [source transitions](useful-patterns.md#source-transitions-exogenous-arrivals), [distributions and `.map()`](petri-net-extensions.md#distributions), [scenarios](scenarios.md).
 
 <img width="1106" height="320" alt="probabilistic-satellites" src="https://github.com/user-attachments/assets/e696a4f7-f61a-4b8b-9b34-1598a7190376" />

--- a/libs/@hashintel/petrinaut/docs/experiments.md
+++ b/libs/@hashintel/petrinaut/docs/experiments.md
@@ -1,0 +1,75 @@
+# Experiments
+
+An **experiment** is a Monte Carlo batch: many independent simulation runs of the current net, all running the same scenario (or no scenario), with results aggregated as distributions of token counts over simulation time. Use experiments when one run isn't enough -- when the model is stochastic and you want to see the spread, not just one trajectory.
+
+Experiments live under the **Simulate** [global mode](drawing-a-net.md#edit-vs-simulate-mode). Open the Simulate sidebar and choose **Experiments**.
+
+## Creating an experiment
+
+1. Switch to **Simulate** mode and open the **Experiments** tab.
+2. Click **Create**. The Create Experiment drawer opens.
+3. Fill in the configuration (see below).
+4. Click **Run**.
+
+### Configuration
+
+| Setting                 | Default                           | Notes                                                                                                                                                                                                              |
+| ----------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Name**                | `Experiment`                      | Free text.                                                                                                                                                                                                         |
+| **Scenario**            | `(Default)`                       | Either `(Default)` (no scenario; uses each place's manually-set initial marking and net-level parameter defaults) or one of your saved [scenarios](scenarios.md). An experiment runs against exactly one scenario. |
+| **Scenario parameters** | each scenario parameter's default | When a scenario is selected, you can override its scenario parameters per experiment. Expressions are evaluated once at start.                                                                                     |
+| **Runs**                | `1000`                            | Positive integer; how many independent simulations to run.                                                                                                                                                         |
+| **Seed**                | `1`                               | Base random seed. Each run gets a deterministic per-run seed derived from this.                                                                                                                                    |
+| **Time step (dt)**      | `1`                               | Same meaning as in single-run simulations (see [Simulation](simulation.md#time-step-dt)).                                                                                                                          |
+| **Max time**            | `180`                             | Each run advances until simulation time reaches this value, then completes.                                                                                                                                        |
+
+The model used is a snapshot of the current net at the time you press **Run**. Editing the net afterwards does not change runs that have already started.
+
+> Currently, an experiment can only run against one scenario at a time. To compare scenarios, create one experiment per scenario.
+
+## Lifecycle and statuses
+
+Experiments progress through five status labels:
+
+| Status           | Meaning                                                                                           |
+| ---------------- | ------------------------------------------------------------------------------------------------- |
+| **Initializing** | The experiment has been created and the worker is starting up.                                    |
+| **Running**      | Runs are in progress.                                                                             |
+| **Complete**     | All runs finished without error.                                                                  |
+| **Error**        | The experiment failed to start or hit an unrecoverable error. The drawer shows the error message. |
+| **Cancelled**    | You clicked **Cancel**, or the worker was cancelled.                                              |
+
+Each experiment runs in its own background Web Worker, so simulation playback and editor interactions stay responsive. Multiple experiments can run concurrently.
+
+### Actions
+
+In the experiment's view drawer (open it by clicking a row in the list, or any experiment in the top-bar **Active experiments** popover):
+
+- **Cancel** -- stops the experiment. Only available while it is initializing or running.
+- **Remove** -- deletes the record and disposes the worker. Available after completion, cancellation, or error.
+- **Close** -- closes the drawer without affecting the experiment.
+
+There is no built-in restart action -- to re-run with the same configuration, **Create** a new experiment with the same settings.
+
+A confirmation prompt blocks browser/tab close while any experiment is initializing or running.
+
+### Notifications
+
+A small toast appears when an experiment **completes** or **errors**, even if its drawer isn't open. The top-bar **Active experiments** popover (see below) lets you jump to any in-flight experiment from anywhere in the app.
+
+## Active experiments popover
+
+When any experiment is **initializing** or **running**, the top bar shows an **Active experiments** flask icon with a count (e.g. "2 active"). Click it for a popover listing each in-flight experiment with its scenario, progress, status, and a time progress bar. Clicking a row jumps directly to Simulate mode, the Experiments tab, and that experiment's drawer.
+
+The popover hides itself again once nothing is in flight.
+
+## Experiments and single-run Play
+
+Experiments and the bottom-bar **Play** controls are independent systems:
+
+- Pressing Play runs a single simulation in the editor and drives the canvas + Timeline panel.
+- Experiments run separately, in their own workers, without animating the canvas.
+
+You can press Play in Edit mode while experiments are running in the background, and switching to Simulate mode does not stop them.
+
+Changing the net while an experiment is running does **not** retroactively affect that experiment -- it captured its model snapshot when you pressed Run.

--- a/libs/@hashintel/petrinaut/docs/petri-net-extensions.md
+++ b/libs/@hashintel/petrinaut/docs/petri-net-extensions.md
@@ -102,7 +102,12 @@ export default TransitionKernel((tokensByPlace, parameters) => {
 });
 ```
 
-`tokensByPlace` is keyed by **place name**. Each value is an array of token objects from that input place. The return value is keyed by **output place name**, each containing an array of token objects to produce.
+`tokensByPlace` is keyed by **place name**. Each value is a tuple of token objects -- one entry per token consumed from that arc, sized to the arc weight. The return value is keyed by **output place name**, each containing an array of token objects to produce sized to the output arc weight.
+
+Two important asymmetries:
+
+- **Uncoloured input places and inhibitor arcs are not included in `tokensByPlace`**. Only typed input places appear, and only for normal (non-inhibitor) arcs.
+- **Uncoloured output places do not need to appear in the return value** -- the engine generates the correct number of plain tokens automatically based on the output arc weight. Coloured output places must appear with one token object per token produced.
 
 Use the menu in the code editor header to **Load default template** for a starting point.
 
@@ -163,6 +168,8 @@ export default Lambda((tokensByPlace, parameters) => {
   return parameters.rate;
 });
 ```
+
+The same `tokensByPlace` rules from the [Transition kernel](#transition-kernel) section apply: only typed input places appear, and only for normal arcs. A transition with **no input arcs** therefore sees an empty `tokensByPlace` and is always structurally enabled -- this is how you model exogenous arrivals (see [Source transitions](useful-patterns.md#source-transitions-exogenous-arrivals)).
 
 ## Inhibitor arcs
 

--- a/libs/@hashintel/petrinaut/docs/scenarios.md
+++ b/libs/@hashintel/petrinaut/docs/scenarios.md
@@ -1,0 +1,111 @@
+# Scenarios
+
+A **scenario** is a saved, named configuration for running the current net: a set of initial token values, optional scenario-only parameters, and overrides for net-level parameters. Scenarios make it easy to compare several "what if" setups without editing the net itself.
+
+Scenarios live under the **Simulate** [global mode](drawing-a-net.md#edit-vs-simulate-mode). To open the scenarios list, switch the mode selector in the top bar from **Edit** to **Simulate**, then choose the **Scenarios** tab in the Simulate sidebar.
+
+## What a scenario contains
+
+A scenario has four parts:
+
+1. **Name** and optional description.
+2. **Scenario parameters** -- numeric variables scoped to this scenario. Referenced in code as `scenario.<identifier>`.
+3. **Parameter bindings** -- expressions that override the default value of each net-level parameter, for this scenario only.
+4. **Initial state** -- the starting marking of each place. Authored either per-place or as a single function (see below).
+
+You can save as many scenarios as you like; they are stored on the net alongside places, transitions, and parameters.
+
+## No built-in default scenario
+
+A new net starts with the scenario list empty and **no scenario selected** (the Simulation Settings dropdown shows "No scenario"). In that state the simulation uses each place's manually-entered initial marking and the net-level parameter defaults.
+
+You will need scenarios when you want to:
+
+- Switch between several pre-configured starting states with one click.
+- Drive the initial marking from expressions and a small set of high-level variables (population size, infection rate, machine count, ...).
+- Run [Monte Carlo experiments](experiments.md) against different scenarios.
+
+## Creating a scenario
+
+1. Switch to **Simulate** mode and open the **Scenarios** tab.
+2. Click **Create**. The Create Scenario drawer opens.
+3. Fill in **Name** (required, must be unique among scenarios) and an optional description.
+4. Add **Scenario parameters** if you need variables scoped to this scenario. Each parameter has an identifier (snake_case, lowercase; the form auto-converts on blur), a type (Real / Integer / Boolean / Ratio), and a default value. Ratios are clamped to `[0, 1]`; booleans are stored as `1` or `0`.
+5. Set **Parameter bindings** for any net-level parameters whose default you want to override. Each binding is a TypeScript expression; leaving it empty keeps the net default (shown in the placeholder).
+6. Configure **Initial state** for each place that should start with tokens.
+7. Click **Create**. Save is blocked while the form has validation or LSP errors -- hover the disabled button to see why.
+
+The view drawer (opened by clicking a row in the Scenarios list) is the same form populated with the existing values. It has **Close** and **Save** buttons.
+
+## Initial state: per-place vs code
+
+The Initial State section has a **Define as code** toggle.
+
+### Per-place mode (default)
+
+You see a row per place. Which places appear depends on the **Show all places** toggle:
+
+- Off (default): only places whose **Default starting place** flag is on (configured in the place's properties panel). If no places are marked, the section is empty and shows a hint.
+- On: every place in the net, with default-starting places listed first.
+
+What you enter per place depends on whether it has a type:
+
+- **Uncoloured places**: a single-line TypeScript expression that evaluates to the token count. The result is rounded down and clamped to `>= 0`. You can reference `parameters.<variable_name>` and `scenario.<identifier>`. Empty/missing means zero tokens.
+- **Coloured places**: a small spreadsheet, one row per token, one column per element of the place's type. Cell values are literal numbers; expressions are not supported in the spreadsheet.
+
+### Code mode (Define as code)
+
+You write a single function body (no `function` keyword, no `export default`) that returns an object keyed by **place name**:
+
+```ts
+return {
+  RawMaterial: scenario.raw_material,
+  AvailableMachines: Array.from({ length: scenario.machines_count }, () => ({
+    machine_damage_ratio: scenario.initial_machine_damage,
+  })),
+};
+```
+
+`parameters` (net-level) and `scenario` (this scenario's parameters) are in scope. For each returned key:
+
+- An **uncoloured** place takes a number (rounded, clamped to `>= 0`).
+- A **coloured** place takes an array of token objects, with one property per type element.
+
+> Place keys are **names** in code mode, but **IDs** in per-place mode. This asymmetry is by design.
+> Unknown place names in code mode are **silently ignored** -- there is no warning if you typo a name.
+
+The TypeScript editor type-checks against the current net's place names and types as you write, so unrecognised names show up as compile errors before save.
+
+## Parameter bindings
+
+Each net-level parameter gets one row. The placeholder shows that parameter's default. A bound expression replaces the default whenever this scenario is active.
+
+Common patterns:
+
+- Hard-coded override: `1.5`
+- Derived from a scenario parameter: `scenario.peak_demand * 1.2`
+- Combination of both: `parameters.base_rate * scenario.surge_multiplier`
+
+Bindings are evaluated once at the start of each run, before the initial state is computed, so you can safely reference parameter values from inside initial-state expressions or code.
+
+## Running a scenario
+
+In **Edit** mode, open **Simulation Settings** (bottom panel). The **Scenario** dropdown lists "No scenario" plus every saved scenario. While a scenario is selected:
+
+- The **Parameters** section in Simulation Settings shows the **scenario parameters** (with the scenario's defaults pre-filled). Adjust them per run; net-level parameter values are not editable here, since they are fixed by the scenario's bindings.
+- The Properties panel **State** sub-view for each place becomes read-only ("Defined by scenario").
+- Pressing **Play** runs the simulation with the scenario's overrides and initial state.
+
+Selecting a different scenario resets the scenario-parameter inputs to that scenario's defaults. The picker is locked while a simulation is running or paused; reset the simulation to switch.
+
+Quick-action buttons next to the dropdown let you edit the selected scenario, create a new one, or jump to the Scenarios management view.
+
+## Pre-bundled scenarios in the example nets
+
+Several of the built-in examples ship with scenarios so you can see realistic configurations. See [Examples](examples.md) for the full list; highlights:
+
+- **SIR Epidemic Model** -- "Seasonal Flu" and "High Virulence Outbreak", driven by `population` and `infected_ratio` scenario parameters plus parameter overrides for infection and recovery rates.
+- **Production Machines** -- "Default Production", driven by `raw_material`, `machines_count`, and `initial_machine_damage`.
+- **Probabilistic Satellites Launcher** -- four orbit scenarios (Moon, Earth, Mars, Solar).
+
+Loading any of these examples is the fastest way to see a working scenario authored in both modes.

--- a/libs/@hashintel/petrinaut/docs/simulation.md
+++ b/libs/@hashintel/petrinaut/docs/simulation.md
@@ -1,6 +1,6 @@
 # Simulation
 
-This page covers running a **single** simulation from Edit mode. For repeatable, named simulation configurations see [Scenarios](scenarios.md); for many-run Monte Carlo batches see [Experiments](experiments.md); for custom timeline plots see [Metrics](metrics.md).
+This page covers running a **single** simulation from Edit mode. For repeatable, named simulation configurations see [Scenarios](scenarios.md); for many-run Monte Carlo batches see [Experiments](experiments.md).
 
 ## Initial state
 

--- a/libs/@hashintel/petrinaut/docs/simulation.md
+++ b/libs/@hashintel/petrinaut/docs/simulation.md
@@ -1,5 +1,7 @@
 # Simulation
 
+This page covers running a **single** simulation from Edit mode. For repeatable, named simulation configurations see [Scenarios](scenarios.md); for many-run Monte Carlo batches see [Experiments](experiments.md); for custom timeline plots see [Metrics](metrics.md).
+
 ## Initial state
 
 Before running a simulation, set the **initial marking** -- the starting tokens in each place.
@@ -13,15 +15,26 @@ Select a place and open the **State** sub-view in its properties:
 
 If no initial marking is set, a place starts empty (zero tokens).
 
+When a [scenario](scenarios.md) is selected in Simulation Settings, the per-place State sub-view becomes read-only ("Defined by scenario") and the scenario's initial state is used instead.
+
 ## Simulation settings
 
 Open the **Simulation Settings** tab in the bottom panel to configure:
 
+### Scenario
+
+The **Scenario** dropdown lists "No scenario" plus every saved [scenario](scenarios.md). Selecting a scenario overrides parameters and the per-place initial marking with the scenario's values for this run. The picker is locked while a simulation is running; reset to change scenario.
+
+Quick-action buttons next to the picker let you edit the selected scenario, create a new scenario, or jump to the [Scenarios](scenarios.md) management view in Simulate mode.
+
 ### Parameters
 
-Override [global parameter](petri-net-extensions.md#global-parameters) values for this run. Each parameter shows its name, variable name, and a value input (pre-filled with the default). Changes here do not modify the parameter definition -- they only apply to the simulation.
+Override values for this run:
 
-Parameter values are locked while a simulation is running. Reset the simulation to change them.
+- With **No scenario** selected: each [net-level parameter](petri-net-extensions.md#global-parameters) shows its name, variable name, and a value input pre-filled with the default.
+- With a scenario selected: the **scenario parameters** are shown instead, pre-filled with that scenario's defaults. Net-level parameter values are fixed by the scenario's [parameter bindings](scenarios.md#parameter-bindings) and are not editable here.
+
+Changes here do not modify the parameter definition or the scenario -- they only apply to the simulation. Parameter values are locked while a simulation is running. Reset the simulation to change them.
 
 ### Time step (dt)
 
@@ -40,9 +53,11 @@ The numerical method for integrating differential equations. Currently only **Eu
 
 Press **Play** in the bottom toolbar. The simulation:
 
-1. Initializes with a random seed, the current dt, and parameter values.
+1. Initializes with a fresh random seed (single-run simulations re-seed each time you press Play, so two consecutive runs of the same stochastic model produce different trajectories), the current dt, and parameter values.
 2. Computes frames in a background Web Worker.
 3. Streams frames to the UI for playback.
+
+If you need reproducibility across multiple runs of the same configuration -- e.g. to compare a stochastic model under different conditions -- use a Monte Carlo [experiment](experiments.md), where you can set the base seed yourself.
 
 If there are unresolved [diagnostics](petri-net-extensions.md#diagnostics) (code errors), pressing Play opens the Diagnostics tab instead of starting the simulation. Fix all errors first.
 

--- a/libs/@hashintel/petrinaut/docs/visual-settings.md
+++ b/libs/@hashintel/petrinaut/docs/visual-settings.md
@@ -1,8 +1,6 @@
 # Visual Settings
 
-Access the settings dialog via the **gear icon** in the viewport controls (bottom-right corner of the canvas).
-
-<!-- screenshot: viewport controls with gear icon highlighted -->
+Access the settings dialog via the **gear icon** in the viewport controls (bottom-right corner of the canvas). The viewport controls are a small floating cluster of buttons -- zoom in / out, fit-to-view, and the gear icon -- anchored to the bottom-right of the canvas.
 
 ## Available settings
 
@@ -26,8 +24,10 @@ When enabled, node positions snap to a grid when placing new nodes or dragging e
 
 Switch between two node rendering styles:
 
-- **Compact** (enabled) -- smaller card-style nodes.
-- **Classic** (disabled) -- larger nodes with more detail.
+- **Compact** (enabled, the default) -- small card-style nodes that show just the place / transition name. Fits more of the net on screen at once; best for large or dense models where you mostly select-and-inspect via the Properties panel.
+- **Classic** (disabled) -- larger nodes with inline summary information (e.g. token counts, firing-rate type indicators). Easier to read at a glance for small models or when teaching / demoing.
+
+Toggle freely -- this setting only affects rendering, not the underlying net.
 
 ### Partial selection
 

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel.tsx
@@ -11,6 +11,8 @@ import {
   mutationActionInputSchemas as petrinautAiMutationToolInputSchemas,
   type Petrinaut,
   type PetrinautAiMutationToolName,
+  readPetrinautDocToolInputSchema,
+  readPetrinautDocToolName,
   setNetTitleToolInputSchema,
   setNetTitleToolName,
 } from "@hashintel/petrinaut-core";
@@ -37,6 +39,7 @@ import { createDiagnosticsAwareAiTransport } from "./ai-assistant-panel/create-d
 import { createReasoningTimingAwareAiTransport } from "./ai-assistant-panel/create-reasoning-timing-aware-ai-transport";
 import { formatDiagnosticsForAi } from "./ai-assistant-panel/format-diagnostics-for-ai";
 import { getInteractiveTool } from "./ai-assistant-panel/interactive-tools/registry";
+import { petrinautDocsContent } from "./ai-assistant-panel/petrinaut-docs-content";
 import {
   type AiToolOutput,
   type AiToolCall,
@@ -349,6 +352,16 @@ export const AiAssistantPanel = ({
           tool: toolCall.toolName,
           toolCallId: toolCall.toolCallId,
           output: diagnosticsContextRef.current,
+        });
+        return;
+      }
+
+      if (toolCall.toolName === readPetrinautDocToolName) {
+        const { doc } = readPetrinautDocToolInputSchema.parse(toolCall.input);
+        safelyAddToolOutput(addToolOutput, {
+          tool: toolCall.toolName,
+          toolCallId: toolCall.toolCallId,
+          output: petrinautDocsContent[doc],
         });
         return;
       }

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel/ai-assistant-contents/get-message-render-items.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel/ai-assistant-contents/get-message-render-items.ts
@@ -1,6 +1,7 @@
 import {
   getLatestNetDefinitionToolName,
   getNetCompilationErrorsToolName,
+  readPetrinautDocToolName,
 } from "@hashintel/petrinaut-core";
 
 import { isToolPart, toToolRenderItem, type ToolRenderItem } from "./tool-list";
@@ -69,7 +70,8 @@ export const getMessageRenderItems = (
 
       if (
         tool.toolName === getLatestNetDefinitionToolName ||
-        tool.toolName === getNetCompilationErrorsToolName
+        tool.toolName === getNetCompilationErrorsToolName ||
+        tool.toolName === readPetrinautDocToolName
       ) {
         flushTools();
         pendingTools.push(tool);

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel/ai-assistant-contents/tool-list.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel/ai-assistant-contents/tool-list.tsx
@@ -6,6 +6,7 @@ import {
   getLatestNetDefinitionToolName,
   getNetCompilationErrorsToolName,
   petrinautAiMutationTools,
+  readPetrinautDocToolName,
   type SelectionItem,
   setNetTitleToolName,
 } from "@hashintel/petrinaut-core";
@@ -23,6 +24,11 @@ import type { InteractiveToolDefinition } from "../interactive-tools/types";
 import type { PetrinautAiMessage } from "../types";
 
 export type ToolTone = "danger" | "info" | "neutral" | "success";
+
+// User-guide pages are published in the repo, so a doc tool row links to the
+// matching markdown page on GitHub (matching the editor "Docs" menu entry).
+const petrinautDocsBaseUrl =
+  "https://github.com/hashintel/hash/blob/main/libs/%40hashintel/petrinaut/docs";
 
 export type ToolRenderItem = {
   id: string;
@@ -205,6 +211,12 @@ const toolItemStyle = cva({
         borderColor: "green.a40",
       },
     },
+    link: {
+      true: {
+        cursor: "pointer",
+        textDecoration: "none",
+      },
+    },
   },
 });
 
@@ -345,6 +357,18 @@ export const getToolSummaryFromPart = (
   if (toolName === getNetCompilationErrorsToolName) {
     return { title: "Checked net compilation errors" };
   }
+  if (toolName === readPetrinautDocToolName) {
+    const docName =
+      typeof part.input === "object" &&
+      part.input !== null &&
+      typeof (part.input as { doc?: unknown }).doc === "string"
+        ? (part.input as { doc: string }).doc
+        : undefined;
+    return {
+      title: docName ? `Read user guide: ${docName}` : "Read user guide",
+      href: docName ? `${petrinautDocsBaseUrl}/${docName}.md` : undefined,
+    };
+  }
   if (toolName === setNetTitleToolName) {
     const proposedTitle =
       typeof part.input === "object" &&
@@ -410,7 +434,8 @@ const getToolTone = ({
 
   if (
     toolName === getLatestNetDefinitionToolName ||
-    toolName === getNetCompilationErrorsToolName
+    toolName === getNetCompilationErrorsToolName ||
+    toolName === readPetrinautDocToolName
   ) {
     return "neutral";
   }
@@ -501,9 +526,39 @@ const ToolItem = ({
   const complete = tool.state === "output-available";
   const errored = tool.state === "output-error";
   const target = tool.summary.target;
+  const href = tool.summary.href;
   const children = tool.summary.items ?? [];
   const expandable = children.length > 0;
   const title = errored ? `${tool.toolName} errored` : tool.summary.title;
+
+  if (href && !errored) {
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={toolItemStyle({ tone: tool.tone, link: true })}
+        data-tone={tool.tone}
+      >
+        <span
+          className={toolStatusStyle({
+            state: complete ? "complete" : "active",
+            tone: tool.tone,
+          })}
+        >
+          {complete ? <Icon name="check" size="xs" /> : null}
+        </span>
+        <span className={toolTextStyle}>
+          <span>{title}</span>
+          {tool.summary.detail && (
+            <span className={toolDetailStyle} data-testid="tool-detail">
+              {tool.summary.detail}
+            </span>
+          )}
+        </span>
+      </a>
+    );
+  }
 
   const button = (
     <button

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel/petrinaut-docs-content.test.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel/petrinaut-docs-content.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "vitest";
+
+import { petrinautDocNames } from "@hashintel/petrinaut-core";
+
+import { petrinautDocsContent, stripImages } from "./petrinaut-docs-content";
+
+describe("stripImages", () => {
+  test("removes HTML <img> tags", () => {
+    const input = `Before
+<img width="160" height="58" alt="add-place" src="https://example.com/x.png" />
+After`;
+    expect(stripImages(input)).toBe("Before\n\nAfter");
+  });
+
+  test("removes markdown image references", () => {
+    const input = "Before\n![drawing-arc](https://example.com/arc.gif)\nAfter";
+    expect(stripImages(input)).toBe("Before\n\nAfter");
+  });
+
+  test("collapses runs of blank lines left behind", () => {
+    const input =
+      'Para1\n\n<img alt="a" src="a" />\n\n<img alt="b" src="b" />\n\nPara2';
+    const output = stripImages(input);
+    expect(output).not.toMatch(/<img/);
+    expect(output).not.toMatch(/\n{3,}/);
+  });
+
+  test("preserves non-image content", () => {
+    const input = "# Title\n\nSome **bold** text and a [link](https://x.test).";
+    expect(stripImages(input)).toBe(input);
+  });
+});
+
+describe("petrinautDocsContent", () => {
+  test("has an entry for every doc name and no embedded images", () => {
+    for (const name of petrinautDocNames) {
+      const content = petrinautDocsContent[name];
+      expect(content.length).toBeGreaterThan(0);
+      expect(content).not.toMatch(/<img\b/i);
+      expect(content).not.toMatch(/!\[[^\]]*]\([^)]*\)/);
+    }
+  });
+});

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel/petrinaut-docs-content.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel/petrinaut-docs-content.ts
@@ -1,0 +1,43 @@
+import {
+  type PetrinautDocName,
+  petrinautDocNames,
+} from "@hashintel/petrinaut-core";
+
+import aiAssistant from "../../../../../../docs/ai-assistant.md?raw";
+import drawingANet from "../../../../../../docs/drawing-a-net.md?raw";
+import examples from "../../../../../../docs/examples.md?raw";
+import experiments from "../../../../../../docs/experiments.md?raw";
+import petriNetExtensions from "../../../../../../docs/petri-net-extensions.md?raw";
+import scenarios from "../../../../../../docs/scenarios.md?raw";
+import simulation from "../../../../../../docs/simulation.md?raw";
+import usefulPatterns from "../../../../../../docs/useful-patterns.md?raw";
+import visualSettings from "../../../../../../docs/visual-settings.md?raw";
+
+const htmlImagePattern = /<img\b[^>]*\/?>(?:\s*<\/img>)?/gi;
+const markdownImagePattern = /!\[[^\]]*]\([^)]*\)/g;
+// Collapse runs of blank lines left behind by image removal so the model
+// doesn't see big empty gaps in the doc body.
+const tripleBlankLinePattern = /\n{3,}/g;
+
+export const stripImages = (markdown: string): string =>
+  markdown
+    .replace(htmlImagePattern, "")
+    .replace(markdownImagePattern, "")
+    .replace(tripleBlankLinePattern, "\n\n");
+
+const rawDocsByName: Record<PetrinautDocName, string> = {
+  "drawing-a-net": drawingANet,
+  "petri-net-extensions": petriNetExtensions,
+  "useful-patterns": usefulPatterns,
+  simulation,
+  scenarios,
+  experiments,
+  "ai-assistant": aiAssistant,
+  "visual-settings": visualSettings,
+  examples,
+};
+
+export const petrinautDocsContent: Record<PetrinautDocName, string> =
+  Object.fromEntries(
+    petrinautDocNames.map((name) => [name, stripImages(rawDocsByName[name])]),
+  ) as Record<PetrinautDocName, string>;

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel/tool-summaries.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel/tool-summaries.ts
@@ -15,6 +15,12 @@ export type AiToolSummary = {
   detail?: string;
   items?: string[];
   target?: AiToolTarget;
+  /**
+   * External URL the tool row links to (opens in a new tab). Set for
+   * read-only tools that surface a user-guide page so the user can open the
+   * page they saw the assistant consult.
+   */
+  href?: string;
 };
 
 export type AiToolBlockedOutput = {

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel/types.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel/types.ts
@@ -7,6 +7,7 @@ import type {
   PetrinautAiMutationToolInput,
   PetrinautAiMutationToolName,
   PetrinautAiToolInput,
+  readPetrinautDocToolName,
   SDCPN,
   setNetTitleToolName,
 } from "@hashintel/petrinaut-core";
@@ -34,6 +35,10 @@ type PetrinautAiUiTools = {
   [setNetTitleToolName]: {
     input: PetrinautAiToolInput<typeof setNetTitleToolName>;
     output: AiToolOutput;
+  };
+  [readPetrinautDocToolName]: {
+    input: PetrinautAiToolInput<typeof readPetrinautDocToolName>;
+    output: string;
   };
 };
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

1. Update the Petrinaut user-facing docs
2. Make these readable to the AI assistant as tool calls, so it can instruct the user how to use the app manually if they ask. The tool call row in the AI's output is a clickable link to the relevant docs page.
3. Add instructions to `AGENTS.md` in `petrinaut` to update the docs when necessary.

Note that the docs **intentionally excludes a metrics page** given that they are changing a lot.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->
<!-- Libraries inside of the `@local` directory are always internal libraries which have no need for publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] require changes to docs which **are made** as part of this PR

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ❓ How to test this?

1. View Petrinaut preview deployment, ask the AI how something about the app works.

## 📹 Demo


<!-- Add a screenshot or video showcasing your work -->

https://github.com/user-attachments/assets/447025de-93f2-4dc5-8d41-a7d1bbb2715d

