### PR TITLE
FE-803: Update inhibitor arc styling to distinguish from read arcs

### DIFF
--- a/.changeset/inhibitor-arc-styling.md
+++ b/.changeset/inhibitor-arc-styling.md
@@ -1,0 +1,5 @@
+---
+"@hashintel/petrinaut": patch
+---
+
+update inhibitor arc styling

--- a/.changeset/inhibitor-arc-styling.md
+++ b/.changeset/inhibitor-arc-styling.md
@@ -2,4 +2,4 @@
 "@hashintel/petrinaut": patch
 ---
 
-update inhibitor arc styling
+Update inhibitor arc styling

--- a/libs/@hashintel/petrinaut/docs/examples.md
+++ b/libs/@hashintel/petrinaut/docs/examples.md
@@ -66,7 +66,6 @@ A software release process with a safety gate and an incident feedback loop. Dep
 
 <img width="1070" height="550" alt="deployment-pipeline" src="https://github.com/user-attachments/assets/44999019-c5f1-4007-8bec-1625a2be213c" />
 
-
 ## Production with Machine Failure
 
 A manufacturing system where machines produce goods, accumulate damage, break down, and are repaired by travelling technicians.

--- a/libs/@hashintel/petrinaut/docs/examples.md
+++ b/libs/@hashintel/petrinaut/docs/examples.md
@@ -64,7 +64,8 @@ A software release process with a safety gate and an incident feedback loop. Dep
 
 **Key concepts:** [inhibitor arcs](petri-net-extensions.md#inhibitor-arcs), [source transitions](useful-patterns.md#source-transitions-exogenous-arrivals), [mutual exclusion](useful-patterns.md#mutual-exclusion-with-inhibitor-arcs), [distributions](petri-net-extensions.md#distributions), [visualizers](petri-net-extensions.md#visualizer).
 
-<img width="1323" height="676" alt="deployment-pipeline" src="https://github.com/user-attachments/assets/002dfe2f-c35c-4a24-a2ba-dd1a73325e67" />
+<img width="1070" height="550" alt="deployment-pipeline" src="https://github.com/user-attachments/assets/44999019-c5f1-4007-8bec-1625a2be213c" />
+
 
 ## Production with Machine Failure
 

--- a/libs/@hashintel/petrinaut/docs/petri-net-extensions.md
+++ b/libs/@hashintel/petrinaut/docs/petri-net-extensions.md
@@ -192,7 +192,7 @@ An inhibitor arc is a special input arc that **prevents** a transition from firi
 
 Inhibitor arcs **do not consume tokens** when the transition fires.
 
-<img width="757" height="577" alt="" src="https://github.com/user-attachments/assets/84bcc51a-5dbb-476f-9c01-081c77ecf06f" />
+<img width="757" height="577" alt="Visual appearance of inhibitor arcs: a solid line crossed by evenly spaced perpendicular tick marks" src="https://github.com/user-attachments/assets/84bcc51a-5dbb-476f-9c01-081c77ecf06f" />
 
 **Example:** in [Deployment Pipeline](examples.md#deployment-pipeline), inhibitor arcs from "IncidentBeingInvestigated" and "DeploymentInProgress" block new deployments while an incident is open or a deployment is already running.
 

--- a/libs/@hashintel/petrinaut/docs/petri-net-extensions.md
+++ b/libs/@hashintel/petrinaut/docs/petri-net-extensions.md
@@ -192,7 +192,7 @@ An inhibitor arc is a special input arc that **prevents** a transition from firi
 
 Inhibitor arcs **do not consume tokens** when the transition fires.
 
-<img width="479" height="401" alt="inhibitor-arc-deployment" src="https://github.com/user-attachments/assets/86e6995a-b7d3-4727-9d7f-2c0e0a63816c" />
+<img width="757" height="577" alt="" src="https://github.com/user-attachments/assets/84bcc51a-5dbb-476f-9c01-081c77ecf06f" />
 
 **Example:** in [Deployment Pipeline](examples.md#deployment-pipeline), inhibitor arcs from "IncidentBeingInvestigated" and "DeploymentInProgress" block new deployments while an incident is open or a deployment is already running.
 

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/components/arc.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/components/arc.tsx
@@ -23,9 +23,7 @@ const INHIBITOR_MARKER_SIZE = (INHIBITOR_MARKER_RADIUS + BASE_STROKE_WIDTH) * 2;
 const READ_MARKER_RADIUS = 4;
 const READ_MARKER_SIZE = (READ_MARKER_RADIUS + BASE_STROKE_WIDTH) * 2;
 
-// Inhibitor arcs are drawn as a solid line crossed by evenly spaced
-// perpendicular tick marks (a "barrier" look) to set them clearly apart from
-// the sparse dotted read arc.
+// Perpendicular tick marks for inhibitor arcs
 const INHIBITOR_TICK_SPACING = 13;
 const INHIBITOR_TICK_HALF_LENGTH = 5;
 
@@ -160,8 +158,7 @@ type TickMark = { x1: number; y1: number; x2: number; y2: number };
  * end so the ticks do not collide with the inhibitor circle marker.
  *
  * This is a pure computation (the path element is never attached to the
- * document) and is safe to run during render; the React Compiler memoizes it on
- * `path`.
+ * document) and is safe to run during render.
  */
 function computeArcTickMarks(path: string): TickMark[] {
   if (typeof document === "undefined") {
@@ -174,12 +171,12 @@ function computeArcTickMarks(path: string): TickMark[] {
   );
   pathElement.setAttribute("d", path);
 
-  // `getTotalLength`/`getPointAtLength` are unavailable in some non-browser
-  // environments (e.g. jsdom); fall back to no ticks rather than throwing.
   let totalLength: number;
   try {
     totalLength = pathElement.getTotalLength();
   } catch {
+    // `getTotalLength`/`getPointAtLength` are unavailable in some non-browser
+    // environments (e.g. jsdom); fall back to no ticks rather than throwing.
     return [];
   }
 
@@ -297,7 +294,6 @@ export const Arc: React.FC<EdgeProps<ArcEdgeType>> = ({
   useFiringAnimation(arcPathRef, firingDelta, data?.weight ?? 1);
 
   // Compute path based on arc rendering setting.
-
   const [arcPath, labelX, labelY] =
     arcRendering === "smoothstep"
       ? getSmoothStepPath({

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/components/arc.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/components/arc.tsx
@@ -198,10 +198,15 @@ function computeArcTickMarks(path: string): TickMark[] {
 
   for (let index = 0; index <= tickCount; index++) {
     const distance = startMargin + index * INHIBITOR_TICK_SPACING;
-    const point = pathElement.getPointAtLength(distance);
-    const ahead = pathElement.getPointAtLength(
-      Math.min(distance + 1, totalLength),
-    );
+
+    let point: DOMPoint;
+    let ahead: DOMPoint;
+    try {
+      point = pathElement.getPointAtLength(distance);
+      ahead = pathElement.getPointAtLength(Math.min(distance + 1, totalLength));
+    } catch {
+      return [];
+    }
 
     const dx = ahead.x - point.x;
     const dy = ahead.y - point.y;

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/components/arc.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/components/arc.tsx
@@ -17,12 +17,17 @@ import type { ArcData, ArcEdgeType } from "../reactflow-types";
 
 const BASE_STROKE_WIDTH = 2;
 const ANIMATION_DURATION_MS = 500;
-const INHIBITOR_DASH_PATTERN = "10 5 3 3 3 5";
 const READ_DASH_PATTERN = "2 6";
 const INHIBITOR_MARKER_RADIUS = 10;
 const INHIBITOR_MARKER_SIZE = (INHIBITOR_MARKER_RADIUS + BASE_STROKE_WIDTH) * 2;
 const READ_MARKER_RADIUS = 4;
 const READ_MARKER_SIZE = (READ_MARKER_RADIUS + BASE_STROKE_WIDTH) * 2;
+
+// Inhibitor arcs are drawn as a solid line crossed by evenly spaced
+// perpendicular tick marks (a "barrier" look) to set them clearly apart from
+// the sparse dotted read arc.
+const INHIBITOR_TICK_SPACING = 13;
+const INHIBITOR_TICK_HALF_LENGTH = 5;
 
 type AnimationState = {
   animation: Animation;
@@ -137,13 +142,87 @@ const weightTextStyle = css({
 function getArcStrokeDasharray(
   arcType: ArcData["arcType"] | undefined,
 ): string | undefined {
-  if (arcType === "inhibitor") {
-    return INHIBITOR_DASH_PATTERN;
-  }
   if (arcType === "read") {
     return READ_DASH_PATTERN;
   }
   return undefined;
+}
+
+type TickMark = { x1: number; y1: number; x2: number; y2: number };
+
+/**
+ * Computes evenly spaced perpendicular tick marks along an SVG path.
+ *
+ * Used to render the inhibitor arc as a crossed "barrier" line. The geometry is
+ * derived from the actual rendered path (bezier, smoothstep, or custom) by
+ * walking a detached path element with `getPointAtLength`, so the ticks follow
+ * whichever arc rendering the user has selected. A margin is left at the target
+ * end so the ticks do not collide with the inhibitor circle marker.
+ *
+ * This is a pure computation (the path element is never attached to the
+ * document) and is safe to run during render; the React Compiler memoizes it on
+ * `path`.
+ */
+function computeArcTickMarks(path: string): TickMark[] {
+  if (typeof document === "undefined") {
+    return [];
+  }
+
+  const pathElement = document.createElementNS(
+    "http://www.w3.org/2000/svg",
+    "path",
+  );
+  pathElement.setAttribute("d", path);
+
+  // `getTotalLength`/`getPointAtLength` are unavailable in some non-browser
+  // environments (e.g. jsdom); fall back to no ticks rather than throwing.
+  let totalLength: number;
+  try {
+    totalLength = pathElement.getTotalLength();
+  } catch {
+    return [];
+  }
+
+  if (!Number.isFinite(totalLength) || totalLength <= 0) {
+    return [];
+  }
+
+  // Keep ticks clear of the source node and of the circle marker at the target.
+  const startMargin = INHIBITOR_TICK_SPACING;
+  const endMargin = INHIBITOR_MARKER_SIZE / 2 + INHIBITOR_TICK_SPACING;
+  const usableLength = totalLength - startMargin - endMargin;
+
+  if (usableLength <= 0) {
+    return [];
+  }
+
+  const tickCount = Math.floor(usableLength / INHIBITOR_TICK_SPACING);
+  const ticks: TickMark[] = [];
+
+  for (let index = 0; index <= tickCount; index++) {
+    const distance = startMargin + index * INHIBITOR_TICK_SPACING;
+    const point = pathElement.getPointAtLength(distance);
+    const ahead = pathElement.getPointAtLength(
+      Math.min(distance + 1, totalLength),
+    );
+
+    const dx = ahead.x - point.x;
+    const dy = ahead.y - point.y;
+    const length = Math.hypot(dx, dy) || 1;
+
+    // Unit vector perpendicular to the path tangent.
+    const nx = -dy / length;
+    const ny = dx / length;
+
+    ticks.push({
+      x1: point.x - nx * INHIBITOR_TICK_HALF_LENGTH,
+      y1: point.y - ny * INHIBITOR_TICK_HALF_LENGTH,
+      x2: point.x + nx * INHIBITOR_TICK_HALF_LENGTH,
+      y2: point.y + ny * INHIBITOR_TICK_HALF_LENGTH,
+    });
+  }
+
+  return ticks;
 }
 
 /**
@@ -217,43 +296,41 @@ export const Arc: React.FC<EdgeProps<ArcEdgeType>> = ({
   // Animate stroke width when firing delta changes (scaled by arc weight)
   useFiringAnimation(arcPathRef, firingDelta, data?.weight ?? 1);
 
-  // Compute path based on arc rendering setting
-  let arcPath: string;
-  let labelX: number;
-  let labelY: number;
+  // Compute path based on arc rendering setting.
 
-  if (arcRendering === "smoothstep") {
-    [arcPath, labelX, labelY] = getSmoothStepPath({
-      sourceX,
-      sourceY,
-      sourcePosition,
-      targetX,
-      targetY,
-      targetPosition,
-    });
-  } else if (arcRendering === "bezier") {
-    [arcPath, labelX, labelY] = getBezierPath({
-      sourceX,
-      sourceY,
-      sourcePosition,
-      targetX,
-      targetY,
-      targetPosition,
-    });
-  } else {
-    [arcPath, labelX, labelY] = getCustomArcPath({
-      sourceX,
-      sourceY,
-      sourcePosition,
-      targetX,
-      targetY,
-      targetPosition,
-    });
-  }
+  const [arcPath, labelX, labelY] =
+    arcRendering === "smoothstep"
+      ? getSmoothStepPath({
+          sourceX,
+          sourceY,
+          sourcePosition,
+          targetX,
+          targetY,
+          targetPosition,
+        })
+      : arcRendering === "bezier"
+        ? getBezierPath({
+            sourceX,
+            sourceY,
+            sourcePosition,
+            targetX,
+            targetY,
+            targetPosition,
+          })
+        : getCustomArcPath({
+            sourceX,
+            sourceY,
+            sourcePosition,
+            targetX,
+            targetY,
+            targetPosition,
+          });
 
   let strokeColor = style?.stroke ?? "#b1b1b7";
   const arcType = data?.arcType;
   const strokeDasharray = getArcStrokeDasharray(arcType);
+
+  const tickMarks = arcType === "inhibitor" ? computeArcTickMarks(arcPath) : [];
   const markerEndOverride =
     arcType === "inhibitor"
       ? `url(#${inhibitorMarkerId})`
@@ -344,6 +421,25 @@ export const Arc: React.FC<EdgeProps<ArcEdgeType>> = ({
             : { ...style, stroke: strokeColor }
         }
       />
+
+      {/* Perpendicular tick marks crossing inhibitor arcs */}
+      {arcType === "inhibitor" && tickMarks.length > 0 && (
+        <g style={{ pointerEvents: "none" }}>
+          {tickMarks.map((tick, index) => (
+            <line
+              // eslint-disable-next-line react/no-array-index-key -- ticks are derived purely from path geometry and re-rendered as a whole
+              key={index}
+              x1={tick.x1}
+              y1={tick.y1}
+              x2={tick.x2}
+              y2={tick.y2}
+              stroke={strokeColor}
+              strokeWidth={BASE_STROKE_WIDTH}
+              strokeLinecap="round"
+            />
+          ))}
+        </g>
+      )}
 
       {/* Labels container */}
       <g transform={`translate(${labelX}, ${labelY})`}>


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We introduced read/enabling arcs in #8774 but the styling was pretty close to the existing inhibitor arcs.

This PR changes the inhibitor arcs to make them easier to distinguish.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->
<!-- Libraries inside of the `@local` directory are always internal libraries which have no need for publishing -->

This PR:

- [x] adds a changeset for Petrinaut

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] require changes to docs which **are made** as part of this PR – **screenshots**

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- Visual change only

## ❓ How to test this?

1. Open preview deployment and draw an inhibitor arc (or load Deployment Pipeline example)

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->

Examples shown to compare read arcs with inhibitor arcs, the net itself isn't meant to make sense.

### Previous

<img width="1328" height="708" alt="Screenshot 2026-06-09 at 11 28 30" src="https://github.com/user-attachments/assets/1f071022-3cd9-46c4-8969-9252b00cbf1a" />

### Now
<img width="1292" height="710" alt="Screenshot 2026-06-09 at 11 09 40" src="https://github.com/user-attachments/assets/35e9d9de-ede5-4155-8afe-971af2cff8a9" />
