### PR TITLE
BE-596: Materialize entity aggregates into `entity_edition_cache`

### DIFF
--- a/libs/@local/graph/migrations/graph-migrations/v009__entities/down.sql
+++ b/libs/@local/graph/migrations/graph-migrations/v009__entities/down.sql
@@ -1,13 +1,4 @@
-DROP VIEW IF EXISTS first_type_title_for_entity;
-DROP VIEW IF EXISTS last_type_title_for_entity;
-DROP VIEW IF EXISTS type_title_for_entity;
-
-DROP VIEW IF EXISTS first_label_for_entity;
-DROP VIEW IF EXISTS last_label_for_entity;
-DROP VIEW IF EXISTS label_for_entity;
-
 DROP TABLE entity_embeddings;
-DROP VIEW entity_is_of_type_ids;
 DROP TABLE entity_is_of_type;
 DROP VIEW entity_has_left_entity;
 DROP VIEW entity_has_right_entity;
@@ -15,6 +6,7 @@ DROP TABLE entity_edge;
 DROP TYPE EDGE_DIRECTION;
 DROP TYPE ENTITY_EDGE_KIND;
 DROP TABLE entity_temporal_metadata;
+DROP TABLE entity_edition_cache;
 DROP TABLE entity_editions;
 DROP TABLE entity_drafts;
 DROP TABLE entity_ids;

--- a/libs/@local/graph/migrations/graph-migrations/v009__entities/up.sql
+++ b/libs/@local/graph/migrations/graph-migrations/v009__entities/up.sql
@@ -21,6 +21,34 @@ CREATE TABLE entity_editions (
     confidence DOUBLE PRECISION
 );
 
+-- Denormalized per-edition cache of the sorting/filtering aggregates, rebuildable at
+-- any time via `reindex_entity_cache`. The four type-derived arrays are positionally
+-- aligned and cover ALL inheritance depths (type containment checks match supertypes),
+-- ordered by (inheritance depth, title, base URL, version DESC) — the direct types form
+-- the prefix of length `direct_types`, and `[1]` is the canonically first direct type.
+-- `versions` carries the numeric versions for consumers needing base URL and version
+-- separately (e.g. HashQL).
+-- `labels` is resolved per direct type (label inheritance lives in each type's
+-- `closed_schema.allOf`), ordered by (title, base URL, version DESC); `labels[1]` is
+-- the display/sort label, NULL when the entity has none. Descending sorts reuse the
+-- same element — no min/max flip.
+CREATE TABLE entity_edition_cache (
+    entity_edition_id UUID PRIMARY KEY REFERENCES entity_editions ON DELETE CASCADE,
+    direct_types INT NOT NULL,
+    labels TEXT [],
+    type_titles TEXT [] NOT NULL,
+    base_urls TEXT [] NOT NULL,
+    versions BIGINT [] NOT NULL,
+    versioned_urls TEXT [] NOT NULL
+);
+
+-- Type filters arrive as containment checks (`@>`); labels/titles are only sorted or
+-- projected, never filtered, so they carry no index.
+CREATE INDEX entity_edition_cache_base_urls ON entity_edition_cache USING gin (base_urls);
+CREATE INDEX entity_edition_cache_versioned_urls ON entity_edition_cache USING gin (
+    versioned_urls
+);
+
 CREATE TABLE entity_temporal_metadata (
     web_id UUID NOT NULL,
     entity_uuid UUID NOT NULL,
@@ -57,16 +85,6 @@ CREATE TABLE entity_is_of_type (
     inheritance_depth INT NOT NULL,
     PRIMARY KEY (entity_edition_id, entity_type_ontology_id)
 );
-
-CREATE VIEW entity_is_of_type_ids AS
-SELECT
-    entity_is_of_type.entity_edition_id,
-    array_agg(ontology_ids.base_url) AS base_urls,
-    array_agg(ontology_ids.version) AS versions
-FROM entity_is_of_type
-INNER JOIN ontology_ids ON entity_is_of_type.entity_type_ontology_id = ontology_ids.ontology_id
-WHERE entity_is_of_type.inheritance_depth = 0
-GROUP BY entity_is_of_type.entity_edition_id;
 
 CREATE TYPE entity_edge_kind AS ENUM ('has-left-entity', 'has-right-entity');
 CREATE TYPE edge_direction AS ENUM ('outgoing', 'incoming');
@@ -126,75 +144,3 @@ CREATE TABLE entity_embeddings (
 
 CREATE UNIQUE INDEX entity_embeddings_idx
 ON entity_embeddings (web_id, entity_uuid, property) NULLS NOT DISTINCT;
-
-
-CREATE VIEW type_title_for_entity AS
-SELECT
-    entity_temporal_metadata.entity_edition_id,
-    entity_types.schema ->> 'title' AS title
-FROM entity_temporal_metadata
-INNER JOIN entity_is_of_type
-    ON entity_temporal_metadata.entity_edition_id = entity_is_of_type.entity_edition_id
-INNER JOIN ontology_temporal_metadata
-    ON entity_is_of_type.entity_type_ontology_id = ontology_temporal_metadata.ontology_id
-INNER JOIN entity_types
-    ON ontology_temporal_metadata.ontology_id = entity_types.ontology_id
-WHERE ontology_temporal_metadata.transaction_time @> now()
-    AND entity_is_of_type.inheritance_depth = 0;
-
-CREATE VIEW first_type_title_for_entity AS
-SELECT
-    type_title_for_entity.entity_edition_id,
-    min(type_title_for_entity.title) AS title
-FROM type_title_for_entity
-GROUP BY type_title_for_entity.entity_edition_id;
-
-CREATE VIEW last_type_title_for_entity AS
-SELECT
-    type_title_for_entity.entity_edition_id,
-    max(type_title_for_entity.title) AS title
-FROM type_title_for_entity
-GROUP BY type_title_for_entity.entity_edition_id;
-
-
-CREATE VIEW label_for_entity AS
-SELECT
-    entity_editions.entity_edition_id,
-    jsonb_extract_path(
-        entity_editions.properties,
-        jsonb_array_elements_text(
-            jsonb_path_query_array(
-                entity_types.closed_schema,
-                '$.allOf[*].labelProperty'
-            )
-        )
-    ) AS label_property
-FROM entity_editions
-INNER JOIN entity_is_of_type
-    ON entity_editions.entity_edition_id = entity_is_of_type.entity_edition_id
-INNER JOIN ontology_temporal_metadata
-    ON entity_is_of_type.entity_type_ontology_id = ontology_temporal_metadata.ontology_id
-INNER JOIN entity_types
-    ON ontology_temporal_metadata.ontology_id = entity_types.ontology_id
-WHERE ontology_temporal_metadata.transaction_time @> now()
-    AND entity_is_of_type.inheritance_depth = 0;
-
-CREATE VIEW first_label_for_entity AS
-SELECT
-    label_for_entity.entity_edition_id,
-    (array_agg(
-        label_for_entity.label_property
-        ORDER BY label_for_entity.label_property ASC
-    ))[1] AS label_property
-FROM label_for_entity
-GROUP BY label_for_entity.entity_edition_id;
-
-CREATE VIEW last_label_for_entity AS
-SELECT
-    label_for_entity.entity_edition_id,
-    (array_agg(
-        label_for_entity.label_property
-        ORDER BY label_for_entity.label_property DESC
-    ))[1] AS label_property
-FROM label_for_entity
-GROUP BY label_for_entity.entity_edition_id;

--- a/libs/@local/graph/postgres-store/postgres_migrations/V51__entity_edition_cache.sql
+++ b/libs/@local/graph/postgres-store/postgres_migrations/V51__entity_edition_cache.sql
@@ -1,0 +1,122 @@
+-- Denormalized per-edition cache of an entity's type/label aggregates. Computing these
+-- inline forces the planner to re-evaluate the aggregation per row in entity-subgraph
+-- queries; reading the cache instead is a single 1:1 join.
+--
+-- The cache is derived data: rows are inserted alongside `entity_is_of_type` writes and
+-- can be fully rebuilt at any time (`reindex_entity_cache`), e.g. after in-place changes
+-- to entity-type schemas. A row exists exactly for editions that have at least one
+-- depth-0 entity type.
+--
+-- The four type-derived arrays (`type_titles`, `base_urls`, `versions`,
+-- `versioned_urls`) are
+-- positionally aligned and cover ALL inheritance depths so that type predicates
+-- (containment via `@>`) match supertypes. Order is (inheritance depth, title,
+-- base URL, version DESC); the entity's direct types therefore form the array prefix
+-- of length `direct_types` (used to project `entityTypeIds`), and `[1]` is the
+-- canonically first direct type, providing the type-title sort key. Titles are taken
+-- from `entity_types` without the `transaction_time @> now()` filter, so the cache
+-- does not depend on type archival state.
+--
+-- `labels` is resolved per DIRECT type (label inheritance already lives in each type's
+-- `closed_schema.allOf`, nearest ancestor first), ordered by the canonical type order
+-- (title, base URL, version DESC) with the `allOf` position as tie-breaker within one
+-- type. `labels[1]` is the entity's display/sort label; NULL means the entity has no
+-- label. Descending sorts use the same element — there is no min/max flip.
+CREATE TABLE entity_edition_cache (
+    entity_edition_id UUID PRIMARY KEY REFERENCES entity_editions ON DELETE CASCADE,
+    direct_types INT NOT NULL,
+    labels TEXT [],
+    type_titles TEXT [] NOT NULL,
+    base_urls TEXT [] NOT NULL,
+    versions BIGINT [] NOT NULL,
+    versioned_urls TEXT [] NOT NULL
+);
+
+INSERT INTO entity_edition_cache (
+    entity_edition_id,
+    direct_types,
+    labels,
+    type_titles,
+    base_urls,
+    versions,
+    versioned_urls
+)
+SELECT
+    types.entity_edition_id,
+    types.direct_types,
+    labels.labels,
+    types.type_titles,
+    types.base_urls,
+    types.versions,
+    types.versioned_urls
+FROM (
+    SELECT
+        entity_is_of_type.entity_edition_id,
+        count(*) FILTER (WHERE entity_is_of_type.inheritance_depth = 0) AS direct_types,
+        array_agg(entity_types.schema ->> 'title'
+            ORDER BY entity_is_of_type.inheritance_depth,
+                entity_types.schema ->> 'title', ontology_ids.base_url,
+                ontology_ids.version DESC
+        ) AS type_titles,
+        array_agg(ontology_ids.base_url
+            ORDER BY entity_is_of_type.inheritance_depth,
+                entity_types.schema ->> 'title', ontology_ids.base_url,
+                ontology_ids.version DESC
+        ) AS base_urls,
+        array_agg(ontology_ids.version
+            ORDER BY entity_is_of_type.inheritance_depth,
+                entity_types.schema ->> 'title', ontology_ids.base_url,
+                ontology_ids.version DESC
+        ) AS versions,
+        array_agg(ontology_ids.base_url || 'v/' || ontology_ids.version
+            ORDER BY entity_is_of_type.inheritance_depth,
+                entity_types.schema ->> 'title', ontology_ids.base_url,
+                ontology_ids.version DESC
+        ) AS versioned_urls
+    FROM entity_is_of_type
+    INNER JOIN ontology_ids
+        ON entity_is_of_type.entity_type_ontology_id = ontology_ids.ontology_id
+    INNER JOIN entity_types
+        ON ontology_ids.ontology_id = entity_types.ontology_id
+    GROUP BY entity_is_of_type.entity_edition_id
+) AS types
+LEFT JOIN (
+    SELECT
+        entity_is_of_type.entity_edition_id,
+        array_agg(label_value.label
+            ORDER BY entity_types.schema ->> 'title', ontology_ids.base_url,
+                ontology_ids.version DESC, label_value.ordinality
+        ) FILTER (WHERE label_value.label IS NOT NULL) AS labels
+    FROM entity_is_of_type
+    INNER JOIN ontology_ids
+        ON entity_is_of_type.entity_type_ontology_id = ontology_ids.ontology_id
+    INNER JOIN entity_types
+        ON ontology_ids.ontology_id = entity_types.ontology_id
+    INNER JOIN entity_editions
+        ON entity_is_of_type.entity_edition_id = entity_editions.entity_edition_id
+    CROSS JOIN LATERAL (
+        SELECT
+            jsonb_extract_path(entity_editions.properties, label_path.path) #>> '{}' AS label,
+            label_path.ordinality
+        FROM jsonb_array_elements_text(jsonb_path_query_array(entity_types.closed_schema, '$.allOf[*].labelProperty'))
+        WITH ORDINALITY AS label_path (path, ordinality)
+    ) AS label_value
+    WHERE entity_is_of_type.inheritance_depth = 0
+    GROUP BY entity_is_of_type.entity_edition_id
+) AS labels
+    ON types.entity_edition_id = labels.entity_edition_id;
+
+-- Type filters arrive as containment checks (`@>`); labels/titles are only sorted or
+-- projected, never filtered, so they carry no index.
+CREATE INDEX entity_edition_cache_base_urls ON entity_edition_cache USING gin (base_urls);
+CREATE INDEX entity_edition_cache_versioned_urls ON entity_edition_cache USING gin (versioned_urls);
+
+-- The cache replaces the per-row aggregate views for every consumer (query compiler and
+-- HashQL), so they are dropped.
+DROP VIEW first_label_for_entity;
+DROP VIEW last_label_for_entity;
+DROP VIEW label_for_entity;
+DROP VIEW first_type_title_for_entity;
+DROP VIEW last_type_title_for_entity;
+DROP VIEW type_title_for_entity;
+DROP VIEW entity_is_of_type_ids;

--- a/libs/@local/graph/postgres-store/src/snapshot/entity/batch.rs
+++ b/libs/@local/graph/postgres-store/src/snapshot/entity/batch.rs
@@ -435,6 +435,15 @@ where
             .await
             .change_context(InsertionError)?;
 
+        // The cache derives `labels` from `entity_editions.properties`, so the normalized
+        // values written above would otherwise leave stale label entries behind.
+        if !edition_ids_updates.is_empty() {
+            postgres_client
+                .reindex_entity_cache()
+                .await
+                .change_context(InsertionError)?;
+        }
+
         Ok(())
     }
 }

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
@@ -2502,7 +2502,10 @@ where
                         ON entity_type_ontology_id = source_entity_type_ontology_id
                      GROUP BY entity_edition_id, target_entity_type_ontology_id;
 
-                    TRUNCATE entity_edition_cache;
+                    -- DELETE instead of TRUNCATE: the runtime role has no TRUNCATE
+                    -- privilege, and DELETE keeps the cache readable for concurrent
+                    -- queries until this transaction commits.
+                    DELETE FROM entity_edition_cache;
                 ",
             )
             .instrument(tracing::info_span!(

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
@@ -81,7 +81,7 @@ use type_system::{
         entity_type::{
             ClosedEntityType, ClosedMultiEntityType, EntityTypeUuid, EntityTypeWithMetadata,
         },
-        id::{BaseUrl, OntologyTypeUuid, OntologyTypeVersion, VersionedUrl},
+        id::{OntologyTypeUuid, VersionedUrl},
     },
     principal::{actor::ActorEntityUuid, actor_group::WebId},
 };
@@ -545,8 +545,8 @@ where
                 let type_ids_idx =
                     (params.include_type_ids || params.include_type_titles).then(|| {
                         (
-                            compiler.add_selection_path(&EntityQueryPath::TypeBaseUrls),
-                            compiler.add_selection_path(&EntityQueryPath::TypeVersions),
+                            compiler.add_selection_path(&EntityQueryPath::TypeVersionedUrls),
+                            compiler.add_selection_path(&EntityQueryPath::DirectTypeCount),
                         )
                     });
 
@@ -610,16 +610,16 @@ where
                             edition_created_by_ids.extend_one(provenance.created_by_id);
                         }
 
-                        if let Some((type_ids, (base_urls_idx, versions_idx))) =
+                        if let Some((type_ids, (versioned_urls_idx, direct_count_idx))) =
                             type_ids.as_mut().zip(type_ids_idx)
                         {
-                            let base_urls: Vec<BaseUrl> = row.get(base_urls_idx);
-                            let versions: Vec<OntologyTypeVersion> = row.get(versions_idx);
+                            let direct_type_count =
+                                usize::try_from(row.get::<_, i32>(direct_count_idx))
+                                    .expect("direct type count should be non-negative");
                             type_ids.extend(
-                                base_urls
+                                row.get::<_, Vec<VersionedUrl>>(versioned_urls_idx)
                                     .into_iter()
-                                    .zip(versions)
-                                    .map(|(base_url, version)| VersionedUrl { base_url, version }),
+                                    .take(direct_type_count),
                             );
                         }
                     })
@@ -1222,6 +1222,21 @@ where
                     WHERE entity_edition_id = ANY($1)
                     GROUP BY entity_edition_id, target_entity_type_ontology_id;
                 ",
+                &[&entity_edition_ids],
+            )
+            .instrument(tracing::info_span!(
+                "INSERT",
+                otel.kind = "client",
+                db.system = "postgresql",
+                peer.service = "Postgres",
+            ))
+            .await
+            .change_context(InsertionError)?;
+
+        transaction
+            .as_client()
+            .query(
+                &insert_entity_edition_cache_statement(true),
                 &[&entity_edition_ids],
             )
             .instrument(tracing::info_span!(
@@ -2486,8 +2501,22 @@ where
                       JOIN entity_type_inherits_from
                         ON entity_type_ontology_id = source_entity_type_ontology_id
                      GROUP BY entity_edition_id, target_entity_type_ontology_id;
+
+                    TRUNCATE entity_edition_cache;
                 ",
             )
+            .instrument(tracing::info_span!(
+                "INSERT",
+                otel.kind = "client",
+                db.system = "postgresql",
+                peer.service = "Postgres",
+            ))
+            .await
+            .change_context(UpdateError)?;
+
+        transaction
+            .as_client()
+            .query(&insert_entity_edition_cache_statement(false), &[])
             .instrument(tracing::info_span!(
                 "INSERT",
                 otel.kind = "client",
@@ -2594,6 +2623,115 @@ struct LockedEntityEdition {
     transaction_time: LeftClosedTemporalInterval<TransactionTime>,
 }
 
+/// Statement template populating `entity_edition_cache` by aggregating the editions'
+/// `entity_is_of_type` rows joined to the referenced types.
+///
+/// Built via [`insert_entity_edition_cache_statement`]: the write paths scope it to the
+/// just-written editions (`$1: UUID[]`), `reindex_entity_cache` runs it unscoped over all
+/// editions. Must run after the editions' `entity_is_of_type` rows (including the
+/// inherited ones) have been written.
+const INSERT_ENTITY_EDITION_CACHE_TEMPLATE: &str = "
+    INSERT INTO entity_edition_cache (
+        entity_edition_id,
+        direct_types,
+        labels,
+        type_titles,
+        base_urls,
+        versions,
+        versioned_urls
+    )
+    SELECT types.entity_edition_id,
+           types.direct_types,
+           labels.labels,
+           types.type_titles,
+           types.base_urls,
+           types.versions,
+           types.versioned_urls
+      FROM (
+          SELECT entity_is_of_type.entity_edition_id,
+                 count(*) FILTER (
+                     WHERE entity_is_of_type.inheritance_depth = 0
+                 ) AS direct_types,
+                 array_agg(entity_types.schema ->> 'title'
+                     ORDER BY entity_is_of_type.inheritance_depth,
+                              entity_types.schema ->> 'title', ontology_ids.base_url,
+                              ontology_ids.version DESC
+                 ) AS type_titles,
+                 array_agg(ontology_ids.base_url
+                     ORDER BY entity_is_of_type.inheritance_depth,
+                              entity_types.schema ->> 'title', ontology_ids.base_url,
+                              ontology_ids.version DESC
+                 ) AS base_urls,
+                 array_agg(ontology_ids.version
+                     ORDER BY entity_is_of_type.inheritance_depth,
+                              entity_types.schema ->> 'title', ontology_ids.base_url,
+                              ontology_ids.version DESC
+                 ) AS versions,
+                 array_agg(ontology_ids.base_url || 'v/' || ontology_ids.version
+                     ORDER BY entity_is_of_type.inheritance_depth,
+                              entity_types.schema ->> 'title', ontology_ids.base_url,
+                              ontology_ids.version DESC
+                 ) AS versioned_urls
+            FROM entity_is_of_type
+            JOIN ontology_ids
+              ON entity_is_of_type.entity_type_ontology_id = ontology_ids.ontology_id
+            JOIN entity_types
+              ON ontology_ids.ontology_id = entity_types.ontology_id
+           /*TYPES_SCOPE*/
+           GROUP BY entity_is_of_type.entity_edition_id
+      ) AS types
+      LEFT JOIN (
+          SELECT entity_is_of_type.entity_edition_id,
+                 array_agg(label_value.label
+                     ORDER BY entity_types.schema ->> 'title', ontology_ids.base_url,
+                              ontology_ids.version DESC, label_value.ordinality
+                 ) FILTER (WHERE label_value.label IS NOT NULL) AS labels
+            FROM entity_is_of_type
+            JOIN ontology_ids
+              ON entity_is_of_type.entity_type_ontology_id = ontology_ids.ontology_id
+            JOIN entity_types
+              ON ontology_ids.ontology_id = entity_types.ontology_id
+            JOIN entity_editions
+              ON entity_is_of_type.entity_edition_id = entity_editions.entity_edition_id
+           CROSS JOIN LATERAL (
+               SELECT jsonb_extract_path(
+                          entity_editions.properties, label_path.path
+                      ) #>> '{}' AS label,
+                      label_path.ordinality
+                 FROM jsonb_array_elements_text(
+                          jsonb_path_query_array(
+                              entity_types.closed_schema, '$.allOf[*].labelProperty'
+                          )
+                      ) WITH ORDINALITY AS label_path (path, ordinality)
+           ) AS label_value
+           WHERE entity_is_of_type.inheritance_depth = 0/*LABELS_SCOPE*/
+           GROUP BY entity_is_of_type.entity_edition_id
+      ) AS labels
+        ON types.entity_edition_id = labels.entity_edition_id;
+";
+
+/// Builds the cache population statement; `scoped` restricts it to the editions in
+/// `$1: UUID[]`.
+fn insert_entity_edition_cache_statement(scoped: bool) -> String {
+    INSERT_ENTITY_EDITION_CACHE_TEMPLATE
+        .replace(
+            "/*TYPES_SCOPE*/",
+            if scoped {
+                "WHERE entity_is_of_type.entity_edition_id = ANY($1)"
+            } else {
+                ""
+            },
+        )
+        .replace(
+            "/*LABELS_SCOPE*/",
+            if scoped {
+                "\n             AND entity_is_of_type.entity_edition_id = ANY($1)"
+            } else {
+                ""
+            },
+        )
+}
+
 impl PostgresStore<tokio_postgres::Transaction<'_>> {
     #[tracing::instrument(level = "info", skip_all)]
     async fn insert_entity_edition(
@@ -2669,6 +2807,21 @@ impl PostgresStore<tokio_postgres::Transaction<'_>> {
                      GROUP BY entity_edition_id, target_entity_type_ontology_id;
                 ",
                 &[&edition_id],
+            )
+            .instrument(tracing::info_span!(
+                "INSERT",
+                otel.kind = "client",
+                db.system = "postgresql",
+                peer.service = "Postgres",
+            ))
+            .await
+            .change_context(InsertionError)?;
+
+        let edition_ids = [edition_id];
+        self.as_client()
+            .query(
+                &insert_entity_edition_cache_statement(true),
+                &[&edition_ids.as_slice()],
             )
             .instrument(tracing::info_span!(
                 "INSERT",

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
@@ -2502,9 +2502,6 @@ where
                         ON entity_type_ontology_id = source_entity_type_ontology_id
                      GROUP BY entity_edition_id, target_entity_type_ontology_id;
 
-                    -- DELETE instead of TRUNCATE: the runtime role has no TRUNCATE
-                    -- privilege, and DELETE keeps the cache readable for concurrent
-                    -- queries until this transaction commits.
                     DELETE FROM entity_edition_cache;
                 ",
             )

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
@@ -2623,14 +2623,26 @@ struct LockedEntityEdition {
     transaction_time: LeftClosedTemporalInterval<TransactionTime>,
 }
 
-/// Statement template populating `entity_edition_cache` by aggregating the editions'
+/// Builds the statement populating `entity_edition_cache` by aggregating the editions'
 /// `entity_is_of_type` rows joined to the referenced types.
 ///
-/// Built via [`insert_entity_edition_cache_statement`]: the write paths scope it to the
-/// just-written editions (`$1: UUID[]`), `reindex_entity_cache` runs it unscoped over all
-/// editions. Must run after the editions' `entity_is_of_type` rows (including the
-/// inherited ones) have been written.
-const INSERT_ENTITY_EDITION_CACHE_TEMPLATE: &str = "
+/// The write paths pass `scoped` to restrict it to the just-written editions
+/// (`$1: UUID[]`), `reindex_entity_cache` runs it unscoped over all editions. Must run
+/// after the editions' `entity_is_of_type` rows (including the inherited ones) have been
+/// written.
+fn insert_entity_edition_cache_statement(scoped: bool) -> String {
+    let types_scope = if scoped {
+        "WHERE entity_is_of_type.entity_edition_id = ANY($1)"
+    } else {
+        ""
+    };
+    let labels_scope = if scoped {
+        "AND entity_is_of_type.entity_edition_id = ANY($1)"
+    } else {
+        ""
+    };
+    format!(
+        "
     INSERT INTO entity_edition_cache (
         entity_edition_id,
         direct_types,
@@ -2677,7 +2689,7 @@ const INSERT_ENTITY_EDITION_CACHE_TEMPLATE: &str = "
               ON entity_is_of_type.entity_type_ontology_id = ontology_ids.ontology_id
             JOIN entity_types
               ON ontology_ids.ontology_id = entity_types.ontology_id
-           /*TYPES_SCOPE*/
+           {types_scope}
            GROUP BY entity_is_of_type.entity_edition_id
       ) AS types
       LEFT JOIN (
@@ -2696,7 +2708,7 @@ const INSERT_ENTITY_EDITION_CACHE_TEMPLATE: &str = "
            CROSS JOIN LATERAL (
                SELECT jsonb_extract_path(
                           entity_editions.properties, label_path.path
-                      ) #>> '{}' AS label,
+                      ) #>> '{{}}' AS label,
                       label_path.ordinality
                  FROM jsonb_array_elements_text(
                           jsonb_path_query_array(
@@ -2704,32 +2716,13 @@ const INSERT_ENTITY_EDITION_CACHE_TEMPLATE: &str = "
                           )
                       ) WITH ORDINALITY AS label_path (path, ordinality)
            ) AS label_value
-           WHERE entity_is_of_type.inheritance_depth = 0/*LABELS_SCOPE*/
+           WHERE entity_is_of_type.inheritance_depth = 0
+             {labels_scope}
            GROUP BY entity_is_of_type.entity_edition_id
       ) AS labels
         ON types.entity_edition_id = labels.entity_edition_id;
-";
-
-/// Builds the cache population statement; `scoped` restricts it to the editions in
-/// `$1: UUID[]`.
-fn insert_entity_edition_cache_statement(scoped: bool) -> String {
-    INSERT_ENTITY_EDITION_CACHE_TEMPLATE
-        .replace(
-            "/*TYPES_SCOPE*/",
-            if scoped {
-                "WHERE entity_is_of_type.entity_edition_id = ANY($1)"
-            } else {
-                ""
-            },
-        )
-        .replace(
-            "/*LABELS_SCOPE*/",
-            if scoped {
-                "\n             AND entity_is_of_type.entity_edition_id = ANY($1)"
-            } else {
-                ""
-            },
-        )
+"
+    )
 }
 
 impl PostgresStore<tokio_postgres::Transaction<'_>> {
@@ -3294,5 +3287,21 @@ impl PostgresStore<tokio_postgres::Transaction<'_>> {
             decision_time: row.get(0),
             transaction_time: row.get(1),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::insert_entity_edition_cache_statement;
+
+    #[test]
+    fn cache_statement_scoping() {
+        let scoped = insert_entity_edition_cache_statement(true);
+        let unscoped = insert_entity_edition_cache_statement(false);
+
+        assert_eq!(scoped.matches("= ANY($1)").count(), 2);
+        assert_eq!(unscoped.matches("= ANY($1)").count(), 0);
+        // the jsonb text-extraction operator must survive the `format!` brace escaping
+        assert!(scoped.contains("#>> '{}'"));
     }
 }

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/query.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/query.rs
@@ -14,7 +14,7 @@ use type_system::{
         },
         property::metadata::PropertyObjectMetadata,
     },
-    ontology::id::{BaseUrl, OntologyTypeVersion, VersionedUrl},
+    ontology::id::VersionedUrl,
 };
 
 use crate::store::postgres::{
@@ -30,8 +30,8 @@ pub struct EntityRecordRowIndices {
     pub decision_time: usize,
 
     pub edition_id: usize,
-    pub type_base_urls_id: usize,
-    pub type_versions_id: usize,
+    pub type_versioned_urls_id: usize,
+    pub direct_type_count_id: usize,
 
     pub properties: usize,
 
@@ -162,12 +162,15 @@ impl QueryRecordDecode for Entity {
                     decision_time: row.get(indices.decision_time),
                     transaction_time: row.get(indices.transaction_time),
                 },
-                entity_type_ids: row
-                    .get::<_, Vec<BaseUrl>>(indices.type_base_urls_id)
-                    .into_iter()
-                    .zip(row.get::<_, Vec<OntologyTypeVersion>>(indices.type_versions_id))
-                    .map(|(base_url, version)| VersionedUrl { base_url, version })
-                    .collect(),
+                entity_type_ids: {
+                    let direct_type_count =
+                        usize::try_from(row.get::<_, i32>(indices.direct_type_count_id))
+                            .expect("direct type count should be non-negative");
+                    row.get::<_, Vec<VersionedUrl>>(indices.type_versioned_urls_id)
+                        .into_iter()
+                        .take(direct_type_count)
+                        .collect()
+                },
                 provenance: EntityProvenance {
                     inferred: row.get(indices.provenance),
                     edition: row.get(indices.edition_provenance),
@@ -224,8 +227,9 @@ impl PostgresRecord for Entity {
             ),
 
             edition_id: compiler.add_selection_path(&EntityQueryPath::EditionId),
-            type_base_urls_id: compiler.add_selection_path(&EntityQueryPath::TypeBaseUrls),
-            type_versions_id: compiler.add_selection_path(&EntityQueryPath::TypeVersions),
+            type_versioned_urls_id: compiler
+                .add_selection_path(&EntityQueryPath::TypeVersionedUrls),
+            direct_type_count_id: compiler.add_selection_path(&EntityQueryPath::DirectTypeCount),
 
             properties: compiler.add_selection_path(&EntityQueryPath::Properties(None)),
 

--- a/libs/@local/graph/postgres-store/src/store/postgres/ontology/entity_type.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/ontology/entity_type.rs
@@ -9,7 +9,7 @@ use hash_graph_authorization::policies::{
     action::ActionName, principal::actor::AuthenticatedActor,
 };
 use hash_graph_store::{
-    entity::ClosedMultiEntityTypeMap,
+    entity::{ClosedMultiEntityTypeMap, EntityStore},
     entity_type::{
         ArchiveEntityTypeParams, ClosedDataTypeDefinition, CommonQueryEntityTypesParams,
         CountEntityTypesParams, CreateEntityTypeParams, EntityTypeQueryPath,
@@ -1951,6 +1951,11 @@ where
         }
 
         transaction.commit().await.change_context(UpdateError)?;
+
+        // The entity edition cache derives type titles, labels (via `closed_schema`), and
+        // the inherited type entries from the data rebuilt above, so it has to be rebuilt
+        // as well — otherwise it silently keeps serving the pre-reindex schemas.
+        EntityStore::reindex_entity_cache(self).await?;
 
         Ok(())
     }

--- a/libs/@local/graph/postgres-store/src/store/postgres/ontology/entity_type.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/ontology/entity_type.rs
@@ -1873,7 +1873,7 @@ where
     #[tracing::instrument(level = "info", skip(self))]
     async fn reindex_entity_type_cache(&mut self) -> Result<(), Report<UpdateError>> {
         tracing::info!("Reindexing entity type cache");
-        let transaction = self.transaction().await.change_context(UpdateError)?;
+        let mut transaction = self.transaction().await.change_context(UpdateError)?;
 
         // We remove the data from the reference tables first
         transaction
@@ -1950,12 +1950,12 @@ where
                 .change_context(UpdateError)?;
         }
 
-        transaction.commit().await.change_context(UpdateError)?;
-
         // The entity edition cache derives type titles, labels (via `closed_schema`), and
         // the inherited type entries from the data rebuilt above, so it has to be rebuilt
         // as well — otherwise it silently keeps serving the pre-reindex schemas.
-        EntityStore::reindex_entity_cache(self).await?;
+        EntityStore::reindex_entity_cache(&mut transaction).await?;
+
+        transaction.commit().await.change_context(UpdateError)?;
 
         Ok(())
     }

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/compile.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/compile.rs
@@ -523,16 +523,12 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
                             | Table::DataTypeConversionAggregation
                             | Table::PropertyTypes
                             | Table::EntityTypes
-                            | Table::FirstTitleForEntity
-                            | Table::LastTitleForEntity
-                            | Table::FirstLabelForEntity
-                            | Table::LastLabelForEntity
+                            | Table::EntityEditionCache
                             | Table::EntityIds
                             | Table::EntityDrafts
                             | Table::EntityTemporalMetadata
                             | Table::EntityEditions
                             | Table::EntityIsOfType
-                            | Table::EntityIsOfTypeIds
                             | Table::EntityHasLeftEntity
                             | Table::EntityHasRightEntity
                             | Table::EntityEdge
@@ -583,16 +579,12 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
                             | Table::DataTypeConversionAggregation
                             | Table::PropertyTypes
                             | Table::EntityTypes
-                            | Table::FirstTitleForEntity
-                            | Table::LastTitleForEntity
-                            | Table::FirstLabelForEntity
-                            | Table::LastLabelForEntity
+                            | Table::EntityEditionCache
                             | Table::EntityIds
                             | Table::EntityDrafts
                             | Table::EntityTemporalMetadata
                             | Table::EntityEditions
                             | Table::EntityIsOfType
-                            | Table::EntityIsOfTypeIds
                             | Table::EntityHasLeftEntity
                             | Table::EntityHasRightEntity
                             | Table::EntityEdge
@@ -884,6 +876,10 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
                     PathToken::Field(Cow::Borrowed(field)),
                 ))
             }
+            Some(JsonField::ArrayElement(index)) => Expression::ArrayElement {
+                expr: Box::new(column_expression),
+                index,
+            },
             Some(JsonField::Label { inheritance_depth }) => {
                 if let Some(label_path) =
                     <R as QueryRecord>::QueryPath::label_property_path(inheritance_depth)
@@ -967,11 +963,13 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
         match expression {
             FilterExpression::Path { path } => {
                 let (column, json_field) = path.terminating_column();
-                let parameter_type = if let Some(JsonField::StaticText(_)) = json_field {
-                    ParameterType::Text
-                } else {
-                    column.parameter_type()
-                };
+                let parameter_type =
+                    if let Some(JsonField::StaticText(_) | JsonField::ArrayElement(_)) = json_field
+                    {
+                        ParameterType::Text
+                    } else {
+                        column.parameter_type()
+                    };
                 (self.compile_path_column(path), parameter_type)
             }
             FilterExpression::Parameter { parameter, convert } => {
@@ -994,11 +992,13 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
         match expression {
             FilterExpressionList::Path { path } => {
                 let (column, json_field) = path.terminating_column();
-                let parameter_type = if let Some(JsonField::StaticText(_)) = json_field {
-                    ParameterType::Text
-                } else {
-                    column.parameter_type()
-                };
+                let parameter_type =
+                    if let Some(JsonField::StaticText(_) | JsonField::ArrayElement(_)) = json_field
+                    {
+                        ParameterType::Text
+                    } else {
+                        column.parameter_type()
+                    };
                 (self.compile_path_column(path), parameter_type)
             }
             FilterExpressionList::ParameterList { parameters } => {

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/entity.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/entity.rs
@@ -9,9 +9,9 @@ use hash_graph_store::{
 use crate::store::postgres::query::{
     PostgresQueryPath,
     table::{
-        Column, EntityEditions, EntityEmbeddings, EntityHasLeftEntity, EntityHasRightEntity,
-        EntityIds, EntityIsOfTypeIds, EntityTemporalMetadata, JsonField, LabelForEntity,
-        ReferenceTable, Relation, TypeTitleForEntity,
+        Column, EntityEditionCache, EntityEditions, EntityEmbeddings, EntityHasLeftEntity,
+        EntityHasRightEntity, EntityIds, EntityTemporalMetadata, JsonField, ReferenceTable,
+        Relation,
     },
 };
 
@@ -40,7 +40,9 @@ impl PostgresQueryPath for EntityQueryPath<'_> {
             | Self::PropertyMetadata(_) => {
                 vec![Relation::EntityEditions]
             }
-            Self::TypeBaseUrls | Self::TypeVersions => vec![Relation::EntityIsOfTypes],
+            Self::TypeBaseUrls | Self::TypeVersionedUrls | Self::DirectTypeCount => {
+                vec![Relation::EntityEditionCache]
+            }
             Self::EntityTypeEdge {
                 edge_kind: SharedEdgeKind::IsOfType,
                 path,
@@ -87,10 +89,7 @@ impl PostgresQueryPath for EntityQueryPath<'_> {
             })
             .chain(path.relations())
             .collect(),
-            Self::FirstTypeTitle => vec![Relation::FirstTitleForEntity],
-            Self::LastTypeTitle => vec![Relation::LastTitleForEntity],
-            Self::FirstLabel => vec![Relation::FirstLabelForEntity],
-            Self::LastLabel => vec![Relation::LastLabelForEntity],
+            Self::FirstTypeTitle | Self::FirstLabel => vec![Relation::EntityEditionCache],
         }
     }
 
@@ -123,8 +122,18 @@ impl PostgresQueryPath for EntityQueryPath<'_> {
             ),
             Self::Archived => (Column::EntityEditions(EntityEditions::Archived), None),
             Self::Embedding => (Column::EntityEmbeddings(EntityEmbeddings::Embedding), None),
-            Self::TypeBaseUrls => (Column::EntityIsOfTypeIds(EntityIsOfTypeIds::BaseUrls), None),
-            Self::TypeVersions => (Column::EntityIsOfTypeIds(EntityIsOfTypeIds::Versions), None),
+            Self::TypeBaseUrls => (
+                Column::EntityEditionCache(EntityEditionCache::BaseUrls),
+                None,
+            ),
+            Self::TypeVersionedUrls => (
+                Column::EntityEditionCache(EntityEditionCache::VersionedUrls),
+                None,
+            ),
+            Self::DirectTypeCount => (
+                Column::EntityEditionCache(EntityEditionCache::DirectTypes),
+                None,
+            ),
             Self::EntityTypeEdge { path, .. } => path.terminating_column(),
             Self::EntityEdge {
                 edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
@@ -198,10 +207,14 @@ impl PostgresQueryPath for EntityQueryPath<'_> {
                 Column::EntityHasRightEntity(EntityHasRightEntity::Provenance),
                 None,
             ),
-            Self::FirstTypeTitle => (Column::FirstTitleForEntity(TypeTitleForEntity::Title), None),
-            Self::LastTypeTitle => (Column::LastTitleForEntity(TypeTitleForEntity::Title), None),
-            Self::FirstLabel => (Column::FirstLabelForEntity(LabelForEntity::Label), None),
-            Self::LastLabel => (Column::LastLabelForEntity(LabelForEntity::Label), None),
+            Self::FirstTypeTitle => (
+                Column::EntityEditionCache(EntityEditionCache::TypeTitles),
+                Some(JsonField::ArrayElement(1)),
+            ),
+            Self::FirstLabel => (
+                Column::EntityEditionCache(EntityEditionCache::Labels),
+                Some(JsonField::ArrayElement(1)),
+            ),
         }
     }
 

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/expression/conditional.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/expression/conditional.rs
@@ -337,6 +337,13 @@ pub enum Expression {
         expr: Box<Self>,
         field: ColumnName<'static>,
     },
+    /// 1-based array subscript access.
+    ///
+    /// Transpiles to `(<expr>)[<index>]` in PostgreSQL.
+    ArrayElement {
+        expr: Box<Self>,
+        index: usize,
+    },
     /// Row expansion - expands a composite type into its constituent columns.
     ///
     /// Transpiles to `(expression).*` in PostgreSQL, which is used to expand
@@ -654,6 +661,11 @@ impl Transpile for Expression {
                 expr.transpile(fmt)?;
                 fmt.write_str(").")?;
                 field.transpile(fmt)
+            }
+            Self::ArrayElement { expr, index } => {
+                fmt.write_char('(')?;
+                expr.transpile(fmt)?;
+                write!(fmt, ")[{index}]")
             }
             Self::ColumnReference(column) => column.transpile(fmt),
             Self::Parameter(index) => write!(fmt, "${index}"),

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/mod.rs
@@ -129,7 +129,16 @@ impl<'s> QueryRecordDecode for EntityQuerySorting<'s> {
 
     fn decode(row: &Row, indices: &Self::Indices) -> Self::Output {
         EntityQueryCursor {
-            values: indices.iter().map(|i| row.get(i)).collect(),
+            values: indices
+                .iter()
+                .map(|i| {
+                    // Sort keys can be NULL (e.g. the label of an unlabeled entity);
+                    // `Json(Null)` is the sentinel `compile` turns into the `IS NULL`
+                    // cursor continuation.
+                    row.get::<_, Option<CursorField>>(i)
+                        .unwrap_or(CursorField::Json(PropertyValue::Null))
+                })
+                .collect(),
         }
     }
 }

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/statement/select.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/statement/select.rs
@@ -1288,6 +1288,41 @@ mod tests {
     }
 
     #[test]
+    fn sort_by_label_and_type_title() {
+        let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
+        let pinned_timestamp = temporal_axes.pinned_timestamp();
+        let mut compiler = SelectCompiler::<Entity>::new(Some(&temporal_axes), true);
+        compiler.add_distinct_selection_with_ordering(
+            &EntityQueryPath::FirstLabel,
+            Distinctness::Distinct,
+            Some((Ordering::Ascending, Some(NullOrdering::Last))),
+        );
+        compiler.add_distinct_selection_with_ordering(
+            &EntityQueryPath::FirstTypeTitle,
+            Distinctness::Distinct,
+            Some((Ordering::Descending, Some(NullOrdering::Last))),
+        );
+
+        test_compilation(
+            &compiler,
+            r#"
+            SELECT
+                DISTINCT ON(("entity_edition_cache_0_1_0"."labels")[1], ("entity_edition_cache_0_1_0"."type_titles")[1])
+                ("entity_edition_cache_0_1_0"."labels")[1],
+                ("entity_edition_cache_0_1_0"."type_titles")[1]
+            FROM "entity_temporal_metadata" AS "entity_temporal_metadata_0_0_0"
+            INNER JOIN "entity_edition_cache" AS "entity_edition_cache_0_1_0"
+              ON "entity_edition_cache_0_1_0"."entity_edition_id" = "entity_temporal_metadata_0_0_0"."entity_edition_id"
+            WHERE "entity_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ
+              AND "entity_temporal_metadata_0_0_0"."decision_time" && $2
+            ORDER BY ("entity_edition_cache_0_1_0"."labels")[1] ASC NULLS LAST,
+                     ("entity_edition_cache_0_1_0"."type_titles")[1] DESC NULLS LAST
+            "#,
+            &[&pinned_timestamp, &temporal_axes.variable_interval()],
+        );
+    }
+
+    #[test]
     fn transpile_offset() {
         let statement = SelectStatement::builder()
             .selects(vec![SelectExpression::Asterisk(None)])
@@ -1400,7 +1435,7 @@ mod tests {
                 &compiler,
                 r#"
                 SELECT ("entity_editions_0_1_0"."properties" - (CASE WHEN
-                    ($1 = ANY("entity_is_of_type_ids_0_1_0"."base_urls"))
+                    ($1 = ANY("entity_edition_cache_0_1_0"."base_urls"))
                     AND ("entity_temporal_metadata_0_0_0"."entity_uuid" != $2)
                     THEN ARRAY[$3]::text[]
                     ELSE ARRAY[]::text[] END))
@@ -1408,8 +1443,8 @@ mod tests {
                 INNER JOIN "entity_editions" AS "entity_editions_0_1_0"
                     ON "entity_editions_0_1_0"."entity_edition_id" =
                         "entity_temporal_metadata_0_0_0"."entity_edition_id"
-                INNER JOIN "entity_is_of_type_ids" AS "entity_is_of_type_ids_0_1_0"
-                    ON "entity_is_of_type_ids_0_1_0"."entity_edition_id" =
+                INNER JOIN "entity_edition_cache" AS "entity_edition_cache_0_1_0"
+                    ON "entity_edition_cache_0_1_0"."entity_edition_id" =
                         "entity_temporal_metadata_0_0_0"."entity_edition_id"
                 WHERE "entity_temporal_metadata_0_0_0"."draft_id" IS NULL
                 "#,

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/table.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/table.rs
@@ -753,7 +753,7 @@ impl DatabaseColumn for EntityEditionCache {
     fn parameter_type(self) -> ParameterType {
         match self {
             Self::EntityEditionId => ParameterType::Uuid,
-            Self::DirectTypes => ParameterType::Decimal,
+            Self::DirectTypes => ParameterType::Integer,
             Self::Labels | Self::TypeTitles => ParameterType::Vector(Box::new(ParameterType::Text)),
             Self::BaseUrls => ParameterType::Vector(Box::new(ParameterType::BaseUrl)),
             Self::Versions => ParameterType::Vector(Box::new(ParameterType::OntologyTypeVersion)),

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/table.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/table.rs
@@ -29,18 +29,14 @@ pub enum Table {
     PropertyTypes,
     PropertyTypeEmbeddings,
     EntityTypes,
-    FirstTitleForEntity,
-    LastTitleForEntity,
-    FirstLabelForEntity,
-    LastLabelForEntity,
     EntityTypeEmbeddings,
     EntityIds,
     EntityDrafts,
     EntityTemporalMetadata,
     EntityEditions,
+    EntityEditionCache,
     EntityEmbeddings,
     EntityIsOfType,
-    EntityIsOfTypeIds,
     EntityHasLeftEntity,
     EntityHasRightEntity,
     EntityEdge,
@@ -342,18 +338,14 @@ impl Table {
             Self::PropertyTypes => "property_types",
             Self::PropertyTypeEmbeddings => "property_type_embeddings",
             Self::EntityTypes => "entity_types",
-            Self::FirstTitleForEntity => "first_type_title_for_entity",
-            Self::LastTitleForEntity => "last_type_title_for_entity",
-            Self::FirstLabelForEntity => "first_label_for_entity",
-            Self::LastLabelForEntity => "last_label_for_entity",
             Self::EntityTypeEmbeddings => "entity_type_embeddings",
             Self::EntityIds => "entity_ids",
             Self::EntityDrafts => "entity_drafts",
             Self::EntityTemporalMetadata => "entity_temporal_metadata",
             Self::EntityEditions => "entity_editions",
+            Self::EntityEditionCache => "entity_edition_cache",
             Self::EntityEmbeddings => "entity_embeddings",
             Self::EntityIsOfType => "entity_is_of_type",
-            Self::EntityIsOfTypeIds => "entity_is_of_type_ids",
             Self::EntityHasLeftEntity => "entity_has_left_entity",
             Self::EntityHasRightEntity => "entity_has_right_entity",
             Self::EntityEdge => "entity_edge",
@@ -373,7 +365,14 @@ pub enum JsonField<'p> {
     JsonPath(&'p JsonPath<'p>),
     JsonPathParameter(usize),
     StaticText(&'static str),
-    Label { inheritance_depth: Option<u32> },
+    /// 1-based Postgres array subscript, e.g. `("table"."column")[1]`.
+    ///
+    /// Filter parameters against subscripted columns are typed as [`ParameterType::Text`],
+    /// so this is only valid for text arrays.
+    ArrayElement(usize),
+    Label {
+        inheritance_depth: Option<u32>,
+    },
 }
 
 impl<'p> JsonField<'p> {
@@ -389,6 +388,7 @@ impl<'p> JsonField<'p> {
             ),
             Self::JsonPathParameter(index) => (JsonField::JsonPathParameter(index), None),
             Self::StaticText(text) => (JsonField::StaticText(text), None),
+            Self::ArrayElement(index) => (JsonField::ArrayElement(index), None),
             Self::Label { inheritance_depth } => (JsonField::Label { inheritance_depth }, None),
         }
     }
@@ -739,57 +739,49 @@ impl DatabaseColumn for EntityTypes {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum LabelForEntity {
-    EditionId,
-    Label,
+pub enum EntityEditionCache {
+    EntityEditionId,
+    DirectTypes,
+    Labels,
+    TypeTitles,
+    BaseUrls,
+    Versions,
+    VersionedUrls,
 }
 
-impl DatabaseColumn for LabelForEntity {
+impl DatabaseColumn for EntityEditionCache {
     fn parameter_type(self) -> ParameterType {
         match self {
-            Self::EditionId => ParameterType::Uuid,
-            Self::Label => ParameterType::Text,
+            Self::EntityEditionId => ParameterType::Uuid,
+            Self::DirectTypes => ParameterType::Decimal,
+            Self::Labels | Self::TypeTitles => ParameterType::Vector(Box::new(ParameterType::Text)),
+            Self::BaseUrls => ParameterType::Vector(Box::new(ParameterType::BaseUrl)),
+            Self::Versions => ParameterType::Vector(Box::new(ParameterType::OntologyTypeVersion)),
+            Self::VersionedUrls => ParameterType::Vector(Box::new(ParameterType::VersionedUrl)),
         }
     }
 
     fn nullable(self) -> bool {
         match self {
-            Self::EditionId | Self::Label => false,
+            Self::Labels => true,
+            Self::EntityEditionId
+            | Self::DirectTypes
+            | Self::TypeTitles
+            | Self::BaseUrls
+            | Self::Versions
+            | Self::VersionedUrls => false,
         }
     }
 
     fn as_str(self) -> &'static str {
         match self {
-            Self::EditionId => "entity_edition_id",
-            Self::Label => "label_property",
-        }
-    }
-}
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum TypeTitleForEntity {
-    EditionId,
-    Title,
-}
-
-impl DatabaseColumn for TypeTitleForEntity {
-    fn parameter_type(self) -> ParameterType {
-        match self {
-            Self::EditionId => ParameterType::Uuid,
-            Self::Title => ParameterType::Text,
-        }
-    }
-
-    fn nullable(self) -> bool {
-        match self {
-            Self::EditionId | Self::Title => false,
-        }
-    }
-
-    fn as_str(self) -> &'static str {
-        match self {
-            Self::EditionId => "entity_edition_id",
-            Self::Title => "title",
+            Self::EntityEditionId => "entity_edition_id",
+            Self::DirectTypes => "direct_types",
+            Self::Labels => "labels",
+            Self::TypeTitles => "type_titles",
+            Self::BaseUrls => "base_urls",
+            Self::Versions => "versions",
+            Self::VersionedUrls => "versioned_urls",
         }
     }
 }
@@ -1114,35 +1106,6 @@ impl DatabaseColumn for EntityIsOfType {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum EntityIsOfTypeIds {
-    EntityEditionId,
-    BaseUrls,
-    Versions,
-}
-
-impl DatabaseColumn for EntityIsOfTypeIds {
-    fn parameter_type(self) -> ParameterType {
-        match self {
-            Self::EntityEditionId => ParameterType::Uuid,
-            Self::BaseUrls => ParameterType::Vector(Box::new(ParameterType::BaseUrl)),
-            Self::Versions => ParameterType::Vector(Box::new(ParameterType::OntologyTypeVersion)),
-        }
-    }
-
-    fn nullable(self) -> bool {
-        false
-    }
-
-    fn as_str(self) -> &'static str {
-        match self {
-            Self::EntityEditionId => "entity_edition_id",
-            Self::BaseUrls => "base_urls",
-            Self::Versions => "versions",
-        }
-    }
-}
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum EntityHasLeftEntity {
     WebId,
     EntityUuid,
@@ -1420,10 +1383,7 @@ pub enum Column {
     EntityIds(EntityIds),
     EntityTemporalMetadata(EntityTemporalMetadata),
     EntityEditions(EntityEditions),
-    FirstLabelForEntity(LabelForEntity),
-    LastLabelForEntity(LabelForEntity),
-    FirstTitleForEntity(TypeTitleForEntity),
-    LastTitleForEntity(TypeTitleForEntity),
+    EntityEditionCache(EntityEditionCache),
     EntityEmbeddings(EntityEmbeddings),
     PropertyTypeConstrainsValuesOn(PropertyTypeConstrainsValuesOn),
     PropertyTypeConstrainsPropertiesOn(PropertyTypeConstrainsPropertiesOn),
@@ -1432,7 +1392,6 @@ pub enum Column {
     EntityTypeConstrainsLinksOn(EntityTypeConstrainsLinksOn, Option<u32>),
     EntityTypeConstrainsLinkDestinationsOn(EntityTypeConstrainsLinkDestinationsOn, Option<u32>),
     EntityIsOfType(EntityIsOfType, Option<u32>),
-    EntityIsOfTypeIds(EntityIsOfTypeIds),
     EntityHasLeftEntity(EntityHasLeftEntity),
     EntityHasRightEntity(EntityHasRightEntity),
 }
@@ -1579,9 +1538,9 @@ impl From<EntityIsOfType> for Column {
     }
 }
 
-impl From<EntityIsOfTypeIds> for Column {
-    fn from(column: EntityIsOfTypeIds) -> Self {
-        Self::EntityIsOfTypeIds(column)
+impl From<EntityEditionCache> for Column {
+    fn from(column: EntityEditionCache) -> Self {
+        Self::EntityEditionCache(column)
     }
 }
 
@@ -1617,10 +1576,7 @@ impl Column {
             Self::EntityIds(_) => Table::EntityIds,
             Self::EntityTemporalMetadata(_) => Table::EntityTemporalMetadata,
             Self::EntityEditions(_) => Table::EntityEditions,
-            Self::FirstLabelForEntity(_) => Table::FirstLabelForEntity,
-            Self::LastLabelForEntity(_) => Table::LastLabelForEntity,
-            Self::FirstTitleForEntity(_) => Table::FirstTitleForEntity,
-            Self::LastTitleForEntity(_) => Table::LastTitleForEntity,
+            Self::EntityEditionCache(_) => Table::EntityEditionCache,
             Self::EntityEmbeddings(_) => Table::EntityEmbeddings,
             Self::DataTypeInheritsFrom(_, inheritance_depth) => {
                 Table::Reference(ReferenceTable::DataTypeInheritsFrom { inheritance_depth })
@@ -1650,7 +1606,6 @@ impl Column {
             Self::EntityIsOfType(_, inheritance_depth) => {
                 Table::Reference(ReferenceTable::EntityIsOfType { inheritance_depth })
             }
-            Self::EntityIsOfTypeIds(_) => Table::EntityIsOfTypeIds,
             Self::EntityHasLeftEntity(_) => Table::Reference(ReferenceTable::EntityHasLeftEntity),
             Self::EntityHasRightEntity(_) => Table::Reference(ReferenceTable::EntityHasRightEntity),
         }
@@ -1681,14 +1636,10 @@ impl Column {
             | Self::EntityIds(_)
             | Self::EntityTemporalMetadata(_)
             | Self::EntityEditions(_)
-            | Self::FirstLabelForEntity(_)
-            | Self::LastLabelForEntity(_)
-            | Self::FirstTitleForEntity(_)
-            | Self::LastTitleForEntity(_)
+            | Self::EntityEditionCache(_)
             | Self::EntityEmbeddings(_)
             | Self::PropertyTypeConstrainsValuesOn(_)
             | Self::PropertyTypeConstrainsPropertiesOn(_)
-            | Self::EntityIsOfTypeIds(_)
             | Self::EntityHasLeftEntity(_)
             | Self::EntityHasRightEntity(_) => None,
         }
@@ -1715,12 +1666,7 @@ impl DatabaseColumn for Column {
             Self::EntityIds(column) => column.parameter_type(),
             Self::EntityTemporalMetadata(column) => column.parameter_type(),
             Self::EntityEditions(column) => column.parameter_type(),
-            Self::FirstLabelForEntity(column) | Self::LastLabelForEntity(column) => {
-                column.parameter_type()
-            }
-            Self::FirstTitleForEntity(column) | Self::LastTitleForEntity(column) => {
-                column.parameter_type()
-            }
+            Self::EntityEditionCache(column) => column.parameter_type(),
             Self::EntityEmbeddings(column) => column.parameter_type(),
             Self::PropertyTypeConstrainsValuesOn(column) => column.parameter_type(),
             Self::PropertyTypeConstrainsPropertiesOn(column) => column.parameter_type(),
@@ -1729,7 +1675,6 @@ impl DatabaseColumn for Column {
             Self::EntityTypeConstrainsLinksOn(column, _) => column.parameter_type(),
             Self::EntityTypeConstrainsLinkDestinationsOn(column, _) => column.parameter_type(),
             Self::EntityIsOfType(column, _) => column.parameter_type(),
-            Self::EntityIsOfTypeIds(column) => column.parameter_type(),
             Self::EntityHasLeftEntity(column) => column.parameter_type(),
             Self::EntityHasRightEntity(column) => column.parameter_type(),
         }
@@ -1754,12 +1699,7 @@ impl DatabaseColumn for Column {
             Self::EntityIds(column) => column.nullable(),
             Self::EntityTemporalMetadata(column) => column.nullable(),
             Self::EntityEditions(column) => column.nullable(),
-            Self::FirstLabelForEntity(column) | Self::LastLabelForEntity(column) => {
-                column.nullable()
-            }
-            Self::FirstTitleForEntity(column) | Self::LastTitleForEntity(column) => {
-                column.nullable()
-            }
+            Self::EntityEditionCache(column) => column.nullable(),
             Self::EntityEmbeddings(column) => column.nullable(),
             Self::PropertyTypeConstrainsValuesOn(column) => column.nullable(),
             Self::PropertyTypeConstrainsPropertiesOn(column) => column.nullable(),
@@ -1768,7 +1708,6 @@ impl DatabaseColumn for Column {
             Self::EntityTypeConstrainsLinksOn(column, _) => column.nullable(),
             Self::EntityTypeConstrainsLinkDestinationsOn(column, _) => column.nullable(),
             Self::EntityIsOfType(column, _) => column.nullable(),
-            Self::EntityIsOfTypeIds(column) => column.nullable(),
             Self::EntityHasLeftEntity(column) => column.nullable(),
             Self::EntityHasRightEntity(column) => column.nullable(),
         }
@@ -1793,8 +1732,7 @@ impl DatabaseColumn for Column {
             Self::EntityIds(column) => column.as_str(),
             Self::EntityTemporalMetadata(column) => column.as_str(),
             Self::EntityEditions(column) => column.as_str(),
-            Self::FirstLabelForEntity(column) | Self::LastLabelForEntity(column) => column.as_str(),
-            Self::FirstTitleForEntity(column) | Self::LastTitleForEntity(column) => column.as_str(),
+            Self::EntityEditionCache(column) => column.as_str(),
             Self::EntityEmbeddings(column) => column.as_str(),
             Self::PropertyTypeConstrainsValuesOn(column) => column.as_str(),
             Self::PropertyTypeConstrainsPropertiesOn(column) => column.as_str(),
@@ -1803,7 +1741,6 @@ impl DatabaseColumn for Column {
             Self::EntityTypeConstrainsLinksOn(column, _) => column.as_str(),
             Self::EntityTypeConstrainsLinkDestinationsOn(column, _) => column.as_str(),
             Self::EntityIsOfType(column, _) => column.as_str(),
-            Self::EntityIsOfTypeIds(column) => column.as_str(),
             Self::EntityHasLeftEntity(column) => column.as_str(),
             Self::EntityHasRightEntity(column) => column.as_str(),
         }
@@ -1856,13 +1793,9 @@ pub enum Relation {
     DataTypeEmbeddings,
     PropertyTypeIds,
     EntityTypeIds,
-    EntityIsOfTypes,
     EntityIds,
     EntityEditions,
-    FirstTitleForEntity,
-    LastTitleForEntity,
-    FirstLabelForEntity,
-    LastLabelForEntity,
+    EntityEditionCache,
     PropertyTypeEmbeddings,
     EntityTypeEmbeddings,
     EntityEmbeddings,
@@ -2060,11 +1993,6 @@ impl Relation {
                 join: Column::EntityTypes(EntityTypes::OntologyId),
                 join_type: JoinType::Inner,
             }),
-            Self::EntityIsOfTypes => ForeignKeyJoin::from_reference(ForeignKeyReference::Single {
-                on: Column::EntityTemporalMetadata(EntityTemporalMetadata::EditionId),
-                join: Column::EntityIsOfTypeIds(EntityIsOfTypeIds::EntityEditionId),
-                join_type: JoinType::Inner,
-            }),
             Self::EntityTypeEmbeddings => {
                 ForeignKeyJoin::from_reference(ForeignKeyReference::Single {
                     on: Column::OntologyTemporalMetadata(OntologyTemporalMetadata::OntologyId),
@@ -2088,32 +2016,11 @@ impl Relation {
                 join: Column::EntityEditions(EntityEditions::EditionId),
                 join_type: JoinType::Inner,
             }),
-            Self::FirstTitleForEntity => {
+            Self::EntityEditionCache => {
                 ForeignKeyJoin::from_reference(ForeignKeyReference::Single {
                     on: Column::EntityTemporalMetadata(EntityTemporalMetadata::EditionId),
-                    join: Column::FirstTitleForEntity(TypeTitleForEntity::EditionId),
+                    join: Column::EntityEditionCache(EntityEditionCache::EntityEditionId),
                     join_type: JoinType::Inner,
-                })
-            }
-            Self::LastTitleForEntity => {
-                ForeignKeyJoin::from_reference(ForeignKeyReference::Single {
-                    on: Column::EntityTemporalMetadata(EntityTemporalMetadata::EditionId),
-                    join: Column::LastTitleForEntity(TypeTitleForEntity::EditionId),
-                    join_type: JoinType::Inner,
-                })
-            }
-            Self::FirstLabelForEntity => {
-                ForeignKeyJoin::from_reference(ForeignKeyReference::Single {
-                    on: Column::EntityTemporalMetadata(EntityTemporalMetadata::EditionId),
-                    join: Column::FirstLabelForEntity(LabelForEntity::EditionId),
-                    join_type: JoinType::LeftOuter,
-                })
-            }
-            Self::LastLabelForEntity => {
-                ForeignKeyJoin::from_reference(ForeignKeyReference::Single {
-                    on: Column::EntityTemporalMetadata(EntityTemporalMetadata::EditionId),
-                    join: Column::LastLabelForEntity(LabelForEntity::EditionId),
-                    join_type: JoinType::LeftOuter,
                 })
             }
             Self::EntityEmbeddings => ForeignKeyJoin::from_reference(ForeignKeyReference::Double {
@@ -2187,13 +2094,9 @@ impl Relation {
             | Self::DataTypeEmbeddings
             | Self::PropertyTypeIds
             | Self::EntityTypeIds
-            | Self::EntityIsOfTypes
             | Self::EntityIds
             | Self::EntityEditions
-            | Self::FirstTitleForEntity
-            | Self::LastTitleForEntity
-            | Self::FirstLabelForEntity
-            | Self::LastLabelForEntity
+            | Self::EntityEditionCache
             | Self::PropertyTypeEmbeddings
             | Self::EntityTypeEmbeddings
             | Self::EntityEmbeddings

--- a/libs/@local/graph/store/src/entity/query.rs
+++ b/libs/@local/graph/store/src/entity/query.rs
@@ -554,7 +554,7 @@ impl QueryPath for EntityQueryPath<'_> {
             Self::TypeBaseUrls | Self::TypeVersionedUrls => {
                 ParameterType::Vector(Box::new(ParameterType::VersionedUrl))
             }
-            Self::DirectTypeCount => ParameterType::Decimal,
+            Self::DirectTypeCount => ParameterType::Integer,
             Self::Properties(_)
             | Self::Label { .. }
             | Self::Provenance(_)

--- a/libs/@local/graph/store/src/entity/query.rs
+++ b/libs/@local/graph/store/src/entity/query.rs
@@ -551,8 +551,9 @@ impl QueryPath for EntityQueryPath<'_> {
         match self {
             Self::EditionId | Self::Uuid | Self::WebId | Self::DraftId => ParameterType::Uuid,
             Self::DecisionTime | Self::TransactionTime => ParameterType::TimeInterval,
-            Self::TypeBaseUrls => ParameterType::Vector(Box::new(ParameterType::VersionedUrl)),
-            Self::TypeVersionedUrls => ParameterType::Vector(Box::new(ParameterType::VersionedUrl)),
+            Self::TypeBaseUrls | Self::TypeVersionedUrls => {
+                ParameterType::Vector(Box::new(ParameterType::VersionedUrl))
+            }
             Self::DirectTypeCount => ParameterType::Decimal,
             Self::Properties(_)
             | Self::Label { .. }

--- a/libs/@local/graph/store/src/entity/query.rs
+++ b/libs/@local/graph/store/src/entity/query.rs
@@ -119,7 +119,14 @@ pub enum EntityQueryPath<'p> {
     /// [`Entity`]: type_system::knowledge::Entity
     /// [`EntityType`]: type_system::ontology::entity_type::EntityType
     /// [`EntityTypeEdge`]: Self::EntityTypeEdge
-    TypeVersions,
+    TypeVersionedUrls,
+    /// The number of direct (non-inherited) types of the [`Entity`].
+    ///
+    /// The type arrays in the edition cache list direct types first, so this is the length
+    /// of the direct-type prefix.
+    ///
+    /// [`Entity`]: type_system::knowledge::Entity
+    DirectTypeCount,
     /// The confidence value for the [`Entity`].
     ///
     /// It's currently not possible to query for the entity confidence value directly.
@@ -466,13 +473,6 @@ pub enum EntityQueryPath<'p> {
     /// [`Entity`]: type_system::knowledge::Entity
     /// [`EntityType`]: type_system::ontology::entity_type::EntityType
     FirstTypeTitle,
-    /// Corresponds to the title of the [`Entity`]'s last [`EntityType`].
-    ///
-    /// It's currently not possible to query for the last title directly.
-    ///
-    /// [`Entity`]: type_system::knowledge::Entity
-    /// [`EntityType`]: type_system::ontology::entity_type::EntityType
-    LastTypeTitle,
     /// Corresponds to the first set label of the [`Entity`] as specified by it's [`EntityType`]s.
     ///
     /// It's currently not possible to query for the first label directly.
@@ -480,13 +480,6 @@ pub enum EntityQueryPath<'p> {
     /// [`Entity`]: type_system::knowledge::Entity
     /// [`EntityType`]: type_system::ontology::entity_type::EntityType
     FirstLabel,
-    /// Corresponds to the last set label of the [`Entity`] as specified by it's [`EntityType`]s.
-    ///
-    /// It's currently not possible to query for the last label directly.
-    ///
-    /// [`Entity`]: type_system::knowledge::Entity
-    /// [`EntityType`]: type_system::ontology::entity_type::EntityType
-    LastLabel,
 }
 
 impl fmt::Display for EntityQueryPath<'_> {
@@ -499,7 +492,8 @@ impl fmt::Display for EntityQueryPath<'_> {
             Self::DecisionTime => fmt.write_str("decisionTime"),
             Self::TransactionTime => fmt.write_str("transactionTime"),
             Self::TypeBaseUrls => fmt.write_str("typeBaseUrls"),
-            Self::TypeVersions => fmt.write_str("typeVersions"),
+            Self::TypeVersionedUrls => fmt.write_str("typeVersionedUrls"),
+            Self::DirectTypeCount => fmt.write_str("directTypeCount"),
             Self::Archived => fmt.write_str("archived"),
             Self::Properties(Some(property)) => write!(fmt, "properties.{property}"),
             Self::Properties(None) => fmt.write_str("properties"),
@@ -547,9 +541,7 @@ impl fmt::Display for EntityQueryPath<'_> {
             Self::RightEntityConfidence => fmt.write_str("rightEntityConfidence"),
             Self::RightEntityProvenance => fmt.write_str("rightEntityProvenance"),
             Self::FirstTypeTitle => fmt.write_str("firstTypeTitle"),
-            Self::LastTypeTitle => fmt.write_str("lasttTypeTitle"),
             Self::FirstLabel => fmt.write_str("firstLabel"),
-            Self::LastLabel => fmt.write_str("lastLabel"),
         }
     }
 }
@@ -560,9 +552,8 @@ impl QueryPath for EntityQueryPath<'_> {
             Self::EditionId | Self::Uuid | Self::WebId | Self::DraftId => ParameterType::Uuid,
             Self::DecisionTime | Self::TransactionTime => ParameterType::TimeInterval,
             Self::TypeBaseUrls => ParameterType::Vector(Box::new(ParameterType::VersionedUrl)),
-            Self::TypeVersions => {
-                ParameterType::Vector(Box::new(ParameterType::OntologyTypeVersion))
-            }
+            Self::TypeVersionedUrls => ParameterType::Vector(Box::new(ParameterType::VersionedUrl)),
+            Self::DirectTypeCount => ParameterType::Decimal,
             Self::Properties(_)
             | Self::Label { .. }
             | Self::Provenance(_)
@@ -577,9 +568,7 @@ impl QueryPath for EntityQueryPath<'_> {
             Self::Archived => ParameterType::Boolean,
             Self::EntityTypeEdge { path, .. } => path.expected_type(),
             Self::EntityEdge { path, .. } => path.expected_type(),
-            Self::FirstTypeTitle | Self::LastTypeTitle | Self::FirstLabel | Self::LastLabel => {
-                ParameterType::Text
-            }
+            Self::FirstTypeTitle | Self::FirstLabel => ParameterType::Text,
         }
     }
 }
@@ -920,7 +909,8 @@ impl<'de: 'p, 'p> EntityQueryPath<'p> {
             Self::DecisionTime => EntityQueryPath::DecisionTime,
             Self::TransactionTime => EntityQueryPath::TransactionTime,
             Self::TypeBaseUrls => EntityQueryPath::TypeBaseUrls,
-            Self::TypeVersions => EntityQueryPath::TypeVersions,
+            Self::TypeVersionedUrls => EntityQueryPath::TypeVersionedUrls,
+            Self::DirectTypeCount => EntityQueryPath::DirectTypeCount,
             Self::Archived => EntityQueryPath::Archived,
             Self::EntityTypeEdge {
                 path,
@@ -956,9 +946,7 @@ impl<'de: 'p, 'p> EntityQueryPath<'p> {
                 EntityQueryPath::PropertyMetadata(path.map(JsonPath::into_owned))
             }
             Self::FirstTypeTitle => EntityQueryPath::FirstTypeTitle,
-            Self::LastTypeTitle => EntityQueryPath::LastTypeTitle,
             Self::FirstLabel => EntityQueryPath::FirstLabel,
-            Self::LastLabel => EntityQueryPath::LastLabel,
         }
     }
 }
@@ -986,19 +974,7 @@ impl<'s, 'de: 's> Deserialize<'de> for EntityQuerySortingRecord<'s> {
             pub nulls: Option<NullOrdering>,
         }
 
-        let mut record = EntityQuerySortingRecord::deserialize(deserializer)?;
-        // If we sort in descending order, we use the last title/label instead of the first one.
-        // TODO: Change behavior when order is fixed
-        //   see https://linear.app/hash/issue/H-3997/make-ontology-type-ids-ordered-in-inheritance-and-entities
-        match (&record.path, record.ordering) {
-            (EntityQueryPath::FirstTypeTitle, Ordering::Descending) => {
-                record.path = EntityQueryPath::LastTypeTitle;
-            }
-            (EntityQueryPath::FirstLabel, Ordering::Descending) => {
-                record.path = EntityQueryPath::LastLabel;
-            }
-            _ => {}
-        }
+        let record = EntityQuerySortingRecord::deserialize(deserializer)?;
 
         Ok(Self {
             path: record.path,

--- a/libs/@local/graph/store/src/filter/protection.rs
+++ b/libs/@local/graph/store/src/filter/protection.rs
@@ -845,9 +845,7 @@ fn collect_from_path<'f, 'p, I: Extend<&'f PropertyFilter<'p>>>(
             collect_from_json_path(json_path.as_ref(), config, excluded);
         }
         EntityQueryPath::EntityEdge { path, .. } => collect_from_path(path, config, excluded),
-        EntityQueryPath::Label { .. }
-        | EntityQueryPath::FirstLabel
-        | EntityQueryPath::LastLabel => {
+        EntityQueryPath::Label { .. } | EntityQueryPath::FirstLabel => {
             // TODO(BE-313): check if label_property is protected
         }
         EntityQueryPath::Embedding => {
@@ -860,7 +858,8 @@ fn collect_from_path<'f, 'p, I: Extend<&'f PropertyFilter<'p>>>(
         | EntityQueryPath::DecisionTime
         | EntityQueryPath::TransactionTime
         | EntityQueryPath::TypeBaseUrls
-        | EntityQueryPath::TypeVersions
+        | EntityQueryPath::TypeVersionedUrls
+        | EntityQueryPath::DirectTypeCount
         | EntityQueryPath::EntityConfidence
         | EntityQueryPath::LeftEntityConfidence
         | EntityQueryPath::LeftEntityProvenance
@@ -874,8 +873,7 @@ fn collect_from_path<'f, 'p, I: Extend<&'f PropertyFilter<'p>>>(
         }
         | EntityQueryPath::Provenance(_)
         | EntityQueryPath::EditionProvenance(_)
-        | EntityQueryPath::FirstTypeTitle
-        | EntityQueryPath::LastTypeTitle => {}
+        | EntityQueryPath::FirstTypeTitle => {}
     }
 }
 

--- a/libs/@local/hashql/eval/src/postgres/projections.rs
+++ b/libs/@local/hashql/eval/src/postgres/projections.rs
@@ -249,6 +249,7 @@ impl Projections {
         .build()
     }
 
+    #[expect(clippy::too_many_lines)]
     fn build_entity_type_ids<'item>(
         &self,
         parameters: &mut Parameters<'_, impl Allocator>,
@@ -260,13 +261,14 @@ impl Projections {
             name: TableName::from(Identifier::from("eec")),
             alias: None,
         };
+        let unnest_ref = TableReference {
+            schema: None,
+            name: TableName::from(Identifier::from("u")),
+            alias: None,
+        };
 
         let inner_from = FromItem::table(Table::EntityEditionCache)
-            .alias(TableReference {
-                schema: None,
-                name: TableName::from(Identifier::from("eec")),
-                alias: None,
-            })
+            .alias(eec_ref.clone())
             .build()
             .cross_join(FromItem::Function {
                 lateral: true,
@@ -284,11 +286,7 @@ impl Projections {
                     .cast(PostgresType::Array(Box::new(PostgresType::Text))),
                 ]),
                 with_ordinality: true,
-                alias: Some(TableReference {
-                    schema: None,
-                    name: TableName::from(Identifier::from("u")),
-                    alias: None,
-                }),
+                alias: Some(unnest_ref.clone()),
                 column_alias: vec![
                     ColumnName::from(Identifier::from("b")),
                     ColumnName::from(Identifier::from("v")),
@@ -312,11 +310,7 @@ impl Projections {
         // depths with the direct types as prefix; `entity_type_ids` only exposes direct types.
         let direct_prefix = query::Expression::less_or_equal(
             query::Expression::ColumnReference(ColumnReference {
-                correlation: Some(TableReference {
-                    schema: None,
-                    name: TableName::from(Identifier::from("u")),
-                    alias: None,
-                }),
+                correlation: Some(unnest_ref),
                 name: ColumnName::from(Identifier::from("ordinality")),
             }),
             query::Expression::ColumnReference(ColumnReference {

--- a/libs/@local/hashql/eval/src/postgres/projections.rs
+++ b/libs/@local/hashql/eval/src/postgres/projections.rs
@@ -115,7 +115,7 @@ impl Projections {
         ColumnReference {
             correlation: Some(TableReference {
                 schema: None,
-                name: TableName::from(Table::EntityIsOfTypeIds),
+                name: TableName::from(Table::EntityEditionCache),
                 alias: Some(alias),
             }),
             name: ComputedColumn::EntityTypeIds.into(),
@@ -176,15 +176,19 @@ impl Projections {
             from = self.build_entity_ids(from, alias);
         }
 
-        // entity_type_ids: self-contained LATERAL that joins entity_is_of_type_ids
-        // internally, unnests the parallel arrays, and aggregates into a JSONB array.
+        // entity_type_ids: self-contained LATERAL that joins entity_edition_cache
+        // internally, unnests the parallel arrays, and aggregates into a JSONB array. The
+        // cache arrays cover all inheritance depths with the direct types as prefix, so the
+        // ordinality predicate restricts the output to the entity's direct types.
         //
         // LEFT JOIN LATERAL (
         //     SELECT jsonb_agg(jsonb_build_object($base_url, u."b", $version, u."v"))
         //            AS "entity_type_ids"
-        //     FROM "entity_is_of_type_ids" AS "eit"
-        //       CROSS JOIN LATERAL UNNEST("eit"."base_urls", "eit"."versions") AS "u"("b", "v")
-        //     WHERE "eit"."entity_edition_id" = "base"."entity_edition_id"
+        //     FROM "entity_edition_cache" AS "eec"
+        //       CROSS JOIN LATERAL UNNEST("eec"."base_urls", "eec"."versions"::text[])
+        //            WITH ORDINALITY AS "u"("b", "v", "ordinality")
+        //     WHERE "eec"."entity_edition_id" = "base"."entity_edition_id"
+        //       AND "u"."ordinality" <= "eec"."direct_types"
         // ) AS <alias> ON TRUE
         if let Some(alias) = self.entity_type_ids {
             from = self.build_entity_type_ids(parameters, from, alias);
@@ -251,16 +255,16 @@ impl Projections {
         from: FromItem<'item>,
         alias: Alias,
     ) -> FromItem<'item> {
-        let eit_ref = TableReference {
+        let eec_ref = TableReference {
             schema: None,
-            name: TableName::from(Identifier::from("eit")),
+            name: TableName::from(Identifier::from("eec")),
             alias: None,
         };
 
-        let inner_from = FromItem::table(Table::EntityIsOfTypeIds)
+        let inner_from = FromItem::table(Table::EntityEditionCache)
             .alias(TableReference {
                 schema: None,
-                name: TableName::from(Identifier::from("eit")),
+                name: TableName::from(Identifier::from("eec")),
                 alias: None,
             })
             .build()
@@ -268,16 +272,18 @@ impl Projections {
                 lateral: true,
                 function: query::Function::Unnest(vec![
                     query::Expression::ColumnReference(ColumnReference {
-                        correlation: Some(eit_ref.clone()),
-                        name: Column::EntityIsOfTypeIds(table::EntityIsOfTypeIds::BaseUrls).into(),
+                        correlation: Some(eec_ref.clone()),
+                        name: Column::EntityEditionCache(table::EntityEditionCache::BaseUrls)
+                            .into(),
                     }),
                     query::Expression::ColumnReference(ColumnReference {
-                        correlation: Some(eit_ref),
-                        name: Column::EntityIsOfTypeIds(table::EntityIsOfTypeIds::Versions).into(),
+                        correlation: Some(eec_ref.clone()),
+                        name: Column::EntityEditionCache(table::EntityEditionCache::Versions)
+                            .into(),
                     })
                     .cast(PostgresType::Array(Box::new(PostgresType::Text))),
                 ]),
-                with_ordinality: false,
+                with_ordinality: true,
                 alias: Some(TableReference {
                     schema: None,
                     name: TableName::from(Identifier::from("u")),
@@ -286,23 +292,36 @@ impl Projections {
                 column_alias: vec![
                     ColumnName::from(Identifier::from("b")),
                     ColumnName::from(Identifier::from("v")),
+                    ColumnName::from(Identifier::from("ordinality")),
                 ],
             });
 
-        // WHERE "eit"."entity_edition_id" = "base"."entity_edition_id"
+        // WHERE "eec"."entity_edition_id" = "base"."entity_edition_id"
         let correlation = query::Expression::equal(
             query::Expression::ColumnReference(ColumnReference {
-                correlation: Some(TableReference {
-                    schema: None,
-                    name: TableName::from(Identifier::from("eit")),
-                    alias: None,
-                }),
-                name: Column::EntityIsOfType(table::EntityIsOfType::EntityEditionId, None).into(),
+                correlation: Some(eec_ref.clone()),
+                name: Column::EntityEditionCache(table::EntityEditionCache::EntityEditionId).into(),
             }),
             query::Expression::ColumnReference(ColumnReference {
                 correlation: Some(self.temporal_metadata()),
                 name: Column::EntityTemporalMetadata(table::EntityTemporalMetadata::EditionId)
                     .into(),
+            }),
+        );
+        // AND "u"."ordinality" <= "eec"."direct_types": the cache arrays cover all inheritance
+        // depths with the direct types as prefix; `entity_type_ids` only exposes direct types.
+        let direct_prefix = query::Expression::less_or_equal(
+            query::Expression::ColumnReference(ColumnReference {
+                correlation: Some(TableReference {
+                    schema: None,
+                    name: TableName::from(Identifier::from("u")),
+                    alias: None,
+                }),
+                name: ColumnName::from(Identifier::from("ordinality")),
+            }),
+            query::Expression::ColumnReference(ColumnReference {
+                correlation: Some(eec_ref),
+                name: Column::EntityEditionCache(table::EntityEditionCache::DirectTypes).into(),
             }),
         );
 
@@ -332,6 +351,7 @@ impl Projections {
             .where_expression({
                 let mut w = query::WhereExpression::default();
                 w.add_condition(correlation);
+                w.add_condition(direct_prefix);
                 w
             })
             .build();
@@ -341,7 +361,7 @@ impl Projections {
             statement: Box::new(subquery),
             alias: Some(TableReference {
                 schema: None,
-                name: TableName::from(Table::EntityIsOfTypeIds),
+                name: TableName::from(Table::EntityEditionCache),
                 alias: Some(alias),
             }),
             column_alias: vec![],

--- a/libs/@local/hashql/eval/tests/ui/postgres/entity-type-ids-lateral.stdout
+++ b/libs/@local/hashql/eval/tests/ui/postgres/entity-type-ids-lateral.stdout
@@ -3,11 +3,11 @@
 SELECT ("continuation_2_0"."row")."block" AS "continuation_2_0_block", ("continuation_2_0"."row")."locals" AS "continuation_2_0_locals", ("continuation_2_0"."row")."values" AS "continuation_2_0_values"
 FROM "entity_temporal_metadata" AS "entity_temporal_metadata_0_0_0"
 LEFT OUTER JOIN LATERAL (SELECT jsonb_agg(jsonb_build_object(($4::text), "b", ($5::text), "v")) AS "entity_type_ids"
-FROM "entity_is_of_type_ids" AS "eit"
-CROSS JOIN LATERAL UNNEST("eit"."base_urls", ("eit"."versions"::text[])) AS "u"("b", "v")
-WHERE "eit"."entity_edition_id" = "entity_temporal_metadata_0_0_0"."entity_edition_id") AS "entity_is_of_type_ids_0_0_1"
+FROM "entity_edition_cache" AS "eec"
+CROSS JOIN LATERAL UNNEST("eec"."base_urls", ("eec"."versions"::text[])) WITH ORDINALITY AS "u"("b", "v", "ordinality")
+WHERE "eec"."entity_edition_id" = "entity_temporal_metadata_0_0_0"."entity_edition_id" AND "u"."ordinality" <= "eec"."direct_types") AS "entity_edition_cache_0_0_1"
   ON TRUE
-CROSS JOIN LATERAL (SELECT (ROW(COALESCE(((to_jsonb("entity_is_of_type_ids_0_0_1"."entity_type_ids") = to_jsonb(($3::jsonb)))::boolean), FALSE), NULL, NULL, NULL)::continuation) AS "row") AS "continuation_2_0"
+CROSS JOIN LATERAL (SELECT (ROW(COALESCE(((to_jsonb("entity_edition_cache_0_0_1"."entity_type_ids") = to_jsonb(($3::jsonb)))::boolean), FALSE), NULL, NULL, NULL)::continuation) AS "row") AS "continuation_2_0"
 WHERE "entity_temporal_metadata_0_0_0"."transaction_time" && ($1::tstzrange) AND "entity_temporal_metadata_0_0_0"."decision_time" && ($2::tstzrange) AND ("continuation_2_0"."row")."filter" IS NOT FALSE
 
 ════ Parameters ════════════════════════════════════════════════════════════════

--- a/libs/@local/hashql/eval/tests/ui/postgres/filter/data_island_provides_without_lateral.snap
+++ b/libs/@local/hashql/eval/tests/ui/postgres/filter/data_island_provides_without_lateral.snap
@@ -82,7 +82,7 @@ SELECT
             END
         )
     ) AS "temporal_versioning",
-    "entity_is_of_type_ids_0_0_2"."entity_type_ids" AS "entity_type_ids",
+    "entity_edition_cache_0_0_2"."entity_type_ids" AS "entity_type_ids",
     "entity_editions_0_0_1"."archived" AS "archived",
     "entity_editions_0_0_1"."confidence" AS "confidence",
     "entity_ids_0_0_3"."provenance" AS "provenance_inferred",
@@ -111,13 +111,16 @@ LEFT OUTER JOIN LATERAL (
         jsonb_agg(
             jsonb_build_object(($12::text), "b", ($13::text), "v")
         ) AS "entity_type_ids"
-    FROM "entity_is_of_type_ids" AS "eit"
+    FROM "entity_edition_cache" AS "eec"
     CROSS JOIN LATERAL
-        unnest("eit"."base_urls", ("eit"."versions"::text [])) AS "u" ("b", "v")
+        unnest(
+            "eec"."base_urls", ("eec"."versions"::text [])
+        ) WITH ORDINALITY AS "u" ("b", "v", "ordinality")
     WHERE
-        "eit"."entity_edition_id"
+        "eec"."entity_edition_id"
         = "entity_temporal_metadata_0_0_0"."entity_edition_id"
-) AS "entity_is_of_type_ids_0_0_2"
+        AND "u"."ordinality" <= "eec"."direct_types"
+) AS "entity_edition_cache_0_0_2"
     ON TRUE
 LEFT OUTER JOIN "entity_has_left_entity" AS "entity_has_left_entity_0_0_4"
     ON

--- a/libs/@local/hashql/eval/tests/ui/postgres/filter/property_mask.snap
+++ b/libs/@local/hashql/eval/tests/ui/postgres/filter/property_mask.snap
@@ -89,7 +89,7 @@ SELECT
             END
         )
     ) AS "temporal_versioning",
-    "entity_is_of_type_ids_0_0_2"."entity_type_ids" AS "entity_type_ids",
+    "entity_edition_cache_0_0_2"."entity_type_ids" AS "entity_type_ids",
     "entity_editions_0_0_1"."archived" AS "archived",
     "entity_editions_0_0_1"."confidence" AS "confidence",
     "entity_ids_0_0_3"."provenance" AS "provenance_inferred",
@@ -121,13 +121,16 @@ LEFT OUTER JOIN LATERAL (
         jsonb_agg(
             jsonb_build_object(($12::text), "b", ($13::text), "v")
         ) AS "entity_type_ids"
-    FROM "entity_is_of_type_ids" AS "eit"
+    FROM "entity_edition_cache" AS "eec"
     CROSS JOIN LATERAL
-        unnest("eit"."base_urls", ("eit"."versions"::text [])) AS "u" ("b", "v")
+        unnest(
+            "eec"."base_urls", ("eec"."versions"::text [])
+        ) WITH ORDINALITY AS "u" ("b", "v", "ordinality")
     WHERE
-        "eit"."entity_edition_id"
+        "eec"."entity_edition_id"
         = "entity_temporal_metadata_0_0_0"."entity_edition_id"
-) AS "entity_is_of_type_ids_0_0_2"
+        AND "u"."ordinality" <= "eec"."direct_types"
+) AS "entity_edition_cache_0_0_2"
     ON TRUE
 LEFT OUTER JOIN "entity_has_left_entity" AS "entity_has_left_entity_0_0_4"
     ON

--- a/libs/@local/hashql/eval/tests/ui/postgres/filter/provides_drives_select_and_joins.snap
+++ b/libs/@local/hashql/eval/tests/ui/postgres/filter/provides_drives_select_and_joins.snap
@@ -84,7 +84,7 @@ SELECT
             END
         )
     ) AS "temporal_versioning",
-    "entity_is_of_type_ids_0_0_2"."entity_type_ids" AS "entity_type_ids",
+    "entity_edition_cache_0_0_2"."entity_type_ids" AS "entity_type_ids",
     "entity_editions_0_0_1"."archived" AS "archived",
     "entity_editions_0_0_1"."confidence" AS "confidence",
     "entity_ids_0_0_3"."provenance" AS "provenance_inferred",
@@ -113,13 +113,16 @@ LEFT OUTER JOIN LATERAL (
         jsonb_agg(
             jsonb_build_object(($12::text), "b", ($13::text), "v")
         ) AS "entity_type_ids"
-    FROM "entity_is_of_type_ids" AS "eit"
+    FROM "entity_edition_cache" AS "eec"
     CROSS JOIN LATERAL
-        unnest("eit"."base_urls", ("eit"."versions"::text [])) AS "u" ("b", "v")
+        unnest(
+            "eec"."base_urls", ("eec"."versions"::text [])
+        ) WITH ORDINALITY AS "u" ("b", "v", "ordinality")
     WHERE
-        "eit"."entity_edition_id"
+        "eec"."entity_edition_id"
         = "entity_temporal_metadata_0_0_0"."entity_edition_id"
-) AS "entity_is_of_type_ids_0_0_2"
+        AND "u"."ordinality" <= "eec"."direct_types"
+) AS "entity_edition_cache_0_0_2"
     ON TRUE
 LEFT OUTER JOIN "entity_has_left_entity" AS "entity_has_left_entity_0_0_4"
     ON


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The entity-type aggregate views dominated `queryEntitySubgraph` runtime: every type filter/sort multiplied rows through `entity_is_of_type` ⋈ ontology joins and forced `DISTINCT ON`. This PR materializes the per-edition aggregates into a new `entity_edition_cache` table maintained on the write path. 

## 🔗 Related links

- [BE-596](https://linear.app/hash/issue/BE-596) _(internal)_

## 🔍 What does this change?

- New `entity_edition_cache` table: `direct_types` count + parallel arrays `labels`, `type_titles`, `base_urls`, `versions`, `versioned_urls` (all inheritance depths, canonical ordering; direct types as array prefix), GIN on `base_urls`/`versioned_urls`
- Migrations in both systems: production `V51` (create + backfill + drop the 7 aggregate views), test-only `v009` updated inline
- Write path populates the cache on entity creation, snapshot restore, and entity-type reindex (`reindex_entity_cache`)
- Read path uses the cache: `Relation::EntityEditionCache`, `TypeVersionedUrls`/`DirectTypeCount` paths, `(labels)[1]` via `Expression::ArrayElement`; HashQL projections unnest from the cache
- Nullable TEXT sort keys decode via `Option<CursorField>`; `Last*` DESC-flip variants removed
- **Behaviour change**: `typeBaseUrls` (and the email-masking rule built on it) is now inheritance-aware — the dropped `entity_is_of_type_ids` view only listed direct types. Entities whose direct type inherits from `user` now get email masking applied; previously their email was exposed.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

- Rolling deploy: writes between the `V51` backfill and the code going live miss the cache — run `reindex-cache --entities` once post-deploy (noted in the migration)
- Dedicated integration tests for the cache (inheritance round-trip, reindex equivalence, label fixtures) follow separately

## 🐾 Next steps

- BE-597 (array type filters), BE-598 (keys-then-hydrate), BE-599 (summary aggregations in SQL), BE-600 (filter selectivity)

## 🛡 What tests cover this?

- Existing suites green (256 lib, 95 insta, 59 compiletest; clippy clean); both migration chains validated up+down
- Backfill validated for result equivalence against the dropped views on a 1.9M-edition dataset (0 mismatches)

## ❓ How to test this?

1. Run `migrate` against an existing database — the backfill populates `entity_edition_cache`
2. Query entities with type filters, label/type-title sorting, `includeTypeIds` — identical results, no aggregate-view joins in the compiled SQL
3. `cd tests/graph/http && sh test.sh`

