### PR TITLE
FE-1189: Supply chain planning parameter UX improvements

### DIFF
--- a/apps/hash-frontend/src/pages/shared/entity-type.tsx
+++ b/apps/hash-frontend/src/pages/shared/entity-type.tsx
@@ -42,6 +42,7 @@ import {
 } from "./entity-type-page/use-entity-type-dependents";
 import { useEntityTypeValue } from "./entity-type-page/use-entity-type-value";
 import { NotFound } from "./not-found";
+import { largePageMaxWidthCss } from "./page-width";
 import { inSlideContainerStyles } from "./shared/slide-styles";
 import { TypeEditorSkeleton } from "./shared/type-editor-skeleton";
 import {
@@ -118,6 +119,46 @@ const TypeDefinition = ({
       ) : null}
       {isFile && tab === "upload" ? <FileUploadsTab isImage={isImage} /> : null}
     </>
+  );
+};
+
+const EntityTypeTabHeaderContainer = ({
+  children,
+  isInSlide,
+}: {
+  children: React.ReactNode;
+  isInSlide: boolean;
+}) => {
+  const { tab } = useEntityTypeTab();
+
+  return (
+    <Container
+      sx={{
+        ...(isInSlide ? inSlideContainerStyles : {}),
+        ...(!isInSlide && tab === "entities" ? largePageMaxWidthCss : {}),
+      }}
+    >
+      {children}
+    </Container>
+  );
+};
+
+const EntityTypeTabBodyContainer = ({
+  children,
+  isInSlide,
+}: {
+  children: React.ReactNode;
+  isInSlide: boolean;
+}) => {
+  const { tab } = useEntityTypeTab();
+
+  return (
+    <TypeDefinitionContainer
+      inSlide={isInSlide}
+      wide={!isInSlide && tab === "entities"}
+    >
+      {children}
+    </TypeDefinitionContainer>
   );
 };
 
@@ -521,7 +562,7 @@ export const EntityType = ({
 
             <EntityTypeTabProvider isInSlide={isInSlide}>
               <Box ref={titleWrapperRef} sx={typeHeaderContainerStyles}>
-                <Container sx={isInSlide ? inSlideContainerStyles : {}}>
+                <EntityTypeTabHeaderContainer isInSlide={isInSlide}>
                   <EntityTypeHeader
                     currentVersion={currentVersion}
                     entityTypeSchema={entityType.schema}
@@ -540,10 +581,10 @@ export const EntityType = ({
                     isImage={isImage}
                     isInSlide={isInSlide}
                   />
-                </Container>
+                </EntityTypeTabHeaderContainer>
               </Box>
 
-              <TypeDefinitionContainer inSlide={isInSlide}>
+              <EntityTypeTabBodyContainer isInSlide={isInSlide}>
                 <TypeDefinition
                   entityTypeBaseUrl={entityTypeBaseUrl ?? null}
                   entityTypeAndPropertyTypes={entityTypeAndPropertyTypes}
@@ -552,7 +593,7 @@ export const EntityType = ({
                   onNavigateToType={onNavigateToType}
                   readonly={isReadonly}
                 />
-              </TypeDefinitionContainer>
+              </EntityTypeTabBodyContainer>
             </EntityTypeTabProvider>
           </Box>
         </EntityTypeContext.Provider>

--- a/apps/hash-frontend/src/pages/shared/shared/type-editor-styling.tsx
+++ b/apps/hash-frontend/src/pages/shared/shared/type-editor-styling.tsx
@@ -1,6 +1,7 @@
 import { Box, Container } from "@mui/material";
 import { type SxProps, type Theme } from "@mui/system";
 
+import { largePageMaxWidthCss } from "../page-width";
 import { inSlideContainerStyles } from "./slide-styles";
 
 export const typeHeaderContainerStyles: SxProps<Theme> = ({ palette }) => ({
@@ -13,16 +14,23 @@ export const typeHeaderContainerStyles: SxProps<Theme> = ({ palette }) => ({
 export const TypeDefinitionContainer = ({
   children,
   inSlide,
+  wide,
 }: {
   children: React.ReactNode;
   inSlide?: boolean;
+  wide?: boolean;
 }) => {
   return (
     <Box
       py={5}
       sx={({ palette }) => ({ background: palette.gray[10], height: "100%" })}
     >
-      <Container sx={inSlide ? inSlideContainerStyles : {}}>
+      <Container
+        sx={{
+          ...(inSlide ? inSlideContainerStyles : {}),
+          ...(!inSlide && wide ? largePageMaxWidthCss : {}),
+        }}
+      >
         {children}
       </Container>
     </Box>

--- a/apps/hash-frontend/src/pages/supply-chain/shared/docs/docs-modal/docs-content/site-overview.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/docs/docs-modal/docs-content/site-overview.tsx
@@ -31,6 +31,11 @@ export const siteOverviewSection: DocSectionDef = {
             them, so their cost is not double-counted. Product-specific steps
             stay attributed to their product.
           </P>
+          <P>
+            The <Term>steps over plan</Term> summary next to the site title uses
+            the same 95th-percentile and 10% threshold as the Over plan
+            opportunities.
+          </P>
           <H4>Opportunities</H4>
           <P>
             The opportunities table at the top ranks the most actionable

--- a/apps/hash-frontend/src/pages/supply-chain/shared/site-aggregation.test.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/site-aggregation.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 
 import {
   computeNodePeriodCost,
-  countBadPlanningParams,
   deduplicateNodes,
   topDwellCosts,
   topPlanningMismatches,
@@ -470,11 +469,5 @@ describe("site rollups", () => {
     expect(topMismatch).toBeDefined();
     expect(topMismatch!.id).toBe("o");
     expect(topMismatch!.deviationPct).toBeCloseTo(200, 6);
-  });
-
-  it("counts nodes whose median exceeds plan by >20%", () => {
-    const bad = siteNode({ id: "b", stats: stats(5, 13), plan: 10 }); // 1.3x
-    const ok = siteNode({ id: "k", stats: stats(5, 11), plan: 10 }); // 1.1x
-    expect(countBadPlanningParams([bad, ok])).toBe(1);
   });
 });

--- a/apps/hash-frontend/src/pages/supply-chain/shared/site-aggregation.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/site-aggregation.ts
@@ -370,15 +370,3 @@ export function topPlanningMismatches(
     .sort((left, right) => right.deviationPct - left.deviationPct)
     .slice(0, count);
 }
-
-export function countBadPlanningParams(
-  nodes: SiteNode[],
-  measure: BaseMeasure = "median",
-): number {
-  return nodes.filter((node) => {
-    if (node.plan == null || node.plan <= 0 || node.stats.n === 0) {
-      return false;
-    }
-    return (selectStat(node.stats, measure) ?? 0) > node.plan * 1.2;
-  }).length;
-}

--- a/apps/hash-frontend/src/pages/supply-chain/shared/stat-chip.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/stat-chip.tsx
@@ -16,6 +16,29 @@ const chip = css({
   borderColor: "bd.subtle",
   _last: { borderRightWidth: "0", pr: "0", mr: "0" },
 });
+const chipButton = css({
+  appearance: "none",
+  bg: "[transparent]",
+  borderTopWidth: "0",
+  borderBottomWidth: "0",
+  borderLeftWidth: "0",
+  pt: "0",
+  pb: "0",
+  pl: "0",
+  mt: "0",
+  mb: "0",
+  ml: "0",
+  color: "[inherit]",
+  cursor: "pointer",
+  font: "inherit",
+  textAlign: "left",
+  _hover: { textDecoration: "underline" },
+  _focusVisible: {
+    outline: "2px solid",
+    outlineColor: "[currentColor]",
+    outlineOffset: "[2px]",
+  },
+});
 const valueBase = css({
   fontWeight: "medium",
   textStyle: "sm",
@@ -35,19 +58,31 @@ export const StatChip = ({
   value,
   label,
   isHighlight,
+  onClick,
 }: {
   value: string;
   label: string;
   isHighlight?: boolean;
+  onClick?: () => void;
 }) => {
-  return (
-    <div className={chip}>
+  const content = (
+    <>
       <span
         className={cx(valueBase, isHighlight ? valueHighlight : valuePlain)}
       >
         {value}
       </span>
       <span className={labelText}>{label}</span>
-    </div>
+    </>
   );
+
+  if (onClick) {
+    return (
+      <button type="button" className={cx(chip, chipButton)} onClick={onClick}>
+        {content}
+      </button>
+    );
+  }
+
+  return <div className={chip}>{content}</div>;
 };

--- a/apps/hash-frontend/src/pages/supply-chain/shared/step-detail-panel.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/step-detail-panel.tsx
@@ -63,6 +63,7 @@ import { recomputeSupplierBlock } from "./supplier-otif";
 import { TIME_RANGE_OPTIONS, timeRangeLongLabel } from "./time-range";
 import { useTimeRange } from "./time-range-context";
 
+import type { BaseMeasure } from "./measure-context";
 import type {
   StepDetail as StepDetailType,
   StepStats,
@@ -313,6 +314,8 @@ interface StepDetailPanelProps {
    */
   stepMaterial?: string | null;
   briefHref?: string;
+  /** Overrides the global headline measure for context-specific entry points. */
+  measureOverride?: BaseMeasure;
   /** All status updates left against this step/node (any order; rendered newest-first). */
   statusEntries?: StatusEntry[];
   /** Opens the shared status dialog for this step. */
@@ -350,6 +353,7 @@ export const StepDetailPanel = ({
   productName,
   stepMaterial,
   briefHref,
+  measureOverride,
   statusEntries = [],
   onStatus,
   statusDialog,
@@ -756,6 +760,7 @@ export const StepDetailPanel = ({
                   timeRange={timeRange}
                   selectedComponent={selectedComponent != null}
                   countOverride={selectedComponentReconciliationCount}
+                  previousCount={periodComparison.previousStats?.n ?? 0}
                 />
 
                 {excludeOutliers && (filteredStep.excluded_count ?? 0) > 0 && (
@@ -884,6 +889,7 @@ export const StepDetailPanel = ({
                       unfilteredStep={step}
                       comparison={periodComparison}
                       timeRange={timeRange}
+                      measureOverride={measureOverride}
                     />
 
                     <StatsRow

--- a/apps/hash-frontend/src/pages/supply-chain/shared/step-detail-panel/step-detail-primitives.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/step-detail-panel/step-detail-primitives.tsx
@@ -144,6 +144,11 @@ const dashText = css({
 // the dashed underline on `obsNoun` so it reads as a strike-through. Restoring a
 // normal line box on the wrapper keeps the underline beneath the text.
 const obsTrigger = css({ display: "inline-flex", lineHeight: "normal" });
+const obsLines = css({
+  display: "inline-flex",
+  flexDirection: "column",
+  gap: "0.5",
+});
 const obsWrap = css({
   display: "inline-flex",
   flexShrink: "0",
@@ -225,13 +230,13 @@ export const PeriodLabel = ({
 export const PlanningAssumptionCell = ({
   plan,
   hasPlan,
-  medianMeetsPlan,
+  measureMeetsPlan,
   planLabel,
   noteRaw,
 }: {
   plan: number | null;
   hasPlan: boolean;
-  medianMeetsPlan: boolean;
+  measureMeetsPlan: boolean;
   planLabel: string | null;
   noteRaw: string | null;
 }) => {
@@ -247,7 +252,7 @@ export const PlanningAssumptionCell = ({
           <span
             className={cx(
               badgeBase,
-              medianMeetsPlan ? badgeSuccess : badgeDanger,
+              measureMeetsPlan ? badgeSuccess : badgeDanger,
             )}
           >
             <ClockIcon />
@@ -450,6 +455,7 @@ export const ObservationCount = ({
   timeRange,
   selectedComponent,
   countOverride,
+  previousCount,
 }: {
   step: StepDetailType;
   stats: StepStats | null;
@@ -457,14 +463,11 @@ export const ObservationCount = ({
   timeRange: TimeRange;
   selectedComponent: boolean;
   countOverride?: number | null;
+  previousCount?: number | null;
 }) => {
   const count = countOverride ?? stats?.n ?? step.stats.n;
-  const periodLabel =
-    timeRange === "3m"
-      ? "last 3 months"
-      : timeRange === "6m"
-        ? "last 6 months"
-        : "last 12 months";
+  const periodMonths = timeRange === "3m" ? 3 : timeRange === "6m" ? 6 : 12;
+  const periodLabel = `last ${periodMonths} months`;
   const noun = countNoun({
     id: step.id,
     label: step.label,
@@ -489,11 +492,21 @@ export const ObservationCount = ({
         nMovements: step.n_movements,
       })}
     >
-      <span className={obsWrap}>
-        <span className={obsCount}>{formatNumber(count)}</span>
-        <span className={obsNoun}>
-          {noun} ({periodLabel})
+      <span className={obsLines}>
+        <span className={obsWrap}>
+          <span className={obsCount}>{formatNumber(count)}</span>
+          <span className={obsNoun}>
+            {noun} ({periodLabel})
+          </span>
         </span>
+        {previousCount != null && (
+          <span className={obsWrap}>
+            <span className={obsCount}>{formatNumber(previousCount)}</span>
+            <span className={obsNoun}>
+              {noun} (previous {periodMonths} months)
+            </span>
+          </span>
+        )}
       </span>
     </Tooltip>
   );

--- a/apps/hash-frontend/src/pages/supply-chain/shared/step-detail-panel/timing-metrics.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/step-detail-panel/timing-metrics.tsx
@@ -19,6 +19,7 @@ import {
   DeltaWithTooltip,
 } from "./step-detail-primitives";
 
+import type { BaseMeasure } from "../measure-context";
 import type { TimeRange } from "../time-range";
 import type { StepDetail as StepDetailType } from "../types";
 
@@ -114,17 +115,20 @@ export const KeyMetricsRow = ({
   unfilteredStep,
   comparison,
   timeRange,
+  measureOverride,
 }: {
   step: StepDetailType;
   unfilteredStep: StepDetailType;
   comparison: PeriodComparison | null;
   timeRange: TimeRange;
+  measureOverride?: BaseMeasure;
 }) => {
   const plan = step.plan;
   const hasPlan = plan != null;
   const pep = step.pct_exceeding_plan;
   const { waccRate, storageCost } = useCostParams();
   const { measure } = useBaseMeasure();
+  const effectiveMeasure = measureOverride ?? measure;
   const { basis } = useProcurementBasis();
 
   // Secondary procurement lead-time figure. `complete_timing` carries the other
@@ -133,9 +137,9 @@ export const KeyMetricsRow = ({
   // counterpart and its gap vs the headline.
   const secondaryStats = step.complete_timing?.stats;
   const secondaryValue = secondaryStats
-    ? selectStat(secondaryStats, measure)
+    ? selectStat(secondaryStats, effectiveMeasure)
     : null;
-  const headlineValue = selectStat(step.stats, measure);
+  const headlineValue = selectStat(step.stats, effectiveMeasure);
   const secondaryGap =
     secondaryValue != null && headlineValue != null
       ? secondaryValue - headlineValue
@@ -184,7 +188,9 @@ export const KeyMetricsRow = ({
         <PlanningAssumptionCell
           plan={plan}
           hasPlan={hasPlan}
-          medianMeetsPlan={(step.stats.median ?? 0) <= (plan ?? 0)}
+          measureMeetsPlan={
+            headlineValue == null || plan == null || headlineValue <= plan
+          }
           planLabel={planLabel}
           noteRaw={planNote}
         />
@@ -229,7 +235,7 @@ export const KeyMetricsRow = ({
         {secondaryValue != null && (
           <div className={cellPlain}>
             <div className={labelWide}>
-              {secondaryLabel} ({MEASURE_LABELS[measure]})
+              {secondaryLabel} ({MEASURE_LABELS[effectiveMeasure]})
             </div>
             <div className={valueRow}>
               <span className={cx(valueBase, valueStrong)}>

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site.tsx
@@ -36,6 +36,7 @@ import { TrendTable } from "./site/trend-table";
 import { useSiteOverviewRows } from "./site/use-site-overview-rows";
 import { VendorDetailPanel } from "./site/vendor-detail-panel";
 
+import type { BaseMeasure } from "../shared/measure-context";
 import type { StatusActionLabel, StatusStore } from "../shared/status";
 import type { Product, SiteNode, StepType } from "../shared/types";
 import type {
@@ -200,6 +201,7 @@ export const SiteOverview = ({
     title: string;
     siteContext: { products: Array<{ id: string; name: string }> };
     briefHref: string;
+    measureOverride?: BaseMeasure;
   } | null>(null);
   const [statusTarget, setStatusTarget] = useState<{
     node: SiteNode;
@@ -282,6 +284,10 @@ export const SiteOverview = ({
   const [oppStatusHidden, setOppStatusHidden] = useState<
     Set<StatusActionLabel>
   >(() => new Set());
+  const [oppSectionRevealRequest, setOppSectionRevealRequest] = useState<{
+    kind: OpportunityKind;
+    requestId: number;
+  } | null>(null);
 
   const {
     loading,
@@ -324,8 +330,17 @@ export const SiteOverview = ({
       buildBriefHref,
     ],
   );
+
+  const overPlanCount = useMemo(
+    () =>
+      opportunities.filter(
+        (opportunity) => opportunity.kind === "planning_over",
+      ).length,
+    [opportunities],
+  );
+
   const handleStepClick = useCallback(
-    (node: SiteNode) => {
+    (node: SiteNode, opportunityKind?: OpportunityKind) => {
       const firstProduct = node.products[0];
       if (!firstProduct) {
         return;
@@ -345,11 +360,32 @@ export const SiteOverview = ({
         briefHref: buildBriefHref(
           isDwellType(node.type) ? "dwell" : "planning",
           node,
+          opportunityKind,
         ),
+        measureOverride:
+          opportunityKind === "planning_over" ||
+          opportunityKind === "planning_under"
+            ? "p95"
+            : undefined,
       });
     },
     [buildBriefHref, siteId],
   );
+
+  const revealOverPlanOpportunities = useCallback(() => {
+    setOppTypeHidden((hiddenKinds) => {
+      if (!hiddenKinds.has("planning_over")) {
+        return hiddenKinds;
+      }
+      const nextHiddenKinds = new Set(hiddenKinds);
+      nextHiddenKinds.delete("planning_over");
+      return nextHiddenKinds;
+    });
+    setOppSectionRevealRequest((previousRequest) => ({
+      kind: "planning_over",
+      requestId: (previousRequest?.requestId ?? 0) + 1,
+    }));
+  }, []);
 
   const handlePanelClose = useCallback(() => {
     trackSupplyChainInteraction({
@@ -394,11 +430,12 @@ export const SiteOverview = ({
                   isHighlight
                 />
               )}
-              {summaryStats.badParams > 0 && (
+              {overPlanCount > 0 && (
                 <StatChip
-                  value={String(summaryStats.badParams)}
-                  label="steps exceeding plan"
+                  value={String(overPlanCount)}
+                  label="steps over plan"
                   isHighlight
+                  onClick={revealOverPlanOpportunities}
                 />
               )}
             </div>
@@ -443,7 +480,9 @@ export const SiteOverview = ({
           opportunities={opportunities}
           siteId={siteSlug}
           statusHistory={opportunityStatusHistory}
-          onRowClick={handleStepClick}
+          onRowClick={(opportunity) =>
+            handleStepClick(opportunity.node, opportunity.kind)
+          }
           onStatus={openStatus}
           sort={oppSort}
           onSort={setOppSort}
@@ -453,6 +492,7 @@ export const SiteOverview = ({
           onProductHiddenChange={setOppProductHidden}
           statusHidden={oppStatusHidden}
           onStatusHiddenChange={setOppStatusHidden}
+          revealSectionRequest={oppSectionRevealRequest}
         />
 
         <div className={chartShrink}>
@@ -602,6 +642,7 @@ export const SiteOverview = ({
           siteContext={selectedStep.siteContext}
           stepMaterial={selectedStep.node.material}
           briefHref={selectedStep.briefHref}
+          measureOverride={selectedStep.measureOverride}
           statusEntries={
             opportunityStatusHistory[statusKey(siteSlug, selectedStep.node)] ??
             []

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/opportunities-table.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/opportunities-table.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { Tooltip } from "@hashintel/ds-components";
 import { css, cx } from "@hashintel/ds-helpers/css";
@@ -216,7 +216,7 @@ interface OpportunitiesTableProps {
   /** Route site slug; scopes status keys to the global store. */
   siteId: string;
   statusHistory?: StatusStore;
-  onRowClick: (node: SiteNode) => void;
+  onRowClick: (opportunity: SiteOpportunity) => void;
   onStatus: (node: SiteNode, title: string) => void;
   sort: { key: SortKey; dir: SortDir } | null;
   onSort: (next: { key: SortKey; dir: SortDir }) => void;
@@ -226,6 +226,10 @@ interface OpportunitiesTableProps {
   onProductHiddenChange: (next: Set<string>) => void;
   statusHidden: Set<StatusActionLabel>;
   onStatusHiddenChange: (next: Set<StatusActionLabel>) => void;
+  revealSectionRequest?: {
+    kind: OpportunityKind;
+    requestId: number;
+  } | null;
 }
 
 const OpportunityColGroup = () => {
@@ -343,10 +347,38 @@ export const OpportunitiesTable = ({
   onProductHiddenChange,
   statusHidden,
   onStatusHiddenChange,
+  revealSectionRequest,
 }: OpportunitiesTableProps) => {
   const [collapsedSections, setCollapsedSections] = useState<
     Set<OpportunityKind>
   >(() => new Set());
+  const sectionRefs = useRef<
+    Partial<Record<OpportunityKind, HTMLTableSectionElement | null>>
+  >({});
+
+  useEffect(() => {
+    if (!revealSectionRequest) {
+      return;
+    }
+
+    const { kind } = revealSectionRequest;
+    setCollapsedSections((previousSections) => {
+      if (!previousSections.has(kind)) {
+        return previousSections;
+      }
+      const nextSections = new Set(previousSections);
+      nextSections.delete(kind);
+      return nextSections;
+    });
+
+    const animationFrame = requestAnimationFrame(() => {
+      sectionRefs.current[kind]?.scrollIntoView({
+        behavior: "smooth",
+        block: "start",
+      });
+    });
+    return () => cancelAnimationFrame(animationFrame);
+  }, [revealSectionRequest]);
 
   const statusOf = useCallback(
     (opportunity: SiteOpportunity): StatusActionLabel =>
@@ -522,7 +554,13 @@ export const OpportunitiesTable = ({
             </tr>
           </thead>
           {grouped.map((section) => (
-            <tbody key={section.id} className={threshold.tbodyDivide}>
+            <tbody
+              key={section.id}
+              ref={(element) => {
+                sectionRefs.current[section.id] = element;
+              }}
+              className={threshold.tbodyDivide}
+            >
               <tr>
                 <td
                   colSpan={5}
@@ -560,10 +598,10 @@ export const OpportunitiesTable = ({
                           "opportunityRowsIn 320ms cubic-bezier(0.2, 0, 0, 1)",
                       }}
                       tabIndex={0}
-                      onClick={() => onRowClick(opportunity.node)}
+                      onClick={() => onRowClick(opportunity)}
                       onKeyDown={(event) => {
                         if (event.key === "Enter") {
-                          onRowClick(opportunity.node);
+                          onRowClick(opportunity);
                         }
                       }}
                     >

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/use-site-overview-rows.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/use-site-overview-rows.ts
@@ -17,7 +17,6 @@ import {
 import {
   totalSiteDwellCost,
   topDwellCosts,
-  countBadPlanningParams,
   computeNodePeriodCost,
 } from "../../shared/site-aggregation";
 import { siteNodeKey } from "../../shared/site-node-key";
@@ -136,9 +135,8 @@ export function useSiteOverviewRows({
 
   const summaryStats = useMemo(() => {
     const dwellCost = totalSiteDwellCost(filteredNodes, waccRate, storageCost);
-    const badParams = countBadPlanningParams(filteredNodes, measure);
-    return { dwellCost: dwellCost > 0 ? dwellCost : null, badParams };
-  }, [filteredNodes, waccRate, storageCost, measure]);
+    return { dwellCost: dwellCost > 0 ? dwellCost : null };
+  }, [filteredNodes, waccRate, storageCost]);
 
   // Site-wide currency for cost formatting: the most common non-null currency
   // across the site's nodes. Falls back to the active dataset/default currency.


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Small UX improvements:

To the supply chain feature:
1. The headline '`n` steps over plan' statistic on the site overview page was out of sync with the actual 'over plan' numbers shown in the opportunity table, as it didn't reflect the chosen filters etc. This has been fixed.
2. This headline statistic is now also a link that when clicked will auto-expand/scroll to the relevant section of the opportunities table.
3. In the opportunities table, over/under plan opportunities are fixed at the actuals _P95_ being -/+_ 10% of the planning assumption (as this is a reasonable benchmark for 'is our assumption well-calibrated'). But the slideover didn't respect this when opened, and instead showed over/under based on the selected basis, so the 'versus plan' chip could be green when the user had clicked to arrive from an 'over plan' opportunity, which was confusing. There's a wider question as to whether the opportunities table should be fixed at the P95 as a comparator rather than the user-selected baseline, but for now this PR makes at least the experience consistent (open slide from opportunities table, which is based on P95 -> slide color indicator based on P95).
4. When in a detail slide, it says '`n` events over the past `[selected period, e.g. 12m]`'. But because the slide includes trend against the previous period, when a user clicks to load the full data table, we also include the previous period's rows for full inspectability of all displayed statistics. This is confusing on small `n` steps, because it says e.g. '3 events' but then the user sees e.g. 6 rows in the data table (on large `n` steps, the user cannot eyeball a discrepancy). The PR adds an additional '`n` events over the previous `[selected period]`' to make it more obvious what's going on.

Elsewhere/drive-by:
1. We recently updated the entities view to give much more space to the visualizer, to account for wide tables and graph viz. But this entity viz is also present on the 'Entities' tab when viewing a type (i.e. view entities of this type). The PR gives this tab the same extra width as afforded to the entities page.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->
<!-- Libraries inside of the `@local` directory are always internal libraries which have no need for publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. On `/supply-chain`
2. By viewing a type and switching to the 'Entities' tab, see additional width.
