### PR TITLE
FE-1209: Fix Petrinaut Core changeset bump

### DIFF
--- a/.changeset/petrinaut-hir-compiler.md
+++ b/.changeset/petrinaut-hir-compiler.md
@@ -1,6 +1,6 @@
 ---
 "@hashintel/petrinaut": patch
-"@hashintel/petrinaut-core": minor
+"@hashintel/petrinaut-core": patch
 ---
 
 Compile all user code (dynamics, rates, kernels, metrics) through a new HIR


### PR DESCRIPTION
Correct the Petrinaut release note so `@hashintel/petrinaut-core` is marked as a patch change rather than a minor change.

This keeps the changeset aligned with the intended scope of the last update and avoids an unnecessary minor release for `petrinaut-core`.