### PR TITLE
H-6604: Fix entity type icon rendering for relative URLs

### DIFF
--- a/apps/hash-frontend/src/pages/@/[shortname].page/edit-pinned-entity-types-modal.tsx
+++ b/apps/hash-frontend/src/pages/@/[shortname].page/edit-pinned-entity-types-modal.tsx
@@ -6,7 +6,7 @@ import { createPortal } from "react-dom";
 import { useFieldArray, useForm } from "react-hook-form";
 
 import {
-  AsteriskRegularIcon,
+  EntityOrTypeIcon,
   IconButton,
   XMarkRegularIcon,
 } from "@hashintel/design-system";
@@ -21,7 +21,6 @@ import { updateEntityMutation } from "../../../graphql/queries/knowledge/entity.
 import { useLatestEntityTypesOptional } from "../../../shared/entity-types-context/hooks";
 import { generateLinkParameters } from "../../../shared/generate-link-parameters";
 import { ArrowUpRightRegularIcon } from "../../../shared/icons/arrow-up-right-regular-icon";
-import { CustomLinkIcon } from "../../../shared/icons/custom-link-icon";
 import { GripDotsVerticalRegularIcon } from "../../../shared/icons/grip-dots-vertical-regular-icon";
 import { PlusRegularIcon } from "../../../shared/icons/plus-regular";
 import { Button, Link, Modal } from "../../../shared/ui";
@@ -328,23 +327,20 @@ export const EditPinnedEntityTypesModal: FunctionComponent<
                                   justifyContent: "center",
                                 }}
                               >
-                                {field.schema.icon ??
-                                  (isSpecialEntityTypeLookup?.[field.schema.$id]
-                                    ?.isLink ? (
-                                    <CustomLinkIcon
-                                      sx={{
-                                        fontSize: 22,
-                                        marginLeft: -0.75,
-                                        marginRight: -0.75,
-                                      }}
-                                    />
-                                  ) : (
-                                    (entityTypeIcons[field.schema.$id] ?? (
-                                      <AsteriskRegularIcon
-                                        sx={{ fontSize: 12 }}
-                                      />
-                                    ))
-                                  ))}
+                                <EntityOrTypeIcon
+                                  entity={null}
+                                  icon={
+                                    field.schema.icon ??
+                                    entityTypeIcons[field.schema.$id]
+                                  }
+                                  isLink={
+                                    !!isSpecialEntityTypeLookup?.[
+                                      field.schema.$id
+                                    ]?.isLink
+                                  }
+                                  fontSize={14}
+                                  fill={({ palette }) => palette.blue[70]}
+                                />
                               </Box>
                               <Typography
                                 sx={{

--- a/apps/hash-frontend/src/pages/actions.page/draft-entities/draft-entities-filters.tsx
+++ b/apps/hash-frontend/src/pages/actions.page/draft-entities/draft-entities-filters.tsx
@@ -6,18 +6,19 @@ import {
   extractBaseUrl,
   extractWebIdFromEntityId,
 } from "@blockprotocol/type-system";
-import { WandMagicSparklesIcon } from "@hashintel/design-system";
+import {
+  EntityOrTypeIcon,
+  WandMagicSparklesIcon,
+} from "@hashintel/design-system";
 
 import { useOrgs } from "../../../components/hooks/use-orgs";
 import { useUsers } from "../../../components/hooks/use-users";
-import { AsteriskLightIcon } from "../../../shared/icons/asterisk-light-icon";
 import { CalendarDayLightIcon } from "../../../shared/icons/calendar-day-light-icon";
 import { CalendarDaysLightIcon } from "../../../shared/icons/calendar-days-light-icon";
 import { CalendarLightIcon } from "../../../shared/icons/calendar-light-icon";
 import { CalendarWeekLightIcon } from "../../../shared/icons/calendar-week-light-icon";
 import { CalendarsLightIcon } from "../../../shared/icons/calendars-light-icon";
 import { HashSolidIcon } from "../../../shared/icons/hash-solid-icon";
-import { LinkRegularIcon } from "../../../shared/icons/link-regular-icon";
 import { UserIcon } from "../../../shared/icons/user-icon";
 import { UsersRegularIcon } from "../../../shared/icons/users-regular-icon";
 import { Button } from "../../../shared/ui";
@@ -353,14 +354,15 @@ export const DraftEntitiesFilters: FunctionComponent<{
             const { baseUrl, icon, isLink, title } = entityType;
 
             return {
-              icon: icon ? (
-                <Box marginRight={1.25} maxWidth={14} component="span">
-                  {icon}
-                </Box>
-              ) : isLink ? (
-                <LinkRegularIcon />
-              ) : (
-                <AsteriskLightIcon />
+              icon: (
+                <EntityOrTypeIcon
+                  entity={null}
+                  icon={icon}
+                  isLink={isLink}
+                  fontSize={14}
+                  fill={({ palette }) => palette.gray[50]}
+                  sx={{ mr: 1.25 }}
+                />
               ),
               label: title,
               value: baseUrl,

--- a/apps/hash-frontend/src/pages/shared/entity-type-page/shared/entity-type-header.tsx
+++ b/apps/hash-frontend/src/pages/shared/entity-type-page/shared/entity-type-header.tsx
@@ -11,6 +11,7 @@ import {
 import {
   ArrowUpRightFromSquareRegularIcon,
   ArrowUpRightIcon,
+  EntityOrTypeIcon,
   EntityTypeIcon,
   LinkTypeIcon,
 } from "@hashintel/design-system";
@@ -115,32 +116,37 @@ export const EntityTypeHeader = ({
                   control={control}
                   name="icon"
                   render={({ field }) => {
-                    const iconImgUrl = field.value?.startsWith("/")
-                      ? new URL(field.value, window.location.origin).href
-                      : field.value;
+                    const iconValue = field.value;
 
                     /**
                      * @todo allow uploading new SVG icons
                      */
-                    if (iconImgUrl?.startsWith("http")) {
+                    if (
+                      typeof iconValue === "string" &&
+                      (iconValue.startsWith("http") ||
+                        iconValue.startsWith("/"))
+                    ) {
                       return (
                         <Box
-                          sx={({ palette }) => ({
-                            backgroundColor: palette.gray[50],
-                            webkitMask: `url(${iconImgUrl}) no-repeat center / contain`,
-                            mask: `url(${iconImgUrl}) no-repeat center / contain`,
-                            width: 40,
-                            height: 40,
+                          sx={{
                             position: "relative",
                             top: entityTypeNameSize.lineHeight / 2 - 20,
-                          })}
-                        />
+                          }}
+                        >
+                          <EntityOrTypeIcon
+                            entity={null}
+                            icon={iconValue}
+                            isLink={isLink}
+                            fontSize={40}
+                            fill={({ palette }) => palette.gray[50]}
+                          />
+                        </Box>
                       );
                     }
 
                     return (
                       <EditEmojiIconButton
-                        icon={field.value}
+                        icon={iconValue}
                         disabled={isReadonly}
                         onChange={(updatedIcon) => field.onChange(updatedIcon)}
                         defaultIcon={

--- a/apps/hash-frontend/src/pages/shared/graph-visualizer/graph-container/graph-data-loader.tsx
+++ b/apps/hash-frontend/src/pages/shared/graph-visualizer/graph-container/graph-data-loader.tsx
@@ -47,6 +47,10 @@ export const GraphDataLoader = memo(({ edges, nodes }: GraphLoaderProps) => {
         !!node.icon?.startsWith("https://") ||
         node.icon?.startsWith("/");
 
+      const imageUrl = node.icon?.startsWith("/")
+        ? new URL(node.icon, window.location.origin).href
+        : node.icon;
+
       graph.addNode(node.nodeId, {
         borderColor: node.borderColor ?? node.color,
         /**
@@ -58,7 +62,7 @@ export const GraphDataLoader = memo(({ edges, nodes }: GraphLoaderProps) => {
         x: index % 20,
         y: Math.floor(index / 20),
         iconColor: customColors.gray[10],
-        image: node.icon,
+        image: imageUrl,
         label: node.label,
         nodeId: node.nodeId,
         nodeTypeId: node.nodeTypeId,

--- a/apps/hash-frontend/src/pages/shared/graph-visualizer/graph-container/graph-data-loader.tsx
+++ b/apps/hash-frontend/src/pages/shared/graph-visualizer/graph-container/graph-data-loader.tsx
@@ -43,7 +43,7 @@ export const GraphDataLoader = memo(({ edges, nodes }: GraphLoaderProps) => {
       }
 
       const hasUrlImage =
-        !!node.icon?.startsWith("http") ||
+        !!node.icon?.startsWith("http://") ||
         !!node.icon?.startsWith("https://") ||
         node.icon?.startsWith("/");
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 🌟 What is the purpose of this PR?

This PR fixes broken entity type icon rendering when the `icon` field contains a relative URL (e.g., `/icon/types/cubes.svg`). Some components were rendering the raw icon value directly instead of using the `EntityOrTypeIcon` component, which handles URL conversion properly.

## 🔗 Related links

- Linear issue: H-6604
- Reference implementation: `entity-or-type-sidebar-item.tsx` (already fixed)

## 🔍 What does this change?

- **`draft-entities-filters.tsx`**: Replaced direct icon rendering with `EntityOrTypeIcon` component for filter type icons
- **`entity-type-header.tsx`**: Replaced manual URL conversion and mask styling with `EntityOrTypeIcon` component
- **`graph-data-loader.tsx`**: Added relative URL to absolute URL conversion before passing icons to the graph visualization library
- **`edit-pinned-entity-types-modal.tsx`**: Replaced direct icon rendering in the pinned types selector (profile page) with `EntityOrTypeIcon`, which previously displayed the raw relative URL string

All changes follow the pattern established in `entity-or-type-sidebar-item.tsx`, which was already correctly using `EntityOrTypeIcon`.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- Existing tests that cover these components should continue to pass
- Manual testing with entity types that have relative URL icons

## ❓ How to test this?

1. Checkout the branch
2. Navigate to the Inbox/Actions page (with draft entities)
3. Check the filter panel on the left - entity type icons should now render correctly
4. Navigate to an entity type page and verify the header icon renders correctly
5. Open the graph visualizer and confirm entity type icons display properly
6. Open the "Pinned types" editor on a user/org profile page and confirm type icons render correctly (not as raw URLs)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [H-6604](https://linear.app/hash/issue/H-6604/fix-entity-type-icon-rendering-for-relative-urls)

<div><a href="https://cursor.com/agents/bc-e6eb0cd4-ee43-4ccd-af31-8a9f947276e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e6eb0cd4-ee43-4ccd-af31-8a9f947276e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

