### PR TITLE
FE-1105: Fix Petri net processes loading in Safari

### DIFF
--- a/apps/hash-frontend/src/lib/csp.ts
+++ b/apps/hash-frontend/src/lib/csp.ts
@@ -4,7 +4,10 @@
  * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
  */
 
-import { apiOrigin } from "@local/hash-isomorphic-utils/environment";
+import {
+  apiOrigin,
+  frontendUrl,
+} from "@local/hash-isomorphic-utils/environment";
 
 const buildDirectiveString = (directives: Record<string, string[]>): string =>
   Object.entries(directives)
@@ -102,24 +105,34 @@ export const buildCspHeader = (nonce: string): string => {
  * compiled with `new Function()` without endangering the parent HASH origin.
  *
  * Key differences vs the default CSP:
- * - `script-src` includes `'unsafe-eval'` so Babel + `new Function()` work.
- * - `connect-src` is `'self'`, but the sandbox's opaque origin makes that
- *   effectively no network reach.
- *   All persistence + AI requests deliberately round-trip through the
- *   host via postMessage instead. `'self'` (rather than `'none'`) is kept only
- *   so Next.js's dev-mode HMR probe doesn't spew CSP-violation noise inside the
- *   iframe; the real isolation is the opaque origin, not this directive.
- * - `frame-ancestors 'self'` — only HASH itself may embed this route.
+ * - `script-src` includes `'unsafe-eval'` so Babel + `new Function()` work,
+ *   and `'unsafe-inline'` (rather than a nonce) because this route is
+ *   statically generated, so the per-request middleware nonce can't be baked
+ *   into its inline framework scripts. Given `'unsafe-eval'` is already
+ *   granted and the isolation is the opaque-origin sandbox, `'unsafe-inline'`
+ *   adds no meaningful risk.
+ * - `connect-src` is `'self'` only — from the opaque-origin sandbox this is
+ *   effectively no network reach. All persistence + AI requests deliberately
+ *   round-trip through the host via postMessage instead.
+ * - `frame-ancestors` — only the HASH frontend may embed this route. Spelled
+ *   out via {@link frontendUrl} for the same opaque-origin reason as the asset
+ *   directives (`'self'` alone matches no ancestor here).
  * - `worker-src` allows `blob:` because Monaco / petrinaut spawn workers
  *   from blob URLs.
  */
-export const buildEmbedCspHeader = (nonce: string): string => {
+export const buildEmbedCspHeader = (): string => {
   const directives: Record<string, string[]> = {
     "default-src": ["'none'"],
 
     "script-src": [
+      // The embed's opaque origin makes `'self'` match nothing; reference the
+      // real origin so Next.js chunks load.
+      frontendUrl,
       "'self'",
-      `'nonce-${nonce}'`,
+      // The route is statically generated, so a per-request nonce can't be
+      // applied to its inline scripts; `'unsafe-inline'` is safe here because
+      // `'unsafe-eval'` is already granted and isolation is the sandbox.
+      "'unsafe-inline'",
       "'wasm-unsafe-eval'",
       // The whole point of the embed route: user-provided code is compiled
       // with `new Function()`, which requires `'unsafe-eval'`. Contained to
@@ -128,24 +141,25 @@ export const buildEmbedCspHeader = (nonce: string): string => {
     ],
 
     "style-src": [
+      frontendUrl,
       "'self'",
       // Required for Emotion/MUI CSS-in-JS inline style injection.
       "'unsafe-inline'",
     ],
 
-    "img-src": ["'self'", "data:", "blob:"],
+    "img-src": [frontendUrl, "'self'", "data:", "blob:"],
 
-    "font-src": ["'self'", "data:"],
+    "font-src": [frontendUrl, "'self'", "data:"],
 
     // Effectively no real reach from the opaque-origin sandbox — see the
     // `connect-src` note in this function's doc comment.
     "connect-src": ["'self'"],
 
-    "worker-src": ["'self'", "blob:"],
+    "worker-src": [frontendUrl, "'self'", "blob:"],
 
     "frame-src": ["'none'"],
 
-    "frame-ancestors": ["'self'"],
+    "frame-ancestors": [frontendUrl, "'self'"],
 
     "object-src": ["'none'"],
     "base-uri": ["'none'"],

--- a/apps/hash-frontend/src/lib/csp.ts
+++ b/apps/hash-frontend/src/lib/csp.ts
@@ -105,12 +105,12 @@ export const buildCspHeader = (nonce: string): string => {
  * compiled with `new Function()` without endangering the parent HASH origin.
  *
  * Key differences vs the default CSP:
- * - `script-src` includes `'unsafe-eval'` so Babel + `new Function()` work,
- *   and `'unsafe-inline'` (rather than a nonce) because this route is
- *   statically generated, so the per-request middleware nonce can't be baked
- *   into its inline framework scripts. Given `'unsafe-eval'` is already
- *   granted and the isolation is the opaque-origin sandbox, `'unsafe-inline'`
- *   adds no meaningful risk.
+ * - `script-src` includes `'unsafe-eval'` so Babel + `new Function()` work.
+ *   Unlike the rest of the app it uses `'unsafe-inline'` rather than a nonce:
+ *   the embed's security boundary is the opaque-origin sandbox, not its CSP —
+ *   it deliberately executes arbitrary user code via `'unsafe-eval'`, so
+ *   nonce-gating its inline framework scripts buys nothing here
+ *   (and a nonce would disable it: @see https://www.w3.org/TR/CSP3/#allow-all-inline).
  * - `connect-src` is `'self'` only — from the opaque-origin sandbox this is
  *   effectively no network reach. All persistence + AI requests deliberately
  *   round-trip through the host via postMessage instead.
@@ -129,9 +129,10 @@ export const buildEmbedCspHeader = (): string => {
       // real origin so Next.js chunks load.
       frontendUrl,
       "'self'",
-      // The route is statically generated, so a per-request nonce can't be
-      // applied to its inline scripts; `'unsafe-inline'` is safe here because
-      // `'unsafe-eval'` is already granted and isolation is the sandbox.
+      // Isolation here is the opaque-origin sandbox, not the CSP, and the
+      // route already runs arbitrary user code via `'unsafe-eval'`, so a
+      // script nonce adds nothing. `'unsafe-inline'` (with the nonce
+      // deliberately omitted, since a nonce would disable it).
       "'unsafe-inline'",
       "'wasm-unsafe-eval'",
       // The whole point of the embed route: user-provided code is compiled

--- a/apps/hash-frontend/src/middleware.page.ts
+++ b/apps/hash-frontend/src/middleware.page.ts
@@ -42,7 +42,7 @@ const petrinautEmbedRouteRegExp = /^\/processes\/[^/]+\/embed(?:\/|$)/;
 export const middleware = async (request: NextRequest) => {
   const nonce = generateNonce();
   const cspHeader = petrinautEmbedRouteRegExp.test(request.nextUrl.pathname)
-    ? buildEmbedCspHeader(nonce)
+    ? buildEmbedCspHeader()
     : buildCspHeader(nonce);
 
   // Forward the nonce to server-side rendering via a request header so that


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Safari has tightened up some security in 26.5.2 (https://support.apple.com/en-gb/127685), including apparently how `self` is interpreted for the purposes of Content-Security-Policy in iframes.

Previously the opaque/null origin iframe reachably via `/processes` was inheriting `self` from the parent (the frontend domain), but now its request for CSS etc from the frontend domain are being rejected.

This PR fixes that, mainly by injecting the frontend origin in the relevant places in the embed's CSP header.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->
<!-- Libraries inside of the `@local` directory are always internal libraries which have no need for publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Visit `/processes` in Safari 26.5.2. and click on a process, check it loads