### PR TITLE
FE-801: Fix cropped selects in petrinaut by removing portaling behaviour

### DIFF
--- a/libs/@hashintel/petrinaut/src/ui/components/select.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/components/select.tsx
@@ -15,15 +15,6 @@ import { css, cva, cx } from "@hashintel/ds-helpers/css";
 
 import type { ComponentProps, ReactNode } from "react";
 
-// -- Helpers ------------------------------------------------------------------
-
-const ConditionalPortal: React.FC<{
-  enabled: boolean;
-  container?: React.RefObject<HTMLElement | null>;
-  children: ReactNode;
-}> = ({ enabled, container, children }) =>
-  enabled ? <Portal container={container}>{children}</Portal> : children;
-
 // -- Figma design tokens ------------------------------------------------------
 
 type SelectSize = "xs" | "sm" | "md" | "lg";
@@ -243,8 +234,6 @@ interface SelectBaseProps {
   className?: string;
   /** Ark UI positioning options */
   positioning?: { sameWidth?: boolean };
-  /** Whether to portal the dropdown. Set to false when inside a Dialog. */
-  portal?: boolean;
   tooltip?: string;
   tooltipOptions?: Omit<ComponentProps<typeof Tooltip>, "children" | "content">;
 }
@@ -264,7 +253,6 @@ export const Select: React.FC<SelectBaseProps> = ({
   triggerClassName,
   className,
   positioning,
-  portal = false,
   tooltip,
   tooltipOptions,
 }) => {
@@ -347,7 +335,7 @@ export const Select: React.FC<SelectBaseProps> = ({
           </>
         )}
       </ArkSelect.Trigger>
-      <ConditionalPortal enabled={portal} container={portalContainerRef}>
+      <Portal container={portalContainerRef}>
         <ArkSelect.Positioner className={positionerStyle}>
           <ArkSelect.Content className={contentStyle}>
             {groups
@@ -362,7 +350,7 @@ export const Select: React.FC<SelectBaseProps> = ({
               : collection.items.map(renderOption)}
           </ArkSelect.Content>
         </ArkSelect.Positioner>
-      </ConditionalPortal>
+      </Portal>
     </ArkSelect.Root>
   );
 

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/create-experiment-drawer.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/create-experiment-drawer.tsx
@@ -762,7 +762,6 @@ const ExperimentMetricRow = ({
             size="xs"
             className={metricKindSelectStyle}
             triggerClassName={metricKindTriggerStyle}
-            portal={false}
             renderTrigger={() => (
               <>
                 <span className={metricKindTriggerLabelStyle}>
@@ -805,7 +804,6 @@ const ExperimentMetricRow = ({
                     onValueChange={(value) => updateMetric({ placeId: value })}
                     options={placeOptions}
                     size="sm"
-                    portal={false}
                   />
                 </div>
               ) : null}
@@ -820,7 +818,6 @@ const ExperimentMetricRow = ({
                       }
                       options={transitionOptions}
                       size="sm"
-                      portal={false}
                     />
                   </div>
                   <div className={fieldStyle}>
@@ -834,7 +831,6 @@ const ExperimentMetricRow = ({
                       }
                       options={transitionModeOptions}
                       size="sm"
-                      portal={false}
                     />
                   </div>
                 </>
@@ -1088,7 +1084,6 @@ export const CreateExperimentDrawer = ({
                   onValueChange={handleScenarioChange}
                   options={scenarioOptions}
                   size="md"
-                  portal={false}
                   renderItem={(option) => (
                     <span
                       style={{ display: "flex", alignItems: "center", gap: 6 }}

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/experiment-metric-timeline.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/experiment-metric-timeline.tsx
@@ -1456,7 +1456,6 @@ export const ExperimentMetricTimeline = ({
                 options={runAggregationOptions}
                 size="xs"
                 className={aggregationSelectStyle}
-                portal={false}
               />
             ) : (
               <Select
@@ -1467,7 +1466,6 @@ export const ExperimentMetricTimeline = ({
                 options={distributionViewOptions}
                 size="xs"
                 className={aggregationSelectStyle}
-                portal={false}
               />
             )}
           </div>
@@ -1489,7 +1487,6 @@ export const ExperimentMetricTimeline = ({
               options={timeAggregationOptions}
               size="xs"
               className={aggregationSelectStyle}
-              portal={false}
             />
           ) : (
             <Select
@@ -1498,7 +1495,6 @@ export const ExperimentMetricTimeline = ({
               options={timeTraceOptions}
               size="xs"
               className={aggregationSelectStyle}
-              portal={false}
             />
           )}
         </div>

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/components/viewport-settings-dialog.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/components/viewport-settings-dialog.tsx
@@ -161,7 +161,6 @@ export const ViewportSettingsDialog: React.FC<ViewportSettingsDialogProps> = ({
               { value: "bezier", label: "Bezier" },
               { value: "custom", label: "Adaptive Bezier" },
             ]}
-            portal={false}
           />
         </SettingRow>
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Removes the ability to turn select portalling off in petrinaut which was leading to selects being cropped in overflow hidden containers.
<img width="438" height="176" alt="Screenshot 2026-06-03 at 16 46 41" src="https://github.com/user-attachments/assets/2655ae5f-5756-4a35-8de8-e7de36b8e617" />

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change
