### PR TITLE
BE-617: Index `entity_is_of_type` for type-filtered lookups

### DIFF
--- a/libs/@local/graph/migrations/graph-migrations/v009__entities/up.sql
+++ b/libs/@local/graph/migrations/graph-migrations/v009__entities/up.sql
@@ -86,6 +86,13 @@ CREATE TABLE entity_is_of_type (
     PRIMARY KEY (entity_edition_id, entity_type_ontology_id)
 );
 
+-- The primary key leads with `entity_edition_id` (the "edition -> types" direction used by
+-- cache builds), so type-filtered lookups cannot use it and fall back to a full scan. This
+-- index leads with the type to make those lookups index-driven, with `entity_edition_id`
+-- trailing to cover the join back to editions.
+CREATE INDEX entity_is_of_type_type_lookup
+ON entity_is_of_type (entity_type_ontology_id, entity_edition_id);
+
 CREATE TYPE entity_edge_kind AS ENUM ('has-left-entity', 'has-right-entity');
 CREATE TYPE edge_direction AS ENUM ('outgoing', 'incoming');
 

--- a/libs/@local/graph/postgres-store/postgres_migrations/V52__entity_is_of_type_type_index.sql
+++ b/libs/@local/graph/postgres-store/postgres_migrations/V52__entity_is_of_type_type_index.sql
@@ -1,0 +1,7 @@
+-- Index for filtering entities by type. The leading `entity_type_ontology_id` lets an
+-- equality predicate on the type drive an index scan; the existing
+-- `unique_entity_is_of_type` leads with `entity_edition_id` and so only serves the reverse
+-- "edition -> types" direction (cache builds, projections). The trailing
+-- `entity_edition_id` makes the index covering for the join back to editions.
+CREATE INDEX entity_is_of_type_type_lookup
+    ON entity_is_of_type (entity_type_ontology_id, entity_edition_id);


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Type-filtered entity lookups sequentially scanned the whole `entity_is_of_type` table even when the type was hyper-selective. The worst case is the per-request `getUserByKratosIdentityId` auth lookup — it filters on the `User` type but scanned millions on **every authenticated request**.

## 🔗 Related links

- [BE-617](https://linear.app/hash/issue/BE-617)

## 🔍 What does this change?

- Adds the index in both migration systems: `postgres_migrations/V52__entity_is_of_type_type_index.sql` (incremental) and `graph-migrations/v009__entities/up.sql` (consolidated).

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

- [x] do not affect the execution graph

## ⚠️ Known issues

- The planner still mis-estimates the type's selectivity (163k est. vs 3 actual in my test) but picks the index anyway; could bite other path choices (BE-600 / statistics).
