### PR TITLE
SRE-750: Upgrade Yarn to 4.16.0

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,9 +1,17 @@
+approvedGitRepositories:
+  - "**"
+
+defaultSemverRangePrefix: ""
+
+enableScripts: false
+
+enableTransparentWorkspaces: false
+
+nmMode: hardlinks-local
+
 # PnP doesn't work with Zed and pnpm would be preferred but doesn't work with due to: https://github.com/yarnpkg/yarn/issues/8734, https://github.com/yarnpkg/berry/issues/3972 etc.
 # This seems to be an allocation error with ZipFS.
 # node-modules is slower during the linking step but works.
-enableTransparentWorkspaces: false
 nodeLinker: node-modules
-nmMode: hardlinks-local
-defaultSemverRangePrefix: ""
-npmMinimalAgeGate: "5d"
-enableScripts: false
+
+npmMinimalAgeGate: 5d

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,6 +1,3 @@
-approvedGitRepositories:
-  - "**"
-
 defaultSemverRangePrefix: ""
 
 enableScripts: false

--- a/package.json
+++ b/package.json
@@ -108,5 +108,5 @@
   "engines": {
     "node": ">= v22"
   },
-  "packageManager": "yarn@4.12.0"
+  "packageManager": "yarn@4.16.0+sha512.5374c94eb4ef6aa8188fb112f20c1aa6569f248d676c5e576e1fd2a1a4d8d87a96df65d9dfe1c2a0252cbe38bda46cf18d955005b81b43cc7607a5c9d56fd2b6"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 8
+  version: 10
   cacheKey: 10c0
 
 "@adobe/css-tools@npm:^4.4.0":


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Upgrades Yarn from 4.12.0 to 4.16.0 and cleans up the `.yarnrc.yml` config.

## 🔗 Related links

- [Yarn 4.13.0 release](https://github.com/yarnpkg/berry/releases/tag/%40yarnpkg%2Fcli%2F4.13.0)
- [Yarn 4.14.0 release](https://github.com/yarnpkg/berry/releases/tag/%40yarnpkg%2Fcli%2F4.14.0)
- [Yarn 4.15.0 release](https://github.com/yarnpkg/berry/releases/tag/%40yarnpkg%2Fcli%2F4.15.0)
- [Yarn 4.16.0 release](https://github.com/yarnpkg/berry/releases/tag/%40yarnpkg%2Fcli%2F4.16.0)

## 🔍 What does this change?

- Bumps `packageManager` from `yarn@4.12.0` to `yarn@4.16.0`
- Lockfile version bumped from 8 to 10 (automatic)
- `.yarnrc.yml` reformatted by the migration (settings alphabetized, spacing normalized)

### Notable changes in Yarn 4.12 → 4.16

**4.13.0:** `upgrade-interactive` improvements (`--mode` option, `c`/`r`/`l` bulk selection shortcuts). Fixed `foreach` ordering when `--topological` isn't set. Enhanced environment variable expansion in config.

**4.14.0:** `enableScripts: false` is now the default (we already set this). `exec:` protocol now respects `enableScripts`. `approvedGitRepositories` introduced (removed in this PR since we have no git deps). PnP watch mode fix. Node 25.7+ ZipFS EBADF fix.

**4.15.0:** `node-modules` linker performance improvement: install state is now cached across workspaces, reducing redundant directory scans in monorepos. `npmMinimalAgeGate` defaults to `1d` (we set `5d`).

**4.16.0:** `yarn npm stage` and staged publishing. Editor SDK support for oxc tooling (PnP only). More Node version EBADF workaround coverage.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

_None._

## 🐾 Next steps

- PnP may be worth re-evaluating: Zed now has official PnP support, and the ZipFS allocation bug has had several fixes since 4.9.0. Needs testing to confirm.
- The `.yarnrc.yml` comment about PnP/Zed/ZipFS could be updated once PnP is retested.

## 🛡 What tests cover this?

- CI will validate that the lockfile and installs work correctly with the new version.

## ❓ How to test this?

1. `rm -rf node_modules && yarn install`
2. Confirm install completes without errors
3. Run `yarn lint:tsc` to verify nothing broke

<details>
<summary>Detailed version-by-version changelog</summary>

### 4.12.0

- npm web login support
- Git clone argument fix (`-c core.autocrlf=false` split into separate args)
- JSON Schema fix

### 4.13.0

- `upgrade-interactive` improvements: `--mode` option and `c`/`r`/`l` bulk selection shortcuts
- Fixed `foreach` ordering when `--topological` isn't set
- Enhanced environment variable expansion in configuration
- `npm audit` now also runs on patched packages
- Registry URL displayed when publishing
- Better error when all semver-matching versions are quarantined
- Fix for float timestamps in `convertToBigIntStats` (fslib)

### 4.14.0

- `enableScripts: false` is now the default (we already set this, no impact)
- `exec:` protocol now respects `enableScripts`
- `approvedGitRepositories` setting added (removed in this PR, no git deps)
- PnP: fix watch mode for files `require`d under PnP
- Node 25.7+ EBADF fix by reading CJS source of zip files
- `yarn why` can now specify a version or range
- OIDC auth support for CircleCI npm publishing

### 4.14.1

- Widened EBADF fstat version gate to include Node 24.15+

### 4.15.0

- **perf:** cache install state across workspaces for `node-modules` linker
- `npmMinimalAgeGate` defaults to `1d` (we set `5d`, no impact)
- Ignore legacy `YARN_IGNORE_SCRIPTS` env var
- Reject dependency names with leading/trailing whitespace (fixes duplicate installs)
- pnpm linker: configurable install concurrency
- Fix for Unicode paths in patch protocol
- PnP: stop using EBADF workaround for Node 26.1.0+

### 4.16.0

- `yarn npm stage` and staged publishing
- Editor SDK support for oxc (`oxfmt` and `oxlint`), PnP only
- PnP: include Node 22.22.3 in fstat workaround
- Stop using EBADF workaround for Node 24.16.0+ (fixed upstream in Node)
</details>
