### PR TITLE
BE-467: Remove `Default` impl from `QueryTemporalAxesUnresolved`

### DIFF
--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
@@ -685,10 +685,7 @@ where
                         entities
                             .iter()
                             .map(|entity| entity.metadata.entity_type_ids.clone()),
-                        QueryTemporalAxesUnresolved::DecisionTime {
-                            pinned: PinnedTemporalAxisUnresolved::new(None),
-                            variable: VariableTemporalAxisUnresolved::new(None, None),
-                        },
+                        QueryTemporalAxesUnresolved::live_only(),
                         None,
                     )
                     .await?
@@ -1527,10 +1524,7 @@ where
                                 .entities
                                 .values()
                                 .map(|entity| entity.metadata.entity_type_ids.clone()),
-                            QueryTemporalAxesUnresolved::DecisionTime {
-                                pinned: PinnedTemporalAxisUnresolved::new(None),
-                                variable: VariableTemporalAxisUnresolved::new(None, None),
-                            },
+                            QueryTemporalAxesUnresolved::live_only(),
                             None,
                         )
                         .await?

--- a/libs/@local/graph/postgres-store/src/store/postgres/ontology/data_type.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/ontology/data_type.rs
@@ -27,10 +27,7 @@ use hash_graph_store::{
             TraversalEdge,
         },
         identifier::{DataTypeVertexId, GraphElementVertexId},
-        temporal_axes::{
-            PinnedTemporalAxisUnresolved, QueryTemporalAxes, QueryTemporalAxesUnresolved,
-            VariableAxis, VariableTemporalAxisUnresolved,
-        },
+        temporal_axes::{QueryTemporalAxes, QueryTemporalAxesUnresolved, VariableAxis},
     },
 };
 use hash_graph_temporal_versioning::{RightBoundedTemporalInterval, Timestamp, TransactionTime};
@@ -625,10 +622,7 @@ where
                             parameters: ParameterList::DataTypeIds(&required_reference_ids),
                         },
                     ),
-                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                        pinned: PinnedTemporalAxisUnresolved::new(None),
-                        variable: VariableTemporalAxisUnresolved::new(None, None),
-                    },
+                    temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                     after: None,
                     limit: None,
                     include_count: false,
@@ -1055,10 +1049,7 @@ where
                             parameters: ParameterList::DataTypeIds(&required_parent_ids),
                         },
                     ),
-                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                        pinned: PinnedTemporalAxisUnresolved::new(None),
-                        variable: VariableTemporalAxisUnresolved::new(None, None),
-                    },
+                    temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                     after: None,
                     limit: None,
                     include_count: false,
@@ -1599,11 +1590,7 @@ where
         authenticated_actor: AuthenticatedActor,
         params: HasPermissionForDataTypesParams<'_>,
     ) -> Result<HashSet<VersionedUrl>, Report<hash_graph_store::error::CheckPermissionError>> {
-        let temporal_axes = QueryTemporalAxesUnresolved::DecisionTime {
-            pinned: PinnedTemporalAxisUnresolved::new(None),
-            variable: VariableTemporalAxisUnresolved::new(None, None),
-        }
-        .resolve();
+        let temporal_axes = QueryTemporalAxesUnresolved::live_only().resolve();
         let mut compiler = SelectCompiler::new(Some(&temporal_axes), true);
 
         let data_type_uuids = params

--- a/libs/@local/graph/postgres-store/src/store/postgres/ontology/entity_type.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/ontology/entity_type.rs
@@ -32,10 +32,7 @@ use hash_graph_store::{
             SubgraphTraversalParams, TraversalEdge,
         },
         identifier::{EntityTypeVertexId, GraphElementVertexId, PropertyTypeVertexId},
-        temporal_axes::{
-            PinnedTemporalAxisUnresolved, QueryTemporalAxes, QueryTemporalAxesUnresolved,
-            VariableAxis, VariableTemporalAxisUnresolved,
-        },
+        temporal_axes::{QueryTemporalAxes, QueryTemporalAxesUnresolved, VariableAxis},
     },
 };
 use hash_graph_temporal_versioning::{RightBoundedTemporalInterval, Timestamp, TransactionTime};
@@ -242,7 +239,7 @@ where
                     traversal_paths: Vec::new(),
                     request: QueryPropertyTypesParams {
                         filter: Filter::for_property_type_uuids(&property_type_uuids),
-                        temporal_axes: QueryTemporalAxesUnresolved::default(),
+                        temporal_axes: QueryTemporalAxesUnresolved::all(),
                         after: None,
                         limit: None,
                         include_count: false,
@@ -1005,10 +1002,7 @@ where
                                 parameters: ParameterList::EntityTypeIds(&required_reference_ids),
                             },
                         ),
-                        temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                            pinned: PinnedTemporalAxisUnresolved::new(None),
-                            variable: VariableTemporalAxisUnresolved::new(None, None),
-                        },
+                        temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                         after: None,
                         limit: None,
                         include_count: false,
@@ -1601,10 +1595,7 @@ where
                                 parameters: ParameterList::EntityTypeIds(&required_reference_ids),
                             },
                         ),
-                        temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                            pinned: PinnedTemporalAxisUnresolved::new(None),
-                            variable: VariableTemporalAxisUnresolved::new(None, None),
-                        },
+                        temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                         after: None,
                         limit: None,
                         include_count: false,
@@ -2051,11 +2042,7 @@ where
                 })
                 .collect()
         } else {
-            let temporal_axes = QueryTemporalAxesUnresolved::DecisionTime {
-                pinned: PinnedTemporalAxisUnresolved::new(None),
-                variable: VariableTemporalAxisUnresolved::new(None, None),
-            }
-            .resolve();
+            let temporal_axes = QueryTemporalAxesUnresolved::live_only().resolve();
             let mut compiler = SelectCompiler::new(Some(&temporal_axes), true);
 
             let entity_type_uuids = params

--- a/libs/@local/graph/postgres-store/src/store/postgres/ontology/property_type.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/ontology/property_type.rs
@@ -25,10 +25,7 @@ use hash_graph_store::{
             TraversalEdge,
         },
         identifier::{DataTypeVertexId, GraphElementVertexId, PropertyTypeVertexId},
-        temporal_axes::{
-            PinnedTemporalAxisUnresolved, QueryTemporalAxes, QueryTemporalAxesUnresolved,
-            VariableAxis, VariableTemporalAxisUnresolved,
-        },
+        temporal_axes::{QueryTemporalAxes, QueryTemporalAxesUnresolved, VariableAxis},
     },
 };
 use hash_graph_temporal_versioning::{RightBoundedTemporalInterval, Timestamp, TransactionTime};
@@ -1152,11 +1149,7 @@ where
         authenticated_actor: AuthenticatedActor,
         params: HasPermissionForPropertyTypesParams<'_>,
     ) -> Result<HashSet<VersionedUrl>, Report<hash_graph_store::error::CheckPermissionError>> {
-        let temporal_axes = QueryTemporalAxesUnresolved::DecisionTime {
-            pinned: PinnedTemporalAxisUnresolved::new(None),
-            variable: VariableTemporalAxisUnresolved::new(None, None),
-        }
-        .resolve();
+        let temporal_axes = QueryTemporalAxesUnresolved::live_only().resolve();
         let mut compiler = SelectCompiler::new(Some(&temporal_axes), true);
 
         let property_type_uuids = params

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/expression/where_clause.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/expression/where_clause.rs
@@ -137,7 +137,7 @@ mod tests {
     #[test]
     #[expect(clippy::too_many_lines)]
     fn transpile_where_expression() {
-        let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
+        let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
         let mut compiler = SelectCompiler::<DataTypeWithMetadata>::new(Some(&temporal_axes), false);
         let mut where_clause = WhereExpression::default();
         assert_eq!(where_clause.transpile_to_string(), "");

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/statement/select.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/statement/select.rs
@@ -157,7 +157,7 @@ mod tests {
 
     #[test]
     fn asterisk() {
-        let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
+        let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
         test_compilation(
             &SelectCompiler::<DataTypeWithMetadata>::with_asterisk(Some(&temporal_axes), false),
             r#"SELECT * FROM "ontology_temporal_metadata" AS "ontology_temporal_metadata_0_0_0""#,
@@ -167,7 +167,7 @@ mod tests {
 
     #[test]
     fn simple_expression() {
-        let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
+        let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
         let pinned_timestamp = temporal_axes.pinned_timestamp();
         let mut compiler =
             SelectCompiler::<DataTypeWithMetadata>::with_asterisk(Some(&temporal_axes), false);
@@ -203,7 +203,7 @@ mod tests {
 
     #[test]
     fn limited_temporal() {
-        let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
+        let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
         let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes), false);
         let filter = Filter::Equal(
             FilterExpression::Path {
@@ -260,7 +260,7 @@ mod tests {
 
     #[test]
     fn specific_version() {
-        let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
+        let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
         let pinned_timestamp = temporal_axes.pinned_timestamp();
         let mut compiler =
             SelectCompiler::<DataTypeWithMetadata>::with_asterisk(Some(&temporal_axes), false);
@@ -309,7 +309,7 @@ mod tests {
 
     #[test]
     fn latest_version() {
-        let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
+        let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
         let pinned_timestamp = temporal_axes.pinned_timestamp();
         let mut compiler =
             SelectCompiler::<DataTypeWithMetadata>::with_asterisk(Some(&temporal_axes), false);
@@ -343,7 +343,7 @@ mod tests {
 
     #[test]
     fn not_latest_version() {
-        let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
+        let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
         let pinned_timestamp = temporal_axes.pinned_timestamp();
         let mut compiler =
             SelectCompiler::<DataTypeWithMetadata>::with_asterisk(Some(&temporal_axes), false);
@@ -377,7 +377,7 @@ mod tests {
 
     #[test]
     fn property_type_by_referenced_data_types() {
-        let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
+        let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
         let pinned_timestamp = temporal_axes.pinned_timestamp();
         let mut compiler =
             SelectCompiler::<PropertyTypeWithMetadata>::with_asterisk(Some(&temporal_axes), false);
@@ -479,7 +479,7 @@ mod tests {
 
     #[test]
     fn property_type_by_referenced_property_types() {
-        let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
+        let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
         let pinned_timestamp = temporal_axes.pinned_timestamp();
         let mut compiler =
             SelectCompiler::<PropertyTypeWithMetadata>::with_asterisk(Some(&temporal_axes), false);
@@ -520,7 +520,7 @@ mod tests {
 
     #[test]
     fn entity_type_by_referenced_property_types() {
-        let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
+        let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
         let pinned_timestamp = temporal_axes.pinned_timestamp();
         let mut compiler =
             SelectCompiler::<EntityTypeWithMetadata>::with_asterisk(Some(&temporal_axes), false);
@@ -562,7 +562,7 @@ mod tests {
 
     #[test]
     fn entity_type_by_referenced_link_types() {
-        let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
+        let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
         let pinned_timestamp = temporal_axes.pinned_timestamp();
         let mut compiler =
             SelectCompiler::<EntityTypeWithMetadata>::with_asterisk(Some(&temporal_axes), false);
@@ -617,7 +617,7 @@ mod tests {
 
     #[test]
     fn entity_type_by_inheritance() {
-        let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
+        let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
         let pinned_timestamp = temporal_axes.pinned_timestamp();
         let mut compiler =
             SelectCompiler::<EntityTypeWithMetadata>::with_asterisk(Some(&temporal_axes), false);
@@ -665,7 +665,7 @@ mod tests {
 
     #[test]
     fn entity_simple_query() {
-        let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
+        let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
         let pinned_timestamp = temporal_axes.pinned_timestamp();
         let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes), false);
 
@@ -700,7 +700,7 @@ mod tests {
 
     #[test]
     fn entity_with_manual_selection() {
-        let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
+        let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
         let pinned_timestamp = temporal_axes.pinned_timestamp();
         let mut compiler = SelectCompiler::<Entity>::new(Some(&temporal_axes), true);
         compiler.add_distinct_selection_with_ordering(
@@ -753,7 +753,7 @@ mod tests {
 
     #[test]
     fn entity_property_query() {
-        let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
+        let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
         let pinned_timestamp = temporal_axes.pinned_timestamp();
         let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes), false);
         let json_path = JsonPath::from_path_tokens(vec![PathToken::Field(Cow::Borrowed(
@@ -794,7 +794,7 @@ mod tests {
 
     #[test]
     fn entity_property_null_query() {
-        let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
+        let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
         let pinned_timestamp = temporal_axes.pinned_timestamp();
         let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes), false);
         let json_path = JsonPath::from_path_tokens(vec![PathToken::Field(Cow::Borrowed(
@@ -828,7 +828,7 @@ mod tests {
 
     #[test]
     fn entity_outgoing_link_query() {
-        let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
+        let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
         let pinned_timestamp = temporal_axes.pinned_timestamp();
         let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes), false);
 
@@ -889,7 +889,7 @@ mod tests {
 
     #[test]
     fn entity_incoming_link_query() {
-        let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
+        let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
         let pinned_timestamp = temporal_axes.pinned_timestamp();
         let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes), false);
 
@@ -950,7 +950,7 @@ mod tests {
 
     #[test]
     fn link_entity_left_right_id() {
-        let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
+        let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
         let pinned_timestamp = temporal_axes.pinned_timestamp();
         let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes), false);
 
@@ -1043,7 +1043,7 @@ mod tests {
     #[test]
     #[expect(clippy::similar_names)]
     fn two_linked_entities() {
-        let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
+        let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
         let pinned_timestamp = temporal_axes.pinned_timestamp();
 
         let entity_a_uuid = Uuid::new_v4();
@@ -1143,7 +1143,7 @@ mod tests {
 
     #[test]
     fn filter_left_and_right() {
-        let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
+        let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
         let pinned_timestamp = temporal_axes.pinned_timestamp();
         let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes), false);
 
@@ -1245,7 +1245,7 @@ mod tests {
 
     #[test]
     fn filter_entity_by_type_versioned_url() {
-        let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
+        let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
         let pinned_timestamp = temporal_axes.pinned_timestamp();
         let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes), false);
 
@@ -1278,7 +1278,7 @@ mod tests {
 
     #[test]
     fn filter_entity_by_any_type_versioned_url() {
-        let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
+        let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
         let pinned_timestamp = temporal_axes.pinned_timestamp();
         let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes), false);
 
@@ -1319,7 +1319,7 @@ mod tests {
 
     #[test]
     fn filter_entity_by_all_type_versioned_url() {
-        let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
+        let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
         let pinned_timestamp = temporal_axes.pinned_timestamp();
         let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes), false);
 
@@ -1360,7 +1360,7 @@ mod tests {
 
     #[test]
     fn filter_entity_own_and_linked_type_stay_separate() {
-        let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
+        let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
         let pinned_timestamp = temporal_axes.pinned_timestamp();
         let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes), false);
 
@@ -1440,7 +1440,7 @@ mod tests {
 
     #[test]
     fn filter_entity_by_no_type_versioned_url() {
-        let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
+        let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
         let pinned_timestamp = temporal_axes.pinned_timestamp();
         let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes), false);
 
@@ -1488,7 +1488,7 @@ mod tests {
 
     #[test]
     fn filter_entity_by_type_starts_with_rejected() {
-        let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
+        let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
         let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes), false);
 
         // String operations have no scalar to operate on once the path resolves to the
@@ -1524,7 +1524,7 @@ mod tests {
 
     #[test]
     fn filter_entity_by_type_versioned_url_not_equal() {
-        let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
+        let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
         let pinned_timestamp = temporal_axes.pinned_timestamp();
         let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes), false);
 
@@ -1567,7 +1567,7 @@ mod tests {
 
     #[test]
     fn filter_entity_by_type_base_url() {
-        let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
+        let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
         let pinned_timestamp = temporal_axes.pinned_timestamp();
         let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes), false);
 
@@ -1645,7 +1645,7 @@ mod tests {
 
     #[test]
     fn sort_by_label_and_type_title() {
-        let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
+        let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
         let pinned_timestamp = temporal_axes.pinned_timestamp();
         let mut compiler = SelectCompiler::<Entity>::new(Some(&temporal_axes), true);
         compiler.add_distinct_selection_with_ordering(
@@ -1714,7 +1714,7 @@ mod tests {
                 },
             };
 
-            let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
+            let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
             let pinned_timestamp = temporal_axes.pinned_timestamp();
             let mut compiler =
                 SelectCompiler::<DataTypeWithMetadata>::with_asterisk(Some(&temporal_axes), false);
@@ -1744,7 +1744,7 @@ mod tests {
                 draft_id: None,
             };
 
-            let temporal_axes = QueryTemporalAxesUnresolved::default().resolve();
+            let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
             let pinned_timestamp = temporal_axes.pinned_timestamp();
             let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes), false);
 

--- a/libs/@local/graph/postgres-store/src/store/validation.rs
+++ b/libs/@local/graph/postgres-store/src/store/validation.rs
@@ -6,12 +6,8 @@ use error_stack::{Report, ResultExt as _, ensure};
 use futures::TryStreamExt as _;
 use hash_graph_authorization::policies::{PolicyComponents, action::ActionName};
 use hash_graph_store::{
-    error::QueryError,
-    filter::Filter,
-    query::Read as _,
-    subgraph::temporal_axes::{
-        PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved, VariableTemporalAxisUnresolved,
-    },
+    error::QueryError, filter::Filter, query::Read as _,
+    subgraph::temporal_axes::QueryTemporalAxesUnresolved,
 };
 use hash_graph_types::ontology::{DataTypeLookup, OntologyTypeProvider};
 use hash_graph_validation::EntityProvider;
@@ -161,13 +157,7 @@ where
                 .store
                 .read_one(
                     &filters,
-                    Some(
-                        &QueryTemporalAxesUnresolved::DecisionTime {
-                            pinned: PinnedTemporalAxisUnresolved::new(None),
-                            variable: VariableTemporalAxisUnresolved::new(None, None),
-                        }
-                        .resolve(),
-                    ),
+                    Some(&QueryTemporalAxesUnresolved::live_only().resolve()),
                     false,
                 )
                 .await;
@@ -216,13 +206,7 @@ where
             .store
             .read_one(
                 &filters,
-                Some(
-                    &QueryTemporalAxesUnresolved::DecisionTime {
-                        pinned: PinnedTemporalAxisUnresolved::new(None),
-                        variable: VariableTemporalAxisUnresolved::new(None, None),
-                    }
-                    .resolve(),
-                ),
+                Some(&QueryTemporalAxesUnresolved::live_only().resolve()),
                 false,
             )
             .await?;
@@ -405,13 +389,7 @@ where
             .store
             .read(
                 &filters,
-                Some(
-                    &QueryTemporalAxesUnresolved::DecisionTime {
-                        pinned: PinnedTemporalAxisUnresolved::new(None),
-                        variable: VariableTemporalAxisUnresolved::new(None, None),
-                    }
-                    .resolve(),
-                ),
+                Some(&QueryTemporalAxesUnresolved::live_only().resolve()),
                 false,
             )
             .await
@@ -498,13 +476,7 @@ where
             .store
             .read_closed_schemas(
                 &filters,
-                Some(
-                    &QueryTemporalAxesUnresolved::DecisionTime {
-                        pinned: PinnedTemporalAxisUnresolved::new(None),
-                        variable: VariableTemporalAxisUnresolved::new(None, None),
-                    }
-                    .resolve(),
-                ),
+                Some(&QueryTemporalAxesUnresolved::live_only().resolve()),
             )
             .await
             .change_context(QueryError)?
@@ -634,13 +606,7 @@ where
             .store
             .read_one(
                 &filters,
-                Some(
-                    &QueryTemporalAxesUnresolved::DecisionTime {
-                        pinned: PinnedTemporalAxisUnresolved::new(None),
-                        variable: VariableTemporalAxisUnresolved::new(None, None),
-                    }
-                    .resolve(),
-                ),
+                Some(&QueryTemporalAxesUnresolved::live_only().resolve()),
                 entity_id.draft_id.is_some(),
             )
             .await?;

--- a/libs/@local/graph/postgres-store/tests/deletion/drafts.rs
+++ b/libs/@local/graph/postgres-store/tests/deletion/drafts.rs
@@ -6,6 +6,7 @@ use hash_graph_store::{
         LinkDeletionBehavior, PatchEntityParams,
     },
     filter::Filter,
+    subgraph::temporal_axes::QueryTemporalAxesUnresolved,
 };
 use type_system::knowledge::entity::EntityId;
 
@@ -49,7 +50,7 @@ async fn draft_only_entity_promoted_to_full_delete() {
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Ignore,
                 },
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -127,7 +128,7 @@ async fn draft_of_published_entity_preserves_published() {
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Ignore,
                 },
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -196,7 +197,7 @@ async fn include_drafts_false_skips_drafts() {
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Ignore,
                 },
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -297,7 +298,7 @@ async fn partial_draft_match_not_promoted() {
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Ignore,
                 },
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -379,7 +380,7 @@ async fn published_and_draft_matched_becomes_full_delete() {
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Ignore,
                 },
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -458,7 +459,7 @@ async fn mixed_full_and_draft_targets() {
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Ignore,
                 },
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -543,7 +544,7 @@ async fn empty_target_guards() {
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Error,
                 },
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -629,7 +630,7 @@ async fn draft_link_entity_edge_survives() {
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Ignore,
                 },
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -662,7 +663,7 @@ async fn draft_link_entity_edge_survives() {
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Ignore,
                 },
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -766,7 +767,7 @@ async fn summary_counts_draft_ids_not_entities() {
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Ignore,
                 },
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )

--- a/libs/@local/graph/postgres-store/tests/deletion/erase.rs
+++ b/libs/@local/graph/postgres-store/tests/deletion/erase.rs
@@ -6,6 +6,7 @@ use hash_graph_store::{
         PatchEntityParams,
     },
     filter::Filter,
+    subgraph::temporal_axes::QueryTemporalAxesUnresolved,
 };
 use type_system::knowledge::property::{
     Property, PropertyObjectWithMetadata, PropertyPatchOperation, PropertyPath,
@@ -39,7 +40,7 @@ async fn removes_entity_ids_row() {
                 filter: Filter::for_entity_by_entity_id(entity_id),
                 include_drafts: false,
                 scope: DeletionScope::Erase,
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -83,7 +84,7 @@ async fn satellite_tables_cleaned() {
                 filter: Filter::for_entity_by_entity_id(entity_id),
                 include_drafts: false,
                 scope: DeletionScope::Erase,
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -172,7 +173,7 @@ async fn entity_with_history() {
                 filter: Filter::for_entity_by_entity_id(entity_id),
                 include_drafts: false,
                 scope: DeletionScope::Erase,
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -219,7 +220,7 @@ async fn double_deletion_is_noop() {
                 filter: Filter::for_entity_by_entity_id(entity_id),
                 include_drafts: false,
                 scope: DeletionScope::Erase,
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -243,7 +244,7 @@ async fn double_deletion_is_noop() {
                 filter: Filter::for_entity_by_entity_id(entity_id),
                 include_drafts: false,
                 scope: DeletionScope::Erase,
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -284,7 +285,7 @@ async fn entity_reuse_after_erase() {
                 filter: Filter::for_entity_by_entity_id(entity_id),
                 include_drafts: false,
                 scope: DeletionScope::Erase,
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -366,7 +367,7 @@ async fn promoted_draft_only_entity() {
                 filter: Filter::for_entity_by_entity_id(base_entity_id),
                 include_drafts: true,
                 scope: DeletionScope::Erase,
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -437,7 +438,7 @@ async fn erase_partial_draft_preserves_entity_ids() {
                 filter: Filter::for_entity_by_entity_id(draft_entity_id),
                 include_drafts: true,
                 scope: DeletionScope::Erase,
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )

--- a/libs/@local/graph/postgres-store/tests/deletion/links.rs
+++ b/libs/@local/graph/postgres-store/tests/deletion/links.rs
@@ -8,10 +8,11 @@ use hash_graph_store::{
     },
     error::DeletionError,
     filter::Filter,
+    subgraph::temporal_axes::QueryTemporalAxesUnresolved,
 };
 
 use crate::{
-    DatabaseTestWrapper, alice, bob, count_entity, create_link, create_person, find_all_axes,
+    DatabaseTestWrapper, alice, bob, count_entity, create_link, create_person,
     get_deletion_provenance, has_any_live_temporal_row, has_archived_provenance, is_entity_live,
     provenance, raw_count, raw_count_archived_temporal_rows, raw_count_entity_edge,
     raw_count_entity_edge_any, raw_entity_ids_exists, seed,
@@ -44,7 +45,7 @@ async fn purge_error_rejects_with_incoming_links() {
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Error,
                 },
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -95,7 +96,7 @@ async fn purge_ignore_succeeds_with_incoming_links() {
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Ignore,
                 },
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -148,7 +149,7 @@ async fn erase_rejects_with_incoming_links() {
                 filter: Filter::for_entity_by_entity_id(id_b),
                 include_drafts: false,
                 scope: DeletionScope::Erase,
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -215,7 +216,7 @@ async fn purge_link_entity_removes_all_edges() {
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Ignore,
                 },
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -289,7 +290,7 @@ async fn self_referential_batch_not_counted() {
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Error,
                 },
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -364,7 +365,7 @@ async fn draft_deletion_skips_link_check() {
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Error,
                 },
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -425,7 +426,7 @@ async fn incoming_link_count_is_accurate() {
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Error,
                 },
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -466,7 +467,7 @@ async fn self_loop_link() {
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Error,
                 },
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -492,7 +493,7 @@ async fn self_loop_link() {
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Error,
                 },
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -542,7 +543,7 @@ async fn chain_deletion() {
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Error,
                 },
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -565,7 +566,7 @@ async fn chain_deletion() {
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Ignore,
                 },
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -617,7 +618,7 @@ async fn bidirectional_links() {
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Error,
                 },
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -645,7 +646,7 @@ async fn bidirectional_links() {
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Error,
                 },
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -694,7 +695,7 @@ async fn erase_batch_excludes_in_batch_links() {
                 ]),
                 include_drafts: false,
                 scope: DeletionScope::Erase,
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -756,7 +757,7 @@ async fn erase_link_entity_alone_succeeds() {
                 filter: Filter::for_entity_by_entity_id(id_link),
                 include_drafts: false,
                 scope: DeletionScope::Erase,
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -823,7 +824,7 @@ async fn purge_archive_archives_incoming_link() {
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Archive,
                 },
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -898,7 +899,7 @@ async fn purge_archive_multiple_incoming_links() {
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Archive,
                 },
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -951,7 +952,7 @@ async fn purge_archive_batch_links_not_archived() {
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Archive,
                 },
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -992,7 +993,7 @@ async fn purge_archive_no_incoming_links() {
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Archive,
                 },
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -1040,7 +1041,7 @@ async fn purge_archive_chain() {
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Archive,
                 },
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -1086,7 +1087,7 @@ async fn purge_archive_self_loop() {
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Archive,
                 },
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -1165,7 +1166,7 @@ async fn purge_archive_includes_draft_link_versions() {
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Archive,
                 },
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -1225,7 +1226,7 @@ async fn erase_rejects_archived_incoming_links() {
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Archive,
                 },
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -1245,7 +1246,7 @@ async fn erase_rejects_archived_incoming_links() {
                 filter: Filter::for_entity_by_entity_id(id_b),
                 include_drafts: false,
                 scope: DeletionScope::Erase,
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -1284,7 +1285,7 @@ async fn purge_error_ignores_archived_links() {
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Archive,
                 },
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -1304,7 +1305,7 @@ async fn purge_error_ignores_archived_links() {
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Error,
                 },
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -1367,7 +1368,7 @@ async fn archive_creates_historical_temporal_rows() {
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Archive,
                 },
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -1401,10 +1402,10 @@ async fn archive_creates_historical_temporal_rows() {
 // temporal_axes controlling entity finding
 // ---------------------------------------------------------------------------
 
-/// Broad temporal axes find archived entities that `live_only_axes` miss.
+/// Broad temporal axes find archived entities that `live_only` miss.
 ///
-/// After archiving link L, `live_only_axes()` won't find it for deletion (returns 0 entities).
-/// `find_all_axes()` (unbounded decision time) finds the archived entity via its temporal
+/// After archiving link L, `live_only()` won't find it for deletion (returns 0 entities).
+/// `all()` (unbounded decision time) finds the archived entity via its temporal
 /// metadata rows (which still exist, just with closed `decision_time`).
 #[tokio::test]
 async fn broad_temporal_axes_find_archived_entities() {
@@ -1428,7 +1429,7 @@ async fn broad_temporal_axes_find_archived_entities() {
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Archive,
                 },
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -1446,7 +1447,7 @@ async fn broad_temporal_axes_find_archived_entities() {
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Ignore,
                 },
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -1455,7 +1456,7 @@ async fn broad_temporal_axes_find_archived_entities() {
 
     assert_eq!(summary_live.full_entities, 0);
 
-    // find_all_axes WILL find archived L
+    // `all()` WILL find archived L
     let summary_all = api
         .store
         .delete_entities(
@@ -1466,12 +1467,12 @@ async fn broad_temporal_axes_find_archived_entities() {
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Ignore,
                 },
-                temporal_axes: find_all_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::all(),
                 decision_time: None,
             },
         )
         .await
-        .expect("purge with find_all_axes should find the archived entity");
+        .expect("purge with `all()` should find the archived entity");
 
     assert_eq!(summary_all.full_entities, 1);
     assert!(
@@ -1486,8 +1487,8 @@ async fn broad_temporal_axes_find_archived_entities() {
 /// The scenario that originally triggered the `entity_is_of_type` FK violation:
 /// 1. Create A, B, and link L (A→B)
 /// 2. "User deletion": Purge A with `Archive` → L archived, A tombstoned
-/// 3. "resetGraph": Erase all with `find_all_axes()` → finds archived L and live B in one batch.
-///    Since L is in the batch, erase doesn't count it as external → succeeds.
+/// 3. "resetGraph": Erase all with `all()` → finds archived L and live B in one batch. Since L is
+///    in the batch, erase doesn't count it as external → succeeds.
 // TODO: Erase cannot find previously-purged tombstones (BE-466)
 //   https://linear.app/hash/issue/BE-466
 #[tokio::test]
@@ -1514,7 +1515,7 @@ async fn user_deletion_then_reset_graph() {
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Archive,
                 },
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -1536,7 +1537,7 @@ async fn user_deletion_then_reset_graph() {
                 ]),
                 include_drafts: true,
                 scope: DeletionScope::Erase,
-                temporal_axes: find_all_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::all(),
                 decision_time: None,
             },
         )
@@ -1599,7 +1600,7 @@ async fn archive_already_archived_link_is_noop() {
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Archive,
                 },
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -1627,7 +1628,7 @@ async fn archive_already_archived_link_is_noop() {
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Archive,
                 },
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )

--- a/libs/@local/graph/postgres-store/tests/deletion/main.rs
+++ b/libs/@local/graph/postgres-store/tests/deletion/main.rs
@@ -523,18 +523,6 @@ pub(crate) async fn has_archived_provenance(
         .get(0)
 }
 
-/// Temporal axes that pin both axes at "now" — finds only live entities.
-///
-/// Equivalent to the old `decision_time: None` behavior. Deliberately pins on the
-/// *transaction-time* axis (unlike [`QueryTemporalAxesUnresolved::live_only`], which varies the
-/// decision-time axis) to reproduce that historical behavior; both find the same live entities.
-pub(crate) fn live_only_axes() -> QueryTemporalAxesUnresolved {
-    QueryTemporalAxesUnresolved::TransactionTime {
-        pinned: PinnedTemporalAxisUnresolved::new(None),
-        variable: VariableTemporalAxisUnresolved::new(None, None),
-    }
-}
-
 /// Temporal axes that pin `decision_time` at a specific past timestamp.
 pub(crate) fn axes_at_decision_time(
     dt: hash_graph_temporal_versioning::Timestamp<hash_graph_temporal_versioning::DecisionTime>,
@@ -566,15 +554,6 @@ pub(crate) async fn raw_count_archived_temporal_rows(
         .await
         .expect("raw_count_archived_temporal_rows query failed")
         .get(0)
-}
-
-/// Returns the "find everything" temporal axes — unbounded decision time, transaction time at
-/// now.
-///
-/// This finds all entities regardless of their temporal state: live, archived, or any past
-/// decision time. Used by `resetGraph` and tests that need to find archived entities.
-pub(crate) fn find_all_axes() -> QueryTemporalAxesUnresolved {
-    QueryTemporalAxesUnresolved::all()
 }
 
 pub(crate) async fn raw_entity_ids_exists(

--- a/libs/@local/graph/postgres-store/tests/deletion/main.rs
+++ b/libs/@local/graph/postgres-store/tests/deletion/main.rs
@@ -27,7 +27,6 @@ use hash_graph_store::{
         PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved, VariableTemporalAxisUnresolved,
     },
 };
-use hash_graph_temporal_versioning::TemporalBound;
 use hash_graph_test_data::{data_type, entity, entity_type, property_type};
 use tokio_postgres::Transaction;
 use type_system::{
@@ -307,13 +306,7 @@ pub(crate) async fn count_entity(
             api.account_id,
             CountEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(entity_id),
-                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                    pinned: PinnedTemporalAxisUnresolved::new(None),
-                    variable: VariableTemporalAxisUnresolved::new(
-                        Some(TemporalBound::Unbounded),
-                        None,
-                    ),
-                },
+                temporal_axes: QueryTemporalAxesUnresolved::all(),
                 include_drafts,
             },
         )
@@ -532,7 +525,9 @@ pub(crate) async fn has_archived_provenance(
 
 /// Temporal axes that pin both axes at "now" — finds only live entities.
 ///
-/// Equivalent to the old `decision_time: None` behavior.
+/// Equivalent to the old `decision_time: None` behavior. Deliberately pins on the
+/// *transaction-time* axis (unlike [`QueryTemporalAxesUnresolved::live_only`], which varies the
+/// decision-time axis) to reproduce that historical behavior; both find the same live entities.
 pub(crate) fn live_only_axes() -> QueryTemporalAxesUnresolved {
     QueryTemporalAxesUnresolved::TransactionTime {
         pinned: PinnedTemporalAxisUnresolved::new(None),
@@ -579,10 +574,7 @@ pub(crate) async fn raw_count_archived_temporal_rows(
 /// This finds all entities regardless of their temporal state: live, archived, or any past
 /// decision time. Used by `resetGraph` and tests that need to find archived entities.
 pub(crate) fn find_all_axes() -> QueryTemporalAxesUnresolved {
-    QueryTemporalAxesUnresolved::DecisionTime {
-        pinned: PinnedTemporalAxisUnresolved::new(None),
-        variable: VariableTemporalAxisUnresolved::new(Some(TemporalBound::Unbounded), None),
-    }
+    QueryTemporalAxesUnresolved::all()
 }
 
 pub(crate) async fn raw_entity_ids_exists(

--- a/libs/@local/graph/postgres-store/tests/deletion/purge.rs
+++ b/libs/@local/graph/postgres-store/tests/deletion/purge.rs
@@ -6,6 +6,7 @@ use hash_graph_store::{
         LinkDeletionBehavior, PatchEntityParams, UpdateEntityEmbeddingsParams,
     },
     filter::Filter,
+    subgraph::temporal_axes::QueryTemporalAxesUnresolved,
 };
 use hash_graph_temporal_versioning::{TemporalTagged as _, Timestamp, TransactionTime};
 use hash_graph_types::{Embedding, knowledge::entity::EntityEmbedding};
@@ -33,7 +34,7 @@ fn purge_params(
 ) -> DeleteEntitiesParams<'static> {
     DeleteEntitiesParams {
         filter,
-        temporal_axes: crate::live_only_axes(),
+        temporal_axes: QueryTemporalAxesUnresolved::live_only(),
         include_drafts: false,
         scope: DeletionScope::Purge {
             link_behavior: LinkDeletionBehavior::Ignore,
@@ -88,7 +89,7 @@ async fn published_entity() {
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Ignore,
                 },
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -181,7 +182,7 @@ async fn published_entity_with_history() {
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Ignore,
                 },
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -231,7 +232,7 @@ async fn no_match_is_noop() {
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Ignore,
                 },
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -274,7 +275,7 @@ async fn include_drafts_irrelevant_for_published() {
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Ignore,
                 },
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -291,7 +292,7 @@ async fn include_drafts_irrelevant_for_published() {
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Ignore,
                 },
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -333,7 +334,7 @@ async fn purge_error_succeeds_without_incoming_links() {
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Error,
                 },
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -637,7 +638,7 @@ async fn batch_with_mixed_entity_states() {
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Ignore,
                 },
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -968,7 +969,7 @@ async fn filter_by_entity_type() {
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Ignore,
                 },
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )
@@ -1112,7 +1113,7 @@ async fn erase_after_purge_is_noop() {
                 filter: Filter::for_entity_by_entity_id(entity_id),
                 include_drafts: false,
                 scope: DeletionScope::Erase,
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 decision_time: None,
             },
         )

--- a/libs/@local/graph/postgres-store/tests/deletion/validation.rs
+++ b/libs/@local/graph/postgres-store/tests/deletion/validation.rs
@@ -8,6 +8,7 @@ use hash_graph_store::{
     },
     error::DeletionError,
     filter::Filter,
+    subgraph::temporal_axes::QueryTemporalAxesUnresolved,
 };
 use hash_graph_temporal_versioning::{
     DecisionTime, TemporalTagged as _, Timestamp, TransactionTime,
@@ -46,7 +47,7 @@ async fn decision_time_exceeds_transaction_time() {
             api.account_id.into(),
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(entity_id),
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 include_drafts: false,
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Ignore,
@@ -158,7 +159,7 @@ async fn decision_time_defaults_to_transaction_time() {
             api.account_id.into(),
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(entity_id),
-                temporal_axes: crate::live_only_axes(),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 include_drafts: false,
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Ignore,

--- a/libs/@local/graph/store/src/subgraph/temporal_axes.rs
+++ b/libs/@local/graph/store/src/subgraph/temporal_axes.rs
@@ -252,8 +252,9 @@ impl QueryTemporalAxesUnresolved {
     ///
     /// Pins the transaction time at the resolution timestamp and leaves the decision time
     /// unbounded up to that timestamp, so the query reaches all entities — live, archived, and
-    /// every past decision-time version. Use this for "erase everything" / `resetGraph`-style
-    /// operations that must also find archived entities.
+    /// every past decision-time version. Use this for any read that must include archived and
+    /// past entities rather than only the currently-live ones (e.g. history-aware queries, or
+    /// erase-all / `resetGraph` operations).
     #[must_use]
     pub fn all() -> Self {
         Self::DecisionTime {

--- a/libs/@local/graph/store/src/subgraph/temporal_axes.rs
+++ b/libs/@local/graph/store/src/subgraph/temporal_axes.rs
@@ -247,16 +247,34 @@ pub enum QueryTemporalAxesUnresolved {
     },
 }
 
-impl Default for QueryTemporalAxesUnresolved {
-    fn default() -> Self {
+impl QueryTemporalAxesUnresolved {
+    /// Axes that match every entity, regardless of its temporal state.
+    ///
+    /// Pins the transaction time at the resolution timestamp and leaves the decision time
+    /// unbounded up to that timestamp, so the query reaches all entities — live, archived, and
+    /// every past decision-time version. Use this for "erase everything" / `resetGraph`-style
+    /// operations that must also find archived entities.
+    #[must_use]
+    pub fn all() -> Self {
         Self::DecisionTime {
             pinned: PinnedTemporalAxisUnresolved::new(None),
             variable: VariableTemporalAxisUnresolved::new(Some(TemporalBound::Unbounded), None),
         }
     }
-}
 
-impl QueryTemporalAxesUnresolved {
+    /// Axes that match only currently-live entities.
+    ///
+    /// Pins both the transaction and decision time at the resolution timestamp, so archived and
+    /// other non-current entities are excluded. This is the conventional "current snapshot" query
+    /// used by most reads.
+    #[must_use]
+    pub fn live_only() -> Self {
+        Self::DecisionTime {
+            pinned: PinnedTemporalAxisUnresolved::new(None),
+            variable: VariableTemporalAxisUnresolved::new(None, None),
+        }
+    }
+
     /// Resolves temporal axes using the provided timestamp.
     ///
     /// Converts unresolved temporal axes into concrete temporal axes by resolving unset values

--- a/libs/@local/graph/store/src/user_deletion.rs
+++ b/libs/@local/graph/store/src/user_deletion.rs
@@ -1,6 +1,5 @@
 use error_stack::{Report, ReportSink, ResultExt as _};
 use hash_graph_authorization::policies::principal::actor::AuthenticatedActor;
-use hash_graph_temporal_versioning::TemporalBound;
 use serde::Serialize;
 use type_system::principal::{actor::UserId, actor_group::WebId};
 
@@ -13,9 +12,7 @@ use crate::{
     filter::{Filter, FilterExpression, Parameter},
     identity_provider::IdentityProvider,
     oauth_provider::OAuthProvider,
-    subgraph::temporal_axes::{
-        PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved, VariableTemporalAxisUnresolved,
-    },
+    subgraph::temporal_axes::QueryTemporalAxesUnresolved,
 };
 
 /// Errors that can occur during user deletion.
@@ -146,13 +143,7 @@ where
             actor,
             DeleteEntitiesParams {
                 filter: web_filter,
-                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                    pinned: PinnedTemporalAxisUnresolved::new(None),
-                    variable: VariableTemporalAxisUnresolved::new(
-                        Some(TemporalBound::Unbounded),
-                        None,
-                    ),
-                },
+                temporal_axes: QueryTemporalAxesUnresolved::all(),
                 include_drafts: true,
                 scope: DeletionScope::Purge {
                     link_behavior: LinkDeletionBehavior::Archive,

--- a/libs/@local/graph/type-fetcher/src/store.rs
+++ b/libs/@local/graph/type-fetcher/src/store.rs
@@ -58,10 +58,7 @@ use hash_graph_store::{
         UnarchivePropertyTypeParams, UpdatePropertyTypeEmbeddingParams, UpdatePropertyTypesParams,
     },
     query::{ConflictBehavior, QueryResult, Read, ReadPaginated, Sorting},
-    subgraph::temporal_axes::{
-        PinnedTemporalAxisUnresolved, QueryTemporalAxes, QueryTemporalAxesUnresolved,
-        VariableTemporalAxisUnresolved,
-    },
+    subgraph::temporal_axes::{QueryTemporalAxes, QueryTemporalAxesUnresolved},
 };
 use hash_graph_temporal_versioning::{DecisionTime, Timestamp, TransactionTime};
 use hash_graph_types::ontology::{
@@ -461,10 +458,7 @@ where
                     actor_id,
                     QueryDataTypesParams {
                         filter: Filter::for_versioned_url(url),
-                        temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                            pinned: PinnedTemporalAxisUnresolved::new(None),
-                            variable: VariableTemporalAxisUnresolved::new(None, None),
-                        },
+                        temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                         after: None,
                         limit: None,
                         include_count: false,
@@ -478,10 +472,7 @@ where
                     actor_id,
                     QueryPropertyTypesParams {
                         filter: Filter::for_versioned_url(url),
-                        temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                            pinned: PinnedTemporalAxisUnresolved::new(None),
-                            variable: VariableTemporalAxisUnresolved::new(None, None),
-                        },
+                        temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                         after: None,
                         limit: None,
                         include_count: false,
@@ -496,10 +487,7 @@ where
                     QueryEntityTypesParams {
                         request: CommonQueryEntityTypesParams {
                             filter: Filter::for_versioned_url(url),
-                            temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                                pinned: PinnedTemporalAxisUnresolved::new(None),
-                                variable: VariableTemporalAxisUnresolved::new(None, None),
-                            },
+                            temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                             after: None,
                             limit: None,
                             include_count: false,

--- a/tests/graph/benches/graph/scenario/stages/entity_queries.rs
+++ b/tests/graph/benches/graph/scenario/stages/entity_queries.rs
@@ -112,7 +112,7 @@ impl QueryEntitiesByUserStage {
                 actor_uuid,
                 QueryEntitiesParams {
                     filter: Filter::All(Vec::new()),
-                    temporal_axes: QueryTemporalAxesUnresolved::default(),
+                    temporal_axes: QueryTemporalAxesUnresolved::all(),
                     sorting: EntityQuerySorting {
                         cursor: None,
                         paths: Vec::new(),

--- a/tests/graph/benches/graph/scenario/stages/entity_type.rs
+++ b/tests/graph/benches/graph/scenario/stages/entity_type.rs
@@ -567,7 +567,7 @@ impl BuildEntityTypeRegistryStage {
                 QueryEntityTypesParams {
                     request: CommonQueryEntityTypesParams {
                         filter: Filter::for_entity_type_uuids(&all_entity_types),
-                        temporal_axes: QueryTemporalAxesUnresolved::default(),
+                        temporal_axes: QueryTemporalAxesUnresolved::all(),
                         after: None,
                         limit: None,
                         include_count: false,

--- a/tests/graph/benches/graph/scenario/stages/reset_db.rs
+++ b/tests/graph/benches/graph/scenario/stages/reset_db.rs
@@ -90,7 +90,7 @@ impl ResetDbStage {
                         ActorEntityUuid::new(uuid::Uuid::nil()).into(),
                         DeleteEntitiesParams {
                             filter: Filter::All(Vec::new()),
-                            temporal_axes: QueryTemporalAxesUnresolved::default(),
+                            temporal_axes: QueryTemporalAxesUnresolved::all(),
                             include_drafts: true,
                             scope: DeletionScope::Erase,
                             decision_time: None,

--- a/tests/graph/benches/read_scaling/knowledge/complete/entity.rs
+++ b/tests/graph/benches/read_scaling/knowledge/complete/entity.rs
@@ -14,13 +14,9 @@ use hash_graph_store::{
     filter::Filter,
     subgraph::{
         edges::{EdgeDirection, SubgraphTraversalParams, TraversalEdge, TraversalPath},
-        temporal_axes::{
-            PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved,
-            VariableTemporalAxisUnresolved,
-        },
+        temporal_axes::QueryTemporalAxesUnresolved,
     },
 };
-use hash_graph_temporal_versioning::TemporalBound;
 use hash_graph_test_data::{data_type, entity, entity_type, property_type};
 use rand::{prelude::IteratorRandom as _, rng};
 use tokio::runtime::Runtime;
@@ -246,13 +242,7 @@ pub fn bench_get_entity_by_id(
                         QueryEntitySubgraphParams::from_parts(
                             QueryEntitiesParams {
                                 filter: Filter::for_entity_by_entity_id(entity_record_id.entity_id),
-                                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                                    pinned: PinnedTemporalAxisUnresolved::new(None),
-                                    variable: VariableTemporalAxisUnresolved::new(
-                                        Some(TemporalBound::Unbounded),
-                                        None,
-                                    ),
-                                },
+                                temporal_axes: QueryTemporalAxesUnresolved::all(),
                                 sorting: EntityQuerySorting {
                                     paths: Vec::new(),
                                     cursor: None,

--- a/tests/graph/benches/read_scaling/knowledge/linkless/entity.rs
+++ b/tests/graph/benches/read_scaling/knowledge/linkless/entity.rs
@@ -9,11 +9,8 @@ use hash_graph_authorization::policies::store::{
 use hash_graph_store::{
     entity::{CreateEntityParams, EntityQuerySorting, EntityStore as _, QueryEntitiesParams},
     filter::Filter,
-    subgraph::temporal_axes::{
-        PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved, VariableTemporalAxisUnresolved,
-    },
+    subgraph::temporal_axes::QueryTemporalAxesUnresolved,
 };
-use hash_graph_temporal_versioning::TemporalBound;
 use hash_graph_test_data::{data_type, entity, entity_type, property_type};
 use rand::{prelude::IteratorRandom as _, rng};
 use tokio::runtime::Runtime;
@@ -180,13 +177,7 @@ pub fn bench_get_entity_by_id(
                     actor_id,
                     QueryEntitiesParams {
                         filter: Filter::for_entity_by_entity_id(entity_record_id.entity_id),
-                        temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                            pinned: PinnedTemporalAxisUnresolved::new(None),
-                            variable: VariableTemporalAxisUnresolved::new(
-                                Some(TemporalBound::Unbounded),
-                                None,
-                            ),
-                        },
+                        temporal_axes: QueryTemporalAxesUnresolved::all(),
                         sorting: EntityQuerySorting {
                             paths: Vec::new(),
                             cursor: None,

--- a/tests/graph/benches/representative_read/knowledge/entity.rs
+++ b/tests/graph/benches/representative_read/knowledge/entity.rs
@@ -9,13 +9,9 @@ use hash_graph_store::{
     filter::{Filter, FilterExpression, JsonPath, Parameter, PathToken},
     subgraph::{
         edges::{EdgeDirection, KnowledgeGraphEdgeKind, SubgraphTraversalParams},
-        temporal_axes::{
-            PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved,
-            VariableTemporalAxisUnresolved,
-        },
+        temporal_axes::QueryTemporalAxesUnresolved,
     },
 };
-use hash_graph_temporal_versioning::TemporalBound;
 use rand::{prelude::IteratorRandom as _, rng};
 use tokio::runtime::Runtime;
 use type_system::{knowledge::entity::id::EntityUuid, principal::actor::ActorEntityUuid};
@@ -51,10 +47,7 @@ pub fn bench_get_entity_by_id(
                                 convert: None,
                             },
                         ),
-                        temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                            pinned: PinnedTemporalAxisUnresolved::new(None),
-                            variable: VariableTemporalAxisUnresolved::new(None, None),
-                        },
+                        temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                         sorting: EntityQuerySorting {
                             paths: Vec::new(),
                             cursor: None,
@@ -109,13 +102,7 @@ pub fn bench_query_entities_by_property(
                     QueryEntitySubgraphParams::from_parts(
                         QueryEntitiesParams {
                             filter,
-                            temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                                pinned: PinnedTemporalAxisUnresolved::new(None),
-                                variable: VariableTemporalAxisUnresolved::new(
-                                    Some(TemporalBound::Unbounded),
-                                    None,
-                                ),
-                            },
+                            temporal_axes: QueryTemporalAxesUnresolved::all(),
                             sorting: EntityQuerySorting {
                                 paths: Vec::new(),
                                 cursor: None,
@@ -175,13 +162,7 @@ pub fn bench_get_link_by_target_by_property(
                     QueryEntitySubgraphParams::from_parts(
                         QueryEntitiesParams {
                             filter,
-                            temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                                pinned: PinnedTemporalAxisUnresolved::new(None),
-                                variable: VariableTemporalAxisUnresolved::new(
-                                    Some(TemporalBound::Unbounded),
-                                    None,
-                                ),
-                            },
+                            temporal_axes: QueryTemporalAxesUnresolved::all(),
                             sorting: EntityQuerySorting {
                                 paths: Vec::new(),
                                 cursor: None,

--- a/tests/graph/benches/representative_read/ontology/entity_type.rs
+++ b/tests/graph/benches/representative_read/ontology/entity_type.rs
@@ -2,11 +2,8 @@ use criterion::{BatchSize::SmallInput, Bencher};
 use hash_graph_store::{
     entity_type::{CommonQueryEntityTypesParams, EntityTypeStore as _, QueryEntityTypesParams},
     filter::Filter,
-    subgraph::temporal_axes::{
-        PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved, VariableTemporalAxisUnresolved,
-    },
+    subgraph::temporal_axes::QueryTemporalAxesUnresolved,
 };
-use hash_graph_temporal_versioning::TemporalBound;
 use rand::{prelude::IteratorRandom as _, rng};
 use tokio::runtime::Runtime;
 use type_system::{ontology::VersionedUrl, principal::actor::ActorEntityUuid};
@@ -35,13 +32,7 @@ pub fn bench_get_entity_type_by_id(
                     QueryEntityTypesParams {
                         request: CommonQueryEntityTypesParams {
                             filter: Filter::for_versioned_url(entity_type_id),
-                            temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                                pinned: PinnedTemporalAxisUnresolved::new(None),
-                                variable: VariableTemporalAxisUnresolved::new(
-                                    Some(TemporalBound::Unbounded),
-                                    None,
-                                ),
-                            },
+                            temporal_axes: QueryTemporalAxesUnresolved::all(),
                             after: None,
                             limit: None,
                             include_count: false,

--- a/tests/graph/integration/postgres/data_type.rs
+++ b/tests/graph/integration/postgres/data_type.rs
@@ -13,11 +13,8 @@ use hash_graph_store::{
     entity::{CreateEntityParams, EntityStore as _},
     filter::Filter,
     query::ConflictBehavior,
-    subgraph::temporal_axes::{
-        PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved, VariableTemporalAxisUnresolved,
-    },
+    subgraph::temporal_axes::QueryTemporalAxesUnresolved,
 };
-use hash_graph_temporal_versioning::TemporalBound;
 use time::OffsetDateTime;
 use type_system::{
     knowledge::{
@@ -106,13 +103,7 @@ async fn query() {
             api.account_id,
             QueryDataTypesParams {
                 filter: Filter::for_versioned_url(&list_v1.id),
-                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                    pinned: PinnedTemporalAxisUnresolved::new(None),
-                    variable: VariableTemporalAxisUnresolved::new(
-                        Some(TemporalBound::Unbounded),
-                        None,
-                    ),
-                },
+                temporal_axes: QueryTemporalAxesUnresolved::all(),
                 after: None,
                 limit: None,
                 include_count: false,
@@ -136,10 +127,7 @@ async fn inheritance() {
     fn create_params(filter: Filter<DataTypeWithMetadata>) -> QueryDataTypesParams {
         QueryDataTypesParams {
             filter,
-            temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                pinned: PinnedTemporalAxisUnresolved::new(None),
-                variable: VariableTemporalAxisUnresolved::new(Some(TemporalBound::Unbounded), None),
-            },
+            temporal_axes: QueryTemporalAxesUnresolved::all(),
             after: None,
             limit: None,
             include_count: false,
@@ -482,13 +470,7 @@ async fn update() {
             api.account_id,
             QueryDataTypesParams {
                 filter: Filter::for_versioned_url(&object_dt_v1.id),
-                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                    pinned: PinnedTemporalAxisUnresolved::new(None),
-                    variable: VariableTemporalAxisUnresolved::new(
-                        Some(TemporalBound::Unbounded),
-                        None,
-                    ),
-                },
+                temporal_axes: QueryTemporalAxesUnresolved::all(),
                 after: None,
                 limit: None,
                 include_count: false,
@@ -505,13 +487,7 @@ async fn update() {
             api.account_id,
             QueryDataTypesParams {
                 filter: Filter::for_versioned_url(&object_dt_v2.id),
-                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                    pinned: PinnedTemporalAxisUnresolved::new(None),
-                    variable: VariableTemporalAxisUnresolved::new(
-                        Some(TemporalBound::Unbounded),
-                        None,
-                    ),
-                },
+                temporal_axes: QueryTemporalAxesUnresolved::all(),
                 after: None,
                 limit: None,
                 include_count: false,

--- a/tests/graph/integration/postgres/email_filter_protection.rs
+++ b/tests/graph/integration/postgres/email_filter_protection.rs
@@ -40,13 +40,9 @@ use hash_graph_store::{
             EdgeDirection, EntityTraversalEdge, EntityTraversalPath, GraphResolveDepths,
             SharedEdgeKind,
         },
-        temporal_axes::{
-            PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved,
-            VariableTemporalAxisUnresolved,
-        },
+        temporal_axes::QueryTemporalAxesUnresolved,
     },
 };
-use hash_graph_temporal_versioning::TemporalBound;
 use hash_graph_test_data::{data_type, entity_type};
 use type_system::{
     knowledge::{
@@ -213,10 +209,7 @@ fn shortname_filter(shortname: &str) -> Filter<'static, type_system::knowledge::
 
 /// Helper to get standard temporal axes for queries.
 fn standard_temporal_axes() -> QueryTemporalAxesUnresolved {
-    QueryTemporalAxesUnresolved::DecisionTime {
-        pinned: PinnedTemporalAxisUnresolved::new(None),
-        variable: VariableTemporalAxisUnresolved::new(Some(TemporalBound::Unbounded), None),
-    }
+    QueryTemporalAxesUnresolved::all()
 }
 
 /// Seeds the database with User and Invitation entity types (with email and shortname properties).

--- a/tests/graph/integration/postgres/entity.rs
+++ b/tests/graph/integration/postgres/entity.rs
@@ -95,10 +95,7 @@ async fn insert() {
         api.account_id,
         QueryEntitiesParams {
             filter: Filter::for_entity_by_entity_id(entity.metadata.record_id.entity_id),
-            temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                pinned: PinnedTemporalAxisUnresolved::new(None),
-                variable: VariableTemporalAxisUnresolved::new(Some(TemporalBound::Unbounded), None),
-            },
+            temporal_axes: QueryTemporalAxesUnresolved::all(),
             sorting: EntityQuerySorting {
                 paths: Vec::new(),
                 cursor: None,
@@ -177,10 +174,7 @@ async fn query() {
         api.account_id,
         QueryEntitiesParams {
             filter: Filter::for_entity_by_entity_id(entity.metadata.record_id.entity_id),
-            temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                pinned: PinnedTemporalAxisUnresolved::new(None),
-                variable: VariableTemporalAxisUnresolved::new(Some(TemporalBound::Unbounded), None),
-            },
+            temporal_axes: QueryTemporalAxesUnresolved::all(),
             sorting: EntityQuerySorting {
                 paths: Vec::new(),
                 cursor: None,
@@ -290,13 +284,7 @@ async fn update() {
             api.account_id,
             CountEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(v2_entity.metadata.record_id.entity_id),
-                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                    pinned: PinnedTemporalAxisUnresolved::new(None),
-                    variable: VariableTemporalAxisUnresolved::new(
-                        Some(TemporalBound::Unbounded),
-                        None,
-                    ),
-                },
+                temporal_axes: QueryTemporalAxesUnresolved::all(),
                 include_drafts: false,
             },
         )
@@ -308,10 +296,7 @@ async fn update() {
         api.account_id,
         QueryEntitiesParams {
             filter: Filter::for_entity_by_entity_id(v2_entity.metadata.record_id.entity_id),
-            temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                pinned: PinnedTemporalAxisUnresolved::new(None),
-                variable: VariableTemporalAxisUnresolved::new(None, None),
-            },
+            temporal_axes: QueryTemporalAxesUnresolved::live_only(),
             sorting: EntityQuerySorting {
                 paths: Vec::new(),
                 cursor: None,

--- a/tests/graph/integration/postgres/entity_type.rs
+++ b/tests/graph/integration/postgres/entity_type.rs
@@ -5,11 +5,8 @@ use hash_graph_store::{
     },
     filter::Filter,
     query::ConflictBehavior,
-    subgraph::temporal_axes::{
-        PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved, VariableTemporalAxisUnresolved,
-    },
+    subgraph::temporal_axes::QueryTemporalAxesUnresolved,
 };
-use hash_graph_temporal_versioning::TemporalBound;
 use hash_graph_test_data::{data_type, entity_type, property_type};
 use type_system::{
     ontology::{
@@ -110,13 +107,7 @@ async fn query() {
             QueryEntityTypesParams {
                 request: CommonQueryEntityTypesParams {
                     filter: Filter::for_versioned_url(&organization_et.id),
-                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                        pinned: PinnedTemporalAxisUnresolved::new(None),
-                        variable: VariableTemporalAxisUnresolved::new(
-                            Some(TemporalBound::Unbounded),
-                            None,
-                        ),
-                    },
+                    temporal_axes: QueryTemporalAxesUnresolved::all(),
                     after: None,
                     limit: None,
                     include_count: false,
@@ -212,13 +203,7 @@ async fn update() {
             QueryEntityTypesParams {
                 request: CommonQueryEntityTypesParams {
                     filter: Filter::for_versioned_url(&page_et_v1.id),
-                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                        pinned: PinnedTemporalAxisUnresolved::new(None),
-                        variable: VariableTemporalAxisUnresolved::new(
-                            Some(TemporalBound::Unbounded),
-                            None,
-                        ),
-                    },
+                    temporal_axes: QueryTemporalAxesUnresolved::all(),
                     after: None,
                     limit: None,
                     include_count: false,
@@ -240,13 +225,7 @@ async fn update() {
             QueryEntityTypesParams {
                 request: CommonQueryEntityTypesParams {
                     filter: Filter::for_versioned_url(&page_et_v2.id),
-                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                        pinned: PinnedTemporalAxisUnresolved::new(None),
-                        variable: VariableTemporalAxisUnresolved::new(
-                            Some(TemporalBound::Unbounded),
-                            None,
-                        ),
-                    },
+                    temporal_axes: QueryTemporalAxesUnresolved::all(),
                     after: None,
                     limit: None,
                     include_count: false,

--- a/tests/graph/integration/postgres/links.rs
+++ b/tests/graph/integration/postgres/links.rs
@@ -10,13 +10,9 @@ use hash_graph_store::{
     filter::{Filter, FilterExpression, Parameter},
     subgraph::{
         edges::{EdgeDirection, KnowledgeGraphEdgeKind, SharedEdgeKind},
-        temporal_axes::{
-            PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved,
-            VariableTemporalAxisUnresolved,
-        },
+        temporal_axes::QueryTemporalAxesUnresolved,
     },
 };
-use hash_graph_temporal_versioning::TemporalBound;
 use hash_graph_test_data::{data_type, entity, entity_type, property_type};
 use type_system::{
     knowledge::{
@@ -228,10 +224,7 @@ async fn insert() {
                     },
                 ),
             ]),
-            temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                pinned: PinnedTemporalAxisUnresolved::new(None),
-                variable: VariableTemporalAxisUnresolved::new(Some(TemporalBound::Unbounded), None),
-            },
+            temporal_axes: QueryTemporalAxesUnresolved::all(),
             sorting: EntityQuerySorting {
                 paths: Vec::new(),
                 cursor: None,
@@ -486,10 +479,7 @@ async fn get_entity_links() {
                     convert: None,
                 },
             ),
-            temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                pinned: PinnedTemporalAxisUnresolved::new(None),
-                variable: VariableTemporalAxisUnresolved::new(None, None),
-            },
+            temporal_axes: QueryTemporalAxesUnresolved::live_only(),
             sorting: EntityQuerySorting {
                 paths: Vec::new(),
                 cursor: None,
@@ -706,10 +696,7 @@ async fn remove_link() {
                         },
                     ),
                 ]),
-                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                    pinned: PinnedTemporalAxisUnresolved::new(None),
-                    variable: VariableTemporalAxisUnresolved::new(None, None),
-                },
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 include_drafts: false,
             },
         )
@@ -768,10 +755,7 @@ async fn remove_link() {
                         },
                     ),
                 ]),
-                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                    pinned: PinnedTemporalAxisUnresolved::new(None),
-                    variable: VariableTemporalAxisUnresolved::new(None, None),
-                },
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                 include_drafts: false,
             },
         )

--- a/tests/graph/integration/postgres/multi_type.rs
+++ b/tests/graph/integration/postgres/multi_type.rs
@@ -8,9 +8,7 @@ use hash_graph_store::{
     },
     error::InsertionError,
     filter::Filter,
-    subgraph::temporal_axes::{
-        PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved, VariableTemporalAxisUnresolved,
-    },
+    subgraph::temporal_axes::QueryTemporalAxesUnresolved,
 };
 use hash_graph_test_data::{data_type, entity, entity_type, property_type};
 use pretty_assertions::assert_eq;
@@ -145,10 +143,7 @@ async fn initial_person() {
         api.account_id,
         QueryEntitiesParams {
             filter: Filter::for_entity_by_type_id(&person_entity_type_id()),
-            temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                pinned: PinnedTemporalAxisUnresolved::new(None),
-                variable: VariableTemporalAxisUnresolved::new(None, None),
-            },
+            temporal_axes: QueryTemporalAxesUnresolved::live_only(),
             sorting: EntityQuerySorting {
                 paths: Vec::new(),
                 cursor: None,
@@ -210,10 +205,7 @@ async fn initial_person() {
         api.account_id,
         QueryEntitiesParams {
             filter: Filter::for_entity_by_type_id(&person_entity_type_id()),
-            temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                pinned: PinnedTemporalAxisUnresolved::new(None),
-                variable: VariableTemporalAxisUnresolved::new(None, None),
-            },
+            temporal_axes: QueryTemporalAxesUnresolved::live_only(),
             sorting: EntityQuerySorting {
                 paths: Vec::new(),
                 cursor: None,
@@ -239,10 +231,7 @@ async fn initial_person() {
         api.account_id,
         QueryEntitiesParams {
             filter: Filter::for_entity_by_type_id(&person_entity_type_id()),
-            temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                pinned: PinnedTemporalAxisUnresolved::new(None),
-                variable: VariableTemporalAxisUnresolved::new(None, None),
-            },
+            temporal_axes: QueryTemporalAxesUnresolved::live_only(),
             sorting: EntityQuerySorting {
                 paths: Vec::new(),
                 cursor: None,
@@ -322,10 +311,7 @@ async fn create_multi() {
         api.account_id,
         QueryEntitiesParams {
             filter: Filter::for_entity_by_type_id(&person_entity_type_id()),
-            temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                pinned: PinnedTemporalAxisUnresolved::new(None),
-                variable: VariableTemporalAxisUnresolved::new(None, None),
-            },
+            temporal_axes: QueryTemporalAxesUnresolved::live_only(),
             sorting: EntityQuerySorting {
                 paths: Vec::new(),
                 cursor: None,
@@ -351,10 +337,7 @@ async fn create_multi() {
         api.account_id,
         QueryEntitiesParams {
             filter: Filter::for_entity_by_type_id(&person_entity_type_id()),
-            temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                pinned: PinnedTemporalAxisUnresolved::new(None),
-                variable: VariableTemporalAxisUnresolved::new(None, None),
-            },
+            temporal_axes: QueryTemporalAxesUnresolved::live_only(),
             sorting: EntityQuerySorting {
                 paths: Vec::new(),
                 cursor: None,
@@ -411,10 +394,7 @@ async fn create_multi() {
         api.account_id,
         QueryEntitiesParams {
             filter: Filter::for_entity_by_type_id(&person_entity_type_id()),
-            temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                pinned: PinnedTemporalAxisUnresolved::new(None),
-                variable: VariableTemporalAxisUnresolved::new(None, None),
-            },
+            temporal_axes: QueryTemporalAxesUnresolved::live_only(),
             sorting: EntityQuerySorting {
                 paths: Vec::new(),
                 cursor: None,
@@ -497,10 +477,7 @@ async fn summary_aggregations() {
         api.account_id,
         QueryEntitiesParams {
             filter: Filter::for_entity_by_type_id(&person_entity_type_id()),
-            temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                pinned: PinnedTemporalAxisUnresolved::new(None),
-                variable: VariableTemporalAxisUnresolved::new(None, None),
-            },
+            temporal_axes: QueryTemporalAxesUnresolved::live_only(),
             sorting: EntityQuerySorting {
                 paths: Vec::new(),
                 cursor: None,
@@ -554,10 +531,7 @@ async fn summary_aggregations() {
         api.account_id,
         QueryEntitiesParams {
             filter: Filter::for_entity_by_type_id(&person_entity_type_id()),
-            temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                pinned: PinnedTemporalAxisUnresolved::new(None),
-                variable: VariableTemporalAxisUnresolved::new(None, None),
-            },
+            temporal_axes: QueryTemporalAxesUnresolved::live_only(),
             sorting: EntityQuerySorting {
                 paths: Vec::new(),
                 cursor: None,

--- a/tests/graph/integration/postgres/partial_updates.rs
+++ b/tests/graph/integration/postgres/partial_updates.rs
@@ -8,9 +8,7 @@ use hash_graph_store::{
         QueryEntitiesParams,
     },
     filter::Filter,
-    subgraph::temporal_axes::{
-        PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved, VariableTemporalAxisUnresolved,
-    },
+    subgraph::temporal_axes::QueryTemporalAxesUnresolved,
 };
 use hash_graph_test_data::{data_type, entity, entity_type, property_type};
 use pretty_assertions::assert_eq;
@@ -164,10 +162,7 @@ async fn properties_add() {
         api.account_id,
         QueryEntitiesParams {
             filter: Filter::for_entity_by_entity_id(entity_id),
-            temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                pinned: PinnedTemporalAxisUnresolved::new(None),
-                variable: VariableTemporalAxisUnresolved::new(None, None),
-            },
+            temporal_axes: QueryTemporalAxesUnresolved::live_only(),
             sorting: EntityQuerySorting {
                 paths: Vec::new(),
                 cursor: None,
@@ -259,10 +254,7 @@ async fn properties_remove() {
         api.account_id,
         QueryEntitiesParams {
             filter: Filter::for_entity_by_entity_id(entity_id),
-            temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                pinned: PinnedTemporalAxisUnresolved::new(None),
-                variable: VariableTemporalAxisUnresolved::new(None, None),
-            },
+            temporal_axes: QueryTemporalAxesUnresolved::live_only(),
             sorting: EntityQuerySorting {
                 paths: Vec::new(),
                 cursor: None,
@@ -356,10 +348,7 @@ async fn properties_replace() {
         api.account_id,
         QueryEntitiesParams {
             filter: Filter::for_entity_by_entity_id(entity_id),
-            temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                pinned: PinnedTemporalAxisUnresolved::new(None),
-                variable: VariableTemporalAxisUnresolved::new(None, None),
-            },
+            temporal_axes: QueryTemporalAxesUnresolved::live_only(),
             sorting: EntityQuerySorting {
                 paths: Vec::new(),
                 cursor: None,
@@ -446,10 +435,7 @@ async fn type_ids() {
         api.account_id,
         QueryEntitiesParams {
             filter: Filter::for_entity_by_entity_id(entity_id),
-            temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                pinned: PinnedTemporalAxisUnresolved::new(None),
-                variable: VariableTemporalAxisUnresolved::new(None, None),
-            },
+            temporal_axes: QueryTemporalAxesUnresolved::live_only(),
             sorting: EntityQuerySorting {
                 paths: Vec::new(),
                 cursor: None,
@@ -504,10 +490,7 @@ async fn type_ids() {
         api.account_id,
         QueryEntitiesParams {
             filter: Filter::for_entity_by_entity_id(entity_id),
-            temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                pinned: PinnedTemporalAxisUnresolved::new(None),
-                variable: VariableTemporalAxisUnresolved::new(None, None),
-            },
+            temporal_axes: QueryTemporalAxesUnresolved::live_only(),
             sorting: EntityQuerySorting {
                 paths: Vec::new(),
                 cursor: None,
@@ -564,10 +547,7 @@ async fn type_ids() {
         api.account_id,
         QueryEntitiesParams {
             filter: Filter::for_entity_by_entity_id(entity_id),
-            temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                pinned: PinnedTemporalAxisUnresolved::new(None),
-                variable: VariableTemporalAxisUnresolved::new(None, None),
-            },
+            temporal_axes: QueryTemporalAxesUnresolved::live_only(),
             sorting: EntityQuerySorting {
                 paths: Vec::new(),
                 cursor: None,

--- a/tests/graph/integration/postgres/property_type.rs
+++ b/tests/graph/integration/postgres/property_type.rs
@@ -5,11 +5,8 @@ use hash_graph_store::{
         UpdatePropertyTypesParams,
     },
     query::ConflictBehavior,
-    subgraph::temporal_axes::{
-        PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved, VariableTemporalAxisUnresolved,
-    },
+    subgraph::temporal_axes::QueryTemporalAxesUnresolved,
 };
-use hash_graph_temporal_versioning::TemporalBound;
 use hash_graph_test_data::{data_type, property_type};
 use type_system::{
     ontology::{
@@ -86,13 +83,7 @@ async fn query() {
             api.account_id,
             QueryPropertyTypesParams {
                 filter: Filter::for_versioned_url(&favorite_quote_pt.id),
-                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                    pinned: PinnedTemporalAxisUnresolved::new(None),
-                    variable: VariableTemporalAxisUnresolved::new(
-                        Some(TemporalBound::Unbounded),
-                        None,
-                    ),
-                },
+                temporal_axes: QueryTemporalAxesUnresolved::all(),
                 after: None,
                 limit: None,
                 include_count: false,
@@ -166,13 +157,7 @@ async fn update() {
             api.account_id,
             QueryPropertyTypesParams {
                 filter: Filter::for_versioned_url(&user_id_pt_v1.id),
-                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                    pinned: PinnedTemporalAxisUnresolved::new(None),
-                    variable: VariableTemporalAxisUnresolved::new(
-                        Some(TemporalBound::Unbounded),
-                        None,
-                    ),
-                },
+                temporal_axes: QueryTemporalAxesUnresolved::all(),
                 after: None,
                 limit: None,
                 include_count: false,
@@ -189,13 +174,7 @@ async fn update() {
             api.account_id,
             QueryPropertyTypesParams {
                 filter: Filter::for_versioned_url(&user_id_pt_v2.id),
-                temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                    pinned: PinnedTemporalAxisUnresolved::new(None),
-                    variable: VariableTemporalAxisUnresolved::new(
-                        Some(TemporalBound::Unbounded),
-                        None,
-                    ),
-                },
+                temporal_axes: QueryTemporalAxesUnresolved::all(),
                 after: None,
                 limit: None,
                 include_count: false,

--- a/tests/graph/integration/postgres/sorting.rs
+++ b/tests/graph/integration/postgres/sorting.rs
@@ -9,13 +9,7 @@ use hash_graph_store::{
     },
     filter::{Filter, JsonPath, PathToken},
     query::{NullOrdering, Ordering},
-    subgraph::{
-        identifier::GraphElementVertexId,
-        temporal_axes::{
-            PinnedTemporalAxisUnresolved, QueryTemporalAxesUnresolved,
-            VariableTemporalAxisUnresolved,
-        },
-    },
+    subgraph::{identifier::GraphElementVertexId, temporal_axes::QueryTemporalAxesUnresolved},
 };
 use hash_graph_test_data::{data_type, entity, entity_type, property_type};
 use pretty_assertions::assert_eq;
@@ -84,10 +78,7 @@ async fn test_root_sorting(
                 traversal_paths: Vec::new(),
                 request: QueryEntitiesParams {
                     filter: Filter::All(Vec::new()),
-                    temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
-                        pinned: PinnedTemporalAxisUnresolved::new(None),
-                        variable: VariableTemporalAxisUnresolved::new(None, None),
-                    },
+                    temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                     sorting: EntityQuerySorting {
                         paths: sorting_paths.clone(),
                         cursor: Option::take(&mut cursor),


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

`QueryTemporalAxesUnresolved` implemented `Default`, which silently resolved to the "find **all** entities, including archived" axes (`DecisionTime { pinned: None, variable: [Unbounded, now] }`). `default()` communicated no intent, so reviewers (and automated review tools) couldn't tell whether a given call site deliberately wanted "find all" or had accidentally picked the wrong axes — this was flagged repeatedly during the BE-460 deletion review.

This PR removes the `Default` impl and replaces it with two intent-revealing named constructors, then routes every call site through them.

## 🔗 Related links

- [BE-467](https://linear.app/hash/issue/BE-467/remove-default-impl-from-querytemporalaxesunresolved) _(internal)_
- Originated from the [BE-460](https://linear.app/hash/issue/BE-460) deletion review _(internal)_

## 🔍 What does this change?

- Remove `impl Default for QueryTemporalAxesUnresolved`.
- Add two documented constructors on `QueryTemporalAxesUnresolved`:
  - `all()` — pins transaction time at the resolution timestamp, decision time unbounded up to it → reaches **all** entities incl. archived. For any archived-inclusive read (history-aware queries, erase-all / `resetGraph`), not only removal.
  - `live_only()` — pins both axes at the resolution timestamp → only currently-live entities (the conventional "current snapshot" query).
- Consolidate every call site onto the constructors (net **−305 LOC** (+214 −519)):
  - 36 `QueryTemporalAxesUnresolved::default()` calls → `all()`.
  - 23 inline copies of the "find all" axes → `all()` (incl. the production `user_deletion.rs` site that triggered BE-460's review confusion).
  - 37 inline copies of the decision-time "current" axes → `live_only()`.
- Remove the deletion-test helpers `live_only_axes()` and `find_all_axes()`, inlining their ~64 call sites onto `live_only()` / `all()`. `live_only_axes()` previously pinned the *transaction-time* axis; switching it to the decision-time `live_only()` finds the same live entities — verified by the suites below. `axes_at_decision_time()` (parameterised) is kept.

Every replacement of `default()`/inline axes is byte-identical to the code it replaces; the only behavioral change is the deletion-test helper's axis, which the tests confirm is equivalent.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

None.

## 🐾 Next steps

None.

## 🛡 What tests cover this?

Existing test suites, all green:

- `hash-graph-postgres-store` unit tests — **136/136 passed** (incl. the `select.rs` SQL-compilation tests that resolve `all()`).
- Deletion + principals + integration DB suites — **364/364 passed** (1 skipped), exercising `all()` and `live_only()` in real queries.
- `clippy --all-features --all-targets` clean across `store`, `postgres-store`, `type-fetcher`, `integration`, `benches`, `api`.

No new tests added — behavior is unchanged, so existing coverage applies.

## ❓ How to test this?

1. `cargo clippy --all-features --all-targets -p hash-graph-store -p hash-graph-postgres-store -p hash-graph-type-fetcher -p hash-graph-integration -p hash-graph-benches -p hash-graph-api`
2. `cargo nextest run -p hash-graph-postgres-store -p hash-graph-integration --all-features` (against a freshly-migrated, unseeded graph DB)


