### PR TITLE
BE-580: Inline type filters onto the edition cache; rework summarizeEntities aggregation

### DIFF
--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/process-automatic-browsing-settings-action.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/process-automatic-browsing-settings-action.ts
@@ -1,5 +1,4 @@
 import { getSimplifiedAiFlowActionInputs } from "@local/hash-isomorphic-utils/flows/action-definitions";
-import { generateVersionedUrlMatchingFilter } from "@local/hash-isomorphic-utils/graph-queries";
 import { systemEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 import { StatusCode } from "@local/status";
 
@@ -34,10 +33,15 @@ export const processAutomaticBrowsingSettingsAction: AiFlowActionActivity<
             { parameter: userAuthentication.actorId },
           ],
         },
-        generateVersionedUrlMatchingFilter(
-          systemEntityTypes.browserPluginSettings.entityTypeId,
-          { ignoreParents: true },
-        ),
+        {
+          equal: [
+            { path: ["type", "baseUrl"] },
+            {
+              parameter:
+                systemEntityTypes.browserPluginSettings.entityTypeBaseUrl,
+            },
+          ],
+        },
       ],
     },
     graphApiClient,

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action.ts
@@ -1,9 +1,6 @@
 import { queryEntities } from "@local/hash-graph-sdk/entity";
 import { generateUuid } from "@local/hash-isomorphic-utils/generate-uuid";
-import {
-  currentTimeInstantTemporalAxes,
-  generateVersionedUrlMatchingFilter,
-} from "@local/hash-isomorphic-utils/graph-queries";
+import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import { systemEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 
 import { getFlowContext } from "../shared/get-flow-context.js";
@@ -91,10 +88,14 @@ export const researchEntitiesAction: AiFlowActionActivity<
         temporalAxes: currentTimeInstantTemporalAxes,
         filter: {
           all: [
-            generateVersionedUrlMatchingFilter(
-              systemEntityTypes.claim.entityTypeId,
-              { ignoreParents: true },
-            ),
+            {
+              equal: [
+                { path: ["type", "baseUrl"] },
+                {
+                  parameter: systemEntityTypes.claim.entityTypeBaseUrl,
+                },
+              ],
+            },
             {
               equal: [
                 {

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/coordinating-agent/summarize-existing-entities.ai.test.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/research-entities-action/coordinating-agent/summarize-existing-entities.ai.test.ts
@@ -3,10 +3,7 @@ import { expect, test } from "vitest";
 
 import { publicUserAccountId } from "@local/hash-backend-utils/public-user-account-id";
 import { queryEntities } from "@local/hash-graph-sdk/entity";
-import {
-  currentTimeInstantTemporalAxes,
-  generateVersionedUrlMatchingFilter,
-} from "@local/hash-isomorphic-utils/graph-queries";
+import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import { systemEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 
 import { graphApiClient } from "../../../shared/graph-api-client.js";
@@ -24,10 +21,14 @@ test.skip(
       {
         filter: {
           all: [
-            generateVersionedUrlMatchingFilter(
-              systemEntityTypes.user.entityTypeId,
-              { ignoreParents: true },
-            ),
+            {
+              equal: [
+                { path: ["type", "baseUrl"] },
+                {
+                  parameter: systemEntityTypes.user.entityTypeBaseUrl,
+                },
+              ],
+            },
           ],
         },
         temporalAxes: currentTimeInstantTemporalAxes,

--- a/apps/hash-ai-worker-ts/src/activities/shared/find-existing-entity.ts
+++ b/apps/hash-ai-worker-ts/src/activities/shared/find-existing-entity.ts
@@ -9,7 +9,6 @@ import { queryEntityTypeSubgraph } from "@local/hash-graph-sdk/entity-type";
 import {
   almostFullOntologyResolveDepths,
   currentTimeInstantTemporalAxes,
-  generateVersionedUrlMatchingFilter,
 } from "@local/hash-isomorphic-utils/graph-queries";
 import { deduplicateSources } from "@local/hash-isomorphic-utils/provenance";
 
@@ -122,9 +121,14 @@ export const findExistingEntity = async ({
       ],
     },
     {
-      any: proposedEntity.entityTypeIds.map((entityTypeId) =>
-        generateVersionedUrlMatchingFilter(entityTypeId),
-      ),
+      any: proposedEntity.entityTypeIds.map((entityTypeId) => ({
+        equal: [
+          { path: ["type", "versionedUrl"] },
+          {
+            parameter: entityTypeId,
+          },
+        ],
+      })),
     },
   ] satisfies AllFilter["all"];
 

--- a/apps/hash-ai-worker-ts/src/shared/testing-utilities/get-alice-user-account-id.ts
+++ b/apps/hash-ai-worker-ts/src/shared/testing-utilities/get-alice-user-account-id.ts
@@ -4,10 +4,7 @@ import {
 } from "@blockprotocol/type-system";
 import { publicUserAccountId } from "@local/hash-backend-utils/public-user-account-id";
 import { queryEntities } from "@local/hash-graph-sdk/entity";
-import {
-  currentTimeInstantTemporalAxes,
-  generateVersionedUrlMatchingFilter,
-} from "@local/hash-isomorphic-utils/graph-queries";
+import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import {
   systemEntityTypes,
   systemPropertyTypes,
@@ -26,10 +23,16 @@ export const getAliceUserAccountId = async () => {
     {
       filter: {
         all: [
-          generateVersionedUrlMatchingFilter(
-            systemEntityTypes.user.entityTypeId,
-            { ignoreParents: true },
-          ),
+          {
+            equal: [
+              {
+                path: ["type", "baseUrl"],
+              },
+              {
+                parameter: systemEntityTypes.user.entityTypeBaseUrl,
+              },
+            ],
+          },
           {
             equal: [
               {

--- a/apps/hash-api/src/auth/create-unverified-email-cleanup-job.ts
+++ b/apps/hash-api/src/auth/create-unverified-email-cleanup-job.ts
@@ -1,8 +1,5 @@
 import { queryEntities } from "@local/hash-graph-sdk/entity";
-import {
-  currentTimeInstantTemporalAxes,
-  generateVersionedUrlMatchingFilter,
-} from "@local/hash-isomorphic-utils/graph-queries";
+import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import { systemEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 
 import { getUserFromEntity } from "../graph/knowledge/system-types/user";
@@ -122,12 +119,12 @@ export const createUnverifiedEmailCleanupJob = ({
       {
         filter: {
           all: [
-            generateVersionedUrlMatchingFilter(
-              systemEntityTypes.user.entityTypeId,
-              {
-                ignoreParents: true,
-              },
-            ),
+            {
+              equal: [
+                { path: ["type", "baseUrl"] },
+                { parameter: systemEntityTypes.user.entityTypeBaseUrl },
+              ],
+            },
             {
               equal: [{ path: ["archived"] }, { parameter: false }],
             },

--- a/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/util.ts
+++ b/apps/hash-api/src/graph/ensure-system-graph-is-initialized/migrate-ontology-types/util.ts
@@ -19,10 +19,7 @@ import { getDataTypeById } from "@local/hash-graph-sdk/data-type";
 import { queryEntities } from "@local/hash-graph-sdk/entity";
 import { getEntityTypeById } from "@local/hash-graph-sdk/entity-type";
 import { getPropertyTypeById } from "@local/hash-graph-sdk/property-type";
-import {
-  currentTimeInstantTemporalAxes,
-  generateVersionedUrlMatchingFilter,
-} from "@local/hash-isomorphic-utils/graph-queries";
+import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import { isSelfHostedInstance } from "@local/hash-isomorphic-utils/instance";
 import {
   blockProtocolDataTypes,
@@ -924,10 +921,11 @@ export const getEntitiesByType: ImpureGraphFunction<
 > = async (context, authentication, { entityTypeId }) =>
   queryEntities(context, authentication, {
     filter: {
-      all: [
-        generateVersionedUrlMatchingFilter(entityTypeId, {
-          ignoreParents: true,
-        }),
+      equal: [
+        { path: ["type", "versionedUrl"] },
+        {
+          parameter: entityTypeId,
+        },
       ],
     },
     temporalAxes: currentTimeInstantTemporalAxes,

--- a/apps/hash-api/src/graph/knowledge/system-types/block.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/block.ts
@@ -8,10 +8,7 @@ import {
   type HashEntity,
   queryEntities,
 } from "@local/hash-graph-sdk/entity";
-import {
-  currentTimeInstantTemporalAxes,
-  generateVersionedUrlMatchingFilter,
-} from "@local/hash-isomorphic-utils/graph-queries";
+import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import {
   systemEntityTypes,
   systemLinkEntityTypes,
@@ -287,10 +284,12 @@ export const getBlockCollectionByBlock: ImpureGraphFunction<
             { parameter: blockEntityUuid },
           ],
         },
-        generateVersionedUrlMatchingFilter(
-          systemEntityTypes.blockCollection.entityTypeId,
-          { ignoreParents: false, pathPrefix: ["leftEntity"] },
-        ),
+        {
+          equal: [
+            { path: ["leftEntity", "type", "baseUrl"] },
+            { parameter: systemEntityTypes.blockCollection.entityTypeBaseUrl },
+          ],
+        },
       ],
     },
     temporalAxes: currentTimeInstantTemporalAxes,

--- a/apps/hash-api/src/graph/knowledge/system-types/linear-integration-entity.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/linear-integration-entity.ts
@@ -13,10 +13,7 @@ import {
   queryEntitySubgraph,
 } from "@local/hash-graph-sdk/entity";
 import { generateUuid } from "@local/hash-isomorphic-utils/generate-uuid";
-import {
-  currentTimeInstantTemporalAxes,
-  generateVersionedUrlMatchingFilter,
-} from "@local/hash-isomorphic-utils/graph-queries";
+import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import {
   systemEntityTypes,
   systemLinkEntityTypes,
@@ -91,10 +88,15 @@ export const getAllLinearIntegrationsWithLinearOrgId: ImpureGraphFunction<
     {
       filter: {
         all: [
-          generateVersionedUrlMatchingFilter(
-            systemEntityTypes.linearIntegration.entityTypeId,
-            { ignoreParents: true },
-          ),
+          {
+            equal: [
+              { path: ["type", "baseUrl"] },
+              {
+                parameter:
+                  systemEntityTypes.linearIntegration.entityTypeBaseUrl,
+              },
+            ],
+          },
           {
             equal: [
               {
@@ -135,10 +137,16 @@ export const getLinearIntegrationByLinearOrgId: ImpureGraphFunction<
         {
           equal: [{ path: ["webId"] }, { parameter: userAccountId }],
         },
-        generateVersionedUrlMatchingFilter(
-          systemEntityTypes.linearIntegration.entityTypeId,
-          { ignoreParents: true },
-        ),
+        {
+          equal: [
+            {
+              path: ["type", "baseUrl"],
+            },
+            {
+              parameter: systemEntityTypes.linearIntegration.entityTypeBaseUrl,
+            },
+          ],
+        },
         {
           equal: [
             {
@@ -203,10 +211,15 @@ export const getSyncedWebsForLinearIntegration: ImpureGraphFunction<
         {
           equal: [{ path: ["archived"] }, { parameter: false }],
         },
-        generateVersionedUrlMatchingFilter(
-          systemLinkEntityTypes.syncLinearDataWith.linkEntityTypeId,
-          { ignoreParents: true },
-        ),
+        {
+          equal: [
+            { path: ["type", "baseUrl"] },
+            {
+              parameter:
+                systemLinkEntityTypes.syncLinearDataWith.linkEntityTypeBaseUrl,
+            },
+          ],
+        },
         {
           equal: [
             { path: ["leftEntity", "uuid"] },
@@ -272,10 +285,16 @@ export const linkIntegrationToWeb: ImpureGraphFunction<
           {
             equal: [{ path: ["archived"] }, { parameter: false }],
           },
-          generateVersionedUrlMatchingFilter(
-            systemLinkEntityTypes.syncLinearDataWith.linkEntityTypeId,
-            { ignoreParents: true },
-          ),
+          {
+            equal: [
+              { path: ["type", "baseUrl"] },
+              {
+                parameter:
+                  systemLinkEntityTypes.syncLinearDataWith
+                    .linkEntityTypeBaseUrl,
+              },
+            ],
+          },
           {
             equal: [
               { path: ["leftEntity", "uuid"] },

--- a/apps/hash-api/src/graph/knowledge/system-types/linear-user-secret.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/linear-user-secret.ts
@@ -9,10 +9,7 @@ import {
   NotFoundError,
 } from "@local/hash-backend-utils/error";
 import { queryEntities } from "@local/hash-graph-sdk/entity";
-import {
-  currentTimeInstantTemporalAxes,
-  generateVersionedUrlMatchingFilter,
-} from "@local/hash-isomorphic-utils/graph-queries";
+import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import {
   systemEntityTypes,
   systemLinkEntityTypes,
@@ -109,21 +106,31 @@ export const getLinearUserSecretByLinearOrgId: ImpureGraphFunction<
           equal: [{ path: ["webId"] }, { parameter: userAccountId as WebId }],
         },
         { equal: [{ path: ["archived"] }, { parameter: false }] },
-        generateVersionedUrlMatchingFilter(
-          systemEntityTypes.userSecret.entityTypeId,
-          { ignoreParents: true },
-        ),
-        generateVersionedUrlMatchingFilter(
-          systemLinkEntityTypes.usesUserSecret.linkEntityTypeId,
-          { ignoreParents: true, pathPrefix: ["incomingLinks"] },
-        ),
-        generateVersionedUrlMatchingFilter(
-          systemEntityTypes.linearIntegration.entityTypeId,
-          {
-            ignoreParents: true,
-            pathPrefix: ["incomingLinks", "leftEntity"],
-          },
-        ),
+        {
+          equal: [
+            { path: ["type", "baseUrl"] },
+            {
+              parameter: systemEntityTypes.userSecret.entityTypeBaseUrl,
+            },
+          ],
+        },
+        {
+          equal: [
+            { path: ["incomingLinks", "type", "baseUrl"] },
+            {
+              parameter:
+                systemLinkEntityTypes.usesUserSecret.linkEntityTypeBaseUrl,
+            },
+          ],
+        },
+        {
+          equal: [
+            { path: ["incomingLinks", "leftEntity", "type", "baseUrl"] },
+            {
+              parameter: systemEntityTypes.linearIntegration.entityTypeBaseUrl,
+            },
+          ],
+        },
         {
           equal: [
             {
@@ -187,13 +194,16 @@ export const getLinearSecretValueByHashWebEntityId: ImpureGraphFunction<
     {
       filter: {
         all: [
-          generateVersionedUrlMatchingFilter(
-            systemLinkEntityTypes.syncLinearDataWith.linkEntityTypeId,
-            {
-              ignoreParents: true,
-              pathPrefix: ["outgoingLinks"],
-            },
-          ),
+          {
+            equal: [
+              { path: ["outgoingLinks", "type", "baseUrl"] },
+              {
+                parameter:
+                  systemLinkEntityTypes.syncLinearDataWith
+                    .linkEntityTypeBaseUrl,
+              },
+            ],
+          },
           {
             equal: [
               { path: ["outgoingLinks", "rightEntity", "uuid"] },

--- a/apps/hash-api/src/graph/knowledge/system-types/notification.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/notification.ts
@@ -10,7 +10,6 @@ import {
 } from "@local/hash-graph-sdk/entity";
 import {
   currentTimeInstantTemporalAxes,
-  generateVersionedUrlMatchingFilter,
   pageOrNotificationNotArchivedFilter,
 } from "@local/hash-isomorphic-utils/graph-queries";
 import {
@@ -247,10 +246,15 @@ export const getMentionNotification: ImpureGraphFunction<
     {
       filter: {
         all: [
-          generateVersionedUrlMatchingFilter(
-            systemEntityTypes.mentionNotification.entityTypeId,
-            { ignoreParents: true },
-          ),
+          {
+            equal: [
+              { path: ["type", "baseUrl"] },
+              {
+                parameter:
+                  systemEntityTypes.mentionNotification.entityTypeBaseUrl,
+              },
+            ],
+          },
           {
             equal: [{ path: ["webId"] }, { parameter: recipient.accountId }],
           },
@@ -506,10 +510,15 @@ export const getCommentNotification: ImpureGraphFunction<
     {
       filter: {
         all: [
-          generateVersionedUrlMatchingFilter(
-            systemEntityTypes.commentNotification.entityTypeId,
-            { ignoreParents: true },
-          ),
+          {
+            equal: [
+              { path: ["type", "baseUrl"] },
+              {
+                parameter:
+                  systemEntityTypes.commentNotification.entityTypeBaseUrl,
+              },
+            ],
+          },
           {
             equal: [{ path: ["webId"] }, { parameter: recipient.accountId }],
           },

--- a/apps/hash-api/src/graph/knowledge/system-types/org.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/org.ts
@@ -308,7 +308,7 @@ export const getOrgByShortname: ImpureGraphFunction<
       all: [
         {
           equal: [
-            { path: ["type(inheritanceDepth = 0)", "baseUrl"] },
+            { path: ["type", "baseUrl"] },
             { parameter: systemEntityTypes.organization.entityTypeBaseUrl },
           ],
         },

--- a/apps/hash-api/src/graph/knowledge/system-types/page.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/page.ts
@@ -16,7 +16,6 @@ import {
 } from "@local/hash-isomorphic-utils/ontology-type-ids";
 import {
   includesPageEntityTypeId,
-  pageEntityTypeFilter,
   pageEntityTypeIds,
 } from "@local/hash-isomorphic-utils/page-entity-type-ids";
 import { simplifyProperties } from "@local/hash-isomorphic-utils/simplify-properties";
@@ -278,7 +277,14 @@ export const getAllPagesInWorkspace: ImpureGraphFunction<
   const { entities: pageEntities } = await queryEntities(ctx, authentication, {
     filter: {
       all: [
-        pageEntityTypeFilter,
+        {
+          equal: [
+            { path: ["type", "baseUrl"] },
+            {
+              parameter: systemEntityTypes.page.entityTypeBaseUrl,
+            },
+          ],
+        },
         {
           equal: [{ path: ["webId"] }, { parameter: webId }],
         },

--- a/apps/hash-api/src/graph/knowledge/system-types/text.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/text.ts
@@ -1,10 +1,7 @@
 import { extractEntityUuidFromEntityId } from "@blockprotocol/type-system";
 import { EntityTypeMismatchError } from "@local/hash-backend-utils/error";
 import { type HashEntity, queryEntities } from "@local/hash-graph-sdk/entity";
-import {
-  currentTimeInstantTemporalAxes,
-  generateVersionedUrlMatchingFilter,
-} from "@local/hash-isomorphic-utils/graph-queries";
+import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import {
   systemEntityTypes,
   systemLinkEntityTypes,
@@ -107,10 +104,16 @@ export const getPageAndBlockByText: ImpureGraphFunction<
     queryEntities(context, authentication, {
       filter: {
         all: [
-          generateVersionedUrlMatchingFilter(
-            systemLinkEntityTypes.hasData.linkEntityTypeId,
-            { ignoreParents: true },
-          ),
+          {
+            equal: [
+              {
+                path: ["type", "baseUrl"],
+              },
+              {
+                parameter: systemLinkEntityTypes.hasData.linkEntityTypeBaseUrl,
+              },
+            ],
+          },
           {
             equal: [
               { path: ["rightEntity", "uuid"] },
@@ -126,10 +129,16 @@ export const getPageAndBlockByText: ImpureGraphFunction<
     queryEntities(context, authentication, {
       filter: {
         all: [
-          generateVersionedUrlMatchingFilter(
-            systemLinkEntityTypes.hasData.linkEntityTypeId,
-            { ignoreParents: true },
-          ),
+          {
+            equal: [
+              {
+                path: ["type", "baseUrl"],
+              },
+              {
+                parameter: systemLinkEntityTypes.hasData.linkEntityTypeBaseUrl,
+              },
+            ],
+          },
           {
             equal: [
               {
@@ -232,20 +241,28 @@ export const getCommentByText: ImpureGraphFunction<
   const matchingHasTextLinks = await queryEntities(context, authentication, {
     filter: {
       all: [
-        generateVersionedUrlMatchingFilter(
-          systemLinkEntityTypes.hasText.linkEntityTypeId,
-          { ignoreParents: true },
-        ),
+        {
+          equal: [
+            {
+              path: ["type", "baseUrl"],
+            },
+            {
+              parameter: systemLinkEntityTypes.hasText.linkEntityTypeBaseUrl,
+            },
+          ],
+        },
         {
           equal: [
             { path: ["rightEntity", "uuid"] },
             { parameter: textEntityUuid },
           ],
         },
-        generateVersionedUrlMatchingFilter(
-          systemEntityTypes.comment.entityTypeId,
-          { ignoreParents: true, pathPrefix: ["leftEntity"] },
-        ),
+        {
+          equal: [
+            { path: ["leftEntity", "type", "baseUrl"] },
+            { parameter: systemEntityTypes.comment.entityTypeBaseUrl },
+          ],
+        },
       ],
     },
     temporalAxes: currentTimeInstantTemporalAxes,

--- a/apps/hash-api/src/graph/knowledge/system-types/text.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/text.ts
@@ -6,10 +6,7 @@ import {
   systemEntityTypes,
   systemLinkEntityTypes,
 } from "@local/hash-isomorphic-utils/ontology-type-ids";
-import {
-  contentLinkTypeFilter,
-  pageEntityTypeFilter,
-} from "@local/hash-isomorphic-utils/page-entity-type-ids";
+import { contentLinkTypeFilter } from "@local/hash-isomorphic-utils/page-entity-type-ids";
 import { simplifyProperties } from "@local/hash-isomorphic-utils/simplify-properties";
 
 import { getLatestEntityById } from "../primitive/entity";
@@ -185,7 +182,14 @@ export const getPageAndBlockByText: ImpureGraphFunction<
   const pageEntities = await queryEntities(context, authentication, {
     filter: {
       all: [
-        pageEntityTypeFilter,
+        {
+          equal: [
+            { path: ["type", "baseUrl"] },
+            {
+              parameter: systemEntityTypes.page.entityTypeBaseUrl,
+            },
+          ],
+        },
         {
           any: matchingContainsLinks.map(({ metadata }) => ({
             equal: [

--- a/apps/hash-api/src/graph/knowledge/system-types/user.ts
+++ b/apps/hash-api/src/graph/knowledge/system-types/user.ts
@@ -20,10 +20,7 @@ import {
   type FeatureFlag,
   featureFlags,
 } from "@local/hash-isomorphic-utils/feature-flags";
-import {
-  currentTimeInstantTemporalAxes,
-  generateVersionedUrlMatchingFilter,
-} from "@local/hash-isomorphic-utils/graph-queries";
+import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import {
   systemEntityTypes,
   systemLinkEntityTypes,
@@ -273,12 +270,14 @@ export const getUser: ImpureGraphFunction<
     } = await queryEntities<UserEntity>(context, authentication, {
       filter: {
         all: [
-          generateVersionedUrlMatchingFilter(
-            systemEntityTypes.user.entityTypeId,
-            {
-              ignoreParents: true,
-            },
-          ),
+          {
+            equal: [
+              { path: ["type", "baseUrl"] },
+              {
+                parameter: systemEntityTypes.user.entityTypeBaseUrl,
+              },
+            ],
+          },
           queryFilter,
         ],
       },
@@ -642,9 +641,14 @@ export const getUserPendingInvitations: ImpureGraphFunction<
       temporalAxes: currentTimeInstantTemporalAxes,
       filter: {
         all: [
-          generateVersionedUrlMatchingFilter(
-            systemEntityTypes.invitation.entityTypeId,
-          ),
+          {
+            equal: [
+              { path: ["type", "baseUrl"] },
+              {
+                parameter: systemEntityTypes.invitation.entityTypeBaseUrl,
+              },
+            ],
+          },
           {
             equal: [
               {

--- a/apps/hash-api/src/graphql/resolvers/knowledge/org/invite-user-to-org.ts
+++ b/apps/hash-api/src/graphql/resolvers/knowledge/org/invite-user-to-org.ts
@@ -12,10 +12,7 @@ import {
 } from "@local/hash-graph-sdk/entity";
 import { getActorGroupRole } from "@local/hash-graph-sdk/principal/actor-group";
 import { frontendUrl } from "@local/hash-isomorphic-utils/environment";
-import {
-  currentTimeInstantTemporalAxes,
-  generateVersionedUrlMatchingFilter,
-} from "@local/hash-isomorphic-utils/graph-queries";
+import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import {
   blockProtocolDataTypes,
   systemDataTypes,
@@ -107,11 +104,19 @@ const generateExistingInvitationFilter = (
 ) => {
   const filter = {
     all: [
-      generateVersionedUrlMatchingFilter(
-        invitation.type === "email"
-          ? systemEntityTypes.invitationViaEmail.entityTypeId
-          : systemEntityTypes.invitationViaShortname.entityTypeId,
-      ),
+      {
+        equal: [
+          {
+            path: ["type", "baseUrl"],
+          },
+          {
+            parameter:
+              invitation.type === "email"
+                ? systemEntityTypes.invitationViaEmail.entityTypeBaseUrl
+                : systemEntityTypes.invitationViaShortname.entityTypeBaseUrl,
+          },
+        ],
+      },
       {
         equal: [
           {

--- a/apps/hash-api/src/graphql/resolvers/knowledge/user/get-usage-records.ts
+++ b/apps/hash-api/src/graphql/resolvers/knowledge/user/get-usage-records.ts
@@ -5,10 +5,7 @@ import {
 import { getWebServiceUsage } from "@local/hash-backend-utils/service-usage";
 import { queryEntities } from "@local/hash-graph-sdk/entity";
 import { isUserHashInstanceAdmin } from "@local/hash-graph-sdk/principal/hash-instance-admins";
-import {
-  currentTimeInstantTemporalAxes,
-  generateVersionedUrlMatchingFilter,
-} from "@local/hash-isomorphic-utils/graph-queries";
+import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import { systemEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 import { simplifyProperties } from "@local/hash-isomorphic-utils/simplify-properties";
 
@@ -45,11 +42,13 @@ export const getUsageRecordsResolver: ResolverFn<
     authentication,
     {
       filter: {
-        all: [
-          generateVersionedUrlMatchingFilter(
-            systemEntityTypes.user.entityTypeId,
-            { ignoreParents: true },
-          ),
+        equal: [
+          {
+            path: ["type", "baseUrl"],
+          },
+          {
+            parameter: systemEntityTypes.user.entityTypeBaseUrl,
+          },
         ],
       },
       temporalAxes: currentTimeInstantTemporalAxes,

--- a/apps/hash-frontend/src/components/hooks/use-orgs-with-links.ts
+++ b/apps/hash-frontend/src/components/hooks/use-orgs-with-links.ts
@@ -3,10 +3,7 @@ import { useMemo } from "react";
 
 import { getRoots } from "@blockprotocol/graph/stdlib";
 import { deserializeQueryEntitySubgraphResponse } from "@local/hash-graph-sdk/entity";
-import {
-  currentTimeInstantTemporalAxes,
-  generateVersionedUrlMatchingFilter,
-} from "@local/hash-isomorphic-utils/graph-queries";
+import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import { systemEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 
 import { queryEntitySubgraphQuery } from "../../graphql/queries/knowledge/entity.queries";
@@ -56,10 +53,14 @@ export const useOrgsWithLinks = ({
                   },
                 ]
               : []),
-            generateVersionedUrlMatchingFilter(
-              systemEntityTypes.organization.entityTypeId,
-              { ignoreParents: true },
-            ),
+            {
+              equal: [
+                { path: ["type", "baseUrl"] },
+                {
+                  parameter: systemEntityTypes.organization.entityTypeBaseUrl,
+                },
+              ],
+            },
           ],
         },
         traversalPaths: [

--- a/apps/hash-frontend/src/components/hooks/use-users-with-links.ts
+++ b/apps/hash-frontend/src/components/hooks/use-users-with-links.ts
@@ -3,10 +3,7 @@ import { useMemo } from "react";
 
 import { getRoots } from "@blockprotocol/graph/stdlib";
 import { deserializeQueryEntitySubgraphResponse } from "@local/hash-graph-sdk/entity";
-import {
-  currentTimeInstantTemporalAxes,
-  generateVersionedUrlMatchingFilter,
-} from "@local/hash-isomorphic-utils/graph-queries";
+import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import { systemEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 
 import { queryEntitySubgraphQuery } from "../../graphql/queries/knowledge/entity.queries";
@@ -54,10 +51,14 @@ export const useUsersWithLinks = ({
                   },
                 ]
               : []),
-            generateVersionedUrlMatchingFilter(
-              systemEntityTypes.user.entityTypeId,
-              { ignoreParents: true },
-            ),
+            {
+              equal: [
+                { path: ["type", "baseUrl"] },
+                {
+                  parameter: systemEntityTypes.user.entityTypeBaseUrl,
+                },
+              ],
+            },
           ],
         },
         traversalPaths: [

--- a/apps/hash-frontend/src/pages/@/[shortname].page.tsx
+++ b/apps/hash-frontend/src/pages/@/[shortname].page.tsx
@@ -11,7 +11,6 @@ import { deserializeQueryEntitySubgraphResponse } from "@local/hash-graph-sdk/en
 import {
   currentTimeInstantTemporalAxes,
   fullTransactionTimeAxis,
-  generateVersionedUrlMatchingFilter,
 } from "@local/hash-isomorphic-utils/graph-queries";
 import { systemEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 import { pluralize } from "@local/hash-isomorphic-utils/pluralize";
@@ -276,11 +275,14 @@ const ProfilePage: NextPageWithLayout = () => {
           all: [
             {
               any:
-                includeEntityTypeIds?.map((entityTypeId) =>
-                  generateVersionedUrlMatchingFilter(entityTypeId, {
-                    ignoreParents: false,
-                  }),
-                ) ?? [],
+                includeEntityTypeIds?.map((entityTypeId) => ({
+                  equal: [
+                    { path: ["type", "versionedUrl"] },
+                    {
+                      parameter: entityTypeId,
+                    },
+                  ],
+                })) ?? [],
             },
             ...(profile
               ? [

--- a/apps/hash-frontend/src/pages/@/[shortname]/shared/flow-visualizer/outputs/claims-output.tsx
+++ b/apps/hash-frontend/src/pages/@/[shortname]/shared/flow-visualizer/outputs/claims-output.tsx
@@ -4,10 +4,7 @@ import { memo, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { getRoots } from "@blockprotocol/graph/stdlib";
 import { entityIdFromComponents } from "@blockprotocol/type-system";
 import { deserializeQueryEntitySubgraphResponse } from "@local/hash-graph-sdk/entity";
-import {
-  currentTimeInstantTemporalAxes,
-  generateVersionedUrlMatchingFilter,
-} from "@local/hash-isomorphic-utils/graph-queries";
+import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import { systemEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 
 import { queryEntitySubgraphQuery } from "../../../../../../graphql/queries/knowledge/entity.queries";
@@ -42,12 +39,12 @@ export const ClaimsOutput = memo(({ proposedEntities }: ClaimsTableProps) => {
       request: {
         filter: {
           all: [
-            generateVersionedUrlMatchingFilter(
-              systemEntityTypes.claim.entityTypeId,
-              {
-                ignoreParents: true,
-              },
-            ),
+            {
+              equal: [
+                { path: ["type", "baseUrl"] },
+                { parameter: systemEntityTypes.claim.entityTypeBaseUrl },
+              ],
+            },
             {
               equal: [
                 {

--- a/apps/hash-frontend/src/pages/index.page/waitlisted.tsx
+++ b/apps/hash-frontend/src/pages/index.page/waitlisted.tsx
@@ -8,10 +8,7 @@ import {
   CheckIcon,
   ChromeIcon,
 } from "@hashintel/design-system";
-import {
-  currentTimeInstantTemporalAxes,
-  generateVersionedUrlMatchingFilter,
-} from "@local/hash-isomorphic-utils/graph-queries";
+import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import { isSelfHostedInstance } from "@local/hash-isomorphic-utils/instance";
 import { systemEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 
@@ -70,9 +67,14 @@ export const Waitlisted = () => {
     {
       variables: {
         request: {
-          filter: generateVersionedUrlMatchingFilter(
-            systemEntityTypes.prospectiveUser.entityTypeId,
-          ),
+          filter: {
+            equal: [
+              { path: ["type", "baseUrl"] },
+              {
+                parameter: systemEntityTypes.prospectiveUser.entityTypeBaseUrl,
+              },
+            ],
+          },
           includeDrafts: false,
           temporalAxes: currentTimeInstantTemporalAxes,
           includeCount: true,

--- a/apps/hash-frontend/src/pages/notes.page.tsx
+++ b/apps/hash-frontend/src/pages/notes.page.tsx
@@ -14,10 +14,7 @@ import {
   deserializeQueryEntitySubgraphResponse,
   type HashEntity,
 } from "@local/hash-graph-sdk/entity";
-import {
-  currentTimeInstantTemporalAxes,
-  generateVersionedUrlMatchingFilter,
-} from "@local/hash-isomorphic-utils/graph-queries";
+import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import { systemEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 
 import { BlockLoadedProvider } from "../blocks/on-block-loaded";
@@ -54,10 +51,12 @@ const NotesPage: NextPageWithLayout = () => {
       request: {
         filter: {
           all: [
-            generateVersionedUrlMatchingFilter(
-              systemEntityTypes.note.entityTypeId,
-              { ignoreParents: true },
-            ),
+            {
+              equal: [
+                { path: ["type", "baseUrl"] },
+                { parameter: systemEntityTypes.note.entityTypeBaseUrl },
+              ],
+            },
             {
               equal: [
                 { path: ["webId"] },

--- a/apps/hash-frontend/src/pages/notifications.page/notifications-with-links-context.tsx
+++ b/apps/hash-frontend/src/pages/notifications.page/notifications-with-links-context.tsx
@@ -13,7 +13,6 @@ import {
 import { generateEntityLabel } from "@local/hash-isomorphic-utils/generate-entity-label";
 import {
   currentTimeInstantTemporalAxes,
-  generateVersionedUrlMatchingFilter,
   pageOrNotificationNotArchivedFilter,
 } from "@local/hash-isomorphic-utils/graph-queries";
 import {
@@ -142,10 +141,14 @@ export const useNotificationsWithLinksContextValue =
                   { parameter: authenticatedUser?.accountId },
                 ],
               },
-              generateVersionedUrlMatchingFilter(
-                systemEntityTypes.notification.entityTypeId,
-                { ignoreParents: false },
-              ),
+              {
+                equal: [
+                  { path: ["type", "baseUrl"] },
+                  {
+                    parameter: systemEntityTypes.notification.entityTypeBaseUrl,
+                  },
+                ],
+              },
               pageOrNotificationNotArchivedFilter,
             ],
           },

--- a/apps/hash-frontend/src/pages/settings/organizations/[shortname]/integrations.page.tsx
+++ b/apps/hash-frontend/src/pages/settings/organizations/[shortname]/integrations.page.tsx
@@ -13,10 +13,7 @@ import { useRouter } from "next/router";
 import { useMemo } from "react";
 
 import { deserializeQueryEntitiesResponse } from "@local/hash-graph-sdk/entity";
-import {
-  currentTimeInstantTemporalAxes,
-  generateVersionedUrlMatchingFilter,
-} from "@local/hash-isomorphic-utils/graph-queries";
+import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import { systemLinkEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 
 import { queryEntitiesQuery } from "../../../../graphql/queries/knowledge/entity.queries";
@@ -58,9 +55,16 @@ const OrgIntegrationsPage: NextPageWithLayout = () => {
         request: {
           filter: {
             all: [
-              generateVersionedUrlMatchingFilter(
-                systemLinkEntityTypes.syncLinearDataWith.linkEntityTypeId,
-              ),
+              {
+                equal: [
+                  { path: ["type", "baseUrl"] },
+                  {
+                    parameter:
+                      systemLinkEntityTypes.syncLinearDataWith
+                        .linkEntityTypeBaseUrl,
+                  },
+                ],
+              },
               {
                 equal: [
                   {

--- a/apps/hash-frontend/src/pages/shared/block-collection/shared/mention-suggester.tsx
+++ b/apps/hash-frontend/src/pages/shared/block-collection/shared/mention-suggester.tsx
@@ -25,10 +25,7 @@ import {
   type HashEntity,
 } from "@local/hash-graph-sdk/entity";
 import { generateEntityLabel } from "@local/hash-isomorphic-utils/generate-entity-label";
-import {
-  currentTimeInstantTemporalAxes,
-  generateVersionedUrlMatchingFilter,
-} from "@local/hash-isomorphic-utils/graph-queries";
+import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import {
   systemEntityTypes,
   systemLinkEntityTypes,
@@ -162,14 +159,21 @@ export const MentionSuggester: FunctionComponent<MentionSuggesterProps> = ({
                 ...authenticatedUser.memberOf.map(({ org: { webId } }) => ({
                   equal: [{ path: ["webId"] }, { parameter: webId }],
                 })),
-                generateVersionedUrlMatchingFilter(
-                  systemEntityTypes.user.entityTypeId,
-                  { ignoreParents: true },
-                ),
-                generateVersionedUrlMatchingFilter(
-                  systemEntityTypes.organization.entityTypeId,
-                  { ignoreParents: true },
-                ),
+                {
+                  equal: [
+                    { path: ["type", "baseUrl"] },
+                    { parameter: systemEntityTypes.user.entityTypeBaseUrl },
+                  ],
+                },
+                {
+                  equal: [
+                    { path: ["type", "baseUrl"] },
+                    {
+                      parameter:
+                        systemEntityTypes.organization.entityTypeBaseUrl,
+                    },
+                  ],
+                },
               ],
             },
             {

--- a/apps/hash-frontend/src/pages/shared/entity-selector.tsx
+++ b/apps/hash-frontend/src/pages/shared/entity-selector.tsx
@@ -14,10 +14,7 @@ import {
   getDisplayFieldsForClosedEntityType,
 } from "@local/hash-graph-sdk/entity";
 import { generateEntityLabel } from "@local/hash-isomorphic-utils/generate-entity-label";
-import {
-  currentTimeInstantTemporalAxes,
-  generateVersionedUrlMatchingFilter,
-} from "@local/hash-isomorphic-utils/graph-queries";
+import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 
 import { queryEntitiesQuery } from "../../graphql/queries/knowledge/entity.queries";
 
@@ -74,11 +71,12 @@ export const EntitySelector = <Multiple extends boolean>({
           !expectedEntityTypes || expectedEntityTypes.length === 0
             ? { all: [] }
             : {
-                any: expectedEntityTypes.map(({ $id }) =>
-                  generateVersionedUrlMatchingFilter($id, {
-                    ignoreParents: false,
-                  }),
-                ),
+                any: expectedEntityTypes.map(({ $id }) => ({
+                  equal: [
+                    { path: ["type", "versionedUrl"] },
+                    { parameter: $id },
+                  ],
+                })),
               },
         temporalAxes: currentTimeInstantTemporalAxes,
         includeDrafts,

--- a/apps/hash-frontend/src/pages/shared/entity/entity-editor/claims-section.tsx
+++ b/apps/hash-frontend/src/pages/shared/entity/entity-editor/claims-section.tsx
@@ -6,10 +6,7 @@ import { getRoots } from "@blockprotocol/graph/stdlib";
 import { extractEntityUuidFromEntityId } from "@blockprotocol/type-system";
 import { Chip, Skeleton } from "@hashintel/design-system";
 import { deserializeSubgraph } from "@local/hash-graph-sdk/subgraph";
-import {
-  currentTimeInstantTemporalAxes,
-  generateVersionedUrlMatchingFilter,
-} from "@local/hash-isomorphic-utils/graph-queries";
+import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import { systemEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 
 import { queryEntitySubgraphQuery } from "../../../../graphql/queries/knowledge/entity.queries";
@@ -47,12 +44,12 @@ export const ClaimsSection = () => {
       request: {
         filter: {
           all: [
-            generateVersionedUrlMatchingFilter(
-              systemEntityTypes.claim.entityTypeId,
-              {
-                ignoreParents: true,
-              },
-            ),
+            {
+              equal: [
+                { path: ["type", "baseUrl"] },
+                { parameter: systemEntityTypes.claim.entityTypeBaseUrl },
+              ],
+            },
             {
               equal: [
                 { path: ["outgoingLinks", "rightEntity", "uuid"] },

--- a/apps/hash-frontend/src/pages/shared/integrations/google/google-auth-context/use-google-accounts.ts
+++ b/apps/hash-frontend/src/pages/shared/integrations/google/google-auth-context/use-google-accounts.ts
@@ -6,10 +6,7 @@ import {
   type HashEntity,
   type SerializedQueryEntitiesResponse,
 } from "@local/hash-graph-sdk/entity";
-import {
-  currentTimeInstantTemporalAxes,
-  generateVersionedUrlMatchingFilter,
-} from "@local/hash-isomorphic-utils/graph-queries";
+import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import { googleEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 
 import { queryEntitiesQuery } from "../../../../../graphql/queries/knowledge/entity.queries";
@@ -38,10 +35,12 @@ export const useGoogleAccounts = (): UseGoogleAccountsResult => {
       request: {
         filter: {
           all: [
-            generateVersionedUrlMatchingFilter(
-              googleEntityTypes.account.entityTypeId,
-              { ignoreParents: true },
-            ),
+            {
+              equal: [
+                { path: ["type", "baseUrl"] },
+                { parameter: googleEntityTypes.account.entityTypeBaseUrl },
+              ],
+            },
             {
               equal: [
                 { path: ["webId"] },

--- a/apps/hash-frontend/src/pages/shared/use-flow-runs-usage.ts
+++ b/apps/hash-frontend/src/pages/shared/use-flow-runs-usage.ts
@@ -7,10 +7,7 @@ import {
 } from "@blockprotocol/graph/stdlib";
 import { extractEntityUuidFromEntityId } from "@blockprotocol/type-system";
 import { deserializeQueryEntitySubgraphResponse } from "@local/hash-graph-sdk/entity";
-import {
-  currentTimeInstantTemporalAxes,
-  generateVersionedUrlMatchingFilter,
-} from "@local/hash-isomorphic-utils/graph-queries";
+import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import {
   systemEntityTypes,
   systemLinkEntityTypes,
@@ -68,12 +65,12 @@ export const useFlowRunsUsage = ({
       request: {
         filter: {
           all: [
-            generateVersionedUrlMatchingFilter(
-              systemEntityTypes.usageRecord.entityTypeId,
-              {
-                ignoreParents: true,
-              },
-            ),
+            {
+              equal: [
+                { path: ["type", "baseUrl"] },
+                { parameter: systemEntityTypes.usageRecord.entityTypeBaseUrl },
+              ],
+            },
             {
               any: flowRunIds.map((flowRunId) => ({
                 equal: [

--- a/apps/hash-frontend/src/shared/account-pages-variables.ts
+++ b/apps/hash-frontend/src/shared/account-pages-variables.ts
@@ -2,7 +2,7 @@ import {
   currentTimeInstantTemporalAxes,
   pageOrNotificationNotArchivedFilter,
 } from "@local/hash-isomorphic-utils/graph-queries";
-import { pageEntityTypeFilter } from "@local/hash-isomorphic-utils/page-entity-type-ids";
+import { systemEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 
 import type { WebId } from "@blockprotocol/type-system";
 import type { QueryEntitySubgraphRequest } from "@local/hash-graph-sdk/entity";
@@ -17,7 +17,14 @@ export const getAccountPagesVariables = ({
   request: {
     filter: {
       all: [
-        pageEntityTypeFilter,
+        {
+          equal: [
+            { path: ["type", "baseUrl"] },
+            {
+              parameter: systemEntityTypes.page.entityTypeBaseUrl,
+            },
+          ],
+        },
         {
           equal: [{ path: ["webId"] }, { parameter: webId }],
         },

--- a/apps/hash-frontend/src/shared/notification-count-context.tsx
+++ b/apps/hash-frontend/src/shared/notification-count-context.tsx
@@ -5,7 +5,6 @@ import { extractEntityUuidFromEntityId } from "@blockprotocol/type-system";
 import { deserializeQueryEntitiesResponse } from "@local/hash-graph-sdk/entity";
 import {
   currentTimeInstantTemporalAxes,
-  generateVersionedUrlMatchingFilter,
   pageOrNotificationNotArchivedFilter,
 } from "@local/hash-isomorphic-utils/graph-queries";
 import { queryEntitiesQuery } from "@local/hash-isomorphic-utils/graphql/queries/entity.queries";
@@ -104,10 +103,14 @@ export const NotificationCountContextProvider: FunctionComponent<
                   { parameter: authenticatedUser?.accountId },
                 ],
               },
-              generateVersionedUrlMatchingFilter(
-                systemEntityTypes.notification.entityTypeId,
-                { ignoreParents: false },
-              ),
+              {
+                equal: [
+                  { path: ["type", "baseUrl"] },
+                  {
+                    parameter: systemEntityTypes.notification.entityTypeBaseUrl,
+                  },
+                ],
+              },
               pageOrNotificationNotArchivedFilter,
             ],
           },
@@ -155,10 +158,16 @@ export const NotificationCountContextProvider: FunctionComponent<
                     { parameter: authenticatedUser?.accountId },
                   ],
                 },
-                generateVersionedUrlMatchingFilter(
-                  systemEntityTypes.notification.entityTypeId,
-                  { ignoreParents: false },
-                ),
+
+                {
+                  equal: [
+                    { path: ["type", "baseUrl"] },
+                    {
+                      parameter:
+                        systemEntityTypes.notification.entityTypeBaseUrl,
+                    },
+                  ],
+                },
                 {
                   equal: [
                     { path: ["outgoingLinks", "rightEntity", "uuid"] },

--- a/apps/hash-frontend/src/shared/use-actors.ts
+++ b/apps/hash-frontend/src/shared/use-actors.ts
@@ -5,10 +5,7 @@ import {
   deserializeQueryEntitiesResponse,
   type SerializedQueryEntitiesResponse,
 } from "@local/hash-graph-sdk/entity";
-import {
-  currentTimeInstantTemporalAxes,
-  generateVersionedUrlMatchingFilter,
-} from "@local/hash-isomorphic-utils/graph-queries";
+import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import { queryEntitiesQuery } from "@local/hash-isomorphic-utils/graphql/queries/entity.queries";
 import { systemEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 
@@ -61,10 +58,14 @@ export const useActors = (params: {
                     { parameter: accountId },
                   ],
                 },
-                generateVersionedUrlMatchingFilter(
-                  systemEntityTypes.machine.entityTypeId,
-                  { ignoreParents: true },
-                ),
+                {
+                  equal: [
+                    { path: ["type", "baseUrl"] },
+                    {
+                      parameter: systemEntityTypes.machine.entityTypeBaseUrl,
+                    },
+                  ],
+                },
               ],
             }),
           ),

--- a/apps/hash-frontend/src/shared/use-user-or-org.ts
+++ b/apps/hash-frontend/src/shared/use-user-or-org.ts
@@ -3,10 +3,7 @@ import { useMemo } from "react";
 
 import { getRoots } from "@blockprotocol/graph/stdlib";
 import { deserializeQueryEntitySubgraphResponse } from "@local/hash-graph-sdk/entity";
-import {
-  currentTimeInstantTemporalAxes,
-  generateVersionedUrlMatchingFilter,
-} from "@local/hash-isomorphic-utils/graph-queries";
+import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import {
   systemEntityTypes,
   systemPropertyTypes,
@@ -73,14 +70,21 @@ export const useUserOrOrg = (
                 : []),
             {
               any: [
-                generateVersionedUrlMatchingFilter(
-                  systemEntityTypes.user.entityTypeId,
-                  { ignoreParents: true },
-                ),
-                generateVersionedUrlMatchingFilter(
-                  systemEntityTypes.organization.entityTypeId,
-                  { ignoreParents: true },
-                ),
+                {
+                  equal: [
+                    { path: ["type", "baseUrl"] },
+                    { parameter: systemEntityTypes.user.entityTypeBaseUrl },
+                  ],
+                },
+                {
+                  equal: [
+                    { path: ["type", "baseUrl"] },
+                    {
+                      parameter:
+                        systemEntityTypes.organization.entityTypeBaseUrl,
+                    },
+                  ],
+                },
               ],
             },
           ],

--- a/apps/hash-integration-worker/src/activities/flow-activities/integration-activities/persist-integration-entities-action.ts
+++ b/apps/hash-integration-worker/src/activities/flow-activities/integration-activities/persist-integration-entities-action.ts
@@ -26,10 +26,7 @@ import {
   queryEntities,
 } from "@local/hash-graph-sdk/entity";
 import { getSimplifiedIntegrationFlowActionInputs } from "@local/hash-isomorphic-utils/flows/action-definitions";
-import {
-  currentTimeInstantTemporalAxes,
-  generateVersionedUrlMatchingFilter,
-} from "@local/hash-isomorphic-utils/graph-queries";
+import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import { stringifyError } from "@local/hash-isomorphic-utils/stringify-error";
 import { StatusCode } from "@local/status";
 
@@ -70,9 +67,12 @@ const findExistingEntity = async (params: {
     {
       filter: {
         all: [
-          generateVersionedUrlMatchingFilter(entityTypeId, {
-            ignoreParents: true,
-          }),
+          {
+            equal: [
+              { path: ["type", "versionedUrl"] },
+              { parameter: entityTypeId },
+            ],
+          },
           { equal: [{ path: ["webId"] }, { parameter: webId }] },
           { equal: [{ path: ["archived"] }, { parameter: false }] },
           propertyFilter,
@@ -158,9 +158,12 @@ const findExistingLink = async (params: {
     {
       filter: {
         all: [
-          generateVersionedUrlMatchingFilter(linkEntityTypeId, {
-            ignoreParents: true,
-          }),
+          {
+            equal: [
+              { path: ["type", "versionedUrl"] },
+              { parameter: linkEntityTypeId },
+            ],
+          },
           { equal: [{ path: ["archived"] }, { parameter: false }] },
           { equal: [{ path: ["webId"] }, { parameter: webId }] },
           linkFilter,

--- a/apps/hash-integration-worker/src/shared/graph-requests.ts
+++ b/apps/hash-integration-worker/src/shared/graph-requests.ts
@@ -8,10 +8,7 @@ import {
   HashLinkEntity,
   queryEntities,
 } from "@local/hash-graph-sdk/entity";
-import {
-  currentTimeInstantTemporalAxes,
-  generateVersionedUrlMatchingFilter,
-} from "@local/hash-isomorphic-utils/graph-queries";
+import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import { linearPropertyTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 
 import type {
@@ -34,9 +31,14 @@ export const getEntitiesByLinearId = async (params: {
     filter: {
       all: [
         params.entityTypeId
-          ? generateVersionedUrlMatchingFilter(params.entityTypeId, {
-              ignoreParents: true,
-            })
+          ? {
+              equal: [
+                { path: ["type", "versionedUrl"] },
+                {
+                  parameter: params.entityTypeId,
+                },
+              ],
+            }
           : [],
         {
           equal: [

--- a/apps/plugin-browser/src/pages/popup/popup-contents/action-center/history/shared/history-row/flow-metadata-cell-contents.tsx
+++ b/apps/plugin-browser/src/pages/popup/popup-contents/action-center/history/shared/history-row/flow-metadata-cell-contents.tsx
@@ -9,10 +9,7 @@ import {
   ClockRegularIcon,
 } from "@hashintel/design-system";
 import { deserializeQueryEntitiesResponse } from "@local/hash-graph-sdk/entity";
-import {
-  currentTimeInstantTemporalAxes,
-  generateVersionedUrlMatchingFilter,
-} from "@local/hash-isomorphic-utils/graph-queries";
+import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import { systemEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 import { simplifyProperties } from "@local/hash-isomorphic-utils/simplify-properties";
 
@@ -56,10 +53,14 @@ const getTotalUsage = ({ flowRunId }: { flowRunId: string }) =>
       request: {
         filter: {
           all: [
-            generateVersionedUrlMatchingFilter(
-              systemEntityTypes.usageRecord.entityTypeId,
-              { ignoreParents: true },
-            ),
+            {
+              equal: [
+                { path: ["type", "baseUrl"] },
+                {
+                  parameter: systemEntityTypes.usageRecord.entityTypeBaseUrl,
+                },
+              ],
+            },
             {
               equal: [
                 { path: ["outgoingLinks", "rightEntity", "uuid"] },

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
@@ -92,7 +92,10 @@ use crate::store::{
     postgres::{
         TraversalContext,
         crud::{QueryIndices, TypedRow},
-        knowledge::entity::{read::EntityEdgeTraversalData, summary::EntitySummaryQuery},
+        knowledge::entity::{
+            read::EntityEdgeTraversalData,
+            summary::{Deduplication, EntitySummaryQuery},
+        },
         query::{
             Distinctness, InsertStatementBuilder, PostgresRecord as _, PostgresSorting as _,
             SelectCompiler, Table,
@@ -1552,7 +1555,24 @@ where
             return Ok(SummarizeEntitiesResponse::default());
         };
         let (statement, parameters) = compiler.compile();
-        let statement = summary_query.statement(&statement);
+
+        // The `hits` CTE only needs to deduplicate editions when the query can emit more than
+        // one row per edition: either a fan-out (to-many) filter join, or a range variable
+        // temporal axis matching the same edition across several decision-time slices. A
+        // collapsed point interval (`[t, t]`) matches at most one slice per entity, so when no
+        // to-many join was added the dedup can be dropped, unlocking a parallel aggregate.
+        let variable_interval = temporal_axes.variable_interval();
+        let temporal_axis_is_point = matches!(
+            (variable_interval.start(), variable_interval.end()),
+            (TemporalBound::Inclusive(start), LimitedTemporalBound::Inclusive(end))
+                if start == end
+        );
+        let dedup = if compiler.has_to_many_join() || !temporal_axis_is_point {
+            Deduplication::Required
+        } else {
+            Deduplication::Skip
+        };
+        let statement = summary_query.statement(&statement, dedup);
 
         let rows = self
             .as_client()

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/summary.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/summary.rs
@@ -65,6 +65,20 @@ impl Dimension {
     }
 }
 
+/// Whether the `hits` CTE must deduplicate editions before aggregating.
+///
+/// The compiled query can emit more than one row per edition when a fan-out (to-many) filter
+/// join was added, or when a range variable temporal axis matches the same edition across
+/// several decision-time slices. Skipping the dedup when either applies would over-count.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Deduplication {
+    /// Deduplicate over `edition_id` via `DISTINCT ON` — duplicates are possible.
+    Required,
+    /// Skip the dedup — the query emits at most one row per edition, so the `DISTINCT ON` sort
+    /// barrier can be dropped to let the planner run a fully parallel partial aggregate.
+    Skip,
+}
+
 /// Compiles and decodes the summary aggregation for one entity query.
 ///
 /// Created via [`Self::new`] *before* limit/sorting are added to the compiler, so the
@@ -142,17 +156,19 @@ impl EntitySummaryQuery {
 
     /// Wraps the compiled selection into the aggregate statement.
     ///
-    /// Filter joins can emit duplicate rows for the same edition, so the `hits` CTE
-    /// deduplicates over `edition_id` rather than the entity identity. This keeps the
-    /// aggregates driven by the temporal axis: a point-in-time query matches one edition
-    /// per entity, an unbounded query matches every edition.
-    pub(crate) fn statement(&self, statement: &str) -> String {
+    /// See [`Deduplication`] for when the `hits` CTE deduplicates over `edition_id`
+    /// ([`Deduplication::Required`]) versus skips the `DISTINCT ON` to allow a fully parallel
+    /// partial aggregate ([`Deduplication::Skip`]).
+    pub(crate) fn statement(&self, statement: &str, dedup: Deduplication) -> String {
         let aliases = (0..self.column_count())
             .map(|index| format!("c{index}"))
             .collect::<Vec<_>>()
             .join(", ");
 
-        let distinct = format!("DISTINCT ON (c{})", self.edition_id_column);
+        let distinct = match dedup {
+            Deduplication::Required => format!("DISTINCT ON (c{})", self.edition_id_column),
+            Deduplication::Skip => String::new(),
+        };
 
         let mut hit_columns = vec![format!("c{} AS web_id", self.web_id_column)];
         if let Some(column) = self.provenance_column {
@@ -201,16 +217,17 @@ impl EntitySummaryQuery {
         }
         if self.type_columns.is_some() {
             branches.push(format!(
-                "SELECT {}::int4, NULL::uuid, t.type_id, count(*), min(t.title) FROM hits CROSS \
-                 JOIN LATERAL unnest(versioned_urls[1:direct_types], type_titles[1:direct_types]) \
-                 AS t (type_id, title) GROUP BY t.type_id",
+                "SELECT {}::int4, NULL::uuid, t.type_id, count(*), min(t.title) FROM (SELECT \
+                 unnest(versioned_urls[1:direct_types]) AS type_id, \
+                 unnest(type_titles[1:direct_types]) AS title FROM hits) AS t GROUP BY t.type_id",
                 Dimension::TypeIds as i32
             ));
         }
 
         format!(
-            "WITH hits AS (SELECT {distinct} {hit_columns} FROM ({statement}) AS raw ({aliases})) \
-             {}",
+            "WITH hits AS (SELECT {distinct} {hit_columns} FROM (
+            {statement}
+            ) AS raw ({aliases})) {}",
             branches.join(" UNION ALL ")
         )
     }
@@ -310,7 +327,7 @@ impl EntitySummaryQuery {
 
 #[cfg(test)]
 mod tests {
-    use super::{Dimension, EntitySummaryQuery, TypeColumns};
+    use super::{Deduplication, Dimension, EntitySummaryQuery, TypeColumns};
     use crate::store::postgres::query::test_helper::trim_whitespace;
 
     #[test]
@@ -347,7 +364,7 @@ mod tests {
         };
 
         pretty_assertions::assert_eq!(
-            trim_whitespace(&summary_query.statement("SELECT 1")),
+            trim_whitespace(&summary_query.statement("SELECT 1", Deduplication::Required)),
             trim_whitespace(
                 "WITH hits AS (SELECT DISTINCT ON (c0)
                     c1 AS web_id,
@@ -356,7 +373,7 @@ mod tests {
                     c4 AS versioned_urls,
                     c5 AS direct_types,
                     c6 AS type_titles
-                 FROM (SELECT 1) AS raw (c0, c1, c2, c3, c4, c5, c6))
+                 FROM ( SELECT 1 ) AS raw (c0, c1, c2, c3, c4, c5, c6))
                  SELECT 0::int4 AS dimension, NULL::uuid AS dimension_id,
                         NULL::text AS dimension_type, count(*) AS matches,
                         NULL::text AS dimension_title FROM hits
@@ -369,9 +386,9 @@ mod tests {
                  SELECT 3::int4, edition_created_by, NULL::text, count(*), NULL::text FROM hits
                   GROUP BY edition_created_by
                  UNION ALL
-                 SELECT 4::int4, NULL::uuid, t.type_id, count(*), min(t.title) FROM hits
-                  CROSS JOIN LATERAL unnest(versioned_urls[1:direct_types],
-                  type_titles[1:direct_types]) AS t (type_id, title)
+                 SELECT 4::int4, NULL::uuid, t.type_id, count(*), min(t.title) FROM (SELECT
+                  unnest(versioned_urls[1:direct_types]) AS type_id,
+                  unnest(type_titles[1:direct_types]) AS title FROM hits) AS t
                   GROUP BY t.type_id"
             ),
         );
@@ -390,14 +407,49 @@ mod tests {
         };
 
         pretty_assertions::assert_eq!(
-            trim_whitespace(&summary_query.statement("SELECT 1")),
+            trim_whitespace(&summary_query.statement("SELECT 1", Deduplication::Required)),
             trim_whitespace(
                 "WITH hits AS (SELECT DISTINCT ON (c0)
                     c1 AS web_id
-                 FROM (SELECT 1) AS raw (c0, c1))
+                 FROM ( SELECT 1 ) AS raw (c0, c1))
                  SELECT 0::int4 AS dimension, NULL::uuid AS dimension_id,
                         NULL::text AS dimension_type, count(*) AS matches,
                         NULL::text AS dimension_title FROM hits"
+            ),
+        );
+    }
+
+    #[test]
+    fn statement_skips_dedup() {
+        let summary_query = EntitySummaryQuery {
+            edition_id_column: 0,
+            web_id_column: 1,
+            provenance_column: None,
+            edition_provenance_column: None,
+            type_columns: Some(TypeColumns {
+                versioned_urls: 2,
+                direct_types: 3,
+                type_titles: 4,
+            }),
+            include_count: false,
+            include_web_ids: false,
+        };
+
+        // With `needs_dedup = false` the `DISTINCT ON` is dropped, so the planner can run a
+        // fully parallel partial aggregate. `c0` (edition_id) is still selected but unused.
+        pretty_assertions::assert_eq!(
+            trim_whitespace(&summary_query.statement("SELECT 1", Deduplication::Skip)),
+            trim_whitespace(
+                "WITH hits AS (SELECT
+                    c1 AS web_id,
+                    c2 AS versioned_urls,
+                    c3 AS direct_types,
+                    c4 AS type_titles
+                 FROM ( SELECT 1 ) AS raw (c0, c1, c2, c3, c4))
+                 SELECT 4::int4, NULL::uuid, t.type_id, count(*), min(t.title) FROM (SELECT
+                  unnest(versioned_urls[1:direct_types]) AS type_id,
+                  unnest(type_titles[1:direct_types]) AS title FROM hits) AS t
+                  GROUP BY t.type_id"
             ),
         );
     }

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/summary.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/summary.rs
@@ -435,8 +435,8 @@ mod tests {
             include_web_ids: false,
         };
 
-        // With `needs_dedup = false` the `DISTINCT ON` is dropped, so the planner can run a
-        // fully parallel partial aggregate. `c0` (edition_id) is still selected but unused.
+        // With `Deduplication::Skip` the `DISTINCT ON` is dropped, so the planner can run a
+        // fully parallel partial aggregate. The raw row still includes `c0` (edition_id), but the aggregation doesn’t reference it.
         pretty_assertions::assert_eq!(
             trim_whitespace(&summary_query.statement("SELECT 1", Deduplication::Skip)),
             trim_whitespace(

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/summary.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/summary.rs
@@ -435,8 +435,9 @@ mod tests {
             include_web_ids: false,
         };
 
-        // With `Deduplication::Skip` the `DISTINCT ON` is dropped, so the planner can run a
-        // fully parallel partial aggregate. The raw row still includes `c0` (edition_id), but the aggregation doesn’t reference it.
+        // With `Deduplication::Skip` the `DISTINCT ON` is dropped, so the planner can run a fully
+        // parallel partial aggregate. The raw row still includes `c0` (edition_id), but the
+        // aggregation doesn’t reference it.
         pretty_assertions::assert_eq!(
             trim_whitespace(&summary_query.statement("SELECT 1", Deduplication::Skip)),
             trim_whitespace(

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/compile.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/compile.rs
@@ -423,7 +423,7 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
         )
     }
 
-    /// Whether any relation joined so far can fan out the base rows (see [`Relation::is_to_many`]).
+    /// Whether any relation joined so far can fan out the base rows.
     ///
     /// `false` guarantees the compiled query emits at most one row per base row, so a downstream
     /// deduplication can be safely skipped. Reflects all filters and selections added before

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/compile.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/compile.rs
@@ -51,6 +51,7 @@ pub struct CompilerArtifacts<'p> {
     required_tables: HashSet<TableReference<'p>>,
     table_info: TableInfo<'p>,
     cursor_disallowed_reason: Option<&'static str>,
+    has_to_many_join: bool,
 }
 
 struct PathSelection {
@@ -144,6 +145,7 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
                     variable_interval_index: None,
                 },
                 cursor_disallowed_reason: None,
+                has_to_many_join: false,
             },
             temporal_axes,
             table_hooks,
@@ -419,6 +421,16 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
             self.statement.transpile_to_string(),
             &self.artifacts.parameters,
         )
+    }
+
+    /// Whether any relation joined so far can fan out the base rows (see [`Relation::is_to_many`]).
+    ///
+    /// `false` guarantees the compiled query emits at most one row per base row, so a downstream
+    /// deduplication can be safely skipped. Reflects all filters and selections added before
+    /// the call.
+    #[must_use]
+    pub const fn has_to_many_join(&self) -> bool {
+        self.artifacts.has_to_many_join
     }
 
     /// Compiles a [`Filter`] to an [`Expression`].
@@ -1292,6 +1304,9 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
 
         let mut is_outer_join_chain = false;
         for relation in path.relations() {
+            if relation.is_to_many() {
+                self.artifacts.has_to_many_join = true;
+            }
             for foreign_key_reference in relation.joins() {
                 let join_type = if is_outer_join_chain {
                     JoinType::LeftOuter

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/statement/select.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/statement/select.rs
@@ -888,6 +888,57 @@ mod tests {
     }
 
     #[test]
+    fn has_to_many_join_flag() {
+        let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
+
+        // A type-URL filter resolves to the edition cache (to-one join) — no fan-out.
+        let mut to_one = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes), false);
+        let to_one_filter = Filter::Equal(
+            FilterExpression::Path {
+                path: EntityQueryPath::EntityTypeEdge {
+                    edge_kind: SharedEdgeKind::IsOfType,
+                    path: EntityTypeQueryPath::VersionedUrl,
+                    inheritance_depth: None,
+                },
+            },
+            FilterExpression::Parameter {
+                parameter: Parameter::Text(Cow::Borrowed("https://example.com/v/1")),
+                convert: None,
+            },
+        );
+        to_one
+            .add_filter(&to_one_filter)
+            .expect("Failed to add filter");
+        assert!(
+            !to_one.has_to_many_join(),
+            "type-URL filter hits the edition cache (to-one) and must not require dedup"
+        );
+
+        // An incoming link traversal fans out — must require dedup.
+        let mut to_many = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes), false);
+        let to_many_filter = Filter::Equal(
+            FilterExpression::Path {
+                path: EntityQueryPath::EntityEdge {
+                    edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
+                    path: Box::new(EntityQueryPath::EditionId),
+                    direction: EdgeDirection::Incoming,
+                },
+            },
+            FilterExpression::Parameter {
+                parameter: Parameter::Uuid(Uuid::nil()),
+                convert: None,
+            },
+        );
+        to_many
+            .add_filter(&to_many_filter)
+            .expect("Failed to add filter");
+        assert!(
+            to_many.has_to_many_join(),
+            "incoming link traversal fans out and must require dedup"
+        );
+    }
+
+    #[test]
     fn entity_incoming_link_query() {
         let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
         let pinned_timestamp = temporal_axes.pinned_timestamp();

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/table.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/table.rs
@@ -1923,6 +1923,32 @@ impl Iterator for ForeignKeyJoin {
 }
 
 impl Relation {
+    /// Whether joining this relation can multiply the number of base rows (fan-out).
+    ///
+    /// Conservative: only relations that join on a unique/primary key — exactly one joined
+    /// row per base row — return `false`. Everything else (edge traversals via
+    /// [`Self::Reference`], link endpoints, embeddings) returns `true`. Adding a new relation
+    /// therefore defaults to `true` (needs dedup), which is the safe direction.
+    ///
+    /// Used to decide whether a downstream `DISTINCT` is required: a query whose joins are all
+    /// to-one cannot emit duplicate base rows, so the dedup can be skipped.
+    #[must_use]
+    pub const fn is_to_many(self) -> bool {
+        !matches!(
+            self,
+            Self::OntologyIds
+                | Self::OntologyOwnedMetadata
+                | Self::OntologyExternalMetadata
+                | Self::OntologyAdditionalMetadata
+                | Self::DataTypeIds
+                | Self::PropertyTypeIds
+                | Self::EntityTypeIds
+                | Self::EntityIds
+                | Self::EntityEditions
+                | Self::EntityEditionCache
+        )
+    }
+
     #[expect(clippy::too_many_lines)]
     #[must_use]
     pub fn joins(self) -> ForeignKeyJoin {

--- a/libs/@local/graph/store/src/entity/store.rs
+++ b/libs/@local/graph/store/src/entity/store.rs
@@ -570,19 +570,9 @@ pub enum LinkDeletionBehavior {
 /// # use hash_graph_store::entity::DeleteEntitiesParams;
 /// let json = serde_json::json!({
 ///     "filter": {
-///         "all": [
-///             {
-///                 "equal": [
-///                     { "path": ["type(inheritanceDepth = 0)", "baseUrl"] },
-///                     { "parameter": "https://hash.ai/@hash/types/entity-type/user/" }
-///                 ]
-///             },
-///             {
-///                 "equal": [
-///                     { "path": ["type(inheritanceDepth = 0)", "version"] },
-///                     { "parameter": 1 }
-///                 ]
-///             }
+///         "equal": [
+///             { "path": ["type", "versionedUrl"] },
+///             { "parameter": "https://hash.ai/@hash/types/entity-type/user/v/1" }
 ///         ]
 ///     },
 ///     "temporalAxes": {

--- a/libs/@local/hash-backend-utils/src/flows.ts
+++ b/libs/@local/hash-backend-utils/src/flows.ts
@@ -7,10 +7,7 @@ import { typedKeys } from "@local/advanced-types/typed-entries";
 import { rewriteSemanticFilter } from "@local/hash-graph-sdk/embeddings";
 import { queryEntities, summarizeEntities } from "@local/hash-graph-sdk/entity";
 import { flowRunsQueryMaxLimit } from "@local/hash-isomorphic-utils/flows/types";
-import {
-  currentTimeInstantTemporalAxes,
-  generateVersionedUrlMatchingFilter,
-} from "@local/hash-isomorphic-utils/graph-queries";
+import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import {
   systemEntityTypes,
   systemPropertyTypes,
@@ -194,10 +191,16 @@ export async function getFlowRuns({
 
   const filter = {
     all: [
-      generateVersionedUrlMatchingFilter(
-        systemEntityTypes.flowRun.entityTypeId,
-        { ignoreParents: true },
-      ),
+      {
+        equal: [
+          {
+            path: ["type", "baseUrl"],
+          },
+          {
+            parameter: systemEntityTypes.flowRun.entityTypeBaseUrl,
+          },
+        ],
+      },
       ...(filters.flowDefinitionIds
         ? [
             {

--- a/libs/@local/hash-backend-utils/src/flows/get-flow-context.ts
+++ b/libs/@local/hash-backend-utils/src/flows/get-flow-context.ts
@@ -2,10 +2,7 @@ import { caching } from "cache-manager";
 import { backOff } from "exponential-backoff";
 
 import { queryEntities } from "@local/hash-graph-sdk/entity";
-import {
-  currentTimeInstantTemporalAxes,
-  generateVersionedUrlMatchingFilter,
-} from "@local/hash-isomorphic-utils/graph-queries";
+import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import {
   systemEntityTypes,
   systemPropertyTypes,
@@ -92,10 +89,16 @@ export const getFlowEntityInfo = async (params: {
                   { parameter: workflowId },
                 ],
               },
-              generateVersionedUrlMatchingFilter(
-                systemEntityTypes.flowRun.entityTypeId,
-                { ignoreParents: true },
-              ),
+              {
+                equal: [
+                  {
+                    path: ["type", "baseUrl"],
+                  },
+                  {
+                    parameter: systemEntityTypes.flowRun.entityTypeBaseUrl,
+                  },
+                ],
+              },
             ],
           },
           temporalAxes: currentTimeInstantTemporalAxes,

--- a/libs/@local/hash-backend-utils/src/flows/process-flow-workflow/common-activities/persist-flow-activity.ts
+++ b/libs/@local/hash-backend-utils/src/flows/process-flow-workflow/common-activities/persist-flow-activity.ts
@@ -1,9 +1,6 @@
 import { HashEntity, queryEntities } from "@local/hash-graph-sdk/entity";
 import { mapFlowRunToEntityProperties } from "@local/hash-isomorphic-utils/flows/mappings";
-import {
-  currentTimeInstantTemporalAxes,
-  generateVersionedUrlMatchingFilter,
-} from "@local/hash-isomorphic-utils/graph-queries";
+import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import {
   systemEntityTypes,
   systemPropertyTypes,
@@ -67,10 +64,16 @@ export const persistFlowActivity = async (
               { parameter: temporalWorkflowId },
             ],
           },
-          generateVersionedUrlMatchingFilter(
-            systemEntityTypes.flowRun.entityTypeId,
-            { ignoreParents: true },
-          ),
+          {
+            equal: [
+              {
+                path: ["type", "baseUrl"],
+              },
+              {
+                parameter: systemEntityTypes.flowRun.entityTypeBaseUrl,
+              },
+            ],
+          },
         ],
       },
       temporalAxes: currentTimeInstantTemporalAxes,

--- a/libs/@local/hash-backend-utils/src/flows/shared/get-flow-run-entity-by-id.ts
+++ b/libs/@local/hash-backend-utils/src/flows/shared/get-flow-run-entity-by-id.ts
@@ -1,8 +1,5 @@
 import { type HashEntity, queryEntities } from "@local/hash-graph-sdk/entity";
-import {
-  currentTimeInstantTemporalAxes,
-  generateVersionedUrlMatchingFilter,
-} from "@local/hash-isomorphic-utils/graph-queries";
+import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import { systemEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 
 import type { ActorEntityUuid, EntityUuid } from "@blockprotocol/type-system";
@@ -27,10 +24,14 @@ export const getFlowRunEntityById = async (params: {
           {
             equal: [{ path: ["uuid"] }, { parameter: flowRunId }],
           },
-          generateVersionedUrlMatchingFilter(
-            systemEntityTypes.flowRun.entityTypeId,
-            { ignoreParents: true },
-          ),
+          {
+            equal: [
+              { path: ["type", "baseUrl"] },
+              {
+                parameter: systemEntityTypes.flowRun.entityTypeBaseUrl,
+              },
+            ],
+          },
         ],
       },
       temporalAxes: currentTimeInstantTemporalAxes,

--- a/libs/@local/hash-backend-utils/src/google.ts
+++ b/libs/@local/hash-backend-utils/src/google.ts
@@ -1,10 +1,7 @@
 import { google } from "googleapis";
 
 import { type HashEntity, queryEntities } from "@local/hash-graph-sdk/entity";
-import {
-  currentTimeInstantTemporalAxes,
-  generateVersionedUrlMatchingFilter,
-} from "@local/hash-isomorphic-utils/graph-queries";
+import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import { googleEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 
 import { getSecretEntitiesForIntegration } from "./user-secret.js";
@@ -59,10 +56,16 @@ export const getGoogleAccountById = async ({
             equal: [{ path: ["webId"] }, { parameter: userAccountId }],
           },
           { equal: [{ path: ["archived"] }, { parameter: false }] },
-          generateVersionedUrlMatchingFilter(
-            googleEntityTypes.account.entityTypeId,
-            { ignoreParents: true },
-          ),
+          {
+            equal: [
+              {
+                path: ["type", "baseUrl"],
+              },
+              {
+                parameter: googleEntityTypes.account.entityTypeBaseUrl,
+              },
+            ],
+          },
           {
             equal: [
               {

--- a/libs/@local/hash-backend-utils/src/machine-actors.ts
+++ b/libs/@local/hash-backend-utils/src/machine-actors.ts
@@ -78,7 +78,7 @@ export const getMachineEntityByIdentifier = async (
             {
               equal: [
                 {
-                  path: ["type(inheritanceDepth = 0)", "baseUrl"],
+                  path: ["type", "baseUrl"],
                 },
                 {
                   parameter: systemEntityTypes.machine.entityTypeBaseUrl,

--- a/libs/@local/hash-backend-utils/src/service-usage.ts
+++ b/libs/@local/hash-backend-utils/src/service-usage.ts
@@ -8,10 +8,7 @@ import {
   queryEntitySubgraph,
 } from "@local/hash-graph-sdk/entity";
 import { generateUuid } from "@local/hash-isomorphic-utils/generate-uuid";
-import {
-  currentTimeInstantTemporalAxes,
-  generateVersionedUrlMatchingFilter,
-} from "@local/hash-isomorphic-utils/graph-queries";
+import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import {
   systemEntityTypes,
   systemLinkEntityTypes,
@@ -76,10 +73,16 @@ export const getWebServiceUsage = async (
         {
           filter: {
             all: [
-              generateVersionedUrlMatchingFilter(
-                systemEntityTypes.usageRecord.entityTypeId,
-                { ignoreParents: true },
-              ),
+              {
+                equal: [
+                  {
+                    path: ["type", "baseUrl"],
+                  },
+                  {
+                    parameter: systemEntityTypes.usageRecord.entityTypeBaseUrl,
+                  },
+                ],
+              },
               {
                 equal: [
                   {
@@ -216,10 +219,16 @@ export const createUsageRecord = async (
     {
       filter: {
         all: [
-          generateVersionedUrlMatchingFilter(
-            systemEntityTypes.serviceFeature.entityTypeId,
-            { ignoreParents: true },
-          ),
+          {
+            equal: [
+              {
+                path: ["type", "baseUrl"],
+              },
+              {
+                parameter: systemEntityTypes.serviceFeature.entityTypeBaseUrl,
+              },
+            ],
+          },
           {
             equal: [
               {

--- a/libs/@local/hash-backend-utils/src/user-secret.ts
+++ b/libs/@local/hash-backend-utils/src/user-secret.ts
@@ -4,10 +4,7 @@ import {
   type HashEntity,
   queryEntitySubgraph,
 } from "@local/hash-graph-sdk/entity";
-import {
-  currentTimeInstantTemporalAxes,
-  generateVersionedUrlMatchingFilter,
-} from "@local/hash-isomorphic-utils/graph-queries";
+import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
 import {
   systemEntityTypes,
   systemLinkEntityTypes,
@@ -37,12 +34,15 @@ export const getSecretEntitiesForIntegration = async ({
   return queryEntitySubgraph({ graphApi: graphApiClient }, authentication, {
     filter: {
       all: [
-        generateVersionedUrlMatchingFilter(
-          systemLinkEntityTypes.usesUserSecret.linkEntityTypeId,
-          {
-            ignoreParents: true,
-          },
-        ),
+        {
+          equal: [
+            { path: ["type", "baseUrl"] },
+            {
+              parameter:
+                systemLinkEntityTypes.usesUserSecret.linkEntityTypeBaseUrl,
+            },
+          ],
+        },
         {
           equal: [
             { path: ["leftEntity", "uuid"] },

--- a/libs/@local/hash-isomorphic-utils/src/graph-queries.ts
+++ b/libs/@local/hash-isomorphic-utils/src/graph-queries.ts
@@ -1,7 +1,4 @@
-import {
-  componentsFromVersionedUrl,
-  splitEntityId,
-} from "@blockprotocol/type-system";
+import { splitEntityId } from "@blockprotocol/type-system";
 import { deserializeSubgraph } from "@local/hash-graph-sdk/subgraph";
 
 import {
@@ -16,19 +13,8 @@ import type {
   QueryTemporalAxesUnresolved,
   SubgraphRootType,
 } from "@blockprotocol/graph";
-import type {
-  EntityId,
-  Timestamp,
-  VersionedUrl,
-} from "@blockprotocol/type-system";
-import type {
-  DataTypeQueryToken,
-  EntityQueryToken,
-  EntityTypeQueryToken,
-  Filter,
-  PropertyTypeQueryToken,
-  Selector,
-} from "@local/hash-graph-client";
+import type { EntityId, Timestamp } from "@blockprotocol/type-system";
+import type { Filter } from "@local/hash-graph-client";
 import type { HashEntity } from "@local/hash-graph-sdk/entity";
 import type { GraphResolveDepths } from "@rust/hash-graph-store/types";
 
@@ -142,57 +128,6 @@ export const fullTransactionTimeAxis: QueryTemporalAxesUnresolved = {
       end: null,
     },
   },
-};
-
-/**
- * Generates a query filter to match a type, given its versionedUrl.
- *
- * @param versionedUrl
- * @param [options] configuration of the returned filter
- * @param [options.forEntityType] if this filter is targeting Entity Type roots rather than Entity roots
- * @param [options.ignoreParents] don't check the type's parents for a match against the versionedUrl
- * @param [options.pathPrefix] the path to the thing to match the type of, if it's not the root of the query
- *     @example ["outgoingLinks", "rightEntity"] to filter query results to things with a linked entity of the given
- *   type
- */
-export const generateVersionedUrlMatchingFilter = (
-  versionedUrl: VersionedUrl,
-  options?: {
-    forEntityType?: boolean;
-    ignoreParents?: boolean;
-    pathPrefix?: (
-      | DataTypeQueryToken
-      | EntityQueryToken
-      | EntityTypeQueryToken
-      | PropertyTypeQueryToken
-      | Selector
-    )[];
-  },
-): Filter => {
-  const {
-    forEntityType,
-    ignoreParents = false,
-    pathPrefix = [],
-  } = options ?? {};
-
-  const { baseUrl, version } = componentsFromVersionedUrl(versionedUrl);
-
-  const basePath: string[] = pathPrefix;
-
-  if (!forEntityType) {
-    basePath.push(ignoreParents ? "type(inheritanceDepth = 0)" : "type");
-  }
-
-  return {
-    all: [
-      {
-        equal: [{ path: [...basePath, "baseUrl"] }, { parameter: baseUrl }],
-      },
-      {
-        equal: [{ path: [...basePath, "version"] }, { parameter: version }],
-      },
-    ],
-  };
 };
 
 /**

--- a/libs/@local/hash-isomorphic-utils/src/page-entity-type-ids.ts
+++ b/libs/@local/hash-isomorphic-utils/src/page-entity-type-ids.ts
@@ -1,4 +1,3 @@
-import { generateVersionedUrlMatchingFilter } from "./graph-queries.js";
 import {
   systemEntityTypes,
   systemLinkEntityTypes,
@@ -35,12 +34,15 @@ export const pageEntityTypeFilter = {
   /**
    * We specify each of these page types individually rather than Page, which they both inherit from,
    * because checking against types involving inheritance is currently slow.
-   * Once H-392 is implemented we can replace it with a single check against 'page', and remove ignoreParents
-   * @todo update this once H-392 is implemented
    */
-  any: pageEntityTypeIds.map((entityTypeId) =>
-    generateVersionedUrlMatchingFilter(entityTypeId, { ignoreParents: true }),
-  ),
+  any: pageEntityTypeIds.map((entityTypeId) => ({
+    equal: [
+      { path: ["type", "versionedUrl"] },
+      {
+        parameter: entityTypeId,
+      },
+    ],
+  })),
 };
 
 export const contentLinkEntityTypeIds: VersionedUrl[] = [
@@ -55,7 +57,12 @@ export const isContentLinkEntityTypeId = (entityTypeId: VersionedUrl) =>
  * Generate a structural query filter for the types which link a block in a Block Collection to its content.
  */
 export const contentLinkTypeFilter = {
-  any: contentLinkEntityTypeIds.map((entityTypeId) =>
-    generateVersionedUrlMatchingFilter(entityTypeId, { ignoreParents: true }),
-  ),
+  any: contentLinkEntityTypeIds.map((entityTypeId) => ({
+    equal: [
+      { path: ["type", "versionedUrl"] },
+      {
+        parameter: entityTypeId,
+      },
+    ],
+  })),
 };

--- a/libs/@local/hash-isomorphic-utils/src/page-entity-type-ids.ts
+++ b/libs/@local/hash-isomorphic-utils/src/page-entity-type-ids.ts
@@ -27,24 +27,6 @@ export const includesPageEntityTypeId = (entityTypeIds: VersionedUrl[]) =>
     pageEntityTypeIds.includes(entityTypeId),
   );
 
-/**
- * A structural query filter to match against any of the system-defined Page types.
- */
-export const pageEntityTypeFilter = {
-  /**
-   * We specify each of these page types individually rather than Page, which they both inherit from,
-   * because checking against types involving inheritance is currently slow.
-   */
-  any: pageEntityTypeIds.map((entityTypeId) => ({
-    equal: [
-      { path: ["type", "versionedUrl"] },
-      {
-        parameter: entityTypeId,
-      },
-    ],
-  })),
-};
-
 export const contentLinkEntityTypeIds: VersionedUrl[] = [
   systemLinkEntityTypes.hasIndexedContent.linkEntityTypeId,
   systemLinkEntityTypes.hasSpatiallyPositionedContent.linkEntityTypeId,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Two changes to how entity queries are compiled in the Postgres store:

- The `summarizeEntities` type aggregation no longer expands the cached type arrays with a per-row `CROSS JOIN LATERAL unnest`, and skips the `DISTINCT ON` deduplication when the compiled query cannot emit duplicate rows.
- Type-matching filters across `apps/` and `libs/` are inlined so they resolve against the materialized `entity_edition_cache` columns instead of the `entity_is_of_type` join.

## 🔗 Related links

- BE-580 _(internal)_

## 🔍 What does this change?

**summarizeEntities aggregation** (`hash-graph-postgres-store`):

- The type-ids branch expands the cache arrays via set-returning `unnest` in the `SELECT` list (`ProjectSet`) instead of `CROSS JOIN LATERAL unnest(...)`.
- Adds `Relation::is_to_many` and `SelectCompiler::has_to_many_join`. The `hits` CTE omits `DISTINCT ON` when no to-many (fan-out) join was added and the variable temporal axis is a collapsed point; otherwise it deduplicates as before. Selection is via a `Deduplication` enum (no boolean parameter).

**Type-filter inlining** (`apps/` + `libs/`):

- Removes `generateVersionedUrlMatchingFilter`. Every call site is inlined as a direct `{ equal: [{ path: ["type", "baseUrl"] }, { parameter: …entityTypeBaseUrl }] }` — `["type", "versionedUrl"]` for raw `VersionedUrl` inputs and version-sensitive sites, `…linkEntityTypeBaseUrl` for link types.
- Drops the `inheritanceDepth = 0` path qualifier: a bare `type` path resolves to the GIN-indexed `entity_edition_cache` `base_urls`/`versioned_urls` columns rather than the `entity_is_of_type` join. The remaining hand-written `inheritanceDepth = 0` filters (`machine-actors`, `org`) and a rustdoc example are migrated to the same form.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- `hash-graph-postgres-store` unit tests: `statement_all_dimensions`, `statement_count_only`, `statement_skips_dedup`, `has_to_many_join_flag`.
- The inlined filters are covered by type-checking (`lint:tsc`).

## ❓ How to test this?

1. `cargo nextest run -p hash-graph-postgres-store`
2. `turbo run lint:tsc` for the affected TypeScript packages.
