### PR TITLE
H-6642: Fix opportunity scope key for some step types

### DIFF
--- a/apps/hash-frontend/src/pages/supply-chain/shared/categories.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/categories.ts
@@ -99,3 +99,35 @@ export const PRODUCTION_TYPES: StepType[] = ["production"];
 export function isProductionType(type: StepType): boolean {
   return PRODUCTION_TYPES.includes(type);
 }
+
+/**
+ * Step types whose `node.id` is *location*-scoped (a plant, hub, or lane)
+ * rather than encoding the good/material that is the step's subject. For these,
+ * the relevant finished good must be appended to any stable identity/scope key,
+ * otherwise different finished goods sharing the same plant/hub/lane collide.
+ *
+ * Contrast with the location-agnostic steps, whose subject is already in
+ * `node.id` and so need no product: procurement (`procurement_<item>`), raw &
+ * intermediate dwell (`*_dwell_<material>`), and production
+ * (`prod_duration_<good>`).
+ *
+ * The location-scoped steps are the finished-good leg from QA onward:
+ * - `qa_hold` -> `prod_to_qa_pla` (plant)
+ * - `post_qa_ship` -> `post_qa_ship_pla` (plant)
+ * - `transit` -> `transit_pla_hub1` / `direct_ship_pla` (lane)
+ * - `destination_dwell` -> `dest_dwell_hub1` (hub)
+ *
+ * Each of these is deduplicated per finished good, so the node always carries a
+ * single product and appending it is stable (a new finished good spawns its own
+ * node/key rather than rekeying existing ones).
+ */
+export const PRODUCT_SPECIFIC_STEP_TYPES: StepType[] = [
+  "qa_hold",
+  "post_qa_ship",
+  "transit",
+  "destination_dwell",
+];
+
+export function isProductSpecificType(type: StepType): boolean {
+  return PRODUCT_SPECIFIC_STEP_TYPES.includes(type);
+}

--- a/apps/hash-frontend/src/pages/supply-chain/shared/site-code.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/site-code.ts
@@ -1,0 +1,7 @@
+/**
+ * Canonical form of a site code, used to scope status updates and to
+ * route/fetch a site's precomputed artifacts.
+ */
+export function normaliseSiteCode(code: string): string {
+  return code.trim().toLowerCase();
+}

--- a/apps/hash-frontend/src/pages/supply-chain/shared/status.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/status.ts
@@ -1,4 +1,4 @@
-import { isDwellType } from "./categories";
+import { isDwellType, isProductSpecificType } from "./categories";
 
 import type { SiteNode } from "./types";
 
@@ -14,9 +14,9 @@ export type StatusOption = (typeof STATUS_OPTIONS)[number];
 
 /** A single status update left against a step/node. */
 export interface StatusEntry {
-  /** ISO timestamp the status was saved (from the entity's creation edition). */
+  /** ISO timestamp the status was first created (original decision time). */
   at: string;
-  /** Author display name, resolved server-side from edition provenance. */
+  /** Author display name, resolved from the status entity's original creator. */
   user: string;
   category: StatusOption;
   text: string;
@@ -38,17 +38,29 @@ export function statusCommentRequired(category: StatusOption): boolean {
 
 /**
  * Stable key for status aggregation: site + opportunity type (dwell vs
- * planning, derived from the node) + node identity. Product IDs are included
- * only for post-QA dwell, where the same step ID needs product disambiguation.
+ * planning, derived from the node) + node identity.
+ *
+ * Product IDs are appended only for product-specific step types (the
+ * finished-good leg from QA onward: `qa_hold`, `post_qa_ship`, `transit`,
+ * `destination_dwell`), whose `node.id` is *location*-scoped (plant/hub/lane)
+ * and so needs finished-good disambiguation -- these are deduplicated per
+ * finished good, so exactly one product is appended and the key stays stable.
+ *
+ * Every other step type keys on `node.id` alone because its subject is already
+ * in the id: procurement on the procured item (`procurement_<item>`), raw &
+ * intermediate dwell on the material dwelling (`*_dwell_<material>`), and
+ * production on the produced thing (`prod_duration_<good>`). These do not
+ * incorporate the (potentially many) products flowing through them, so the key
+ * stays stable as product membership changes.
+ *
  * It intentionally excludes time range and measure so status history remains
  * stable across filters.
  */
 export function statusKey(siteId: string, node: SiteNode): string {
   const type = isDwellType(node.type) ? "dwell" : "planning";
-  const nodeKey =
-    node.type === "post_qa_ship"
-      ? `${node.id}-${node.products.map((product) => product.id).join(",")}`
-      : node.id;
+  const nodeKey = isProductSpecificType(node.type)
+    ? `${node.id}-${node.products.map((product) => product.id).join(",")}`
+    : node.id;
   return [siteId, type, nodeKey].join("::");
 }
 

--- a/apps/hash-frontend/src/pages/supply-chain/shared/status.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/status.ts
@@ -45,6 +45,8 @@ export function statusCommentRequired(category: StatusOption): boolean {
  * `destination_dwell`), whose `node.id` is *location*-scoped (plant/hub/lane)
  * and so needs finished-good disambiguation -- these are deduplicated per
  * finished good, so exactly one product is appended and the key stays stable.
+ * The product ids are sorted before joining so the key stays deterministic even
+ * if that single-product invariant is ever relaxed to multiple products.
  *
  * Every other step type keys on `node.id` alone because its subject is already
  * in the id: procurement on the procured item (`procurement_<item>`), raw &
@@ -59,7 +61,10 @@ export function statusCommentRequired(category: StatusOption): boolean {
 export function statusKey(siteId: string, node: SiteNode): string {
   const type = isDwellType(node.type) ? "dwell" : "planning";
   const nodeKey = isProductSpecificType(node.type)
-    ? `${node.id}-${node.products.map((product) => product.id).join(",")}`
+    ? `${node.id}-${node.products
+        .map((product) => product.id)
+        .sort()
+        .join(",")}`
     : node.id;
   return [siteId, type, nodeKey].join("::");
 }

--- a/apps/hash-frontend/src/pages/supply-chain/site/[site-id].page.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/site/[site-id].page.tsx
@@ -2,6 +2,7 @@ import { useRouter } from "next/router";
 import { useEffect } from "react";
 
 import { useRegistry } from "../shared/registry-context";
+import { normaliseSiteCode } from "../shared/site-code";
 import { getSupplyChainLayout } from "../shared/supply-chain-layout";
 import { trackSupplyChainViewed } from "../shared/telemetry";
 import { SiteOverview } from "../supply-chain-data-shell/site";
@@ -12,10 +13,11 @@ import type { NextPageWithLayout } from "../../../shared/layout";
 const SitePage: NextPageWithLayout = () => {
   const router = useRouter();
   const { products, sites } = useRegistry();
-  const siteId =
+  const siteId = normaliseSiteCode(
     typeof router.query["site-id"] === "string"
       ? router.query["site-id"]
-      : (sites[0]?.slug ?? "");
+      : (sites[0]?.slug ?? ""),
+  );
   const opportunityStatusStore = useSupplyChainStatusState(siteId);
 
   useEffect(() => {

--- a/apps/hash-frontend/src/pages/supply-chain/site/[site-id]/opportunity/[opportunity-type]/[product-id]/[step-id].page.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/site/[site-id]/opportunity/[opportunity-type]/[product-id]/[step-id].page.tsx
@@ -6,6 +6,7 @@ import {
   SupplyChainAppSkeleton,
 } from "../../../../../shared/load-state";
 import { useRegistry } from "../../../../../shared/registry-context";
+import { normaliseSiteCode } from "../../../../../shared/site-code";
 import { getSupplyChainLayout } from "../../../../../shared/supply-chain-layout";
 import {
   trackSupplyChainInteraction,
@@ -28,7 +29,7 @@ const OpportunityPage: NextPageWithLayout = () => {
     "product-id"?: string;
     "step-id"?: string;
   };
-  const siteId = query["site-id"] ?? "";
+  const siteId = normaliseSiteCode(query["site-id"] ?? "");
   const productId = query["product-id"] ?? "";
   const stepId = query["step-id"] ?? "";
   const opportunityType = normaliseOpportunityType(query["opportunity-type"]);

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell.tsx
@@ -8,6 +8,7 @@ import {
 
 import { css } from "@hashintel/ds-helpers/css";
 
+import { useMemoCompare } from "../../shared/use-memo-compare";
 import { useAuthInfo } from "../shared/auth-info-context";
 import { useActiveWorkspace } from "../shared/workspace-context";
 import {
@@ -172,7 +173,8 @@ export const SupplyChainDataShell = ({
   const { authenticatedUser } = useAuthInfo();
   const { activeWorkspace } = useActiveWorkspace();
 
-  const candidateWebIds = useMemo(
+  // Avoid full reloads when the user object but not its web memberships change.
+  const candidateWebIds = useMemoCompare(
     () =>
       getOrderedWebIds([
         scope,
@@ -180,6 +182,13 @@ export const SupplyChainDataShell = ({
         authenticatedUser?.accountId as WebId | undefined,
       ]),
     [authenticatedUser, scope],
+    (previous, next) => {
+      const previousSet = new Set(previous);
+      const nextSet = new Set(next);
+      return (
+        previousSet.size === nextSet.size && previousSet.isSupersetOf(nextSet)
+      );
+    },
   );
 
   const [searchParams, setSearchParams] = useSearchParams();

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/opportunity/opportunity-utils.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/opportunity/opportunity-utils.ts
@@ -1,3 +1,4 @@
+import { isProductSpecificType } from "../../shared/categories";
 import {
   computeMonthlyCost,
   computePeriodCost,
@@ -289,14 +290,12 @@ export function buildOpportunityBackLink(
   return query ? `${path}?${query}` : path;
 }
 
-const PRODUCT_SPECIFIC_STEP_TYPES = new Set<StepType>(["post_qa_ship"]);
-
 export function firstProductForNode(
   node: SiteNode,
   requestedProductId?: string,
 ): string {
   if (
-    PRODUCT_SPECIFIC_STEP_TYPES.has(node.type) &&
+    isProductSpecificType(node.type) &&
     requestedProductId &&
     node.products.some((product) => product.id === requestedProductId)
   ) {

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product.tsx
@@ -20,6 +20,7 @@ import { useProcurementBasis } from "../shared/procurement-basis-context";
 import { filterGraphNodeByDateRange } from "../shared/range-filter";
 import { ScopeSelect } from "../shared/scope-select";
 import { SegmentedControl } from "../shared/segmented-control";
+import { normaliseSiteCode } from "../shared/site-code";
 import { StatChip } from "../shared/stat-chip";
 import { statusKey } from "../shared/status";
 import { StatusDialog } from "../shared/status-dialog";
@@ -474,13 +475,32 @@ export const Overview = ({
       : null;
   }, [graph.nodes, graph.product_name, productId, selectedStepId]);
 
-  const selectedSiteId = selectedNode?.plant ?? "";
-  const opportunityStatusStore = useSupplyChainStatusState(selectedSiteId);
+  // Stable site code for the product: the plant where the finished good is
+  // produced/QA'd. Transit and destination-dwell nodes carry lane/hub
+  // identifiers in `plant`, so scoping the status hook / status keys / brief
+  // links off the *selected* step's plant made the site scope jump around as
+  // the selection changed (re-initialising the status hook and splitting status
+  // history across scopes). The site code is smaller and less likely to change,
+  // so derive it once from the graph and use it for the whole product page.
+  //
+  // `node.plant` is the raw (upper-case) SAP plant code, whereas the site
+  // overview scopes by the lower-cased route slug; `normaliseSiteCode` reconciles
+  // the two so status set on the site overview lines up with the product page.
+  const productSiteId = useMemo(() => {
+    const homeNode =
+      graph.nodes.find((node) => node.type === "production") ??
+      graph.nodes.find((node) => node.type === "qa_hold") ??
+      graph.nodes.find(
+        (node) => node.type !== "transit" && node.type !== "destination_dwell",
+      );
+    return normaliseSiteCode(homeNode?.plant ?? graph.nodes[0]?.plant ?? "");
+  }, [graph.nodes]);
+  const opportunityStatusStore = useSupplyChainStatusState(productSiteId);
   const selectedStatusKey = selectedNode
-    ? statusKey(selectedSiteId, selectedNode)
+    ? statusKey(productSiteId, selectedNode)
     : null;
   const selectedBriefHref = useMemo(() => {
-    if (!selectedNode || !selectedSiteId) {
+    if (!selectedNode || !productSiteId) {
       return undefined;
     }
     const params = new URLSearchParams({ range: timeRange });
@@ -491,10 +511,10 @@ export const Overview = ({
       }
     }
 
-    return `/supply-chain/site/${selectedSiteId}/opportunity/${
+    return `/supply-chain/site/${productSiteId}/opportunity/${
       isDwellType(selectedNode.type) ? "dwell" : "planning"
     }/${productId}/${selectedNode.id}?${params.toString()}`;
-  }, [productId, searchParams, selectedNode, selectedSiteId, timeRange]);
+  }, [productId, searchParams, selectedNode, productSiteId, timeRange]);
 
   const statusTargetIsSelectedNode =
     selectedNode != null &&

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product/shared/category-icon.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product/shared/category-icon.tsx
@@ -19,6 +19,9 @@ export const CategoryIcon = ({
     viewBox: "0 0 14 14",
     fill: "none",
     className,
+    // Prevent flexbox from squeezing the icon when it sits next to long,
+    // wrapping label text (e.g. two-line step titles in cards).
+    style: { flexShrink: 0, minWidth: size, minHeight: size },
     "aria-hidden": true as const,
   };
 

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product/whatif.test.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product/whatif.test.ts
@@ -121,7 +121,7 @@ function baseNode(overrides: Partial<GraphNode>): GraphNode {
     label: "Post QA Ship",
     type: "post_qa_ship",
     material: null,
-    plant: "JPGB",
+    plant: "P1",
     stats: {
       n: 3,
       mean: 5.3,

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site.tsx
@@ -570,6 +570,7 @@ export const SiteOverview = ({
           {tab === "dwell" && (
             <DwellTable
               rows={dwellRows}
+              siteId={siteSlug}
               sort={dwellSort}
               onSort={setDwellSort}
               onRowClick={handleStepClick}
@@ -583,6 +584,7 @@ export const SiteOverview = ({
           {tab === "planning" && (
             <PlanningTable
               rows={filteredPlanningRows}
+              siteId={siteSlug}
               sort={planSort}
               onSort={setPlanSort}
               onRowClick={handleStepClick}
@@ -594,6 +596,7 @@ export const SiteOverview = ({
           {tab === "trends" && (
             <TrendTable
               rows={filteredTrendRows}
+              siteId={siteSlug}
               sort={trendSort}
               onSort={setTrendSort}
               onRowClick={handleStepClick}

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/dwell-table.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/dwell-table.tsx
@@ -28,6 +28,7 @@ import type { SiteNode } from "../../shared/types";
 
 export const DwellTable = ({
   rows,
+  siteId,
   sort,
   onSort,
   onRowClick,
@@ -38,6 +39,8 @@ export const DwellTable = ({
   currency,
 }: {
   rows: DwellRow[];
+  /** Route site slug; scopes status keys to the global store. */
+  siteId: string;
   sort: { key: SortKey; dir: SortDir };
   onSort: (s: { key: SortKey; dir: SortDir }) => void;
   onRowClick: (node: SiteNode) => void;
@@ -173,7 +176,7 @@ export const DwellTable = ({
 
                   <StatusActionButton
                     state={deriveStatusActionState(
-                      statusHistory[statusKey(row.plant, row)],
+                      statusHistory[statusKey(siteId, row)],
                     )}
                     onClick={(event) => {
                       event.stopPropagation();

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/opportunities.test.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/opportunities.test.ts
@@ -234,30 +234,94 @@ describe("statusKey", () => {
     }
   });
 
-  it("shares status keys for non-post-QA steps across products", () => {
-    const transit = dwell({
-      id: "transit",
-      type: "transit",
+  it("keys location-agnostic steps on node.id alone (shared across products)", () => {
+    // Production is keyed on the *produced thing*, which lives in `node.id`
+    // (e.g. `prod_duration_green_blend`). The `products` array lists the
+    // finished goods that consume this production, and must not be part of the
+    // key -- it drifts as the product mix changes.
+    const greenBlendProduction = planning({
+      id: "prod_duration_green_blend",
+      type: "production",
       products: [{ id: "p1", name: "Product 1" }],
     });
-    const destinationDwell = dwell({
-      id: "destination",
-      type: "destination_dwell",
-      products: [{ id: "p2", name: "Product 2" }],
-    });
 
+    // Same produced thing consumed by a different finished good -> same key.
+    expect(
+      statusKey("site-a", {
+        ...greenBlendProduction,
+        products: [{ id: "p2", name: "Product 2" }],
+      }),
+    ).toBe(statusKey("site-a", greenBlendProduction));
+    expect(statusKey("site-a", greenBlendProduction)).toBe(
+      "site-a::planning::prod_duration_green_blend",
+    );
+
+    // Different produced thing -> different key, without embedding any product.
     expect(
       statusKey(
         "site-a",
-        dwell({
-          ...transit,
-          products: [{ id: "p2", name: "Product 2" }],
+        planning({
+          id: "prod_duration_harbor_dark_roast",
+          type: "production",
+          products: [{ id: "p1", name: "Product 1" }],
         }),
       ),
-    ).toBe(statusKey("site-a", transit));
-    expect(statusKey("site-a", destinationDwell)).toBe(
-      "site-a::dwell::destination",
+    ).not.toBe(statusKey("site-a", greenBlendProduction));
+
+    // Intermediate dwell keys on the material dwelling (in `node.id`); the
+    // consuming finished good is deliberately shared, not part of the key.
+    const imDwell = dwell({
+      id: "intermed_dwell_green_blend",
+      type: "intermediate_dwell",
+      products: [{ id: "p1", name: "Product 1" }],
+    });
+    expect(
+      statusKey("site-a", {
+        ...imDwell,
+        products: [{ id: "p2", name: "Product 2" }],
+      }),
+    ).toBe(statusKey("site-a", imDwell));
+    expect(statusKey("site-a", imDwell)).toBe(
+      "site-a::dwell::intermed_dwell_green_blend",
     );
+  });
+
+  it("disambiguates location-scoped steps (transit, destination dwell) by product", () => {
+    // Transit ids are lane-scoped (`transit_pla_hub1`) with the finished good
+    // only in `products`, so the product must be appended. Transit is a
+    // planning-category step.
+    const transit = planning({
+      id: "transit_pla_hub1",
+      type: "transit",
+      products: [{ id: "p1", name: "Product 1" }],
+    });
+    expect(statusKey("site-a", transit)).toBe(
+      "site-a::planning::transit_pla_hub1-p1",
+    );
+    expect(
+      statusKey("site-a", {
+        ...transit,
+        products: [{ id: "p2", name: "Product 2" }],
+      }),
+    ).toBe("site-a::planning::transit_pla_hub1-p2");
+
+    // Destination dwell ids are hub-scoped (`dest_dwell_hub1`); the thing
+    // dwelling is the finished good, so the product must be appended. It is a
+    // dwell-category step.
+    const destDwell = dwell({
+      id: "dest_dwell_hub1",
+      type: "destination_dwell",
+      products: [{ id: "p1", name: "Product 1" }],
+    });
+    expect(statusKey("site-a", destDwell)).toBe(
+      "site-a::dwell::dest_dwell_hub1-p1",
+    );
+    expect(
+      statusKey("site-a", {
+        ...destDwell,
+        products: [{ id: "p2", name: "Product 2" }],
+      }),
+    ).toBe("site-a::dwell::dest_dwell_hub1-p2");
   });
 
   it("disambiguates post-QA dwell status by product", () => {
@@ -274,6 +338,24 @@ describe("statusKey", () => {
         products: [{ id: "p2", name: "Product 2" }],
       }),
     ).toBe("site-a::dwell::post-qa-p2");
+  });
+
+  it("disambiguates production -> QA release (qa_hold) status by product", () => {
+    const qaHold = planning({
+      id: "prod-to-qa",
+      type: "qa_hold",
+      products: [{ id: "p1", name: "Product 1" }],
+    });
+
+    // qa_hold is a planning-category step, so it lives under `::planning::`, but
+    // it is a single-finished-good step so the product is part of the key.
+    expect(statusKey("site-a", qaHold)).toBe("site-a::planning::prod-to-qa-p1");
+    expect(
+      statusKey("site-a", {
+        ...qaHold,
+        products: [{ id: "p2", name: "Product 2" }],
+      }),
+    ).toBe("site-a::planning::prod-to-qa-p2");
   });
 
   it("distinguishes dwell and planning nodes", () => {

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/planning-table.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/planning-table.tsx
@@ -61,6 +61,7 @@ const PlanningSampleTooltip = ({
 };
 export const PlanningTable = ({
   rows,
+  siteId,
   sort,
   onSort,
   onRowClick,
@@ -69,6 +70,8 @@ export const PlanningTable = ({
   onStatus,
 }: {
   rows: PlanningRow[];
+  /** Route site slug; scopes status keys to the global store. */
+  siteId: string;
   sort: { key: SortKey; dir: SortDir };
   onSort: (s: { key: SortKey; dir: SortDir }) => void;
   onRowClick: (node: SiteNode) => void;
@@ -231,7 +234,7 @@ export const PlanningTable = ({
 
                     <StatusActionButton
                       state={deriveStatusActionState(
-                        statusHistory[statusKey(row.plant, row)],
+                        statusHistory[statusKey(siteId, row)],
                       )}
                       onClick={(event) => {
                         event.stopPropagation();

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/trend-table.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/trend-table.tsx
@@ -148,6 +148,7 @@ const TrendSampleTooltip = ({
 };
 export const TrendTable = ({
   rows,
+  siteId,
   sort,
   onSort,
   onRowClick,
@@ -155,6 +156,8 @@ export const TrendTable = ({
   onStatus,
 }: {
   rows: TrendRow[];
+  /** Route site slug; scopes status keys to the global store. */
+  siteId: string;
   sort: { key: SortKey; dir: SortDir };
   onSort: (s: { key: SortKey; dir: SortDir }) => void;
   onRowClick: (node: SiteNode) => void;
@@ -278,7 +281,7 @@ export const TrendTable = ({
               <td className={cx(threshold.td, threshold.tdRight)}>
                 <StatusActionButton
                   state={deriveStatusActionState(
-                    statusHistory[statusKey(row.plant, row)],
+                    statusHistory[statusKey(siteId, row)],
                   )}
                   onClick={(event) => {
                     event.stopPropagation();

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/use-supply-chain-status-state.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/use-supply-chain-status-state.ts
@@ -170,7 +170,7 @@ const parseStatusReports = (entities: HashEntity[]): RawStatusReport[] => {
         getStringProperty(entity, statusCategoryBaseUrl),
       ),
       text: getStringProperty(entity, statusTextBaseUrl) ?? "",
-      authorId: entity.metadata.provenance.edition.createdById,
+      authorId: entity.metadata.provenance.createdById,
     });
   }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The scope key by which opportunities are tracked didn't include the product id for some steps where it should (e.g. post-QA dwell), which meant that any update against those steps appeared on all steps of that type.

This PR fixes that by including the product in the scope key.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->
<!-- Libraries inside of the `@local` directory are always internal libraries which have no need for publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
