### PR TITLE
FE-751: Style username in signup-registration messaging

### DIFF
--- a/apps/hash-frontend/src/pages/signup.page/signup-registration-right-info.tsx
+++ b/apps/hash-frontend/src/pages/signup.page/signup-registration-right-info.tsx
@@ -10,7 +10,11 @@ import { PizzaSolidIcon } from "../../shared/icons/pizza-solid-icon";
 
 import type { FunctionComponent, ReactNode } from "react";
 
-const infoItems: { title: string; description: string; icon: ReactNode }[] = [
+const infoItems: {
+  title: string;
+  description: React.ReactNode;
+  icon: ReactNode;
+}[] = [
   /** @todo: add this info item when email verification is supported */
   // {
   //   title: "Skip email verification",
@@ -25,7 +29,11 @@ const infoItems: { title: string; description: string; icon: ReactNode }[] = [
   },
   {
     title: "Reserve your username",
-    description: "@pizza goes fast!",
+    description: (
+      <>
+        <code>@pizza</code> goes fast!
+      </>
+    ),
     icon: <PizzaSolidIcon />,
   },
 ];
@@ -79,6 +87,16 @@ export const SignupRegistrationRightInfo: FunctionComponent = () => {
                 color: ({ palette }) => palette.blue[40],
                 fontSize: 14,
                 lineHeight: "130%",
+                code: {
+                  fontFamily:
+                    'Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+                  fontSize: "0.85em",
+                  color: ({ palette }) => palette.blue[25],
+                  background: "rgba(255, 255, 255, 0.1)",
+                  borderRadius: "4px",
+                  paddingX: 0.75,
+                  paddingY: 0.25,
+                },
               }}
             >
               {description}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Adds a small amount of styling to help improve the comprehension of the messaging on the user signup page by making it clear that @pizza is a username.

Although personally, I still find that the copy reads uncomfortably and I think updating the copy would be a better fix. Here's a couple alternatives I cobbled together that I think could work better:
- Before someone else grabs @pizza _(if we want to run with a subtle pizza joke)_
- To get a short handle like @pizza _(neutral, but clear)_
- Be @you, not @you2087 _(if we want something with a bit more urgency/marketing copy - may need to reserve those usernames though)_

@vilkinsons let me know if you prefer any of them and I'll switch them over - otherwise I'll just keep the original messaging.

Finally - the new styles:
<img width="1240" height="611" alt="Screenshot 2026-06-11 at 15 37 42" src="https://github.com/user-attachments/assets/35aa12e1-544a-4d47-9beb-a78792195a9b" />

(And old for reference):
<img width="382" height="247" alt="Screenshot 2026-06-11 at 15 33 37" src="https://github.com/user-attachments/assets/e7dc567c-c66d-4af7-8b55-aa6f8f91e8a3" />

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change
