### PR TITLE
BE-601: Fix the exists filter to compile to IS NOT NULL

### DIFF
--- a/apps/hash-api/src/graph/knowledge/primitive/entity.ts
+++ b/apps/hash-api/src/graph/knowledge/primitive/entity.ts
@@ -234,7 +234,7 @@ export const getLatestEntityById = async <
      * ...whether the prioritisation is fixed behavior or varied by parameter.
      */
     allFilter.push({
-      exists: { path: ["draftId"] },
+      not: { exists: { path: ["draftId"] } },
     });
   }
 

--- a/apps/hash-api/src/graph/knowledge/system-types/notification.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/notification.ts
@@ -517,11 +517,13 @@ export const getCommentNotification: ImpureGraphFunction<
           {
             any: [
               {
-                exists: {
-                  path: [
-                    "properties",
-                    systemPropertyTypes.archived.propertyTypeBaseUrl,
-                  ],
+                not: {
+                  exists: {
+                    path: [
+                      "properties",
+                      systemPropertyTypes.archived.propertyTypeBaseUrl,
+                    ],
+                  },
                 },
               },
               {

--- a/apps/hash-frontend/src/pages/actions.page/draft-entities-context.tsx
+++ b/apps/hash-frontend/src/pages/actions.page/draft-entities-context.tsx
@@ -69,10 +69,8 @@ export const DraftEntitiesContextProvider: FunctionComponent<
           filter: {
             all: [
               {
-                not: {
-                  exists: {
-                    path: ["draftId"],
-                  },
+                exists: {
+                  path: ["draftId"],
                 },
               },
               {

--- a/apps/hash-frontend/src/shared/draft-entities-count-context.tsx
+++ b/apps/hash-frontend/src/shared/draft-entities-count-context.tsx
@@ -51,10 +51,8 @@ export const DraftEntitiesCountContextProvider: FunctionComponent<
           filter: {
             all: [
               {
-                not: {
-                  exists: {
-                    path: ["draftId"],
-                  },
+                exists: {
+                  path: ["draftId"],
                 },
               },
               {

--- a/apps/hash-frontend/src/shared/use-entity-type-entities.tsx
+++ b/apps/hash-frontend/src/shared/use-entity-type-entities.tsx
@@ -66,11 +66,13 @@ export const generateUseEntityTypeEntitiesFilter = ({
           {
             any: [
               {
-                exists: {
-                  path: [
-                    "properties",
-                    systemPropertyTypes.archived.propertyTypeBaseUrl,
-                  ],
+                not: {
+                  exists: {
+                    path: [
+                      "properties",
+                      systemPropertyTypes.archived.propertyTypeBaseUrl,
+                    ],
+                  },
                 },
               },
               {

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/compile.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/compile.rs
@@ -241,7 +241,7 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
         let table = Table::EntityTemporalMetadata.aliased(alias);
         if self.artifacts.table_info.tables.insert(table.clone()) {
             if !self.include_drafts {
-                conditions.push(Expression::exists(Expression::ColumnReference(
+                conditions.push(Expression::is_null(Expression::ColumnReference(
                     Column::EntityTemporalMetadata(EntityTemporalMetadata::DraftId).aliased(alias),
                 )));
             }
@@ -450,7 +450,7 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
                 self.compile_filter_expression(lhs).0,
                 self.compile_filter_expression(rhs).0,
             ),
-            Filter::Exists { path } => Expression::exists(self.compile_path_column(path)),
+            Filter::Exists { path } => Expression::is_not_null(self.compile_path_column(path)),
             Filter::Greater(lhs, rhs) => Expression::greater(
                 self.compile_filter_expression(lhs).0,
                 self.compile_filter_expression(rhs).0,

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/expression/conditional.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/expression/conditional.rs
@@ -1039,6 +1039,16 @@ mod tests {
             r#""data_types_0_1_0"."schema"->>'description' IS NULL"#,
             &[],
         );
+
+        // Double negation (e.g. `Not(IsRemote)`, where `IsRemote` is itself `Not(Exists)`):
+        // three nested `Not`s over `IsNull` must still resolve to `IS NOT NULL`.
+        test_condition(
+            &Filter::Not(Box::new(Filter::Not(Box::new(Filter::Exists {
+                path: DataTypeQueryPath::Description,
+            })))),
+            r#""data_types_0_1_0"."schema"->>'description' IS NOT NULL"#,
+            &[],
+        );
     }
 
     #[test]

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/expression/conditional.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/expression/conditional.rs
@@ -424,11 +424,16 @@ impl Expression {
     }
 
     #[must_use]
-    pub fn exists(expr: Self) -> Self {
+    pub fn is_null(expr: Self) -> Self {
         Self::Unary(UnaryExpression {
             op: UnaryOperator::IsNull,
             expr: Box::new(expr),
         })
+    }
+
+    #[must_use]
+    pub fn is_not_null(expr: Self) -> Self {
+        Self::is_null(expr).not()
     }
 
     #[must_use]
@@ -1023,7 +1028,7 @@ mod tests {
             &Filter::Exists {
                 path: DataTypeQueryPath::Description,
             },
-            r#""data_types_0_1_0"."schema"->>'description' IS NULL"#,
+            r#""data_types_0_1_0"."schema"->>'description' IS NOT NULL"#,
             &[],
         );
 
@@ -1031,7 +1036,7 @@ mod tests {
             &Filter::Not(Box::new(Filter::Exists {
                 path: DataTypeQueryPath::Description,
             })),
-            r#""data_types_0_1_0"."schema"->>'description' IS NOT NULL"#,
+            r#""data_types_0_1_0"."schema"->>'description' IS NULL"#,
             &[],
         );
     }

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/expression/unary.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/expression/unary.rs
@@ -29,20 +29,24 @@ pub struct UnaryExpression {
 impl Transpile for UnaryExpression {
     fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match self.op {
-            UnaryOperator::Not => {
-                if let Expression::Unary(Self {
+            UnaryOperator::Not => match &*self.expr {
+                Expression::Unary(Self {
                     op: UnaryOperator::IsNull,
                     expr,
-                }) = &*self.expr
-                {
+                }) => {
                     expr.transpile(fmt)?;
                     fmt.write_str(" IS NOT NULL")
-                } else {
+                }
+                Expression::Unary(Self {
+                    op: UnaryOperator::Not,
+                    expr,
+                }) => expr.transpile(fmt),
+                _ => {
                     fmt.write_str("NOT(")?;
                     self.expr.transpile(fmt)?;
                     fmt.write_char(')')
                 }
-            }
+            },
             UnaryOperator::IsNull => {
                 self.expr.transpile(fmt)?;
                 fmt.write_str(" IS NULL")

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/expression/unary.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/expression/unary.rs
@@ -41,6 +41,7 @@ impl Transpile for UnaryExpression {
                     op: UnaryOperator::Not,
                     expr,
                 }) => expr.transpile(fmt),
+                #[expect(clippy::wildcard_enum_match_arm)]
                 _ => {
                     fmt.write_str("NOT(")?;
                     self.expr.transpile(fmt)?;

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/expression/unary.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/expression/unary.rs
@@ -29,6 +29,7 @@ pub struct UnaryExpression {
 impl Transpile for UnaryExpression {
     fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match self.op {
+            #[expect(clippy::wildcard_enum_match_arm)]
             UnaryOperator::Not => match &*self.expr {
                 Expression::Unary(Self {
                     op: UnaryOperator::IsNull,
@@ -41,7 +42,6 @@ impl Transpile for UnaryExpression {
                     op: UnaryOperator::Not,
                     expr,
                 }) => expr.transpile(fmt),
-                #[expect(clippy::wildcard_enum_match_arm)]
                 _ => {
                     fmt.write_str("NOT(")?;
                     self.expr.transpile(fmt)?;

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/expression/where_clause.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/expression/where_clause.rs
@@ -199,9 +199,9 @@ mod tests {
             )
         );
 
-        let filter_c = Filter::Not(Box::new(Filter::Exists {
+        let filter_c = Filter::Exists {
             path: DataTypeQueryPath::Description,
-        }));
+        };
         where_clause.add_condition(
             compiler
                 .compile_filter(&filter_c)

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/statement/select.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/statement/select.rs
@@ -814,7 +814,7 @@ mod tests {
             WHERE "entity_temporal_metadata_0_0_0"."draft_id" IS NULL
               AND "entity_temporal_metadata_0_0_0"."transaction_time" @> $2::TIMESTAMPTZ
               AND "entity_temporal_metadata_0_0_0"."decision_time" && $3
-              AND jsonb_path_query_first("entity_editions_0_1_0"."properties", (($1::text)::jsonpath)) IS NULL
+              AND jsonb_path_query_first("entity_editions_0_1_0"."properties", (($1::text)::jsonpath)) IS NOT NULL
             "#,
             &[
                 &json_path,

--- a/libs/@local/graph/store/src/filter/mod.rs
+++ b/libs/@local/graph/store/src/filter/mod.rs
@@ -279,9 +279,9 @@ impl<'p> Filter<'p, DataTypeWithMetadata> {
                     convert: None,
                 },
             ),
-            DataTypeResourceFilter::IsRemote => Self::Exists {
+            DataTypeResourceFilter::IsRemote => Self::Not(Box::new(Self::Exists {
                 path: DataTypeQueryPath::WebId,
-            },
+            })),
         }
     }
 
@@ -520,9 +520,9 @@ impl<'p> Filter<'p, PropertyTypeWithMetadata> {
                     convert: None,
                 },
             ),
-            PropertyTypeResourceFilter::IsRemote => Self::Exists {
+            PropertyTypeResourceFilter::IsRemote => Self::Not(Box::new(Self::Exists {
                 path: PropertyTypeQueryPath::WebId,
-            },
+            })),
         }
     }
 
@@ -680,9 +680,9 @@ impl<'p> Filter<'p, EntityTypeWithMetadata> {
                     convert: None,
                 },
             ),
-            EntityTypeResourceFilter::IsRemote => Self::Exists {
+            EntityTypeResourceFilter::IsRemote => Self::Not(Box::new(Self::Exists {
                 path: EntityTypeQueryPath::WebId,
-            },
+            })),
         }
     }
 

--- a/libs/@local/hash-isomorphic-utils/src/graph-queries.ts
+++ b/libs/@local/hash-isomorphic-utils/src/graph-queries.ts
@@ -261,8 +261,10 @@ const archivedBaseUrl = systemPropertyTypes.archived.propertyTypeBaseUrl;
 export const pageOrNotificationNotArchivedFilter: Filter = {
   any: [
     {
-      exists: {
-        path: ["properties", archivedBaseUrl],
+      not: {
+        exists: {
+          path: ["properties", archivedBaseUrl],
+        },
       },
     },
     {

--- a/tests/graph/integration/postgres/email_filter_protection.rs
+++ b/tests/graph/integration/postgres/email_filter_protection.rs
@@ -160,19 +160,15 @@ fn email_filter(email: &str) -> Filter<'static, type_system::knowledge::entity::
     )
 }
 
-/// Helper to create an "exists" filter for the email property.
-/// Helper to create a filter that matches entities where email property exists (is NOT NULL).
-///
-/// Note: In this codebase, `Filter::Exists` transpiles to `IS NULL` (checking for absence),
-/// so to check for existence we use `Not(Exists { ... })` which transpiles to `IS NOT NULL`.
+/// Helper to create a filter that matches entities where the email property exists (`IS NOT NULL`).
 fn email_exists_filter() -> Filter<'static, type_system::knowledge::entity::Entity> {
-    Filter::Not(Box::new(Filter::Exists {
+    Filter::Exists {
         path: hash_graph_store::entity::EntityQueryPath::Properties(Some(
             JsonPath::from_path_tokens(vec![PathToken::Field(Cow::Owned(
                 EMAIL_PROPERTY_BASE_URL.to_owned(),
             ))]),
         )),
-    }))
+    }
 }
 
 /// Helper to create a "startsWith" filter for the email property.


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The `exists` query filter compiled to `IS NULL` — a check for *absence*, the opposite of what its name implies. This was a documented landmine: callers had to wrap it in `Not(...)` to express "present", with explanatory comments.

This flips `Filter::Exists` to compile to `IS NOT NULL` (value present), the intuitive meaning. Absence (`IS NULL`) is now expressed as `Not(Exists)`.

## 🔗 Related links

- [BE-601](https://linear.app/hash/issue/BE-601) *(internal)*

## 🔍 What does this change?

- `Filter::Exists { path }` now compiles to `<path> IS NOT NULL` (was `IS NULL`).
- No new SQL operator: `Expression::exists` is split into `is_null` / `is_not_null` (the latter is `Not(IsNull)`), and the transpiler gains a double-negation fold `NOT(NOT(x)) → x` so `Not(Exists)` stays a clean `IS NULL`.
- `IsRemote` resource filters now wrap in `Not(Exists { WebId })`; the non-draft `draft_id IS NULL` condition uses `is_null` directly.

### ⚠️ This flips the semantics of the `"exists"` wire operator

The serde wire tag `"exists"` is unchanged, but it now means `IS NOT NULL` instead of `IS NULL`. **All in-repo consumers have been migrated** to preserve behaviour by toggling the `not` wrapper (`exists` ↔ `not(exists)`):

- `hash-api`: draft handling in `entity.ts`, archived filter in `notification.ts`
- `hash-frontend`: draft count/list contexts, archived filter in `use-entity-type-entities`
- `@local/hash-isomorphic-utils`: the shared `pageOrNotificationNotArchivedFilter` (used across notifications / pages / account-pages)

An exhaustive search (`exists:` in TS, `Filter::Exists` in Rust) found no other consumers. Thanks to Cursor Bugbot for catching the initial regression.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

The `"exists"` wire tag still reads as "present" but is a legacy name; renaming it at the API level would require a coordinated client migration and is out of scope here.

## 🐾 Next steps

Part of the broader Entities-Visualizer query-performance work (BE-596 … BE-600).

## 🛡 What tests cover this?

- Transpile unit tests in `unary.rs` / `conditional.rs` / `where_clause.rs` / `select.rs` assert the new `IS NOT NULL` / `IS NULL` output.
- `hash-graph-store` filter tests and the `email_filter_protection` integration test exercise the `IsRemote` and email-existence paths.
- 177 Rust unit tests pass; clippy clean. `@apps/hash-api` and `@local/hash-isomorphic-utils` type-check clean.

## ❓ How to test this?

```
cargo nextest run -p hash-graph-postgres-store -p hash-graph-store --lib
```

Then verify draft exclusion / archived filtering behave unchanged in the entities table and draft views.

## 📹 Demo

n/a — internal query-compiler change.
