### PR TITLE
FE-1133: Add drawer to ds

### DIFF
--- a/libs/@hashintel/ds-components/src/beta/spinner/speed.story.tsx
+++ b/libs/@hashintel/ds-components/src/beta/spinner/speed.story.tsx
@@ -1,5 +1,5 @@
 import { Spinner } from "../spinner";
 
 export const App = () => {
-  return <Spinner animationDuration=".8s" />;
+  return <Spinner animationDuration="[.8s]" />;
 };

--- a/libs/@hashintel/ds-components/src/components/Dialog/dialog.recipe.ts
+++ b/libs/@hashintel/ds-components/src/components/Dialog/dialog.recipe.ts
@@ -20,22 +20,6 @@ export const styles = sva({
           visibility: "hidden",
         },
     },
-    backdrop: {
-      background: "black.a60",
-      position: "fixed",
-      inset: "0",
-      width: "[100dvw]",
-      height: "[100dvh]",
-      zIndex: "modal",
-      _open: {
-        animationName: "fadeIn",
-        animationDuration: "fast",
-      },
-      _closed: {
-        animationName: "fadeOut",
-        animationDuration: "faster",
-      },
-    },
     positioner: {
       display: "flex",
       flexDirection: "column",
@@ -70,7 +54,8 @@ export const styles = sva({
       width: "[100%]",
       maxHeight: "[calc(100dvh - 2rem)]",
       outline: "none",
-      boxShadow: "[0 10px 40px rgba(0, 0, 0, 0.2)]",
+      boxShadow:
+        "[0 0 0 1px rgba(0, 0, 0, 0.03), 0 1px 2px -1px rgba(0, 0, 0, 0.06), 0 8px 16px -6px rgba(0, 0, 0, 0.09), 0 18px 32px -14px rgba(0, 0, 0, 0.16)]",
       borderRadius: "xl",
       backgroundColor: "neutral.s10",
       padding: "1",

--- a/libs/@hashintel/ds-components/src/components/Dialog/dialog.recipe.ts
+++ b/libs/@hashintel/ds-components/src/components/Dialog/dialog.recipe.ts
@@ -13,12 +13,6 @@ export const styles = sva({
   base: {
     stackRoot: {
       display: "contents",
-      // Hide the backdrop of any dialog that has a nested dialog above it so
-      // the overlay doesn't darken cumulatively as the stack grows.
-      '&:has([data-scope="dialog"][data-part="content"][data-has-nested]) [data-scope="dialog"][data-part="backdrop"]':
-        {
-          visibility: "hidden",
-        },
     },
     positioner: {
       display: "flex",

--- a/libs/@hashintel/ds-components/src/components/Dialog/dialog.recipe.ts
+++ b/libs/@hashintel/ds-components/src/components/Dialog/dialog.recipe.ts
@@ -54,6 +54,7 @@ export const styles = sva({
       backgroundColor: "neutral.s10",
       padding: "1",
 
+      // The first (bottom-most) dialog scales in/out like a popover.
       _open: {
         animationName: "popoverIn",
         animationDuration: "fast",
@@ -62,6 +63,16 @@ export const styles = sva({
         animationName: "popoverOut",
         animationDuration: "faster",
       },
+      // Turn off animating a nested dialog in, as its too noisy on top of animating the lower dialogs into a stack
+      '[data-overlay-stack-root]:has([data-part="backdrop"][data-state="open"]) ~ [data-overlay-stack-root] &':
+        {
+          _open: {
+            animationName: "[none]",
+          },
+          _closed: {
+            animationName: "[none]",
+          },
+        },
       // When another dialog is opened on top, shift this one up-and-left by
       // 30px per layer above it so the stack reads visually.
       "&[data-has-nested]": {

--- a/libs/@hashintel/ds-components/src/components/Dialog/dialog.recipe.ts
+++ b/libs/@hashintel/ds-components/src/components/Dialog/dialog.recipe.ts
@@ -29,11 +29,11 @@ export const styles = sva({
       zIndex: "modal",
       _open: {
         animationName: "fadeIn",
-        animationDuration: "normal",
+        animationDuration: "fast",
       },
       _closed: {
         animationName: "fadeOut",
-        animationDuration: "fast",
+        animationDuration: "faster",
       },
     },
     positioner: {
@@ -76,12 +76,12 @@ export const styles = sva({
       padding: "1",
 
       _open: {
-        animationName: "fadeIn",
-        animationDuration: "normal",
+        animationName: "popoverIn",
+        animationDuration: "fast",
       },
       _closed: {
-        animationName: "fadeOut",
-        animationDuration: "fast",
+        animationName: "popoverOut",
+        animationDuration: "faster",
       },
       // When another dialog is opened on top, shift this one up-and-left by
       // 30px per layer above it so the stack reads visually.

--- a/libs/@hashintel/ds-components/src/components/Dialog/dialog.recipe.ts
+++ b/libs/@hashintel/ds-components/src/components/Dialog/dialog.recipe.ts
@@ -2,27 +2,14 @@ import { dialogAnatomy } from "@ark-ui/react/anatomy";
 
 import { sva } from "@hashintel/ds-helpers/css";
 
+/**
+ * The header / body / footer chrome is shared with the Drawer and lives in
+ * `../../util/overlay-parts.recipe`; the `--panel-*` custom properties
+ * declared on `content` below feed that shared chrome via inheritance.
+ */
 export const styles = sva({
   className: "dialog",
-  slots: dialogAnatomy
-    .extendWith(
-      "stackRoot",
-      "header",
-      "headerMain",
-      "headerText",
-      "titleIcon",
-      "headerActions",
-      "headerRight",
-      "hasCustomHeader",
-      "body",
-      "footer",
-      "footerActions",
-      "footerSecondaryActions",
-      "closeButton",
-      "loadingOverlay",
-      "loadingSpinner",
-    )
-    .keys(),
+  slots: dialogAnatomy.extendWith("stackRoot").keys(),
   base: {
     stackRoot: {
       display: "contents",
@@ -74,17 +61,15 @@ export const styles = sva({
       },
     },
     content: {
-      "--dialog-horizontal-padding": "var(--spacing-5\\.5)",
-      "--dialog-top-padding": "var(--spacing-4)",
-      "--dialog-close-button-gap": "var(--spacing-2)",
+      "--panel-horizontal-padding": "var(--spacing-5\\.5)",
+      "--panel-top-padding": "var(--spacing-4)",
+      "--panel-close-button-gap": "var(--spacing-2)",
       position: "relative",
       display: "flex",
       flexDirection: "column",
       width: "[100%]",
       maxHeight: "[calc(100dvh - 2rem)]",
       outline: "none",
-      // boxShadow:
-      // "[0px 0px 1px 0px rgba(0,0,0,0.02), 0px 1px 1px -0.5px rgba(0,0,0,0.04), 0px 6px 6px -3px rgba(0,0,0,0.04), 0px 12px 12px -6px rgba(0,0,0,0.03), 0px 24px 24px -12px rgba(0,0,0,0.02)]",
       boxShadow: "[0 10px 40px rgba(0, 0, 0, 0.2)]",
       borderRadius: "xl",
       backgroundColor: "neutral.s10",
@@ -106,190 +91,27 @@ export const styles = sva({
           "translate(calc(var(--nested-layer-count) * -22px), calc(var(--nested-layer-count) * -22px))",
       },
     },
-    header: {
-      flex: "[0 0 auto]",
-      backgroundColor: "white",
-      border: "[1px solid {colors.neutral.s50}]",
-      borderTopRadius: "lg",
-      borderBottom: "[1px solid {colors.neutral.s30}]",
-      paddingX: "[var(--dialog-horizontal-padding)]",
-      paddingTop: "[var(--dialog-top-padding)]",
-      paddingBottom: "3.5",
-    },
-    hasCustomHeader: {
-      display: "flex",
-      alignItems: "flex-start",
-      gap: "2",
-      flex: "[1 1 auto]",
-      minWidth: "0",
-    },
-    headerMain: {},
-    headerText: {},
-    titleIcon: {
-      float: "start",
-      marginLeft: "-0.5",
-      marginRight: "2",
-      color: "neutral.s90",
-      flex: "[0 0 auto]",
-      backgroundColor: "neutral.s25",
-      borderRadius: "full",
-      padding: "1",
-      alignSelf: "flex-start",
-      top: "[1.5px]",
-      position: "relative",
-    },
-    title: {
-      display: "inline",
-      fontWeight: "semibold",
-      textStyle: "lg",
-      color: "fg.body",
-    },
-    description: {
-      color: "fg.muted",
-      textStyle: "sm",
-      marginTop: "-0.5",
-    },
-    headerRight: {
-      float: "end",
-      display: "flex",
-      alignItems: "center",
-      gap: "[1px]",
-    },
-    headerActions: {
-      display: "flex",
-      marginLeft: "auto",
-      alignItems: "center",
-      gap: "[1px]",
-      flex: "[0 0 auto]",
-      marginTop:
-        "[calc(var(--dialog-top-padding) * -1 + var(--dialog-close-button-gap))]",
-    },
-    body: {
-      position: "relative",
-      flex: "[1 1 auto]",
-      minHeight: "0",
-      overflow: "auto",
-      scrollbarWidth: "[thin]",
-      background: "white",
-      border: "[1px solid {colors.neutral.s50}]",
-      borderTop: "none",
-      color: "fg.body",
-      textStyle: "sm",
-      paddingX: "[var(--dialog-horizontal-padding)]",
-      paddingTop: "4",
-      paddingBottom: "5",
-      // While loading, lock the body's scroll so the absolutely-positioned
-      // overlay stays pinned to the visible area instead of riding the
-      // scrolled content.
-      '[aria-busy="true"] &': {
-        overflow: "hidden",
-      },
-      _focusVisible: {
-        outlineColor: "neutral.a50",
-      },
-    },
-    footer: {
-      flex: "[0 0 auto]",
-      display: "flex",
-      alignItems: "flex-start",
-      justifyContent: "space-between",
-      gap: "3",
-      paddingX: "[var(--dialog-horizontal-padding)]",
-      paddingTop: "3.5",
-      paddingBottom: "3",
-    },
-    footerActions: {
-      display: "flex",
-      flexWrap: "wrap",
-      justifyContent: "flex-end",
-      alignItems: "center",
-      gap: "2",
-      marginLeft: "auto",
-    },
-    footerSecondaryActions: {
-      display: "flex",
-      flexWrap: "wrap",
-      alignItems: "center",
-      gap: "2",
-    },
-    closeButton: {
-      flex: "[0 0 auto]",
-      marginLeft: "auto",
-      float: "end",
-      position: "relative",
-      zIndex: "[1]",
-      marginTop:
-        "[calc(var(--dialog-top-padding) * -1 + var(--dialog-close-button-gap))]",
-      marginRight:
-        "[calc(var(--dialog-horizontal-padding) * -1 + var(--dialog-close-button-gap))]",
-    },
-    loadingOverlay: {
-      position: "absolute",
-      inset: "0",
-      display: "flex",
-      alignItems: "center",
-      justifyContent: "center",
-      background: "[rgba(255, 255, 255, 0.88)]",
-      zIndex: "[1]",
-      borderRadius: "[inherit]",
-    },
-    loadingSpinner: {
-      width: "[auto !important]",
-      aspectRatio: "1",
-      maxHeight: "[60%]",
-      color: "black",
-    },
   },
   variants: {
     size: {
       xs: {
         content: {
           maxWidth: "[400px]",
-          "--dialog-horizontal-padding": "var(--spacing-4)",
-          "--dialog-top-padding": "var(--spacing-3\\.5)",
-        },
-        header: {
-          paddingBottom: "3",
-        },
-        body: {
-          paddingTop: "4",
-          paddingBottom: "4.5",
-        },
-        footer: {
-          paddingTop: "3",
-          paddingBottom: "2.5",
+          "--panel-horizontal-padding": "var(--spacing-4)",
+          "--panel-top-padding": "var(--spacing-3\\.5)",
         },
       },
       sm: {
         content: { maxWidth: "[520px]" },
-        loadingSpinner: { height: "[38px !important]" },
       },
       md: {
         content: { maxWidth: "[640px]" },
-        loadingSpinner: { height: "[40px !important]" },
-        headerMain: { display: "flex", alignItems: "flex-start", gap: "2" },
-        titleIcon: { marginRight: "0" },
-        headerText: { flex: "[1 1 auto]", minWidth: "[0]" },
       },
       lg: {
         content: { maxWidth: "[860px]" },
-        loadingSpinner: {
-          height: "[45px !important]",
-          color: "neutral.s115",
-        },
-        headerMain: { display: "flex", alignItems: "flex-start", gap: "2" },
-        titleIcon: { marginRight: "0" },
-        headerText: { flex: "[1 1 auto]", minWidth: "[0]" },
       },
       xl: {
         content: { maxWidth: "[1060px]" },
-        loadingSpinner: {
-          height: "[50px !important]",
-          color: "neutral.s115",
-        },
-        headerMain: { display: "flex", alignItems: "flex-start", gap: "2" },
-        titleIcon: { marginRight: "0" },
-        headerText: { flex: "[1 1 auto]", minWidth: "[0]" },
       },
       fullScreen: {
         positioner: { padding: "0" },
@@ -300,71 +122,9 @@ export const styles = sva({
           maxHeight: "[100dvh]",
           borderRadius: "[0]",
         },
-        loadingSpinner: {
-          height: "[50px !important]",
-          color: "neutral.s110",
-        },
-        headerMain: { display: "flex", alignItems: "flex-start", gap: "2" },
-        titleIcon: { marginRight: "0" },
-        headerText: { flex: "[1 1 auto]", minWidth: "[0]" },
-      },
-    },
-    variant: {
-      partitionedFooter: {
-        body: {
-          borderBottomRadius: "lg",
-        },
-      },
-      plain: {
-        header: {
-          borderBottomColor: "neutral.s20",
-        },
-        body: {
-          borderBottom: "none",
-        },
-        footer: {
-          backgroundColor: "white",
-          border: "[1px solid {colors.neutral.s50}]",
-          borderBottomRadius: "lg",
-          borderTop: "[1px solid {colors.neutral.s20}]",
-        },
-      },
-    },
-    hasIcon: {
-      true: {
-        description: { marginTop: "0.5" },
-      },
-    },
-    headerless: {
-      true: {
-        header: {
-          paddingBottom: "0",
-          borderBottom: "none",
-        },
-        closeButton: {
-          marginBottom: "-1.5",
-        },
-        body: {
-          paddingTop: "0",
-          paddingBottom: "6",
-        },
       },
     },
   },
-  compoundVariants: [
-    {
-      headerless: true,
-      size: "xs",
-      css: {
-        header: {
-          paddingBottom: "0",
-        },
-        body: {
-          paddingBottom: "5",
-        },
-      },
-    },
-  ],
   defaultVariants: {
     size: "md",
   },

--- a/libs/@hashintel/ds-components/src/components/Dialog/dialog.recipe.ts
+++ b/libs/@hashintel/ds-components/src/components/Dialog/dialog.recipe.ts
@@ -63,7 +63,7 @@ export const styles = sva({
     content: {
       "--panel-horizontal-padding": "var(--spacing-5\\.5)",
       "--panel-top-padding": "var(--spacing-4)",
-      "--panel-close-button-gap": "var(--spacing-2)",
+      "--panel-close-button-gap": "var(--spacing-3\\.5)",
       position: "relative",
       display: "flex",
       flexDirection: "column",
@@ -99,10 +99,16 @@ export const styles = sva({
           maxWidth: "[400px]",
           "--panel-horizontal-padding": "var(--spacing-4)",
           "--panel-top-padding": "var(--spacing-3\\.5)",
+          "--panel-close-button-gap": "var(--spacing-2\\.5)",
         },
       },
       sm: {
-        content: { maxWidth: "[520px]" },
+        content: {
+          maxWidth: "[520px]",
+          "--panel-horizontal-padding": "var(--spacing-4)",
+          "--panel-top-padding": "var(--spacing-3\\.5)",
+          "--panel-close-button-gap": "var(--spacing-2\\.5)",
+        },
       },
       md: {
         content: { maxWidth: "[640px]" },

--- a/libs/@hashintel/ds-components/src/components/Dialog/dialog.tsx
+++ b/libs/@hashintel/ds-components/src/components/Dialog/dialog.tsx
@@ -1,181 +1,23 @@
 import { Dialog as ArkDialog } from "@ark-ui/react/dialog";
 import { Portal } from "@ark-ui/react/portal";
+import { useMemo } from "react";
+
+import { cx } from "@hashintel/ds-helpers/css";
+
 import {
-  Children,
-  createContext,
-  isValidElement,
-  useContext,
-  useMemo,
-} from "react";
-
-import { css, cx } from "@hashintel/ds-helpers/css";
-
+  OverlayBody,
+  OverlayFooter,
+  OverlayHeader,
+  OverlaySections,
+  type OverlayBodyProps,
+  type OverlayFooterProps,
+  type OverlayHeaderProps,
+  type OverlayShouldCloseOn,
+} from "../../util/overlay-parts";
 import { usePortalContainerRef } from "../../util/portal-container-context";
-import { Button } from "../Button/button";
-import { Icon, type IconName } from "../Icon/icon";
-import { LoadingSpinner } from "../Loading/loading-spinner";
 import { styles } from "./dialog.recipe";
 
-import type { ExclusifyUnion, RequireAtLeastOne } from "type-fest";
-
 export type DialogSize = "xs" | "sm" | "md" | "lg" | "xl" | "fullScreen";
-
-export type DialogShouldCloseOn =
-  | "closeButtonAndOverlay"
-  | "closeButton"
-  | "none";
-
-const DialogContext = createContext<{
-  classes: ReturnType<typeof styles>;
-  onClose?: () => void;
-  renderCloseButton: boolean;
-  loading?: boolean;
-} | null>(null);
-
-const useDialogContext = () => {
-  const ctx = useContext(DialogContext);
-  if (!ctx) {
-    throw new Error(
-      "Dialog.Header, Dialog.Body and Dialog.Footer must be rendered inside <Dialog>",
-    );
-  }
-  return ctx;
-};
-
-type HeaderProps = ExclusifyUnion<
-  | {
-      title?: React.ReactNode;
-      description?: React.ReactNode;
-      iconName?: IconName;
-      actions?: React.ReactNode;
-    }
-  | {
-      children?: React.ReactNode;
-    }
->;
-const Header = ({
-  title,
-  description,
-  iconName,
-  actions,
-  children,
-}: HeaderProps) => {
-  const { classes, onClose, renderCloseButton } = useDialogContext();
-
-  const hasStructuredHeader =
-    title !== undefined ||
-    description !== undefined ||
-    iconName !== undefined ||
-    actions !== undefined;
-
-  const closeButton = renderCloseButton && (
-    <Button
-      variant="ghost"
-      className={classes.closeButton}
-      aria-label="Close dialog"
-      onClick={() => {
-        onClose?.();
-      }}
-      iconName="close"
-      size="sm"
-    />
-  );
-
-  if (!hasStructuredHeader) {
-    return (
-      <div className={cx(classes.header, classes.hasCustomHeader)}>
-        {children && <div>{children}</div>}
-        {closeButton}
-      </div>
-    );
-  }
-
-  return (
-    <div className={classes.header}>
-      <div className={classes.headerMain}>
-        {iconName && (
-          <Icon name={iconName} size="md" className={classes.titleIcon} />
-        )}
-        {/*
-         * The actions/close float to the end within this text column so the
-         * title and description wrap around them. On md and up the column is a
-         * flex item (its own formatting context) sitting to the right of the
-         * flexed icon; on xs/sm it is a transparent block, so the icon float
-         * from headerMain still reaches the text.
-         */}
-        <div className={classes.headerText}>
-          {actions ? (
-            <div className={classes.headerRight}>
-              <div className={classes.headerActions}>{actions}</div>
-              {closeButton}
-            </div>
-          ) : (
-            closeButton
-          )}
-          {title && (
-            <ArkDialog.Title className={classes.title}>{title}</ArkDialog.Title>
-          )}
-          {description && (
-            <ArkDialog.Description className={classes.description}>
-              {description}
-            </ArkDialog.Description>
-          )}
-        </div>
-      </div>
-    </div>
-  );
-};
-
-type FooterProps = ExclusifyUnion<
-  | { children?: React.ReactNode }
-  | RequireAtLeastOne<{
-      actions?: React.ReactNode;
-      secondaryActions?: React.ReactNode;
-    }>
->;
-const Footer = ({ children, actions, secondaryActions }: FooterProps) => {
-  const { classes } = useDialogContext();
-
-  return (
-    <div className={classes.footer}>
-      {children ?? (
-        <>
-          {secondaryActions && (
-            <div className={classes.footerSecondaryActions}>
-              {secondaryActions}
-            </div>
-          )}
-          {actions && <div className={classes.footerActions}>{actions}</div>}
-        </>
-      )}
-    </div>
-  );
-};
-
-type BodyProps = {
-  children: React.ReactNode;
-  /** Turn padding on/off. Used when the body content controls padding itself. defaults to true */
-  withPadding?: boolean;
-};
-const Body = ({ children, withPadding = true }: BodyProps) => {
-  const { classes, loading } = useDialogContext();
-
-  return (
-    <div
-      className={cx(
-        classes.body,
-        !withPadding && css({ padding: "[0 !important]" }),
-      )}
-    >
-      {children}
-      {loading ? (
-        <div className={classes.loadingOverlay} aria-live="polite">
-          <LoadingSpinner size="lg" className={classes.loadingSpinner} />
-        </div>
-      ) : null}
-    </div>
-  );
-};
 
 const DialogRoot = ({
   className,
@@ -196,16 +38,16 @@ const DialogRoot = ({
   variant?: "partitionedFooter" | "plain";
   children:
     | readonly [
-        React.ReactElement<HeaderProps, typeof Header>,
-        React.ReactElement<BodyProps, typeof Body>,
-        React.ReactElement<FooterProps, typeof Footer>?,
+        React.ReactElement<OverlayHeaderProps, typeof OverlayHeader>,
+        React.ReactElement<OverlayBodyProps, typeof OverlayBody>,
+        React.ReactElement<OverlayFooterProps, typeof OverlayFooter>?,
       ]
     | readonly [
-        React.ReactElement<BodyProps, typeof Body>,
-        React.ReactElement<FooterProps, typeof Footer>?,
+        React.ReactElement<OverlayBodyProps, typeof OverlayBody>,
+        React.ReactElement<OverlayFooterProps, typeof OverlayFooter>?,
       ]
-    | React.ReactElement<BodyProps, typeof Body>;
-  shouldCloseOn?: DialogShouldCloseOn;
+    | React.ReactElement<OverlayBodyProps, typeof OverlayBody>;
+  shouldCloseOn?: OverlayShouldCloseOn;
   loading?: boolean;
   onClose?: () => void;
   initialFocusRef?: React.RefObject<HTMLElement>;
@@ -213,32 +55,11 @@ const DialogRoot = ({
 } & React.AriaAttributes) => {
   const portalContainerRef = usePortalContainerRef();
 
-  const headerChild = Children.toArray(children).find(
-    (child): child is React.ReactElement<HeaderProps, typeof Header> =>
-      isValidElement(child) && child.type === Header,
-  );
-  const hasHeader = !!headerChild;
-  const titleIconName = headerChild?.props.iconName;
-
-  const classes = useMemo(
-    () =>
-      styles({
-        size,
-        headerless: !hasHeader,
-        hasIcon: !!titleIconName,
-        variant,
-      }),
-    [size, hasHeader, titleIconName, variant],
-  );
+  const classes = useMemo(() => styles({ size }), [size]);
 
   const renderCloseButton = shouldCloseOn !== "none";
   const closeOnEscape = shouldCloseOn !== "none";
   const closeOnInteractOutside = shouldCloseOn === "closeButtonAndOverlay";
-
-  const ctx = useMemo(
-    () => ({ classes, onClose, renderCloseButton, loading }),
-    [classes, onClose, renderCloseButton, loading],
-  );
 
   return (
     <ArkDialog.Root
@@ -265,13 +86,18 @@ const DialogRoot = ({
               aria-busy={loading ?? undefined}
               onKeyDown={onKeyDown}
             >
-              <DialogContext.Provider value={ctx}>
-                {
-                  // if there's no header, we still display an empty one to display the close button + for layout
-                  !hasHeader && <Header />
-                }
+              <OverlaySections
+                size={size}
+                variant={variant}
+                onClose={onClose}
+                renderCloseButton={renderCloseButton}
+                loading={loading}
+                Title={ArkDialog.Title}
+                Description={ArkDialog.Description}
+                componentName="Dialog"
+              >
                 {children}
-              </DialogContext.Provider>
+              </OverlaySections>
             </ArkDialog.Content>
           </ArkDialog.Positioner>
         </div>
@@ -281,7 +107,7 @@ const DialogRoot = ({
 };
 
 export const Dialog = Object.assign(DialogRoot, {
-  Header,
-  Body,
-  Footer,
+  Header: OverlayHeader,
+  Body: OverlayBody,
+  Footer: OverlayFooter,
 });

--- a/libs/@hashintel/ds-components/src/components/Dialog/dialog.tsx
+++ b/libs/@hashintel/ds-components/src/components/Dialog/dialog.tsx
@@ -107,7 +107,7 @@ const DialogRoot = ({
       finalFocusEl={returnFocusRef ? () => returnFocusRef.current : undefined}
     >
       <Portal container={portalContainerRef}>
-        <div className={classes.stackRoot}>
+        <div className={classes.stackRoot} data-overlay-stack-root="">
           <ArkDialog.Backdrop className={backdropClassName} />
           <ArkDialog.Positioner className={classes.positioner}>
             <ArkDialog.Content

--- a/libs/@hashintel/ds-components/src/components/Dialog/dialog.tsx
+++ b/libs/@hashintel/ds-components/src/components/Dialog/dialog.tsx
@@ -14,10 +14,13 @@ import {
   type OverlayHeaderProps,
   type OverlayShouldCloseOn,
 } from "../../util/overlay-parts";
+import { overlayPartsStyles } from "../../util/overlay-parts.recipe";
 import { usePortalContainerRef } from "../../util/portal-container-context";
 import { styles } from "./dialog.recipe";
 
 export type DialogSize = "xs" | "sm" | "md" | "lg" | "xl" | "fullScreen";
+
+const backdropClassName = overlayPartsStyles({ component: "dialog" }).backdrop;
 
 const DialogRoot = ({
   className,
@@ -105,7 +108,7 @@ const DialogRoot = ({
     >
       <Portal container={portalContainerRef}>
         <div className={classes.stackRoot}>
-          <ArkDialog.Backdrop className={classes.backdrop} />
+          <ArkDialog.Backdrop className={backdropClassName} />
           <ArkDialog.Positioner className={classes.positioner}>
             <ArkDialog.Content
               {...ariaAttributes}

--- a/libs/@hashintel/ds-components/src/components/Dialog/dialog.tsx
+++ b/libs/@hashintel/ds-components/src/components/Dialog/dialog.tsx
@@ -1,6 +1,6 @@
 import { Dialog as ArkDialog } from "@ark-ui/react/dialog";
 import { Portal } from "@ark-ui/react/portal";
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { cx } from "@hashintel/ds-helpers/css";
 
@@ -61,15 +61,42 @@ const DialogRoot = ({
   const closeOnEscape = shouldCloseOn !== "none";
   const closeOnInteractOutside = shouldCloseOn === "closeButtonAndOverlay";
 
+  // The parent mounts/unmounts the Dialog to open/close it, but Ark only plays
+  // the open/close animations when `open` actually transitions. So we drive
+  // `open` internally: it starts closed and flips open on the next frame
+  // (playing the enter animation), and every close request flips it back to
+  // closed to play the exit animation. The parent-facing `onClose` is deferred
+  // until that exit animation completes, so the dialog finishes fading out
+  // before it unmounts.
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => {
+      setOpen(true);
+    });
+    return () => {
+      cancelAnimationFrame(frame);
+    };
+  }, []);
+
+  const requestClose = () => {
+    setOpen(false);
+  };
+
   return (
     <ArkDialog.Root
-      open
+      open={open}
+      lazyMount
+      unmountOnExit
       closeOnEscape={closeOnEscape}
       closeOnInteractOutside={closeOnInteractOutside}
       onOpenChange={(event) => {
         if (!event.open) {
-          onClose?.();
+          requestClose();
         }
+      }}
+      onExitComplete={() => {
+        onClose?.();
       }}
       initialFocusEl={
         initialFocusRef ? () => initialFocusRef.current : undefined
@@ -89,7 +116,7 @@ const DialogRoot = ({
               <OverlaySections
                 size={size}
                 variant={variant}
-                onClose={onClose}
+                onClose={requestClose}
                 renderCloseButton={renderCloseButton}
                 loading={loading}
                 Title={ArkDialog.Title}

--- a/libs/@hashintel/ds-components/src/components/Drawer/drawer.recipe.ts
+++ b/libs/@hashintel/ds-components/src/components/Drawer/drawer.recipe.ts
@@ -10,7 +10,7 @@ import { sva } from "@hashintel/ds-helpers/css";
  * The drawer can be anchored to any viewport edge via the `position` variant,
  * which sets the anchor, the panel's dimensions, the rounded corners (the edge
  * it's flush against stays square), the shadow direction, and the slide
- * animation. `size` feeds `--drawer-width` and `--drawer-height`; `position`
+ * animation. `size` feeds `--panel-width` and `--panel-height`; `position`
  * maps the width to `maxWidth` (left/right) or the height to `maxHeight`
  * (top/bottom), since a top/bottom sheet reads best much shorter than a
  * left/right drawer is wide.
@@ -62,21 +62,21 @@ export const styles = sva({
     size: {
       sm: {
         content: {
-          "--drawer-width": "520px",
-          "--drawer-height": "280px",
+          "--panel-width": "520px",
+          "--panel-height": "280px",
           "--panel-horizontal-padding": "var(--spacing-4)",
           "--panel-top-padding": "var(--spacing-3\\.5)",
           "--panel-close-button-gap": "var(--spacing-2\\.5)",
         },
       },
       md: {
-        content: { "--drawer-width": "640px", "--drawer-height": "400px" },
+        content: { "--panel-width": "640px", "--panel-height": "400px" },
       },
       lg: {
-        content: { "--drawer-width": "860px", "--drawer-height": "560px" },
+        content: { "--panel-width": "860px", "--panel-height": "560px" },
       },
       xl: {
-        content: { "--drawer-width": "1060px", "--drawer-height": "720px" },
+        content: { "--panel-width": "1060px", "--panel-height": "720px" },
       },
     },
     position: {
@@ -88,7 +88,7 @@ export const styles = sva({
         },
         content: {
           height: "[100dvh]",
-          maxWidth: "[var(--drawer-width)]",
+          maxWidth: "[var(--panel-width)]",
           borderTopLeftRadius: "xl",
           borderBottomLeftRadius: "xl",
           borderTopRightRadius: "[0]",
@@ -107,7 +107,7 @@ export const styles = sva({
         },
         content: {
           height: "[100dvh]",
-          maxWidth: "[var(--drawer-width)]",
+          maxWidth: "[var(--panel-width)]",
           borderTopRightRadius: "xl",
           borderBottomRightRadius: "xl",
           borderTopLeftRadius: "[0]",
@@ -127,7 +127,7 @@ export const styles = sva({
         },
         content: {
           height: "[100%]",
-          maxHeight: "[var(--drawer-height)]",
+          maxHeight: "[var(--panel-height)]",
           borderBottomLeftRadius: "xl",
           borderBottomRightRadius: "xl",
           borderTopLeftRadius: "[0]",
@@ -147,7 +147,7 @@ export const styles = sva({
         },
         content: {
           height: "[100%]",
-          maxHeight: "[var(--drawer-height)]",
+          maxHeight: "[var(--panel-height)]",
           borderTopLeftRadius: "xl",
           borderTopRightRadius: "xl",
           borderBottomLeftRadius: "[0]",

--- a/libs/@hashintel/ds-components/src/components/Drawer/drawer.recipe.ts
+++ b/libs/@hashintel/ds-components/src/components/Drawer/drawer.recipe.ts
@@ -21,12 +21,6 @@ export const styles = sva({
   base: {
     stackRoot: {
       display: "contents",
-      // Hide the backdrop of any drawer that has a nested drawer above it so
-      // the overlay doesn't darken cumulatively as the stack grows.
-      '&:has([data-scope="drawer"][data-part="content"][data-has-nested]) [data-scope="drawer"][data-part="backdrop"]':
-        {
-          visibility: "hidden",
-        },
     },
     positioner: {
       display: "flex",
@@ -49,7 +43,7 @@ export const styles = sva({
       outline: "none",
       backgroundColor: "neutral.s10",
       padding: "1",
-      transition: "[transform 0.2s ease, translate 0.2s ease]",
+      transition: "[transform 0.2s ease, translate 0.12s ease]",
       _open: {
         animationDuration: "normal",
       },

--- a/libs/@hashintel/ds-components/src/components/Drawer/drawer.recipe.ts
+++ b/libs/@hashintel/ds-components/src/components/Drawer/drawer.recipe.ts
@@ -51,7 +51,7 @@ export const styles = sva({
     content: {
       "--panel-horizontal-padding": "var(--spacing-5\\.5)",
       "--panel-top-padding": "var(--spacing-4)",
-      "--panel-close-button-gap": "var(--spacing-2)",
+      "--panel-close-button-gap": "var(--spacing-3\\.5)",
       position: "relative",
       display: "flex",
       flexDirection: "column",
@@ -81,7 +81,12 @@ export const styles = sva({
   variants: {
     size: {
       sm: {
-        content: { maxWidth: "[520px]" },
+        content: {
+          maxWidth: "[520px]",
+          "--panel-horizontal-padding": "var(--spacing-4)",
+          "--panel-top-padding": "var(--spacing-3\\.5)",
+          "--panel-close-button-gap": "var(--spacing-2\\.5)",
+        },
       },
       md: {
         content: { maxWidth: "[640px]" },

--- a/libs/@hashintel/ds-components/src/components/Drawer/drawer.recipe.ts
+++ b/libs/@hashintel/ds-components/src/components/Drawer/drawer.recipe.ts
@@ -29,11 +29,11 @@ export const styles = sva({
       zIndex: "modal",
       _open: {
         animationName: "fadeIn",
-        animationDuration: "normal",
+        animationDuration: "faster",
       },
       _closed: {
         animationName: "fadeOut",
-        animationDuration: "fast",
+        animationDuration: "fastest",
       },
     },
     positioner: {

--- a/libs/@hashintel/ds-components/src/components/Drawer/drawer.recipe.ts
+++ b/libs/@hashintel/ds-components/src/components/Drawer/drawer.recipe.ts
@@ -2,27 +2,14 @@ import { drawerAnatomy } from "@ark-ui/react/anatomy";
 
 import { sva } from "@hashintel/ds-helpers/css";
 
+/**
+ * The header / body / footer chrome is shared with the Dialog and lives in
+ * `../../util/overlay-parts.recipe`; the `--panel-*` custom properties
+ * declared on `content` below feed that shared chrome via inheritance.
+ */
 export const styles = sva({
   className: "drawer",
-  slots: drawerAnatomy
-    .extendWith(
-      "stackRoot",
-      "header",
-      "headerMain",
-      "headerText",
-      "titleIcon",
-      "headerActions",
-      "headerRight",
-      "hasCustomHeader",
-      "body",
-      "footer",
-      "footerActions",
-      "footerSecondaryActions",
-      "closeButton",
-      "loadingOverlay",
-      "loadingSpinner",
-    )
-    .keys(),
+  slots: drawerAnatomy.extendWith("stackRoot").keys(),
   base: {
     stackRoot: {
       display: "contents",
@@ -51,46 +38,34 @@ export const styles = sva({
     },
     positioner: {
       display: "flex",
-      // Anchor the drawer to the trailing (right) edge, stretched to the full
-      // viewport height.
       justifyContent: "flex-end",
       alignItems: "stretch",
       position: "fixed",
       inset: "0",
       width: "[100dvw]",
       height: "[100dvh]",
-      // The panel itself is full height and scrolls its own body, so the
-      // slid-in content is clipped rather than producing a page scrollbar.
       overflow: "hidden",
       overscrollBehaviorY: "none",
       zIndex: "modal",
     },
     content: {
-      "--drawer-horizontal-padding": "var(--spacing-5\\.5)",
-      "--drawer-top-padding": "var(--spacing-4)",
-      "--drawer-close-button-gap": "var(--spacing-2)",
+      "--panel-horizontal-padding": "var(--spacing-5\\.5)",
+      "--panel-top-padding": "var(--spacing-4)",
+      "--panel-close-button-gap": "var(--spacing-2)",
       position: "relative",
       display: "flex",
       flexDirection: "column",
-      // Sized to `maxWidth` (per size), pinned to the right edge and stretched
-      // to the full viewport height like a side sheet.
       width: "[100%]",
       height: "[100dvh]",
       maxHeight: "[100dvh]",
       outline: "none",
-      // Shadow spills to the left, into the viewport it slides over.
       boxShadow: "[-10px 0 40px rgba(0, 0, 0, 0.2)]",
-      // Only the leading (left) edge is rounded; the trailing edge sits flush
-      // against the side of the viewport.
       borderTopLeftRadius: "xl",
       borderBottomLeftRadius: "xl",
       borderTopRightRadius: "[0]",
       borderBottomRightRadius: "[0]",
       backgroundColor: "neutral.s10",
       padding: "1",
-      // Smoothly animate the swipe snap-back when a drag doesn't cross the
-      // dismiss threshold. Ark UI zeroes this out inline while actively
-      // dragging, so the panel still tracks the pointer 1:1.
       transition: "[transform 0.2s ease]",
 
       _open: {
@@ -102,213 +77,20 @@ export const styles = sva({
         animationDuration: "fast",
       },
     },
-    header: {
-      flex: "[0 0 auto]",
-      backgroundColor: "white",
-      border: "[1px solid {colors.neutral.s50}]",
-      borderTopRadius: "lg",
-      borderBottom: "[1px solid {colors.neutral.s30}]",
-      paddingX: "[var(--drawer-horizontal-padding)]",
-      paddingTop: "[var(--drawer-top-padding)]",
-      paddingBottom: "3.5",
-    },
-    hasCustomHeader: {
-      display: "flex",
-      alignItems: "flex-start",
-      gap: "2",
-      flex: "[1 1 auto]",
-      minWidth: "0",
-    },
-    headerMain: {},
-    headerText: {},
-    titleIcon: {
-      float: "start",
-      marginLeft: "-0.5",
-      marginRight: "2",
-      color: "neutral.s90",
-      flex: "[0 0 auto]",
-      backgroundColor: "neutral.s25",
-      borderRadius: "full",
-      padding: "1",
-      alignSelf: "flex-start",
-      top: "[1.5px]",
-      position: "relative",
-    },
-    title: {
-      display: "inline",
-      fontWeight: "semibold",
-      textStyle: "lg",
-      color: "fg.body",
-    },
-    description: {
-      color: "fg.muted",
-      textStyle: "sm",
-      marginTop: "-0.5",
-    },
-    headerRight: {
-      float: "end",
-      display: "flex",
-      alignItems: "center",
-      gap: "[1px]",
-    },
-    headerActions: {
-      display: "flex",
-      marginLeft: "auto",
-      alignItems: "center",
-      gap: "[1px]",
-      flex: "[0 0 auto]",
-      marginTop:
-        "[calc(var(--drawer-top-padding) * -1 + var(--drawer-close-button-gap))]",
-    },
-    body: {
-      position: "relative",
-      flex: "[1 1 auto]",
-      minHeight: "0",
-      overflow: "auto",
-      scrollbarWidth: "[thin]",
-      background: "white",
-      border: "[1px solid {colors.neutral.s50}]",
-      borderTop: "none",
-      color: "fg.body",
-      textStyle: "sm",
-      paddingX: "[var(--drawer-horizontal-padding)]",
-      paddingTop: "4",
-      paddingBottom: "5",
-      // While loading, lock the body's scroll so the absolutely-positioned
-      // overlay stays pinned to the visible area instead of riding the
-      // scrolled content.
-      '[aria-busy="true"] &': {
-        overflow: "hidden",
-      },
-      _focusVisible: {
-        outlineColor: "neutral.a50",
-      },
-    },
-    footer: {
-      flex: "[0 0 auto]",
-      display: "flex",
-      alignItems: "flex-start",
-      justifyContent: "space-between",
-      gap: "3",
-      paddingX: "[var(--drawer-horizontal-padding)]",
-      paddingTop: "3.5",
-      paddingBottom: "3",
-    },
-    footerActions: {
-      display: "flex",
-      flexWrap: "wrap",
-      justifyContent: "flex-end",
-      alignItems: "center",
-      gap: "2",
-      marginLeft: "auto",
-    },
-    footerSecondaryActions: {
-      display: "flex",
-      flexWrap: "wrap",
-      alignItems: "center",
-      gap: "2",
-    },
-    closeButton: {
-      flex: "[0 0 auto]",
-      marginLeft: "auto",
-      float: "end",
-      position: "relative",
-      zIndex: "[1]",
-      marginTop:
-        "[calc(var(--drawer-top-padding) * -1 + var(--drawer-close-button-gap))]",
-      marginRight:
-        "[calc(var(--drawer-horizontal-padding) * -1 + var(--drawer-close-button-gap))]",
-    },
-    loadingOverlay: {
-      position: "absolute",
-      inset: "0",
-      display: "flex",
-      alignItems: "center",
-      justifyContent: "center",
-      background: "[rgba(255, 255, 255, 0.88)]",
-      zIndex: "[1]",
-      borderRadius: "[inherit]",
-    },
-    loadingSpinner: {
-      width: "[auto !important]",
-      aspectRatio: "1",
-      maxHeight: "[60%]",
-      color: "black",
-    },
   },
   variants: {
     size: {
       sm: {
         content: { maxWidth: "[520px]" },
-        loadingSpinner: { height: "[38px !important]" },
       },
       md: {
         content: { maxWidth: "[640px]" },
-        loadingSpinner: { height: "[40px !important]" },
-        headerMain: { display: "flex", alignItems: "flex-start", gap: "2" },
-        titleIcon: { marginRight: "0" },
-        headerText: { flex: "[1 1 auto]", minWidth: "[0]" },
       },
       lg: {
         content: { maxWidth: "[860px]" },
-        loadingSpinner: {
-          height: "[45px !important]",
-          color: "neutral.s115",
-        },
-        headerMain: { display: "flex", alignItems: "flex-start", gap: "2" },
-        titleIcon: { marginRight: "0" },
-        headerText: { flex: "[1 1 auto]", minWidth: "[0]" },
       },
       xl: {
         content: { maxWidth: "[1060px]" },
-        loadingSpinner: {
-          height: "[50px !important]",
-          color: "neutral.s115",
-        },
-        headerMain: { display: "flex", alignItems: "flex-start", gap: "2" },
-        titleIcon: { marginRight: "0" },
-        headerText: { flex: "[1 1 auto]", minWidth: "[0]" },
-      },
-    },
-    variant: {
-      partitionedFooter: {
-        body: {
-          borderBottomRadius: "lg",
-        },
-      },
-      plain: {
-        header: {
-          borderBottomColor: "neutral.s20",
-        },
-        body: {
-          borderBottom: "none",
-        },
-        footer: {
-          backgroundColor: "white",
-          border: "[1px solid {colors.neutral.s50}]",
-          borderBottomRadius: "lg",
-          borderTop: "[1px solid {colors.neutral.s20}]",
-        },
-      },
-    },
-    hasIcon: {
-      true: {
-        description: { marginTop: "0.5" },
-      },
-    },
-    headerless: {
-      true: {
-        header: {
-          paddingBottom: "0",
-          borderBottom: "none",
-        },
-        closeButton: {
-          marginBottom: "-1.5",
-        },
-        body: {
-          paddingTop: "0",
-          paddingBottom: "6",
-        },
       },
     },
   },

--- a/libs/@hashintel/ds-components/src/components/Drawer/drawer.recipe.ts
+++ b/libs/@hashintel/ds-components/src/components/Drawer/drawer.recipe.ts
@@ -1,0 +1,318 @@
+import { drawerAnatomy } from "@ark-ui/react/anatomy";
+
+import { sva } from "@hashintel/ds-helpers/css";
+
+export const styles = sva({
+  className: "drawer",
+  slots: drawerAnatomy
+    .extendWith(
+      "stackRoot",
+      "header",
+      "headerMain",
+      "headerText",
+      "titleIcon",
+      "headerActions",
+      "headerRight",
+      "hasCustomHeader",
+      "body",
+      "footer",
+      "footerActions",
+      "footerSecondaryActions",
+      "closeButton",
+      "loadingOverlay",
+      "loadingSpinner",
+    )
+    .keys(),
+  base: {
+    stackRoot: {
+      display: "contents",
+      // Hide the backdrop of any drawer that has a nested drawer above it so
+      // the overlay doesn't darken cumulatively as the stack grows.
+      '&:has([data-scope="drawer"][data-part="content"][data-has-nested]) [data-scope="drawer"][data-part="backdrop"]':
+        {
+          visibility: "hidden",
+        },
+    },
+    backdrop: {
+      background: "black.a60",
+      position: "fixed",
+      inset: "0",
+      width: "[100dvw]",
+      height: "[100dvh]",
+      zIndex: "modal",
+      _open: {
+        animationName: "fadeIn",
+        animationDuration: "normal",
+      },
+      _closed: {
+        animationName: "fadeOut",
+        animationDuration: "fast",
+      },
+    },
+    positioner: {
+      display: "flex",
+      // Anchor the drawer to the trailing (right) edge, stretched to the full
+      // viewport height.
+      justifyContent: "flex-end",
+      alignItems: "stretch",
+      position: "fixed",
+      inset: "0",
+      width: "[100dvw]",
+      height: "[100dvh]",
+      // The panel itself is full height and scrolls its own body, so the
+      // slid-in content is clipped rather than producing a page scrollbar.
+      overflow: "hidden",
+      overscrollBehaviorY: "none",
+      zIndex: "modal",
+    },
+    content: {
+      "--drawer-horizontal-padding": "var(--spacing-5\\.5)",
+      "--drawer-top-padding": "var(--spacing-4)",
+      "--drawer-close-button-gap": "var(--spacing-2)",
+      position: "relative",
+      display: "flex",
+      flexDirection: "column",
+      // Sized to `maxWidth` (per size), pinned to the right edge and stretched
+      // to the full viewport height like a side sheet.
+      width: "[100%]",
+      height: "[100dvh]",
+      maxHeight: "[100dvh]",
+      outline: "none",
+      // Shadow spills to the left, into the viewport it slides over.
+      boxShadow: "[-10px 0 40px rgba(0, 0, 0, 0.2)]",
+      // Only the leading (left) edge is rounded; the trailing edge sits flush
+      // against the side of the viewport.
+      borderTopLeftRadius: "xl",
+      borderBottomLeftRadius: "xl",
+      borderTopRightRadius: "[0]",
+      borderBottomRightRadius: "[0]",
+      backgroundColor: "neutral.s10",
+      padding: "1",
+      // Smoothly animate the swipe snap-back when a drag doesn't cross the
+      // dismiss threshold. Ark UI zeroes this out inline while actively
+      // dragging, so the panel still tracks the pointer 1:1.
+      transition: "[transform 0.2s ease]",
+
+      _open: {
+        animationName: "drawerSlideIn",
+        animationDuration: "normal",
+      },
+      _closed: {
+        animationName: "drawerSlideOut",
+        animationDuration: "fast",
+      },
+    },
+    header: {
+      flex: "[0 0 auto]",
+      backgroundColor: "white",
+      border: "[1px solid {colors.neutral.s50}]",
+      borderTopRadius: "lg",
+      borderBottom: "[1px solid {colors.neutral.s30}]",
+      paddingX: "[var(--drawer-horizontal-padding)]",
+      paddingTop: "[var(--drawer-top-padding)]",
+      paddingBottom: "3.5",
+    },
+    hasCustomHeader: {
+      display: "flex",
+      alignItems: "flex-start",
+      gap: "2",
+      flex: "[1 1 auto]",
+      minWidth: "0",
+    },
+    headerMain: {},
+    headerText: {},
+    titleIcon: {
+      float: "start",
+      marginLeft: "-0.5",
+      marginRight: "2",
+      color: "neutral.s90",
+      flex: "[0 0 auto]",
+      backgroundColor: "neutral.s25",
+      borderRadius: "full",
+      padding: "1",
+      alignSelf: "flex-start",
+      top: "[1.5px]",
+      position: "relative",
+    },
+    title: {
+      display: "inline",
+      fontWeight: "semibold",
+      textStyle: "lg",
+      color: "fg.body",
+    },
+    description: {
+      color: "fg.muted",
+      textStyle: "sm",
+      marginTop: "-0.5",
+    },
+    headerRight: {
+      float: "end",
+      display: "flex",
+      alignItems: "center",
+      gap: "[1px]",
+    },
+    headerActions: {
+      display: "flex",
+      marginLeft: "auto",
+      alignItems: "center",
+      gap: "[1px]",
+      flex: "[0 0 auto]",
+      marginTop:
+        "[calc(var(--drawer-top-padding) * -1 + var(--drawer-close-button-gap))]",
+    },
+    body: {
+      position: "relative",
+      flex: "[1 1 auto]",
+      minHeight: "0",
+      overflow: "auto",
+      scrollbarWidth: "[thin]",
+      background: "white",
+      border: "[1px solid {colors.neutral.s50}]",
+      borderTop: "none",
+      color: "fg.body",
+      textStyle: "sm",
+      paddingX: "[var(--drawer-horizontal-padding)]",
+      paddingTop: "4",
+      paddingBottom: "5",
+      // While loading, lock the body's scroll so the absolutely-positioned
+      // overlay stays pinned to the visible area instead of riding the
+      // scrolled content.
+      '[aria-busy="true"] &': {
+        overflow: "hidden",
+      },
+      _focusVisible: {
+        outlineColor: "neutral.a50",
+      },
+    },
+    footer: {
+      flex: "[0 0 auto]",
+      display: "flex",
+      alignItems: "flex-start",
+      justifyContent: "space-between",
+      gap: "3",
+      paddingX: "[var(--drawer-horizontal-padding)]",
+      paddingTop: "3.5",
+      paddingBottom: "3",
+    },
+    footerActions: {
+      display: "flex",
+      flexWrap: "wrap",
+      justifyContent: "flex-end",
+      alignItems: "center",
+      gap: "2",
+      marginLeft: "auto",
+    },
+    footerSecondaryActions: {
+      display: "flex",
+      flexWrap: "wrap",
+      alignItems: "center",
+      gap: "2",
+    },
+    closeButton: {
+      flex: "[0 0 auto]",
+      marginLeft: "auto",
+      float: "end",
+      position: "relative",
+      zIndex: "[1]",
+      marginTop:
+        "[calc(var(--drawer-top-padding) * -1 + var(--drawer-close-button-gap))]",
+      marginRight:
+        "[calc(var(--drawer-horizontal-padding) * -1 + var(--drawer-close-button-gap))]",
+    },
+    loadingOverlay: {
+      position: "absolute",
+      inset: "0",
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      background: "[rgba(255, 255, 255, 0.88)]",
+      zIndex: "[1]",
+      borderRadius: "[inherit]",
+    },
+    loadingSpinner: {
+      width: "[auto !important]",
+      aspectRatio: "1",
+      maxHeight: "[60%]",
+      color: "black",
+    },
+  },
+  variants: {
+    size: {
+      sm: {
+        content: { maxWidth: "[520px]" },
+        loadingSpinner: { height: "[38px !important]" },
+      },
+      md: {
+        content: { maxWidth: "[640px]" },
+        loadingSpinner: { height: "[40px !important]" },
+        headerMain: { display: "flex", alignItems: "flex-start", gap: "2" },
+        titleIcon: { marginRight: "0" },
+        headerText: { flex: "[1 1 auto]", minWidth: "[0]" },
+      },
+      lg: {
+        content: { maxWidth: "[860px]" },
+        loadingSpinner: {
+          height: "[45px !important]",
+          color: "neutral.s115",
+        },
+        headerMain: { display: "flex", alignItems: "flex-start", gap: "2" },
+        titleIcon: { marginRight: "0" },
+        headerText: { flex: "[1 1 auto]", minWidth: "[0]" },
+      },
+      xl: {
+        content: { maxWidth: "[1060px]" },
+        loadingSpinner: {
+          height: "[50px !important]",
+          color: "neutral.s115",
+        },
+        headerMain: { display: "flex", alignItems: "flex-start", gap: "2" },
+        titleIcon: { marginRight: "0" },
+        headerText: { flex: "[1 1 auto]", minWidth: "[0]" },
+      },
+    },
+    variant: {
+      partitionedFooter: {
+        body: {
+          borderBottomRadius: "lg",
+        },
+      },
+      plain: {
+        header: {
+          borderBottomColor: "neutral.s20",
+        },
+        body: {
+          borderBottom: "none",
+        },
+        footer: {
+          backgroundColor: "white",
+          border: "[1px solid {colors.neutral.s50}]",
+          borderBottomRadius: "lg",
+          borderTop: "[1px solid {colors.neutral.s20}]",
+        },
+      },
+    },
+    hasIcon: {
+      true: {
+        description: { marginTop: "0.5" },
+      },
+    },
+    headerless: {
+      true: {
+        header: {
+          paddingBottom: "0",
+          borderBottom: "none",
+        },
+        closeButton: {
+          marginBottom: "-1.5",
+        },
+        body: {
+          paddingTop: "0",
+          paddingBottom: "6",
+        },
+      },
+    },
+  },
+  defaultVariants: {
+    size: "md",
+  },
+});

--- a/libs/@hashintel/ds-components/src/components/Drawer/drawer.recipe.ts
+++ b/libs/@hashintel/ds-components/src/components/Drawer/drawer.recipe.ts
@@ -43,7 +43,7 @@ export const styles = sva({
       outline: "none",
       backgroundColor: "neutral.s10",
       padding: "1",
-      transition: "[transform 0.2s ease, translate 0.12s ease]",
+      transition: "[transform 0.2s ease, translate 0.15s ease]",
       _open: {
         animationDuration: "normal",
       },

--- a/libs/@hashintel/ds-components/src/components/Drawer/drawer.recipe.ts
+++ b/libs/@hashintel/ds-components/src/components/Drawer/drawer.recipe.ts
@@ -20,22 +20,6 @@ export const styles = sva({
           visibility: "hidden",
         },
     },
-    backdrop: {
-      background: "black.a60",
-      position: "fixed",
-      inset: "0",
-      width: "[100dvw]",
-      height: "[100dvh]",
-      zIndex: "modal",
-      _open: {
-        animationName: "fadeIn",
-        animationDuration: "faster",
-      },
-      _closed: {
-        animationName: "fadeOut",
-        animationDuration: "fastest",
-      },
-    },
     positioner: {
       display: "flex",
       justifyContent: "flex-end",
@@ -47,6 +31,7 @@ export const styles = sva({
       overflow: "hidden",
       overscrollBehaviorY: "none",
       zIndex: "modal",
+      paddingLeft: "[10%]",
     },
     content: {
       "--panel-horizontal-padding": "var(--spacing-5\\.5)",
@@ -59,7 +44,8 @@ export const styles = sva({
       height: "[100dvh]",
       maxHeight: "[100dvh]",
       outline: "none",
-      boxShadow: "[-10px 0 40px rgba(0, 0, 0, 0.2)]",
+      boxShadow:
+        "[-1px 0 0 0 rgba(0, 0, 0, 0.03), -1px 0 2px -1px rgba(0, 0, 0, 0.06), -8px 0 16px -6px rgba(0, 0, 0, 0.09), -18px 0 32px -14px rgba(0, 0, 0, 0.16)]",
       borderTopLeftRadius: "xl",
       borderBottomLeftRadius: "xl",
       borderTopRightRadius: "[0]",

--- a/libs/@hashintel/ds-components/src/components/Drawer/drawer.recipe.ts
+++ b/libs/@hashintel/ds-components/src/components/Drawer/drawer.recipe.ts
@@ -49,7 +49,7 @@ export const styles = sva({
       outline: "none",
       backgroundColor: "neutral.s10",
       padding: "1",
-      transition: "[transform 0.2s ease]",
+      transition: "[transform 0.2s ease, translate 0.2s ease]",
       _open: {
         animationDuration: "normal",
       },

--- a/libs/@hashintel/ds-components/src/components/Drawer/drawer.recipe.ts
+++ b/libs/@hashintel/ds-components/src/components/Drawer/drawer.recipe.ts
@@ -4,8 +4,16 @@ import { sva } from "@hashintel/ds-helpers/css";
 
 /**
  * The header / body / footer chrome is shared with the Dialog and lives in
- * `../../util/overlay-parts.recipe`; the `--panel-*` custom properties
- * declared on `content` below feed that shared chrome via inheritance.
+ * `../../util/overlay-parts.recipe`; the `--panel-*` custom properties declared
+ * on `content` below feed that shared chrome via inheritance.
+ *
+ * The drawer can be anchored to any viewport edge via the `position` variant,
+ * which sets the anchor, the panel's dimensions, the rounded corners (the edge
+ * it's flush against stays square), the shadow direction, and the slide
+ * animation. `size` feeds `--drawer-width` and `--drawer-height`; `position`
+ * maps the width to `maxWidth` (left/right) or the height to `maxHeight`
+ * (top/bottom), since a top/bottom sheet reads best much shorter than a
+ * left/right drawer is wide.
  */
 export const styles = sva({
   className: "drawer",
@@ -22,8 +30,6 @@ export const styles = sva({
     },
     positioner: {
       display: "flex",
-      justifyContent: "flex-end",
-      alignItems: "stretch",
       position: "fixed",
       inset: "0",
       width: "[100dvw]",
@@ -31,7 +37,6 @@ export const styles = sva({
       overflow: "hidden",
       overscrollBehaviorY: "none",
       zIndex: "modal",
-      paddingLeft: "[10%]",
     },
     content: {
       "--panel-horizontal-padding": "var(--spacing-5\\.5)",
@@ -41,25 +46,14 @@ export const styles = sva({
       display: "flex",
       flexDirection: "column",
       width: "[100%]",
-      height: "[100dvh]",
-      maxHeight: "[100dvh]",
       outline: "none",
-      boxShadow:
-        "[-1px 0 0 0 rgba(0, 0, 0, 0.03), -1px 0 2px -1px rgba(0, 0, 0, 0.06), -8px 0 16px -6px rgba(0, 0, 0, 0.09), -18px 0 32px -14px rgba(0, 0, 0, 0.16)]",
-      borderTopLeftRadius: "xl",
-      borderBottomLeftRadius: "xl",
-      borderTopRightRadius: "[0]",
-      borderBottomRightRadius: "[0]",
       backgroundColor: "neutral.s10",
       padding: "1",
       transition: "[transform 0.2s ease]",
-
       _open: {
-        animationName: "drawerSlideIn",
         animationDuration: "normal",
       },
       _closed: {
-        animationName: "drawerSlideOut",
         animationDuration: "fast",
       },
     },
@@ -68,24 +62,106 @@ export const styles = sva({
     size: {
       sm: {
         content: {
-          maxWidth: "[520px]",
+          "--drawer-width": "520px",
+          "--drawer-height": "280px",
           "--panel-horizontal-padding": "var(--spacing-4)",
           "--panel-top-padding": "var(--spacing-3\\.5)",
           "--panel-close-button-gap": "var(--spacing-2\\.5)",
         },
       },
       md: {
-        content: { maxWidth: "[640px]" },
+        content: { "--drawer-width": "640px", "--drawer-height": "400px" },
       },
       lg: {
-        content: { maxWidth: "[860px]" },
+        content: { "--drawer-width": "860px", "--drawer-height": "560px" },
       },
       xl: {
-        content: { maxWidth: "[1060px]" },
+        content: { "--drawer-width": "1060px", "--drawer-height": "720px" },
+      },
+    },
+    position: {
+      right: {
+        positioner: {
+          justifyContent: "flex-end",
+          alignItems: "stretch",
+          paddingLeft: "[10%]",
+        },
+        content: {
+          height: "[100dvh]",
+          maxWidth: "[var(--drawer-width)]",
+          borderTopLeftRadius: "xl",
+          borderBottomLeftRadius: "xl",
+          borderTopRightRadius: "[0]",
+          borderBottomRightRadius: "[0]",
+          boxShadow:
+            "[-1px 0 0 0 rgba(0, 0, 0, 0.03), -1px 0 2px -1px rgba(0, 0, 0, 0.06), -8px 0 16px -6px rgba(0, 0, 0, 0.09), -18px 0 32px -14px rgba(0, 0, 0, 0.16)]",
+          _open: { animationName: "drawerSlideInRight" },
+          _closed: { animationName: "drawerSlideOutRight" },
+        },
+      },
+      left: {
+        positioner: {
+          justifyContent: "flex-start",
+          alignItems: "stretch",
+          paddingRight: "[10%]",
+        },
+        content: {
+          height: "[100dvh]",
+          maxWidth: "[var(--drawer-width)]",
+          borderTopRightRadius: "xl",
+          borderBottomRightRadius: "xl",
+          borderTopLeftRadius: "[0]",
+          borderBottomLeftRadius: "[0]",
+          boxShadow:
+            "[1px 0 0 0 rgba(0, 0, 0, 0.03), 1px 0 2px -1px rgba(0, 0, 0, 0.06), 8px 0 16px -6px rgba(0, 0, 0, 0.09), 18px 0 32px -14px rgba(0, 0, 0, 0.16)]",
+          _open: { animationName: "drawerSlideInLeft" },
+          _closed: { animationName: "drawerSlideOutLeft" },
+        },
+      },
+      top: {
+        positioner: {
+          flexDirection: "column",
+          justifyContent: "flex-start",
+          alignItems: "stretch",
+          paddingBottom: "[10%]",
+        },
+        content: {
+          height: "[100%]",
+          maxHeight: "[var(--drawer-height)]",
+          borderBottomLeftRadius: "xl",
+          borderBottomRightRadius: "xl",
+          borderTopLeftRadius: "[0]",
+          borderTopRightRadius: "[0]",
+          boxShadow:
+            "[0 1px 0 0 rgba(0, 0, 0, 0.03), 0 1px 2px -1px rgba(0, 0, 0, 0.06), 0 8px 16px -6px rgba(0, 0, 0, 0.09), 0 18px 32px -14px rgba(0, 0, 0, 0.16)]",
+          _open: { animationName: "drawerSlideInTop" },
+          _closed: { animationName: "drawerSlideOutTop" },
+        },
+      },
+      bottom: {
+        positioner: {
+          flexDirection: "column",
+          justifyContent: "flex-end",
+          alignItems: "stretch",
+          paddingTop: "[10%]",
+        },
+        content: {
+          height: "[100%]",
+          maxHeight: "[var(--drawer-height)]",
+          borderTopLeftRadius: "xl",
+          borderTopRightRadius: "xl",
+          borderBottomLeftRadius: "[0]",
+          borderBottomRightRadius: "[0]",
+          boxShadow:
+            "[0 -1px 0 0 rgba(0, 0, 0, 0.03), 0 -1px 2px -1px rgba(0, 0, 0, 0.06), 0 -8px 16px -6px rgba(0, 0, 0, 0.09), 0 -18px 32px -14px rgba(0, 0, 0, 0.16)]",
+          _open: { animationName: "drawerSlideInBottom" },
+          _closed: { animationName: "drawerSlideOutBottom" },
+        },
       },
     },
   },
   defaultVariants: {
     size: "md",
+    position: "right",
   },
 });

--- a/libs/@hashintel/ds-components/src/components/Drawer/drawer.stories.tsx
+++ b/libs/@hashintel/ds-components/src/components/Drawer/drawer.stories.tsx
@@ -4,7 +4,7 @@ import { css } from "@hashintel/ds-helpers/css";
 
 import { Button } from "../Button/button";
 import { Icon } from "../Icon/icon";
-import { Drawer, type DrawerSize } from "./drawer";
+import { Drawer, type DrawerPosition, type DrawerSize } from "./drawer";
 
 import type { Story, StoryDefault } from "@ladle/react";
 
@@ -281,6 +281,41 @@ export const Examples: Story = () => (
   </div>
 );
 
+const positions = [
+  "left",
+  "top",
+  "right",
+  "bottom",
+] as const satisfies readonly DrawerPosition[];
+
+export const Positions: Story = () => (
+  <div className={stackStyles}>
+    {positions.map((position) => (
+      <DrawerExample
+        key={position}
+        buttonLabel={position}
+        renderDrawer={(close) => (
+          <Drawer position={position} onClose={close}>
+            <Drawer.Header
+              title={`${position} drawer`}
+              iconName="gear"
+              description={`Anchored to the ${position} edge of the viewport.`}
+            />
+            <Drawer.Body>{sampleBody}</Drawer.Body>
+            <Drawer.Footer
+              actions={
+                <Button variant="solid" tone="brand" onClick={close}>
+                  Done
+                </Button>
+              }
+            />
+          </Drawer>
+        )}
+      />
+    ))}
+  </div>
+);
+
 const sizes = ["sm", "md", "lg", "xl"] as const satisfies readonly DrawerSize[];
 
 const renderKitchenSink = (
@@ -344,6 +379,26 @@ export const Sizes: Story = () => (
             renderKitchenSink(size, close, { loading: true })
           }
         />
+        <DrawerExample
+          buttonLabel={`Bottom — ${size}`}
+          renderDrawer={(close) => (
+            <Drawer size={size} position="bottom" onClose={close}>
+              <Drawer.Header
+                title={`Bottom drawer (${size})`}
+                iconName="gear"
+                description="Anchored to the bottom edge, sized for this height."
+              />
+              <Drawer.Body>{sampleBody}</Drawer.Body>
+              <Drawer.Footer
+                actions={
+                  <Button variant="solid" tone="brand" onClick={close}>
+                    Done
+                  </Button>
+                }
+              />
+            </Drawer>
+          )}
+        />
         {size === "sm" ? (
           <>
             <DrawerExample
@@ -384,6 +439,29 @@ export const Sizes: Story = () => (
             <Drawer.Header
               title="Custom width (480px)"
               description="maxWidth is overridden via className."
+            />
+            <Drawer.Body>{sampleBody}</Drawer.Body>
+            <Drawer.Footer
+              actions={
+                <Button variant="solid" tone="brand" onClick={close}>
+                  Save changes
+                </Button>
+              }
+            />
+          </Drawer>
+        )}
+      />
+      <DrawerExample
+        buttonLabel="Custom height (320px, bottom)"
+        renderDrawer={(close) => (
+          <Drawer
+            position="bottom"
+            className={css({ maxHeight: "[320px]" })}
+            onClose={close}
+          >
+            <Drawer.Header
+              title="Custom height (320px)"
+              description="maxHeight is overridden via className on a bottom drawer."
             />
             <Drawer.Body>{sampleBody}</Drawer.Body>
             <Drawer.Footer

--- a/libs/@hashintel/ds-components/src/components/Drawer/drawer.stories.tsx
+++ b/libs/@hashintel/ds-components/src/components/Drawer/drawer.stories.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { css } from "@hashintel/ds-helpers/css";
 
 import { Button } from "../Button/button";
+import { Dialog } from "../Dialog/dialog";
 import { Icon } from "../Icon/icon";
 import { Drawer, type DrawerPosition, type DrawerSize } from "./drawer";
 
@@ -644,104 +645,156 @@ export const Overflow: Story = () => (
   </div>
 );
 
-const StackedDrawers = () => {
-  const [first, setFirst] = useState(false);
-  const [second, setSecond] = useState(false);
-  const [third, setThird] = useState(false);
-  const [fourth, setFourth] = useState(false);
+const StackedExample = ({
+  buttonLabel,
+  position,
+}: {
+  buttonLabel: string;
+  position: DrawerPosition;
+}) => {
+  const [l1, setL1] = useState(false);
+  const [l2, setL2] = useState(false);
+  const [l3, setL3] = useState(false);
+  const [l4, setL4] = useState(false);
+  const [l5, setL5] = useState(false);
+  const [l6, setL6] = useState(false);
+  const [l7, setL7] = useState(false);
 
   return (
     <>
-      <Button onClick={() => setFirst(true)}>Open stacked drawers</Button>
-      {first ? (
-        <Drawer size="md" onClose={() => setFirst(false)}>
+      <Button onClick={() => setL1(true)}>{buttonLabel}</Button>
+      {l1 ? (
+        <Drawer size="lg" position={position} onClose={() => setL1(false)}>
           <Drawer.Header
-            title="First drawer"
+            title="Drawer 1 (lg)"
             iconName="gear"
             description="Open the next drawer to stack another on top."
           />
           <Drawer.Body>{sampleBody}</Drawer.Body>
           <Drawer.Footer
             actions={
-              <Button
-                variant="solid"
-                tone="brand"
-                onClick={() => setSecond(true)}
-              >
-                Open second drawer
+              <Button variant="solid" tone="brand" onClick={() => setL2(true)}>
+                Open lg drawer
               </Button>
             }
           />
         </Drawer>
       ) : null}
-      {second ? (
-        <Drawer size="md" onClose={() => setSecond(false)}>
+      {l2 ? (
+        <Drawer size="lg" position={position} onClose={() => setL2(false)}>
           <Drawer.Header
-            title="Second drawer"
+            title="Drawer 2 (lg)"
             iconName="gear"
-            description="Open the next drawer to stack a small drawer on top."
+            description="Open a smaller drawer to stack it on top."
           />
           <Drawer.Body>{sampleBody}</Drawer.Body>
           <Drawer.Footer
             actions={
-              <Button
-                variant="solid"
-                tone="brand"
-                onClick={() => setThird(true)}
-              >
-                Open small drawer
+              <Button variant="solid" tone="brand" onClick={() => setL3(true)}>
+                Open sm drawer
               </Button>
             }
           />
         </Drawer>
       ) : null}
-      {third ? (
-        <Drawer size="sm" onClose={() => setThird(false)}>
+      {l3 ? (
+        <Drawer size="sm" position={position} onClose={() => setL3(false)}>
           <Drawer.Header
-            title="Small drawer"
+            title="Drawer 3 (sm)"
+            iconName="gear"
+            description="Open a medium drawer to stack it on top."
+          />
+          <Drawer.Body>{sampleBody}</Drawer.Body>
+          <Drawer.Footer
+            actions={
+              <Button variant="solid" tone="brand" onClick={() => setL4(true)}>
+                Open md drawer
+              </Button>
+            }
+          />
+        </Drawer>
+      ) : null}
+      {l4 ? (
+        <Drawer size="md" position={position} onClose={() => setL4(false)}>
+          <Drawer.Header
+            title="Drawer 4 (md)"
+            iconName="gear"
+            description="Open a dialog to stack it on top of the drawers."
+          />
+          <Drawer.Body>{sampleBody}</Drawer.Body>
+          <Drawer.Footer
+            actions={
+              <Button variant="solid" tone="brand" onClick={() => setL5(true)}>
+                Open dialog
+              </Button>
+            }
+          />
+        </Drawer>
+      ) : null}
+      {l5 ? (
+        <Dialog size="md" onClose={() => setL5(false)}>
+          <Dialog.Header
+            title="Dialog"
             iconName="info"
-            description="Open another small drawer on top of this one."
+            description="A dialog stacked in the middle. Open another drawer to keep stacking."
+          />
+          <Dialog.Body>{sampleBody}</Dialog.Body>
+          <Dialog.Footer
+            actions={
+              <Button variant="solid" tone="brand" onClick={() => setL6(true)}>
+                Open lg drawer
+              </Button>
+            }
+          />
+        </Dialog>
+      ) : null}
+      {l6 ? (
+        <Drawer size="lg" position={position} onClose={() => setL6(false)}>
+          <Drawer.Header
+            title="Drawer 5 (lg)"
+            iconName="info"
+            description="Open a final dialog to top off the stack."
           />
           <Drawer.Body>{sampleBody}</Drawer.Body>
           <Drawer.Footer
             actions={
-              <Button
-                variant="solid"
-                tone="brand"
-                onClick={() => setFourth(true)}
-              >
-                Open another small drawer
+              <Button variant="solid" tone="brand" onClick={() => setL7(true)}>
+                Open dialog
               </Button>
             }
           />
         </Drawer>
       ) : null}
-      {fourth ? (
-        <Drawer size="sm" onClose={() => setFourth(false)}>
-          <Drawer.Header
-            title="Another small drawer"
+      {l7 ? (
+        <Dialog size="md" onClose={() => setL7(false)}>
+          <Dialog.Header
+            title="Dialog"
             iconName="info"
             description="This is the top of the stack."
           />
-          <Drawer.Body>{sampleBody}</Drawer.Body>
-          <Drawer.Footer
+          <Dialog.Body>{sampleBody}</Dialog.Body>
+          <Dialog.Footer
             actions={
-              <Button
-                variant="solid"
-                tone="brand"
-                onClick={() => setFourth(false)}
-              >
+              <Button variant="solid" tone="brand" onClick={() => setL7(false)}>
                 Done
               </Button>
             }
           />
-        </Drawer>
+        </Dialog>
       ) : null}
     </>
   );
 };
 
-export const Stacked: Story = () => <StackedDrawers />;
+export const Stacked: Story = () => (
+  <div className={stackStyles}>
+    <StackedExample buttonLabel="Open stacked drawers" position="right" />
+    <StackedExample
+      buttonLabel="Open stacked bottom drawers"
+      position="bottom"
+    />
+  </div>
+);
 
 export const ShouldCloseOn: Story = () => (
   <div className={stackStyles}>

--- a/libs/@hashintel/ds-components/src/components/Drawer/drawer.stories.tsx
+++ b/libs/@hashintel/ds-components/src/components/Drawer/drawer.stories.tsx
@@ -1,0 +1,737 @@
+import { useState } from "react";
+
+import { css } from "@hashintel/ds-helpers/css";
+
+import { Button } from "../Button/button";
+import { Icon } from "../Icon/icon";
+import { Drawer, type DrawerSize } from "./drawer";
+
+import type { Story, StoryDefault } from "@ladle/react";
+
+export default {
+  title: "Components/Drawer",
+} satisfies StoryDefault;
+
+const sampleBody = (
+  <p>
+    The body of the drawer can contain any content you like — forms,
+    descriptions, lists, or rich text. It scrolls independently of the header
+    and footer.
+  </p>
+);
+
+type ExampleProps = {
+  buttonLabel: string;
+  renderDrawer: (close: () => void) => React.ReactElement;
+};
+
+const DrawerExample = ({ buttonLabel, renderDrawer }: ExampleProps) => {
+  const [open, setOpen] = useState(false);
+  const close = () => setOpen(false);
+
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>{buttonLabel}</Button>
+      {open ? renderDrawer(close) : null}
+    </>
+  );
+};
+
+const stackStyles = css({
+  display: "flex",
+  flexWrap: "wrap",
+  gap: "3",
+  alignItems: "flex-start",
+});
+
+type DrawerVariant = "partitionedFooter" | "plain";
+
+const buildExampleEntries = (variant: DrawerVariant): ExampleProps[] => [
+  {
+    buttonLabel: "Title only",
+    renderDrawer: (close) => (
+      <Drawer variant={variant} onClose={close}>
+        <Drawer.Header title="Account settings" />
+        <Drawer.Body>{sampleBody}</Drawer.Body>
+      </Drawer>
+    ),
+  },
+  {
+    buttonLabel: "Title + icon",
+    renderDrawer: (close) => (
+      <Drawer variant={variant} onClose={close}>
+        <Drawer.Header title="Settings" iconName="gear" />
+        <Drawer.Body>{sampleBody}</Drawer.Body>
+      </Drawer>
+    ),
+  },
+  {
+    buttonLabel: "Description only",
+    renderDrawer: (close) => (
+      <Drawer variant={variant} onClose={close}>
+        <Drawer.Header description="A description without a title, written long enough that it wraps onto a second line so we can check how the header lays out when only the subtext is present." />
+        <Drawer.Body>{sampleBody}</Drawer.Body>
+      </Drawer>
+    ),
+  },
+  {
+    buttonLabel: "Footer actions",
+    renderDrawer: (close) => (
+      <Drawer variant={variant} onClose={close}>
+        <Drawer.Body>
+          <p>
+            Do you want to save your changes before closing? Select close to go
+            back.
+          </p>
+        </Drawer.Body>
+        <Drawer.Footer
+          actions={
+            <>
+              <Button variant="subtle" tone="neutral" onClick={close}>
+                Close
+              </Button>
+              <Button variant="solid" tone="brand" onClick={close}>
+                Save
+              </Button>
+            </>
+          }
+        />
+      </Drawer>
+    ),
+  },
+  {
+    buttonLabel: "Kitchen sink",
+    renderDrawer: (close) => (
+      <Drawer variant={variant} onClose={close}>
+        <Drawer.Header
+          title="Edit workspace"
+          iconName="gear"
+          description="Update the details for your workspace."
+          actions={
+            <Button
+              variant="ghost"
+              tone="neutral"
+              size="sm"
+              iconName="externalLink"
+              tooltip="Open docs"
+            />
+          }
+        />
+        <Drawer.Body>{sampleBody}</Drawer.Body>
+        <Drawer.Footer
+          actions={
+            <Button variant="solid" tone="brand" onClick={close}>
+              Save changes
+            </Button>
+          }
+          secondaryActions={
+            <Button variant="subtle" tone="error" onClick={close}>
+              Delete
+            </Button>
+          }
+        />
+      </Drawer>
+    ),
+  },
+  {
+    buttonLabel: "Custom header",
+    renderDrawer: (close) => (
+      <Drawer variant={variant} onClose={close}>
+        <Drawer.Header>
+          <div
+            className={css({
+              display: "flex",
+              alignItems: "center",
+              gap: "3",
+              width: "[100%]",
+            })}
+          >
+            <div
+              className={css({
+                width: "10",
+                height: "10",
+                borderRadius: "full",
+                background: "blue.s90",
+                color: "fg.onSolid",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+              })}
+            >
+              <Icon name="sparkles" size="md" />
+            </div>
+            <div>
+              <div className={css({ fontWeight: "semibold", textStyle: "lg" })}>
+                Custom header layout
+              </div>
+              <div className={css({ color: "fg.muted", textStyle: "sm" })}>
+                Built from arbitrary content.
+              </div>
+            </div>
+          </div>
+        </Drawer.Header>
+        <Drawer.Body>{sampleBody}</Drawer.Body>
+      </Drawer>
+    ),
+  },
+  {
+    buttonLabel: "Custom footer",
+    renderDrawer: (close) => (
+      <Drawer variant={variant} onClose={close}>
+        <Drawer.Header title="Custom footer" />
+        <Drawer.Body>{sampleBody}</Drawer.Body>
+        <Drawer.Footer>
+          <div
+            className={css({
+              display: "flex",
+              alignItems: "center",
+              gap: "3",
+              width: "[100%]",
+            })}
+          >
+            <Icon
+              name="info"
+              size="sm"
+              className={css({ color: "fg.muted" })}
+            />
+            <span className={css({ color: "fg.muted", textStyle: "sm" })}>
+              All changes are saved automatically.
+            </span>
+            <Button
+              className={css({ marginLeft: "auto" })}
+              variant="solid"
+              tone="neutral"
+              onClick={close}
+            >
+              Done
+            </Button>
+          </div>
+        </Drawer.Footer>
+      </Drawer>
+    ),
+  },
+  {
+    buttonLabel: "Kitchen sink (no padding)",
+    renderDrawer: (close) => (
+      <Drawer variant={variant} onClose={close}>
+        <Drawer.Header
+          title="Edit workspace"
+          iconName="gear"
+          description="Body content controls its own padding."
+        />
+        <Drawer.Body withPadding={false}>
+          <p>
+            This body container has zero padding from the drawer, so it spans
+            edge-to-edge. The content within decides its own layout.
+          </p>
+        </Drawer.Body>
+        <Drawer.Footer
+          actions={
+            <Button variant="solid" tone="brand" onClick={close}>
+              Save
+            </Button>
+          }
+          secondaryActions={
+            <Button variant="subtle" tone="neutral" onClick={close}>
+              Cancel
+            </Button>
+          }
+        />
+      </Drawer>
+    ),
+  },
+];
+
+export const Examples: Story = () => (
+  <div className={css({ display: "flex", flexDirection: "column", gap: "4" })}>
+    {(["partitionedFooter", "plain"] as const).map((variant) => (
+      <div
+        key={variant}
+        className={css({
+          display: "flex",
+          gap: "3",
+          alignItems: "center",
+          flexWrap: "wrap",
+        })}
+      >
+        <div className={css({ minWidth: "[8rem]", fontWeight: "medium" })}>
+          {variant}
+        </div>
+        {buildExampleEntries(variant).map((entry) => (
+          <DrawerExample
+            key={entry.buttonLabel}
+            buttonLabel={entry.buttonLabel}
+            renderDrawer={entry.renderDrawer}
+          />
+        ))}
+      </div>
+    ))}
+  </div>
+);
+
+const sizes = ["sm", "md", "lg", "xl"] as const satisfies readonly DrawerSize[];
+
+const renderKitchenSink = (
+  size: DrawerSize,
+  close: () => void,
+  options?: { loading?: boolean },
+) => (
+  <Drawer size={size} loading={options?.loading} onClose={close}>
+    <Drawer.Header
+      title={`Kitchen sink (${size})`}
+      iconName="gear"
+      description="All the bells and whistles, sized for this width."
+      actions={
+        <Button
+          variant="ghost"
+          tone="neutral"
+          size="sm"
+          iconName="externalLink"
+          tooltip="Open docs"
+        />
+      }
+    />
+    <Drawer.Body>{sampleBody}</Drawer.Body>
+    <Drawer.Footer
+      actions={
+        <Button variant="solid" tone="brand" onClick={close}>
+          Save changes
+        </Button>
+      }
+      secondaryActions={
+        <Button variant="subtle" tone="error" onClick={close}>
+          Delete
+        </Button>
+      }
+    />
+  </Drawer>
+);
+
+export const Sizes: Story = () => (
+  <div className={css({ display: "flex", flexDirection: "column", gap: "4" })}>
+    {sizes.map((size) => (
+      <div
+        key={size}
+        className={css({
+          display: "flex",
+          gap: "3",
+          alignItems: "center",
+          flexWrap: "wrap",
+        })}
+      >
+        <div className={css({ minWidth: "[6rem]", fontWeight: "medium" })}>
+          {size}
+        </div>
+        <DrawerExample
+          buttonLabel={`Kitchen sink — ${size}`}
+          renderDrawer={(close) => renderKitchenSink(size, close)}
+        />
+        <DrawerExample
+          buttonLabel={`Loading — ${size}`}
+          renderDrawer={(close) =>
+            renderKitchenSink(size, close, { loading: true })
+          }
+        />
+        {size === "sm" ? (
+          <>
+            <DrawerExample
+              buttonLabel={`No header — ${size}`}
+              renderDrawer={(close) => (
+                <Drawer size={size} onClose={close}>
+                  <Drawer.Body>{sampleBody}</Drawer.Body>
+                </Drawer>
+              )}
+            />
+            <DrawerExample
+              buttonLabel={`No header, no padding — ${size}`}
+              renderDrawer={(close) => (
+                <Drawer size={size} onClose={close}>
+                  <Drawer.Body withPadding={false}>{sampleBody}</Drawer.Body>
+                </Drawer>
+              )}
+            />
+          </>
+        ) : null}
+      </div>
+    ))}
+    <div
+      className={css({
+        display: "flex",
+        gap: "3",
+        alignItems: "center",
+        flexWrap: "wrap",
+      })}
+    >
+      <div className={css({ minWidth: "[6rem]", fontWeight: "medium" })}>
+        custom
+      </div>
+      <DrawerExample
+        buttonLabel="Custom width (480px)"
+        renderDrawer={(close) => (
+          <Drawer className={css({ maxWidth: "[480px]" })} onClose={close}>
+            <Drawer.Header
+              title="Custom width (480px)"
+              description="maxWidth is overridden via className."
+            />
+            <Drawer.Body>{sampleBody}</Drawer.Body>
+            <Drawer.Footer
+              actions={
+                <Button variant="solid" tone="brand" onClick={close}>
+                  Save changes
+                </Button>
+              }
+            />
+          </Drawer>
+        )}
+      />
+    </div>
+  </div>
+);
+
+const overflowingTitle =
+  "A really, really long title that probably wraps onto multiple lines and helps verify how the header handles wrapped text without breaking the layout";
+
+const overflowingDescription =
+  "And the description gets a similarly verbose treatment so we can verify the header subtext also handles wrapping across multiple lines, especially when paired with a long title and a row of title actions.";
+
+const overflowingBody = (
+  <div className={css({ display: "flex", flexDirection: "column", gap: "3" })}>
+    {Array.from({ length: 20 }).map((_, index) => (
+      // eslint-disable-next-line react/no-array-index-key
+      <p key={index}>
+        Paragraph {index + 1}. Lorem ipsum dolor sit amet, consectetur
+        adipiscing elit. Donec efficitur, nisl sed eleifend dictum, ipsum nisi
+        rhoncus odio, et fringilla justo lectus ac neque.
+      </p>
+    ))}
+  </div>
+);
+
+const renderOverflowKitchenSink = (
+  close: () => void,
+  options?: { loading?: boolean },
+) => (
+  <Drawer loading={options?.loading} onClose={close}>
+    <Drawer.Header
+      title={overflowingTitle}
+      iconName="gear"
+      description={overflowingDescription}
+      actions={
+        <>
+          <Button
+            variant="ghost"
+            tone="neutral"
+            size="sm"
+            iconName="externalLink"
+            tooltip="Open docs"
+          />
+          <Button
+            variant="ghost"
+            tone="neutral"
+            size="sm"
+            iconName="info"
+            tooltip="More info"
+          />
+        </>
+      }
+    />
+    <Drawer.Body>{overflowingBody}</Drawer.Body>
+    <Drawer.Footer
+      actions={
+        <>
+          <Button variant="solid" tone="brand" onClick={close}>
+            Save these long-form changes for later review
+          </Button>
+          <Button variant="solid" tone="brand" onClick={close}>
+            Done
+          </Button>
+          <Button variant="solid" tone="brand" onClick={close}>
+            Done
+          </Button>
+        </>
+      }
+      secondaryActions={
+        <Button variant="subtle" tone="error" onClick={close}>
+          Delete this workspace permanently
+        </Button>
+      }
+    />
+  </Drawer>
+);
+
+const renderOverflowCustom = (
+  close: () => void,
+  options?: { loading?: boolean },
+) => (
+  <Drawer loading={options?.loading} onClose={close}>
+    <Drawer.Header>
+      <div
+        className={css({
+          display: "flex",
+          flexDirection: "column",
+          gap: "2",
+          width: "[100%]",
+        })}
+      >
+        <div className={css({ fontWeight: "semibold", textStyle: "lg" })}>
+          A custom header with significant content that should test how
+          arbitrary header content wraps and lays out
+        </div>
+        <div className={css({ color: "fg.muted", textStyle: "sm" })}>
+          Plus a fairly long subtitle so we can validate multi-line wrapping
+          behaviour within a custom header slot.
+        </div>
+      </div>
+    </Drawer.Header>
+    <Drawer.Body>{overflowingBody}</Drawer.Body>
+    <Drawer.Footer>
+      <div
+        className={css({
+          display: "flex",
+          alignItems: "center",
+          gap: "3",
+          width: "[100%]",
+          flexWrap: "wrap",
+        })}
+      >
+        <span className={css({ color: "fg.muted", textStyle: "sm" })}>
+          A custom footer with a long status message to test wrapping behaviour
+          and layout adjustments under content pressure.
+        </span>
+        <Button
+          className={css({ marginLeft: "auto" })}
+          variant="solid"
+          tone="neutral"
+          onClick={close}
+        >
+          Done
+        </Button>
+      </div>
+    </Drawer.Footer>
+  </Drawer>
+);
+
+const renderOverflowBodyOnly = (
+  close: () => void,
+  options?: { loading?: boolean },
+) => (
+  <Drawer loading={options?.loading} onClose={close}>
+    <Drawer.Body>{overflowingBody}</Drawer.Body>
+  </Drawer>
+);
+
+export const Overflow: Story = () => (
+  <div className={css({ display: "flex", flexDirection: "column", gap: "4" })}>
+    {([false, true] as const).map((loading) => (
+      <div
+        key={String(loading)}
+        className={css({
+          display: "flex",
+          gap: "3",
+          alignItems: "center",
+          flexWrap: "wrap",
+        })}
+      >
+        <div className={css({ minWidth: "[6rem]", fontWeight: "medium" })}>
+          {loading ? "loading" : "default"}
+        </div>
+        <DrawerExample
+          buttonLabel={`Kitchen sink${loading ? " — loading" : ""}`}
+          renderDrawer={(close) =>
+            renderOverflowKitchenSink(close, { loading })
+          }
+        />
+        <DrawerExample
+          buttonLabel={`Custom header + footer${loading ? " — loading" : ""}`}
+          renderDrawer={(close) => renderOverflowCustom(close, { loading })}
+        />
+        <DrawerExample
+          buttonLabel={`No header + footer${loading ? " — loading" : ""}`}
+          renderDrawer={(close) => renderOverflowBodyOnly(close, { loading })}
+        />
+      </div>
+    ))}
+  </div>
+);
+
+const StackedDrawers = () => {
+  const [first, setFirst] = useState(false);
+  const [second, setSecond] = useState(false);
+  const [third, setThird] = useState(false);
+  const [fourth, setFourth] = useState(false);
+
+  return (
+    <>
+      <Button onClick={() => setFirst(true)}>Open stacked drawers</Button>
+      {first ? (
+        <Drawer size="md" onClose={() => setFirst(false)}>
+          <Drawer.Header
+            title="First drawer"
+            iconName="gear"
+            description="Open the next drawer to stack another on top."
+          />
+          <Drawer.Body>{sampleBody}</Drawer.Body>
+          <Drawer.Footer
+            actions={
+              <Button
+                variant="solid"
+                tone="brand"
+                onClick={() => setSecond(true)}
+              >
+                Open second drawer
+              </Button>
+            }
+          />
+        </Drawer>
+      ) : null}
+      {second ? (
+        <Drawer size="md" onClose={() => setSecond(false)}>
+          <Drawer.Header
+            title="Second drawer"
+            iconName="gear"
+            description="Open the next drawer to stack a small drawer on top."
+          />
+          <Drawer.Body>{sampleBody}</Drawer.Body>
+          <Drawer.Footer
+            actions={
+              <Button
+                variant="solid"
+                tone="brand"
+                onClick={() => setThird(true)}
+              >
+                Open small drawer
+              </Button>
+            }
+          />
+        </Drawer>
+      ) : null}
+      {third ? (
+        <Drawer size="sm" onClose={() => setThird(false)}>
+          <Drawer.Header
+            title="Small drawer"
+            iconName="info"
+            description="Open another small drawer on top of this one."
+          />
+          <Drawer.Body>{sampleBody}</Drawer.Body>
+          <Drawer.Footer
+            actions={
+              <Button
+                variant="solid"
+                tone="brand"
+                onClick={() => setFourth(true)}
+              >
+                Open another small drawer
+              </Button>
+            }
+          />
+        </Drawer>
+      ) : null}
+      {fourth ? (
+        <Drawer size="sm" onClose={() => setFourth(false)}>
+          <Drawer.Header
+            title="Another small drawer"
+            iconName="info"
+            description="This is the top of the stack."
+          />
+          <Drawer.Body>{sampleBody}</Drawer.Body>
+          <Drawer.Footer
+            actions={
+              <Button
+                variant="solid"
+                tone="brand"
+                onClick={() => setFourth(false)}
+              >
+                Done
+              </Button>
+            }
+          />
+        </Drawer>
+      ) : null}
+    </>
+  );
+};
+
+export const Stacked: Story = () => <StackedDrawers />;
+
+export const ShouldCloseOn: Story = () => (
+  <div className={stackStyles}>
+    <DrawerExample
+      buttonLabel="closeButtonAndOverlay (default)"
+      renderDrawer={(close) => (
+        <Drawer shouldCloseOn="closeButtonAndOverlay" onClose={close}>
+          <Drawer.Header
+            title="Close button and overlay"
+            iconName="info"
+            description="Escape, the close button, and clicking the overlay all close the drawer."
+          />
+          <Drawer.Body>{sampleBody}</Drawer.Body>
+          <Drawer.Footer
+            actions={
+              <Button variant="solid" tone="brand" onClick={close}>
+                Done
+              </Button>
+            }
+          />
+        </Drawer>
+      )}
+    />
+
+    <DrawerExample
+      buttonLabel="closeButton"
+      renderDrawer={(close) => (
+        <Drawer shouldCloseOn="closeButton" onClose={close}>
+          <Drawer.Header
+            title="Close button only"
+            iconName="info"
+            description="Escape and the close button close the drawer. Overlay clicks do not."
+          />
+          <Drawer.Body>{sampleBody}</Drawer.Body>
+          <Drawer.Footer
+            actions={
+              <Button variant="solid" tone="brand" onClick={close}>
+                Done
+              </Button>
+            }
+          />
+        </Drawer>
+      )}
+    />
+
+    <DrawerExample
+      buttonLabel="none"
+      renderDrawer={(close) => (
+        <Drawer shouldCloseOn="none" onClose={close}>
+          <Drawer.Header
+            title="No default close"
+            iconName="info"
+            description="No close button is rendered, and neither escape nor overlay clicks close the drawer."
+          />
+          <Drawer.Body>{sampleBody}</Drawer.Body>
+          <Drawer.Footer
+            actions={
+              <Button variant="solid" tone="brand" onClick={close}>
+                Done
+              </Button>
+            }
+          />
+        </Drawer>
+      )}
+    />
+
+    <DrawerExample
+      buttonLabel="none + no header"
+      renderDrawer={(close) => (
+        <Drawer shouldCloseOn="none" onClose={close}>
+          <Drawer.Body>{sampleBody}</Drawer.Body>
+          <Drawer.Footer
+            actions={
+              <Button variant="solid" tone="brand" onClick={close}>
+                Done
+              </Button>
+            }
+          />
+        </Drawer>
+      )}
+    />
+  </div>
+);

--- a/libs/@hashintel/ds-components/src/components/Drawer/drawer.stories.tsx
+++ b/libs/@hashintel/ds-components/src/components/Drawer/drawer.stories.tsx
@@ -240,6 +240,18 @@ const buildExampleEntries = (variant: DrawerVariant): ExampleProps[] => [
       </Drawer>
     ),
   },
+  {
+    buttonLabel: "No backdrop",
+    renderDrawer: (close) => (
+      <Drawer variant={variant} showBackdrop={false} onClose={close}>
+        <Drawer.Header
+          title="No backdrop"
+          description="Rendered with showBackdrop={false}, so the page behind stays visible with no dimmed overlay."
+        />
+        <Drawer.Body>{sampleBody}</Drawer.Body>
+      </Drawer>
+    ),
+  },
 ];
 
 export const Examples: Story = () => (

--- a/libs/@hashintel/ds-components/src/components/Drawer/drawer.tsx
+++ b/libs/@hashintel/ds-components/src/components/Drawer/drawer.tsx
@@ -1,0 +1,290 @@
+import { Drawer as ArkDrawer } from "@ark-ui/react/drawer";
+import { Portal } from "@ark-ui/react/portal";
+import {
+  Children,
+  createContext,
+  isValidElement,
+  useContext,
+  useMemo,
+} from "react";
+
+import { css, cx } from "@hashintel/ds-helpers/css";
+
+import { usePortalContainerRef } from "../../util/portal-container-context";
+import { Button } from "../Button/button";
+import { Icon, type IconName } from "../Icon/icon";
+import { LoadingSpinner } from "../Loading/loading-spinner";
+import { styles } from "./drawer.recipe";
+
+import type { ExclusifyUnion, RequireAtLeastOne } from "type-fest";
+
+export type DrawerSize = "sm" | "md" | "lg" | "xl";
+
+export type DrawerShouldCloseOn =
+  | "closeButtonAndOverlay"
+  | "closeButton"
+  | "none";
+
+const DrawerContext = createContext<{
+  classes: ReturnType<typeof styles>;
+  onClose?: () => void;
+  renderCloseButton: boolean;
+  loading?: boolean;
+} | null>(null);
+
+const useDrawerContext = () => {
+  const ctx = useContext(DrawerContext);
+  if (!ctx) {
+    throw new Error(
+      "Drawer.Header, Drawer.Body and Drawer.Footer must be rendered inside <Drawer>",
+    );
+  }
+  return ctx;
+};
+
+type HeaderProps = ExclusifyUnion<
+  | {
+      title?: React.ReactNode;
+      description?: React.ReactNode;
+      iconName?: IconName;
+      actions?: React.ReactNode;
+    }
+  | {
+      children?: React.ReactNode;
+    }
+>;
+const Header = ({
+  title,
+  description,
+  iconName,
+  actions,
+  children,
+}: HeaderProps) => {
+  const { classes, onClose, renderCloseButton } = useDrawerContext();
+
+  const hasStructuredHeader =
+    title !== undefined ||
+    description !== undefined ||
+    iconName !== undefined ||
+    actions !== undefined;
+
+  const closeButton = renderCloseButton && (
+    <Button
+      variant="ghost"
+      className={classes.closeButton}
+      aria-label="Close drawer"
+      onClick={() => {
+        onClose?.();
+      }}
+      iconName="close"
+      size="sm"
+    />
+  );
+
+  if (!hasStructuredHeader) {
+    return (
+      <div className={cx(classes.header, classes.hasCustomHeader)}>
+        {children && <div>{children}</div>}
+        {closeButton}
+      </div>
+    );
+  }
+
+  return (
+    <div className={classes.header}>
+      <div className={classes.headerMain}>
+        {iconName && (
+          <Icon name={iconName} size="md" className={classes.titleIcon} />
+        )}
+        {/*
+         * The actions/close float to the end within this text column so the
+         * title and description wrap around them. On md and up the column is a
+         * flex item (its own formatting context) sitting to the right of the
+         * flexed icon; on sm it is a transparent block, so the icon float
+         * from headerMain still reaches the text.
+         */}
+        <div className={classes.headerText}>
+          {actions ? (
+            <div className={classes.headerRight}>
+              <div className={classes.headerActions}>{actions}</div>
+              {closeButton}
+            </div>
+          ) : (
+            closeButton
+          )}
+          {title && (
+            <ArkDrawer.Title className={classes.title}>{title}</ArkDrawer.Title>
+          )}
+          {description && (
+            <ArkDrawer.Description className={classes.description}>
+              {description}
+            </ArkDrawer.Description>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+type FooterProps = ExclusifyUnion<
+  | { children?: React.ReactNode }
+  | RequireAtLeastOne<{
+      actions?: React.ReactNode;
+      secondaryActions?: React.ReactNode;
+    }>
+>;
+const Footer = ({ children, actions, secondaryActions }: FooterProps) => {
+  const { classes } = useDrawerContext();
+
+  return (
+    <div className={classes.footer}>
+      {children ?? (
+        <>
+          {secondaryActions && (
+            <div className={classes.footerSecondaryActions}>
+              {secondaryActions}
+            </div>
+          )}
+          {actions && <div className={classes.footerActions}>{actions}</div>}
+        </>
+      )}
+    </div>
+  );
+};
+
+type BodyProps = {
+  children: React.ReactNode;
+  /** Turn padding on/off. Used when the body content controls padding itself. defaults to true */
+  withPadding?: boolean;
+};
+const Body = ({ children, withPadding = true }: BodyProps) => {
+  const { classes, loading } = useDrawerContext();
+
+  return (
+    <div
+      className={cx(
+        classes.body,
+        !withPadding && css({ padding: "[0 !important]" }),
+      )}
+    >
+      {children}
+      {loading ? (
+        <div className={classes.loadingOverlay} aria-live="polite">
+          <LoadingSpinner size="lg" className={classes.loadingSpinner} />
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+const DrawerRoot = ({
+  className,
+  size = "md",
+  variant = "partitionedFooter",
+  children,
+  shouldCloseOn = "closeButtonAndOverlay",
+  loading,
+  onClose,
+  initialFocusRef,
+  returnFocusRef,
+  onKeyDown,
+  ...ariaAttributes
+}: {
+  className?: string;
+  size?: DrawerSize;
+  onKeyDown?: React.KeyboardEventHandler<Element>;
+  variant?: "partitionedFooter" | "plain";
+  children:
+    | readonly [
+        React.ReactElement<HeaderProps, typeof Header>,
+        React.ReactElement<BodyProps, typeof Body>,
+        React.ReactElement<FooterProps, typeof Footer>?,
+      ]
+    | readonly [
+        React.ReactElement<BodyProps, typeof Body>,
+        React.ReactElement<FooterProps, typeof Footer>?,
+      ]
+    | React.ReactElement<BodyProps, typeof Body>;
+  shouldCloseOn?: DrawerShouldCloseOn;
+  loading?: boolean;
+  onClose?: () => void;
+  initialFocusRef?: React.RefObject<HTMLElement>;
+  returnFocusRef?: React.RefObject<HTMLElement>;
+} & React.AriaAttributes) => {
+  const portalContainerRef = usePortalContainerRef();
+
+  const headerChild = Children.toArray(children).find(
+    (child): child is React.ReactElement<HeaderProps, typeof Header> =>
+      isValidElement(child) && child.type === Header,
+  );
+  const hasHeader = !!headerChild;
+  const titleIconName = headerChild?.props.iconName;
+
+  const classes = useMemo(
+    () =>
+      styles({
+        size,
+        headerless: !hasHeader,
+        hasIcon: !!titleIconName,
+        variant,
+      }),
+    [size, hasHeader, titleIconName, variant],
+  );
+
+  const renderCloseButton = shouldCloseOn !== "none";
+  const closeOnEscape = shouldCloseOn !== "none";
+  const closeOnInteractOutside = shouldCloseOn === "closeButtonAndOverlay";
+
+  const ctx = useMemo(
+    () => ({ classes, onClose, renderCloseButton, loading }),
+    [classes, onClose, renderCloseButton, loading],
+  );
+
+  return (
+    <ArkDrawer.Root
+      open
+      // Slides in from the right; swiping the panel back towards that edge
+      // dismisses it.
+      swipeDirection="end"
+      closeOnEscape={closeOnEscape}
+      closeOnInteractOutside={closeOnInteractOutside}
+      onOpenChange={(event) => {
+        if (!event.open) {
+          onClose?.();
+        }
+      }}
+      initialFocusEl={
+        initialFocusRef ? () => initialFocusRef.current : undefined
+      }
+      finalFocusEl={returnFocusRef ? () => returnFocusRef.current : undefined}
+    >
+      <Portal container={portalContainerRef}>
+        <div className={classes.stackRoot}>
+          <ArkDrawer.Backdrop className={classes.backdrop} />
+          <ArkDrawer.Positioner className={classes.positioner}>
+            <ArkDrawer.Content
+              {...ariaAttributes}
+              className={cx(classes.content, className)}
+              aria-busy={loading ?? undefined}
+              onKeyDown={onKeyDown}
+            >
+              <DrawerContext.Provider value={ctx}>
+                {
+                  // if there's no header, we still display an empty one to display the close button + for layout
+                  !hasHeader && <Header />
+                }
+                {children}
+              </DrawerContext.Provider>
+            </ArkDrawer.Content>
+          </ArkDrawer.Positioner>
+        </div>
+      </Portal>
+    </ArkDrawer.Root>
+  );
+};
+
+export const Drawer = Object.assign(DrawerRoot, {
+  Header,
+  Body,
+  Footer,
+});

--- a/libs/@hashintel/ds-components/src/components/Drawer/drawer.tsx
+++ b/libs/@hashintel/ds-components/src/components/Drawer/drawer.tsx
@@ -14,16 +14,20 @@ import {
   type OverlayHeaderProps,
   type OverlayShouldCloseOn,
 } from "../../util/overlay-parts";
+import { overlayPartsStyles } from "../../util/overlay-parts.recipe";
 import { usePortalContainerRef } from "../../util/portal-container-context";
 import { styles } from "./drawer.recipe";
 
 export type DrawerSize = "sm" | "md" | "lg" | "xl";
+
+const backdropClassName = overlayPartsStyles({ component: "drawer" }).backdrop;
 
 const DrawerRoot = ({
   className,
   size = "md",
   variant = "partitionedFooter",
   children,
+  showBackdrop = true,
   shouldCloseOn = "closeButtonAndOverlay",
   loading,
   onClose,
@@ -36,6 +40,8 @@ const DrawerRoot = ({
   size?: DrawerSize;
   onKeyDown?: React.KeyboardEventHandler<Element>;
   variant?: "partitionedFooter" | "plain";
+  /** Render the dimmed overlay behind the drawer. Defaults to `true`. */
+  showBackdrop?: boolean;
   children:
     | readonly [
         React.ReactElement<OverlayHeaderProps, typeof OverlayHeader>,
@@ -88,6 +94,10 @@ const DrawerRoot = ({
       lazyMount
       unmountOnExit
       swipeDirection="end"
+      // Without a backdrop the drawer is non-modal, so the page behind stays interactive
+      // But we still want to keep focus trapped even when modal={false}
+      modal={showBackdrop}
+      trapFocus
       closeOnEscape={closeOnEscape}
       closeOnInteractOutside={closeOnInteractOutside}
       onOpenChange={(event) => {
@@ -105,7 +115,7 @@ const DrawerRoot = ({
     >
       <Portal container={portalContainerRef}>
         <div className={classes.stackRoot}>
-          <ArkDrawer.Backdrop className={classes.backdrop} />
+          {showBackdrop && <ArkDrawer.Backdrop className={backdropClassName} />}
           <ArkDrawer.Positioner className={classes.positioner}>
             <ArkDrawer.Content
               {...ariaAttributes}

--- a/libs/@hashintel/ds-components/src/components/Drawer/drawer.tsx
+++ b/libs/@hashintel/ds-components/src/components/Drawer/drawer.tsx
@@ -1,6 +1,6 @@
 import { Drawer as ArkDrawer } from "@ark-ui/react/drawer";
 import { Portal } from "@ark-ui/react/portal";
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { cx } from "@hashintel/ds-helpers/css";
 
@@ -61,16 +61,42 @@ const DrawerRoot = ({
   const closeOnEscape = shouldCloseOn !== "none";
   const closeOnInteractOutside = shouldCloseOn === "closeButtonAndOverlay";
 
+  // The parent mounts/unmounts the Drawer to open/close it, but Ark only plays
+  // the slide animations when `open` actually transitions. So we drive `open`
+  // internally: it starts closed and flips open on the next frame (playing the
+  // enter animation), and every close request flips it back to closed to play
+  // the exit animation. The parent-facing `onClose` is deferred until that exit
+  // animation completes, so the panel finishes sliding out before it unmounts.
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => {
+      setOpen(true);
+    });
+    return () => {
+      cancelAnimationFrame(frame);
+    };
+  }, []);
+
+  const requestClose = () => {
+    setOpen(false);
+  };
+
   return (
     <ArkDrawer.Root
-      open
+      open={open}
+      lazyMount
+      unmountOnExit
       swipeDirection="end"
       closeOnEscape={closeOnEscape}
       closeOnInteractOutside={closeOnInteractOutside}
       onOpenChange={(event) => {
         if (!event.open) {
-          onClose?.();
+          requestClose();
         }
+      }}
+      onExitComplete={() => {
+        onClose?.();
       }}
       initialFocusEl={
         initialFocusRef ? () => initialFocusRef.current : undefined
@@ -90,7 +116,7 @@ const DrawerRoot = ({
               <OverlaySections
                 size={size}
                 variant={variant}
-                onClose={onClose}
+                onClose={requestClose}
                 renderCloseButton={renderCloseButton}
                 loading={loading}
                 Title={ArkDrawer.Title}

--- a/libs/@hashintel/ds-components/src/components/Drawer/drawer.tsx
+++ b/libs/@hashintel/ds-components/src/components/Drawer/drawer.tsx
@@ -65,11 +65,15 @@ const translateForPosition = (
  * order so a drawer can offset itself far enough to keep its edge peeking out
  * from behind the drawers stacked on top of it. Measuring from the DOM means
  * drawers with custom widths/heights stack correctly, not just the preset sizes.
+ * Each entry also tracks whether its drawer is still open: a drawer that has
+ * begun closing immediately stops offsetting the drawers beneath it, so they
+ * un-nest in step with its slide-out instead of after it finishes and unmounts.
  */
 type DrawerStackEntry = {
   order: number;
   position: DrawerPosition;
   extent: number;
+  open: boolean;
 };
 const drawerStackEntries = new Map<string, DrawerStackEntry>();
 const drawerStackListeners = new Set<() => void>();
@@ -102,22 +106,25 @@ const computeDrawerStackTranslate = (id: string): string => {
 
   let aboveExtent = 0;
   let aboveTranslation = 0;
-  for (const [index, entry] of stack.entries()) {
+  let hasOpenAbove = false;
+  for (const entry of stack) {
     const extent = entry.extent;
-    const translation =
-      index === 0
-        ? 0
-        : Math.max(
-            extent,
-            aboveExtent + STACK_LAYER_OFFSET_PX + aboveTranslation,
-          ) - extent;
+    const translation = hasOpenAbove
+      ? Math.max(
+          extent,
+          aboveExtent + STACK_LAYER_OFFSET_PX + aboveTranslation,
+        ) - extent
+      : 0;
 
     if (entry.order === self.order) {
       return translateForPosition(self.position, translation);
     }
 
-    aboveExtent = extent;
-    aboveTranslation = translation;
+    if (entry.open) {
+      aboveExtent = extent;
+      aboveTranslation = translation;
+      hasOpenAbove = true;
+    }
   }
 
   return "0 0";
@@ -125,6 +132,7 @@ const computeDrawerStackTranslate = (id: string): string => {
 
 const useDrawerStackTranslate = (
   position: DrawerPosition,
+  open: boolean,
 ): {
   ref: (node: HTMLDivElement | null) => void;
   translate: string;
@@ -161,11 +169,12 @@ const useDrawerStackTranslate = (
         existing &&
         existing.order === order &&
         existing.position === position &&
-        existing.extent === extent
+        existing.extent === extent &&
+        existing.open === open
       ) {
         return;
       }
-      drawerStackEntries.set(id, { order, position, extent });
+      drawerStackEntries.set(id, { order, position, extent, open });
       emitDrawerStackChange();
     };
 
@@ -178,7 +187,7 @@ const useDrawerStackTranslate = (
       drawerStackEntries.delete(id);
       emitDrawerStackChange();
     };
-  }, [id, position, contentNode]);
+  }, [id, position, contentNode, open]);
 
   const translate = useSyncExternalStore(
     subscribeToDrawerStack,
@@ -233,13 +242,6 @@ const DrawerRoot = ({
 
   const classes = useMemo(() => styles({ size, position }), [size, position]);
 
-  const { ref: stackContentRef, translate: stackTranslate } =
-    useDrawerStackTranslate(position);
-
-  const renderCloseButton = shouldCloseOn !== "none";
-  const closeOnEscape = shouldCloseOn !== "none";
-  const closeOnInteractOutside = shouldCloseOn === "closeButtonAndOverlay";
-
   // The parent mounts/unmounts the Drawer to open/close it, but Ark only plays
   // the slide animations when `open` actually transitions. So we drive `open`
   // internally: it starts closed and flips open on the next frame (playing the
@@ -256,6 +258,16 @@ const DrawerRoot = ({
       cancelAnimationFrame(frame);
     };
   }, []);
+
+  // `open` is passed to the stack tracker so a drawer stops offsetting the
+  // drawers beneath it the moment it starts closing, letting them un-nest in
+  // step with its slide-out.
+  const { ref: stackContentRef, translate: stackTranslate } =
+    useDrawerStackTranslate(position, open);
+
+  const renderCloseButton = shouldCloseOn !== "none";
+  const closeOnEscape = shouldCloseOn !== "none";
+  const closeOnInteractOutside = shouldCloseOn === "closeButtonAndOverlay";
 
   const requestClose = () => {
     setOpen(false);

--- a/libs/@hashintel/ds-components/src/components/Drawer/drawer.tsx
+++ b/libs/@hashintel/ds-components/src/components/Drawer/drawer.tsx
@@ -1,181 +1,23 @@
 import { Drawer as ArkDrawer } from "@ark-ui/react/drawer";
 import { Portal } from "@ark-ui/react/portal";
+import { useMemo } from "react";
+
+import { cx } from "@hashintel/ds-helpers/css";
+
 import {
-  Children,
-  createContext,
-  isValidElement,
-  useContext,
-  useMemo,
-} from "react";
-
-import { css, cx } from "@hashintel/ds-helpers/css";
-
+  OverlayBody,
+  OverlayFooter,
+  OverlayHeader,
+  OverlaySections,
+  type OverlayBodyProps,
+  type OverlayFooterProps,
+  type OverlayHeaderProps,
+  type OverlayShouldCloseOn,
+} from "../../util/overlay-parts";
 import { usePortalContainerRef } from "../../util/portal-container-context";
-import { Button } from "../Button/button";
-import { Icon, type IconName } from "../Icon/icon";
-import { LoadingSpinner } from "../Loading/loading-spinner";
 import { styles } from "./drawer.recipe";
 
-import type { ExclusifyUnion, RequireAtLeastOne } from "type-fest";
-
 export type DrawerSize = "sm" | "md" | "lg" | "xl";
-
-export type DrawerShouldCloseOn =
-  | "closeButtonAndOverlay"
-  | "closeButton"
-  | "none";
-
-const DrawerContext = createContext<{
-  classes: ReturnType<typeof styles>;
-  onClose?: () => void;
-  renderCloseButton: boolean;
-  loading?: boolean;
-} | null>(null);
-
-const useDrawerContext = () => {
-  const ctx = useContext(DrawerContext);
-  if (!ctx) {
-    throw new Error(
-      "Drawer.Header, Drawer.Body and Drawer.Footer must be rendered inside <Drawer>",
-    );
-  }
-  return ctx;
-};
-
-type HeaderProps = ExclusifyUnion<
-  | {
-      title?: React.ReactNode;
-      description?: React.ReactNode;
-      iconName?: IconName;
-      actions?: React.ReactNode;
-    }
-  | {
-      children?: React.ReactNode;
-    }
->;
-const Header = ({
-  title,
-  description,
-  iconName,
-  actions,
-  children,
-}: HeaderProps) => {
-  const { classes, onClose, renderCloseButton } = useDrawerContext();
-
-  const hasStructuredHeader =
-    title !== undefined ||
-    description !== undefined ||
-    iconName !== undefined ||
-    actions !== undefined;
-
-  const closeButton = renderCloseButton && (
-    <Button
-      variant="ghost"
-      className={classes.closeButton}
-      aria-label="Close drawer"
-      onClick={() => {
-        onClose?.();
-      }}
-      iconName="close"
-      size="sm"
-    />
-  );
-
-  if (!hasStructuredHeader) {
-    return (
-      <div className={cx(classes.header, classes.hasCustomHeader)}>
-        {children && <div>{children}</div>}
-        {closeButton}
-      </div>
-    );
-  }
-
-  return (
-    <div className={classes.header}>
-      <div className={classes.headerMain}>
-        {iconName && (
-          <Icon name={iconName} size="md" className={classes.titleIcon} />
-        )}
-        {/*
-         * The actions/close float to the end within this text column so the
-         * title and description wrap around them. On md and up the column is a
-         * flex item (its own formatting context) sitting to the right of the
-         * flexed icon; on sm it is a transparent block, so the icon float
-         * from headerMain still reaches the text.
-         */}
-        <div className={classes.headerText}>
-          {actions ? (
-            <div className={classes.headerRight}>
-              <div className={classes.headerActions}>{actions}</div>
-              {closeButton}
-            </div>
-          ) : (
-            closeButton
-          )}
-          {title && (
-            <ArkDrawer.Title className={classes.title}>{title}</ArkDrawer.Title>
-          )}
-          {description && (
-            <ArkDrawer.Description className={classes.description}>
-              {description}
-            </ArkDrawer.Description>
-          )}
-        </div>
-      </div>
-    </div>
-  );
-};
-
-type FooterProps = ExclusifyUnion<
-  | { children?: React.ReactNode }
-  | RequireAtLeastOne<{
-      actions?: React.ReactNode;
-      secondaryActions?: React.ReactNode;
-    }>
->;
-const Footer = ({ children, actions, secondaryActions }: FooterProps) => {
-  const { classes } = useDrawerContext();
-
-  return (
-    <div className={classes.footer}>
-      {children ?? (
-        <>
-          {secondaryActions && (
-            <div className={classes.footerSecondaryActions}>
-              {secondaryActions}
-            </div>
-          )}
-          {actions && <div className={classes.footerActions}>{actions}</div>}
-        </>
-      )}
-    </div>
-  );
-};
-
-type BodyProps = {
-  children: React.ReactNode;
-  /** Turn padding on/off. Used when the body content controls padding itself. defaults to true */
-  withPadding?: boolean;
-};
-const Body = ({ children, withPadding = true }: BodyProps) => {
-  const { classes, loading } = useDrawerContext();
-
-  return (
-    <div
-      className={cx(
-        classes.body,
-        !withPadding && css({ padding: "[0 !important]" }),
-      )}
-    >
-      {children}
-      {loading ? (
-        <div className={classes.loadingOverlay} aria-live="polite">
-          <LoadingSpinner size="lg" className={classes.loadingSpinner} />
-        </div>
-      ) : null}
-    </div>
-  );
-};
 
 const DrawerRoot = ({
   className,
@@ -196,16 +38,16 @@ const DrawerRoot = ({
   variant?: "partitionedFooter" | "plain";
   children:
     | readonly [
-        React.ReactElement<HeaderProps, typeof Header>,
-        React.ReactElement<BodyProps, typeof Body>,
-        React.ReactElement<FooterProps, typeof Footer>?,
+        React.ReactElement<OverlayHeaderProps, typeof OverlayHeader>,
+        React.ReactElement<OverlayBodyProps, typeof OverlayBody>,
+        React.ReactElement<OverlayFooterProps, typeof OverlayFooter>?,
       ]
     | readonly [
-        React.ReactElement<BodyProps, typeof Body>,
-        React.ReactElement<FooterProps, typeof Footer>?,
+        React.ReactElement<OverlayBodyProps, typeof OverlayBody>,
+        React.ReactElement<OverlayFooterProps, typeof OverlayFooter>?,
       ]
-    | React.ReactElement<BodyProps, typeof Body>;
-  shouldCloseOn?: DrawerShouldCloseOn;
+    | React.ReactElement<OverlayBodyProps, typeof OverlayBody>;
+  shouldCloseOn?: OverlayShouldCloseOn;
   loading?: boolean;
   onClose?: () => void;
   initialFocusRef?: React.RefObject<HTMLElement>;
@@ -213,38 +55,15 @@ const DrawerRoot = ({
 } & React.AriaAttributes) => {
   const portalContainerRef = usePortalContainerRef();
 
-  const headerChild = Children.toArray(children).find(
-    (child): child is React.ReactElement<HeaderProps, typeof Header> =>
-      isValidElement(child) && child.type === Header,
-  );
-  const hasHeader = !!headerChild;
-  const titleIconName = headerChild?.props.iconName;
-
-  const classes = useMemo(
-    () =>
-      styles({
-        size,
-        headerless: !hasHeader,
-        hasIcon: !!titleIconName,
-        variant,
-      }),
-    [size, hasHeader, titleIconName, variant],
-  );
+  const classes = useMemo(() => styles({ size }), [size]);
 
   const renderCloseButton = shouldCloseOn !== "none";
   const closeOnEscape = shouldCloseOn !== "none";
   const closeOnInteractOutside = shouldCloseOn === "closeButtonAndOverlay";
 
-  const ctx = useMemo(
-    () => ({ classes, onClose, renderCloseButton, loading }),
-    [classes, onClose, renderCloseButton, loading],
-  );
-
   return (
     <ArkDrawer.Root
       open
-      // Slides in from the right; swiping the panel back towards that edge
-      // dismisses it.
       swipeDirection="end"
       closeOnEscape={closeOnEscape}
       closeOnInteractOutside={closeOnInteractOutside}
@@ -268,13 +87,18 @@ const DrawerRoot = ({
               aria-busy={loading ?? undefined}
               onKeyDown={onKeyDown}
             >
-              <DrawerContext.Provider value={ctx}>
-                {
-                  // if there's no header, we still display an empty one to display the close button + for layout
-                  !hasHeader && <Header />
-                }
+              <OverlaySections
+                size={size}
+                variant={variant}
+                onClose={onClose}
+                renderCloseButton={renderCloseButton}
+                loading={loading}
+                Title={ArkDrawer.Title}
+                Description={ArkDrawer.Description}
+                componentName="Drawer"
+              >
                 {children}
-              </DrawerContext.Provider>
+              </OverlaySections>
             </ArkDrawer.Content>
           </ArkDrawer.Positioner>
         </div>
@@ -284,7 +108,7 @@ const DrawerRoot = ({
 };
 
 export const Drawer = Object.assign(DrawerRoot, {
-  Header,
-  Body,
-  Footer,
+  Header: OverlayHeader,
+  Body: OverlayBody,
+  Footer: OverlayFooter,
 });

--- a/libs/@hashintel/ds-components/src/components/Drawer/drawer.tsx
+++ b/libs/@hashintel/ds-components/src/components/Drawer/drawer.tsx
@@ -287,7 +287,7 @@ const DrawerRoot = ({
       finalFocusEl={returnFocusRef ? () => returnFocusRef.current : undefined}
     >
       <Portal container={portalContainerRef}>
-        <div className={classes.stackRoot}>
+        <div className={classes.stackRoot} data-overlay-stack-root="">
           {showBackdrop && <ArkDrawer.Backdrop className={backdropClassName} />}
           <ArkDrawer.Positioner className={classes.positioner}>
             <ArkDrawer.Content

--- a/libs/@hashintel/ds-components/src/components/Drawer/drawer.tsx
+++ b/libs/@hashintel/ds-components/src/components/Drawer/drawer.tsx
@@ -1,6 +1,14 @@
 import { Drawer as ArkDrawer } from "@ark-ui/react/drawer";
 import { Portal } from "@ark-ui/react/portal";
-import { useEffect, useMemo, useState } from "react";
+import {
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
 
 import { cx } from "@hashintel/ds-helpers/css";
 
@@ -32,6 +40,154 @@ const swipeDirectionByPosition = {
   top: "up",
   bottom: "down",
 } as const;
+
+// How far each stacked drawer peeks out from behind the one on top of it.
+const STACK_LAYER_OFFSET_PX = 20;
+
+const translateForPosition = (
+  position: DrawerPosition,
+  offset: number,
+): string => {
+  const translateByPosition: Record<DrawerPosition, string> = {
+    right: `${-offset}px 0`,
+    left: `${offset}px 0`,
+    top: `0 ${offset}px`,
+    bottom: `0 ${-offset}px`,
+  };
+  return translateByPosition[position];
+};
+
+/**
+ * Ark's drawer stack counts nested drawers regardless of edge, but we only want
+ * the "stack of papers" offset to apply between drawers on the *same* edge. This
+ * lightweight shared store tracks each open drawer's position, its measured
+ * extent (width or height, whichever runs along its stacking axis) and open
+ * order so a drawer can offset itself far enough to keep its edge peeking out
+ * from behind the drawers stacked on top of it. Measuring from the DOM means
+ * drawers with custom widths/heights stack correctly, not just the preset sizes.
+ */
+type DrawerStackEntry = {
+  order: number;
+  position: DrawerPosition;
+  extent: number;
+};
+const drawerStackEntries = new Map<string, DrawerStackEntry>();
+const drawerStackListeners = new Set<() => void>();
+let drawerStackOrderCounter = 0;
+
+const emitDrawerStackChange = () => {
+  for (const listener of drawerStackListeners) {
+    listener();
+  }
+};
+
+const subscribeToDrawerStack = (listener: () => void) => {
+  drawerStackListeners.add(listener);
+  return () => {
+    drawerStackListeners.delete(listener);
+  };
+};
+
+// Translations are resolved from the top of the stack downward: the top drawer
+// doesn't move, and each drawer beneath it is translated so that at minimum 20px of edge is showing
+const computeDrawerStackTranslate = (id: string): string => {
+  const self = drawerStackEntries.get(id);
+  if (!self) {
+    return "0 0";
+  }
+
+  const stack = [...drawerStackEntries.values()]
+    .filter((entry) => entry.position === self.position)
+    .sort((a, b) => b.order - a.order);
+
+  let aboveExtent = 0;
+  let aboveTranslation = 0;
+  for (const [index, entry] of stack.entries()) {
+    const extent = entry.extent;
+    const translation =
+      index === 0
+        ? 0
+        : Math.max(
+            extent,
+            aboveExtent + STACK_LAYER_OFFSET_PX + aboveTranslation,
+          ) - extent;
+
+    if (entry.order === self.order) {
+      return translateForPosition(self.position, translation);
+    }
+
+    aboveExtent = extent;
+    aboveTranslation = translation;
+  }
+
+  return "0 0";
+};
+
+const useDrawerStackTranslate = (
+  position: DrawerPosition,
+): {
+  ref: (node: HTMLDivElement | null) => void;
+  translate: string;
+} => {
+  const id = useId();
+  // The open order is captured once and kept stable across re-measures so a
+  // drawer keeps its place in the stack even as its measured extent updates.
+  const orderRef = useRef<number | null>(null);
+  // The content element is tracked as state (via a callback ref) so the effect
+  // below re-runs once it mounts — the drawer's `lazyMount` means the panel
+  // isn't in the DOM on the first render.
+  const [contentNode, setContentNode] = useState<HTMLDivElement | null>(null);
+
+  useLayoutEffect(() => {
+    if (!contentNode) {
+      return;
+    }
+    if (orderRef.current === null) {
+      drawerStackOrderCounter += 1;
+      orderRef.current = drawerStackOrderCounter;
+    }
+    const order = orderRef.current;
+
+    // Measure the panel's extent along its stacking axis and register it. A
+    // `ResizeObserver` keeps it current if the panel is resized (e.g. a custom
+    // width, or the viewport clamping the panel on small screens).
+    const measure = () => {
+      const extent =
+        position === "left" || position === "right"
+          ? contentNode.offsetWidth
+          : contentNode.offsetHeight;
+      const existing = drawerStackEntries.get(id);
+      if (
+        existing &&
+        existing.order === order &&
+        existing.position === position &&
+        existing.extent === extent
+      ) {
+        return;
+      }
+      drawerStackEntries.set(id, { order, position, extent });
+      emitDrawerStackChange();
+    };
+
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(contentNode);
+
+    return () => {
+      observer.disconnect();
+      drawerStackEntries.delete(id);
+      emitDrawerStackChange();
+    };
+  }, [id, position, contentNode]);
+
+  const translate = useSyncExternalStore(
+    subscribeToDrawerStack,
+    () => computeDrawerStackTranslate(id),
+    () => "0 0",
+  );
+
+  return { ref: setContentNode, translate };
+};
 
 const DrawerRoot = ({
   className,
@@ -76,6 +232,9 @@ const DrawerRoot = ({
   const portalContainerRef = usePortalContainerRef();
 
   const classes = useMemo(() => styles({ size, position }), [size, position]);
+
+  const { ref: stackContentRef, translate: stackTranslate } =
+    useDrawerStackTranslate(position);
 
   const renderCloseButton = shouldCloseOn !== "none";
   const closeOnEscape = shouldCloseOn !== "none";
@@ -133,8 +292,10 @@ const DrawerRoot = ({
           <ArkDrawer.Positioner className={classes.positioner}>
             <ArkDrawer.Content
               {...ariaAttributes}
+              ref={stackContentRef}
               data-drawer-position={position}
               className={cx(classes.content, className)}
+              style={{ translate: stackTranslate }}
               aria-busy={loading ?? undefined}
               onKeyDown={onKeyDown}
             >

--- a/libs/@hashintel/ds-components/src/components/Drawer/drawer.tsx
+++ b/libs/@hashintel/ds-components/src/components/Drawer/drawer.tsx
@@ -20,12 +20,24 @@ import { styles } from "./drawer.recipe";
 
 export type DrawerSize = "sm" | "md" | "lg" | "xl";
 
+export type DrawerPosition = "left" | "top" | "right" | "bottom";
+
 const backdropClassName = overlayPartsStyles({ component: "drawer" }).backdrop;
+
+// Which way the panel is swiped to dismiss, per anchor edge. Ark resolves
+// "start"/"end" to left/right based on the writing direction.
+const swipeDirectionByPosition = {
+  right: "end",
+  left: "start",
+  top: "up",
+  bottom: "down",
+} as const;
 
 const DrawerRoot = ({
   className,
   size = "md",
   variant = "partitionedFooter",
+  position = "right",
   children,
   showBackdrop = true,
   shouldCloseOn = "closeButtonAndOverlay",
@@ -40,6 +52,8 @@ const DrawerRoot = ({
   size?: DrawerSize;
   onKeyDown?: React.KeyboardEventHandler<Element>;
   variant?: "partitionedFooter" | "plain";
+  /** Which viewport edge the drawer is anchored to. Defaults to `"right"`. */
+  position?: DrawerPosition;
   /** Render the dimmed overlay behind the drawer. Defaults to `true`. */
   showBackdrop?: boolean;
   children:
@@ -61,7 +75,7 @@ const DrawerRoot = ({
 } & React.AriaAttributes) => {
   const portalContainerRef = usePortalContainerRef();
 
-  const classes = useMemo(() => styles({ size }), [size]);
+  const classes = useMemo(() => styles({ size, position }), [size, position]);
 
   const renderCloseButton = shouldCloseOn !== "none";
   const closeOnEscape = shouldCloseOn !== "none";
@@ -93,7 +107,7 @@ const DrawerRoot = ({
       open={open}
       lazyMount
       unmountOnExit
-      swipeDirection="end"
+      swipeDirection={swipeDirectionByPosition[position]}
       // Without a backdrop the drawer is non-modal, so the page behind stays interactive
       // But we still want to keep focus trapped even when modal={false}
       modal={showBackdrop}
@@ -119,6 +133,7 @@ const DrawerRoot = ({
           <ArkDrawer.Positioner className={classes.positioner}>
             <ArkDrawer.Content
               {...ariaAttributes}
+              data-drawer-position={position}
               className={cx(classes.content, className)}
               aria-busy={loading ?? undefined}
               onKeyDown={onKeyDown}

--- a/libs/@hashintel/ds-components/src/components/SegmentedControl/segmented-control.tsx
+++ b/libs/@hashintel/ds-components/src/components/SegmentedControl/segmented-control.tsx
@@ -54,7 +54,7 @@ const itemStyles = css({
   textAlign: "center",
   cursor: "pointer",
   transition: "all",
-  transitionDuration: "200ms",
+  transitionDuration: "normal",
   _disabled: {
     cursor: "not-allowed",
     opacity: "0.6",

--- a/libs/@hashintel/ds-components/src/main.ts
+++ b/libs/@hashintel/ds-components/src/main.ts
@@ -34,6 +34,7 @@ export { TextInput } from "./components/TextInput/text-input";
 export { TextMark } from "./components/TextMark/text-mark";
 export { Toggle } from "./components/Toggle/toggle";
 export { Tooltip } from "./components/Tooltip/tooltip";
+export { useAvoidScrollWidthChange } from "./util/use-avoid-scroll-width-change";
 export {
   PortalContainerContext,
   usePortalContainerRef,

--- a/libs/@hashintel/ds-components/src/main.ts
+++ b/libs/@hashintel/ds-components/src/main.ts
@@ -5,6 +5,7 @@ export { CharacterCount } from "./components/CharacterCount/character-count";
 export { Checkbox } from "./components/Checkbox/checkbox";
 export { CheckboxGroup } from "./components/CheckboxGroup/checkbox-group";
 export { Dialog } from "./components/Dialog/dialog";
+export { Drawer } from "./components/Drawer/drawer";
 export { Form } from "./components/Form/form";
 export { HelpTooltip } from "./components/HelpTooltip/help-tooltip";
 export { Icon, type IconName, iconNames } from "./components/Icon/icon";

--- a/libs/@hashintel/ds-components/src/main.ts
+++ b/libs/@hashintel/ds-components/src/main.ts
@@ -34,8 +34,8 @@ export { TextInput } from "./components/TextInput/text-input";
 export { TextMark } from "./components/TextMark/text-mark";
 export { Toggle } from "./components/Toggle/toggle";
 export { Tooltip } from "./components/Tooltip/tooltip";
-export { useAvoidScrollWidthChange } from "./util/use-avoid-scroll-width-change";
 export {
   PortalContainerContext,
   usePortalContainerRef,
 } from "./util/portal-container-context";
+export { useAvoidScrollWidthChange } from "./util/use-avoid-scroll-width-change";

--- a/libs/@hashintel/ds-components/src/preset.ts
+++ b/libs/@hashintel/ds-components/src/preset.ts
@@ -116,13 +116,37 @@ export function createPreset(options?: PresetOptions) {
             from: { opacity: "1" },
             to: { opacity: "0" },
           },
-          drawerSlideIn: {
+          drawerSlideInRight: {
             from: { transform: "translateX(100%)" },
             to: { transform: "translateX(0)" },
           },
-          drawerSlideOut: {
+          drawerSlideOutRight: {
             from: { transform: "translateX(0)" },
             to: { transform: "translateX(100%)" },
+          },
+          drawerSlideInLeft: {
+            from: { transform: "translateX(-100%)" },
+            to: { transform: "translateX(0)" },
+          },
+          drawerSlideOutLeft: {
+            from: { transform: "translateX(0)" },
+            to: { transform: "translateX(-100%)" },
+          },
+          drawerSlideInTop: {
+            from: { transform: "translateY(-100%)" },
+            to: { transform: "translateY(0)" },
+          },
+          drawerSlideOutTop: {
+            from: { transform: "translateY(0)" },
+            to: { transform: "translateY(-100%)" },
+          },
+          drawerSlideInBottom: {
+            from: { transform: "translateY(100%)" },
+            to: { transform: "translateY(0)" },
+          },
+          drawerSlideOutBottom: {
+            from: { transform: "translateY(0)" },
+            to: { transform: "translateY(100%)" },
           },
           popoverIn: {
             from: { opacity: "0", transform: "scale(0.98)" },

--- a/libs/@hashintel/ds-components/src/preset.ts
+++ b/libs/@hashintel/ds-components/src/preset.ts
@@ -116,6 +116,14 @@ export function createPreset(options?: PresetOptions) {
             from: { opacity: "1" },
             to: { opacity: "0" },
           },
+          drawerSlideIn: {
+            from: { transform: "translateX(100%)" },
+            to: { transform: "translateX(0)" },
+          },
+          drawerSlideOut: {
+            from: { transform: "translateX(0)" },
+            to: { transform: "translateX(100%)" },
+          },
           popoverIn: {
             from: { opacity: "0", transform: "scale(0.98)" },
             to: { opacity: "1", transform: "scale(1)" },

--- a/libs/@hashintel/ds-components/src/preset/tokens.ts
+++ b/libs/@hashintel/ds-components/src/preset/tokens.ts
@@ -10,6 +10,7 @@ import {
   red,
   staticColors,
 } from "./tokens/gen";
+import { durations } from "./tokens/stubs/durations";
 import { zIndex } from "./tokens/stubs/z-index";
 import { createSemanticSet } from "./tokens/utils";
 
@@ -88,6 +89,7 @@ export const tokens = {
   radii: scaledRadii,
   lineHeights: scaledLineHeights as typeof pandaPreset.theme.tokens.lineHeights,
   zIndex,
+  durations,
 };
 
 export const semanticTokens = {

--- a/libs/@hashintel/ds-components/src/util/overlay-parts.recipe.ts
+++ b/libs/@hashintel/ds-components/src/util/overlay-parts.recipe.ts
@@ -45,7 +45,6 @@ export const overlayPartsStyles = sva({
       display: "flex",
       alignItems: "flex-start",
       gap: "2",
-      flex: "[1 1 auto]",
       minWidth: "0",
     },
     headerMain: {},
@@ -229,6 +228,10 @@ export const overlayPartsStyles = sva({
         },
         body: {
           borderBottom: "none",
+          "&:last-child": {
+            borderBottomRadius: "lg",
+            borderBottom: "[1px solid {colors.neutral.s50}]",
+          },
         },
         footer: {
           backgroundColor: "white",

--- a/libs/@hashintel/ds-components/src/util/overlay-parts.recipe.ts
+++ b/libs/@hashintel/ds-components/src/util/overlay-parts.recipe.ts
@@ -54,6 +54,12 @@ export const overlayPartsStyles = sva({
       paddingX: "[var(--panel-horizontal-padding)]",
       paddingTop: "[var(--panel-top-padding)]",
       paddingBottom: "3.5",
+      '[data-drawer-position="right"] &': { borderTopRightRadius: "[0]" },
+      '[data-drawer-position="left"] &': { borderTopLeftRadius: "[0]" },
+      '[data-drawer-position="top"] &': {
+        borderTopLeftRadius: "[0]",
+        borderTopRightRadius: "[0]",
+      },
     },
     hasCustomHeader: {
       display: "flex",
@@ -116,6 +122,14 @@ export const overlayPartsStyles = sva({
       paddingX: "[var(--panel-horizontal-padding)]",
       paddingTop: "4",
       paddingBottom: "5",
+      '[data-drawer-position="right"] &': { borderBottomRightRadius: "[0]" },
+      '[data-drawer-position="left"] &': { borderBottomLeftRadius: "[0]" },
+      '[data-drawer-position="bottom"] &': {
+        "&:last-child": {
+          borderBottomLeftRadius: "[0]",
+          borderBottomRightRadius: "[0]",
+        },
+      },
       // While loading, lock the body's scroll so the absolutely-positioned
       // overlay stays pinned to the visible area instead of riding the
       // scrolled content.
@@ -135,6 +149,12 @@ export const overlayPartsStyles = sva({
       paddingX: "[var(--panel-horizontal-padding)]",
       paddingTop: "3.5",
       paddingBottom: "3",
+      '[data-drawer-position="right"] &': { borderBottomRightRadius: "[0]" },
+      '[data-drawer-position="left"] &': { borderBottomLeftRadius: "[0]" },
+      '[data-drawer-position="bottom"] &': {
+        borderBottomLeftRadius: "[0]",
+        borderBottomRightRadius: "[0]",
+      },
     },
     footerActions: {
       display: "flex",
@@ -262,19 +282,7 @@ export const overlayPartsStyles = sva({
           _closed: { animationDuration: "faster" },
         },
       },
-      // The Drawer is pinned flush against the right edge of the viewport with
-      // square right-hand corners, so its chrome squares off the right corners
-      // the Dialog leaves rounded. Physical-corner longhands are used so they
-      // override the two-corner shorthands above in the cascade; the body's
-      // `:last-child` clause likewise beats the rounding the `plain` variant
-      // restores on a footerless body.
       drawer: {
-        header: { borderTopRightRadius: "[0]" },
-        body: {
-          borderBottomRightRadius: "[0]",
-          "&:last-child": { borderBottomRightRadius: "[0]" },
-        },
-        footer: { borderBottomRightRadius: "[0]" },
         backdrop: {
           _open: { animationDuration: "faster" },
           _closed: { animationDuration: "fastest" },

--- a/libs/@hashintel/ds-components/src/util/overlay-parts.recipe.ts
+++ b/libs/@hashintel/ds-components/src/util/overlay-parts.recipe.ts
@@ -44,6 +44,17 @@ export const overlayPartsStyles = sva({
       _closed: {
         animationName: "fadeOut",
       },
+      // Hide this backdrop while a later sibling overlay has an open backdrop of its own.
+      '[data-overlay-stack-root]:has(~ [data-overlay-stack-root] [data-part="backdrop"][data-state="open"]) &':
+        {
+          visibility: "hidden",
+        },
+      // Freeze this backdrop's fade while an earlier sibling is already dimming
+      // behind it
+      '[data-overlay-stack-root]:has([data-part="backdrop"][data-state="open"]) ~ [data-overlay-stack-root] &':
+        {
+          animationName: "[none]",
+        },
     },
     header: {
       flex: "[0 0 auto]",

--- a/libs/@hashintel/ds-components/src/util/overlay-parts.recipe.ts
+++ b/libs/@hashintel/ds-components/src/util/overlay-parts.recipe.ts
@@ -1,10 +1,9 @@
 import { sva } from "@hashintel/ds-helpers/css";
 
 /**
- * Shared slot styles for the header / body / footer chrome rendered inside both
- * the Dialog and Drawer components. Each component owns its own recipe for the
- * surrounding structural slots (backdrop, positioner, content, stackRoot); this
- * recipe is the single source of truth for everything between them.
+ * Shared slot styles for the Dialog and Drawer components: the dimmed
+ * `backdrop` plus the header / body / footer chrome. Each component owns its own
+ * recipe for the remaining structural slots (positioner, content, stackRoot).
  *
  * The `--panel-*` custom properties consumed below are declared on each
  * component's `content` slot (the chrome's ancestor) and inherited down, so the
@@ -13,6 +12,7 @@ import { sva } from "@hashintel/ds-helpers/css";
 export const overlayPartsStyles = sva({
   className: "panel",
   slots: [
+    "backdrop",
     "header",
     "hasCustomHeader",
     "headerMain",
@@ -31,6 +31,20 @@ export const overlayPartsStyles = sva({
     "loadingSpinner",
   ],
   base: {
+    backdrop: {
+      background: "black.a60",
+      position: "fixed",
+      inset: "0",
+      width: "[100dvw]",
+      height: "[100dvh]",
+      zIndex: "modal",
+      _open: {
+        animationName: "fadeIn",
+      },
+      _closed: {
+        animationName: "fadeOut",
+      },
+    },
     header: {
       flex: "[0 0 auto]",
       backgroundColor: "white",
@@ -242,7 +256,12 @@ export const overlayPartsStyles = sva({
       },
     },
     component: {
-      dialog: {},
+      dialog: {
+        backdrop: {
+          _open: { animationDuration: "fast" },
+          _closed: { animationDuration: "faster" },
+        },
+      },
       // The Drawer is pinned flush against the right edge of the viewport with
       // square right-hand corners, so its chrome squares off the right corners
       // the Dialog leaves rounded. Physical-corner longhands are used so they
@@ -256,6 +275,10 @@ export const overlayPartsStyles = sva({
           "&:last-child": { borderBottomRightRadius: "[0]" },
         },
         footer: { borderBottomRightRadius: "[0]" },
+        backdrop: {
+          _open: { animationDuration: "faster" },
+          _closed: { animationDuration: "fastest" },
+        },
       },
     },
     hasIcon: {

--- a/libs/@hashintel/ds-components/src/util/overlay-parts.recipe.ts
+++ b/libs/@hashintel/ds-components/src/util/overlay-parts.recipe.ts
@@ -241,6 +241,23 @@ export const overlayPartsStyles = sva({
         },
       },
     },
+    component: {
+      dialog: {},
+      // The Drawer is pinned flush against the right edge of the viewport with
+      // square right-hand corners, so its chrome squares off the right corners
+      // the Dialog leaves rounded. Physical-corner longhands are used so they
+      // override the two-corner shorthands above in the cascade; the body's
+      // `:last-child` clause likewise beats the rounding the `plain` variant
+      // restores on a footerless body.
+      drawer: {
+        header: { borderTopRightRadius: "[0]" },
+        body: {
+          borderBottomRightRadius: "[0]",
+          "&:last-child": { borderBottomRightRadius: "[0]" },
+        },
+        footer: { borderBottomRightRadius: "[0]" },
+      },
+    },
     hasIcon: {
       true: {
         description: { marginTop: "0.5" },

--- a/libs/@hashintel/ds-components/src/util/overlay-parts.recipe.ts
+++ b/libs/@hashintel/ds-components/src/util/overlay-parts.recipe.ts
@@ -1,0 +1,279 @@
+import { sva } from "@hashintel/ds-helpers/css";
+
+/**
+ * Shared slot styles for the header / body / footer chrome rendered inside both
+ * the Dialog and Drawer components. Each component owns its own recipe for the
+ * surrounding structural slots (backdrop, positioner, content, stackRoot); this
+ * recipe is the single source of truth for everything between them.
+ *
+ * The `--panel-*` custom properties consumed below are declared on each
+ * component's `content` slot (the chrome's ancestor) and inherited down, so the
+ * two components can tune horizontal/top padding without diverging this recipe.
+ */
+export const overlayPartsStyles = sva({
+  className: "panel",
+  slots: [
+    "header",
+    "hasCustomHeader",
+    "headerMain",
+    "headerText",
+    "titleIcon",
+    "title",
+    "description",
+    "headerRight",
+    "headerActions",
+    "body",
+    "footer",
+    "footerActions",
+    "footerSecondaryActions",
+    "closeButton",
+    "loadingOverlay",
+    "loadingSpinner",
+  ],
+  base: {
+    header: {
+      flex: "[0 0 auto]",
+      backgroundColor: "white",
+      border: "[1px solid {colors.neutral.s50}]",
+      borderTopRadius: "lg",
+      borderBottom: "[1px solid {colors.neutral.s30}]",
+      paddingX: "[var(--panel-horizontal-padding)]",
+      paddingTop: "[var(--panel-top-padding)]",
+      paddingBottom: "3.5",
+    },
+    hasCustomHeader: {
+      display: "flex",
+      alignItems: "flex-start",
+      gap: "2",
+      flex: "[1 1 auto]",
+      minWidth: "0",
+    },
+    headerMain: {},
+    headerText: {},
+    titleIcon: {
+      float: "start",
+      marginLeft: "-0.5",
+      marginRight: "2",
+      color: "neutral.s90",
+      flex: "[0 0 auto]",
+      backgroundColor: "neutral.s25",
+      borderRadius: "full",
+      padding: "1",
+      alignSelf: "flex-start",
+      top: "[1.5px]",
+      position: "relative",
+    },
+    title: {
+      display: "inline",
+      fontWeight: "semibold",
+      textStyle: "lg",
+      color: "fg.body",
+    },
+    description: {
+      color: "fg.muted",
+      textStyle: "sm",
+      marginTop: "-0.5",
+    },
+    headerRight: {
+      float: "end",
+      display: "flex",
+      alignItems: "center",
+      gap: "[1px]",
+    },
+    headerActions: {
+      display: "flex",
+      marginLeft: "auto",
+      alignItems: "center",
+      gap: "[1px]",
+      flex: "[0 0 auto]",
+      marginTop:
+        "[calc(var(--panel-top-padding) * -1 + var(--panel-close-button-gap))]",
+    },
+    body: {
+      position: "relative",
+      flex: "[1 1 auto]",
+      minHeight: "0",
+      overflow: "auto",
+      scrollbarWidth: "[thin]",
+      background: "white",
+      border: "[1px solid {colors.neutral.s50}]",
+      borderTop: "none",
+      color: "fg.body",
+      textStyle: "sm",
+      paddingX: "[var(--panel-horizontal-padding)]",
+      paddingTop: "4",
+      paddingBottom: "5",
+      // While loading, lock the body's scroll so the absolutely-positioned
+      // overlay stays pinned to the visible area instead of riding the
+      // scrolled content.
+      '[aria-busy="true"] &': {
+        overflow: "hidden",
+      },
+      _focusVisible: {
+        outlineColor: "neutral.a50",
+      },
+    },
+    footer: {
+      flex: "[0 0 auto]",
+      display: "flex",
+      alignItems: "flex-start",
+      justifyContent: "space-between",
+      gap: "3",
+      paddingX: "[var(--panel-horizontal-padding)]",
+      paddingTop: "3.5",
+      paddingBottom: "3",
+    },
+    footerActions: {
+      display: "flex",
+      flexWrap: "wrap",
+      justifyContent: "flex-end",
+      alignItems: "center",
+      gap: "2",
+      marginLeft: "auto",
+    },
+    footerSecondaryActions: {
+      display: "flex",
+      flexWrap: "wrap",
+      alignItems: "center",
+      gap: "2",
+    },
+    closeButton: {
+      flex: "[0 0 auto]",
+      marginLeft: "auto",
+      float: "end",
+      position: "relative",
+      zIndex: "[1]",
+      marginTop:
+        "[calc(var(--panel-top-padding) * -1 + var(--panel-close-button-gap))]",
+      marginRight:
+        "[calc(var(--panel-horizontal-padding) * -1 + var(--panel-close-button-gap))]",
+    },
+    loadingOverlay: {
+      position: "absolute",
+      inset: "0",
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      background: "[rgba(255, 255, 255, 0.88)]",
+      zIndex: "[1]",
+      borderRadius: "[inherit]",
+    },
+    loadingSpinner: {
+      width: "[auto !important]",
+      aspectRatio: "1",
+      maxHeight: "[60%]",
+      color: "black",
+    },
+  },
+  variants: {
+    size: {
+      xs: {
+        header: {
+          paddingBottom: "3",
+        },
+        body: {
+          paddingTop: "4",
+          paddingBottom: "4.5",
+        },
+        footer: {
+          paddingTop: "3",
+          paddingBottom: "2.5",
+        },
+      },
+      sm: {
+        loadingSpinner: { height: "[38px !important]" },
+      },
+      md: {
+        loadingSpinner: { height: "[40px !important]" },
+        headerMain: { display: "flex", alignItems: "flex-start", gap: "2" },
+        titleIcon: { marginRight: "0" },
+        headerText: { flex: "[1 1 auto]", minWidth: "[0]" },
+      },
+      lg: {
+        loadingSpinner: {
+          height: "[45px !important]",
+          color: "neutral.s115",
+        },
+        headerMain: { display: "flex", alignItems: "flex-start", gap: "2" },
+        titleIcon: { marginRight: "0" },
+        headerText: { flex: "[1 1 auto]", minWidth: "[0]" },
+      },
+      xl: {
+        loadingSpinner: {
+          height: "[50px !important]",
+          color: "neutral.s115",
+        },
+        headerMain: { display: "flex", alignItems: "flex-start", gap: "2" },
+        titleIcon: { marginRight: "0" },
+        headerText: { flex: "[1 1 auto]", minWidth: "[0]" },
+      },
+      fullScreen: {
+        loadingSpinner: {
+          height: "[50px !important]",
+          color: "neutral.s110",
+        },
+        headerMain: { display: "flex", alignItems: "flex-start", gap: "2" },
+        titleIcon: { marginRight: "0" },
+        headerText: { flex: "[1 1 auto]", minWidth: "[0]" },
+      },
+    },
+    variant: {
+      partitionedFooter: {
+        body: {
+          borderBottomRadius: "lg",
+        },
+      },
+      plain: {
+        header: {
+          borderBottomColor: "neutral.s20",
+        },
+        body: {
+          borderBottom: "none",
+        },
+        footer: {
+          backgroundColor: "white",
+          border: "[1px solid {colors.neutral.s50}]",
+          borderBottomRadius: "lg",
+          borderTop: "[1px solid {colors.neutral.s20}]",
+        },
+      },
+    },
+    hasIcon: {
+      true: {
+        description: { marginTop: "0.5" },
+      },
+    },
+    headerless: {
+      true: {
+        header: {
+          paddingBottom: "0",
+          borderBottom: "none",
+        },
+        closeButton: {
+          marginBottom: "-1.5",
+        },
+        body: {
+          paddingTop: "0",
+          paddingBottom: "6",
+        },
+      },
+    },
+  },
+  compoundVariants: [
+    {
+      headerless: true,
+      size: "xs",
+      css: {
+        header: {
+          paddingBottom: "0",
+        },
+        body: {
+          paddingBottom: "5",
+        },
+      },
+    },
+  ],
+  defaultVariants: {
+    size: "md",
+  },
+});

--- a/libs/@hashintel/ds-components/src/util/overlay-parts.tsx
+++ b/libs/@hashintel/ds-components/src/util/overlay-parts.tsx
@@ -176,7 +176,10 @@ export const OverlayFooter = ({
 
 export type OverlayBodyProps = {
   children: React.ReactNode;
-  /** Turn padding on/off. Used when the body content controls padding itself. defaults to true */
+  /**
+   * Turn padding on/off. Used when the body content controls padding itself. defaults to true.
+   * If set, you will need to apply useAvoidScrollWidthChange yourself if the content height/width can change.
+   * */
   withPadding?: boolean;
 };
 

--- a/libs/@hashintel/ds-components/src/util/overlay-parts.tsx
+++ b/libs/@hashintel/ds-components/src/util/overlay-parts.tsx
@@ -4,6 +4,7 @@ import {
   isValidElement,
   useContext,
   useMemo,
+  useRef,
 } from "react";
 
 import { css, cx } from "@hashintel/ds-helpers/css";
@@ -12,6 +13,7 @@ import { Button } from "../components/Button/button";
 import { Icon, type IconName } from "../components/Icon/icon";
 import { LoadingSpinner } from "../components/Loading/loading-spinner";
 import { overlayPartsStyles } from "./overlay-parts.recipe";
+import { useAvoidScrollWidthChange } from "./use-avoid-scroll-width-change";
 
 import type { ExclusifyUnion, RequireAtLeastOne } from "type-fest";
 
@@ -184,8 +186,17 @@ export const OverlayBody = ({
 }: OverlayBodyProps) => {
   const { classes, loading } = useOverlayContext();
 
+  const bodyRef = useRef<HTMLDivElement>(null);
+
+  // Hold the body's content width steady as its vertical scrollbar appears and
+  // disappears, so content doesn't shift sideways (a no-op with overlay
+  // scrollbars). Skipped when the body forgoes its own padding, since it then
+  // has no gutter to manage.
+  useAvoidScrollWidthChange(bodyRef, withPadding);
+
   return (
     <div
+      ref={bodyRef}
       className={cx(
         classes.body,
         !withPadding && css({ padding: "[0 !important]" }),

--- a/libs/@hashintel/ds-components/src/util/overlay-parts.tsx
+++ b/libs/@hashintel/ds-components/src/util/overlay-parts.tsx
@@ -1,0 +1,281 @@
+import {
+  Children,
+  createContext,
+  isValidElement,
+  useContext,
+  useMemo,
+} from "react";
+
+import { css, cx } from "@hashintel/ds-helpers/css";
+
+import { Button } from "../components/Button/button";
+import { Icon, type IconName } from "../components/Icon/icon";
+import { LoadingSpinner } from "../components/Loading/loading-spinner";
+import { overlayPartsStyles } from "./overlay-parts.recipe";
+
+import type { ExclusifyUnion, RequireAtLeastOne } from "type-fest";
+
+export type OverlayShouldCloseOn =
+  | "closeButtonAndOverlay"
+  | "closeButton"
+  | "none";
+
+/**
+ * The Ark UI `Title` / `Description` primitives differ between Dialog and
+ * Drawer (each wires up its own `aria-labelledby` / `aria-describedby`), so the
+ * owning component injects them through context rather than the shared chrome
+ * importing a specific namespace.
+ */
+type OverlayPrimitive = React.ElementType;
+
+type OverlayContextValue = {
+  classes: ReturnType<typeof overlayPartsStyles>;
+  onClose?: () => void;
+  renderCloseButton: boolean;
+  loading?: boolean;
+  Title: OverlayPrimitive;
+  Description: OverlayPrimitive;
+  /** "Dialog" | "Drawer" — drives the close-button label and error message. */
+  componentName: string;
+};
+
+const OverlayContext = createContext<OverlayContextValue | null>(null);
+
+const useOverlayContext = () => {
+  const ctx = useContext(OverlayContext);
+  if (!ctx) {
+    throw new Error(
+      "OverlayHeader, OverlayBody and OverlayFooter must be rendered inside a <Dialog> or <Drawer>",
+    );
+  }
+  return ctx;
+};
+
+export type OverlayHeaderProps = ExclusifyUnion<
+  | {
+      title?: React.ReactNode;
+      description?: React.ReactNode;
+      iconName?: IconName;
+      actions?: React.ReactNode;
+    }
+  | {
+      children?: React.ReactNode;
+    }
+>;
+
+export const OverlayHeader = ({
+  title,
+  description,
+  iconName,
+  actions,
+  children,
+}: OverlayHeaderProps) => {
+  const {
+    classes,
+    onClose,
+    renderCloseButton,
+    Title,
+    Description,
+    componentName,
+  } = useOverlayContext();
+
+  const hasStructuredHeader =
+    title !== undefined ||
+    description !== undefined ||
+    iconName !== undefined ||
+    actions !== undefined;
+
+  const closeButton = renderCloseButton && (
+    <Button
+      variant="ghost"
+      className={classes.closeButton}
+      aria-label={`Close ${componentName.toLowerCase()}`}
+      onClick={() => {
+        onClose?.();
+      }}
+      iconName="close"
+      size="sm"
+    />
+  );
+
+  if (!hasStructuredHeader) {
+    return (
+      <div className={cx(classes.header, classes.hasCustomHeader)}>
+        {children && <div>{children}</div>}
+        {closeButton}
+      </div>
+    );
+  }
+
+  return (
+    <div className={classes.header}>
+      <div className={classes.headerMain}>
+        {iconName && (
+          <Icon name={iconName} size="md" className={classes.titleIcon} />
+        )}
+        {/*
+         * The actions/close float to the end within this text column so the
+         * title and description wrap around them. On md and up the column is a
+         * flex item (its own formatting context) sitting to the right of the
+         * flexed icon; below that it is a transparent block, so the icon float
+         * from headerMain still reaches the text.
+         */}
+        <div className={classes.headerText}>
+          {actions ? (
+            <div className={classes.headerRight}>
+              <div className={classes.headerActions}>{actions}</div>
+              {closeButton}
+            </div>
+          ) : (
+            closeButton
+          )}
+          {title && <Title className={classes.title}>{title}</Title>}
+          {description && (
+            <Description className={classes.description}>
+              {description}
+            </Description>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export type OverlayFooterProps = ExclusifyUnion<
+  | { children?: React.ReactNode }
+  | RequireAtLeastOne<{
+      actions?: React.ReactNode;
+      secondaryActions?: React.ReactNode;
+    }>
+>;
+
+export const OverlayFooter = ({
+  children,
+  actions,
+  secondaryActions,
+}: OverlayFooterProps) => {
+  const { classes } = useOverlayContext();
+
+  return (
+    <div className={classes.footer}>
+      {children ?? (
+        <>
+          {secondaryActions && (
+            <div className={classes.footerSecondaryActions}>
+              {secondaryActions}
+            </div>
+          )}
+          {actions && <div className={classes.footerActions}>{actions}</div>}
+        </>
+      )}
+    </div>
+  );
+};
+
+export type OverlayBodyProps = {
+  children: React.ReactNode;
+  /** Turn padding on/off. Used when the body content controls padding itself. defaults to true */
+  withPadding?: boolean;
+};
+
+export const OverlayBody = ({
+  children,
+  withPadding = true,
+}: OverlayBodyProps) => {
+  const { classes, loading } = useOverlayContext();
+
+  return (
+    <div
+      className={cx(
+        classes.body,
+        !withPadding && css({ padding: "[0 !important]" }),
+      )}
+    >
+      {children}
+      {loading ? (
+        <div className={classes.loadingOverlay} aria-live="polite">
+          <LoadingSpinner size="lg" className={classes.loadingSpinner} />
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+/**
+ * Renders the shared chrome context inside a Dialog/Drawer `Content`. Detects
+ * whether the caller supplied an `OverlayHeader` (to size the chrome and, if
+ * absent, render an empty header carrying just the close button) and computes
+ * the shared slot classes from the recipe.
+ */
+export const OverlaySections = ({
+  size,
+  variant,
+  onClose,
+  renderCloseButton,
+  loading,
+  Title,
+  Description,
+  componentName,
+  children,
+}: {
+  size: "xs" | "sm" | "md" | "lg" | "xl" | "fullScreen";
+  variant: "partitionedFooter" | "plain";
+  onClose?: () => void;
+  renderCloseButton: boolean;
+  loading?: boolean;
+  Title: OverlayPrimitive;
+  Description: OverlayPrimitive;
+  componentName: string;
+  children: React.ReactNode;
+}) => {
+  const headerChild = Children.toArray(children).find(
+    (
+      child,
+    ): child is React.ReactElement<OverlayHeaderProps, typeof OverlayHeader> =>
+      isValidElement(child) && child.type === OverlayHeader,
+  );
+  const hasHeader = !!headerChild;
+  const titleIconName = headerChild?.props.iconName;
+
+  const classes = useMemo(
+    () =>
+      overlayPartsStyles({
+        size,
+        variant,
+        hasIcon: !!titleIconName,
+        headerless: !hasHeader,
+      }),
+    [size, variant, titleIconName, hasHeader],
+  );
+
+  const ctx = useMemo(
+    () => ({
+      classes,
+      onClose,
+      renderCloseButton,
+      loading,
+      Title,
+      Description,
+      componentName,
+    }),
+    [
+      classes,
+      onClose,
+      renderCloseButton,
+      loading,
+      Title,
+      Description,
+      componentName,
+    ],
+  );
+
+  return (
+    <OverlayContext.Provider value={ctx}>
+      {
+        // if there's no header, we still display an empty one to display the close button + for layout
+        !hasHeader && <OverlayHeader />
+      }
+      {children}
+    </OverlayContext.Provider>
+  );
+};

--- a/libs/@hashintel/ds-components/src/util/overlay-parts.tsx
+++ b/libs/@hashintel/ds-components/src/util/overlay-parts.tsx
@@ -37,8 +37,8 @@ type OverlayContextValue = {
   loading?: boolean;
   Title: OverlayPrimitive;
   Description: OverlayPrimitive;
-  /** "Dialog" | "Drawer" — drives the close-button label and error message. */
-  componentName: string;
+  /** Sets the close-button label and squares off the Drawer's right edge. */
+  componentName: "Dialog" | "Drawer";
 };
 
 const OverlayContext = createContext<OverlayContextValue | null>(null);
@@ -236,7 +236,7 @@ export const OverlaySections = ({
   loading?: boolean;
   Title: OverlayPrimitive;
   Description: OverlayPrimitive;
-  componentName: string;
+  componentName: "Dialog" | "Drawer";
   children: React.ReactNode;
 }) => {
   const headerChild = Children.toArray(children).find(
@@ -253,10 +253,11 @@ export const OverlaySections = ({
       overlayPartsStyles({
         size,
         variant,
+        component: componentName === "Drawer" ? "drawer" : "dialog",
         hasIcon: !!titleIconName,
         headerless: !hasHeader,
       }),
-    [size, variant, titleIconName, hasHeader],
+    [size, variant, componentName, titleIconName, hasHeader],
   );
 
   const ctx = useMemo(

--- a/libs/@hashintel/ds-components/src/util/use-avoid-scroll-width-change.ts
+++ b/libs/@hashintel/ds-components/src/util/use-avoid-scroll-width-change.ts
@@ -1,0 +1,204 @@
+import { type RefObject, useLayoutEffect } from "react";
+
+let cachedScrollbarSize: number | null = null;
+
+/**
+ * Measure the browser's classic scrollbar thickness using a throwaway element.
+ * Returns `0` for overlay scrollbars. The result is cached after first use.
+ */
+const measureScrollbarSize = (): number => {
+  if (cachedScrollbarSize !== null) {
+    return cachedScrollbarSize;
+  }
+
+  if (typeof document === "undefined") {
+    return 0;
+  }
+
+  const probe = document.createElement("div");
+  probe.style.position = "absolute";
+  probe.style.top = "-9999px";
+  probe.style.width = "100px";
+  probe.style.height = "100px";
+  probe.style.overflow = "scroll";
+
+  document.body.appendChild(probe);
+  cachedScrollbarSize = probe.offsetWidth - probe.clientWidth;
+  document.body.removeChild(probe);
+
+  return cachedScrollbarSize;
+};
+
+/**
+ * Keep the internal (content) size of a scrollable element constant as its
+ * scrollbars appear and disappear, on either axis.
+ *
+ * A classic (non-overlay) scrollbar consumes part of the element's client box:
+ * a vertical scrollbar eats into the client width, a horizontal scrollbar eats
+ * into the client height. So when content grows large enough to need scrolling,
+ * the space available to children shrinks — and snaps back when it no longer
+ * needs to scroll. This causes a visible jump ("jank").
+ *
+ * This hook keeps the content's inset constant across both states so they
+ * expose the same internal size. The inset is held at the larger of the
+ * element's existing padding and the scrollbar's thickness, on each axis
+ * independently:
+ * - while a scrollbar is absent the managed padding covers the whole inset;
+ * - while it is present the scrollbar itself occupies part of the inset, so the
+ *   managed padding shrinks to cover only the remainder.
+ *
+ * The gutter is managed on `padding-right` (`padding-left` in RTL) for a
+ * vertical scrollbar, keeping the internal width stable, and on
+ * `padding-bottom` for a horizontal scrollbar, keeping the internal height
+ * stable.
+ *
+ * Crucially, this respects any padding the element already has. Rather than
+ * clobbering the author's padding, the appearing scrollbar *consumes* it: if
+ * the element has 16px of padding and the scrollbar is 15px, the scrollbar sits
+ * within that padding and the content never moves, with 1px of padding left
+ * over. Only when the existing padding is smaller than the scrollbar does the
+ * hook reserve the extra space, so the content still does not jump.
+ *
+ * Both axes are handled independently and detected automatically, so the hook
+ * works whether the element scrolls vertically, horizontally, or both.
+ *
+ * On platforms with overlay scrollbars (e.g. macOS by default) the measured
+ * scrollbar thickness is `0`, so the hook is a no-op.
+ *
+ * @param ref - ref to the scrollable element to stabilise.
+ * @param enabled - whether to apply the gutter; when `false` the hook is a
+ *   no-op and releases any padding it previously reserved.
+ */
+export const useAvoidScrollWidthChange = (
+  ref: RefObject<HTMLElement | null>,
+  enabled = true,
+): void => {
+  useLayoutEffect(() => {
+    const element = ref.current;
+
+    if (!enabled || !element || typeof ResizeObserver === "undefined") {
+      return;
+    }
+
+    /**
+     * The side on which the vertical scrollbar is rendered (and therefore the
+     * inline side we manage the gutter on) depends on the writing direction.
+     */
+    const inlineGutterSide = (): "paddingLeft" | "paddingRight" =>
+      getComputedStyle(element).direction === "rtl"
+        ? "paddingLeft"
+        : "paddingRight";
+
+    // The element's own padding, captured before we touch it. A scrollbar that
+    // appears should consume this padding rather than be reserved on top of it,
+    // so we need to know how much padding the author already asked for.
+    const initialStyle = getComputedStyle(element);
+    const authorPadding = {
+      paddingLeft: parseFloat(initialStyle.paddingLeft) || 0,
+      paddingRight: parseFloat(initialStyle.paddingRight) || 0,
+      paddingBottom: parseFloat(initialStyle.paddingBottom) || 0,
+    };
+
+    // The element's own *inline* padding declarations, so we can hand authority
+    // back to the author (and any stylesheet rules) on cleanup, and whenever our
+    // desired padding happens to coincide with theirs.
+    const initialInlinePadding = {
+      paddingLeft: element.style.paddingLeft,
+      paddingRight: element.style.paddingRight,
+      paddingBottom: element.style.paddingBottom,
+    };
+
+    // Write a managed padding value, but defer to the author's own declaration
+    // when our desired value matches theirs, so we never needlessly clobber a
+    // stylesheet rule (and so overlay-scrollbar platforms stay a true no-op).
+    const setManagedPadding = (
+      side: "paddingLeft" | "paddingRight" | "paddingBottom",
+      desired: number,
+      authorValue: number,
+    ): void => {
+      element.style[side] =
+        desired === authorValue ? initialInlinePadding[side] : `${desired}px`;
+    };
+
+    // Track the values we last wrote, per axis, so repeated observer callbacks
+    // that don't change anything are skipped — this lets the layout converge
+    // and stops the ResizeObserver from looping.
+    let appliedInlineGutter: number | null = null;
+    let appliedBlockGutter: number | null = null;
+
+    const sync = (): void => {
+      const hasVerticalScrollbar = element.scrollHeight > element.clientHeight;
+      const hasHorizontalScrollbar = element.scrollWidth > element.clientWidth;
+
+      const style = getComputedStyle(element);
+
+      // The real scrollbar thickness is the difference between the element's
+      // border box and its (padding-inclusive) client box on the relevant axis,
+      // minus the borders, read live while the scrollbar is present. When it is
+      // absent that difference is zero, so we fall back to a probe measurement.
+      const borderX =
+        parseFloat(style.borderLeftWidth) + parseFloat(style.borderRightWidth);
+      const borderY =
+        parseFloat(style.borderTopWidth) + parseFloat(style.borderBottomWidth);
+
+      const liveWidth = element.offsetWidth - element.clientWidth - borderX;
+      const scrollbarWidth = liveWidth > 0 ? liveWidth : measureScrollbarSize();
+
+      const liveHeight = element.offsetHeight - element.clientHeight - borderY;
+      const scrollbarHeight =
+        liveHeight > 0 ? liveHeight : measureScrollbarSize();
+
+      const gutterSide = inlineGutterSide();
+      const authorInline = authorPadding[gutterSide];
+      const authorBlock = authorPadding.paddingBottom;
+
+      // Hold the inline inset constant at `max(authorPadding, scrollbarWidth)`.
+      // While the scrollbar is present it occupies `scrollbarWidth` of that
+      // inset, so the managed padding only needs to cover the rest (which is the
+      // author's leftover padding, if it exceeded the scrollbar). While absent
+      // the padding covers the whole inset.
+      const desiredInlineGutter = hasVerticalScrollbar
+        ? Math.max(authorInline - scrollbarWidth, 0)
+        : Math.max(authorInline, scrollbarWidth);
+
+      // Likewise for the block inset and a horizontal scrollbar.
+      const desiredBlockGutter = hasHorizontalScrollbar
+        ? Math.max(authorBlock - scrollbarHeight, 0)
+        : Math.max(authorBlock, scrollbarHeight);
+
+      if (desiredInlineGutter !== appliedInlineGutter) {
+        appliedInlineGutter = desiredInlineGutter;
+        setManagedPadding(gutterSide, desiredInlineGutter, authorInline);
+      }
+
+      if (desiredBlockGutter !== appliedBlockGutter) {
+        appliedBlockGutter = desiredBlockGutter;
+        setManagedPadding("paddingBottom", desiredBlockGutter, authorBlock);
+      }
+    };
+
+    const resizeObserver = new ResizeObserver(sync);
+    resizeObserver.observe(element);
+
+    // Content changes (children added/removed/resized) can toggle a scrollbar
+    // without changing the element's own box, so watch the subtree too.
+    const mutationObserver = new MutationObserver(sync);
+    mutationObserver.observe(element, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+    });
+
+    sync();
+
+    return () => {
+      resizeObserver.disconnect();
+      mutationObserver.disconnect();
+      // Restore whatever inline padding the author had (usually none), handing
+      // control back to their stylesheet rather than leaving our values behind.
+      element.style.paddingLeft = initialInlinePadding.paddingLeft;
+      element.style.paddingRight = initialInlinePadding.paddingRight;
+      element.style.paddingBottom = initialInlinePadding.paddingBottom;
+    };
+  }, [ref, enabled]);
+};

--- a/libs/@hashintel/ds-components/src/util/use-avoid-scroll-width-change.ts
+++ b/libs/@hashintel/ds-components/src/util/use-avoid-scroll-width-change.ts
@@ -127,8 +127,8 @@ export const useAvoidScrollWidthChange = (
     let appliedBlockGutter: number | null = null;
 
     const sync = (): void => {
-      const hasVerticalScrollbar = element.scrollHeight > element.clientHeight;
-      const hasHorizontalScrollbar = element.scrollWidth > element.clientWidth;
+      const hasVerticalScrollbar = element.scrollHeight >= element.clientHeight;
+      const hasHorizontalScrollbar = element.scrollWidth >= element.clientWidth;
 
       const style = getComputedStyle(element);
 

--- a/libs/@hashintel/ds-components/src/util/use-avoid-scroll-width-change.ts
+++ b/libs/@hashintel/ds-components/src/util/use-avoid-scroll-width-change.ts
@@ -1,14 +1,29 @@
 import { type RefObject, useLayoutEffect } from "react";
 
-let cachedScrollbarSize: number | null = null;
+/**
+ * Probed scrollbar thickness, cached per `scrollbar-width` mode
+ * (`"auto"`/`"thin"`/`"none"`) since each mode renders a different thickness.
+ */
+const cachedScrollbarSize = new Map<string, number>();
 
 /**
  * Measure the browser's classic scrollbar thickness using a throwaway element.
- * Returns `0` for overlay scrollbars. The result is cached after first use.
+ * Returns `0` for overlay scrollbars.
+ *
+ * The probe mirrors the target element's `scrollbar-width` so that a `thin`
+ * scrollbar is measured as thin — otherwise the reserved gutter would be sized
+ * for the default (wider) bar and wouldn't match the one that actually appears,
+ * which would make the content box a different size in the two states and defeat
+ * the whole point of the hook. The result is cached per mode after first use.
+ *
+ * @param scrollbarWidthMode - the target's computed `scrollbar-width` value.
  */
-const measureScrollbarSize = (): number => {
-  if (cachedScrollbarSize !== null) {
-    return cachedScrollbarSize;
+const measureScrollbarSize = (scrollbarWidthMode: string): number => {
+  const mode = scrollbarWidthMode || "auto";
+
+  const cached = cachedScrollbarSize.get(mode);
+  if (cached !== undefined) {
+    return cached;
   }
 
   if (typeof document === "undefined") {
@@ -21,12 +36,16 @@ const measureScrollbarSize = (): number => {
   probe.style.width = "100px";
   probe.style.height = "100px";
   probe.style.overflow = "scroll";
+  if (mode !== "auto") {
+    probe.style.setProperty("scrollbar-width", mode);
+  }
 
   document.body.appendChild(probe);
-  cachedScrollbarSize = probe.offsetWidth - probe.clientWidth;
+  const size = probe.offsetWidth - probe.clientWidth;
   document.body.removeChild(probe);
 
-  return cachedScrollbarSize;
+  cachedScrollbarSize.set(mode, size);
+  return size;
 };
 
 /**
@@ -59,6 +78,13 @@ const measureScrollbarSize = (): number => {
  * over. Only when the existing padding is smaller than the scrollbar does the
  * hook reserve the extra space, so the content still does not jump.
  *
+ * Because the reserved inset is identical whether or not the scrollbar is
+ * present, toggling the scrollbar does not change the content-box size, and so
+ * cannot itself flip the scrollbar back — which is what keeps the observers from
+ * oscillating. The measurement/write cycle is additionally coalesced into a
+ * single animation frame and guarded by a small write threshold so sub-pixel
+ * measurement noise can't thrash it.
+ *
  * Both axes are handled independently and detected automatically, so the hook
  * works whether the element scrolls vertically, horizontally, or both.
  *
@@ -79,15 +105,6 @@ export const useAvoidScrollWidthChange = (
     if (!enabled || !element || typeof ResizeObserver === "undefined") {
       return;
     }
-
-    /**
-     * The side on which the vertical scrollbar is rendered (and therefore the
-     * inline side we manage the gutter on) depends on the writing direction.
-     */
-    const inlineGutterSide = (): "paddingLeft" | "paddingRight" =>
-      getComputedStyle(element).direction === "rtl"
-        ? "paddingLeft"
-        : "paddingRight";
 
     // The element's own padding, captured before we touch it. A scrollbar that
     // appears should consume this padding rather than be reserved on top of it,
@@ -122,33 +139,104 @@ export const useAvoidScrollWidthChange = (
 
     // Track the values we last wrote, per axis, so repeated observer callbacks
     // that don't change anything are skipped — this lets the layout converge
-    // and stops the ResizeObserver from looping.
+    // and stops the observers from looping.
     let appliedInlineGutter: number | null = null;
     let appliedBlockGutter: number | null = null;
 
-    const sync = (): void => {
-      const hasVerticalScrollbar = element.scrollHeight >= element.clientHeight;
-      const hasHorizontalScrollbar = element.scrollWidth >= element.clientWidth;
+    // The last scrollbar thickness we saw *live* on the element, per axis. When
+    // the scrollbar is absent we can't measure it, so we reserve this remembered
+    // width instead — guaranteeing the reserved inset equals the width the bar
+    // will occupy when it returns, which is what makes the inset constant across
+    // both states (and therefore non-oscillating). Falls back to a probe until
+    // we've seen a real bar at least once.
+    let liveScrollbarWidth: number | null = null;
+    let liveScrollbarHeight: number | null = null;
 
+    // A live reading below this is treated as no bar rather than a real one.
+    // `offsetWidth`/`clientWidth` are integer-rounded, so their difference can
+    // carry up to ~1px of noise when no scrollbar is present; the thinnest real
+    // scrollbar is several px, so this floor cleanly separates the two.
+    const SCROLLBAR_MIN_PX = 2;
+
+    // Only rewrite a gutter when it moves by at least this much. A real toggle
+    // moves it by a whole scrollbar width; this threshold just absorbs
+    // sub-pixel measurement noise so it can't rewrite frame after frame.
+    const WRITE_THRESHOLD_PX = 1;
+
+    const applyGutter = (
+      side: "paddingLeft" | "paddingRight" | "paddingBottom",
+      desired: number,
+      applied: number | null,
+      authorValue: number,
+    ): number => {
+      if (
+        applied !== null &&
+        Math.abs(desired - applied) < WRITE_THRESHOLD_PX
+      ) {
+        return applied;
+      }
+      setManagedPadding(side, desired, authorValue);
+      return desired;
+    };
+
+    const sync = (): void => {
+      // Single computed-style read per pass; everything below derives from it.
       const style = getComputedStyle(element);
+
+      // The side on which the vertical scrollbar is rendered (and therefore the
+      // inline side we manage the gutter on) depends on the writing direction.
+      const gutterSide: "paddingLeft" | "paddingRight" =
+        style.direction === "rtl" ? "paddingLeft" : "paddingRight";
+      const scrollbarWidthMode = style.getPropertyValue("scrollbar-width");
 
       // The real scrollbar thickness is the difference between the element's
       // border box and its (padding-inclusive) client box on the relevant axis,
-      // minus the borders, read live while the scrollbar is present. When it is
-      // absent that difference is zero, so we fall back to a probe measurement.
+      // minus the borders — i.e. the space the bar is consuming right now. When
+      // no bar is present that difference is zero.
       const borderX =
         parseFloat(style.borderLeftWidth) + parseFloat(style.borderRightWidth);
       const borderY =
         parseFloat(style.borderTopWidth) + parseFloat(style.borderBottomWidth);
 
       const liveWidth = element.offsetWidth - element.clientWidth - borderX;
-      const scrollbarWidth = liveWidth > 0 ? liveWidth : measureScrollbarSize();
-
       const liveHeight = element.offsetHeight - element.clientHeight - borderY;
-      const scrollbarHeight =
-        liveHeight > 0 ? liveHeight : measureScrollbarSize();
 
-      const gutterSide = inlineGutterSide();
+      // Remember the last real bar thickness we saw, per axis, so we can reserve
+      // exactly that width while the bar is absent (we can't measure it then).
+      if (liveWidth > SCROLLBAR_MIN_PX) {
+        liveScrollbarWidth = liveWidth;
+      }
+      if (liveHeight > SCROLLBAR_MIN_PX) {
+        liveScrollbarHeight = liveHeight;
+      }
+
+      // Detect presence primarily from the space the bar is consuming, not from
+      // `scrollHeight > clientHeight`. Those are integer-rounded, so a bar can
+      // already be painted (and eating space) while a <1px overflow still rounds
+      // to `scrollHeight === clientHeight`; keying off consumed space avoids that
+      // blind spot and also catches always-on (`overflow: scroll`) bars. The
+      // overflow comparison remains as a fallback for overlay scrollbars, which
+      // overflow without consuming any space.
+      const hasVerticalScrollbar =
+        liveWidth > SCROLLBAR_MIN_PX ||
+        element.scrollHeight > element.clientHeight;
+      const hasHorizontalScrollbar =
+        liveHeight > SCROLLBAR_MIN_PX ||
+        element.scrollWidth > element.clientWidth;
+
+      // Use the live width when a bar is actually consuming space; otherwise
+      // fall back to the last one we saw (or a matching probe before we've ever
+      // seen one). Keeping this in step with the presence check above is what
+      // makes the reserved inset identical in both states.
+      const scrollbarWidth =
+        liveWidth > SCROLLBAR_MIN_PX
+          ? liveWidth
+          : (liveScrollbarWidth ?? measureScrollbarSize(scrollbarWidthMode));
+      const scrollbarHeight =
+        liveHeight > SCROLLBAR_MIN_PX
+          ? liveHeight
+          : (liveScrollbarHeight ?? measureScrollbarSize(scrollbarWidthMode));
+
       const authorInline = authorPadding[gutterSide];
       const authorBlock = authorPadding.paddingBottom;
 
@@ -166,32 +254,63 @@ export const useAvoidScrollWidthChange = (
         ? Math.max(authorBlock - scrollbarHeight, 0)
         : Math.max(authorBlock, scrollbarHeight);
 
-      if (desiredInlineGutter !== appliedInlineGutter) {
-        appliedInlineGutter = desiredInlineGutter;
-        setManagedPadding(gutterSide, desiredInlineGutter, authorInline);
-      }
-
-      if (desiredBlockGutter !== appliedBlockGutter) {
-        appliedBlockGutter = desiredBlockGutter;
-        setManagedPadding("paddingBottom", desiredBlockGutter, authorBlock);
-      }
+      appliedInlineGutter = applyGutter(
+        gutterSide,
+        desiredInlineGutter,
+        appliedInlineGutter,
+        authorInline,
+      );
+      appliedBlockGutter = applyGutter(
+        "paddingBottom",
+        desiredBlockGutter,
+        appliedBlockGutter,
+        authorBlock,
+      );
     };
 
-    const resizeObserver = new ResizeObserver(sync);
+    // Coalesce bursts of observer callbacks (e.g. many mutations in one tick)
+    // into a single measurement + write on the next frame. Deferring the write
+    // out of the observer's own delivery also avoids the "ResizeObserver loop
+    // completed with undelivered notifications" warning.
+    let frameId = 0;
+    const scheduleSync = (): void => {
+      if (frameId !== 0) {
+        return;
+      }
+      if (typeof requestAnimationFrame === "undefined") {
+        sync();
+        return;
+      }
+      frameId = requestAnimationFrame(() => {
+        frameId = 0;
+        sync();
+      });
+    };
+
+    const resizeObserver = new ResizeObserver(scheduleSync);
     resizeObserver.observe(element);
 
-    // Content changes (children added/removed/resized) can toggle a scrollbar
-    // without changing the element's own box, so watch the subtree too.
-    const mutationObserver = new MutationObserver(sync);
+    // Content changes (children added/removed/resized, text edited) can toggle a
+    // scrollbar without changing the element's own box — and because the element
+    // is a fixed-size scroll container, the ResizeObserver won't fire for those.
+    // So we must watch the whole subtree. We deliberately do NOT observe
+    // `attributes`: that would make our own padding writes re-trigger the
+    // observer. The cost of the broad subtree watch is bounded by the frame
+    // coalescing above (a burst of mutations still results in a single sync).
+    const mutationObserver = new MutationObserver(scheduleSync);
     mutationObserver.observe(element, {
       childList: true,
       subtree: true,
       characterData: true,
     });
 
+    // Run once synchronously so the gutter is correct before the first paint.
     sync();
 
     return () => {
+      if (frameId !== 0 && typeof cancelAnimationFrame !== "undefined") {
+        cancelAnimationFrame(frameId);
+      }
       resizeObserver.disconnect();
       mutationObserver.disconnect();
       // Restore whatever inline padding the author had (usually none), handing


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Adds a new Drawer component to the DS.
Updates Dialog to share many of the same internal components/styling + improves some of the nesting and mounting/unmounting animations.
Add a use-avoid-scroll-width-change hook so that expandable content inside drawers/dialogs doesn't trigger reflow when a scrollbar gets added/removed.
Also adds the duration tokens to panda so that some ark animations work properly (and fixes new panda css errors caused by adding the tokens)

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change
