### PR TITLE
FE-427: Handle inheritance in type graph viz, fix table empty state

### DIFF
--- a/apps/hash-frontend/src/components/grid/grid.tsx
+++ b/apps/hash-frontend/src/components/grid/grid.tsx
@@ -442,7 +442,7 @@ export const Grid = <
     });
   }, [columns, columnSizes]);
 
-  const emptyStateText = dataLoading ? "Loading..." : "No results";
+  const emptyStateText = dataLoading ? "Loading..." : "No results found.";
 
   const getSkeletonCellContent = useCallback(
     ([colIndex]: Item): TextCell => ({
@@ -660,7 +660,8 @@ export const Grid = <
         drawFocusRing={false}
         drawHeader={drawHeader ?? defaultDrawHeader}
         getCellContent={
-          sortedAndFilteredRows?.length
+          typeof sortedAndFilteredRows?.length === "number" &&
+          sortedAndFilteredRows.length > 0
             ? createGetCellContent(sortedAndFilteredRows)
             : getSkeletonCellContent
         }
@@ -696,7 +697,12 @@ export const Grid = <
         rangeSelect="cell"
         ref={gridRef}
         rowHeight={gridRowHeight}
-        rows={sortedAndFilteredRows?.length ?? 1}
+        rows={
+          typeof sortedAndFilteredRows?.length === "number" &&
+          sortedAndFilteredRows.length > 0
+            ? sortedAndFilteredRows.length
+            : 1
+        }
         smoothScrollX
         smoothScrollY
         theme={gridTheme}

--- a/apps/hash-frontend/src/components/grid/grid.tsx
+++ b/apps/hash-frontend/src/components/grid/grid.tsx
@@ -442,7 +442,9 @@ export const Grid = <
     });
   }, [columns, columnSizes]);
 
-  const emptyStateText = dataLoading ? "Loading..." : "No results found.";
+  const emptyStateText = dataLoading
+    ? "Loading..."
+    : "No results with the applied filters.";
 
   const getSkeletonCellContent = useCallback(
     ([colIndex]: Item): TextCell => ({

--- a/apps/hash-frontend/src/pages/@/[shortname].page/edit-user-profile-info-modal/user-profile-info-modal-header.tsx
+++ b/apps/hash-frontend/src/pages/@/[shortname].page/edit-user-profile-info-modal/user-profile-info-modal-header.tsx
@@ -1,65 +1,54 @@
-import { faImage } from "@fortawesome/free-regular-svg-icons";
-import { Box, buttonClasses, styled } from "@mui/material";
+import { Box, styled } from "@mui/material";
 import Image from "next/image";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useRef } from "react";
 
-import {
-  Avatar,
-  FontAwesomeIcon,
-  IconButton,
-  RotateRegularIcon,
-  XMarkRegularIcon,
-} from "@hashintel/design-system";
+import { Avatar, IconButton, XMarkRegularIcon } from "@hashintel/design-system";
 import {
   systemEntityTypes,
   systemLinkEntityTypes,
 } from "@local/hash-isomorphic-utils/ontology-type-ids";
 
-import { useBlockProtocolArchiveEntity } from "../../../../components/hooks/block-protocol-functions/knowledge/use-block-protocol-archive-entity";
 import { useFileUploads } from "../../../../shared/file-upload-context";
-import { TrashRegularIcon } from "../../../../shared/icons/trash-regular-icon";
-import { Button } from "../../../../shared/ui";
 import { useAuthInfo } from "../../../shared/auth-info-context";
 import { getImageUrlFromEntityProperties } from "../../../shared/get-file-properties";
 import { useUpdateProfileAvatar } from "../../[shortname]/shared/use-update-profile-avatar";
 import { leftColumnWidth } from "../util";
 
 import type { User } from "../../../../lib/user-and-org";
-import type { ButtonProps } from "../../../../shared/ui";
 import type { WebId } from "@blockprotocol/type-system";
 import type { ChangeEventHandler, FunctionComponent } from "react";
 
-const AvatarButton = styled((props: ButtonProps) => (
-  <Button variant="tertiary" {...props} />
-))(({ theme }) => ({
-  background: "transparent",
-  borderWidth: 0,
-  padding: 0,
-  minHeight: "unset",
-  fontSize: 12,
-  [`.${buttonClasses.startIcon}`]: {
-    marginLeft: 0,
-    transition: theme.transitions.create("color"),
-    color: "#FFFFFF80",
-    padding: theme.spacing(0.75),
-    background: "#0E1114CC",
-    borderRadius: 4,
-  },
-  [`&.${buttonClasses.disabled}`]: {
-    background: "transparent",
-    color: theme.palette.common.white,
-    opacity: 0.5,
-  },
-  color: theme.palette.common.white,
-  "&:hover": {
-    background: "transparent",
-    color: theme.palette.common.white,
-    [`.${buttonClasses.startIcon}`]: {
-      color: theme.palette.common.white,
-      background: "#0E1114CC",
-    },
-  },
-}));
+// const AvatarButton = styled((props: ButtonProps) => (
+//   <Button variant="tertiary" {...props} />
+// ))(({ theme }) => ({
+//   background: "transparent",
+//   borderWidth: 0,
+//   padding: 0,
+//   minHeight: "unset",
+//   fontSize: 12,
+//   [`.${buttonClasses.startIcon}`]: {
+//     marginLeft: 0,
+//     transition: theme.transitions.create("color"),
+//     color: "#FFFFFF80",
+//     padding: theme.spacing(0.75),
+//     background: "#0E1114CC",
+//     borderRadius: 4,
+//   },
+//   [`&.${buttonClasses.disabled}`]: {
+//     background: "transparent",
+//     color: theme.palette.common.white,
+//     opacity: 0.5,
+//   },
+//   color: theme.palette.common.white,
+//   "&:hover": {
+//     background: "transparent",
+//     color: theme.palette.common.white,
+//     [`.${buttonClasses.startIcon}`]: {
+//       color: theme.palette.common.white,
+//       background: "#0E1114CC",
+//     },
+//   },
+// }));
 
 const CloseIconButton = styled(IconButton)(({ theme }) => ({
   background: theme.palette.common.black,
@@ -84,11 +73,11 @@ export const UserProfileInfoModalHeader: FunctionComponent<{
   const { updateProfileAvatar, newAvatarImageUploading } =
     useUpdateProfileAvatar({ profile: userProfile });
 
-  const [newCoverImageUploading, setNewCoverImageUploading] = useState(false);
+  // const [newCoverImageUploading, setNewCoverImageUploading] = useState(false);
 
   const existingCoverImageEntity = userProfile.hasCoverImage?.imageEntity;
 
-  const { archiveEntity } = useBlockProtocolArchiveEntity();
+  // const { archiveEntity } = useBlockProtocolArchiveEntity();
   const { uploadFile } = useFileUploads();
   const { refetch: refetchUserAndOrgs } = useAuthInfo();
 
@@ -109,10 +98,10 @@ export const UserProfileInfoModalHeader: FunctionComponent<{
     [],
   );
 
-  const handleChangeCoverImage = useCallback(
-    () => coverImageInputRef.current?.click(),
-    [],
-  );
+  // const handleChangeCoverImage = useCallback(
+  //   () => coverImageInputRef.current?.click(),
+  //   [],
+  // );
 
   const handleAvatarImageFileUpload = useCallback<
     ChangeEventHandler<HTMLInputElement>
@@ -145,7 +134,7 @@ export const UserProfileInfoModalHeader: FunctionComponent<{
         throw new Error("No file provided");
       }
 
-      setNewCoverImageUploading(true);
+      // setNewCoverImageUploading(true);
 
       await uploadFile({
         webId: userProfile.accountId as WebId,
@@ -183,7 +172,7 @@ export const UserProfileInfoModalHeader: FunctionComponent<{
       void refetchUserProfile();
       void refetchUserAndOrgs();
 
-      setNewCoverImageUploading(false);
+      // setNewCoverImageUploading(false);
     },
     [
       existingCoverImageEntity,
@@ -194,21 +183,21 @@ export const UserProfileInfoModalHeader: FunctionComponent<{
     ],
   );
 
-  const handleRemoveCoverImage = useCallback(async () => {
-    if (userProfile.hasCoverImage) {
-      await archiveEntity({
-        data: {
-          entityId:
-            userProfile.hasCoverImage.linkEntity.metadata.recordId.entityId,
-        },
-      });
+  // const handleRemoveCoverImage = useCallback(async () => {
+  //   if (userProfile.hasCoverImage) {
+  //     await archiveEntity({
+  //       data: {
+  //         entityId:
+  //           userProfile.hasCoverImage.linkEntity.metadata.recordId.entityId,
+  //       },
+  //     });
 
-      /** @todo: consider also archiving image file entity */
+  //     /** @todo: consider also archiving image file entity */
 
-      void refetchUserProfile();
-      void refetchUserAndOrgs();
-    }
-  }, [userProfile, archiveEntity, refetchUserProfile, refetchUserAndOrgs]);
+  //     void refetchUserProfile();
+  //     void refetchUserAndOrgs();
+  //   }
+  // }, [userProfile, archiveEntity, refetchUserProfile, refetchUserAndOrgs]);
 
   return (
     <Box
@@ -265,7 +254,7 @@ export const UserProfileInfoModalHeader: FunctionComponent<{
           sx={{ display: "none" }}
           accept="image/*"
         />
-        {userProfile.hasCoverImage ? (
+        {/* {userProfile.hasCoverImage ? (
           <>
             <AvatarButton
               disabled={newCoverImageUploading}
@@ -291,7 +280,7 @@ export const UserProfileInfoModalHeader: FunctionComponent<{
           >
             Add cover image
           </AvatarButton>
-        )}
+        )} */}
       </Box>
       <Box>
         <CloseIconButton

--- a/apps/hash-frontend/src/pages/@/[shortname].page/edit-user-profile-info-modal/user-profile-info-modal-header.tsx
+++ b/apps/hash-frontend/src/pages/@/[shortname].page/edit-user-profile-info-modal/user-profile-info-modal-header.tsx
@@ -254,6 +254,7 @@ export const UserProfileInfoModalHeader: FunctionComponent<{
           sx={{ display: "none" }}
           accept="image/*"
         />
+        {/* @todo H-931: Make cover image appear on user profile page, uncomment handling */}
         {/* {userProfile.hasCoverImage ? (
           <>
             <AvatarButton

--- a/apps/hash-frontend/src/pages/shared/type-graph-visualizer.tsx
+++ b/apps/hash-frontend/src/pages/shared/type-graph-visualizer.tsx
@@ -1,6 +1,7 @@
 import { useTheme } from "@mui/material";
 import { useCallback, useMemo } from "react";
 
+import { extractBaseUrl } from "@blockprotocol/type-system";
 import { typedEntries, typedValues } from "@local/advanced-types/typed-entries";
 
 import { useEntityTypesContextRequired } from "../../shared/entity-types-context/hooks/use-entity-types-context-required";
@@ -15,12 +16,70 @@ import type {
 } from "./graph-visualizer";
 import type {
   DataTypeWithMetadata,
+  EntityType,
   EntityTypeWithMetadata,
   PropertyTypeWithMetadata,
   VersionedUrl,
 } from "@blockprotocol/type-system";
 
 const anythingNodeId = "anything";
+
+const getSelfAndAncestorEntityTypes = (
+  entityType: EntityType,
+  entityTypesById: Record<VersionedUrl, EntityType>,
+): EntityType[] => {
+  const selfAndAncestors: EntityType[] = [];
+  const visited = new Set<VersionedUrl>();
+  const queue = [entityType];
+
+  for (const currentEntityType of queue) {
+    const entityTypeId = currentEntityType.$id;
+
+    if (visited.has(entityTypeId)) {
+      continue;
+    }
+
+    visited.add(entityTypeId);
+    selfAndAncestors.push(currentEntityType);
+
+    for (const { $ref } of currentEntityType.allOf ?? []) {
+      const parentEntityType = entityTypesById[$ref];
+
+      if (parentEntityType) {
+        queue.push(parentEntityType);
+      }
+    }
+  }
+
+  return selfAndAncestors;
+};
+
+const getInheritedLinks = (
+  selfAndAncestors: EntityType[],
+): NonNullable<EntityType["links"]> => {
+  const inheritedLinks: NonNullable<EntityType["links"]> = {};
+  const linkTypeBaseUrlsSeen = new Set<string>();
+
+  for (const entityType of selfAndAncestors) {
+    for (const [linkTypeId, linkSchema] of typedEntries(
+      entityType.links ?? {},
+    )) {
+      const linkTypeBaseUrl = extractBaseUrl(linkTypeId);
+
+      if (linkTypeBaseUrlsSeen.has(linkTypeBaseUrl)) {
+        continue;
+      }
+
+      inheritedLinks[linkTypeId] = linkSchema;
+      linkTypeBaseUrlsSeen.add(linkTypeBaseUrl);
+    }
+  }
+
+  return inheritedLinks;
+};
+
+const getInheritedIcon = (selfAndAncestors: EntityType[]) =>
+  selfAndAncestors.find(({ icon }) => !!icon)?.icon;
 
 const defaultConfig = {
   graphKey: "type-graph",
@@ -50,7 +109,8 @@ export const TypeGraphVisualizer = ({
 }) => {
   const { palette } = useTheme();
 
-  const { isSpecialEntityTypeLookup } = useEntityTypesContextRequired();
+  const { entityTypes, isSpecialEntityTypeLookup } =
+    useEntityTypesContextRequired();
 
   const { edges, nodes } = useMemo(() => {
     const edgesToAdd: GraphVizEdge[] = [];
@@ -82,6 +142,18 @@ export const TypeGraphVisualizer = ({
       }
     > = {};
 
+    const entityTypesById: Record<VersionedUrl, EntityType> = {};
+
+    for (const type of entityTypes ?? []) {
+      entityTypesById[type.schema.$id] = type.schema;
+    }
+
+    for (const type of types) {
+      if (type.schema.kind === "entityType") {
+        entityTypesById[type.schema.$id] = type.schema;
+      }
+    }
+
     for (const { schema } of types) {
       if (schema.kind !== "entityType") {
         /**
@@ -91,6 +163,10 @@ export const TypeGraphVisualizer = ({
       }
 
       const entityTypeId = schema.$id;
+      const selfAndAncestors = getSelfAndAncestorEntityTypes(
+        schema,
+        entityTypesById,
+      );
 
       const isLink = isSpecialEntityTypeLookup?.[entityTypeId]?.isLink;
       if (isLink) {
@@ -104,6 +180,7 @@ export const TypeGraphVisualizer = ({
       nodesToAdd.push({
         nodeId: entityTypeId,
         color: palette.blue[70],
+        icon: getInheritedIcon(selfAndAncestors),
         label: schema.title,
         size: 18,
       });
@@ -111,7 +188,7 @@ export const TypeGraphVisualizer = ({
       addedNodeIds.add(entityTypeId);
 
       for (const [linkTypeId, destinationSchema] of typedEntries(
-        schema.links ?? {},
+        getInheritedLinks(selfAndAncestors),
       )) {
         const destinationTypeIds =
           "oneOf" in destinationSchema.items
@@ -133,9 +210,7 @@ export const TypeGraphVisualizer = ({
         }`;
 
         if (!addedNodeIds.has(linkNodeId)) {
-          const linkSchema = types.find(
-            (type) => type.schema.$id === linkTypeId,
-          )?.schema;
+          const linkSchema = entityTypesById[linkTypeId];
 
           if (!linkSchema) {
             continue;
@@ -243,7 +318,7 @@ export const TypeGraphVisualizer = ({
       edges: edgesToAdd,
       nodes: nodesToAdd,
     };
-  }, [isSpecialEntityTypeLookup, palette, types]);
+  }, [entityTypes, isSpecialEntityTypeLookup, palette, types]);
 
   const onNodeClick = useCallback<
     NonNullable<GraphVisualizerProps<StaticNodeSizing>["onNodeSecondClick"]>

--- a/apps/hash-frontend/src/pages/shared/types-table.tsx
+++ b/apps/hash-frontend/src/pages/shared/types-table.tsx
@@ -473,6 +473,8 @@ export const TypesTable: FunctionComponent<{
     HEADER_HEIGHT + TOP_CONTEXT_BAR_HEIGHT + 170 + tableHeaderHeight
   }px + ${theme.spacing(5)}) - ${theme.spacing(5)})`;
 
+  const displayedRowCount = Math.max(filteredRows?.length ?? 1, 1);
+
   const currentlyDisplayedRowsRef = useRef<TypesTableRow[] | null>(null);
 
   const onTypeClick = useCallback(
@@ -549,7 +551,7 @@ export const TypesTable: FunctionComponent<{
                 ${maxTableHeight},
                 calc(
                   ${gridHeaderHeightWithBorder}px +
-                  (${filteredRows?.length ?? 1} * ${gridRowHeight}px) +
+                  (${displayedRowCount} * ${gridRowHeight}px) +
                   ${gridHorizontalScrollbarHeight}px
                 )
               )`}

--- a/libs/@hashintel/type-editor/src/entity-type-editor/link-list-card/inherited-link-row.tsx
+++ b/libs/@hashintel/type-editor/src/entity-type-editor/link-list-card/inherited-link-row.tsx
@@ -36,7 +36,7 @@ export const InheritedLinkRow = ({
   const linkSchema = linkTypes[$id]?.schema;
 
   if (!linkSchema) {
-    throw new Error(`Inherited property type ${$id} not found`);
+    throw new Error(`Inherited link type ${$id} not found`);
   }
 
   return (

--- a/libs/@hashintel/type-editor/src/entity-type-editor/link-list-card/inherited-link-row.tsx
+++ b/libs/@hashintel/type-editor/src/entity-type-editor/link-list-card/inherited-link-row.tsx
@@ -1,6 +1,4 @@
-import { TableCell, Tooltip } from "@mui/material";
-
-import { fluidFontClassName } from "@hashintel/design-system/theme";
+import { Box, TableCell, Tooltip } from "@mui/material";
 
 import { useEntityTypesOptions } from "../../shared/entity-types-options-context";
 import { ArrowTurnDownRightIcon } from "../shared/arrow-turn-down-right-icon";
@@ -8,7 +6,6 @@ import {
   EntityTypeTableRow,
   EntityTypeTableTitleCellText,
 } from "../shared/entity-type-table";
-import { generateReadonlyMessage } from "../shared/generate-readonly-message";
 import { Link } from "../shared/link";
 import {
   MultipleValuesCellSummary,
@@ -42,71 +39,63 @@ export const InheritedLinkRow = ({
     throw new Error(`Inherited property type ${$id} not found`);
   }
 
-  const readonlyMessage = generateReadonlyMessage({
-    inheritanceChain,
-  });
-
   return (
     <EntityTypeTableRow inherited>
       <TableCell>
         <EntityTypeTableTitleCellText>
-          <ArrowTurnDownRightIcon sx={{ mr: 1 }} />
-          <Link href={$id} style={{ color: "inherit", fontWeight: 500 }}>
-            {linkSchema.title}
-          </Link>
+          <Tooltip
+            title={`Inherited from ${
+              inheritanceChain[inheritanceChain.length - 1]!.schema.title
+            }`}
+          >
+            <Box component="span" sx={{ display: "inline-flex" }}>
+              <ArrowTurnDownRightIcon sx={{ mr: 1 }} />
+              <Link href={$id} style={{ color: "inherit", fontWeight: 500 }}>
+                {linkSchema.title}
+              </Link>
+            </Box>
+          </Tooltip>
         </EntityTypeTableTitleCellText>
       </TableCell>
-      <Tooltip
-        placement="top"
-        classes={{ popper: fluidFontClassName }}
-        title={readonlyMessage}
-      >
-        <TableCell sx={{ py: "0 !important" }}>
-          <DestinationTypeContainer>
-            {destinationEntityTypes.length ? (
-              destinationEntityTypes.map((entityTypeId) => {
-                const entityType = entityTypes[entityTypeId];
+      <TableCell sx={{ py: "0 !important" }}>
+        <DestinationTypeContainer>
+          {destinationEntityTypes.length ? (
+            destinationEntityTypes.map((entityTypeId) => {
+              const entityType = entityTypes[entityTypeId];
 
-                if (!entityType) {
-                  throw new Error(
-                    `Destination entity type ${entityTypeId} not found in options`,
-                  );
-                }
-
-                return (
-                  <DestinationEntityType
-                    key={entityTypeId}
-                    entityTypeSchema={entityType.schema}
-                  />
+              if (!entityType) {
+                throw new Error(
+                  `Destination entity type ${entityTypeId} not found in options`,
                 );
-              })
-            ) : (
-              <AnythingChip />
-            )}
-          </DestinationTypeContainer>
-        </TableCell>
-      </Tooltip>
-      <Tooltip
-        placement="top"
-        classes={{ popper: fluidFontClassName }}
-        title={readonlyMessage}
-      >
-        <TableCell sx={{ p: "0 !important" }}>
-          <MultipleValuesControlContainer
-            canToggle={false}
-            menuOpen={false}
-            isReadOnly
-            showSummary
-          >
-            <MultipleValuesCellSummary
-              show
-              infinity={infinity}
-              min={minValue}
-              max={maxValue}
-            />
-          </MultipleValuesControlContainer>
-        </TableCell>
-      </Tooltip>
+              }
+
+              return (
+                <DestinationEntityType
+                  key={entityTypeId}
+                  entityTypeSchema={entityType.schema}
+                />
+              );
+            })
+          ) : (
+            <AnythingChip />
+          )}
+        </DestinationTypeContainer>
+      </TableCell>
+      <TableCell sx={{ p: "0 !important" }}>
+        <MultipleValuesControlContainer
+          canToggle={false}
+          menuOpen={false}
+          isReadOnly
+          showSummary
+        >
+          <MultipleValuesCellSummary
+            show
+            infinity={infinity}
+            min={minValue}
+            max={maxValue}
+          />
+        </MultipleValuesControlContainer>
+      </TableCell>
 
       <TypeMenuCell editable={false} typeId={$id} variant="link" />
     </EntityTypeTableRow>


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

A few small fixes:
1. The type graph viz wasn't handling inheritance (inherited links not showing), nor displaying icons on nodes. 
2. The entities and type tables weren't showing the 'No results shown' text.
3. Commented out the user cover image editing UI as the cover image isn't actually shown
4. Fixed some tooltips in the type editor that could clash with each other.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->
<!-- Libraries inside of the `@local` directory are always internal libraries which have no need for publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🐾 Next steps

Later follow-ups:
- H-4638: Better profile empty state
- H-931: Display cover image in user profile, restore editing UI
