### PR TITLE
BE-633: Fix aliased mutable references in `Report::frames_mut`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1848,7 +1848,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
 dependencies = [
  "digest 0.10.7",
- "spin 0.10.0",
+ "spin",
 ]
 
 [[package]]
@@ -2667,7 +2667,7 @@ dependencies = [
 
 [[package]]
 name = "error-stack"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "ansi-to-html",
  "anyhow",
@@ -2684,7 +2684,7 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_core",
- "spin 0.12.1",
+ "spin",
  "supports-color",
  "supports-unicode",
  "thiserror 2.0.18",
@@ -9274,12 +9274,6 @@ name = "spin"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
-
-[[package]]
-name = "spin"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5231412d905519dca6a5deb0327d407be68d6c941feec004533401d3a0a715"
 
 [[package]]
 name = "spki"

--- a/libs/error-stack/CHANGELOG.md
+++ b/libs/error-stack/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to `error-stack` will be documented in this file.
 - Support for [`defmt`](https://defmt.ferrous-systems.com).
 - Better support for serialization and deserialization of `Report`.
 
+## [0.8.0](https://github.com/hashintel/hash/tree/error-stack%400.8.0/libs/error-stack) - 2026-07-03
+
+### Breaking Changes
+
+- Fix a soundness hole in `Report::frames_mut`: the returned iterator handed out `&mut Frame`s with independent lifetimes, so a frame and one of its sources (via `Frame::sources_mut`) could be borrowed mutably at the same time — undefined behavior triggerable from safe code, up to segfaults. `frames_mut` now takes a visitor closure (`FnMut(&mut Frame) -> ControlFlow<()>`) instead of returning an iterator, and the `FramesMut` type has been removed. `Report::downcast_mut` is unaffected.
+
 ## [0.7.1](https://github.com/hashintel/hash/tree/error-stack%400.7.1/libs/error-stack) - 2026-05-27
 
 ### Fixes

--- a/libs/error-stack/CHANGELOG.md
+++ b/libs/error-stack/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to `error-stack` will be documented in this file.
 
 ### Breaking Changes
 
-- Fix a soundness hole in `Report::frames_mut`: the returned iterator handed out `&mut Frame`s with independent lifetimes, so a frame and one of its sources (via `Frame::sources_mut`) could be borrowed mutably at the same time — undefined behavior triggerable from safe code, up to segfaults. `frames_mut` now takes a visitor closure (`FnMut(&mut Frame) -> ControlFlow<()>`) instead of returning an iterator, and the `FramesMut` type has been removed. `Report::downcast_mut` is unaffected.
+- Fix a soundness hole in `Report::frames_mut`: the returned iterator handed out `&mut Frame`s with independent lifetimes, so a frame and one of its sources (via `Frame::sources_mut`) could be borrowed mutably at the same time — undefined behavior triggerable from safe code, up to segfaults. `frames_mut` now takes a visitor closure (`FnMut(&mut Frame) -> ControlFlow<()>`) instead of returning an iterator, and the `FramesMut` type has been removed. `Report::downcast_mut` is unaffected. ([#8946](https://github.com/hashintel/hash/pull/8946))
 
 ## [0.7.1](https://github.com/hashintel/hash/tree/error-stack%400.7.1/libs/error-stack) - 2026-05-27
 

--- a/libs/error-stack/Cargo.toml
+++ b/libs/error-stack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "error-stack"
-version       = "0.7.1"
+version       = "0.8.0"
 authors       = { workspace = true }
 edition       = "2021"
 rust-version  = "1.83.0"

--- a/libs/error-stack/package.json
+++ b/libs/error-stack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rust/error-stack",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "private": true,
   "description": "A context-aware error-handling library that supports arbitrary attached user data",
   "license": "MIT OR Apache-2.0",

--- a/libs/error-stack/src/frame/mod.rs
+++ b/libs/error-stack/src/frame/mod.rs
@@ -11,15 +11,15 @@ pub use self::kind::{AttachmentKind, FrameKind};
 
 /// A single context or attachment inside of a [`Report`].
 ///
-/// `Frame`s are organized as a singly linked list, which can be iterated by calling
-/// [`Report::frames()`]. The head contains the current context or attachment, and the tail contains
-/// the root context created by [`Report::new()`]. The next `Frame` can be accessed by requesting it
-/// by calling [`Report::request_ref()`].
+/// `Frame`s are organized as a tree, which can be traversed by calling [`Report::frames()`].
+/// The top contains the most recent context or attachment, the leaves contain the root contexts
+/// created by [`Report::new()`]. The `Frame`s below a frame can be accessed by calling
+/// [`sources()`].
 ///
 /// [`Report`]: crate::Report
 /// [`Report::frames()`]: crate::Report::frames
 /// [`Report::new()`]: crate::Report::new
-/// [`Report::request_ref()`]: crate::Report::request_ref
+/// [`sources()`]: Self::sources
 pub struct Frame {
     frame: Box<dyn FrameImpl>,
     sources: Box<[Self]>,

--- a/libs/error-stack/src/iter.rs
+++ b/libs/error-stack/src/iter.rs
@@ -3,15 +3,14 @@
 use alloc::{vec, vec::Vec};
 #[cfg(nightly)]
 use core::marker::PhantomData;
-use core::{
-    fmt,
-    iter::FusedIterator,
-    slice::{Iter, IterMut},
-};
+use core::{fmt, iter::FusedIterator, slice::Iter};
 
 use crate::Frame;
 
-/// Helper function, which is used in both [`Frames`] and [`FramesMut`].
+/// Helper function, which is used in both [`Frames`] and the mutable frame traversals on
+/// [`Report`].
+///
+/// [`Report`]: crate::Report
 ///
 /// To traverse the frames, the following algorithm is used:
 /// Given a list of iterators, take the last iterator, and use items from it until the iterator has
@@ -31,7 +30,7 @@ use crate::Frame;
 /// 7) Out: G Stack: [H]
 /// 8) Out: H Stack: -
 /// ```
-fn next<I: Iterator<Item = T>, T>(iter: &mut Vec<I>) -> Option<T> {
+pub(crate) fn next<I: Iterator<Item = T>, T>(iter: &mut Vec<I>) -> Option<T> {
     let out;
     loop {
         let last = iter.last_mut()?;
@@ -107,49 +106,6 @@ impl fmt::Debug for Frames<'_> {
         fmt.debug_list().entries(self.clone()).finish()
     }
 }
-
-/// Iterator over the mutable [`Frame`] stack of a [`Report`].
-///
-/// Use [`Report::frames_mut()`] to create this iterator.
-///
-/// [`Report`]: crate::Report
-/// [`Report::frames_mut()`]: crate::Report::frames_mut
-#[must_use]
-pub struct FramesMut<'r> {
-    stack: Vec<IterMut<'r, Frame>>,
-}
-
-impl<'r> FramesMut<'r> {
-    pub(crate) fn new(frames: &'r mut [Frame]) -> Self {
-        Self {
-            stack: vec![frames.iter_mut()],
-        }
-    }
-}
-
-impl<'r> Iterator for FramesMut<'r> {
-    type Item = &'r mut Frame;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let frame = next(&mut self.stack)?;
-        let frame: *mut Frame = frame;
-
-        // SAFETY:
-        // We require both mutable access to the frame for all sources (as a mutable iterator) and
-        // we need to return the mutable frame itself. We will never access the same value twice,
-        // and only store their mutable iterator until the next `next()` call. This function acts
-        // like a dynamic chain of multiple `IterMut`. The borrow checker is unable to prove that
-        // subsequent calls to `next()` won't access the same data.
-        // NB: It's almost never possible to implement a mutable iterator without `unsafe`.
-        unsafe {
-            self.stack.push((*frame).sources_mut().iter_mut());
-
-            Some(&mut *frame)
-        }
-    }
-}
-
-impl FusedIterator for FramesMut<'_> {}
 
 /// Iterator over requested references in the [`Frame`] stack of a [`Report`].
 ///

--- a/libs/error-stack/src/report.rs
+++ b/libs/error-stack/src/report.rs
@@ -1,5 +1,5 @@
 use alloc::{boxed::Box, vec, vec::Vec};
-use core::{error::Error, marker::PhantomData, mem, panic::Location};
+use core::{error::Error, marker::PhantomData, mem, ops::ControlFlow, panic::Location};
 #[cfg(feature = "backtrace")]
 use std::backtrace::{Backtrace, BacktraceStatus};
 #[cfg(feature = "std")]
@@ -13,7 +13,7 @@ use crate::iter::{RequestRef, RequestValue};
 use crate::{
     Attachment, Frame, OpaqueAttachment,
     context::SourceContext,
-    iter::{Frames, FramesMut},
+    iter::{self, Frames},
 };
 
 /// Contains a [`Frame`] stack consisting of [`Error`] contexts and attachments.
@@ -592,9 +592,49 @@ impl<C: ?Sized> Report<C> {
         Frames::new(&self.frames)
     }
 
-    /// Returns an iterator over the [`Frame`] stack of the report with mutable elements.
-    pub fn frames_mut(&mut self) -> FramesMut<'_> {
-        FramesMut::new(&mut self.frames)
+    /// Visits every [`Frame`] of the report mutably, in the same order as [`frames()`].
+    ///
+    /// Returning [`ControlFlow::Break`] from `visitor` stops the traversal early. The break is
+    /// propagated to the caller, a full traversal returns [`ControlFlow::Continue`].
+    ///
+    /// This is deliberately not an [`Iterator`]: an iterator over `&mut Frame` hands out
+    /// references whose lifetimes are independent of each other, so a frame and one of its
+    /// sources (reachable via [`Frame::sources_mut`]) could be borrowed mutably at the same
+    /// time. Scoping mutable access to a visitor rules that out.
+    ///
+    /// ## Example
+    ///
+    /// ```rust
+    /// # use std::{fs, io, path::Path};
+    /// # use core::ops::ControlFlow;
+    /// # use error_stack::Report;
+    /// # fn read_file(path: impl AsRef<Path>) -> Result<String, Report<io::Error>> {
+    /// #     fs::read_to_string(path.as_ref()).map_err(Report::from)
+    /// # }
+    /// let mut report = read_file("test.txt").unwrap_err();
+    /// let flow = report.frames_mut(|frame| {
+    ///     if let Some(io_error) = frame.downcast_mut::<io::Error>() {
+    ///         *io_error = io::Error::from(io::ErrorKind::Other);
+    ///         return ControlFlow::Break(());
+    ///     }
+    ///     ControlFlow::Continue(())
+    /// });
+    /// assert!(flow.is_break());
+    /// ```
+    ///
+    /// [`frames()`]: Self::frames
+    pub fn frames_mut(
+        &mut self,
+        mut visitor: impl FnMut(&mut Frame) -> ControlFlow<()>,
+    ) -> ControlFlow<()> {
+        // If lending iterators ever land in `core`, this should become one: yielding `&mut Frame`
+        // bound to the `next()` borrow is sound and more ergonomic than a visitor.
+        let mut stack = vec![self.frames.iter_mut()];
+        while let Some(frame) = iter::next(&mut stack) {
+            visitor(frame)?;
+            stack.push(frame.sources_mut().iter_mut());
+        }
+        ControlFlow::Continue(())
     }
 
     /// Creates an iterator of references of type `T` that have been [`attached`](Self::attach) or
@@ -668,7 +708,17 @@ impl<C: ?Sized> Report<C> {
     /// `T` can either be an attachment or a new [`Error`] context.
     #[must_use]
     pub fn downcast_mut<T: Send + Sync + 'static>(&mut self) -> Option<&mut T> {
-        self.frames_mut().find_map(Frame::downcast_mut::<T>)
+        // This cannot use `frames_mut` as the found reference needs to outlive the visitor
+        // closure. Each frame is either returned or descended into, never both, so the borrow
+        // checker accepts this without `unsafe`.
+        let mut stack = vec![self.frames.iter_mut()];
+        while let Some(frame) = iter::next(&mut stack) {
+            if frame.is::<T>() {
+                return frame.downcast_mut();
+            }
+            stack.push(frame.sources_mut().iter_mut());
+        }
+        None
     }
 }
 

--- a/libs/error-stack/tests/test_downcast.rs
+++ b/libs/error-stack/tests/test_downcast.rs
@@ -38,3 +38,64 @@ fn downcast_mut() {
         .expect("Attachment not found");
     assert_eq!(attachment.0, 20);
 }
+
+#[test]
+fn downcast_mut_deep() {
+    let mut report = create_report()
+        .attach_opaque(AttachmentA(10))
+        .change_context(ContextA(0))
+        .attach_opaque(AttachmentB(0));
+
+    let attachment = report
+        .downcast_mut::<AttachmentA>()
+        .expect("Attachment not found");
+    attachment.0 += 10;
+
+    let attachment = report
+        .downcast_ref::<AttachmentA>()
+        .expect("Attachment not found");
+    assert_eq!(attachment.0, 20);
+}
+
+#[test]
+fn downcast_mut_second_root() {
+    let mut report = create_report().expand();
+    report.push(create_report().attach_opaque(AttachmentA(10)));
+
+    let attachment = report
+        .downcast_mut::<AttachmentA>()
+        .expect("Attachment not found");
+    attachment.0 += 10;
+
+    let attachment = report
+        .downcast_ref::<AttachmentA>()
+        .expect("Attachment not found");
+    assert_eq!(attachment.0, 20);
+}
+
+#[test]
+fn downcast_mut_returns_outermost() {
+    let mut report = create_report()
+        .attach_opaque(AttachmentA(1))
+        .attach_opaque(AttachmentB(2))
+        .attach_opaque(AttachmentA(3));
+
+    let attachment = report
+        .downcast_mut::<AttachmentA>()
+        .expect("Attachment not found");
+    assert_eq!(attachment.0, 3);
+    attachment.0 = 30;
+
+    let values: Vec<_> = report
+        .frames()
+        .filter_map(|frame| frame.downcast_ref::<AttachmentA>())
+        .map(|attachment| attachment.0)
+        .collect();
+    assert_eq!(values, [30, 1]);
+}
+
+#[test]
+fn downcast_mut_miss() {
+    let mut report = create_report().attach_opaque(AttachmentA(10));
+    assert!(report.downcast_mut::<AttachmentB>().is_none());
+}

--- a/libs/error-stack/tests/test_frame.rs
+++ b/libs/error-stack/tests/test_frame.rs
@@ -2,7 +2,7 @@
 
 mod common;
 
-use core::{any::TypeId, iter::zip, panic::Location};
+use core::{any::TypeId, iter::zip, ops::ControlFlow, panic::Location};
 
 use common::*;
 
@@ -12,16 +12,20 @@ fn opaque_attachment() {
         .attach_opaque(AttachmentA(10))
         .attach_opaque(AttachmentB(20));
 
-    let frame = report.frames_mut().next().expect("No frame found");
-    let source = frame
-        .sources_mut()
-        .first_mut()
-        .expect("No source frame found");
-    let attachment = source
-        .downcast_mut::<AttachmentA>()
-        .expect("Wrong source frame");
-    attachment.0 += 10;
+    let flow = report.frames_mut(|frame| {
+        let source = frame
+            .sources_mut()
+            .first_mut()
+            .expect("No source frame found");
+        let attachment = source
+            .downcast_mut::<AttachmentA>()
+            .expect("Wrong source frame");
+        attachment.0 += 10;
+        ControlFlow::Break(())
+    });
+    assert!(flow.is_break(), "No frame found");
 
+    let frame = report.frames().next().expect("No frame found");
     assert_eq!(frame.sources().len(), 1);
     let source = frame.sources().first().expect("No source frame found");
     let attachment = source
@@ -37,16 +41,20 @@ fn sources() {
     report_a.push(report_b);
     let mut report = report_a.attach_opaque(AttachmentB(30));
 
-    let frame = report.frames_mut().next().expect("No frames");
-    assert_eq!(frame.sources().len(), 2);
+    let flow = report.frames_mut(|frame| {
+        assert_eq!(frame.sources().len(), 2);
 
-    for source in frame.sources_mut() {
-        let attachment = source
-            .downcast_mut::<AttachmentA>()
-            .expect("Wrong source frame");
-        attachment.0 += 5;
-    }
+        for source in frame.sources_mut() {
+            let attachment = source
+                .downcast_mut::<AttachmentA>()
+                .expect("Wrong source frame");
+            attachment.0 += 5;
+        }
+        ControlFlow::Break(())
+    });
+    assert!(flow.is_break(), "No frames");
 
+    let frame = report.frames().next().expect("No frames");
     for (source, expect) in zip(frame.sources(), [15, 25]) {
         let attachment = source
             .downcast_ref::<AttachmentA>()
@@ -61,16 +69,20 @@ fn printable_attachment() {
         .attach(PrintableA(10))
         .attach(PrintableB(20));
 
-    let frame = report.frames_mut().next().expect("No frame found");
-    let source = frame
-        .sources_mut()
-        .first_mut()
-        .expect("No source frame found");
-    let attachment = source
-        .downcast_mut::<PrintableA>()
-        .expect("Wrong source frame");
-    attachment.0 += 10;
+    let flow = report.frames_mut(|frame| {
+        let source = frame
+            .sources_mut()
+            .first_mut()
+            .expect("No source frame found");
+        let attachment = source
+            .downcast_mut::<PrintableA>()
+            .expect("Wrong source frame");
+        attachment.0 += 10;
+        ControlFlow::Break(())
+    });
+    assert!(flow.is_break(), "No frame found");
 
+    let frame = report.frames().next().expect("No frame found");
     assert_eq!(frame.sources().len(), 1);
     let source = frame.sources().first().expect("No source frame found");
     let attachment = source
@@ -83,22 +95,24 @@ fn printable_attachment() {
 fn context() {
     let mut report = create_report().change_context(ContextA(10));
 
-    let mut frames = report.frames_mut();
+    let flow = report.frames_mut(|frame| {
+        assert_eq!(frame.sources().len(), 1);
+        assert!(frame.is::<Location>(), "not a location frame");
 
-    let frame = frames.next().expect("No location frame found");
-    assert_eq!(frame.sources().len(), 1);
-    assert!(frame.is::<Location>(), "not a location frame");
+        let source = frame
+            .sources_mut()
+            .first_mut()
+            .expect("no source frame found");
 
-    let source = frame
-        .sources_mut()
-        .first_mut()
-        .expect("no source frame found");
+        let context = source
+            .downcast_mut::<ContextA>()
+            .expect("not a context frame");
+        context.0 += 10;
+        ControlFlow::Break(())
+    });
+    assert!(flow.is_break(), "No location frame found");
 
-    let context = source
-        .downcast_mut::<ContextA>()
-        .expect("not a context frame");
-    context.0 += 10;
-
+    let frame = report.frames().next().expect("No location frame found");
     assert_eq!(frame.sources().len(), 1);
     let source = frame.sources().first().expect("no source frame found");
     let context = source

--- a/libs/error-stack/tests/test_iter.rs
+++ b/libs/error-stack/tests/test_iter.rs
@@ -5,6 +5,7 @@ extern crate alloc;
 use core::{
     error::Error,
     fmt::{Display, Formatter, Write as _},
+    ops::ControlFlow,
 };
 
 mod common;
@@ -92,11 +93,40 @@ fn iter() {
 fn iter_mut() {
     let mut report = build();
 
+    let mut chars = Vec::new();
+    let flow = report.frames_mut(|frame| {
+        if let Some(ch) = frame.downcast_mut::<Char>() {
+            chars.push(ch.0);
+            ch.0 = ch.0.to_ascii_lowercase();
+        }
+        ControlFlow::Continue(())
+    });
+    assert!(flow.is_continue());
+    assert_eq!(chars, ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']);
+
     assert_eq!(
         report
-            .frames_mut()
+            .frames()
             .filter_map(|frame| frame.downcast_ref::<Char>().map(|ch| ch.0))
             .collect::<Vec<_>>(),
-        ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
+        ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']
     );
+}
+
+#[test]
+fn iter_mut_break() {
+    let mut report = build();
+
+    let mut chars = Vec::new();
+    let flow = report.frames_mut(|frame| {
+        if let Some(ch) = frame.downcast_ref::<Char>() {
+            chars.push(ch.0);
+            if ch.0 == 'D' {
+                return ControlFlow::Break(());
+            }
+        }
+        ControlFlow::Continue(())
+    });
+    assert!(flow.is_break());
+    assert_eq!(chars, ['A', 'B', 'C', 'D']);
 }

--- a/libs/error-stack/tests/ui/frames_mut_escape.rs
+++ b/libs/error-stack/tests/ui/frames_mut_escape.rs
@@ -1,0 +1,28 @@
+//! A `&mut Frame` must not be able to escape the `frames_mut` visitor. Two escaped references
+//! could alias the same frame (directly and through `Frame::sources_mut`), which is the
+//! soundness hole the visitor API exists to close.
+
+use core::{error::Error, fmt, ops::ControlFlow};
+
+use error_stack::{Frame, Report};
+
+#[derive(Debug)]
+pub struct RootError;
+
+impl fmt::Display for RootError {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.write_str("root error")
+    }
+}
+
+impl Error for RootError {}
+
+fn main() {
+    let mut report = Report::new(RootError).attach("attachment");
+
+    let mut escaped: Vec<&mut Frame> = Vec::new();
+    let _ = report.frames_mut(|frame| {
+        escaped.push(frame);
+        ControlFlow::Continue(())
+    });
+}

--- a/libs/error-stack/tests/ui/frames_mut_escape.stderr
+++ b/libs/error-stack/tests/ui/frames_mut_escape.stderr
@@ -1,0 +1,13 @@
+error[E0521]: borrowed data escapes outside of closure
+  --> tests/ui/frames_mut_escape.rs:25:9
+   |
+23 |     let mut escaped: Vec<&mut Frame> = Vec::new();
+   |         ----------- `escaped` declared here, outside of the closure body
+24 |     let _ = report.frames_mut(|frame| {
+   |                                ----- `frame` is a reference that is only valid in the closure body
+25 |         escaped.push(frame);
+   |         ^^^^^^^^^^^^^^^^^^^ `frame` escapes the closure body here
+   |
+   = note: requirement occurs because of a mutable reference to `Vec<&mut Frame>`
+   = note: mutable references are invariant over their type parameter
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

`Report::frames_mut` returned an iterator handing out `&mut Frame`s with independent lifetimes. Combined with `Frame::sources_mut`, safe code could obtain two live mutable references to the same frame — undefined behavior, demonstrated as a segfault in #8945. The iterator is replaced with a visitor, so mutable access is scoped to the callback and the aliasing is ruled out by the borrow checker.

## 🔗 Related links

- Fixes https://github.com/hashintel/hash/issues/8945
- [BE-633](https://linear.app/hash/issue/BE-633) _(internal)_

## 🔍 What does this change?

- Remove `FramesMut`, and with it the only `unsafe` block in `iter.rs`
- `Report::frames_mut` now takes `FnMut(&mut Frame) -> ControlFlow<()>` and visits frames in the same order as `frames()`
- Reimplement `Report::downcast_mut` without the iterator (public API unchanged)
- Bump `error-stack` to 0.8.0
- Drive-by: correct the `Frame` docs (frames form a tree, not a linked list)

The version bump re-resolved the optional (and currently unused) `spin` dependency in `Cargo.lock` to the already-present 0.10.0.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] modifies a **Cargo**-publishable library and **I have amended the version**

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph
## 🛡 What tests cover this?

- Rewritten `test_frame.rs`/`test_iter.rs`: traversal order over grouped reports, early exit via `ControlFlow::Break`, mutation visibility
- New `downcast_mut` tests: descent past non-matching frames, target in a second root, outermost-match-wins, miss returns `None`
- New compile-fail UI test pinning that a `&mut Frame` cannot escape the visitor
- Miri passes on all affected test files

## ❓ How to test this?

1. `turbo run test:unit --filter '@rust/error-stack'`
2. `cargo miri test --package error-stack --all-features --test test_iter --test test_frame --test test_downcast`
