### PR TITLE
SRE-737: Remove dismiss-stale-approvals preflight job

### DIFF
--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -9,26 +9,12 @@ on:
   merge_group:
 
 jobs:
-  stale-approvals:
-    name: Stale approvals
-    permissions:
-      actions: read
-      contents: read
-      # Required by the reusable workflow to extract job_workflow_ref from the
-      # OIDC token to resolve the correct checkout ref for the composite action.
-      # see: https://github.com/actions/toolkit/issues/1264
-      # TODO: Remove once $/ syntax is available
-      # see: https://github.com/orgs/community/discussions/26245#discussioncomment-15601440
-      id-token: write
-      pull-requests: write
-    uses: hashintel/.github/.github/workflows/preflight-stale-approvals.yml@e12e306a03b1939c357d92c55b48d539d4286bd6
-
   dependencies:
     name: Dependencies
     permissions:
       contents: read
       pull-requests: write
-    uses: hashintel/.github/.github/workflows/preflight-dependencies.yml@e12e306a03b1939c357d92c55b48d539d4286bd6
+    uses: hashintel/.github/.github/workflows/preflight-dependencies.yml@ae4227bc6b6375f06ac30093826318283eefb203
 
   labeler:
     name: Labeler
@@ -47,10 +33,10 @@ jobs:
     name: Todo comments
     permissions:
       contents: read
-    uses: hashintel/.github/.github/workflows/preflight-todo-comments.yml@e12e306a03b1939c357d92c55b48d539d4286bd6
+    uses: hashintel/.github/.github/workflows/preflight-todo-comments.yml@ae4227bc6b6375f06ac30093826318283eefb203
 
   pr-title:
     name: PR title
     permissions:
       contents: read
-    uses: hashintel/.github/.github/workflows/preflight-pr-title.yml@e12e306a03b1939c357d92c55b48d539d4286bd6
+    uses: hashintel/.github/.github/workflows/preflight-pr-title.yml@ae4227bc6b6375f06ac30093826318283eefb203

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "test": "npm-run-all --continue-on-error \"test:*\"",
     "test:integration": "CARGO_TERM_PROGRESS_WHEN=never turbo run test:integration --env-mode=loose --",
     "test:playwright": "CARGO_TERM_PROGRESS_WHEN=never turbo run test:integration --env-mode=loose --filter @tests/hash-playwright --",
-    "test:stale-approvals": "bash .github/actions/dismiss-stale-approvals/self-test.sh",
     "test:unit": "CARGO_TERM_PROGRESS_WHEN=never turbo run test:unit --env-mode=loose --"
   },
   "devDependencies": {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Remove the now-dangling `stale-approvals` preflight job. The `dismiss-stale-approvals` reusable workflow and composite action were deleted from `hashintel/.github` (hashintel/.github#70, SRE-737); stale-approval dismissal is now handled GitHub-natively via the org branch-protection rulesets (`dismiss_stale_reviews_on_push`).

## 🔗 Related links

- [SRE-737](https://linear.app/hash/issue/SRE-737) _(internal)_
- hashintel/.github#70 — removed the reusable workflow + action

## 🔍 What does this change?

- Drop the `stale-approvals` job from `.github/workflows/preflight.yml`
- Bump the remaining preflight reusable-workflow refs (`dependencies`, `todo-comments`, `pr-title`) to the new `.github` SHA `ae4227b`
- Remove the dead `test:stale-approvals` npm script — it pointed at `.github/actions/dismiss-stale-approvals/self-test.sh`, which only ever existed in `hashintel/.github`

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

The Preflight workflow runs on this PR (path-triggered) and validates the remaining jobs.

## ❓ How to test this?

1. Confirm Preflight passes without a "Stale approvals" job.
2. Confirm `Stale approvals / Dismiss` is no longer a required check (handled by the ruleset migration).
