### PR TITLE
FE-797: Fix tooltip zIndex

### DIFF
--- a/libs/@hashintel/ds-components/src/components/Tooltip/tooltip.recipe.ts
+++ b/libs/@hashintel/ds-components/src/components/Tooltip/tooltip.recipe.ts
@@ -12,7 +12,7 @@ export const triggerStyles = css({
 });
 
 export const positionerStyles = css({
-  zIndex: "tooltip",
+  zIndex: "tooltip !important",
 });
 
 export const contentStyles = cva({

--- a/libs/@hashintel/petrinaut/.gitignore
+++ b/libs/@hashintel/petrinaut/.gitignore
@@ -1,0 +1,2 @@
+# PandaCSS
+styled-system

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/components/ai-cta-modal.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/components/ai-cta-modal.tsx
@@ -174,7 +174,6 @@ export const AiCtaModal = ({
           onClick={onDismiss}
           aria-label="Dismiss"
           iconName="close"
-          tooltip="Dismiss"
         />
         <div className={aiCtaModalIconStyle}>
           <AiAssistantIcon size={32} />


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Panda was not applying the zIndex style to tooltips. Why does panda not apply the style that I've set? Who knows. This PR fixes this by adding !important which seems to force panda to apply the style.
I also add styled-system to petrinauts gitignore file to avoid it being committed during development.
I also remove the tooltip from the ai-cta close button, as its obvious + redundant (but leave the aria label)

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change
