### PR TITLE
BE-444: Fix email verification failing for uppercase signups

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -4,4 +4,4 @@
 
 HASH_GRAPH_ALLOWED_URL_DOMAIN_PATTERN="(?:http://localhost:3000|https://hash\\.ai)/@(?P<shortname>[\\w-]+)/types/(?P<kind>(?:data-type)|(?:property-type)|(?:entity-type))/[\\w\\-_%]+/"
 
-USER_EMAIL_ALLOW_LIST='["charlie@example.com", "signup-allow@example.com", "signin-test@example.com", "signout-test@example.com", "pw-change@example.com", "pw-recovery@example.com", "mfa-enable@example.com", "mfa-login@example.com", "mfa-backup@example.com", "mfa-disable@example.com", "mfa-wrong-code@example.com"]'
+USER_EMAIL_ALLOW_LIST='["charlie@example.com", "signup-allow@example.com", "signup-uppercase@example.com", "signin-test@example.com", "signout-test@example.com", "pw-change@example.com", "pw-recovery@example.com", "mfa-enable@example.com", "mfa-login@example.com", "mfa-backup@example.com", "mfa-disable@example.com", "mfa-wrong-code@example.com"]'

--- a/apps/hash-api/src/auth/create-auth-handlers.ts
+++ b/apps/hash-api/src/auth/create-auth-handlers.ts
@@ -8,7 +8,7 @@ import { publicUserAccountId } from "@local/hash-backend-utils/public-user-accou
 import { createUser, getUser } from "../graph/knowledge/system-types/user";
 import { systemAccountId } from "../graph/system-account";
 import { hydraAdmin } from "./ory-hydra";
-import { isUserEmailVerified, kratosFrontendApi } from "./ory-kratos";
+import { kratosFrontendApi } from "./ory-kratos";
 
 import type { ImpureGraphContext } from "../graph/context-types";
 import type { User } from "../graph/knowledge/system-types/user";
@@ -122,7 +122,6 @@ export const getUserAndSession = async ({
   logger: Logger;
   sessionToken?: string;
 }): Promise<{
-  primaryEmailVerified?: boolean;
   session?: Session;
   user?: User;
 }> => {
@@ -158,13 +157,6 @@ export const getUserAndSession = async ({
 
     const { id: kratosIdentityId, traits } = identity as KratosUserIdentity;
 
-    const primaryEmailAddress = traits.emails[0];
-
-    const primaryEmailVerified =
-      identity.verifiable_addresses?.find(
-        ({ value }) => value === primaryEmailAddress,
-      )?.verified === true;
-
     let user = await getUser(context, authentication, {
       kratosIdentityId,
       emails: traits.emails,
@@ -191,7 +183,7 @@ export const getUserAndSession = async ({
       }
     }
 
-    return { primaryEmailVerified, session: kratosSession, user };
+    return { session: kratosSession, user };
   }
 
   return {};
@@ -226,9 +218,6 @@ export const createAuthMiddleware = (params: {
           },
         );
         if (user) {
-          req.primaryEmailVerified = await isUserEmailVerified(
-            user.kratosIdentityId,
-          );
           req.user = user;
           next();
           return;
@@ -236,14 +225,13 @@ export const createAuthMiddleware = (params: {
       }
     }
 
-    const { primaryEmailVerified, session, user } = await getUserAndSession({
+    const { session, user } = await getUserAndSession({
       context,
       cookie: req.header("cookie"),
       logger,
       sessionToken: accessOrSessionToken,
     });
     if (session) {
-      req.primaryEmailVerified = primaryEmailVerified;
       req.session = session;
       req.user = user;
     }

--- a/apps/hash-api/src/auth/create-unverified-email-cleanup-job.test.ts
+++ b/apps/hash-api/src/auth/create-unverified-email-cleanup-job.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import { isPrimaryEmailVerified } from "./create-unverified-email-cleanup-job";
+
+import type { Identity } from "@ory/kratos-client";
+
+/**
+ * Build a minimal Kratos identity for the cleanup-job predicate. Only the
+ * fields `isPrimaryEmailVerified` reads (`traits.emails`, `verifiable_addresses`)
+ * are populated; the rest of the `Identity` shape is irrelevant here.
+ */
+const identity = (
+  emails: string[],
+  verifiableAddresses: Array<{ value: string; verified: boolean }>,
+): Identity =>
+  ({
+    traits: { emails },
+    verifiable_addresses: verifiableAddresses,
+  }) as unknown as Identity;
+
+describe("isPrimaryEmailVerified (cleanup-job deletion gate)", () => {
+  it("treats a verified address as verified despite trait/address casing mismatch", () => {
+    expect(
+      isPrimaryEmailVerified(
+        identity(
+          ["User@Example.com"],
+          [{ value: "user@example.com", verified: true }],
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("treats a verified address as verified when casing matches", () => {
+    expect(
+      isPrimaryEmailVerified(
+        identity(
+          ["user@example.com"],
+          [{ value: "user@example.com", verified: true }],
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("treats a genuinely unverified address as unverified (eligible for cleanup)", () => {
+    expect(
+      isPrimaryEmailVerified(
+        identity(
+          ["User@Example.com"],
+          [{ value: "user@example.com", verified: false }],
+        ),
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false when there is no verifiable address", () => {
+    expect(isPrimaryEmailVerified(identity(["user@example.com"], []))).toBe(
+      false,
+    );
+  });
+
+  it("returns false when the identity has no email traits", () => {
+    expect(
+      isPrimaryEmailVerified(
+        identity([], [{ value: "user@example.com", verified: true }]),
+      ),
+    ).toBe(false);
+  });
+});

--- a/apps/hash-api/src/auth/create-unverified-email-cleanup-job.ts
+++ b/apps/hash-api/src/auth/create-unverified-email-cleanup-job.ts
@@ -3,11 +3,16 @@ import {
   currentTimeInstantTemporalAxes,
   generateVersionedUrlMatchingFilter,
 } from "@local/hash-isomorphic-utils/graph-queries";
+import { normalizeEmail } from "@local/hash-isomorphic-utils/normalize";
 import { systemEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 
 import { getUserFromEntity } from "../graph/knowledge/system-types/user";
 import { systemAccountId } from "../graph/system-account";
-import { deleteKratosIdentity, kratosIdentityApi } from "./ory-kratos";
+import {
+  deleteKratosIdentity,
+  getVerifiedEmailsFromKratosIdentity,
+  kratosIdentityApi,
+} from "./ory-kratos";
 
 import type { ImpureGraphContext } from "../graph/context-types";
 import type { Logger } from "@local/hash-backend-utils/logger";
@@ -71,7 +76,7 @@ const parseIdentityCreatedAt = (identity: Identity): Date | undefined => {
   return createdAt;
 };
 
-const isPrimaryEmailVerified = (identity: Identity): boolean => {
+export const isPrimaryEmailVerified = (identity: Identity): boolean => {
   const identityTraits = identity.traits as { emails?: string[] };
   const primaryEmailAddress = identityTraits.emails?.[0];
 
@@ -79,10 +84,8 @@ const isPrimaryEmailVerified = (identity: Identity): boolean => {
     return false;
   }
 
-  return (
-    identity.verifiable_addresses?.find(
-      ({ value }) => value === primaryEmailAddress,
-    )?.verified === true
+  return getVerifiedEmailsFromKratosIdentity(identity).includes(
+    normalizeEmail(primaryEmailAddress),
   );
 };
 

--- a/apps/hash-api/src/auth/ory-kratos.ts
+++ b/apps/hash-api/src/auth/ory-kratos.ts
@@ -2,6 +2,7 @@ import { Configuration } from "@ory/client";
 import { FrontendApi, IdentityApi } from "@ory/kratos-client";
 
 import { getRequiredEnv } from "@local/hash-backend-utils/environment";
+import { normalizeEmail } from "@local/hash-isomorphic-utils/normalize";
 
 import type { CreateIdentityBody, Identity } from "@ory/kratos-client";
 
@@ -31,7 +32,7 @@ export const getVerifiedEmailsFromKratosIdentity = (
 ): string[] =>
   (identity.verifiable_addresses ?? [])
     .filter((address) => address.verified === true)
-    .map(({ value }) => value);
+    .map(({ value }) => normalizeEmail(value));
 
 export const createKratosIdentity = async (
   params: Omit<CreateIdentityBody, "schema_id" | "traits"> & {

--- a/apps/hash-api/src/express.d.ts
+++ b/apps/hash-api/src/express.d.ts
@@ -9,7 +9,6 @@ declare global {
       context: ImpureGraphContext<true, true> & {
         vaultClient?: VaultClient;
       };
-      primaryEmailVerified: boolean | undefined;
       session: Session | undefined;
       user: User | undefined;
     }

--- a/apps/hash-api/src/graph/knowledge/system-types/user.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/user.ts
@@ -172,11 +172,18 @@ export const getUserFromEntity: PureGraphFunction<
 
   const {
     displayName,
-    email: emails,
+    email,
     enabledFeatureFlags: maybeFeatureFlags,
     kratosIdentityId,
     shortname,
   } = simplifyProperties(entity.properties);
+
+  // `email` is typed as a required property, but property-level permission
+  // masking can drop it at runtime for non-owners (see `getUser`'s Kratos
+  // back-fill). Model that nullability, then canonicalise so every `User` built
+  // from an entity compares case-insensitively regardless of signup casing.
+  const emails =
+    (email as [string, ...string[]] | undefined)?.map(normalizeEmail) ?? [];
 
   const isAccountSignupComplete = !!shortname && !!displayName;
 
@@ -190,11 +197,7 @@ export const getUserFromEntity: PureGraphFunction<
       entity.metadata.recordId.entityId,
     ) as UserId,
     displayName,
-    // Canonicalise at the single point every `User` is built from an entity, so
-    // case-insensitive comparisons hold regardless of the casing stored at
-    // signup.
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- the non-nullable type lies; property-level masking drops `email` at runtime
-    emails: emails?.map(normalizeEmail) as typeof emails,
+    emails,
     enabledFeatureFlags,
     entity,
     isAccountSignupComplete,

--- a/apps/hash-api/src/graph/knowledge/system-types/user.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/user.ts
@@ -183,7 +183,7 @@ export const getUserFromEntity: PureGraphFunction<
   // back-fill). Model that nullability, then canonicalise so every `User` built
   // from an entity compares case-insensitively regardless of signup casing.
   const emails =
-    (email as [string, ...string[]] | undefined)?.map(normalizeEmail) ?? [];
+(email as typeof email | undefined)?.map(normalizeEmail) ?? [];
 
   const isAccountSignupComplete = !!shortname && !!displayName;
 

--- a/apps/hash-api/src/graph/knowledge/system-types/user.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/user.ts
@@ -182,8 +182,7 @@ export const getUserFromEntity: PureGraphFunction<
   // masking can drop it at runtime for non-owners (see `getUser`'s Kratos
   // back-fill). Model that nullability, then canonicalise so every `User` built
   // from an entity compares case-insensitively regardless of signup casing.
-  const emails =
-    (email as typeof email | undefined)?.map(normalizeEmail) ?? [];
+  const emails = (email as typeof email | undefined)?.map(normalizeEmail) ?? [];
 
   const isAccountSignupComplete = !!shortname && !!displayName;
 

--- a/apps/hash-api/src/graph/knowledge/system-types/user.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/user.ts
@@ -183,7 +183,7 @@ export const getUserFromEntity: PureGraphFunction<
   // back-fill). Model that nullability, then canonicalise so every `User` built
   // from an entity compares case-insensitively regardless of signup casing.
   const emails =
-(email as typeof email | undefined)?.map(normalizeEmail) ?? [];
+    (email as typeof email | undefined)?.map(normalizeEmail) ?? [];
 
   const isAccountSignupComplete = !!shortname && !!displayName;
 

--- a/apps/hash-api/src/graph/knowledge/system-types/user.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/user.ts
@@ -24,6 +24,7 @@ import {
   currentTimeInstantTemporalAxes,
   generateVersionedUrlMatchingFilter,
 } from "@local/hash-isomorphic-utils/graph-queries";
+import { normalizeEmail } from "@local/hash-isomorphic-utils/normalize";
 import {
   systemEntityTypes,
   systemLinkEntityTypes,
@@ -140,9 +141,11 @@ export const checkEmailVerificationAndUsageStatus = async (
   | { status: "verified"; kratosIdentityId: string }
   | { status: "not-verified"; kratosIdentityId: string }
 > => {
+  const normalizedEmail = normalizeEmail(email);
+
   try {
     const { data: identities } = await kratosIdentityApi.listIdentities({
-      credentialsIdentifier: email,
+      credentialsIdentifier: normalizedEmail,
     });
 
     if (identities.length === 0) {
@@ -150,7 +153,7 @@ export const checkEmailVerificationAndUsageStatus = async (
     }
 
     const verifiedEmails = getVerifiedEmailsFromKratosIdentity(identities[0]!);
-    if (verifiedEmails.includes(email)) {
+    if (verifiedEmails.includes(normalizedEmail)) {
       return { status: "verified", kratosIdentityId: identities[0]!.id };
     } else {
       return { status: "not-verified", kratosIdentityId: identities[0]!.id };
@@ -187,7 +190,11 @@ export const getUserFromEntity: PureGraphFunction<
       entity.metadata.recordId.entityId,
     ) as UserId,
     displayName,
-    emails,
+    // Canonicalise at the single point every `User` is built from an entity, so
+    // case-insensitive comparisons hold regardless of the casing stored at
+    // signup.
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- the non-nullable type lies; property-level masking drops `email` at runtime
+    emails: emails?.map(normalizeEmail) as typeof emails,
     enabledFeatureFlags,
     entity,
     isAccountSignupComplete,

--- a/apps/hash-api/src/graphql/resolvers/knowledge/org/invite-user-to-org.ts
+++ b/apps/hash-api/src/graphql/resolvers/knowledge/org/invite-user-to-org.ts
@@ -16,6 +16,7 @@ import {
   currentTimeInstantTemporalAxes,
   generateVersionedUrlMatchingFilter,
 } from "@local/hash-isomorphic-utils/graph-queries";
+import { normalizeEmail } from "@local/hash-isomorphic-utils/normalize";
 import {
   blockProtocolDataTypes,
   systemDataTypes,
@@ -173,7 +174,7 @@ export const inviteUserToOrgResolver: ResolverFn<
   let existingUserToInvite: User | null = null;
 
   const userEmail = unnormalisedUserEmail
-    ? unnormalisedUserEmail.trim().toLowerCase()
+    ? normalizeEmail(unnormalisedUserEmail)
     : null;
 
   if (userEmail) {

--- a/apps/hash-api/src/shared/user-has-access-to-hash.ts
+++ b/apps/hash-api/src/shared/user-has-access-to-hash.ts
@@ -1,3 +1,5 @@
+import { normalizeEmail } from "@local/hash-isomorphic-utils/normalize";
+
 import {
   getUserPendingInvitations,
   type User,
@@ -25,7 +27,9 @@ if (process.env.USER_EMAIL_ALLOW_LIST) {
       );
     }
 
-    userEmailAllowList = uncheckedUserEmailAllowList;
+    // Normalise so the allowlist matches the canonical (lowercased) emails
+    // surfaced on `user.emails`, regardless of how an admin cased entries.
+    userEmailAllowList = uncheckedUserEmailAllowList.map(normalizeEmail);
   } catch (error) {
     if (error instanceof SyntaxError) {
       throw new Error(

--- a/apps/hash-frontend/src/lib/user-and-org.ts
+++ b/apps/hash-frontend/src/lib/user-and-org.ts
@@ -12,6 +12,7 @@ import {
   extractWebIdFromEntityId,
 } from "@blockprotocol/type-system";
 import { getFirstEntityRevision } from "@local/hash-isomorphic-utils/entity";
+import { normalizeEmail } from "@local/hash-isomorphic-utils/normalize";
 import {
   systemEntityTypes,
   systemLinkEntityTypes,
@@ -374,9 +375,11 @@ export const constructUser = (params: {
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- permissions means this may be undefined. @todo types to account for property-level permissions
   const primaryEmailAddress = email?.[0] ?? "";
 
+  const normalizedPrimaryEmail = normalizeEmail(primaryEmailAddress);
+
   const isPrimaryEmailAddressVerified =
     params.verifiableAddresses?.find(
-      ({ value }) => value === primaryEmailAddress,
+      ({ value }) => normalizeEmail(value) === normalizedPrimaryEmail,
     )?.verified === true;
 
   const minimalUser = constructMinimalUser({ userEntity });

--- a/apps/hash-frontend/src/pages/_app.page.tsx
+++ b/apps/hash-frontend/src/pages/_app.page.tsx
@@ -20,6 +20,7 @@ import { getRoots } from "@blockprotocol/graph/stdlib";
 import { createEmotionCache, theme } from "@hashintel/design-system/theme";
 import { featureFlags } from "@local/hash-isomorphic-utils/feature-flags";
 import { mapGqlSubgraphFieldsFragmentToSubgraph } from "@local/hash-isomorphic-utils/graph-queries";
+import { normalizeEmail } from "@local/hash-isomorphic-utils/normalize";
 
 import { getHashInstanceSettings } from "../graphql/queries/knowledge/hash-instance.queries";
 import { hasAccessToHashQuery, meQuery } from "../graphql/queries/user.queries";
@@ -290,9 +291,11 @@ const getPrimaryEmailVerificationStatus = async (cookie?: string) =>
         return false;
       }
 
+      const normalizedPrimaryEmail = normalizeEmail(primaryEmailAddress);
+
       return (
         identity.verifiable_addresses?.find(
-          ({ value }) => value === primaryEmailAddress,
+          ({ value }) => normalizeEmail(value) === normalizedPrimaryEmail,
         )?.verified === true
       );
     })

--- a/libs/@local/hash-isomorphic-utils/src/normalize.test.ts
+++ b/libs/@local/hash-isomorphic-utils/src/normalize.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeEmail } from "./normalize.js";
+
+describe("normalizeEmail", () => {
+  it("lowercases the address", () => {
+    expect(normalizeEmail("User@Example.com")).toBe("user@example.com");
+    expect(normalizeEmail("Signup-Allow@Example.COM")).toBe(
+      "signup-allow@example.com",
+    );
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(normalizeEmail("  user@example.com  ")).toBe("user@example.com");
+    expect(normalizeEmail("\tUser@Example.com\n")).toBe("user@example.com");
+  });
+
+  it("is idempotent on already-normalized input", () => {
+    const normalized = normalizeEmail("User@Example.com");
+    expect(normalizeEmail(normalized)).toBe(normalized);
+  });
+
+  it("only trims and lowercases — it does not canonicalize the local part", () => {
+    // Guards the comparison contract: normalization must not strip `+tag`
+    // suffixes or dots, which would silently change email matching everywhere.
+    expect(normalizeEmail("First.Last+Tag@Example.com")).toBe(
+      "first.last+tag@example.com",
+    );
+  });
+});

--- a/libs/@local/hash-isomorphic-utils/src/normalize.ts
+++ b/libs/@local/hash-isomorphic-utils/src/normalize.ts
@@ -6,3 +6,13 @@
  */
 export const normalizeWhitespace = (string: string) =>
   string.replace(/\s+/g, " ").trim();
+
+/**
+ * Canonical form of an email address for case-insensitive comparison.
+ *
+ * Kratos lowercases the login identifier but leaves the trait and
+ * `verifiable_addresses[].value` in the casing typed at signup, so emails read
+ * back from Kratos are inconsistently cased.
+ */
+export const normalizeEmail = (email: string): string =>
+  email.trim().toLowerCase();

--- a/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/org-invitation-email-casing.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/org-invitation-email-casing.test.ts
@@ -1,0 +1,201 @@
+import { beforeAll, describe, expect, it } from "vitest";
+
+import {
+  createKratosIdentity,
+  deleteKratosIdentity,
+} from "@apps/hash-api/src/auth/ory-kratos";
+import { ensureSystemGraphIsInitialized } from "@apps/hash-api/src/graph/ensure-system-graph-is-initialized";
+import { createOrg } from "@apps/hash-api/src/graph/knowledge/system-types/org";
+import {
+  checkEmailVerificationAndUsageStatus,
+  createUser,
+  getUserPendingInvitations,
+  getUserVerifiedEmails,
+  isUserMemberOfOrg,
+} from "@apps/hash-api/src/graph/knowledge/system-types/user";
+import { systemAccountId } from "@apps/hash-api/src/graph/system-account";
+import { acceptOrgInvitationResolver } from "@apps/hash-api/src/graphql/resolvers/knowledge/org/accept-org-invitation";
+import { inviteUserToOrgResolver } from "@apps/hash-api/src/graphql/resolvers/knowledge/org/invite-user-to-org";
+import { Logger } from "@local/hash-backend-utils/logger";
+import { addActorGroupAdministrator } from "@local/hash-graph-sdk/principal/actor-group";
+
+import { resetGraph } from "../../../admin-server";
+import {
+  createTestImpureGraphContext,
+  createTestUser,
+  generateRandomShortname,
+} from "../../../util";
+
+import type { EmailTransporter } from "@apps/hash-api/src/email/transporters";
+import type { Org } from "@apps/hash-api/src/graph/knowledge/system-types/org";
+import type { User } from "@apps/hash-api/src/graph/knowledge/system-types/user";
+import type { LoggedInGraphQLContext } from "@apps/hash-api/src/graphql/context";
+import type { EntityId } from "@blockprotocol/type-system";
+import type { AuthenticationContext } from "@local/hash-graph-sdk/authentication-context";
+import type { GraphQLResolveInfo } from "graphql";
+
+const logger = new Logger({
+  environment: "test",
+  level: "debug",
+  serviceName: "integration-tests",
+});
+
+const graphContext = createTestImpureGraphContext();
+
+// Resolvers ignore `info`; a cast keeps the call signature satisfied.
+const resolverInfo = {} as unknown as GraphQLResolveInfo;
+
+const graphQLContextForUser = (user: User): LoggedInGraphQLContext => ({
+  dataSources: {
+    graphApi: graphContext.graphApi,
+    uploadProvider: graphContext.uploadProvider,
+  },
+  emailTransporter: {
+    sendMail: async () => {},
+  } as unknown as EmailTransporter,
+  logger,
+  authentication: { actorId: user.accountId },
+  user,
+  provenance: { ...graphContext.provenance, actorType: "user" },
+  temporal: graphContext.temporalClient,
+});
+
+describe("org invitation with a mixed-case signup email", () => {
+  // Shortname must be lowercase, but the email deliberately carries upper-case
+  // characters to reproduce a cased signup.
+  const shortname = generateRandomShortname("invcase");
+  const casedEmail = `Cased-${shortname}@Example.com`;
+  const lowercasedEmail = casedEmail.toLowerCase();
+
+  let invitee: User;
+  let inviter: User;
+  let testOrg: Org;
+  let systemAuthentication: AuthenticationContext;
+  let invitationEntityId: EntityId;
+
+  beforeAll(async () => {
+    await ensureSystemGraphIsInitialized({
+      logger,
+      context: graphContext,
+      seedSystemPolicies: true,
+    });
+
+    // `systemAccountId` is only populated during system-graph init.
+    systemAuthentication = { actorId: systemAccountId };
+
+    const identity = await createKratosIdentity({
+      traits: { emails: [casedEmail] },
+      verifyEmails: true,
+    });
+
+    invitee = await createUser(graphContext, systemAuthentication, {
+      emails: [casedEmail],
+      kratosIdentityId: identity.id,
+      shortname,
+      displayName: shortname,
+    });
+
+    // Create the org as the system account (a machine actor, matching the test
+    // context's provenance), then grant the inviter the administrator role the
+    // invite resolver requires.
+    inviter = await createTestUser(graphContext, "invadmin", logger);
+    testOrg = await createOrg(graphContext, systemAuthentication, {
+      name: "Invite Casing Test Org",
+      shortname: generateRandomShortname("invorg"),
+    });
+    await addActorGroupAdministrator(
+      graphContext.graphApi,
+      systemAuthentication,
+      {
+        actorId: inviter.accountId,
+        actorGroupId: testOrg.webId,
+      },
+    );
+
+    return async () => {
+      await deleteKratosIdentity({
+        kratosIdentityId: invitee.kratosIdentityId,
+      });
+      await deleteKratosIdentity({
+        kratosIdentityId: inviter.kratosIdentityId,
+      });
+      await resetGraph();
+    };
+  });
+
+  it("normalizes the email when building the user from the entity", () => {
+    expect(invitee.emails).toContain(lowercasedEmail);
+    expect(invitee.emails).not.toContain(casedEmail);
+  });
+
+  it("resolves the cased user via a differently-cased email lookup", async () => {
+    const result = await checkEmailVerificationAndUsageStatus(
+      casedEmail.toUpperCase(),
+    );
+
+    expect(result.status).toBe("verified");
+    if (result.status === "verified") {
+      expect(result.kratosIdentityId).toBe(invitee.kratosIdentityId);
+    }
+  });
+
+  it("reports the verified email in normalized form", async () => {
+    const verifiedEmails = await getUserVerifiedEmails(
+      graphContext,
+      systemAuthentication,
+      { user: invitee },
+    );
+
+    expect(verifiedEmails).toContain(lowercasedEmail);
+  });
+
+  it("lets an org admin invite the cased user by a differently-cased email", async () => {
+    const invited = await inviteUserToOrgResolver(
+      {},
+      { orgWebId: testOrg.webId, userEmail: casedEmail.toUpperCase() },
+      graphQLContextForUser(inviter),
+      resolverInfo,
+    );
+
+    expect(invited).toBe(true);
+
+    const pendingInvitations = await getUserPendingInvitations(
+      graphContext,
+      systemAuthentication,
+      { user: invitee },
+    );
+
+    expect(pendingInvitations).toHaveLength(1);
+    invitationEntityId = pendingInvitations[0]!.invitationEntityId;
+  });
+
+  it("lets the cased user accept the invitation and become a member", async () => {
+    const result = await acceptOrgInvitationResolver(
+      {},
+      { orgInvitationEntityId: invitationEntityId },
+      graphQLContextForUser(invitee),
+      resolverInfo,
+    );
+
+    expect(result.accepted).toBe(true);
+
+    const isMember = await isUserMemberOfOrg(
+      graphContext,
+      systemAuthentication,
+      {
+        userEntityId: invitee.entity.metadata.recordId.entityId,
+        orgEntityUuid: testOrg.webId,
+      },
+    );
+
+    expect(isMember).toBe(true);
+  });
+
+  it("does not resolve a never-registered email", async () => {
+    const result = await checkEmailVerificationAndUsageStatus(
+      `never-${shortname}@example.com`,
+    );
+
+    expect(result.status).toBe("email-not-found");
+  });
+});

--- a/tests/hash-playwright/tests/account/signup.spec.ts
+++ b/tests/hash-playwright/tests/account/signup.spec.ts
@@ -29,6 +29,33 @@ test("allowlisted user can verify email and complete signup", async ({
   await completeSignup(page, { shortname, displayName: "New User" });
 });
 
+test("user signing up with an uppercase email can verify and complete signup", async ({
+  page,
+}) => {
+  const { email } = testUsers.signupUppercase;
+  const uppercaseEmail = email.toUpperCase();
+
+  await deleteUserByEmail(email);
+
+  const { emailDispatchTimestamp } = await registerUser(page, {
+    email: uppercaseEmail,
+    password: defaultPassword,
+  });
+
+  // Registered with the uppercased address but look up the code by its
+  // lowercased form; the helper matches recipients case-insensitively, so the
+  // casing mismatch between registration and lookup doesn't lose the email.
+  await verifyEmailOnPage(page, {
+    email,
+    afterTimestamp: emailDispatchTimestamp,
+  });
+
+  const uniqueSuffix = `${Date.now()}${Math.floor(Math.random() * 1_000)}`;
+  const shortname = `upper${uniqueSuffix}`.slice(0, 24);
+
+  await completeSignup(page, { shortname, displayName: "Uppercase User" });
+});
+
 test("waitlisted user is redirected to waitlist after signup", async ({
   page,
 }) => {

--- a/tests/hash-playwright/tests/shared/get-kratos-verification-code.ts
+++ b/tests/hash-playwright/tests/shared/get-kratos-verification-code.ts
@@ -83,6 +83,15 @@ const pollForKratosCode = async ({
   const maxWaitMs = 10_000;
   const pollIntervalMs = 250;
   const timestampBufferMs = 5_000;
+  // Match recipients case-insensitively: a user may sign up with an uppercased
+  // address while Kratos delivers the email to the lowercased one.
+  const normalizedTarget = emailAddress.toLowerCase();
+  const isSentToTarget = (
+    addresses: MailslurperMailItem["toAddresses"],
+  ): boolean =>
+    extractToAddresses(addresses).some(
+      (address) => address.toLowerCase() === normalizedTarget,
+    );
   let elapsed = 0;
   let lastError: unknown;
   let lastMailItems: MailslurperMailItem[] | undefined;
@@ -110,7 +119,7 @@ const pollForKratosCode = async ({
 
             return (
               subjectFilter(mailItem.subject) &&
-              extractToAddresses(mailItem.toAddresses).includes(emailAddress) &&
+              isSentToTarget(mailItem.toAddresses) &&
               (!afterTimestamp ||
                 (typeof sentTimestamp === "number" &&
                   sentTimestamp >= afterTimestamp - timestampBufferMs))
@@ -143,7 +152,7 @@ const pollForKratosCode = async ({
 
   const allItems = lastMailItems ?? [];
   const toTargetAddress = allItems.filter((item) =>
-    extractToAddresses(item.toAddresses).includes(emailAddress),
+    isSentToTarget(item.toAddresses),
   );
   const matchingSubject = toTargetAddress.filter((item) =>
     subjectFilter(item.subject),

--- a/tests/hash-playwright/tests/shared/get-kratos-verification-code.ts
+++ b/tests/hash-playwright/tests/shared/get-kratos-verification-code.ts
@@ -1,3 +1,4 @@
+import { normalizeEmail } from "@local/hash-isomorphic-utils/normalize";
 import { sleep } from "@local/hash-isomorphic-utils/sleep";
 
 type MailslurperMailAddress = {
@@ -85,12 +86,12 @@ const pollForKratosCode = async ({
   const timestampBufferMs = 5_000;
   // Match recipients case-insensitively: a user may sign up with an uppercased
   // address while Kratos delivers the email to the lowercased one.
-  const normalizedTarget = emailAddress.toLowerCase();
+  const normalizedTarget = normalizeEmail(emailAddress);
   const isSentToTarget = (
     addresses: MailslurperMailItem["toAddresses"],
   ): boolean =>
     extractToAddresses(addresses).some(
-      (address) => address.toLowerCase() === normalizedTarget,
+      (address) => normalizeEmail(address) === normalizedTarget,
     );
   let elapsed = 0;
   let lastError: unknown;

--- a/tests/hash-playwright/tests/shared/test-users.ts
+++ b/tests/hash-playwright/tests/shared/test-users.ts
@@ -52,4 +52,9 @@ export const testUsers = {
     "signup-allow",
     "Signup Allow",
   ),
+  signupUppercase: user(
+    "signup-uppercase@example.com",
+    "signup-uppercase",
+    "Signup Uppercase",
+  ),
 } as const;

--- a/turbo.json
+++ b/turbo.json
@@ -66,7 +66,7 @@
     },
     // Test commands
     "test:unit": {
-      "dependsOn": ["codegen"],
+      "dependsOn": ["codegen", "^build"],
       "env": ["TEST_COVERAGE"]
     },
     "test:integration": {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Signing up with a mixed-case email (e.g. `T@HASH.ai`) left the user stuck on the email-verification screen: Kratos delivered the code to the lowercased address and accepted it (consuming it), but the account never unlocked. The cause was **case-sensitive email comparisons** between Kratos `verifiable_addresses[].value` (the casing typed at signup) and a normalized/lowercased source — and that comparison logic was **duplicated across the frontend and backend** and had drifted.

This PR makes all email comparisons case-insensitive via a single shared helper, fixing the reported signup flow and several adjacent latent bugs of the same class.

## 🔗 Related links

- [BE-444](https://linear.app/hash/issue/BE-444/email-verification-code-fails-when-signing-up-with-uppercase-email) _(internal)_
- Original report & Kratos/app logs in the Slack thread _(internal)_

## 🔍 What does this change?

- Adds a shared `normalizeEmail` helper (`@local/hash-isomorphic-utils/normalize`, `.trim().toLowerCase()`) imported by both frontend and backend, so the comparison logic can no longer drift.
- **Frontend (the user-facing gate):** normalizes both sides of the verification check in `getPrimaryEmailVerificationStatus` (`_app.page.tsx`) and `isPrimaryEmailAddressVerified` (`user-and-org.ts`). This is what unblocks the stuck verification screen.
- **Backend:** normalizes emails read from Kratos at the single `getUserFromEntity` funnel and in `getVerifiedEmailsFromKratosIdentity`, the allowlist on parse (`user-has-access-to-hash.ts`), and `checkEmailVerificationAndUsageStatus`.
- **Cleanup job:** `isPrimaryEmailVerified` now compares case-insensitively — previously a verified mixed-case account could be classed as unverified and **archived + its Kratos identity deleted** (data loss).
- Removes the dead `req.primaryEmailVerified` machinery (computed in `create-auth-handlers`, never read anywhere; `express.d.ts` field included).

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

- Emails are normalized **on read** (`getUserFromEntity`, the Kratos read helpers) rather than **on write** — the user entity still stores the email in its original casing. This is safe because every comparison path now normalizes (TS via `normalizeEmail`, and the graph admin delete-by-email already lowercases both sides in SQL). Flagged so a future exact-match graph filter against the stored `email` property doesn't get caught out.

## 🐾 Next steps

- If stored canonicalization is ever wanted, normalize at write time in `createUser` (would also cover any future stored-value exact-match query).

## 🛡 What tests cover this?

- **New e2e** (`signup.spec.ts`): registers with an uppercased allowlisted email, verifies via Mailslurper, completes signup. Demonstrably failed pre-fix (stuck at the verify gate, then at completion).
- **New unit** (`normalize.test.ts`): pins the `normalizeEmail` contract (trim + lowercase, idempotent, no local-part canonicalization).
- **New unit** (`create-unverified-email-cleanup-job.test.ts`): guards the data-loss path — a verified mixed-case identity is recognized as verified.
- Existing signup e2e (lowercase + waitlist) still pass — no regression.

## ❓ How to test this?

1. Check out the branch and run the test stack (Kratos + Mailslurper + API + frontend).
2. Sign up with a mixed-case email such as `Foo@Example.com`.
3. Enter the verification code from Mailslurper.
4. Confirm you advance past the verification screen and can complete signup (set shortname + display name) rather than being stuck on "Verify your email address".

Automated: `turbo run test:unit --filter '@local/hash-isomorphic-utils' --filter '@apps/hash-api'` and the Playwright `signup` spec on `account-chromium`.

## 📹 Demo

n/a — backend + frontend logic fix; covered by the e2e regression test above.
