### PR TITLE
FE-1153: Collapse per-type switches into a type-policy registry

### DIFF
--- a/.changeset/fe-1153-type-policy-registry.md
+++ b/.changeset/fe-1153-type-policy-registry.md
@@ -1,0 +1,5 @@
+---
+"@hashintel/petrinaut-core": patch
+---
+
+Expose the per-type policy registry (`TYPE_POLICIES`) and related helpers.

--- a/libs/@hashintel/petrinaut-core/src/default-codes.ts
+++ b/libs/@hashintel/petrinaut-core/src/default-codes.ts
@@ -1,20 +1,10 @@
+import { TYPE_POLICIES } from "./simulation/engine/type-policies";
+
 import type { Color } from "./types/sdcpn";
 
 const defaultTokenAttributeSource = (
   element: Color["elements"][number],
-): string => {
-  switch (element.type) {
-    case "boolean":
-      return "false";
-    case "integer":
-    case "real":
-      return "0";
-    case "string":
-      return '""';
-    case "uuid":
-      return "Uuid.generate()";
-  }
-};
+): string => TYPE_POLICIES[element.type].defaultValueSource;
 
 export function generateDefaultVisualizerCode(type: Color): string {
   return `// This function defines how to visualize the tokens in the place of type "${

--- a/libs/@hashintel/petrinaut-core/src/index.ts
+++ b/libs/@hashintel/petrinaut-core/src/index.ts
@@ -334,9 +334,16 @@ export { buildMetricState } from "./simulation/frames/metric-state";
 export {
   coerceTokenAttributeValue,
   coerceTokenRecord,
+  coerceToStoredTokenAttributeValue,
   defaultTokenAttributeValue,
   encodeTokenAttributeValue,
 } from "./simulation/engine/token-values";
+export {
+  COLOR_ELEMENT_TYPES,
+  TYPE_POLICIES,
+  type StoredTokenAttributeValue,
+  type TypePolicy,
+} from "./simulation/engine/type-policies";
 export {
   computeTokenSlotLayout,
   createTokenRegionViews,

--- a/libs/@hashintel/petrinaut-core/src/lsp/lib/generate-virtual-files.ts
+++ b/libs/@hashintel/petrinaut-core/src/lsp/lib/generate-virtual-files.ts
@@ -6,6 +6,7 @@ import {
   getTransitionLogicAvailability,
   type PetrinautExtensionSettings,
 } from "../../extensions";
+import { TYPE_POLICIES } from "../../simulation/engine/type-policies";
 import { getItemFilePath } from "./file-paths";
 
 import type {
@@ -28,19 +29,12 @@ function sanitizeColorId(colorId: string): string {
 }
 
 /**
- * Maps SDCPN element types to TypeScript types
+ * Maps SDCPN element types to TypeScript types. `ratio` is a scenario
+ * parameter type (not a `ColorElementType`), so it is handled here rather
+ * than in the type-policy registry.
  */
 function toTsType(type: ColorElementType | "ratio"): string {
-  if (type === "boolean") {
-    return "boolean";
-  }
-  if (type === "uuid") {
-    return "bigint";
-  }
-  if (type === "string") {
-    return "string";
-  }
-  return "number";
+  return type === "ratio" ? "number" : TYPE_POLICIES[type].tsInputType;
 }
 
 /**
@@ -83,13 +77,13 @@ function toKernelOutputTokenType(
 ): string {
   const properties = color.elements
     .map((element) => {
-      if (element.type === "uuid") {
-        return `  ${element.name}?: bigint | string | PetrinautUuid;`;
-      }
       if (element.type === "real" && stochasticityEnabled) {
         return `  ${element.name}: number | Distribution;`;
       }
-      return `  ${element.name}: ${toTsType(element.type)};`;
+      const policy = TYPE_POLICIES[element.type];
+      return `  ${element.name}${policy.kernelOutputOptional ? "?" : ""}: ${
+        policy.tsKernelOutputType
+      };`;
     })
     .join("\n");
 

--- a/libs/@hashintel/petrinaut-core/src/schema-migration.ts
+++ b/libs/@hashintel/petrinaut-core/src/schema-migration.ts
@@ -1,10 +1,7 @@
-import {
-  coerceTokenAttributeValue,
-  defaultTokenAttributeValue,
-} from "./simulation/engine/token-values";
-import { formatUuid } from "./simulation/engine/uuid";
+import { coerceToStoredTokenAttributeValue } from "./simulation/engine/token-values";
+import { TYPE_POLICIES } from "./simulation/engine/type-policies";
 
-import type { Color, SDCPN, TokenAttributeValue } from "./types/sdcpn";
+import type { ColorElementType, Color, SDCPN } from "./types/sdcpn";
 
 type ColorElement = Color["elements"][number];
 
@@ -30,33 +27,24 @@ export type TypeElementEdit =
 type ScenarioRowCell = number | boolean | string;
 
 /**
- * Converts a runtime token attribute value to its at-rest scenario-row form:
- * `uuid` bigints become canonical lowercase UUID strings; everything else is
- * already JSON-safe.
- */
-const toStoredCell = (value: TokenAttributeValue): ScenarioRowCell =>
-  typeof value === "bigint" ? formatUuid(value) : value;
-
-/**
  * Total coercion of a stored row cell to `element`'s type. Falls back to the
  * element type's default value when coercion throws (e.g. `"abc"` → `integer`
- * yields `0`).
+ * yields `0`). `uuid` results are stored as canonical lowercase UUID strings.
  */
 const coerceStoredCell = (
   element: ColorElement,
   cell: unknown,
-): ScenarioRowCell => {
-  try {
-    return toStoredCell(
-      coerceTokenAttributeValue(
-        element,
-        cell,
-        `Scenario cell for element "${element.name}"`,
-      ),
-    );
-  } catch {
-    return toStoredCell(defaultTokenAttributeValue(element.type));
-  }
+): ScenarioRowCell =>
+  coerceToStoredTokenAttributeValue(
+    element,
+    cell,
+    `Scenario cell for element "${element.name}"`,
+  );
+
+/** The element type's default value in its at-rest scenario-row form. */
+const defaultStoredCell = (type: ColorElementType): ScenarioRowCell => {
+  const policy = TYPE_POLICIES[type];
+  return policy.encodeAtRest(policy.defaultValue);
 };
 
 /**
@@ -185,7 +173,7 @@ export function migrateScenarioRowsForTypeEdit(
           if (columnIndex === coerceIndex) {
             return coerceStoredCell(element, cell);
           }
-          return cell ?? toStoredCell(defaultTokenAttributeValue(element.type));
+          return cell ?? defaultStoredCell(element.type);
         });
       }
     }

--- a/libs/@hashintel/petrinaut-core/src/schemas/entity-schemas.ts
+++ b/libs/@hashintel/petrinaut-core/src/schemas/entity-schemas.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import { COLOR_ELEMENT_TYPES } from "../simulation/engine/type-policies";
 import { displayNameSchema } from "../validation/display-name";
 import { entityNameSchema } from "../validation/entity-name";
 import { variableNameSchema } from "../validation/variable-name";
@@ -159,7 +160,7 @@ export const colorElementSchema = z
         description:
           "Token attribute identifier used DIRECTLY in code. Lambdas, kernels, dynamics, visualizers, and metrics destructure tokens as `{ <name> }`, so this must be a valid JavaScript identifier (e.g. `machine_damage_ratio`, `x`, `velocity`). Spaces, hyphens, and leading digits will break user code that references the attribute; prefer lower_snake_case for consistency with parameter naming.",
       }),
-    type: z.enum(["real", "integer", "boolean", "uuid", "string"]).meta({
+    type: z.enum(COLOR_ELEMENT_TYPES).meta({
       description:
         "`real` is continuous and may be updated by dynamics. `integer`, `boolean`, `uuid`, and `string` are discrete token attributes updated by transition kernels. `integer` values are stored as Float64 and rounded on read/write: they are exact only within ±2^53 (±9,007,199,254,740,992); values beyond that lose precision silently. `uuid` is a 128-bit RFC 4122 identifier: runtime code sees it as a `bigint`, frame buffers store it as two little-endian 64-bit lanes, and at-rest data (documents, scenarios) uses canonical lowercase strings. `uuid` fields are OPTIONAL in kernel outputs — omitted values are auto-generated deterministically from the seeded simulation RNG — and non-UUID inputs are converted deterministically via UUIDv5. `string` is variable-length text, compared by value: runtime code sees plain JS strings, and each distinct value is stored once per run via interning — frame buffers hold 64-bit pool references. Kernels and markings write `string` values (missing values become the empty string); dynamics can read but never update them.",
     }),

--- a/libs/@hashintel/petrinaut-core/src/simulation/authoring/scenario/compile-scenario.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/authoring/scenario/compile-scenario.ts
@@ -1,5 +1,5 @@
 import { coerceTokenRecord } from "../../engine/token-values";
-import { formatUuid } from "../../engine/uuid";
+import { TYPE_POLICIES } from "../../engine/type-policies";
 import { runSandboxed, SHADOWED_GLOBALS } from "../sandbox";
 
 import type { Color, Parameter, Place, Scenario } from "../../../types/sdcpn";
@@ -94,10 +94,11 @@ function evaluateExpression(
 type MarkingTokenRecord = Record<string, InitialTokenAttributeValue>;
 
 /**
- * Coerces one raw token source through the runtime codec, then converts uuid
- * attributes back to canonical lowercase strings so the compiled initial
- * state stays JSON-serializable. Arbitrary uuid inputs (free text, numbers)
- * are normalized deterministically via `toUuid` inside `coerceTokenRecord`.
+ * Coerces one raw token source through the runtime codec, then converts each
+ * attribute to its at-rest form (uuid bigints become canonical lowercase
+ * strings) so the compiled initial state stays JSON-serializable. Arbitrary
+ * uuid inputs (free text, numbers) are normalized deterministically via
+ * `toUuid` inside `coerceTokenRecord`.
  */
 function compileTokenRecord(
   source: Record<string, unknown>,
@@ -108,12 +109,11 @@ function compileTokenRecord(
     elements,
     "Scenario initial state token",
   );
-  const token: MarkingTokenRecord = { ...coerced };
+  const token: MarkingTokenRecord = {};
   for (const element of elements) {
-    if (element.type === "uuid") {
-      const value = coerced[element.name];
-      token[element.name] = formatUuid(typeof value === "bigint" ? value : 0n);
-    }
+    token[element.name] = TYPE_POLICIES[element.type].encodeAtRest(
+      coerced[element.name]!,
+    );
   }
   return token;
 }

--- a/libs/@hashintel/petrinaut-core/src/simulation/engine/token-layout.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/engine/token-layout.ts
@@ -3,24 +3,15 @@ import {
   decodeTokenAttributeValue,
   encodeTokenAttributeValue,
 } from "./token-values";
+import { TYPE_POLICIES } from "./type-policies";
 import { NIL_UUID, toUuid } from "./uuid";
 
 import type { Color, ColorElementType, TokenRecord } from "../../types/sdcpn";
+import type { PhysicalKind } from "./type-policies";
+
+export type { PhysicalKind } from "./type-policies";
 
 type ColorElement = Color["elements"][number];
-
-/**
- * Physical (buffer-level) representation of one token attribute in the
- * format-v2 packed struct layout:
- *
- * - `f64`: 8 bytes, 8-byte aligned (`real` and `integer` elements).
- * - `u8`: 1 byte, 1-byte aligned (`boolean` elements).
- * - `u64`: 8 bytes, 8-byte aligned (`string` elements — one little-endian
- *   64-bit ID into the simulation's `StringPool`, not the string itself).
- * - `u64x2`: 16 bytes, 8-byte aligned (`uuid` elements — two little-endian
- *   64-bit lanes: `lo` at the field's byteOffset, `hi` at +8).
- */
-export type PhysicalKind = "f64" | "u8" | "u64" | "u64x2";
 
 /**
  * Read side of the per-run string pool, needed to decode `string` (u64 pool
@@ -79,17 +70,7 @@ const PHYSICAL_TYPES: Record<PhysicalKind, PhysicalType> = {
 };
 
 function physicalTypeFor(elementType: ColorElementType): PhysicalType {
-  switch (elementType) {
-    case "boolean":
-      return PHYSICAL_TYPES.u8;
-    case "integer":
-    case "real":
-      return PHYSICAL_TYPES.f64;
-    case "string":
-      return PHYSICAL_TYPES.u64;
-    case "uuid":
-      return PHYSICAL_TYPES.u64x2;
-  }
+  return PHYSICAL_TYPES[TYPE_POLICIES[elementType].physicalKind];
 }
 
 const alignTo = (value: number, alignment: number): number =>

--- a/libs/@hashintel/petrinaut-core/src/simulation/engine/token-values.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/engine/token-values.ts
@@ -1,4 +1,5 @@
-import { formatUuid, NIL_UUID, toUuid } from "./uuid";
+import { TYPE_POLICIES } from "./type-policies";
+import { formatUuid } from "./uuid";
 
 import type {
   Color,
@@ -6,6 +7,7 @@ import type {
   TokenAttributeValue,
   TokenRecord,
 } from "../../types/sdcpn";
+import type { StoredTokenAttributeValue } from "./type-policies";
 
 type ColorElement = Color["elements"][number];
 
@@ -27,44 +29,7 @@ export function describeTokenValuesForError(values: unknown): string {
 export function defaultTokenAttributeValue(
   type: ColorElementType,
 ): TokenAttributeValue {
-  switch (type) {
-    case "boolean":
-      return false;
-    case "integer":
-    case "real":
-      return 0;
-    case "string":
-      return "";
-    case "uuid":
-      return NIL_UUID;
-  }
-}
-
-function coerceNumber(value: unknown, context: string): number {
-  const numberValue = typeof value === "number" ? value : Number(value);
-  if (!Number.isFinite(numberValue)) {
-    throw new Error(`${context} must be a finite number.`);
-  }
-  return numberValue;
-}
-
-function coerceBoolean(value: unknown, context: string): boolean {
-  if (typeof value === "boolean") {
-    return value;
-  }
-  if (typeof value === "number") {
-    return value !== 0;
-  }
-  if (typeof value === "string") {
-    const normalized = value.trim().toLowerCase();
-    if (normalized === "true" || normalized === "1") {
-      return true;
-    }
-    if (normalized === "false" || normalized === "0" || normalized === "") {
-      return false;
-    }
-  }
-  throw new Error(`${context} must be a boolean.`);
+  return TYPE_POLICIES[type].defaultValue;
 }
 
 export function coerceTokenAttributeValue(
@@ -72,24 +37,32 @@ export function coerceTokenAttributeValue(
   value: unknown,
   context: string,
 ): TokenAttributeValue {
-  const rawValue = value ?? defaultTokenAttributeValue(element.type);
-  switch (element.type) {
-    case "real":
-      return coerceNumber(rawValue, context);
-    case "integer":
-      return Math.round(coerceNumber(rawValue, context));
-    case "boolean":
-      return coerceBoolean(rawValue, context);
-    case "string":
-      // Total conversion: any value stringifies; undefined/null → "" (the
-      // ?? default above resolves them to "" before this arm).
-      // eslint-disable-next-line typescript/no-base-to-string -- intentional: non-primitives map through their default stringification, keeping the conversion total
-      return typeof rawValue === "string" ? rawValue : String(rawValue);
-    case "uuid":
-      // Total conversion: bigints and UUID strings pass through/parse, and
-      // any other value maps deterministically to a UUIDv5 — never throws.
-      return toUuid(rawValue);
+  const policy = TYPE_POLICIES[element.type];
+  // Nullish values resolve to the type's default before coercion (e.g.
+  // undefined/null → "" for string elements).
+  return policy.coerce(value ?? policy.defaultValue, context);
+}
+
+/**
+ * Total coercion of an arbitrary value to `element`'s JSON-serializable
+ * at-rest form (the shape stored in documents and scenario rows — `uuid`
+ * values become canonical lowercase strings). Falls back to the element
+ * type's default value when coercion throws (e.g. `"abc"` → `integer`
+ * yields `0`).
+ */
+export function coerceToStoredTokenAttributeValue(
+  element: ColorElement,
+  value: unknown,
+  context: string,
+): StoredTokenAttributeValue {
+  const policy = TYPE_POLICIES[element.type];
+  let coerced: TokenAttributeValue;
+  try {
+    coerced = coerceTokenAttributeValue(element, value, context);
+  } catch {
+    coerced = policy.defaultValue;
   }
+  return policy.encodeAtRest(coerced);
 }
 
 export function coerceTokenRecord(
@@ -115,29 +88,20 @@ export function coerceTokenRecord(
  * `uuid` and `string` elements never reach this codec: uuid lanes are
  * assembled/split directly in `token-layout.ts` (`readTokenRecord` /
  * `writeTokenValue`), and string pool references resolve through the run's
- * `StringPool` there — the arms here only keep the switch exhaustive over
- * `ColorElementType`.
+ * `StringPool` there — their policies carry no number-slot decoder, so they
+ * throw here.
  */
 export function decodeTokenAttributeValue(
   element: ColorElement,
   encodedValue: number,
 ): TokenAttributeValue {
-  switch (element.type) {
-    case "real":
-      return encodedValue;
-    case "integer":
-      return Math.round(encodedValue);
-    case "boolean":
-      return encodedValue !== 0;
-    case "string":
-      throw new Error(
-        `decodeTokenAttributeValue received string element "${element.name}"; string pool references are decoded in token-layout.ts`,
-      );
-    case "uuid":
-      throw new Error(
-        `decodeTokenAttributeValue received uuid element "${element.name}"; uuid lanes are decoded in token-layout.ts`,
-      );
+  const decodeNumberSlot = TYPE_POLICIES[element.type].decodeNumberSlot;
+  if (!decodeNumberSlot) {
+    throw new Error(
+      `decodeTokenAttributeValue received ${element.type} element "${element.name}"; ${element.type} fields are decoded in token-layout.ts`,
+    );
   }
+  return decodeNumberSlot(encodedValue);
 }
 
 /**

--- a/libs/@hashintel/petrinaut-core/src/simulation/engine/type-policies.test.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/engine/type-policies.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+
+import { colorElementSchema } from "../../schemas/entity-schemas";
+import { computeTokenSlotLayout } from "./token-layout";
+import { coerceTokenAttributeValue } from "./token-values";
+import { COLOR_ELEMENT_TYPES, TYPE_POLICIES } from "./type-policies";
+
+import type { Color, ColorElementType } from "../../types/sdcpn";
+import type { PhysicalKind } from "./type-policies";
+
+type ColorElement = Color["elements"][number];
+
+const element = (type: ColorElementType): ColorElement => ({
+  elementId: `${type}_element`,
+  name: `${type}_element`,
+  type,
+});
+
+/** Byte width and alignment of each physical kind in the packed layout. */
+const PHYSICAL_WIDTHS: Record<
+  PhysicalKind,
+  { byteSize: number; align: number }
+> = {
+  f64: { byteSize: 8, align: 8 },
+  u8: { byteSize: 1, align: 1 },
+  u64: { byteSize: 8, align: 8 },
+  u64x2: { byteSize: 16, align: 8 },
+};
+
+/**
+ * Conformance test for the type-policy registry: adding a sixth
+ * `ColorElementType` must fail loudly here (and at compile time via the
+ * `Record<ColorElementType, TypePolicy>` shape of `TYPE_POLICIES`) until
+ * every touchpoint is defined.
+ */
+describe("TYPE_POLICIES", () => {
+  it("covers exactly the canonical ColorElementType list", () => {
+    expect(Object.keys(TYPE_POLICIES).sort()).toEqual(
+      [...COLOR_ELEMENT_TYPES].sort(),
+    );
+  });
+
+  it("matches the zod colour element schema's enum", () => {
+    expect(colorElementSchema.shape.type.options).toEqual([
+      ...COLOR_ELEMENT_TYPES,
+    ]);
+  });
+
+  describe.each(COLOR_ELEMENT_TYPES)("%s", (type) => {
+    const policy = TYPE_POLICIES[type];
+
+    it("has every field populated", () => {
+      expect(Object.keys(PHYSICAL_WIDTHS)).toContain(policy.physicalKind);
+      expect(policy.defaultValue).toBeDefined();
+      expect(policy.defaultValueSource).not.toBe("");
+      expect(policy.tsInputType).not.toBe("");
+      expect(policy.tsKernelOutputType).not.toBe("");
+      expect(typeof policy.kernelOutputOptional).toBe("boolean");
+      expect(typeof policy.coerce).toBe("function");
+      expect(typeof policy.encodeAtRest).toBe("function");
+      expect(typeof policy.parseEditorText).toBe("function");
+    });
+
+    it("agrees with computeTokenSlotLayout on the physical layout", () => {
+      const layout = computeTokenSlotLayout([element(type)]);
+
+      expect(layout.fields).toHaveLength(1);
+      const field = layout.fields[0]!;
+      const physical = PHYSICAL_WIDTHS[policy.physicalKind];
+      expect(field.kind).toBe(policy.physicalKind);
+      expect(field.byteSize).toBe(physical.byteSize);
+      expect(field.byteOffset % physical.align).toBe(0);
+      expect(layout.strideBytes).toBeGreaterThanOrEqual(physical.byteSize);
+    });
+
+    it("carries a number-slot decoder exactly for f64/u8 kinds", () => {
+      const isNumberSlot =
+        policy.physicalKind === "f64" || policy.physicalKind === "u8";
+      expect(policy.decodeNumberSlot !== null).toBe(isNumberSlot);
+    });
+
+    it("round-trips the default value through coercion unchanged", () => {
+      expect(
+        coerceTokenAttributeValue(
+          element(type),
+          policy.defaultValue,
+          "conformance",
+        ),
+      ).toBe(policy.defaultValue);
+      expect(policy.coerce(policy.defaultValue, "conformance")).toBe(
+        policy.defaultValue,
+      );
+    });
+
+    it("encodes at rest to a JSON-serializable value", () => {
+      const stored = policy.encodeAtRest(policy.defaultValue);
+      expect(typeof stored).not.toBe("bigint");
+      expect(() => JSON.stringify(stored)).not.toThrow();
+      expect(JSON.stringify(stored)).toBeDefined();
+    });
+
+    it("parses editor text totally (empty input yields a value of the type)", () => {
+      const parsed = policy.parseEditorText("");
+      // The parsed empty-input value must itself coerce cleanly.
+      expect(policy.coerce(parsed, "conformance")).toBe(parsed);
+    });
+  });
+});

--- a/libs/@hashintel/petrinaut-core/src/simulation/engine/type-policies.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/engine/type-policies.ts
@@ -1,0 +1,219 @@
+import { formatUuid, NIL_UUID, toUuid } from "./uuid";
+
+import type { ColorElementType, TokenAttributeValue } from "../../types/sdcpn";
+
+/**
+ * Physical (buffer-level) representation of one token attribute in the
+ * packed-struct token layout:
+ *
+ * - `f64`: 8 bytes, 8-byte aligned (`real` and `integer` elements).
+ * - `u8`: 1 byte, 1-byte aligned (`boolean` elements).
+ * - `u64`: 8 bytes, 8-byte aligned (`string` elements — one little-endian
+ *   64-bit ID into the simulation's `StringPool`, not the string itself).
+ * - `u64x2`: 16 bytes, 8-byte aligned (`uuid` elements — two little-endian
+ *   64-bit lanes: `lo` at the field's byteOffset, `hi` at +8).
+ */
+export type PhysicalKind = "f64" | "u8" | "u64" | "u64x2";
+
+/**
+ * JSON-serializable at-rest form of a token attribute value, as stored in
+ * documents, scenario `per_place` rows, and compiled initial markings.
+ * `uuid` bigints are stored as canonical lowercase 36-character strings;
+ * every other type's runtime form is already JSON-safe.
+ */
+export type StoredTokenAttributeValue = number | boolean | string;
+
+/**
+ * Everything the rest of the codebase needs to know about one
+ * `ColorElementType`, gathered in a single registry so adding a new element
+ * type means filling in exactly one record (plus the genuinely structural
+ * sites, e.g. uuid sentinel handling in `encode-kernel-token.ts`).
+ *
+ * `type-policies.test.ts` is the conformance test: it fails loudly when a
+ * type is missing a policy or a policy is internally inconsistent.
+ */
+export type TypePolicy = {
+  /** Physical layout kind in the packed token struct (see `token-layout.ts`). */
+  physicalKind: PhysicalKind;
+  /** Logical default value (runtime form). */
+  defaultValue: TokenAttributeValue;
+  /**
+   * TS source expression producing a default value for this type in
+   * generated default transition-kernel code (see `default-codes.ts`).
+   */
+  defaultValueSource: string;
+  /** TS type string the LSP virtual files use for token *inputs*. */
+  tsInputType: string;
+  /**
+   * TS type string the LSP virtual files use for transition-kernel *output*
+   * token attributes. Mode-dependent widening (e.g. `real` accepting a
+   * `Distribution` under stochasticity) stays in the generator.
+   */
+  tsKernelOutputType: string;
+  /**
+   * Whether kernel outputs may omit the attribute (`uuid` values are
+   * auto-generated from the seeded simulation RNG when omitted).
+   */
+  kernelOutputOptional: boolean;
+  /**
+   * Coerces an arbitrary (non-nullish) value to this type's runtime form.
+   * Throws with `context` when the value is not convertible; `uuid` and
+   * `string` conversions are total and never throw.
+   */
+  coerce: (value: unknown, context: string) => TokenAttributeValue;
+  /**
+   * Decodes one number-slot (`f64` / `u8`) buffer value back into a logical
+   * token attribute value, or `null` for types not stored in number slots
+   * (`uuid` lanes and `string` pool references are decoded in
+   * `token-layout.ts`).
+   */
+  decodeNumberSlot: ((encodedValue: number) => TokenAttributeValue) | null;
+  /** Converts a runtime value to its JSON-serializable at-rest form. */
+  encodeAtRest: (value: TokenAttributeValue) => StoredTokenAttributeValue;
+  /**
+   * Parses raw spreadsheet cell editor text into a runtime value. Total:
+   * unparseable input falls back to a zero-ish value rather than throwing.
+   */
+  parseEditorText: (rawValue: string) => TokenAttributeValue;
+};
+
+/**
+ * Every `ColorElementType`, in declaration order of the union. The canonical
+ * runtime list — the zod colour element schema and the conformance test both
+ * derive from it. `satisfies` keeps it in lockstep with the union (and
+ * `TYPE_POLICIES` being a `Record` over the union guarantees the reverse
+ * direction: a new union member without a policy fails to compile).
+ */
+export const COLOR_ELEMENT_TYPES = [
+  "real",
+  "integer",
+  "boolean",
+  "uuid",
+  "string",
+] as const satisfies readonly ColorElementType[];
+
+function coerceNumber(value: unknown, context: string): number {
+  const numberValue = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(numberValue)) {
+    throw new Error(`${context} must be a finite number.`);
+  }
+  return numberValue;
+}
+
+function coerceBoolean(value: unknown, context: string): boolean {
+  if (typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value === "number") {
+    return value !== 0;
+  }
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === "true" || normalized === "1") {
+      return true;
+    }
+    if (normalized === "false" || normalized === "0" || normalized === "") {
+      return false;
+    }
+  }
+  throw new Error(`${context} must be a boolean.`);
+}
+
+/**
+ * At-rest identity for types whose runtime form is already JSON-safe. Total
+ * over `TokenAttributeValue`: a (well-typed-ly unreachable) bigint is
+ * formatted rather than leaking into JSON.
+ */
+const storeVerbatim = (value: TokenAttributeValue): StoredTokenAttributeValue =>
+  typeof value === "bigint" ? formatUuid(value) : value;
+
+/**
+ * Editor text → finite number. Pasting "Infinity" or overflowing notation
+ * must not leak non-finite numbers into stored state (coercion rejects them
+ * later); non-finite parses clamp to 0.
+ */
+function parseFiniteNumber(rawValue: string): number {
+  const parsed = Number.parseFloat(rawValue);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export const TYPE_POLICIES: Record<ColorElementType, TypePolicy> = {
+  real: {
+    physicalKind: "f64",
+    defaultValue: 0,
+    defaultValueSource: "0",
+    tsInputType: "number",
+    tsKernelOutputType: "number",
+    kernelOutputOptional: false,
+    coerce: coerceNumber,
+    decodeNumberSlot: (encodedValue) => encodedValue,
+    encodeAtRest: storeVerbatim,
+    parseEditorText: (rawValue) => parseFiniteNumber(rawValue),
+  },
+  integer: {
+    physicalKind: "f64",
+    defaultValue: 0,
+    defaultValueSource: "0",
+    tsInputType: "number",
+    tsKernelOutputType: "number",
+    kernelOutputOptional: false,
+    coerce: (value, context) => Math.round(coerceNumber(value, context)),
+    decodeNumberSlot: (encodedValue) => Math.round(encodedValue),
+    encodeAtRest: storeVerbatim,
+    parseEditorText: (rawValue) => Math.round(parseFiniteNumber(rawValue)),
+  },
+  boolean: {
+    physicalKind: "u8",
+    defaultValue: false,
+    defaultValueSource: "false",
+    tsInputType: "boolean",
+    tsKernelOutputType: "boolean",
+    kernelOutputOptional: false,
+    coerce: coerceBoolean,
+    decodeNumberSlot: (encodedValue) => encodedValue !== 0,
+    encodeAtRest: storeVerbatim,
+    parseEditorText: (rawValue) => {
+      const normalized = rawValue.trim().toLowerCase();
+      return normalized === "true" || normalized === "1";
+    },
+  },
+  uuid: {
+    physicalKind: "u64x2",
+    defaultValue: NIL_UUID,
+    defaultValueSource: "Uuid.generate()",
+    tsInputType: "bigint",
+    // uuid kernel outputs also accept UUID strings and the `Uuid.generate()`
+    // / `Uuid.from(value)` sentinels.
+    tsKernelOutputType: "bigint | string | PetrinautUuid",
+    kernelOutputOptional: true,
+    // Total conversion: bigints and UUID strings pass through/parse, and any
+    // other value maps deterministically to a UUIDv5 — never throws.
+    coerce: (value) => toUuid(value),
+    decodeNumberSlot: null,
+    // toUuid unconditionally: it passes in-range bigints through and maps
+    // everything else (including out-of-range bigints) deterministically,
+    // so the stored string is always a canonical UUID.
+    encodeAtRest: (value) => formatUuid(toUuid(value)),
+    // Valid UUID strings parse; anything else converts deterministically via
+    // UUIDv5. Clearing the cell resets to the nil uuid.
+    parseEditorText: (rawValue) => {
+      const trimmed = rawValue.trim();
+      return trimmed === "" ? NIL_UUID : toUuid(trimmed);
+    },
+  },
+  string: {
+    physicalKind: "u64",
+    defaultValue: "",
+    defaultValueSource: '""',
+    tsInputType: "string",
+    tsKernelOutputType: "string",
+    kernelOutputOptional: false,
+    // Total conversion: any value stringifies; nullish values resolve to the
+    // default ("") before reaching this.
+    coerce: (value) => (typeof value === "string" ? value : String(value)),
+    decodeNumberSlot: null,
+    encodeAtRest: storeVerbatim,
+    // Identity — string cells keep the entered text verbatim (no trim).
+    parseEditorText: (rawValue) => rawValue,
+  },
+};

--- a/libs/@hashintel/petrinaut/src/react/simulation/provider/migrate-initial-marking.ts
+++ b/libs/@hashintel/petrinaut/src/react/simulation/provider/migrate-initial-marking.ts
@@ -1,7 +1,5 @@
 import {
-  coerceTokenAttributeValue,
-  defaultTokenAttributeValue,
-  formatUuid,
+  coerceToStoredTokenAttributeValue,
   type Color,
   type InitialMarking,
   type InitialTokenAttributeValue,
@@ -74,19 +72,12 @@ const typeElementsNeedMigration = (
 const coerceStoredValue = (
   element: ColorElement,
   value: unknown,
-): InitialTokenAttributeValue => {
-  let coerced;
-  try {
-    coerced = coerceTokenAttributeValue(
-      element,
-      value,
-      `Initial marking value for element "${element.name}"`,
-    );
-  } catch {
-    coerced = defaultTokenAttributeValue(element.type);
-  }
-  return typeof coerced === "bigint" ? formatUuid(coerced) : coerced;
-};
+): InitialTokenAttributeValue =>
+  coerceToStoredTokenAttributeValue(
+    element,
+    value,
+    `Initial marking value for element "${element.name}"`,
+  );
 
 /**
  * Rebuilds one name-keyed token record against the type's new elements:

--- a/libs/@hashintel/petrinaut/src/ui/components/spreadsheet.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/components/spreadsheet.tsx
@@ -5,6 +5,7 @@ import {
   defaultTokenAttributeValue,
   formatUuid,
   toUuid,
+  TYPE_POLICIES,
 } from "@hashintel/petrinaut-core";
 
 export interface SpreadsheetColumn {
@@ -276,37 +277,12 @@ const getCellTitle = (
   return undefined;
 };
 
-// Pasting "Infinity" or overflowing notation must not leak non-finite
-// numbers into stored state (the runtime codecs reject them later).
-const parseFiniteNumber = (rawValue: string): number => {
-  const parsed = Number.parseFloat(rawValue);
-  return Number.isFinite(parsed) ? parsed : 0;
-};
+/** Untyped columns parse like `real` (the per-type behaviour lives in core). */
 const parseCellValue = (
   column: SpreadsheetColumn | undefined,
   rawValue: string,
-): SpreadsheetCellValue => {
-  switch (column?.type) {
-    case "boolean": {
-      const normalized = rawValue.trim().toLowerCase();
-      return normalized === "true" || normalized === "1";
-    }
-    case "integer":
-      return Math.round(parseFiniteNumber(rawValue));
-    case "string":
-      // Identity — string cells keep the entered text verbatim (no trim).
-      return rawValue;
-    case "uuid": {
-      // Valid UUID strings parse; anything else converts deterministically
-      // via UUIDv5. Clearing the cell resets to the nil uuid.
-      const trimmed = rawValue.trim();
-      return trimmed === "" ? 0n : toUuid(trimmed);
-    }
-    case "real":
-    default:
-      return parseFiniteNumber(rawValue);
-  }
-};
+): SpreadsheetCellValue =>
+  TYPE_POLICIES[column?.type ?? "real"].parseEditorText(rawValue);
 
 export const Spreadsheet: React.FC<SpreadsheetProps> = ({
   columns,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Pure refactor closing out the discrete-types architecture retrospective: adding a token dimension type previously meant editing `switch (element.type)` statements in seven far-apart places (buffer layout, coercion/defaults, generated kernel code, LSP virtual files, schema migration, scenario compilation, spreadsheet cell parsing) that stayed consistent by convention only. This PR gathers the per-type *data* into a single `TYPE_POLICIES` registry in petrinaut-core and adds a conformance test so a sixth type fails loudly until every touchpoint is defined.

## 🔗 Related links

- [FE-1153: Petrinaut: collapse per-type switches into a type-policy registry](https://linear.app/hash/issue/FE-1153/petrinaut-collapse-per-type-switches-into-a-type-policy-registry) _(internal)_
- Top of the discrete-types stack: #8956 → #8953 → #8951 → #8944 → #8943 → #8764.

## 🚫 Blocked by

- [ ] #8956 (and its base chain — merges first)

## 🔍 What does this change?

**New `simulation/engine/type-policies.ts`**: `TYPE_POLICIES: Record<ColorElementType, TypePolicy>` where each policy carries:

- `physicalKind` (`f64` | `u8` | `u64` | `u64x2`) — packed-struct layout kind
- `defaultValue` (runtime form) and `defaultValueSource` (TS expression for generated default kernels, e.g. `Uuid.generate()`)
- `tsInputType` / `tsKernelOutputType` / `kernelOutputOptional` — LSP virtual-file type strings
- `coerce(value, context)` — runtime coercion (the old switch bodies)
- `decodeNumberSlot` — f64/u8 slot decode, `null` for uuid/string (decoded in `token-layout.ts`)
- `encodeAtRest(value)` — runtime → JSON-safe document form (uuid bigint → canonical lowercase string)
- `parseEditorText(raw)` — total spreadsheet cell parse

Plus `COLOR_ELEMENT_TYPES`, the canonical runtime list of the union (`as const satisfies` keeps it in lockstep; the `Record` shape guarantees the reverse direction at compile time).

**Consumers converted** (existing exported function names kept as thin wrappers, so the public API is unchanged): `token-values.ts` (defaults/coercion/number-slot decode; new shared `coerceToStoredTokenAttributeValue` helper), `token-layout.ts` (`physicalTypeFor`), `default-codes.ts`, `lsp/lib/generate-virtual-files.ts`, `schema-migration.ts`, `compile-scenario.ts`, and in the React package `migrate-initial-marking.ts` and the spreadsheet's `parseCellValue`. The zod colour element schema's `type` enum now derives from `COLOR_ELEMENT_TYPES`.

**Deliberately left structural** (control flow, not per-type data): uuid sentinel/RNG handling and string interning in `encode-kernel-token.ts`; uuid-lane/string-pool read-write paths in `token-layout.ts`; the `real`+stochasticity `Distribution` union and `?: never` derivative exclusions in the LSP generator; spreadsheet uuid short-form/overlay and boolean-checkbox rendering (presentation); `scenario-mapping.ts` / `initial-state-editor.tsx` at-rest decoding (intentionally laxer semantics than core coercion — converting them would change behaviour).

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] modifies an **npm**-publishable library and **I have added a changeset file(s)** (`fe-1153-type-policy-registry.md` — the registry and its types are new public exports)

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] do not require any changes to docs (no user-facing behaviour change)

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

- The registry intentionally does not absorb mode-dependent LSP logic or UI rendering; those stay exhaustive switches at their sites.

## 🐾 Next steps

- A future Enum element type should be addable by filling in one `TypePolicy` record plus the structural sites the conformance test points at.

## 🛡 What tests cover this?

- New `type-policies.test.ts` (32 assertions): registry keys ≡ `COLOR_ELEMENT_TYPES` ≡ the zod enum's options; per type: `physicalKind` agrees with `computeTokenSlotLayout` (kind, width, alignment); `decodeNumberSlot` present iff f64/u8; defaults round-trip coercion unchanged; at-rest encode is JSON-serializable; editor parse is total and coercion-stable.
- All pre-existing tests pass unmodified (665 core + 149 UI), which is the no-behaviour-change evidence.

## ❓ How to test this?

`npx turbo run lint:tsc lint:eslint test:unit --filter '@hashintel/petrinaut-core' --filter '@hashintel/petrinaut'` — behaviour is otherwise identical to #8956.

## 📹 Demo

N/A — no user-facing change.

