### PR TITLE
H-6553: Update `env` handling in `next.config.js`

### DIFF
--- a/apps/hash-frontend/next.config.js
+++ b/apps/hash-frontend/next.config.js
@@ -38,8 +38,11 @@ const sentryWebpackPluginOptions = {
 process.env.NEXT_PUBLIC_SHOW_WORKER_COST =
   process.env.SHOW_WORKER_COST ?? "false";
 
-// This allows the frontend to generate the graph type IDs in the browser
-process.env.NEXT_PUBLIC_FRONTEND_URL = process.env.FRONTEND_URL;
+if (process.env.FRONTEND_URL) {
+  // Feeds frontendUrl in isomorphic-utils/environment.ts
+  // Fallbacks to Vercel-provided URL, and ultimately localhost:3000.
+  process.env.NEXT_PUBLIC_FRONTEND_URL = process.env.FRONTEND_URL;
+}
 
 // The API origin
 process.env.NEXT_PUBLIC_API_ORIGIN =


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We had a line in `next.config.js` that assumed `FRONTEND_URL` would be present, and if absent coerces it to the string `"undefined"`.

This short-circuits the intended behaviour of [the frontendUrl decider](https://github.com/hashintel/hash/blob/b9e62e07304487eb5d8585f03bc9ecb64a54809e/libs/%40local/hash-isomorphic-utils/src/environment.ts#L3). 

Instead, we want to be able to have Vercel preview deployments take this value from the Vercel-provided environment variable, and therefore omit `FRONTEND_URL` in preview. 

This doesn't affect non-Vercel deployments (e.g. frontend-in-Docker), or any other part of the system, which should still provide `FRONTEND_URL`. It's only to allow preview frontend deployments to generate navigation links correctly.


## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->
<!-- Libraries inside of the `@local` directory are always internal libraries which have no need for publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ❓ How to test this?

1. Check that the frontend deploys
2. Visit the preview deployment and confirm that links in the sidebar etc navigate around the preview deployment and don't take you to `stage.hash.ai` (previous behaviour)