### PR TITLE
FE-856: Fix jsx leaked render + broken entity table filtering in hash-frontend

### DIFF
--- a/apps/hash-api/src/graph/knowledge/system-types/notification.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/notification.ts
@@ -513,32 +513,6 @@ export const getCommentNotification: ImpureGraphFunction<
           {
             equal: [{ path: ["webId"] }, { parameter: recipient.accountId }],
           },
-          /** @todo: enforce the type of these links somehow */
-          {
-            any: [
-              {
-                not: {
-                  exists: {
-                    path: [
-                      "properties",
-                      systemPropertyTypes.archived.propertyTypeBaseUrl,
-                    ],
-                  },
-                },
-              },
-              {
-                equal: [
-                  {
-                    path: [
-                      "properties",
-                      systemPropertyTypes.archived.propertyTypeBaseUrl,
-                    ],
-                  },
-                  { parameter: false },
-                ],
-              },
-            ],
-          },
         ],
       },
       traversalPaths: [

--- a/apps/hash-frontend/eslint.config.js
+++ b/apps/hash-frontend/eslint.config.js
@@ -1,3 +1,5 @@
+import reactX from "eslint-plugin-react-x";
+
 import {
   defineConfig,
   createBase,
@@ -15,9 +17,13 @@ export default [
   ]),
   ...defineConfig([
     {
+      plugins: {
+        "react-x": reactX,
+      },
       rules: {
         "jsx-a11y/label-has-associated-control": "off",
         "import/no-default-export": "error",
+        "react-x/no-leaked-conditional-rendering": "error",
         "no-restricted-imports": [
           "error",
           {

--- a/apps/hash-frontend/package.json
+++ b/apps/hash-frontend/package.json
@@ -158,6 +158,7 @@
     "@types/url-regex-safe": "1.0.2",
     "@welldone-software/why-did-you-render": "10.0.1",
     "eslint": "9.39.4",
+    "eslint-plugin-react-x": "1.17.2",
     "graphology-types": "0.24.8",
     "rimraf": "6.1.3",
     "sass": "1.93.2",

--- a/apps/hash-frontend/src/pages/@/[shortname]/shared/flow-visualizer/outputs.tsx
+++ b/apps/hash-frontend/src/pages/@/[shortname]/shared/flow-visualizer/outputs.tsx
@@ -223,7 +223,7 @@ const SectionTabButton = ({
           {label}
         </Typography>
       </IconButton>
-      {additionalControlElements && (
+      {additionalControlElements ? (
         <Collapse
           orientation="horizontal"
           in={active}
@@ -231,7 +231,7 @@ const SectionTabButton = ({
         >
           {additionalControlElements}
         </Collapse>
-      )}
+      ) : null}
     </Stack>
   );
 };

--- a/apps/hash-frontend/src/pages/shared/entities-visualizer/data/build-filter.ts
+++ b/apps/hash-frontend/src/pages/shared/entities-visualizer/data/build-filter.ts
@@ -1,5 +1,4 @@
 import { ignoreNoisySystemTypesFilter } from "@local/hash-isomorphic-utils/graph-queries";
-import { systemPropertyTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 
 import type { EntitiesFilterState } from "./types";
 import type { BaseUrl, VersionedUrl, WebId } from "@blockprotocol/type-system";
@@ -15,29 +14,6 @@ const buildArchivedClauses = (includeArchived: boolean): Filter[] => {
   return [
     {
       notEqual: [{ path: ["archived"] }, { parameter: true }],
-    },
-    {
-      any: [
-        {
-          exists: {
-            path: [
-              "properties",
-              systemPropertyTypes.archived.propertyTypeBaseUrl,
-            ],
-          },
-        },
-        {
-          equal: [
-            {
-              path: [
-                "properties",
-                systemPropertyTypes.archived.propertyTypeBaseUrl,
-              ],
-            },
-            { parameter: false },
-          ],
-        },
-      ],
     },
   ];
 };

--- a/apps/hash-frontend/src/pages/shared/entities-visualizer/entities-table.tsx
+++ b/apps/hash-frontend/src/pages/shared/entities-visualizer/entities-table.tsx
@@ -791,7 +791,7 @@ export const EntitiesTable: FunctionComponent<
   }, [rows.length]);
 
   const hasMoreRowsAvailable =
-    totalResultCount && totalResultCount > rows.length;
+    !!totalResultCount && totalResultCount > rows.length;
   const loadMoreRowHeight = 60;
 
   return (

--- a/apps/hash-frontend/src/pages/shared/not-found.tsx
+++ b/apps/hash-frontend/src/pages/shared/not-found.tsx
@@ -86,7 +86,7 @@ export const NotFound = ({
               are logged in as{" "}
               <strong>{authenticatedUser.emails[0]?.address}</strong>
             </Typography>
-            {additionalText && (
+            {additionalText ? (
               <Typography
                 component="p"
                 variant="regularTextParagraphs"
@@ -94,7 +94,7 @@ export const NotFound = ({
               >
                 {additionalText}
               </Typography>
-            )}
+            ) : null}
             <Box mt={5}>
               <GoBackButton />
             </Box>

--- a/apps/hash-frontend/src/shared/use-entity-type-entities.tsx
+++ b/apps/hash-frontend/src/shared/use-entity-type-entities.tsx
@@ -10,7 +10,6 @@ import {
   currentTimeInstantTemporalAxes,
   ignoreNoisySystemTypesFilter,
 } from "@local/hash-isomorphic-utils/graph-queries";
-import { systemPropertyTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 
 import { queryEntitySubgraphQuery } from "../graphql/queries/knowledge/entity.queries";
 import { apolloClient } from "../lib/apollo-client";
@@ -62,31 +61,6 @@ export const generateUseEntityTypeEntitiesFilter = ({
       ? [
           {
             notEqual: [{ path: ["archived"] }, { parameter: true }],
-          },
-          {
-            any: [
-              {
-                not: {
-                  exists: {
-                    path: [
-                      "properties",
-                      systemPropertyTypes.archived.propertyTypeBaseUrl,
-                    ],
-                  },
-                },
-              },
-              {
-                equal: [
-                  {
-                    path: [
-                      "properties",
-                      systemPropertyTypes.archived.propertyTypeBaseUrl,
-                    ],
-                  },
-                  { parameter: false },
-                ],
-              },
-            ],
           },
         ]
       : []),

--- a/yarn.lock
+++ b/yarn.lock
@@ -653,6 +653,7 @@ __metadata:
     elkjs: "npm:0.11.0"
     emoji-mart: "npm:5.6.0"
     eslint: "npm:9.39.4"
+    eslint-plugin-react-x: "npm:1.17.2"
     fractional-indexing: "npm:3.2.0"
     framer-motion: "npm:11.18.2"
     graphology: "npm:0.26.0"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

- adds `react-x/no-leaked-conditional-rendering` to hash-frontend eslint. eslint-plugin-react-x is typeaware so is better then eslint-plugin-react. Also fixes any existing issues found
- also fixes broken entity table filtering

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change
