### PR TITLE
BE-582: HashQL: Change opaque types from invariant to covariant

### DIFF
--- a/libs/@local/hashql/core/src/type/inference/solver/graph.rs
+++ b/libs/@local/hashql/core/src/type/inference/solver/graph.rs
@@ -113,6 +113,7 @@ impl Edges {
 }
 
 impl Default for Edges {
+    #[inline]
     fn default() -> Self {
         Self::new()
     }

--- a/libs/@local/hashql/core/src/type/inference/solver/mod.rs
+++ b/libs/@local/hashql/core/src/type/inference/solver/mod.rs
@@ -220,6 +220,7 @@ struct VariableConstraintSatisfiability {
 }
 
 impl Default for VariableConstraintSatisfiability {
+    #[inline]
     fn default() -> Self {
         Self { upper: true }
     }

--- a/libs/@local/hashql/core/src/type/inference/solver/tests.rs
+++ b/libs/@local/hashql/core/src/type/inference/solver/tests.rs
@@ -1,3 +1,4 @@
+#![expect(clippy::similar_names)]
 use hashql_diagnostics::Success;
 
 use super::{Constraint, InferenceSolver, VariableConstraint};
@@ -2361,6 +2362,55 @@ fn deferred_upper_constraint() {
         &env,
         substitution.infer(hole2).expect("should be resolved"),
         number,
+    );
+}
+
+// Regression test: W(A()) as W<AB> where AB = A | B.
+// The constraint system is: W<?1> <: W<A | B>, with ?1 having lower bound A from the
+// constructor call. The solver should decompose through the opaque covariantly and resolve
+// ?1 = A, since A <: A | B.
+#[test]
+fn opaque_covariant_subtype_through_union() {
+    scaffold!(heap, env, builder);
+
+    let hole = builder.fresh_hole();
+
+    let null = builder.null();
+    let integer = builder.integer();
+
+    // newtype A = Null
+    let type_a = builder.opaque("A", null);
+    // newtype B = Integer
+    let type_b = builder.opaque("B", integer);
+    // type AB = A | B
+    let type_ab = builder.union([type_a, type_b]);
+
+    // W<?1> (the value produced by the constructor call)
+    let w_hole = builder.opaque("W", builder.infer(hole));
+    // W<AB> (the target type from the `as` annotation)
+    let w_ab = builder.opaque("W", type_ab);
+
+    let mut inference = InferenceEnvironment::new(&env);
+    // ?1 has lower bound A (from the constructor argument A() flowing into W's parameter)
+    inference.add_constraint(Constraint::LowerBound {
+        variable: Variable::synthetic(VariableKind::Hole(hole)),
+        bound: type_a,
+    });
+    // W<?1> <: W<AB> (from the `as` expression)
+    inference.collect_constraints(Variance::Covariant, w_hole, w_ab);
+
+    let solver = inference.into_solver();
+    let Success {
+        value: substitution,
+        advisories,
+    } = solver.solve().expect("should have solved");
+    assert!(advisories.is_empty());
+
+    // ?1 should resolve to A
+    assert_equivalent(
+        &env,
+        substitution.infer(hole).expect("should be resolved"),
+        type_a,
     );
 }
 

--- a/libs/@local/hashql/core/src/type/kind/opaque.rs
+++ b/libs/@local/hashql/core/src/type/kind/opaque.rs
@@ -24,19 +24,29 @@ use crate::{
 /// even if their representations are identical. This contrasts with structural typing where
 /// compatibility is based on structure alone.
 ///
-/// # Type System Design
+/// # Semantic Model
 ///
-/// This implementation uses a refined context-sensitive variance approach:
-/// - For concrete types or when inference is disabled: Opaque types are **invariant** with respect
-///   to their inner representation, enforcing strict nominal typing semantics.
-/// - Only for non-concrete types during inference: Opaque types use a **covariant-like** approach
-///   that allows them to act as "carriers" for inference variables.
+/// For each opaque name `N`, the type constructor is interpreted as:
 ///
-/// This precise, context-sensitive approach provides several benefits:
-/// 1. Proper constraint propagation for types containing inference variables
-/// 2. Strict nominal type safety for all concrete types
-/// 3. Clear separation between inference and checking phases
-/// 4. Consistent variance behavior across the type system
+/// ```text
+/// ⟦N<T>⟧ = { wrap_N(v) | v ∈ ⟦T⟧ }
+/// ```
+///
+/// with `wrap_N` injective and distinct names having disjoint images. This gives:
+///
+/// - **Covariance**: `⟦A⟧ ⊆ ⟦B⟧ ⟹ ⟦N<A>⟧ ⊆ ⟦N<B>⟧`, so `N<A> <: N<B>`.
+/// - **Nominal separation**: if `N ≠ M`, then `⟦N<A>⟧ ∩ ⟦M<B>⟧ = ∅`.
+/// - **Meet**: `⟦N<A>⟧ ∩ ⟦N<B>⟧ = ⟦N<A ∧ B>⟧`.
+/// - **Join**: `⟦N<A>⟧ ∪ ⟦N<B>⟧ = ⟦N<A ∨ B>⟧`, extensionally.
+///
+/// Covariance is sound because HashQL values are immutable: the wrapper has no operation
+/// that can exploit a `W<B>` view to smuggle an arbitrary `B` back into a `W<A>`. This
+/// removes the classic mutation-based unsoundness argument (Pierce, TAPL Ch. 15).
+///
+/// An opaque type is never the global top: `W(⊤)` is only the top of the `W` fiber
+/// (all `W`-wrapped values), not the whole universe, because it does not contain
+/// unwrapped values or values of other opaque families. However, `W(⊥)` IS the
+/// global bottom: wrapping an empty set gives an empty set, and `∅ ⊆ S` for any `S`.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct OpaqueType<'heap> {
     pub name: Symbol<'heap>,
@@ -134,21 +144,14 @@ impl<'heap> Lattice<'heap> for OpaqueType<'heap> {
 
     /// Computes the meet (greatest lower bound) of two opaque types.
     ///
-    /// The meet operation uses a refined context-sensitive approach:
+    /// For same-name opaques, meets the inner representations covariantly:
+    /// `W<A|B> & W<A>` produces `W<A>`, because `meet(A|B, A) = A`.
     ///
-    /// When inference is enabled AND at least one type contains inference variables:
-    /// - If types have different names: Return Never (empty set).
-    /// - If types have the same name: Meet their inner representations, allowing the opaque type to
-    ///   act as a "carrier" for inference variables until they are resolved.
+    /// During inference with non-concrete types, both representations are kept as a
+    /// "carrier" to defer evaluation until inference variables are resolved.
     ///
-    /// Otherwise (for concrete types or when inference is disabled):
-    /// - If types have different names: Return Never (empty set).
-    /// - If types have the same name but different representations: Return Never (empty set).
-    /// - If types have the same name and equivalent representations: Return the type itself.
-    ///
-    /// This approach prevents premature failure during inference while maintaining strict
-    /// nominal semantics once types are fully resolved. It allows constraint propagation while
-    /// preserving type safety.
+    /// For different-name opaques, returns Never (empty set): distinct nominal types have
+    /// no common subtype.
     fn meet(
         self: Type<'heap, Self>,
         other: Type<'heap, Self>,
@@ -158,26 +161,38 @@ impl<'heap> Lattice<'heap> for OpaqueType<'heap> {
             return SmallVec::new();
         }
 
+        if env.is_equivalent(self.kind.repr, other.kind.repr) {
+            return SmallVec::from_slice_copy(&[self.id]);
+        }
+
         if env.is_inference_enabled()
             && (!env.is_concrete(self.kind.repr) || !env.is_concrete(other.kind.repr))
         {
+            // During inference, keep both representations as carriers. The meet is deferred
+            // until inference variables are resolved and the result is simplified.
             let self_repr = env.r#type(self.kind.repr);
             let other_repr = env.r#type(other.kind.repr);
 
-            // We circumvent `env.meet` here, by directly meeting the representations. This is
-            // intentional, so that we can propagate the meet result instead of having a
-            // `Intersection`.
             let result = self_repr.meet(other_repr, env);
 
-            // If any of the types aren't concrete, we effectively convert ourselves into a
-            // "carrier" to defer evaluation of the term, once inference is completed we'll simplify
-            // and postprocess the result.
-            self.postprocess_lattice(result, env.environment)
-        } else if env.is_equivalent(self.kind.repr, other.kind.repr) {
-            SmallVec::from_slice_copy(&[self.id])
-        } else {
-            SmallVec::new()
+            return self.postprocess_lattice(result, env.environment);
         }
+
+        // For concrete same-name opaques, meet the inner representations through the full
+        // lattice meet path which handles simplification (e.g. `Number | Never` to `Number`).
+        let repr = env.meet(self.kind.repr, other.kind.repr);
+
+        if env.is_bottom(repr) {
+            return SmallVec::new();
+        }
+
+        SmallVec::from_slice_copy(&[env.environment.intern_type(PartialType {
+            span: self.span,
+            kind: env.environment.intern_kind(TypeKind::Opaque(OpaqueType {
+                name: self.kind.name,
+                repr,
+            })),
+        })])
     }
 
     fn projection(
@@ -201,8 +216,11 @@ impl<'heap> Lattice<'heap> for OpaqueType<'heap> {
         env.is_bottom(self.kind.repr)
     }
 
-    fn is_top(self: Type<'heap, Self>, env: &mut AnalysisEnvironment<'_, 'heap>) -> bool {
-        env.is_top(self.kind.repr)
+    fn is_top(self: Type<'heap, Self>, _env: &mut AnalysisEnvironment<'_, 'heap>) -> bool {
+        // W(Unknown) is the top of the W fiber, not the global top. It does not contain
+        // unwrapped values or values of other opaque families. Reporting true here would
+        // cause `T | W(Unknown)` to collapse to `Unknown`, destroying nominal separation.
+        false
     }
 
     fn is_concrete(self: Type<'heap, Self>, env: &mut AnalysisEnvironment<'_, 'heap>) -> bool {
@@ -231,10 +249,14 @@ impl<'heap> Lattice<'heap> for OpaqueType<'heap> {
 
     /// Determines if one opaque type is a subtype of another.
     ///
-    /// Implements invariant nominal typing semantics:
+    /// Implements covariant nominal typing semantics:
     /// 1. Types with different names are always unrelated (neither is a subtype of the other)
-    /// 2. Types with the same name follow invariant rules for their inner representation (enforced
-    ///    via the `in_invariant` context)
+    /// 2. Types with the same name check their inner representations covariantly
+    ///
+    /// Covariance is sound because HashQL values are immutable: there is no operation that
+    /// could "put back" a value through the opaque boundary, so the classic mutation-based
+    /// unsoundness argument does not apply. The nominal boundary (distinct names) is preserved
+    /// regardless of variance.
     fn is_subtype_of(
         self: Type<'heap, Self>,
         supertype: Type<'heap, Self>,
@@ -248,7 +270,7 @@ impl<'heap> Lattice<'heap> for OpaqueType<'heap> {
             return false;
         }
 
-        env.is_subtype_of(Variance::Invariant, self.kind.repr, supertype.kind.repr)
+        env.is_subtype_of(Variance::Covariant, self.kind.repr, supertype.kind.repr)
     }
 
     fn is_equivalent(
@@ -297,8 +319,10 @@ impl<'heap> Inference<'heap> for OpaqueType<'heap> {
             return;
         }
 
-        // Opaque types are invariant in regards to their arguments
-        env.collect_constraints(Variance::Invariant, self.kind.repr, supertype.kind.repr);
+        // Opaque types are covariant: the inner representation of the subtype must be a subtype
+        // of the inner representation of the supertype. This is sound because HashQL values are
+        // immutable.
+        env.collect_constraints(Variance::Covariant, self.kind.repr, supertype.kind.repr);
     }
 
     fn instantiate(self: Type<'heap, Self>, env: &mut InstantiateEnvironment<'_, 'heap>) -> TypeId {

--- a/libs/@local/hashql/core/src/type/kind/tests/opaque.rs
+++ b/libs/@local/hashql/core/src/type/kind/tests/opaque.rs
@@ -114,9 +114,9 @@ fn meet_same_name_different_repr() {
 
     let mut lattice_env = LatticeEnvironment::new(&env);
 
-    // Meeting should result in an opaque type with the same name but representation
-    // that is the meet of the two representations (just Number in this case)
-    assert_equiv!(env, a.meet(b, &mut lattice_env), []);
+    // Meeting covariantly: meet(Number, Number|String) = Number,
+    // so the result is MyType<Number> (which is `a`).
+    assert_equiv!(env, a.meet(b, &mut lattice_env), [a.id]);
 }
 
 #[test]
@@ -180,8 +180,8 @@ fn is_subtype_of() {
 
     let mut analysis_env = AnalysisEnvironment::new(&env);
 
-    // a should not be a subtype of b (invariant)
-    assert!(!a.is_subtype_of(b, &mut analysis_env));
+    // a should be a subtype of b (Number <: Number|String, covariant)
+    assert!(a.is_subtype_of(b, &mut analysis_env));
 
     // b should not be a subtype of a (Number|String is not a subtype of Number)
     assert!(!b.is_subtype_of(a, &mut analysis_env));
@@ -307,6 +307,24 @@ fn lattice_laws() {
 }
 
 #[test]
+fn is_not_top() {
+    let heap = Heap::new();
+    let env = Environment::new(&heap);
+    let mut analysis_env = AnalysisEnvironment::new(&env);
+
+    // An opaque wrapping Unknown is NOT the global top. It is only the top of
+    // its own fiber. Reporting true would cause `T | W<Unknown>` to collapse
+    // to `Unknown`, destroying nominal separation between opaque families.
+    let unknown = instantiate(&env, TypeKind::Unknown);
+    opaque!(env, opaque_unknown, "W", unknown);
+    assert!(!opaque_unknown.is_top(&mut analysis_env));
+
+    // Sanity: raw Unknown IS top
+    let raw_unknown = env.r#type(unknown);
+    assert!(raw_unknown.is_top(&mut analysis_env));
+}
+
+#[test]
 fn is_concrete() {
     let heap = Heap::new();
     let env = Environment::new(&heap);
@@ -350,14 +368,14 @@ fn collect_constraints_same_name() {
     // Collect constraints between the two opaque types
     number_opaque.collect_constraints(infer_opaque, &mut inference_env);
 
-    // Since opaque types are invariant, we should get an equality constraint
-    // rather than just an upper or lower bound
+    // Since opaque types are covariant, we get a lower bound constraint:
+    // the concrete type constrains the inference variable from below.
     let constraints = inference_env.take_constraints();
     assert_eq!(
         constraints,
-        [Constraint::Equals {
+        [Constraint::LowerBound {
             variable: Variable::synthetic(VariableKind::Hole(hole)),
-            r#type: number
+            bound: number
         }]
     );
 }
@@ -408,13 +426,14 @@ fn collect_constraints_nested() {
     // Collect constraints between the two nested opaque types
     outer_a.collect_constraints(outer_b, &mut inference_env);
 
-    // Due to invariance through the chain, we should get an equality constraint
+    // Due to covariance through the chain, we get an upper bound constraint:
+    // the hole is in the subtype position, so the concrete type is an upper bound.
     let constraints = inference_env.take_constraints();
     assert_eq!(
         constraints,
-        [Constraint::Equals {
+        [Constraint::UpperBound {
             variable: Variable::synthetic(VariableKind::Hole(hole)),
-            r#type: number
+            bound: number
         }]
     );
 }
@@ -483,17 +502,17 @@ fn collect_constraints_generic_params() {
     // Collect constraints between the two opaque types with generic parameters
     inference_env.collect_constraints(Variance::Covariant, opaque_a, opaque_b);
 
-    // Due to invariance, we should get an equality constraint between the generic parameters
+    // Due to covariance, we get an ordering constraint between the generic parameters
     let constraints = inference_env.take_constraints();
     assert_eq!(constraints.len(), 1);
     assert_eq!(
         constraints[0],
-        Constraint::Unify {
-            lhs: Variable {
+        Constraint::Ordering {
+            lower: Variable {
                 span: SpanId::SYNTHETIC,
                 kind: VariableKind::Generic(arg1)
             },
-            rhs: Variable {
+            upper: Variable {
                 span: SpanId::SYNTHETIC,
                 kind: VariableKind::Generic(arg2)
             }
@@ -522,17 +541,17 @@ fn collect_constraints_multiple_infer_vars() {
     // Collect constraints between the two opaque types
     opaque_a.collect_constraints(opaque_b, &mut inference_env);
 
-    // Due to invariance, we should get an equality constraint between the inference variables
+    // Due to covariance, we get an ordering constraint between the inference variables
     let constraints = inference_env.take_constraints();
     assert_eq!(constraints.len(), 1);
     assert_eq!(
         constraints[0],
-        Constraint::Unify {
-            lhs: Variable {
+        Constraint::Ordering {
+            lower: Variable {
                 span: SpanId::SYNTHETIC,
                 kind: VariableKind::Hole(hole_var1)
             },
-            rhs: Variable {
+            upper: Variable {
                 span: SpanId::SYNTHETIC,
                 kind: VariableKind::Hole(hole_var2)
             }
@@ -560,18 +579,18 @@ fn collect_constraints_infer_and_generic_var() {
     // Collect constraints between the two opaque types
     opaque_a.collect_constraints(opaque_b, &mut inference_env);
 
-    // Due to invariance, we should get an equality constraint between the inference variable
+    // Due to covariance, we get an ordering constraint between the inference variable
     // and the generic variable
     let constraints = inference_env.take_constraints();
     assert_eq!(constraints.len(), 1);
     assert_eq!(
         constraints[0],
-        Constraint::Unify {
-            lhs: Variable {
+        Constraint::Ordering {
+            lower: Variable {
                 span: SpanId::SYNTHETIC,
                 kind: VariableKind::Hole(hole_var1)
             },
-            rhs: Variable {
+            upper: Variable {
                 span: SpanId::SYNTHETIC,
                 kind: VariableKind::Generic(arg)
             }

--- a/libs/@local/hashql/core/src/type/recursion.rs
+++ b/libs/@local/hashql/core/src/type/recursion.rs
@@ -58,6 +58,7 @@ pub struct RecursionBoundary<'heap, A: Allocator = Global> {
 }
 
 impl Default for RecursionBoundary<'_> {
+    #[inline]
     fn default() -> Self {
         Self::new()
     }

--- a/libs/@local/hashql/core/src/type/visit.rs
+++ b/libs/@local/hashql/core/src/type/visit.rs
@@ -709,6 +709,7 @@ impl<'heap, A: Allocator> RecursiveVisitorGuard<'heap, A> {
 }
 
 impl Default for RecursiveVisitorGuard<'_> {
+    #[inline]
     fn default() -> Self {
         Self::new()
     }

--- a/libs/@local/hashql/hir/tests/ui/lower/checking/collect-filter-graph.stdout
+++ b/libs/@local/hashql/hir/tests/ui/lower/checking/collect-filter-graph.stdout
@@ -33,7 +33,7 @@
                         entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                         web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
                     ),
-                    left_entity_provenance: ?,
+                    left_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?),
                     right_entity_confidence: ::core::option::None(Null)
                     | ::core::option::Some(::graph::types::knowledge::entity::Confidence(Number)),
                     right_entity_id: ::graph::types::knowledge::entity::EntityId(
@@ -42,7 +42,7 @@
                         entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                         web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
                     ),
-                    right_entity_provenance: ?
+                    right_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?)
                 )),
                 metadata: ::graph::types::knowledge::entity::EntityMetadata(
                     archived: Boolean,
@@ -52,10 +52,10 @@
                         base_url: ::graph::types::ontology::BaseUrl(::core::url::Url(String)),
                         version: ::graph::ontology::OntologyTypeVersion(String)
                     )>,
-                    properties: ?,
+                    properties: ::graph::types::knowledge::entity::PropertyObjectMetadata(?),
                     provenance: ::graph::types::knowledge::entity::EntityProvenance(
-                        edition: ?,
-                        inferred: ?
+                        edition: ::graph::types::knowledge::entity::EntityEditionProvenance(?),
+                        inferred: ::graph::types::knowledge::entity::InferredEntityProvenance(?)
                     ),
                     record_id: ::graph::types::knowledge::entity::RecordId(
                         edition_id: ::graph::types::knowledge::entity::EntityEditionId(::core::uuid::Uuid(String)),
@@ -111,7 +111,7 @@
 │                          entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
 │                          web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
 │                      ),
-│                      left_entity_provenance: ?,
+│                      left_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?),
 │                      right_entity_confidence: ::core::option::None(Null)
 │                      | ::core::option::Some(::graph::types::knowledge::entity::Confidence(Number)),
 │                      right_entity_id: ::graph::types::knowledge::entity::EntityId(
@@ -120,7 +120,7 @@
 │                          entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
 │                          web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
 │                      ),
-│                      right_entity_provenance: ?
+│                      right_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?)
 │                  )),
 │                  metadata: ::graph::types::knowledge::entity::EntityMetadata(
 │                      archived: Boolean,
@@ -130,10 +130,10 @@
 │                          base_url: ::graph::types::ontology::BaseUrl(::core::url::Url(String)),
 │                          version: ::graph::ontology::OntologyTypeVersion(String)
 │                      )>,
-│                      properties: ?,
+│                      properties: ::graph::types::knowledge::entity::PropertyObjectMetadata(?),
 │                      provenance: ::graph::types::knowledge::entity::EntityProvenance(
-│                          edition: ?,
-│                          inferred: ?
+│                          edition: ::graph::types::knowledge::entity::EntityEditionProvenance(?),
+│                          inferred: ::graph::types::knowledge::entity::InferredEntityProvenance(?)
 │                      ),
 │                      record_id: ::graph::types::knowledge::entity::RecordId(
 │                          edition_id: ::graph::types::knowledge::entity::EntityEditionId(::core::uuid::Uuid(String)),
@@ -180,7 +180,7 @@
                entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
            ),
-           left_entity_provenance: ?,
+           left_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?),
            right_entity_confidence: ::core::option::None(Null)
            | ::core::option::Some(::graph::types::knowledge::entity::Confidence(Number)),
            right_entity_id: ::graph::types::knowledge::entity::EntityId(
@@ -189,7 +189,7 @@
                entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
            ),
-           right_entity_provenance: ?
+           right_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?)
        )),
        metadata: ::graph::types::knowledge::entity::EntityMetadata(
            archived: Boolean,
@@ -199,10 +199,10 @@
                base_url: ::graph::types::ontology::BaseUrl(::core::url::Url(String)),
                version: ::graph::ontology::OntologyTypeVersion(String)
            )>,
-           properties: ?,
+           properties: ::graph::types::knowledge::entity::PropertyObjectMetadata(?),
            provenance: ::graph::types::knowledge::entity::EntityProvenance(
-               edition: ?,
-               inferred: ?
+               edition: ::graph::types::knowledge::entity::EntityEditionProvenance(?),
+               inferred: ::graph::types::knowledge::entity::InferredEntityProvenance(?)
            ),
            record_id: ::graph::types::knowledge::entity::RecordId(
                edition_id: ::graph::types::knowledge::entity::EntityEditionId(::core::uuid::Uuid(String)),
@@ -246,7 +246,7 @@
                        entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                        web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
                    ),
-                   left_entity_provenance: ?,
+                   left_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?),
                    right_entity_confidence: ::core::option::None(Null)
                    | ::core::option::Some(::graph::types::knowledge::entity::Confidence(Number)),
                    right_entity_id: ::graph::types::knowledge::entity::EntityId(
@@ -255,7 +255,7 @@
                        entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                        web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
                    ),
-                   right_entity_provenance: ?
+                   right_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?)
                )),
                metadata: ::graph::types::knowledge::entity::EntityMetadata(
                    archived: Boolean,
@@ -265,10 +265,10 @@
                        base_url: ::graph::types::ontology::BaseUrl(::core::url::Url(String)),
                        version: ::graph::ontology::OntologyTypeVersion(String)
                    )>,
-                   properties: ?,
+                   properties: ::graph::types::knowledge::entity::PropertyObjectMetadata(?),
                    provenance: ::graph::types::knowledge::entity::EntityProvenance(
-                       edition: ?,
-                       inferred: ?
+                       edition: ::graph::types::knowledge::entity::EntityEditionProvenance(?),
+                       inferred: ::graph::types::knowledge::entity::InferredEntityProvenance(?)
                    ),
                    record_id: ::graph::types::knowledge::entity::RecordId(
                        edition_id: ::graph::types::knowledge::entity::EntityEditionId(::core::uuid::Uuid(String)),
@@ -310,7 +310,7 @@
                    entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                    web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
                ),
-               left_entity_provenance: ?,
+               left_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?),
                right_entity_confidence: ::core::option::None(Null)
                | ::core::option::Some(::graph::types::knowledge::entity::Confidence(Number)),
                right_entity_id: ::graph::types::knowledge::entity::EntityId(
@@ -319,7 +319,7 @@
                    entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                    web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
                ),
-               right_entity_provenance: ?
+               right_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?)
            )),
            metadata: ::graph::types::knowledge::entity::EntityMetadata(
                archived: Boolean,
@@ -329,10 +329,10 @@
                    base_url: ::graph::types::ontology::BaseUrl(::core::url::Url(String)),
                    version: ::graph::ontology::OntologyTypeVersion(String)
                )>,
-               properties: ?,
+               properties: ::graph::types::knowledge::entity::PropertyObjectMetadata(?),
                provenance: ::graph::types::knowledge::entity::EntityProvenance(
-                   edition: ?,
-                   inferred: ?
+                   edition: ::graph::types::knowledge::entity::EntityEditionProvenance(?),
+                   inferred: ::graph::types::knowledge::entity::InferredEntityProvenance(?)
                ),
                record_id: ::graph::types::knowledge::entity::RecordId(
                    edition_id: ::graph::types::knowledge::entity::EntityEditionId(::core::uuid::Uuid(String)),
@@ -376,7 +376,7 @@
 │                      entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
 │                      web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
 │                  ),
-│                  left_entity_provenance: ?,
+│                  left_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?),
 │                  right_entity_confidence: ::core::option::None(Null)
 │                  | ::core::option::Some(::graph::types::knowledge::entity::Confidence(Number)),
 │                  right_entity_id: ::graph::types::knowledge::entity::EntityId(
@@ -385,7 +385,7 @@
 │                      entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
 │                      web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
 │                  ),
-│                  right_entity_provenance: ?
+│                  right_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?)
 │              )),
 │              metadata: ::graph::types::knowledge::entity::EntityMetadata(
 │                  archived: Boolean,
@@ -395,10 +395,10 @@
 │                      base_url: ::graph::types::ontology::BaseUrl(::core::url::Url(String)),
 │                      version: ::graph::ontology::OntologyTypeVersion(String)
 │                  )>,
-│                  properties: ?,
+│                  properties: ::graph::types::knowledge::entity::PropertyObjectMetadata(?),
 │                  provenance: ::graph::types::knowledge::entity::EntityProvenance(
-│                      edition: ?,
-│                      inferred: ?
+│                      edition: ::graph::types::knowledge::entity::EntityEditionProvenance(?),
+│                      inferred: ::graph::types::knowledge::entity::InferredEntityProvenance(?)
 │                  ),
 │                  record_id: ::graph::types::knowledge::entity::RecordId(
 │                      edition_id: ::graph::types::knowledge::entity::EntityEditionId(::core::uuid::Uuid(String)),
@@ -447,7 +447,7 @@
                    entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                    web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
                ),
-               left_entity_provenance: ?,
+               left_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?),
                right_entity_confidence: ::core::option::None(Null)
                | ::core::option::Some(::graph::types::knowledge::entity::Confidence(Number)),
                right_entity_id: ::graph::types::knowledge::entity::EntityId(
@@ -456,7 +456,7 @@
                    entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                    web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
                ),
-               right_entity_provenance: ?
+               right_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?)
            )),
            metadata: ::graph::types::knowledge::entity::EntityMetadata(
                archived: Boolean,
@@ -466,10 +466,10 @@
                    base_url: ::graph::types::ontology::BaseUrl(::core::url::Url(String)),
                    version: ::graph::ontology::OntologyTypeVersion(String)
                )>,
-               properties: ?,
+               properties: ::graph::types::knowledge::entity::PropertyObjectMetadata(?),
                provenance: ::graph::types::knowledge::entity::EntityProvenance(
-                   edition: ?,
-                   inferred: ?
+                   edition: ::graph::types::knowledge::entity::EntityEditionProvenance(?),
+                   inferred: ::graph::types::knowledge::entity::InferredEntityProvenance(?)
                ),
                record_id: ::graph::types::knowledge::entity::RecordId(
                    edition_id: ::graph::types::knowledge::entity::EntityEditionId(::core::uuid::Uuid(String)),
@@ -514,7 +514,7 @@
                        entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                        web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
                    ),
-                   left_entity_provenance: ?,
+                   left_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?),
                    right_entity_confidence: ::core::option::None(Null)
                    | ::core::option::Some(::graph::types::knowledge::entity::Confidence(Number)),
                    right_entity_id: ::graph::types::knowledge::entity::EntityId(
@@ -523,7 +523,7 @@
                        entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                        web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
                    ),
-                   right_entity_provenance: ?
+                   right_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?)
                )),
                metadata: ::graph::types::knowledge::entity::EntityMetadata(
                    archived: Boolean,
@@ -533,10 +533,10 @@
                        base_url: ::graph::types::ontology::BaseUrl(::core::url::Url(String)),
                        version: ::graph::ontology::OntologyTypeVersion(String)
                    )>,
-                   properties: ?,
+                   properties: ::graph::types::knowledge::entity::PropertyObjectMetadata(?),
                    provenance: ::graph::types::knowledge::entity::EntityProvenance(
-                       edition: ?,
-                       inferred: ?
+                       edition: ::graph::types::knowledge::entity::EntityEditionProvenance(?),
+                       inferred: ::graph::types::knowledge::entity::InferredEntityProvenance(?)
                    ),
                    record_id: ::graph::types::knowledge::entity::RecordId(
                        edition_id: ::graph::types::knowledge::entity::EntityEditionId(::core::uuid::Uuid(String)),
@@ -578,7 +578,7 @@
                        entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                        web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
                    ),
-                   left_entity_provenance: ?,
+                   left_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?),
                    right_entity_confidence: ::core::option::None(Null)
                    | ::core::option::Some(::graph::types::knowledge::entity::Confidence(Number)),
                    right_entity_id: ::graph::types::knowledge::entity::EntityId(
@@ -587,7 +587,7 @@
                        entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                        web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
                    ),
-                   right_entity_provenance: ?
+                   right_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?)
                )),
                metadata: ::graph::types::knowledge::entity::EntityMetadata(
                    archived: Boolean,
@@ -597,10 +597,10 @@
                        base_url: ::graph::types::ontology::BaseUrl(::core::url::Url(String)),
                        version: ::graph::ontology::OntologyTypeVersion(String)
                    )>,
-                   properties: ?,
+                   properties: ::graph::types::knowledge::entity::PropertyObjectMetadata(?),
                    provenance: ::graph::types::knowledge::entity::EntityProvenance(
-                       edition: ?,
-                       inferred: ?
+                       edition: ::graph::types::knowledge::entity::EntityEditionProvenance(?),
+                       inferred: ::graph::types::knowledge::entity::InferredEntityProvenance(?)
                    ),
                    record_id: ::graph::types::knowledge::entity::RecordId(
                        edition_id: ::graph::types::knowledge::entity::EntityEditionId(::core::uuid::Uuid(String)),
@@ -643,7 +643,7 @@
                        entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                        web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
                    ),
-                   left_entity_provenance: ?,
+                   left_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?),
                    right_entity_confidence: ::core::option::None(Null)
                    | ::core::option::Some(::graph::types::knowledge::entity::Confidence(Number)),
                    right_entity_id: ::graph::types::knowledge::entity::EntityId(
@@ -652,7 +652,7 @@
                        entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                        web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
                    ),
-                   right_entity_provenance: ?
+                   right_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?)
                )),
                metadata: ::graph::types::knowledge::entity::EntityMetadata(
                    archived: Boolean,
@@ -662,10 +662,10 @@
                        base_url: ::graph::types::ontology::BaseUrl(::core::url::Url(String)),
                        version: ::graph::ontology::OntologyTypeVersion(String)
                    )>,
-                   properties: ?,
+                   properties: ::graph::types::knowledge::entity::PropertyObjectMetadata(?),
                    provenance: ::graph::types::knowledge::entity::EntityProvenance(
-                       edition: ?,
-                       inferred: ?
+                       edition: ::graph::types::knowledge::entity::EntityEditionProvenance(?),
+                       inferred: ::graph::types::knowledge::entity::InferredEntityProvenance(?)
                    ),
                    record_id: ::graph::types::knowledge::entity::RecordId(
                        edition_id: ::graph::types::knowledge::entity::EntityEditionId(::core::uuid::Uuid(String)),
@@ -709,7 +709,7 @@
                    entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                    web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
                ),
-               left_entity_provenance: ?,
+               left_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?),
                right_entity_confidence: ::core::option::None(Null)
                | ::core::option::Some(::graph::types::knowledge::entity::Confidence(Number)),
                right_entity_id: ::graph::types::knowledge::entity::EntityId(
@@ -718,7 +718,7 @@
                    entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                    web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
                ),
-               right_entity_provenance: ?
+               right_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?)
            )),
            metadata: ::graph::types::knowledge::entity::EntityMetadata(
                archived: Boolean,
@@ -728,10 +728,10 @@
                    base_url: ::graph::types::ontology::BaseUrl(::core::url::Url(String)),
                    version: ::graph::ontology::OntologyTypeVersion(String)
                )>,
-               properties: ?,
+               properties: ::graph::types::knowledge::entity::PropertyObjectMetadata(?),
                provenance: ::graph::types::knowledge::entity::EntityProvenance(
-                   edition: ?,
-                   inferred: ?
+                   edition: ::graph::types::knowledge::entity::EntityEditionProvenance(?),
+                   inferred: ::graph::types::knowledge::entity::InferredEntityProvenance(?)
                ),
                record_id: ::graph::types::knowledge::entity::RecordId(
                    edition_id: ::graph::types::knowledge::entity::EntityEditionId(::core::uuid::Uuid(String)),
@@ -797,7 +797,7 @@
                        entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                        web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
                    ),
-                   left_entity_provenance: ?,
+                   left_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?),
                    right_entity_confidence: ::core::option::None(Null)
                    | ::core::option::Some(::graph::types::knowledge::entity::Confidence(Number)),
                    right_entity_id: ::graph::types::knowledge::entity::EntityId(
@@ -806,7 +806,7 @@
                        entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                        web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
                    ),
-                   right_entity_provenance: ?
+                   right_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?)
                )),
                metadata: ::graph::types::knowledge::entity::EntityMetadata(
                    archived: Boolean,
@@ -816,10 +816,10 @@
                        base_url: ::graph::types::ontology::BaseUrl(::core::url::Url(String)),
                        version: ::graph::ontology::OntologyTypeVersion(String)
                    )>,
-                   properties: ?,
+                   properties: ::graph::types::knowledge::entity::PropertyObjectMetadata(?),
                    provenance: ::graph::types::knowledge::entity::EntityProvenance(
-                       edition: ?,
-                       inferred: ?
+                       edition: ::graph::types::knowledge::entity::EntityEditionProvenance(?),
+                       inferred: ::graph::types::knowledge::entity::InferredEntityProvenance(?)
                    ),
                    record_id: ::graph::types::knowledge::entity::RecordId(
                        edition_id: ::graph::types::knowledge::entity::EntityEditionId(::core::uuid::Uuid(String)),
@@ -907,7 +907,7 @@
 │                  entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
 │                  web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
 │              ),
-│              left_entity_provenance: ?,
+│              left_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?),
 │              right_entity_confidence: ::core::option::None(Null)
 │              | ::core::option::Some(::graph::types::knowledge::entity::Confidence(Number)),
 │              right_entity_id: ::graph::types::knowledge::entity::EntityId(
@@ -916,7 +916,7 @@
 │                  entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
 │                  web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
 │              ),
-│              right_entity_provenance: ?
+│              right_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?)
 │          )),
 │          metadata: ::graph::types::knowledge::entity::EntityMetadata(
 │              archived: Boolean,
@@ -926,10 +926,10 @@
 │                  base_url: ::graph::types::ontology::BaseUrl(::core::url::Url(String)),
 │                  version: ::graph::ontology::OntologyTypeVersion(String)
 │              )>,
-│              properties: ?,
+│              properties: ::graph::types::knowledge::entity::PropertyObjectMetadata(?),
 │              provenance: ::graph::types::knowledge::entity::EntityProvenance(
-│                  edition: ?,
-│                  inferred: ?
+│                  edition: ::graph::types::knowledge::entity::EntityEditionProvenance(?),
+│                  inferred: ::graph::types::knowledge::entity::InferredEntityProvenance(?)
 │              ),
 │              record_id: ::graph::types::knowledge::entity::RecordId(
 │                  edition_id: ::graph::types::knowledge::entity::EntityEditionId(::core::uuid::Uuid(String)),
@@ -977,7 +977,7 @@
                    entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                    web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
                ),
-               left_entity_provenance: ?,
+               left_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?),
                right_entity_confidence: ::core::option::None(Null)
                | ::core::option::Some(::graph::types::knowledge::entity::Confidence(Number)),
                right_entity_id: ::graph::types::knowledge::entity::EntityId(
@@ -986,7 +986,7 @@
                    entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                    web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
                ),
-               right_entity_provenance: ?
+               right_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?)
            )),
            metadata: ::graph::types::knowledge::entity::EntityMetadata(
                archived: Boolean,
@@ -996,10 +996,10 @@
                    base_url: ::graph::types::ontology::BaseUrl(::core::url::Url(String)),
                    version: ::graph::ontology::OntologyTypeVersion(String)
                )>,
-               properties: ?,
+               properties: ::graph::types::knowledge::entity::PropertyObjectMetadata(?),
                provenance: ::graph::types::knowledge::entity::EntityProvenance(
-                   edition: ?,
-                   inferred: ?
+                   edition: ::graph::types::knowledge::entity::EntityEditionProvenance(?),
+                   inferred: ::graph::types::knowledge::entity::InferredEntityProvenance(?)
                ),
                record_id: ::graph::types::knowledge::entity::RecordId(
                    edition_id: ::graph::types::knowledge::entity::EntityEditionId(::core::uuid::Uuid(String)),
@@ -1072,10 +1072,10 @@
            base_url: ::graph::types::ontology::BaseUrl(::core::url::Url(String)),
            version: ::graph::ontology::OntologyTypeVersion(String)
        )>,
-       properties: ?,
+       properties: ::graph::types::knowledge::entity::PropertyObjectMetadata(?),
        provenance: ::graph::types::knowledge::entity::EntityProvenance(
-           edition: ?,
-           inferred: ?
+           edition: ::graph::types::knowledge::entity::EntityEditionProvenance(?),
+           inferred: ::graph::types::knowledge::entity::InferredEntityProvenance(?)
        ),
        record_id: ::graph::types::knowledge::entity::RecordId(
            edition_id: ::graph::types::knowledge::entity::EntityEditionId(::core::uuid::Uuid(String)),
@@ -1113,7 +1113,7 @@
                entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
            ),
-           left_entity_provenance: ?,
+           left_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?),
            right_entity_confidence: ::core::option::None(Null)
            | ::core::option::Some(::graph::types::knowledge::entity::Confidence(Number)),
            right_entity_id: ::graph::types::knowledge::entity::EntityId(
@@ -1122,7 +1122,7 @@
                entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
            ),
-           right_entity_provenance: ?
+           right_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?)
        )),
        metadata: ::graph::types::knowledge::entity::EntityMetadata(
            archived: Boolean,
@@ -1132,10 +1132,10 @@
                base_url: ::graph::types::ontology::BaseUrl(::core::url::Url(String)),
                version: ::graph::ontology::OntologyTypeVersion(String)
            )>,
-           properties: ?,
+           properties: ::graph::types::knowledge::entity::PropertyObjectMetadata(?),
            provenance: ::graph::types::knowledge::entity::EntityProvenance(
-               edition: ?,
-               inferred: ?
+               edition: ::graph::types::knowledge::entity::EntityEditionProvenance(?),
+               inferred: ::graph::types::knowledge::entity::InferredEntityProvenance(?)
            ),
            record_id: ::graph::types::knowledge::entity::RecordId(
                edition_id: ::graph::types::knowledge::entity::EntityEditionId(::core::uuid::Uuid(String)),

--- a/libs/@local/hashql/hir/tests/ui/lower/checking/filter-graph.stdout
+++ b/libs/@local/hashql/hir/tests/ui/lower/checking/filter-graph.stdout
@@ -30,7 +30,7 @@
                     entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                     web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
                 ),
-                left_entity_provenance: ?,
+                left_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?),
                 right_entity_confidence: ::core::option::None(Null)
                 | ::core::option::Some(::graph::types::knowledge::entity::Confidence(Number)),
                 right_entity_id: ::graph::types::knowledge::entity::EntityId(
@@ -39,7 +39,7 @@
                     entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                     web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
                 ),
-                right_entity_provenance: ?
+                right_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?)
             )),
             metadata: ::graph::types::knowledge::entity::EntityMetadata(
                 archived: Boolean,
@@ -49,10 +49,10 @@
                     base_url: ::graph::types::ontology::BaseUrl(::core::url::Url(String)),
                     version: ::graph::ontology::OntologyTypeVersion(String)
                 )>,
-                properties: ?,
+                properties: ::graph::types::knowledge::entity::PropertyObjectMetadata(?),
                 provenance: ::graph::types::knowledge::entity::EntityProvenance(
-                    edition: ?,
-                    inferred: ?
+                    edition: ::graph::types::knowledge::entity::EntityEditionProvenance(?),
+                    inferred: ::graph::types::knowledge::entity::InferredEntityProvenance(?)
                 ),
                 record_id: ::graph::types::knowledge::entity::RecordId(
                     edition_id: ::graph::types::knowledge::entity::EntityEditionId(::core::uuid::Uuid(String)),
@@ -106,7 +106,7 @@
 │                      entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
 │                      web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
 │                  ),
-│                  left_entity_provenance: ?,
+│                  left_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?),
 │                  right_entity_confidence: ::core::option::None(Null)
 │                  | ::core::option::Some(::graph::types::knowledge::entity::Confidence(Number)),
 │                  right_entity_id: ::graph::types::knowledge::entity::EntityId(
@@ -115,7 +115,7 @@
 │                      entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
 │                      web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
 │                  ),
-│                  right_entity_provenance: ?
+│                  right_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?)
 │              )),
 │              metadata: ::graph::types::knowledge::entity::EntityMetadata(
 │                  archived: Boolean,
@@ -125,10 +125,10 @@
 │                      base_url: ::graph::types::ontology::BaseUrl(::core::url::Url(String)),
 │                      version: ::graph::ontology::OntologyTypeVersion(String)
 │                  )>,
-│                  properties: ?,
+│                  properties: ::graph::types::knowledge::entity::PropertyObjectMetadata(?),
 │                  provenance: ::graph::types::knowledge::entity::EntityProvenance(
-│                      edition: ?,
-│                      inferred: ?
+│                      edition: ::graph::types::knowledge::entity::EntityEditionProvenance(?),
+│                      inferred: ::graph::types::knowledge::entity::InferredEntityProvenance(?)
 │                  ),
 │                  record_id: ::graph::types::knowledge::entity::RecordId(
 │                      edition_id: ::graph::types::knowledge::entity::EntityEditionId(::core::uuid::Uuid(String)),
@@ -177,7 +177,7 @@
                    entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                    web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
                ),
-               left_entity_provenance: ?,
+               left_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?),
                right_entity_confidence: ::core::option::None(Null)
                | ::core::option::Some(::graph::types::knowledge::entity::Confidence(Number)),
                right_entity_id: ::graph::types::knowledge::entity::EntityId(
@@ -186,7 +186,7 @@
                    entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                    web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
                ),
-               right_entity_provenance: ?
+               right_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?)
            )),
            metadata: ::graph::types::knowledge::entity::EntityMetadata(
                archived: Boolean,
@@ -196,10 +196,10 @@
                    base_url: ::graph::types::ontology::BaseUrl(::core::url::Url(String)),
                    version: ::graph::ontology::OntologyTypeVersion(String)
                )>,
-               properties: ?,
+               properties: ::graph::types::knowledge::entity::PropertyObjectMetadata(?),
                provenance: ::graph::types::knowledge::entity::EntityProvenance(
-                   edition: ?,
-                   inferred: ?
+                   edition: ::graph::types::knowledge::entity::EntityEditionProvenance(?),
+                   inferred: ::graph::types::knowledge::entity::InferredEntityProvenance(?)
                ),
                record_id: ::graph::types::knowledge::entity::RecordId(
                    edition_id: ::graph::types::knowledge::entity::EntityEditionId(::core::uuid::Uuid(String)),
@@ -244,7 +244,7 @@
                        entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                        web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
                    ),
-                   left_entity_provenance: ?,
+                   left_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?),
                    right_entity_confidence: ::core::option::None(Null)
                    | ::core::option::Some(::graph::types::knowledge::entity::Confidence(Number)),
                    right_entity_id: ::graph::types::knowledge::entity::EntityId(
@@ -253,7 +253,7 @@
                        entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                        web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
                    ),
-                   right_entity_provenance: ?
+                   right_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?)
                )),
                metadata: ::graph::types::knowledge::entity::EntityMetadata(
                    archived: Boolean,
@@ -263,10 +263,10 @@
                        base_url: ::graph::types::ontology::BaseUrl(::core::url::Url(String)),
                        version: ::graph::ontology::OntologyTypeVersion(String)
                    )>,
-                   properties: ?,
+                   properties: ::graph::types::knowledge::entity::PropertyObjectMetadata(?),
                    provenance: ::graph::types::knowledge::entity::EntityProvenance(
-                       edition: ?,
-                       inferred: ?
+                       edition: ::graph::types::knowledge::entity::EntityEditionProvenance(?),
+                       inferred: ::graph::types::knowledge::entity::InferredEntityProvenance(?)
                    ),
                    record_id: ::graph::types::knowledge::entity::RecordId(
                        edition_id: ::graph::types::knowledge::entity::EntityEditionId(::core::uuid::Uuid(String)),
@@ -308,7 +308,7 @@
                        entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                        web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
                    ),
-                   left_entity_provenance: ?,
+                   left_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?),
                    right_entity_confidence: ::core::option::None(Null)
                    | ::core::option::Some(::graph::types::knowledge::entity::Confidence(Number)),
                    right_entity_id: ::graph::types::knowledge::entity::EntityId(
@@ -317,7 +317,7 @@
                        entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                        web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
                    ),
-                   right_entity_provenance: ?
+                   right_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?)
                )),
                metadata: ::graph::types::knowledge::entity::EntityMetadata(
                    archived: Boolean,
@@ -327,10 +327,10 @@
                        base_url: ::graph::types::ontology::BaseUrl(::core::url::Url(String)),
                        version: ::graph::ontology::OntologyTypeVersion(String)
                    )>,
-                   properties: ?,
+                   properties: ::graph::types::knowledge::entity::PropertyObjectMetadata(?),
                    provenance: ::graph::types::knowledge::entity::EntityProvenance(
-                       edition: ?,
-                       inferred: ?
+                       edition: ::graph::types::knowledge::entity::EntityEditionProvenance(?),
+                       inferred: ::graph::types::knowledge::entity::InferredEntityProvenance(?)
                    ),
                    record_id: ::graph::types::knowledge::entity::RecordId(
                        edition_id: ::graph::types::knowledge::entity::EntityEditionId(::core::uuid::Uuid(String)),
@@ -373,7 +373,7 @@
                        entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                        web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
                    ),
-                   left_entity_provenance: ?,
+                   left_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?),
                    right_entity_confidence: ::core::option::None(Null)
                    | ::core::option::Some(::graph::types::knowledge::entity::Confidence(Number)),
                    right_entity_id: ::graph::types::knowledge::entity::EntityId(
@@ -382,7 +382,7 @@
                        entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                        web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
                    ),
-                   right_entity_provenance: ?
+                   right_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?)
                )),
                metadata: ::graph::types::knowledge::entity::EntityMetadata(
                    archived: Boolean,
@@ -392,10 +392,10 @@
                        base_url: ::graph::types::ontology::BaseUrl(::core::url::Url(String)),
                        version: ::graph::ontology::OntologyTypeVersion(String)
                    )>,
-                   properties: ?,
+                   properties: ::graph::types::knowledge::entity::PropertyObjectMetadata(?),
                    provenance: ::graph::types::knowledge::entity::EntityProvenance(
-                       edition: ?,
-                       inferred: ?
+                       edition: ::graph::types::knowledge::entity::EntityEditionProvenance(?),
+                       inferred: ::graph::types::knowledge::entity::InferredEntityProvenance(?)
                    ),
                    record_id: ::graph::types::knowledge::entity::RecordId(
                        edition_id: ::graph::types::knowledge::entity::EntityEditionId(::core::uuid::Uuid(String)),
@@ -439,7 +439,7 @@
                    entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                    web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
                ),
-               left_entity_provenance: ?,
+               left_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?),
                right_entity_confidence: ::core::option::None(Null)
                | ::core::option::Some(::graph::types::knowledge::entity::Confidence(Number)),
                right_entity_id: ::graph::types::knowledge::entity::EntityId(
@@ -448,7 +448,7 @@
                    entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                    web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
                ),
-               right_entity_provenance: ?
+               right_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?)
            )),
            metadata: ::graph::types::knowledge::entity::EntityMetadata(
                archived: Boolean,
@@ -458,10 +458,10 @@
                    base_url: ::graph::types::ontology::BaseUrl(::core::url::Url(String)),
                    version: ::graph::ontology::OntologyTypeVersion(String)
                )>,
-               properties: ?,
+               properties: ::graph::types::knowledge::entity::PropertyObjectMetadata(?),
                provenance: ::graph::types::knowledge::entity::EntityProvenance(
-                   edition: ?,
-                   inferred: ?
+                   edition: ::graph::types::knowledge::entity::EntityEditionProvenance(?),
+                   inferred: ::graph::types::knowledge::entity::InferredEntityProvenance(?)
                ),
                record_id: ::graph::types::knowledge::entity::RecordId(
                    edition_id: ::graph::types::knowledge::entity::EntityEditionId(::core::uuid::Uuid(String)),
@@ -527,7 +527,7 @@
                        entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                        web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
                    ),
-                   left_entity_provenance: ?,
+                   left_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?),
                    right_entity_confidence: ::core::option::None(Null)
                    | ::core::option::Some(::graph::types::knowledge::entity::Confidence(Number)),
                    right_entity_id: ::graph::types::knowledge::entity::EntityId(
@@ -536,7 +536,7 @@
                        entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                        web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
                    ),
-                   right_entity_provenance: ?
+                   right_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?)
                )),
                metadata: ::graph::types::knowledge::entity::EntityMetadata(
                    archived: Boolean,
@@ -546,10 +546,10 @@
                        base_url: ::graph::types::ontology::BaseUrl(::core::url::Url(String)),
                        version: ::graph::ontology::OntologyTypeVersion(String)
                    )>,
-                   properties: ?,
+                   properties: ::graph::types::knowledge::entity::PropertyObjectMetadata(?),
                    provenance: ::graph::types::knowledge::entity::EntityProvenance(
-                       edition: ?,
-                       inferred: ?
+                       edition: ::graph::types::knowledge::entity::EntityEditionProvenance(?),
+                       inferred: ::graph::types::knowledge::entity::InferredEntityProvenance(?)
                    ),
                    record_id: ::graph::types::knowledge::entity::RecordId(
                        edition_id: ::graph::types::knowledge::entity::EntityEditionId(::core::uuid::Uuid(String)),
@@ -637,7 +637,7 @@
 │                  entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
 │                  web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
 │              ),
-│              left_entity_provenance: ?,
+│              left_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?),
 │              right_entity_confidence: ::core::option::None(Null)
 │              | ::core::option::Some(::graph::types::knowledge::entity::Confidence(Number)),
 │              right_entity_id: ::graph::types::knowledge::entity::EntityId(
@@ -646,7 +646,7 @@
 │                  entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
 │                  web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
 │              ),
-│              right_entity_provenance: ?
+│              right_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?)
 │          )),
 │          metadata: ::graph::types::knowledge::entity::EntityMetadata(
 │              archived: Boolean,
@@ -656,10 +656,10 @@
 │                  base_url: ::graph::types::ontology::BaseUrl(::core::url::Url(String)),
 │                  version: ::graph::ontology::OntologyTypeVersion(String)
 │              )>,
-│              properties: ?,
+│              properties: ::graph::types::knowledge::entity::PropertyObjectMetadata(?),
 │              provenance: ::graph::types::knowledge::entity::EntityProvenance(
-│                  edition: ?,
-│                  inferred: ?
+│                  edition: ::graph::types::knowledge::entity::EntityEditionProvenance(?),
+│                  inferred: ::graph::types::knowledge::entity::InferredEntityProvenance(?)
 │              ),
 │              record_id: ::graph::types::knowledge::entity::RecordId(
 │                  edition_id: ::graph::types::knowledge::entity::EntityEditionId(::core::uuid::Uuid(String)),
@@ -707,7 +707,7 @@
                    entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                    web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
                ),
-               left_entity_provenance: ?,
+               left_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?),
                right_entity_confidence: ::core::option::None(Null)
                | ::core::option::Some(::graph::types::knowledge::entity::Confidence(Number)),
                right_entity_id: ::graph::types::knowledge::entity::EntityId(
@@ -716,7 +716,7 @@
                    entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                    web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
                ),
-               right_entity_provenance: ?
+               right_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?)
            )),
            metadata: ::graph::types::knowledge::entity::EntityMetadata(
                archived: Boolean,
@@ -726,10 +726,10 @@
                    base_url: ::graph::types::ontology::BaseUrl(::core::url::Url(String)),
                    version: ::graph::ontology::OntologyTypeVersion(String)
                )>,
-               properties: ?,
+               properties: ::graph::types::knowledge::entity::PropertyObjectMetadata(?),
                provenance: ::graph::types::knowledge::entity::EntityProvenance(
-                   edition: ?,
-                   inferred: ?
+                   edition: ::graph::types::knowledge::entity::EntityEditionProvenance(?),
+                   inferred: ::graph::types::knowledge::entity::InferredEntityProvenance(?)
                ),
                record_id: ::graph::types::knowledge::entity::RecordId(
                    edition_id: ::graph::types::knowledge::entity::EntityEditionId(::core::uuid::Uuid(String)),
@@ -802,10 +802,10 @@
            base_url: ::graph::types::ontology::BaseUrl(::core::url::Url(String)),
            version: ::graph::ontology::OntologyTypeVersion(String)
        )>,
-       properties: ?,
+       properties: ::graph::types::knowledge::entity::PropertyObjectMetadata(?),
        provenance: ::graph::types::knowledge::entity::EntityProvenance(
-           edition: ?,
-           inferred: ?
+           edition: ::graph::types::knowledge::entity::EntityEditionProvenance(?),
+           inferred: ::graph::types::knowledge::entity::InferredEntityProvenance(?)
        ),
        record_id: ::graph::types::knowledge::entity::RecordId(
            edition_id: ::graph::types::knowledge::entity::EntityEditionId(::core::uuid::Uuid(String)),
@@ -843,7 +843,7 @@
                entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
            ),
-           left_entity_provenance: ?,
+           left_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?),
            right_entity_confidence: ::core::option::None(Null)
            | ::core::option::Some(::graph::types::knowledge::entity::Confidence(Number)),
            right_entity_id: ::graph::types::knowledge::entity::EntityId(
@@ -852,7 +852,7 @@
                entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
            ),
-           right_entity_provenance: ?
+           right_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?)
        )),
        metadata: ::graph::types::knowledge::entity::EntityMetadata(
            archived: Boolean,
@@ -862,10 +862,10 @@
                base_url: ::graph::types::ontology::BaseUrl(::core::url::Url(String)),
                version: ::graph::ontology::OntologyTypeVersion(String)
            )>,
-           properties: ?,
+           properties: ::graph::types::knowledge::entity::PropertyObjectMetadata(?),
            provenance: ::graph::types::knowledge::entity::EntityProvenance(
-               edition: ?,
-               inferred: ?
+               edition: ::graph::types::knowledge::entity::EntityEditionProvenance(?),
+               inferred: ::graph::types::knowledge::entity::InferredEntityProvenance(?)
            ),
            record_id: ::graph::types::knowledge::entity::RecordId(
                edition_id: ::graph::types::knowledge::entity::EntityEditionId(::core::uuid::Uuid(String)),

--- a/libs/@local/hashql/hir/tests/ui/lower/checking/minimal-graph.stdout
+++ b/libs/@local/hashql/hir/tests/ui/lower/checking/minimal-graph.stdout
@@ -27,7 +27,7 @@
                entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
            ),
-           left_entity_provenance: ?,
+           left_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?),
            right_entity_confidence: ::core::option::None(Null)
            | ::core::option::Some(::graph::types::knowledge::entity::Confidence(Number)),
            right_entity_id: ::graph::types::knowledge::entity::EntityId(
@@ -36,7 +36,7 @@
                entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
            ),
-           right_entity_provenance: ?
+           right_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?)
        )),
        metadata: ::graph::types::knowledge::entity::EntityMetadata(
            archived: Boolean,
@@ -46,10 +46,10 @@
                base_url: ::graph::types::ontology::BaseUrl(::core::url::Url(String)),
                version: ::graph::ontology::OntologyTypeVersion(String)
            )>,
-           properties: ?,
+           properties: ::graph::types::knowledge::entity::PropertyObjectMetadata(?),
            provenance: ::graph::types::knowledge::entity::EntityProvenance(
-               edition: ?,
-               inferred: ?
+               edition: ::graph::types::knowledge::entity::EntityEditionProvenance(?),
+               inferred: ::graph::types::knowledge::entity::InferredEntityProvenance(?)
            ),
            record_id: ::graph::types::knowledge::entity::RecordId(
                edition_id: ::graph::types::knowledge::entity::EntityEditionId(::core::uuid::Uuid(String)),
@@ -93,7 +93,7 @@
                        entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                        web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
                    ),
-                   left_entity_provenance: ?,
+                   left_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?),
                    right_entity_confidence: ::core::option::None(Null)
                    | ::core::option::Some(::graph::types::knowledge::entity::Confidence(Number)),
                    right_entity_id: ::graph::types::knowledge::entity::EntityId(
@@ -102,7 +102,7 @@
                        entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                        web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
                    ),
-                   right_entity_provenance: ?
+                   right_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?)
                )),
                metadata: ::graph::types::knowledge::entity::EntityMetadata(
                    archived: Boolean,
@@ -112,10 +112,10 @@
                        base_url: ::graph::types::ontology::BaseUrl(::core::url::Url(String)),
                        version: ::graph::ontology::OntologyTypeVersion(String)
                    )>,
-                   properties: ?,
+                   properties: ::graph::types::knowledge::entity::PropertyObjectMetadata(?),
                    provenance: ::graph::types::knowledge::entity::EntityProvenance(
-                       edition: ?,
-                       inferred: ?
+                       edition: ::graph::types::knowledge::entity::EntityEditionProvenance(?),
+                       inferred: ::graph::types::knowledge::entity::InferredEntityProvenance(?)
                    ),
                    record_id: ::graph::types::knowledge::entity::RecordId(
                        edition_id: ::graph::types::knowledge::entity::EntityEditionId(::core::uuid::Uuid(String)),
@@ -157,7 +157,7 @@
                    entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                    web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
                ),
-               left_entity_provenance: ?,
+               left_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?),
                right_entity_confidence: ::core::option::None(Null)
                | ::core::option::Some(::graph::types::knowledge::entity::Confidence(Number)),
                right_entity_id: ::graph::types::knowledge::entity::EntityId(
@@ -166,7 +166,7 @@
                    entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                    web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
                ),
-               right_entity_provenance: ?
+               right_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?)
            )),
            metadata: ::graph::types::knowledge::entity::EntityMetadata(
                archived: Boolean,
@@ -176,10 +176,10 @@
                    base_url: ::graph::types::ontology::BaseUrl(::core::url::Url(String)),
                    version: ::graph::ontology::OntologyTypeVersion(String)
                )>,
-               properties: ?,
+               properties: ::graph::types::knowledge::entity::PropertyObjectMetadata(?),
                provenance: ::graph::types::knowledge::entity::EntityProvenance(
-                   edition: ?,
-                   inferred: ?
+                   edition: ::graph::types::knowledge::entity::EntityEditionProvenance(?),
+                   inferred: ::graph::types::knowledge::entity::InferredEntityProvenance(?)
                ),
                record_id: ::graph::types::knowledge::entity::RecordId(
                    edition_id: ::graph::types::knowledge::entity::EntityEditionId(::core::uuid::Uuid(String)),
@@ -222,7 +222,7 @@
                    entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                    web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
                ),
-               left_entity_provenance: ?,
+               left_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?),
                right_entity_confidence: ::core::option::None(Null)
                | ::core::option::Some(::graph::types::knowledge::entity::Confidence(Number)),
                right_entity_id: ::graph::types::knowledge::entity::EntityId(
@@ -231,7 +231,7 @@
                    entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                    web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
                ),
-               right_entity_provenance: ?
+               right_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?)
            )),
            metadata: ::graph::types::knowledge::entity::EntityMetadata(
                archived: Boolean,
@@ -241,10 +241,10 @@
                    base_url: ::graph::types::ontology::BaseUrl(::core::url::Url(String)),
                    version: ::graph::ontology::OntologyTypeVersion(String)
                )>,
-               properties: ?,
+               properties: ::graph::types::knowledge::entity::PropertyObjectMetadata(?),
                provenance: ::graph::types::knowledge::entity::EntityProvenance(
-                   edition: ?,
-                   inferred: ?
+                   edition: ::graph::types::knowledge::entity::EntityEditionProvenance(?),
+                   inferred: ::graph::types::knowledge::entity::InferredEntityProvenance(?)
                ),
                record_id: ::graph::types::knowledge::entity::RecordId(
                    edition_id: ::graph::types::knowledge::entity::EntityEditionId(::core::uuid::Uuid(String)),
@@ -310,7 +310,7 @@
                        entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                        web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
                    ),
-                   left_entity_provenance: ?,
+                   left_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?),
                    right_entity_confidence: ::core::option::None(Null)
                    | ::core::option::Some(::graph::types::knowledge::entity::Confidence(Number)),
                    right_entity_id: ::graph::types::knowledge::entity::EntityId(
@@ -319,7 +319,7 @@
                        entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                        web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
                    ),
-                   right_entity_provenance: ?
+                   right_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?)
                )),
                metadata: ::graph::types::knowledge::entity::EntityMetadata(
                    archived: Boolean,
@@ -329,10 +329,10 @@
                        base_url: ::graph::types::ontology::BaseUrl(::core::url::Url(String)),
                        version: ::graph::ontology::OntologyTypeVersion(String)
                    )>,
-                   properties: ?,
+                   properties: ::graph::types::knowledge::entity::PropertyObjectMetadata(?),
                    provenance: ::graph::types::knowledge::entity::EntityProvenance(
-                       edition: ?,
-                       inferred: ?
+                       edition: ::graph::types::knowledge::entity::EntityEditionProvenance(?),
+                       inferred: ::graph::types::knowledge::entity::InferredEntityProvenance(?)
                    ),
                    record_id: ::graph::types::knowledge::entity::RecordId(
                        edition_id: ::graph::types::knowledge::entity::EntityEditionId(::core::uuid::Uuid(String)),

--- a/libs/@local/hashql/hir/tests/ui/lower/specialization/collect-custom-collect.stderr
+++ b/libs/@local/hashql/hir/tests/ui/lower/specialization/collect-custom-collect.stderr
@@ -19,7 +19,7 @@ error[lower::specialization::non-intrinsic-graph-operation]: Non-intrinsic funct
   │                           entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
   │                           web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
   │                       ),
-  │                       left_entity_provenance: ?,
+  │                       left_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?),
   │                       right_entity_confidence: ::core::option::None(Null)
   │                       | ::core::option::Some(::graph::types::knowledge::entity::Confidence(Number)),
   │                       right_entity_id: ::graph::types::knowledge::entity::EntityId(
@@ -28,7 +28,7 @@ error[lower::specialization::non-intrinsic-graph-operation]: Non-intrinsic funct
   │                           entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
   │                           web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
   │                       ),
-  │                       right_entity_provenance: ?
+  │                       right_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?)
   │                   )),
   │                   metadata: ::graph::types::knowledge::entity::EntityMetadata(
   │                       archived: Boolean,
@@ -38,10 +38,10 @@ error[lower::specialization::non-intrinsic-graph-operation]: Non-intrinsic funct
   │                           base_url: ::graph::types::ontology::BaseUrl(::core::url::Url(String)),
   │                           version: ::graph::ontology::OntologyTypeVersion(String)
   │                       )>,
-  │                       properties: ?,
+  │                       properties: ::graph::types::knowledge::entity::PropertyObjectMetadata(?),
   │                       provenance: ::graph::types::knowledge::entity::EntityProvenance(
-  │                           edition: ?,
-  │                           inferred: ?
+  │                           edition: ::graph::types::knowledge::entity::EntityEditionProvenance(?),
+  │                           inferred: ::graph::types::knowledge::entity::InferredEntityProvenance(?)
   │                       ),
   │                       record_id: ::graph::types::knowledge::entity::RecordId(
   │                           edition_id: ::graph::types::knowledge::entity::EntityEditionId(::core::uuid::Uuid(String)),
@@ -83,7 +83,7 @@ error[lower::specialization::non-intrinsic-graph-operation]: Non-intrinsic funct
   │                       entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
   │                       web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
   │                   ),
-  │                   left_entity_provenance: ?,
+  │                   left_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?),
   │                   right_entity_confidence: ::core::option::None(Null)
   │                   | ::core::option::Some(::graph::types::knowledge::entity::Confidence(Number)),
   │                   right_entity_id: ::graph::types::knowledge::entity::EntityId(
@@ -92,7 +92,7 @@ error[lower::specialization::non-intrinsic-graph-operation]: Non-intrinsic funct
   │                       entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
   │                       web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
   │                   ),
-  │                   right_entity_provenance: ?
+  │                   right_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?)
   │               )),
   │               metadata: ::graph::types::knowledge::entity::EntityMetadata(
   │                   archived: Boolean,
@@ -102,10 +102,10 @@ error[lower::specialization::non-intrinsic-graph-operation]: Non-intrinsic funct
   │                       base_url: ::graph::types::ontology::BaseUrl(::core::url::Url(String)),
   │                       version: ::graph::ontology::OntologyTypeVersion(String)
   │                   )>,
-  │                   properties: ?,
+  │                   properties: ::graph::types::knowledge::entity::PropertyObjectMetadata(?),
   │                   provenance: ::graph::types::knowledge::entity::EntityProvenance(
-  │                       edition: ?,
-  │                       inferred: ?
+  │                       edition: ::graph::types::knowledge::entity::EntityEditionProvenance(?),
+  │                       inferred: ::graph::types::knowledge::entity::InferredEntityProvenance(?)
   │                   ),
   │                   record_id: ::graph::types::knowledge::entity::RecordId(
   │                       edition_id: ::graph::types::knowledge::entity::EntityEditionId(::core::uuid::Uuid(String)),

--- a/libs/@local/hashql/hir/tests/ui/lower/specialization/collect-filter-graph.stdout
+++ b/libs/@local/hashql/hir/tests/ui/lower/specialization/collect-filter-graph.stdout
@@ -31,7 +31,7 @@
                 entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                 web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
             ),
-            left_entity_provenance: ?,
+            left_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?),
             right_entity_confidence: ::core::option::None(Null)
             | ::core::option::Some(::graph::types::knowledge::entity::Confidence(Number)),
             right_entity_id: ::graph::types::knowledge::entity::EntityId(
@@ -40,7 +40,7 @@
                 entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                 web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
             ),
-            right_entity_provenance: ?
+            right_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?)
         )),
         metadata: ::graph::types::knowledge::entity::EntityMetadata(
             archived: Boolean,
@@ -50,10 +50,10 @@
                 base_url: ::graph::types::ontology::BaseUrl(::core::url::Url(String)),
                 version: ::graph::ontology::OntologyTypeVersion(String)
             )>,
-            properties: ?,
+            properties: ::graph::types::knowledge::entity::PropertyObjectMetadata(?),
             provenance: ::graph::types::knowledge::entity::EntityProvenance(
-                edition: ?,
-                inferred: ?
+                edition: ::graph::types::knowledge::entity::EntityEditionProvenance(?),
+                inferred: ::graph::types::knowledge::entity::InferredEntityProvenance(?)
             ),
             record_id: ::graph::types::knowledge::entity::RecordId(
                 edition_id: ::graph::types::knowledge::entity::EntityEditionId(::core::uuid::Uuid(String)),

--- a/libs/@local/hashql/hir/tests/ui/lower/specialization/filter-graph.stdout
+++ b/libs/@local/hashql/hir/tests/ui/lower/specialization/filter-graph.stdout
@@ -30,7 +30,7 @@
                     entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                     web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
                 ),
-                left_entity_provenance: ?,
+                left_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?),
                 right_entity_confidence: ::core::option::None(Null)
                 | ::core::option::Some(::graph::types::knowledge::entity::Confidence(Number)),
                 right_entity_id: ::graph::types::knowledge::entity::EntityId(
@@ -39,7 +39,7 @@
                     entity_uuid: ::graph::types::knowledge::entity::EntityUuid(::core::uuid::Uuid(String)),
                     web_id: ::graph::types::principal::actor_group::web::WebId(::graph::types::principal::actor_group::ActorGroupEntityUuid(::core::uuid::Uuid(String)))
                 ),
-                right_entity_provenance: ?
+                right_entity_provenance: ::graph::types::knowledge::entity::PropertyProvenance(?)
             )),
             metadata: ::graph::types::knowledge::entity::EntityMetadata(
                 archived: Boolean,
@@ -49,10 +49,10 @@
                     base_url: ::graph::types::ontology::BaseUrl(::core::url::Url(String)),
                     version: ::graph::ontology::OntologyTypeVersion(String)
                 )>,
-                properties: ?,
+                properties: ::graph::types::knowledge::entity::PropertyObjectMetadata(?),
                 provenance: ::graph::types::knowledge::entity::EntityProvenance(
-                    edition: ?,
-                    inferred: ?
+                    edition: ::graph::types::knowledge::entity::EntityEditionProvenance(?),
+                    inferred: ::graph::types::knowledge::entity::InferredEntityProvenance(?)
                 ),
                 record_id: ::graph::types::knowledge::entity::RecordId(
                     edition_id: ::graph::types::knowledge::entity::EntityEditionId(::core::uuid::Uuid(String)),


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Opaque types in HashQL were previously treated as **invariant** in their inner representation. This was overly restrictive: because HashQL values are immutable, there is no mutation-based unsoundness argument that would require invariance. This PR changes opaque types to be **covariant**, meaning `W<A> <: W<B>` whenever `A <: B`, while still preserving nominal separation between distinct opaque families.

This fixes a regression where expressions like `W(A()) as W<A | B>` would fail to type-check, because the solver could not propagate constraints through the opaque wrapper when the target type was a union. With covariance, the solver correctly decomposes `W<?1> <: W<A | B>` into `?1 <: A | B`, and combined with the lower bound `A <: ?1`, resolves `?1 = A`.

The `is_top` implementation for opaque types is also corrected: `W<Unknown>` is the top of the `W` fiber only, not the global top. Returning `true` previously caused `T | W<Unknown>` to incorrectly collapse to `Unknown`, destroying nominal separation between opaque families.

As a consequence of covariance, inference constraints that previously generated `Equals`/`Unify` constraints now generate `LowerBound`/`UpperBound`/`Ordering` constraints, and the `meet` operation for same-name concrete opaques now correctly computes the meet of their inner representations rather than requiring identical representations.

The snapshot test outputs for HIR lowering are updated to reflect that inference variables inside opaque wrappers now display with their opaque wrapper (e.g. `::graph::types::knowledge::entity::PropertyProvenance(?)` instead of bare `?`), which is a direct consequence of the solver now propagating through the opaque boundary.

## 🔍 What does this change?

- Changed `OpaqueType::is_subtype_of` to use `Variance::Covariant` instead of `Variance::Invariant`.
- Changed `OpaqueType::collect_constraints` to emit covariant constraints instead of invariant ones.
- Fixed `OpaqueType::is_top` to always return `false`, since an opaque type is never the global top regardless of its inner representation.
- Rewrote `OpaqueType::meet` to handle the concrete same-name case by computing the full lattice meet of the inner representations, rather than requiring structural equality.
- Added a regression test `opaque_covariant_subtype_through_union` covering the `W(A()) as W<A | B>` pattern.
- Added a unit test `is_not_top` verifying that `W<Unknown>` is not the global top.
- Updated existing opaque type tests to reflect the new covariant constraint shapes (`LowerBound`/`UpperBound`/`Ordering` instead of `Equals`/`Unify`).
- Updated HIR lowering snapshot outputs to reflect that inference variables inside opaque wrappers are now displayed with their nominal wrapper.
- Updated the `OpaqueType` doc comment with a formal denotational semantics model justifying covariance.

## 🛡 What tests cover this?

- New regression test `opaque_covariant_subtype_through_union` in the inference solver test suite.
- New unit test `is_not_top` in the opaque type test suite.
- Updated existing opaque type lattice and inference constraint tests.
- Updated HIR lowering UI snapshot tests.

## ❓ How to test this?

1. Run `cargo test` in `libs/@local/hashql/core`.
2. Run the HIR lowering UI tests in `libs/@local/hashql/hir`.
3. Confirm all tests pass and snapshot outputs match.
