### PR TITLE
SRE-747: Tag ECR :staging on the image, not a single-entry index

### DIFF
--- a/.github/actions/tag-if-newer/action.yml
+++ b/.github/actions/tag-if-newer/action.yml
@@ -8,10 +8,18 @@ description: >
   job's `concurrency: { queue: max }` for the check-then-set to be race-free
   (serialized); without it the read/compare/write is a TOCTOU race.
 
-  Registry-agnostic: uses `docker buildx imagetools`, so it works for both ECR
-  and GHCR. The caller MUST already be authenticated to the registry and MUST
-  check out with `fetch-depth: 0` (the currently-tagged commit can be arbitrarily
-  far back, and `git merge-base --is-ancestor` needs it in local history).
+  Registry-aware advance: the current-revision read uses `docker buildx
+  imagetools inspect` for both registries, but the tag move differs. GHCR is
+  multi-arch, so the mutable tag is assembled with `imagetools create` (a
+  manifest list is correct there). ECR is single-arch and is scanned by
+  Inspector / promoted by digest, so its mutable tag must stay a flat image —
+  `imagetools create` always synthesizes an index, which is exactly what broke
+  ECR :staging (SRE-747). For ECR we re-PUT the source manifest bytes under the
+  mutable tag via `aws ecr put-image`: same digest, no index. The caller MUST
+  already be authenticated to the registry (ECR additionally needs AWS
+  credentials and region configured) and MUST check out with `fetch-depth: 0`
+  (the currently-tagged commit can be arbitrarily far back, and
+  `git merge-base --is-ancestor` needs it in local history).
 
 inputs:
   image:
@@ -99,8 +107,43 @@ runs:
     - name: Advance ${{ inputs.mutable-tag }} to ${{ inputs.source-tag }}
       if: steps.decide.outputs.advanced == 'true'
       uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
+      env:
+        IMAGE: ${{ inputs.image }}
+        MUTABLE_TAG: ${{ inputs.mutable-tag }}
+        SOURCE_TAG: ${{ inputs.source-tag }}
       with:
         timeout_minutes: 5
         max_attempts: 3
         retry_wait_seconds: 10
-        command: docker buildx imagetools create --tag "${{ inputs.image }}:${{ inputs.mutable-tag }}" "${{ inputs.image }}:${{ inputs.source-tag }}"
+        command: |
+          set -euo pipefail
+          # TODO(SRE-759): `crane tag` would collapse this whole branch into one
+          #   registry-agnostic line (preserves media type: flat for ECR, index
+          #   for GHCR) — at the cost of a new dependency. See the issue.
+          if [[ "$IMAGE" == *.dkr.ecr.*.amazonaws.com/* ]]; then
+            repo="${IMAGE#*.amazonaws.com/}"
+            manifest="$(aws ecr batch-get-image \
+              --repository-name "$repo" \
+              --image-ids imageTag="$SOURCE_TAG" \
+              --query 'images[0].imageManifest' --output text)"
+            if [[ -z "$manifest" || "$manifest" == "None" ]]; then
+              echo "::error ::no manifest found for $repo:$SOURCE_TAG" >&2
+              exit 1
+            fi
+            # A retry after a partial success re-sends the same bytes+tag, which
+            # ECR rejects with ImageAlreadyExistsException — that's the intended
+            # end state, so treat it as success.
+            if ! out="$(aws ecr put-image \
+              --repository-name "$repo" \
+              --image-tag "$MUTABLE_TAG" \
+              --image-manifest "$manifest" 2>&1)"; then
+              if grep -q 'ImageAlreadyExistsException' <<<"$out"; then
+                echo "::notice ::$repo:$MUTABLE_TAG already points at $SOURCE_TAG"
+              else
+                echo "$out" >&2
+                exit 1
+              fi
+            fi
+          else
+            docker buildx imagetools create --tag "$IMAGE:$MUTABLE_TAG" "$IMAGE:$SOURCE_TAG"
+          fi


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Since #8801 (SRE-739), the ECR `:staging` tag has been applied to an **image index** instead of the image itself (SRE-747) — blocking promotion to production and breaking Inspector findings.

**Root cause:** the `tag-if-newer` action advanced the mutable tag with `docker buildx imagetools create`, whose only job is to assemble a manifest list — it wraps even a single source in an index. On ECR (single-arch, arm64) that produced a single-entry image index whose digest no longer matched the `:sha`/`:run` image. Same problem class as SRE-613, different cause (there it was BuildKit provenance; here it's the retag tool).

**Fix:** advance the ECR tag with `aws ecr put-image` — re-PUT the exact source manifest bytes under the mutable tag (same digest, flat image, no index). GHCR keeps `imagetools create`, where a multi-arch manifest list is the correct, intended shape.

## 🔗 Related links

- [SRE-747](https://linear.app/hash/issue/SRE-747/ecr-tags-are-applied-to-image-index-only) _(internal)_
- [SRE-613](https://linear.app/hash/issue/SRE-613/replace-buildkit-provenance-embedding-with-aws-signer-for-container) — same image-index problem class _(internal)_

## 🚫 Blocked by

- none

## 🔍 What does this change?

- `tag-if-newer` now branches the advance step by registry:
  - **ECR** (`*.dkr.ecr.*.amazonaws.com/*`): `aws ecr batch-get-image` fetches the `:sha-<sha>` manifest, `aws ecr put-image` re-PUTs it under the mutable tag → identical digest, flat image. A retry after a partial success hits `ImageAlreadyExistsException`, which is the intended end state and is treated as success.
  - **GHCR**: unchanged (`imagetools create`).
- The current-revision read (resolve step) and the out-of-order guard (`git merge-base --is-ancestor`) are untouched and stay shared.
- Action doc block updated to describe the registry-aware advance.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

- **The `is_main` path is not exercised by CI before merge** — the `stage` job (which runs `tag-if-newer` for ECR `:staging`) only runs on `main` pushes, so this fix is first exercised on the first `main` run after merge. Two assumptions that run must confirm:
  - `aws ecr put-image` accepts the `batch-get-image` manifest without an explicit `--image-manifest-media-type` (aws-cli v2 infers it from the OCI manifest's `mediaType`).
  - The resolve step's `imagetools inspect` still reads `org.opencontainers.image.revision` from the now-**flat** ECR image (via `.image.config.Labels`), not only from an index.
- The existing buggy `:staging` index self-heals on the first post-merge `main` run (put-image overwrites it with the flat image).

## 🐾 Next steps

- [SRE-759](https://linear.app/hash/issue/SRE-759/consider-crane-tag-to-unify-mutable-tag-advance-across-ecrghcr): consider `crane tag` to collapse the ECR/GHCR branch into one registry-agnostic line (tradeoff: new dependency, buildx stays for the resolve step). Marked with a `TODO(SRE-759)` at the branch.

## 🛡 What tests cover this?

- No automated tests (CI workflow / composite-action config). Validated locally: YAML parses, branch/repo-strip logic verified (`469…amazonaws.com/hashintel/hash/graph` → `hashintel/hash/graph`; `ghcr.io/...` → imagetools branch). The ECR mutation itself is only exercisable on the first post-merge `main` run (see Known issues).

## ❓ How to test this?

1. On merge, watch the first `main` run's `stage` job: `:staging` on ECR should resolve to the **same digest** as the run's `:sha-<sha>` / `:run-<run_id>` tags (no separate index digest).
2. `aws ecr describe-images --repository-name hashintel/hash/<service> --image-ids imageTag=staging` → `imageManifestMediaType` should be an image manifest, not `...image.index.v1+json`.

## 📹 Demo

n/a — CI / infra change.
