### PR TITLE
FE-1129: Token encoding playground (Storybook)

### DIFF
--- a/.changeset/token-codec-exports.md
+++ b/.changeset/token-codec-exports.md
@@ -1,0 +1,6 @@
+---
+"@hashintel/petrinaut-core": patch
+"@hashintel/petrinaut": patch
+---
+
+Export the token value codec and `compileUserCode` from `@hashintel/petrinaut-core`.

--- a/libs/@hashintel/petrinaut-core/src/index.ts
+++ b/libs/@hashintel/petrinaut-core/src/index.ts
@@ -332,6 +332,15 @@ export {
 } from "./simulation/authoring/scenario/compile-scenario";
 export { buildMetricState } from "./simulation/frames/metric-state";
 export {
+  coerceTokenAttributeValue,
+  coerceTokenRecord,
+  decodeTokenAttributeValue,
+  decodeTokenRecord,
+  defaultTokenAttributeValue,
+  encodeTokenAttributeValue,
+} from "./simulation/engine/token-values";
+export { compileUserCode } from "./simulation/authoring/user-code/compile-user-code";
+export {
   displayNameSchema,
   validateDisplayName,
 } from "./validation/display-name";

--- a/libs/@hashintel/petrinaut/src/ui/components/spreadsheet.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/components/spreadsheet.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from "react";
 
 import { css, cva } from "@hashintel/ds-helpers/css";
+import { defaultTokenAttributeValue } from "@hashintel/petrinaut-core";
 
 export interface SpreadsheetColumn {
   id: string;
@@ -192,16 +193,8 @@ const booleanCellStyle = css({
 
 const getDefaultCellValue = (
   column: SpreadsheetColumn | undefined,
-): SpreadsheetCellValue => {
-  switch (column?.type) {
-    case "boolean":
-      return false;
-    case "integer":
-    case "real":
-    default:
-      return 0;
-  }
-};
+): SpreadsheetCellValue =>
+  column?.type ? defaultTokenAttributeValue(column.type) : 0;
 
 const formatCellValue = (value: SpreadsheetCellValue): string => String(value);
 

--- a/libs/@hashintel/petrinaut/src/ui/dev/token-encoding-playground/dimension-editor.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/dev/token-encoding-playground/dimension-editor.tsx
@@ -1,0 +1,121 @@
+import { Button, Select, TextInput } from "@hashintel/ds-components";
+import { css } from "@hashintel/ds-helpers/css";
+
+import type { PlaygroundDimension } from "./physical-layout";
+import type { SelectItem } from "@hashintel/ds-components";
+import type { ColorElementType } from "@hashintel/petrinaut-core";
+
+export type DimensionEditorProps = {
+  dimensions: PlaygroundDimension[];
+  onChange: (dimensions: PlaygroundDimension[]) => void;
+};
+
+const typeOptions: SelectItem<ColorElementType>[] = [
+  { value: "real", text: "Real" },
+  { value: "integer", text: "Integer" },
+  { value: "boolean", text: "Boolean" },
+];
+
+const listStyle = css({
+  display: "flex",
+  flexDirection: "column",
+  gap: "1.5",
+});
+
+const rowStyle = css({
+  display: "flex",
+  alignItems: "center",
+  gap: "1",
+});
+
+const nameInputStyle = css({
+  display: "flex",
+  flex: "[1]",
+  minWidth: "[0]",
+
+  "& input": {
+    fontFamily: "mono",
+  },
+});
+
+const typeSelectStyle = css({
+  width: "[110px]",
+  flexShrink: 0,
+});
+
+/**
+ * Store-free version of the type-properties dimension list: local state only,
+ * for the playground story.
+ */
+export const DimensionEditor: React.FC<DimensionEditorProps> = ({
+  dimensions,
+  onChange,
+}) => {
+  const updateAt = (index: number, update: Partial<PlaygroundDimension>) => {
+    onChange(
+      dimensions.map((dimension, dimensionIndex) =>
+        dimensionIndex === index ? { ...dimension, ...update } : dimension,
+      ),
+    );
+  };
+
+  return (
+    <div className={listStyle}>
+      {dimensions.map((dimension, index) => (
+        // eslint-disable-next-line react/no-array-index-key -- rows are positional
+        <div key={index} className={rowStyle}>
+          <TextInput
+            value={dimension.name}
+            size="sm"
+            width="fullWidth"
+            className={nameInputStyle}
+            placeholder="dimension_name"
+            onChange={(name) => updateAt(index, { name })}
+            connectToRightInput
+          />
+          <Select
+            required
+            value={dimension.type}
+            onChange={(type) => updateAt(index, { type })}
+            items={typeOptions}
+            size="sm"
+            className={typeSelectStyle}
+            connectToLeftInput
+          />
+          <Button
+            onClick={() =>
+              onChange(dimensions.filter((_, other) => other !== index))
+            }
+            size="xxs"
+            variant="ghost"
+            iconName="close"
+            aria-label={`Remove dimension ${dimension.name}`}
+          />
+        </div>
+      ))}
+      <Button
+        onClick={() =>
+          onChange([
+            ...dimensions,
+            // First free dim_N: length alone can collide after removals.
+            {
+              name: (() => {
+                let index = dimensions.length;
+                while (dimensions.some((d) => d.name === `dim_${index}`)) {
+                  index++;
+                }
+                return `dim_${index}`;
+              })(),
+              type: "real",
+            },
+          ])
+        }
+        size="xs"
+        variant="ghost"
+        iconName="plus"
+      >
+        Add dimension
+      </Button>
+    </div>
+  );
+};

--- a/libs/@hashintel/petrinaut/src/ui/dev/token-encoding-playground/monaco-typescript.d.ts
+++ b/libs/@hashintel/petrinaut/src/ui/dev/token-encoding-playground/monaco-typescript.d.ts
@@ -1,0 +1,18 @@
+/**
+ * monaco-editor 0.55 ships its TypeScript language service untyped — the
+ * contribution's `.d.ts` is an empty `export {}` and the old
+ * `monaco.languages.typescript` namespace types were removed. Declare the
+ * minimal surface the playground uses.
+ */
+declare module "monaco-editor/esm/vs/language/typescript/monaco.contribution.js" {
+  export type PlaygroundExtraLib = { content: string; filePath?: string };
+
+  export const typescriptDefaults: {
+    setCompilerOptions(options: Record<string, unknown>): void;
+    setEagerModelSync(enabled: boolean): void;
+    setExtraLibs(libs: PlaygroundExtraLib[]): void;
+    setModeConfiguration(config: Record<string, boolean>): void;
+  };
+
+  export const ScriptTarget: { ES2020: number };
+}

--- a/libs/@hashintel/petrinaut/src/ui/dev/token-encoding-playground/physical-layout.test.ts
+++ b/libs/@hashintel/petrinaut/src/ui/dev/token-encoding-playground/physical-layout.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  computeTokenLayout,
+  decodeToken,
+  encodeToken,
+  getFieldBits,
+  getFieldHex,
+} from "./physical-layout";
+
+import type { PlaygroundDimension } from "./physical-layout";
+
+const DIMENSIONS: PlaygroundDimension[] = [
+  { name: "active", type: "boolean" },
+  { name: "amount", type: "real" },
+  { name: "count", type: "integer" },
+];
+
+describe("computeTokenLayout", () => {
+  it("v1 keeps declaration order with one f64 slot per dimension", () => {
+    const layout = computeTokenLayout(DIMENSIONS, "v1");
+
+    expect(layout.strideBytes).toBe(24);
+    expect(layout.paddingRanges).toEqual([]);
+    expect(
+      layout.fields.map((f) => [f.name, f.physical.kind, f.byteOffset]),
+    ).toEqual([
+      ["active", "f64", 0],
+      ["amount", "f64", 8],
+      ["count", "f64", 16],
+    ]);
+  });
+
+  it("v2 orders by decreasing alignment and pads the stride to 8", () => {
+    const layout = computeTokenLayout(DIMENSIONS, "v2");
+
+    // amount and count (f64, align 8) first — stable relative order — then
+    // the u8 boolean, then 7 bytes of tail padding.
+    expect(
+      layout.fields.map((f) => [f.name, f.physical.kind, f.byteOffset]),
+    ).toEqual([
+      ["amount", "f64", 0],
+      ["count", "f64", 8],
+      ["active", "u8", 16],
+    ]);
+    expect(layout.strideBytes).toBe(24);
+    expect(layout.paddingRanges).toEqual([{ start: 17, end: 24 }]);
+  });
+
+  it("returns an empty layout for no dimensions", () => {
+    const layout = computeTokenLayout([], "v2");
+    expect(layout.strideBytes).toBe(0);
+    expect(layout.fields).toEqual([]);
+  });
+});
+
+describe("encodeToken / decodeToken", () => {
+  it.each(["v1", "v2"] as const)(
+    "round-trips with product coercion in %s mode",
+    (mode) => {
+      const layout = computeTokenLayout(DIMENSIONS, mode);
+      const { stored, decoded } = encodeToken(layout, {
+        active: true,
+        amount: 1.25,
+        count: 2.7,
+      });
+
+      expect(stored).toEqual({ active: true, amount: 1.25, count: 3 });
+      expect(decoded).toEqual({ active: true, amount: 1.25, count: 3 });
+    },
+  );
+
+  it("applies typed defaults for missing values", () => {
+    const layout = computeTokenLayout(DIMENSIONS, "v2");
+    const { decoded } = encodeToken(layout, {});
+    expect(decoded).toEqual({ active: false, amount: 0, count: 0 });
+  });
+
+  it("stores booleans as a single byte in v2", () => {
+    const layout = computeTokenLayout(
+      [{ name: "flag", type: "boolean" }],
+      "v2",
+    );
+    const { buffer } = encodeToken(layout, { flag: true });
+    expect(layout.strideBytes).toBe(8);
+    expect(new Uint8Array(buffer)[0]).toBe(1);
+    expect(decodeToken(layout, buffer)).toEqual({ flag: true });
+  });
+});
+
+describe("bit inspection", () => {
+  it("exposes IEEE-754 bits MSB-first for f64 fields", () => {
+    const layout = computeTokenLayout([{ name: "x", type: "real" }], "v1");
+    const { buffer } = encodeToken(layout, { x: -2 });
+    const bits = getFieldBits(buffer, layout.fields[0]!);
+
+    // -2 = sign 1, exponent 0x400 (10000000000), mantissa all zero.
+    expect(bits).toHaveLength(64);
+    expect(bits[0]).toBe(1);
+    expect(bits.slice(1, 12).join("")).toBe("10000000000");
+    expect(bits.slice(12).every((bit) => bit === 0)).toBe(true);
+    expect(getFieldHex(buffer, layout.fields[0]!)).toBe("0xc000000000000000");
+  });
+});

--- a/libs/@hashintel/petrinaut/src/ui/dev/token-encoding-playground/physical-layout.ts
+++ b/libs/@hashintel/petrinaut/src/ui/dev/token-encoding-playground/physical-layout.ts
@@ -1,0 +1,265 @@
+import {
+  coerceTokenAttributeValue,
+  decodeTokenAttributeValue,
+  encodeTokenAttributeValue,
+} from "@hashintel/petrinaut-core";
+
+import type { ColorElementType, TokenRecord } from "@hashintel/petrinaut-core";
+
+/**
+ * Physical (buffer-level) representation of one token attribute.
+ *
+ * This mirrors the planned "format v2" abstraction for engine frames: the
+ * logical schema type (`ColorElementType`) maps to a physical type with a
+ * byte size and alignment, and a per-colour struct layout is computed from
+ * that mapping. `u64x2` exists for future 128-bit types (FE-1121) — the
+ * memory view renders it, but no logical type maps to it yet.
+ */
+export type PhysicalKind = "f64" | "u8" | "u64x2";
+
+export type PhysicalType = {
+  kind: PhysicalKind;
+  byteSize: number;
+  align: number;
+};
+
+/**
+ * - `v1`: the shipped engine encoding — every dimension is one Float64 slot,
+ *   in declaration order.
+ * - `v2`: the planned packed-struct encoding — booleans become `u8`, fields
+ *   are ordered by decreasing alignment, stride is rounded up to 8 bytes.
+ */
+export type LayoutMode = "v1" | "v2";
+
+export type PlaygroundDimension = {
+  name: string;
+  type: ColorElementType;
+};
+
+export type LayoutField = {
+  name: string;
+  elementType: ColorElementType;
+  physical: PhysicalType;
+  byteOffset: number;
+};
+
+/** Half-open byte range `[start, end)` within one token's stride. */
+export type ByteRange = { start: number; end: number };
+
+export type TokenLayout = {
+  mode: LayoutMode;
+  /** sizeof(token) — total bytes per token, including padding. */
+  strideBytes: number;
+  fields: LayoutField[];
+  /** Alignment gaps and tail padding. */
+  paddingRanges: ByteRange[];
+};
+
+const PHYSICAL_TYPES: Record<PhysicalKind, PhysicalType> = {
+  f64: { kind: "f64", byteSize: 8, align: 8 },
+  u8: { kind: "u8", byteSize: 1, align: 1 },
+  u64x2: { kind: "u64x2", byteSize: 16, align: 8 },
+};
+
+export function physicalTypeFor(
+  elementType: ColorElementType,
+  mode: LayoutMode,
+): PhysicalType {
+  if (mode === "v1") {
+    return PHYSICAL_TYPES.f64;
+  }
+  switch (elementType) {
+    case "boolean":
+      return PHYSICAL_TYPES.u8;
+    case "integer":
+    case "real":
+      return PHYSICAL_TYPES.f64;
+  }
+}
+
+const alignTo = (value: number, alignment: number): number =>
+  Math.ceil(value / alignment) * alignment;
+
+/**
+ * Computes the packed struct layout for one token (the C `sizeof` and
+ * `offsetof`). In `v2` mode, fields are ordered by decreasing alignment
+ * (stable within equal alignment) so no interior padding is wasted, and the
+ * stride is rounded up to 8 bytes so consecutive tokens keep f64 fields
+ * 8-aligned.
+ */
+export function computeTokenLayout(
+  dimensions: readonly PlaygroundDimension[],
+  mode: LayoutMode,
+): TokenLayout {
+  const withPhysical = dimensions.map((dimension) => ({
+    dimension,
+    physical: physicalTypeFor(dimension.type, mode),
+  }));
+  const ordered =
+    mode === "v2"
+      ? [...withPhysical].sort((a, b) => b.physical.align - a.physical.align)
+      : withPhysical;
+
+  const fields: LayoutField[] = [];
+  const paddingRanges: ByteRange[] = [];
+  let cursor = 0;
+  for (const { dimension, physical } of ordered) {
+    const byteOffset = alignTo(cursor, physical.align);
+    if (byteOffset > cursor) {
+      paddingRanges.push({ start: cursor, end: byteOffset });
+    }
+    fields.push({
+      name: dimension.name,
+      elementType: dimension.type,
+      physical,
+      byteOffset,
+    });
+    cursor = byteOffset + physical.byteSize;
+  }
+
+  const strideBytes = fields.length === 0 ? 0 : alignTo(cursor, 8);
+  if (strideBytes > cursor) {
+    paddingRanges.push({ start: cursor, end: strideBytes });
+  }
+
+  return { mode, strideBytes, fields, paddingRanges };
+}
+
+export type EncodedToken = {
+  buffer: ArrayBuffer;
+  /** The coerced value actually stored (integers rounded, booleans as 0/1). */
+  stored: TokenRecord;
+  /** The value read back out of the buffer — the full round-trip. */
+  decoded: TokenRecord;
+};
+
+const toColorElement = (field: LayoutField) => ({
+  elementId: field.name,
+  name: field.name,
+  type: field.elementType,
+});
+
+export function decodeToken(
+  layout: TokenLayout,
+  buffer: ArrayBuffer,
+): TokenRecord {
+  const view = new DataView(buffer);
+  const token: TokenRecord = {};
+  for (const field of layout.fields) {
+    const element = toColorElement(field);
+    switch (field.physical.kind) {
+      case "f64":
+        token[field.name] = decodeTokenAttributeValue(
+          element,
+          view.getFloat64(field.byteOffset, true),
+        );
+        break;
+      case "u8":
+        token[field.name] = decodeTokenAttributeValue(
+          element,
+          view.getUint8(field.byteOffset),
+        );
+        break;
+      case "u64x2":
+        throw new Error(
+          `Token.${field.name}: 128-bit decoding is not implemented yet (FE-1121)`,
+        );
+    }
+  }
+  return token;
+}
+
+/**
+ * Encodes one token record into a fresh buffer using the real product codec
+ * (`encodeTokenAttributeValue`) for value coercion, then decodes it back so
+ * callers can show the round-trip. All multi-byte values are little-endian,
+ * matching the platform layout of the engine's typed-array views.
+ */
+export function encodeToken(
+  layout: TokenLayout,
+  record: Record<string, unknown>,
+): EncodedToken {
+  const buffer = new ArrayBuffer(layout.strideBytes);
+  const view = new DataView(buffer);
+  const stored: TokenRecord = {};
+
+  for (const field of layout.fields) {
+    const element = toColorElement(field);
+    const context = `Token.${field.name}`;
+    const slotValue = encodeTokenAttributeValue(
+      element,
+      record[field.name],
+      context,
+    );
+    switch (field.physical.kind) {
+      case "f64":
+        view.setFloat64(field.byteOffset, slotValue, true);
+        break;
+      case "u8":
+        view.setUint8(field.byteOffset, slotValue);
+        break;
+      case "u64x2":
+        throw new Error(
+          `Token.${field.name}: 128-bit encoding is not implemented yet (FE-1121)`,
+        );
+    }
+    stored[field.name] = coerceTokenAttributeValue(
+      element,
+      record[field.name],
+      context,
+    );
+  }
+
+  return { buffer, stored, decoded: decodeToken(layout, buffer) };
+}
+
+/**
+ * Returns one field's bits most-significant first (the "logical" reading
+ * order: for f64 that is sign, exponent, mantissa). Multi-byte values are
+ * stored little-endian, so the byte walk is reversed.
+ */
+export function getFieldBits(
+  buffer: ArrayBuffer,
+  field: LayoutField,
+): number[] {
+  const bytes = new Uint8Array(
+    buffer,
+    field.byteOffset,
+    field.physical.byteSize,
+  );
+  const bits: number[] = [];
+  for (let byteIndex = bytes.length - 1; byteIndex >= 0; byteIndex--) {
+    for (let bit = 7; bit >= 0; bit--) {
+      // eslint-disable-next-line no-bitwise -- bit extraction is the point here
+      bits.push((bytes[byteIndex]! >> bit) & 1);
+    }
+  }
+  return bits;
+}
+
+/** Hex form of the field's stored bytes, most-significant byte first. */
+export function getFieldHex(buffer: ArrayBuffer, field: LayoutField): string {
+  const bytes = new Uint8Array(
+    buffer,
+    field.byteOffset,
+    field.physical.byteSize,
+  );
+  let hex = "";
+  for (let byteIndex = bytes.length - 1; byteIndex >= 0; byteIndex--) {
+    hex += bytes[byteIndex]!.toString(16).padStart(2, "0");
+  }
+  return `0x${hex}`;
+}
+
+/**
+ * IEEE-754 double anatomy for a bit index in MSB-first order:
+ * bit 0 = sign, bits 1–11 = exponent, bits 12–63 = mantissa.
+ */
+export type F64BitPart = "sign" | "exponent" | "mantissa";
+
+export function f64BitPart(msbFirstIndex: number): F64BitPart {
+  if (msbFirstIndex === 0) {
+    return "sign";
+  }
+  return msbFirstIndex <= 11 ? "exponent" : "mantissa";
+}

--- a/libs/@hashintel/petrinaut/src/ui/dev/token-encoding-playground/playground-monaco.ts
+++ b/libs/@hashintel/petrinaut/src/ui/dev/token-encoding-playground/playground-monaco.ts
@@ -1,0 +1,210 @@
+/**
+ * Story-scoped Monaco TypeScript language service.
+ *
+ * The shared `MonacoProvider` deliberately does NOT load Monaco's TypeScript
+ * worker — the product's language features come from the SDCPN LSP instead.
+ * The playground opts back in locally: it imports the TS language
+ * contribution (side effect + module exports) and routes the `typescript`
+ * worker label to the real ts.worker, leaving the provider's editor worker
+ * untouched. This keeps the playground fully independent from the SDCPN LSP.
+ */
+import {
+  ScriptTarget,
+  typescriptDefaults,
+} from "monaco-editor/esm/vs/language/typescript/monaco.contribution.js";
+
+import type { PlaygroundDimension } from "./physical-layout";
+import type { Monaco } from "@monaco-editor/react";
+
+/**
+ * The TS mode's feature flags. The product's editors are `typescript`
+ * models backed by the SDCPN LSP — Monaco's built-in TS service must never
+ * touch them, or it adds bogus "Cannot find name 'TransitionKernel'"
+ * diagnostics on top of the LSP's. So: everything OFF at module load, ON
+ * only while the playground is mounted.
+ */
+const TS_MODE_OFF: Record<string, boolean> = {
+  completionItems: false,
+  hovers: false,
+  documentSymbols: false,
+  definitions: false,
+  references: false,
+  documentHighlights: false,
+  rename: false,
+  diagnostics: false,
+  documentRangeFormattingEdits: false,
+  signatureHelp: false,
+  onTypeFormattingEdits: false,
+  codeActions: false,
+  inlayHints: false,
+};
+
+const TS_MODE_PLAYGROUND: Record<string, boolean> = {
+  ...TS_MODE_OFF,
+  completionItems: true,
+  hovers: true,
+  diagnostics: true,
+  signatureHelp: true,
+};
+
+// Importing the contribution above registers the TS mode for every
+// `typescript` model in this Monaco instance. Silence it immediately; the
+// playground re-enables it for the duration of its mount.
+typescriptDefaults.setModeConfiguration(TS_MODE_OFF);
+
+let environmentPatched = false;
+let playgroundActive = false;
+let currentDefs: string | null = null;
+let environmentBeforePatch: typeof window.MonacoEnvironment;
+
+/**
+ * Enables the TS language service for the playground's lifetime. Must run
+ * after `MonacoProvider`'s init (which assigns `MonacoEnvironment`) and
+ * before the playground's `typescript` model is created — callers guarantee
+ * this by resolving `MonacoContext` first and calling this before rendering
+ * the editor. Pair with {@link disableTypescriptLanguageService} on unmount.
+ */
+export function enableTypescriptLanguageService(): void {
+  if (!playgroundActive) {
+    playgroundActive = true;
+    typescriptDefaults.setModeConfiguration(TS_MODE_PLAYGROUND);
+  }
+  if (environmentPatched) {
+    return;
+  }
+  environmentPatched = true;
+
+  const previousEnvironment = window.MonacoEnvironment;
+  environmentBeforePatch = previousEnvironment;
+  window.MonacoEnvironment = {
+    getWorker(workerId: string, label: string) {
+      if (label === "typescript" || label === "javascript") {
+        return new Worker(
+          new URL(
+            "monaco-editor/esm/vs/language/typescript/ts.worker.js",
+            import.meta.url,
+          ),
+          { type: "module" },
+        );
+      }
+      if (previousEnvironment?.getWorker) {
+        return previousEnvironment.getWorker(workerId, label);
+      }
+      return new Worker(
+        new URL(
+          "monaco-editor/esm/vs/editor/editor.worker.js",
+          import.meta.url,
+        ),
+        { type: "module" },
+      );
+    },
+  };
+
+  typescriptDefaults.setCompilerOptions({
+    target: ScriptTarget.ES2020,
+    strict: true,
+    noEmit: true,
+    allowNonTsExtensions: true,
+  });
+  typescriptDefaults.setEagerModelSync(true);
+}
+
+/** Minimal structural view of `monaco.editor` (oxlint cannot resolve the
+ * `Monaco` type through the esm editor.api path, tsc can). */
+type MonacoEditorApi = {
+  getModels(): unknown[];
+  setModelMarkers(model: unknown, owner: string, markers: never[]): void;
+};
+
+/**
+ * Turns the built-in TS service back off (playground unmount) and clears any
+ * markers it produced, so product editors — whose diagnostics come from the
+ * SDCPN LSP — are unaffected for the rest of the session.
+ */
+export function disableTypescriptLanguageService(monaco: Monaco): void {
+  if (!playgroundActive) {
+    return;
+  }
+  playgroundActive = false;
+  typescriptDefaults.setModeConfiguration(TS_MODE_OFF);
+  // Drop the playground's extra-lib declarations too, so they can't leak
+  // into `typescript` models created later in the same Monaco instance.
+  currentDefs = null;
+  typescriptDefaults.setExtraLibs([]);
+  // Restore the provider's worker routing too, so the playground's ts.worker
+  // redirection can't outlive the mount.
+  if (environmentPatched) {
+    environmentPatched = false;
+    window.MonacoEnvironment = environmentBeforePatch;
+  }
+  const editorApi = (monaco as unknown as { editor: MonacoEditorApi }).editor;
+  for (const model of editorApi.getModels()) {
+    editorApi.setModelMarkers(model, "typescript", []);
+  }
+}
+
+const IDENTIFIER_RE = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
+/**
+ * Whether a dimension participates in the playground at all: names must be
+ * valid identifiers to appear in the generated `Token` type, and the SAME
+ * predicate must gate the memory layout, or the two views desync (a slot
+ * encoded in the buffer with no corresponding property in the editor).
+ */
+export const isEncodableDimension = (dimension: PlaygroundDimension): boolean =>
+  IDENTIFIER_RE.test(dimension.name);
+
+/**
+ * The dimensions the playground actually encodes: valid identifiers, first
+ * occurrence per name. Duplicate names would collapse to one JS property
+ * while occupying separate buffer slots, desyncing the value editor from the
+ * memory view (and emitting duplicate keys in the generated `Token` type).
+ */
+export const encodableDimensions = (
+  dimensions: readonly PlaygroundDimension[],
+): PlaygroundDimension[] => {
+  const seen = new Set<string>();
+  return dimensions.filter((dimension) => {
+    if (!isEncodableDimension(dimension) || seen.has(dimension.name)) {
+      return false;
+    }
+    seen.add(dimension.name);
+    return true;
+  });
+};
+
+/**
+ * Generates the declarations the value editor is checked against — the
+ * playground equivalent of the LSP virtual defs files. Mirrors the LSP's
+ * type mapping: real/integer → number, boolean → boolean.
+ * Expects a pre-filtered ({@link isEncodableDimension}) list.
+ */
+export function generateTokenDefs(
+  dimensions: readonly PlaygroundDimension[],
+): string {
+  const properties = dimensions
+    .filter((dimension) => IDENTIFIER_RE.test(dimension.name))
+    .map(
+      (dimension) =>
+        `  ${dimension.name}: ${dimension.type === "boolean" ? "boolean" : "number"};`,
+    );
+
+  return [
+    "/** One token of the playground colour — edit dimensions on the left. */",
+    properties.length > 0
+      ? `type Token = {\n${properties.join("\n")}\n};`
+      : "type Token = Record<string, never>;",
+    "declare function Token(create: () => Token): unknown;",
+    "",
+  ].join("\n");
+}
+
+export function setPlaygroundTokenDefs(defs: string): void {
+  if (defs === currentDefs) {
+    return;
+  }
+  currentDefs = defs;
+  typescriptDefaults.setExtraLibs([
+    { content: defs, filePath: "file:///playground/token-defs.d.ts" },
+  ]);
+}

--- a/libs/@hashintel/petrinaut/src/ui/dev/token-encoding-playground/token-encoding-playground.stories.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/dev/token-encoding-playground/token-encoding-playground.stories.tsx
@@ -1,0 +1,29 @@
+import { MonacoProvider } from "../../monaco/provider";
+import { TokenEncodingPlayground } from "./token-encoding-playground";
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+/**
+ * Interactive inspector for the simulation token encoding: define a colour's
+ * dimensions, author a token value, and see the exact bits stored in the
+ * frame buffer — in the shipped v1 layout (uniform f64 slots) or the planned
+ * format-v2 packed struct (u8 booleans, alignment padding).
+ */
+const meta = {
+  title: "Dev / Token Encoding Playground",
+  parameters: {
+    layout: "padded",
+  },
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {
+  render: () => (
+    <MonacoProvider>
+      <TokenEncodingPlayground />
+    </MonacoProvider>
+  ),
+};

--- a/libs/@hashintel/petrinaut/src/ui/dev/token-encoding-playground/token-encoding-playground.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/dev/token-encoding-playground/token-encoding-playground.tsx
@@ -1,0 +1,259 @@
+import { Suspense, use, useEffect, useState } from "react";
+
+import { css } from "@hashintel/ds-helpers/css";
+import { compileUserCode } from "@hashintel/petrinaut-core";
+
+import { SegmentGroup } from "../../components/segment-group";
+import { CodeEditor } from "../../monaco/code-editor";
+import { MonacoContext } from "../../monaco/context";
+import { DimensionEditor } from "./dimension-editor";
+import { computeTokenLayout, encodeToken } from "./physical-layout";
+import {
+  disableTypescriptLanguageService,
+  enableTypescriptLanguageService,
+  encodableDimensions,
+  generateTokenDefs,
+  setPlaygroundTokenDefs,
+} from "./playground-monaco";
+import { TokenMemoryView } from "./token-memory-view";
+
+import type {
+  EncodedToken,
+  LayoutMode,
+  PlaygroundDimension,
+  TokenLayout,
+} from "./physical-layout";
+import type { BitOrder } from "./token-memory-view";
+
+const DEFAULT_DIMENSIONS: PlaygroundDimension[] = [
+  { name: "amount", type: "real" },
+  { name: "count", type: "integer" },
+  { name: "active", type: "boolean" },
+];
+
+const DEFAULT_CODE = `export default Token(() => ({
+  amount: 1.25,
+  count: 2.7,
+  active: true,
+}));
+`;
+
+type EvaluationResult =
+  | {
+      ok: true;
+      layout: TokenLayout;
+      encoded: EncodedToken;
+      input: Record<string, unknown>;
+    }
+  | { ok: false; error: string };
+
+function evaluate(
+  code: string,
+  dimensions: PlaygroundDimension[],
+  mode: LayoutMode,
+): EvaluationResult {
+  try {
+    const layout = computeTokenLayout(dimensions, mode);
+    // Same pipeline user code takes in the product (Babel TS-strip + eval).
+    const create = compileUserCode<[]>(code, "Token");
+    const raw: unknown = create();
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+      throw new Error("Token(() => …) must return an object");
+    }
+    const input = raw as Record<string, unknown>;
+    return { ok: true, layout, encoded: encodeToken(layout, input), input };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+// -- Styles ---------------------------------------------------------------
+
+const containerStyle = css({
+  display: "flex",
+  flexDirection: "column",
+  gap: "4",
+});
+
+const topRowStyle = css({
+  display: "flex",
+  gap: "4",
+  alignItems: "stretch",
+});
+
+const paneStyle = css({
+  display: "flex",
+  flexDirection: "column",
+  gap: "2",
+});
+
+const dimensionsPaneStyle = css({
+  width: "[300px]",
+  flexShrink: 0,
+});
+
+const editorPaneStyle = css({
+  flex: "[1]",
+  minWidth: "[0]",
+});
+
+const paneTitleStyle = css({
+  fontSize: "xs",
+  fontWeight: "medium",
+  color: "neutral.s90",
+  textTransform: "uppercase",
+  letterSpacing: "[0.05em]",
+});
+
+const togglesStyle = css({
+  display: "flex",
+  gap: "4",
+  alignItems: "center",
+  flexWrap: "wrap",
+});
+
+const errorStyle = css({
+  fontFamily: "mono",
+  fontSize: "xs",
+  color: "red.s105",
+  background: "red.a25",
+  borderRadius: "sm",
+  padding: "2",
+  whiteSpace: "pre-wrap",
+});
+
+const editorFallbackStyle = css({
+  fontSize: "xs",
+  color: "neutral.s80",
+  padding: "2",
+});
+
+// -- Editor (needs Monaco context resolved before mounting) -----------------
+
+const PlaygroundEditor: React.FC<{
+  code: string;
+  onChange: (code: string) => void;
+  defs: string;
+}> = ({ code, onChange, defs }) => {
+  // Suspends until MonacoProvider's init has run — required so the worker
+  // environment patch below lands after the provider's assignment.
+  const { monaco } = use(use(MonacoContext));
+  // Both calls are idempotent and MUST run before the editor's `typescript`
+  // model is created below (worker routing + extra libs).
+  enableTypescriptLanguageService();
+  setPlaygroundTokenDefs(defs);
+
+  // The built-in TS service is playground-scoped: it must not shadow the
+  // SDCPN LSP in the product's editors, so re-enable after StrictMode
+  // remounts and switch it off (clearing its markers) on unmount.
+  useEffect(() => {
+    enableTypescriptLanguageService();
+    return () => disableTypescriptLanguageService(monaco);
+  }, [monaco]);
+
+  return (
+    <CodeEditor
+      height={200}
+      defaultLanguage="typescript"
+      path="file:///playground/token.ts"
+      value={code}
+      onChange={(next) => onChange(next ?? "")}
+      options={{ minimap: { enabled: false }, scrollBeyondLastLine: false }}
+    />
+  );
+};
+
+// -- Playground -------------------------------------------------------------
+
+/**
+ * Dev-only playground: define a colour's dimensions, author a token value,
+ * and inspect the exact bits the simulation buffer would hold — in the
+ * shipped v1 encoding (uniform f64 slots) or the planned v2 packed layout.
+ */
+export const TokenEncodingPlayground: React.FC = () => {
+  const [dimensions, setDimensions] =
+    useState<PlaygroundDimension[]>(DEFAULT_DIMENSIONS);
+  const [code, setCode] = useState(DEFAULT_CODE);
+  const [layoutMode, setLayoutMode] = useState<LayoutMode>("v1");
+  const [bitOrder, setBitOrder] = useState<BitOrder>("logical");
+  const [result, setResult] = useState<EvaluationResult | null>(null);
+
+  // The layout and the generated Token type must be built from the SAME
+  // dimension list: invalid identifiers and duplicate names are dropped from
+  // the type, so they must not occupy slots in the memory view either.
+  const effectiveDimensions = encodableDimensions(dimensions);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      // Filter inside the effect: depending on a derived array would rerun
+      // the debounce whenever the reference changes rather than the data.
+      setResult(evaluate(code, encodableDimensions(dimensions), layoutMode));
+    }, 250);
+    return () => clearTimeout(timer);
+  }, [code, dimensions, layoutMode]);
+
+  return (
+    <div className={containerStyle}>
+      <div className={topRowStyle}>
+        <div className={`${paneStyle} ${dimensionsPaneStyle}`}>
+          <span className={paneTitleStyle}>Dimensions</span>
+          <DimensionEditor dimensions={dimensions} onChange={setDimensions} />
+        </div>
+        <div className={`${paneStyle} ${editorPaneStyle}`}>
+          <span className={paneTitleStyle}>Token value</span>
+          <Suspense
+            fallback={
+              <div className={editorFallbackStyle}>Loading editor…</div>
+            }
+          >
+            <PlaygroundEditor
+              code={code}
+              onChange={setCode}
+              defs={generateTokenDefs(effectiveDimensions)}
+            />
+          </Suspense>
+        </div>
+      </div>
+
+      <div className={togglesStyle}>
+        <SegmentGroup
+          size="sm"
+          value={layoutMode}
+          onChange={(value) => setLayoutMode(value as LayoutMode)}
+          options={[
+            { value: "v1", label: "v1 — uniform f64 (shipped)" },
+            { value: "v2", label: "v2 — packed struct (planned)" },
+          ]}
+        />
+        <SegmentGroup
+          size="sm"
+          value={bitOrder}
+          onChange={(value) => setBitOrder(value as BitOrder)}
+          options={[
+            { value: "logical", label: "Logical bits (MSB→LSB)" },
+            { value: "memory", label: "Memory bytes (little-endian)" },
+          ]}
+        />
+      </div>
+
+      <div className={paneStyle}>
+        <span className={paneTitleStyle}>Encoded token memory</span>
+        {result === null ? null : result.ok ? (
+          <TokenMemoryView
+            layout={result.layout}
+            buffer={result.encoded.buffer}
+            input={result.input}
+            stored={result.encoded.stored}
+            decoded={result.encoded.decoded}
+            bitOrder={bitOrder}
+          />
+        ) : (
+          <div className={errorStyle}>{result.error}</div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/libs/@hashintel/petrinaut/src/ui/dev/token-encoding-playground/token-memory-view.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/dev/token-encoding-playground/token-memory-view.tsx
@@ -1,0 +1,457 @@
+import { useState } from "react";
+
+import { css, cva } from "@hashintel/ds-helpers/css";
+
+import { f64BitPart } from "./physical-layout";
+
+import type { LayoutField, TokenLayout } from "./physical-layout";
+import type { TokenRecord } from "@hashintel/petrinaut-core";
+
+export type BitOrder = "logical" | "memory";
+
+export type TokenMemoryViewProps = {
+  layout: TokenLayout;
+  buffer: ArrayBuffer;
+  /** Raw values returned by the user's code, before coercion. */
+  input: Record<string, unknown>;
+  stored: TokenRecord;
+  decoded: TokenRecord;
+  bitOrder: BitOrder;
+};
+
+// One hue per field, cycled. Lightness encodes the IEEE-754 part.
+const FIELD_HUES = [217, 27, 271, 162, 336, 195];
+
+const fieldColor = (fieldIndex: number, lightness: number): string =>
+  `hsl(${FIELD_HUES[fieldIndex % FIELD_HUES.length]!} 75% ${lightness}%)`;
+
+const PADDING_BACKGROUND =
+  "repeating-linear-gradient(45deg, #f2f2f2, #f2f2f2 2px, #d8d8d8 2px, #d8d8d8 4px)";
+
+const bitLightness = (field: LayoutField, msbFirstIndex: number): number => {
+  if (field.physical.kind !== "f64") {
+    return 78;
+  }
+  switch (f64BitPart(msbFirstIndex)) {
+    case "sign":
+      return 52;
+    case "exponent":
+      return 68;
+    case "mantissa":
+      return 86;
+  }
+};
+
+// -- Group model ------------------------------------------------------------
+
+type BitCell = { value: number; lightness: number };
+
+type ByteRow = {
+  /** Absolute byte index within the token stride, e.g. `b12`. */
+  label: string;
+  bits: BitCell[];
+};
+
+type SlotGroup = {
+  key: string;
+  field: LayoutField | null; // null = padding
+  fieldIndex: number;
+  startByte: number;
+  rows: ByteRow[];
+};
+
+/**
+ * One group per field (and per padding range), each holding one row per byte
+ * (8 bits). `logical` order lists the most-significant byte first; `memory`
+ * order follows the buffer (little-endian: least-significant byte first).
+ */
+function buildSlotGroups(
+  layout: TokenLayout,
+  buffer: ArrayBuffer,
+  bitOrder: BitOrder,
+): SlotGroup[] {
+  const bytes = new Uint8Array(buffer);
+  const groups: SlotGroup[] = [];
+
+  for (const [fieldIndex, field] of layout.fields.entries()) {
+    const size = field.physical.byteSize;
+    const byteIndices = Array.from({ length: size }, (_, position) =>
+      bitOrder === "logical" ? size - 1 - position : position,
+    );
+    groups.push({
+      // Positional key: dimension names are user input and may collide.
+      key: `field-${field.byteOffset}`,
+      field,
+      fieldIndex,
+      startByte: field.byteOffset,
+      rows: byteIndices.map((byteWithinField) => {
+        const byteIndex = field.byteOffset + byteWithinField;
+        const bits: BitCell[] = [];
+        for (let bit = 7; bit >= 0; bit--) {
+          // eslint-disable-next-line no-bitwise -- bit extraction is the point here
+          const value = ((bytes[byteIndex] ?? 0) >> bit) & 1;
+          const lsbFirstIndex = byteWithinField * 8 + bit;
+          const msbFirstIndex = size * 8 - 1 - lsbFirstIndex;
+          bits.push({ value, lightness: bitLightness(field, msbFirstIndex) });
+        }
+        return { label: `b${byteIndex}`, bits };
+      }),
+    });
+  }
+
+  for (const range of layout.paddingRanges) {
+    groups.push({
+      key: `padding-${range.start}`,
+      field: null,
+      fieldIndex: -1,
+      startByte: range.start,
+      rows: Array.from({ length: range.end - range.start }, (_, offset) => ({
+        label: `b${range.start + offset}`,
+        bits: Array.from({ length: 8 }, () => ({ value: 0, lightness: 0 })),
+      })),
+    });
+  }
+
+  return groups.sort((a, b) => a.startByte - b.startByte);
+}
+
+// -- Styles -------------------------------------------------------------------
+
+const containerStyle = css({
+  display: "flex",
+  gap: "4",
+  alignItems: "flex-start",
+  fontSize: "xs",
+});
+
+const legendStyle = css({
+  display: "flex",
+  flexDirection: "column",
+  gap: "1.5",
+  width: "[170px]",
+  flexShrink: 0,
+  color: "neutral.s100",
+});
+
+const legendChipStyle = css({
+  display: "inline-flex",
+  alignItems: "center",
+  gap: "1.5",
+  cursor: "default",
+  fontFamily: "mono",
+
+  "& i": {
+    display: "inline-block",
+    width: "3",
+    height: "3",
+    borderRadius: "xs",
+    borderWidth: "[1px]",
+    borderStyle: "solid",
+    borderColor: "[rgba(0,0,0,0.25)]",
+    flexShrink: 0,
+  },
+});
+
+const legendNoteStyle = css({
+  color: "neutral.s90",
+  fontSize: "[10px]",
+  lineHeight: "[1.35]",
+});
+
+const gridStyle = css({
+  display: "flex",
+  flexDirection: "column",
+  gap: "1",
+  flexShrink: 0,
+});
+
+const groupStyle = cva({
+  base: {
+    display: "flex",
+    flexDirection: "column",
+    borderRadius: "xs",
+    outlineWidth: "[2px]",
+    outlineStyle: "solid",
+    outlineOffset: "[1px]",
+    transition: "[outline-color 0.1s ease]",
+  },
+  variants: {
+    isHighlighted: {
+      true: {},
+      false: { outlineColor: "[transparent]" },
+    },
+  },
+});
+
+const byteRowStyle = css({
+  display: "flex",
+  alignItems: "center",
+  gap: "1.5",
+});
+
+const byteLabelStyle = css({
+  width: "[26px]",
+  textAlign: "right",
+  fontFamily: "mono",
+  fontSize: "[9px]",
+  color: "neutral.s80",
+  flexShrink: 0,
+});
+
+const bitRowStyle = css({
+  display: "flex",
+  overflow: "hidden",
+
+  "& + &": {},
+});
+
+const bitStyle = css({
+  width: "[13px]",
+  height: "[13px]",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  fontSize: "[8px]",
+  fontFamily: "mono",
+  color: "[rgba(0,0,0,0.72)]",
+  borderWidth: "[0.5px]",
+  borderStyle: "solid",
+  borderColor: "[rgba(0,0,0,0.15)]",
+});
+
+const infoPanelStyle = css({
+  flex: "[1]",
+  minWidth: "[240px]",
+  position: "sticky",
+  top: "2",
+  display: "flex",
+  flexDirection: "column",
+  gap: "1",
+  fontFamily: "mono",
+  fontSize: "[11px]",
+  color: "neutral.s100",
+  borderWidth: "[1px]",
+  borderStyle: "solid",
+  borderColor: "neutral.bd.subtle",
+  borderRadius: "md",
+  padding: "2.5",
+  minHeight: "[86px]",
+});
+
+const infoTitleStyle = css({
+  fontSize: "sm",
+  fontWeight: "semibold",
+});
+
+const infoHintStyle = css({
+  color: "neutral.s80",
+  fontFamily: "[inherit]",
+});
+
+const roundTripStyle = css({
+  "& b": {
+    color: "neutral.s110",
+  },
+});
+
+// -- Helpers --------------------------------------------------------------
+
+const formatValue = (value: unknown): string => {
+  if (typeof value === "number") {
+    return Object.is(value, -0) ? "-0" : String(value);
+  }
+  if (typeof value === "bigint") {
+    return `${value}n`;
+  }
+  if (value === undefined) {
+    return "undefined";
+  }
+  try {
+    // stringify returns undefined for functions/symbols despite its typing.
+    const json = JSON.stringify(value) as string | undefined;
+    // eslint-disable-next-line typescript/no-base-to-string -- dev-tool display of arbitrary user values; default stringification is an acceptable last resort
+    return json ?? String(value);
+  } catch {
+    // Cyclic objects (and other non-serializable user values) still render.
+    // eslint-disable-next-line typescript/no-base-to-string -- same as above
+    return String(value);
+  }
+};
+
+const fieldHex = (buffer: ArrayBuffer, field: LayoutField): string => {
+  const bytes = new Uint8Array(
+    buffer,
+    field.byteOffset,
+    field.physical.byteSize,
+  );
+  let hex = "";
+  for (let byteIndex = bytes.length - 1; byteIndex >= 0; byteIndex--) {
+    hex += bytes[byteIndex]!.toString(16).padStart(2, "0");
+  }
+  return `0x${hex}`;
+};
+
+// -- Component ----------------------------------------------------------------
+
+/**
+ * Renders one encoded token as a compact memory column: one byte (8 bits)
+ * per row, grouped by slot. Hovering a slot (or its legend chip) highlights
+ * the whole slot and reveals its details in the side panel. Built against
+ * the format-v2 abstraction (`TokenLayout`): any mix of field widths and
+ * padding renders, not just uniform f64 slots.
+ */
+export const TokenMemoryView: React.FC<TokenMemoryViewProps> = ({
+  layout,
+  buffer,
+  input,
+  stored,
+  decoded,
+  bitOrder,
+}) => {
+  const [hoveredKey, setHoveredKey] = useState<string | null>(null);
+
+  if (layout.fields.length === 0) {
+    return (
+      <div className={containerStyle}>
+        <span className={legendNoteStyle}>
+          Add at least one dimension to see the encoded token.
+        </span>
+      </div>
+    );
+  }
+
+  const groups = buildSlotGroups(layout, buffer, bitOrder);
+  const hoveredGroup = groups.find((group) => group.key === hoveredKey) ?? null;
+  const hasF64 = layout.fields.some((field) => field.physical.kind === "f64");
+
+  return (
+    <div className={containerStyle}>
+      {/* Left side: static legend */}
+      <div className={legendStyle}>
+        {layout.fields.map((field, fieldIndex) => (
+          <span
+            key={`field-${field.byteOffset}`}
+            className={legendChipStyle}
+            // Focusable chip: hover details must also be reachable by keyboard.
+            role="button"
+            tabIndex={0}
+            onMouseEnter={() => setHoveredKey(`field-${field.byteOffset}`)}
+            onMouseLeave={() => setHoveredKey(null)}
+            onFocus={() => setHoveredKey(`field-${field.byteOffset}`)}
+            onBlur={() => setHoveredKey(null)}
+            onClick={() => setHoveredKey(`field-${field.byteOffset}`)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" || event.key === " ") {
+                event.preventDefault();
+                setHoveredKey(`field-${field.byteOffset}`);
+              }
+            }}
+          >
+            <i style={{ background: fieldColor(fieldIndex, 70) }} />
+            {field.name} · {field.physical.kind}
+          </span>
+        ))}
+        {layout.paddingRanges.length > 0 ? (
+          <span className={legendChipStyle}>
+            <i style={{ background: PADDING_BACKGROUND }} />
+            padding
+          </span>
+        ) : null}
+        <span className={legendNoteStyle}>
+          sizeof(token) = {layout.strideBytes} B ({layout.mode})
+        </span>
+        {hasF64 ? (
+          <span className={legendNoteStyle}>
+            f64 shading: dark = sign · medium = exponent · light = mantissa
+          </span>
+        ) : null}
+        <span className={legendNoteStyle}>
+          {bitOrder === "logical"
+            ? "rows: most-significant byte first"
+            : "rows: buffer order (little-endian)"}
+        </span>
+      </div>
+
+      {/* Middle: the memory column, one byte per row */}
+      <div className={gridStyle}>
+        {groups.map((group) => (
+          <div
+            key={group.key}
+            className={groupStyle({ isHighlighted: hoveredKey === group.key })}
+            style={
+              hoveredKey === group.key
+                ? {
+                    outlineColor: group.field
+                      ? fieldColor(group.fieldIndex, 45)
+                      : "#999999",
+                  }
+                : undefined
+            }
+            onMouseEnter={() => setHoveredKey(group.key)}
+            onMouseLeave={() => setHoveredKey(null)}
+          >
+            {group.rows.map((row) => (
+              <div key={row.label} className={byteRowStyle}>
+                <span className={byteLabelStyle}>{row.label}</span>
+                <div className={bitRowStyle}>
+                  {row.bits.map((bit, bitIndex) => (
+                    <span
+                      // eslint-disable-next-line react/no-array-index-key -- bits are purely positional
+                      key={bitIndex}
+                      className={bitStyle}
+                      style={{
+                        background: group.field
+                          ? fieldColor(group.fieldIndex, bit.lightness)
+                          : PADDING_BACKGROUND,
+                      }}
+                    >
+                      {group.field ? bit.value : ""}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+
+      {/* Right side: details, only for the hovered slot */}
+      <div className={infoPanelStyle}>
+        {hoveredGroup === null ? (
+          <span className={infoHintStyle}>
+            Hover a slot (or a legend entry) for details.
+          </span>
+        ) : hoveredGroup.field === null ? (
+          <>
+            <span className={infoTitleStyle}>padding</span>
+            <span>
+              {hoveredGroup.rows.length} B — alignTo(…, 8) keeps consecutive
+              tokens 8-byte aligned
+            </span>
+          </>
+        ) : (
+          <>
+            <span
+              className={infoTitleStyle}
+              style={{ color: fieldColor(hoveredGroup.fieldIndex, 35) }}
+            >
+              {hoveredGroup.field.name}
+            </span>
+            <span>
+              {hoveredGroup.field.elementType} →{" "}
+              {hoveredGroup.field.physical.kind} · offset{" "}
+              {hoveredGroup.field.byteOffset} ·{" "}
+              {hoveredGroup.field.physical.byteSize} B
+            </span>
+            <span>{fieldHex(buffer, hoveredGroup.field)}</span>
+            <span className={roundTripStyle}>
+              input {formatValue(input[hoveredGroup.field.name])} → stored{" "}
+              <b>{formatValue(stored[hoveredGroup.field.name])}</b> → reads back{" "}
+              <b>{formatValue(decoded[hoveredGroup.field.name])}</b>
+            </span>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/place-properties/subviews/place-initial-state/initial-state-editor.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/place-properties/subviews/place-initial-state/initial-state-editor.tsx
@@ -1,5 +1,7 @@
 import { use, useMemo } from "react";
 
+import { defaultTokenAttributeValue } from "@hashintel/petrinaut-core";
+
 import { PlaybackContext } from "../../../../../../../../react/playback/context";
 import { SimulationContext } from "../../../../../../../../react/simulation/context";
 import { Spreadsheet } from "../../../../../../../components/spreadsheet";
@@ -10,16 +12,8 @@ import type {
 } from "../../../../../../../components/spreadsheet";
 import type { Color, Place, TokenRecord } from "@hashintel/petrinaut-core";
 
-const getDefaultValue = (column: SpreadsheetColumn): SpreadsheetCellValue => {
-  switch (column.type) {
-    case "boolean":
-      return false;
-    case "integer":
-    case "real":
-    default:
-      return 0;
-  }
-};
+const getDefaultValue = (column: SpreadsheetColumn): SpreadsheetCellValue =>
+  column.type ? defaultTokenAttributeValue(column.type) : 0;
 
 /**
  * InitialStateEditor - A component for editing initial tokens in a place


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Adds a dev-only Storybook playground for inspecting how token values are encoded into the simulation frame buffers: define a colour's dimensions, author a token value in a typed Monaco editor, and see the exact bits stored — with coercion round-trips made visible (`input 2.7 → stored 3 → reads back 3`).

It doubles as the visual testbed for the packed-struct token layout (format v2, follow-up PR), and lands a small enabler: the token value codec is now exported from `@hashintel/petrinaut-core` instead of being duplicated in UI components.

## 🔗 Related links

- [FE-1129: Petrinaut: token encoding playground (Storybook)](https://linear.app/hash/issue/FE-1129/petrinaut-token-encoding-playground-storybook) _(internal)_
- Stacked on #8764; the format-v2 PR stacks on this one.

## 🚫 Blocked by

- [ ] #8764 (base branch — merges first)

## 🔍 What does this change?

- Exports the token value codec (`coerceTokenAttributeValue`, `coerceTokenRecord`, `encodeTokenAttributeValue`, `decodeTokenAttributeValue`, `decodeTokenRecord`, `defaultTokenAttributeValue`) and `compileUserCode` from `@hashintel/petrinaut-core`; the spreadsheet and initial-state editors reuse `defaultTokenAttributeValue` instead of local switches.
- Adds `src/ui/dev/token-encoding-playground/` with a Storybook story (**Dev / Token Encoding Playground**):
  - store-free dimensions editor (name + Real/Integer/Boolean select);
  - Monaco value editor (`export default Token(() => ({ … }))`) typed against declarations generated live from the dimensions;
  - a compact memory view: one byte (8 bits) per row grouped by slot, one colour per field with IEEE-754 anatomy shading (sign/exponent/mantissa), hatched padding, hover highlights the whole slot and reveals offset/size/hex and the coercion round-trip in a side panel; toggle between logical (MSB→LSB) and little-endian memory byte order.
- Evaluation runs the real product pipeline (`compileUserCode` + the real codec), debounced, with errors displayed inline.
- Monaco's built-in TypeScript language service is imported for the playground only and **strictly scoped to its mount**: silenced at module load, enabled while mounted, disabled with markers cleared on unmount — so it never shadows the SDCPN LSP in the product's editors (verified: opening the playground then an LSP-backed editor story shows zero foreign diagnostics).

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] modifies an **npm**-publishable library and **I have added a changeset file(s)**

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change
  - (dev-only Storybook tooling — explicitly out of scope for the user guide)

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

- The playground evaluates authored code in-page (same `compileUserCode` pipeline and same-realm sandboxing posture as the product's code surfaces) — acceptable for a dev tool, not a hardened boundary.

## 🐾 Next steps

- Format v2 (packed struct token layout) stacks on this PR and switches the playground to render the real engine layout module.
- 128-bit field rendering (UUID, FE-1121) once that type lands.

## 🛡 What tests cover this?

- `libs/@hashintel/petrinaut/src/ui/dev/token-encoding-playground/physical-layout.test.ts` (layout ordering/padding/stride, encode/decode round-trips, IEEE-754 bit extraction)
- Full `test:unit`, `lint:tsc` (tsgo), `lint:eslint` (oxlint) for both petrinaut packages

## ❓ How to test this?

1. `yarn dev` in `libs/@hashintel/petrinaut`, open **Dev / Token Encoding Playground**.
2. Edit dimensions (add a Boolean, rename one) — the editor's `Token` type updates live; wrong-typed values get squiggles.
3. Enter `count: 2.7` — the memory view shows the stored value `3` and the round-trip line.
4. Hover slots/legend chips — whole-slot highlight + details panel.
5. Open **Components / CodeEditor / With LSP** afterwards — no stray TypeScript diagnostics on the product editor.

## 📹 Demo

_The story itself is the demo — screenshots in the Storybook story render exactly what reviewers will see locally._