### PR TITLE
FE-1103: Add radio component to DS

### DIFF
--- a/libs/@hashintel/ds-components/src/components/Checkbox/checkbox.tsx
+++ b/libs/@hashintel/ds-components/src/components/Checkbox/checkbox.tsx
@@ -30,16 +30,16 @@ export const Checkbox = ({
   tone = "neutral",
   ...ariaProps
 }: {
-  /** Render the box in the indeterminate ("partially checked") state */
-  indeterminate?: boolean;
+  /** An optional label rendered alongside the box */
+  label?: React.ReactNode;
   /** Which side of the box the label is rendered on */
   labelPlacement?: "left" | "right";
   /** Vertical alignment of the box against the label when it wraps over multiple lines */
   labelAlign?: "top" | "center";
-  /** An optional label rendered alongside the box */
-  label?: React.ReactNode;
   /** The tone applied when the checkbox is checked */
   tone?: Exclude<Tone, "error"> | "success";
+  /** Render the box in the indeterminate ("partially checked") state */
+  indeterminate?: boolean;
 } & SharedInputProps<HTMLInputElement, boolean> &
   React.AriaAttributes) => {
   const fieldIdFromContext = useFieldId();

--- a/libs/@hashintel/ds-components/src/components/Radio/radio.recipe.ts
+++ b/libs/@hashintel/ds-components/src/components/Radio/radio.recipe.ts
@@ -1,0 +1,199 @@
+import { sva } from "@hashintel/ds-helpers/css";
+
+import { srOnly } from "../../util/css-mixins";
+
+export const styles = sva({
+  slots: ["container", "root", "control", "label", "input"],
+  base: {
+    root: {
+      position: "relative",
+      display: "inline-flex",
+      width: "[fit-content]",
+      gap: "[6px]",
+      cursor: "pointer",
+      lineHeight: "[1.2]",
+      "&:has(input:disabled)": {
+        cursor: "unset",
+        color: "neutral.s75",
+      },
+    },
+    control: {
+      display: "inline-flex",
+      alignItems: "center",
+      justifyContent: "center",
+      flexShrink: "0",
+      color: "neutral.s00",
+      backgroundColor: "white",
+      borderRadius: "[50%]",
+      border: "[1px solid var(--colors-neutral-a60)]",
+      transition: "[background-color 0.07s ease, border-color 0.07s ease]",
+
+      "&::after": {
+        content: '""',
+        borderRadius: "[50%]",
+        backgroundColor: "[currentColor]",
+        opacity: "[var(--radio-dot-opacity, 0)]",
+        transition: "[opacity 0.07s ease]",
+      },
+      "input:checked ~ &": {
+        "--radio-dot-opacity": "1",
+      },
+      "input:not(:checked) ~ &": {
+        boxShadow: "[inset 0 1px 1px var(--colors-neutral-a30)]",
+      },
+      "input:focus-visible ~ &": {
+        outline: "[1px solid var(--colors-neutral-s80)]",
+      },
+      "input:disabled ~ &": {
+        backgroundColor: "neutral.a20",
+        borderColor: "neutral.a45",
+        boxShadow: "[none]",
+      },
+      "label:not(:has(input:disabled)):hover input:not(:checked) ~ &": {
+        backgroundColor: "neutral.a20",
+        borderColor: "neutral.a70",
+      },
+    },
+    label: {
+      alignSelf: "center",
+    },
+    input: srOnly,
+  },
+  variants: {
+    size: {
+      xxs: {
+        root: { gap: "[6px]", fontSize: "[11px]", marginBlock: "[-1.5px]" },
+        control: {
+          width: "[12px]",
+          height: "[12px]",
+          marginBlock: "[1.5px]",
+          "&::after": { width: "[5px]", height: "[5px]" },
+        },
+      },
+      xs: {
+        root: { gap: "[8px]", fontSize: "[12px]", marginBlock: "[-1.5px]" },
+        control: {
+          width: "[14px]",
+          height: "[14px]",
+          marginBlock: "[1.5px]",
+          "&::after": { width: "[6px]", height: "[6px]" },
+        },
+      },
+      sm: {
+        root: { gap: "[8px]", fontSize: "[14px]", marginBlock: "[-1.5px]" },
+        control: {
+          width: "[16px]",
+          height: "[16px]",
+          marginBlock: "[1.5px]",
+          "&::after": { width: "[7px]", height: "[7px]" },
+        },
+      },
+      md: {
+        root: { gap: "[10px]", fontSize: "[15px]", marginBlock: "[-2px]" },
+        control: {
+          width: "[18px]",
+          height: "[18px]",
+          marginBlock: "[2px]",
+          "&::after": { width: "[8px]", height: "[8px]" },
+        },
+      },
+      lg: {
+        root: { gap: "[12px]", fontSize: "[17px]", marginBlock: "[-2px]" },
+        control: {
+          width: "[20px]",
+          height: "[20px]",
+          marginBlock: "[2px]",
+          "&::after": { width: "[9px]", height: "[9px]" },
+        },
+      },
+    },
+    tone: {
+      neutral: {
+        control: {
+          "input:checked ~ &": {
+            backgroundColor: "neutral.s120",
+            borderColor: "neutral.s120",
+          },
+          "input:checked:disabled ~ &": {
+            backgroundColor: "neutral.s90",
+            borderColor: "neutral.s90",
+          },
+          "label:not(:has(input:disabled)):hover input:checked ~ &": {
+            backgroundColor: "neutral.s110",
+            borderColor: "neutral.s110",
+          },
+        },
+      },
+      brand: {
+        control: {
+          "input:checked ~ &": {
+            backgroundColor: "blue.s85",
+            borderColor: "blue.s85",
+          },
+          "input:checked:disabled ~ &": {
+            backgroundColor: "blue.s55",
+            borderColor: "blue.s55",
+          },
+          "label:not(:has(input:disabled)):hover input:checked ~ &": {
+            backgroundColor: "blue.s75",
+            borderColor: "blue.s75",
+          },
+        },
+      },
+      success: {
+        control: {
+          "input:checked ~ &": {
+            backgroundColor: "green.s85",
+            borderColor: "green.s85",
+          },
+          "input:checked:disabled ~ &": {
+            backgroundColor: "green.s55",
+            borderColor: "green.s55",
+          },
+          "label:not(:has(input:disabled)):hover input:checked ~ &": {
+            backgroundColor: "green.s70",
+            borderColor: "green.s70",
+          },
+        },
+      },
+    },
+    invalid: {
+      true: {
+        control: {
+          borderColor: "red.s70 !important",
+          "input:not(:checked) ~ &": {
+            boxShadow: "[inset 0px 1px 1px var(--colors-red-a30)]",
+          },
+          "input:focus-visible ~ &": {
+            outline: "[1px solid var(--colors-red-s50)]",
+          },
+          "label:not(:has(input:disabled)):hover input:not(:checked) ~ &": {
+            borderColor: "red.a60 !important",
+          },
+        },
+      },
+      false: {},
+    },
+    labelPlacement: {
+      left: {
+        root: { flexDirection: "row-reverse" },
+      },
+      right: {},
+    },
+    labelAlign: {
+      top: {
+        root: { alignItems: "flex-start" },
+      },
+      center: {
+        root: { alignItems: "center" },
+      },
+    },
+  },
+  defaultVariants: {
+    size: "md",
+    tone: "neutral",
+    invalid: false,
+    labelPlacement: "right",
+    labelAlign: "top",
+  },
+});

--- a/libs/@hashintel/ds-components/src/components/Radio/radio.stories.tsx
+++ b/libs/@hashintel/ds-components/src/components/Radio/radio.stories.tsx
@@ -1,0 +1,193 @@
+import { Fragment, useState } from "react";
+
+import { css } from "@hashintel/ds-helpers/css";
+
+import { formInputSizes } from "../../util/form-shared";
+import { Radio } from "./radio";
+
+import type { Story, StoryDefault } from "@ladle/react";
+
+type RadioProps = React.ComponentProps<typeof Radio>;
+
+const tones: NonNullable<RadioProps["tone"]>[] = [
+  "neutral",
+  "brand",
+  "success",
+];
+
+const labelPlacements: NonNullable<RadioProps["labelPlacement"]>[] = [
+  "left",
+  "right",
+];
+
+const ControlledRadio = ({
+  defaultValue = false,
+  ...props
+}: Omit<RadioProps, "value" | "onChange"> & { defaultValue?: boolean }) => {
+  const [value, setValue] = useState(defaultValue);
+  return <Radio {...props} value={value} onChange={setValue} />;
+};
+
+export default {
+  title: "Components/Radio",
+  parameters: {
+    layout: "centered",
+  },
+  argTypes: {
+    tone: {
+      control: { type: "select", options: tones },
+    },
+    size: {
+      control: { type: "select", options: formInputSizes },
+    },
+    disabled: { control: { type: "boolean" } },
+    invalid: { control: { type: "boolean" } },
+    labelPlacement: { control: { type: "select", options: labelPlacements } },
+    label: { control: { type: "text" } },
+  },
+  args: {
+    tone: "neutral",
+    size: "md",
+    disabled: false,
+    invalid: false,
+    labelPlacement: "right",
+  },
+} satisfies StoryDefault<RadioProps>;
+
+type Example = {
+  label: string;
+  props: Omit<RadioProps, "value" | "onChange">;
+  /** The selected state to render the example in */
+  defaultValue: boolean;
+  /** When set, a second column renders the same example in the disabled state */
+  withDisabled?: boolean;
+};
+
+// Constrains the radio width so a long label wraps onto multiple lines.
+const wrappingLabelClass = css({ maxWidth: "[260px]" });
+
+const examples: Example[] = [
+  // Each tone is shown in its selected state, alongside a disabled variant.
+  ...tones.map<Example>((tone) => ({
+    label: `tone=${tone}`,
+    props: { tone },
+    defaultValue: true,
+    withDisabled: true,
+  })),
+  { label: "unselected", props: {}, defaultValue: false, withDisabled: true },
+  {
+    label: "invalid",
+    props: { invalid: true },
+    defaultValue: false,
+    withDisabled: true,
+  },
+  {
+    label: "label",
+    props: { label: "Send me updates" },
+    defaultValue: true,
+    withDisabled: true,
+  },
+  {
+    label: "labelPlacement: left",
+    props: { label: "Send me updates", labelPlacement: "left" },
+    defaultValue: true,
+  },
+  {
+    label: "labelAlign: center",
+    props: {
+      label: "I agree to the terms of service and privacy policy",
+      className: wrappingLabelClass,
+      labelAlign: "center",
+    },
+    defaultValue: true,
+  },
+];
+
+const headingClass = css({
+  fontSize: "[12px]",
+  fontWeight: "medium",
+  color: "neutral.s90",
+});
+
+const labelClass = css({
+  fontSize: "[12px]",
+  color: "neutral.s80",
+});
+
+export const Default: Story<RadioProps> = () => (
+  <div
+    className={css({
+      display: "grid",
+      gridTemplateColumns: "[200px max-content max-content]",
+      alignItems: "center",
+      columnGap: "[32px]",
+      rowGap: "[12px]",
+    })}
+  >
+    <span />
+    <span className={headingClass}>Default</span>
+    <span className={headingClass}>Disabled</span>
+    {examples.map(({ label, props, defaultValue, withDisabled }) => (
+      <Fragment key={label}>
+        <span className={labelClass}>{label}</span>
+        <ControlledRadio {...props} defaultValue={defaultValue} />
+        {withDisabled ? (
+          <ControlledRadio {...props} disabled defaultValue={defaultValue} />
+        ) : (
+          <span />
+        )}
+      </Fragment>
+    ))}
+  </div>
+);
+
+Default.parameters = {
+  actions: { disable: true },
+  interactions: { disable: true },
+  controls: { disable: true },
+};
+
+export const Sizes: Story<RadioProps> = () => (
+  <div
+    className={css({
+      display: "flex",
+      flexDirection: "column",
+      gap: "[16px]",
+    })}
+  >
+    {formInputSizes.map((size) => (
+      <div
+        key={size}
+        className={css({
+          display: "flex",
+          alignItems: "flex-start",
+          gap: "[24px]",
+        })}
+      >
+        <span
+          className={css({
+            width: "[40px]",
+            fontSize: "[12px]",
+            color: "neutral.s80",
+          })}
+        >
+          {size}
+        </span>
+        <ControlledRadio size={size} defaultValue />
+        <ControlledRadio size={size} label="Label" defaultValue />
+        <ControlledRadio
+          size={size}
+          label="I agree to the terms of service and privacy policy"
+          className={wrappingLabelClass}
+          defaultValue
+        />
+      </div>
+    ))}
+  </div>
+);
+
+Sizes.parameters = {
+  actions: { disable: true },
+  interactions: { disable: true },
+  controls: { disable: true },
+};

--- a/libs/@hashintel/ds-components/src/components/Radio/radio.tsx
+++ b/libs/@hashintel/ds-components/src/components/Radio/radio.tsx
@@ -1,0 +1,88 @@
+import { useId } from "react";
+
+import { cx } from "@hashintel/ds-helpers/css";
+
+import { useFieldId } from "../Form/field-id-context";
+import { styles } from "./radio.recipe";
+
+import type { SharedInputProps, Tone } from "../../util/form-shared";
+
+// The value submitted by the underlying radio input when it is selected. A
+// single boolean radio has no meaningful option value, so this is an arbitrary
+// stable string (matching the native default for checkable inputs).
+const SELECTED_VALUE = "on";
+
+export const Radio = ({
+  className,
+  disabled,
+  required,
+  size = "md",
+  name,
+  value,
+  onChange,
+  onFocus,
+  onBlur,
+  invalid,
+  testId,
+  htmlForId,
+  ref,
+  inputRef,
+  autoFocus,
+  labelPlacement = "right",
+  labelAlign = "top",
+  label,
+  tone = "neutral",
+  ...ariaProps
+}: {
+  /** An optional label rendered alongside the circle */
+  label?: React.ReactNode;
+  /** Which side of the circle the label is rendered on */
+  labelPlacement?: "left" | "right";
+  /** Vertical alignment of the circle against the label when it wraps over multiple lines */
+  labelAlign?: "top" | "center";
+  /** The tone applied when the radio is selected */
+  tone?: Exclude<Tone, "error"> | "success";
+} & SharedInputProps<HTMLInputElement, boolean> &
+  React.AriaAttributes) => {
+  const fieldIdFromContext = useFieldId();
+  const generatedId = useId();
+  // Always resolve to a concrete id so the label can be explicitly linked to
+  // the input (an external `<FormField>` label takes precedence via context).
+  const inputId = htmlForId ?? fieldIdFromContext ?? generatedId;
+
+  const classes = styles({
+    size,
+    tone,
+    invalid: !!invalid,
+    labelPlacement,
+    labelAlign,
+  });
+
+  return (
+    <label
+      ref={ref as React.Ref<HTMLLabelElement>}
+      htmlFor={inputId}
+      className={cx(classes.root, className)}
+      data-testid={testId}
+      {...ariaProps}
+    >
+      <input
+        ref={inputRef}
+        type="radio"
+        className={classes.input}
+        id={inputId}
+        name={name}
+        value={SELECTED_VALUE}
+        checked={value}
+        disabled={disabled}
+        required={required}
+        autoFocus={autoFocus}
+        onChange={(event) => onChange(event.target.checked)}
+        onFocus={onFocus}
+        onBlur={onBlur}
+      />
+      <span className={classes.control} aria-hidden="true" />
+      {label && <span className={classes.label}>{label}</span>}
+    </label>
+  );
+};

--- a/libs/@hashintel/ds-components/src/main.ts
+++ b/libs/@hashintel/ds-components/src/main.ts
@@ -17,6 +17,7 @@ export type {
   ItemOrGroup,
 } from "./components/Menu/SelectableList/selectable-list";
 export { NumberInput } from "./components/NumberInput/number-input";
+export { Radio } from "./components/Radio/radio";
 export {
   RadioGroup,
   type RadioGroupOption,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Adds a Radio component to DS.

This doesn't use ark-ui internally, as ark-ui doesn't include any standalone radio component and won't render its RadioGroup.Item components without a RadioGroup.Root wrapper, so using ark-ui in this Radio component would prevent it from being re-usable + composable. However this implements all the same features as ark-ui's radio, and when implementing RadioGroup (up next) this component will get wrapped in ark-ui's <RadioGroup.Item> component so we can still use ark-ui for RadioGroup.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change