### PR TITLE
FE-1126: Adjust title wrapping in larger dialogs

### DIFF
--- a/libs/@hashintel/ds-components/src/components/Dialog/dialog.recipe.ts
+++ b/libs/@hashintel/ds-components/src/components/Dialog/dialog.recipe.ts
@@ -8,6 +8,8 @@ export const styles = sva({
     .extendWith(
       "stackRoot",
       "header",
+      "headerMain",
+      "headerText",
       "titleIcon",
       "headerActions",
       "headerRight",
@@ -121,6 +123,8 @@ export const styles = sva({
       flex: "[1 1 auto]",
       minWidth: "0",
     },
+    headerMain: {},
+    headerText: {},
     titleIcon: {
       float: "start",
       marginLeft: "-0.5",
@@ -263,6 +267,9 @@ export const styles = sva({
       md: {
         content: { maxWidth: "[640px]" },
         loadingSpinner: { height: "[40px !important]" },
+        headerMain: { display: "flex", alignItems: "flex-start", gap: "2" },
+        titleIcon: { marginRight: "0" },
+        headerText: { flex: "[1 1 auto]", minWidth: "[0]" },
       },
       lg: {
         content: { maxWidth: "[860px]" },
@@ -270,6 +277,9 @@ export const styles = sva({
           height: "[45px !important]",
           color: "neutral.s115",
         },
+        headerMain: { display: "flex", alignItems: "flex-start", gap: "2" },
+        titleIcon: { marginRight: "0" },
+        headerText: { flex: "[1 1 auto]", minWidth: "[0]" },
       },
       xl: {
         content: { maxWidth: "[1060px]" },
@@ -277,6 +287,9 @@ export const styles = sva({
           height: "[50px !important]",
           color: "neutral.s115",
         },
+        headerMain: { display: "flex", alignItems: "flex-start", gap: "2" },
+        titleIcon: { marginRight: "0" },
+        headerText: { flex: "[1 1 auto]", minWidth: "[0]" },
       },
       fullScreen: {
         positioner: { padding: "0" },
@@ -291,6 +304,9 @@ export const styles = sva({
           height: "[50px !important]",
           color: "neutral.s110",
         },
+        headerMain: { display: "flex", alignItems: "flex-start", gap: "2" },
+        titleIcon: { marginRight: "0" },
+        headerText: { flex: "[1 1 auto]", minWidth: "[0]" },
       },
     },
     variant: {

--- a/libs/@hashintel/ds-components/src/components/Dialog/dialog.tsx
+++ b/libs/@hashintel/ds-components/src/components/Dialog/dialog.tsx
@@ -92,27 +92,36 @@ const Header = ({
 
   return (
     <div className={classes.header}>
-      <div>
+      <div className={classes.headerMain}>
         {iconName && (
           <Icon name={iconName} size="md" className={classes.titleIcon} />
         )}
-        {actions ? (
-          <div className={classes.headerRight}>
-            <div className={classes.headerActions}>{actions}</div>
-            {closeButton}
-          </div>
-        ) : (
-          closeButton
-        )}
-        {title && (
-          <ArkDialog.Title className={classes.title}>{title}</ArkDialog.Title>
-        )}
+        {/*
+         * The actions/close float to the end within this text column so the
+         * title and description wrap around them. On md and up the column is a
+         * flex item (its own formatting context) sitting to the right of the
+         * flexed icon; on xs/sm it is a transparent block, so the icon float
+         * from headerMain still reaches the text.
+         */}
+        <div className={classes.headerText}>
+          {actions ? (
+            <div className={classes.headerRight}>
+              <div className={classes.headerActions}>{actions}</div>
+              {closeButton}
+            </div>
+          ) : (
+            closeButton
+          )}
+          {title && (
+            <ArkDialog.Title className={classes.title}>{title}</ArkDialog.Title>
+          )}
+          {description && (
+            <ArkDialog.Description className={classes.description}>
+              {description}
+            </ArkDialog.Description>
+          )}
+        </div>
       </div>
-      {description && (
-        <ArkDialog.Description className={classes.description}>
-          {description}
-        </ArkDialog.Description>
-      )}
     </div>
   );
 };


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Based on feedback from design. Previously on dialogs sized md and up the titles looked like this:
<img width="750" height="304" alt="Screenshot 2026-07-02 at 16 05 28" src="https://github.com/user-attachments/assets/75d72430-d201-493b-8323-64351cea54f3" />

Now they look like this instead:
<img width="710" height="294" alt="Screenshot 2026-07-02 at 16 05 18" src="https://github.com/user-attachments/assets/987668bd-fb24-4c51-afb7-74f6d8d69090" />

For smaller dialogs, where title space is at a premium we still use the old style:
<img width="527" height="324" alt="Screenshot 2026-07-02 at 16 05 44" src="https://github.com/user-attachments/assets/e963a852-355c-4be9-af16-2a0d53590a10" />


## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change
