### PR TITLE
SRE-758: Add `approvedGitRepositories` to `.yarnrc.yml`

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,5 @@
+approvedGitRepositories: []
+
 defaultSemverRangePrefix: ""
 
 enableScripts: false


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR explicitly sets `approvedGitRepositories` to an empty list in the Yarn configuration. This ensures that no Git repositories are approved for use as dependencies, enforcing that all dependencies must be sourced from the npm registry rather than directly from Git sources.

Required because during pulling, the lockfile changes from version 8 to 10, and a new corepack download, which leads to the migration running which sets `approvedGitRepositories` to `[**]`, explicitly specifying the configuration value should circumvent the rewrite.

## 🔍 What does this change?

- Adds `approvedGitRepositories: []` to `.yarnrc.yml`, explicitly disallowing Git repository dependencies.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- No automated tests required for configuration changes.

## ❓ How to test this?

1. Checkout the branch.
2. Attempt to add a Git repository as a dependency.
3. Confirm that Yarn rejects it.
