### PR TITLE
FE-1162: Add Petrinaut optimizer status endpoint

### DIFF
--- a/apps/hash-api/README.md
+++ b/apps/hash-api/README.md
@@ -30,6 +30,11 @@ The HASH Backend API service is configured using the following environment varia
 - Redis
   - `HASH_REDIS_HOST`: the hostname for the Redis server.
   - `HASH_REDIS_PORT`: the port number of the Redis server.
+- Petrinaut optimizer
+  - `HASH_PETRINAUT_OPT_HOST`: the hostname of the Petrinaut optimizer service.
+  - `HASH_PETRINAUT_OPT_PORT`: the port of the Petrinaut optimizer service.
+  - Both variables are optional for local NodeAPI development, but must be set
+    together to enable the Petrinaut optimizer endpoints.
 - `FRONTEND_URL`: The URL the frontend is hosted on.
 - Vault
   - `HASH_VAULT_HOST`: The host address (including protocol) that the Vault server is running on, e.g. `http://127.0.0.1`

--- a/apps/hash-api/package.json
+++ b/apps/hash-api/package.json
@@ -48,6 +48,7 @@
     "@local/hash-graph-client": "workspace:*",
     "@local/hash-graph-sdk": "workspace:*",
     "@local/hash-isomorphic-utils": "workspace:*",
+    "@local/petrinaut-optimizer-types": "workspace:*",
     "@local/status": "workspace:*",
     "@mailchimp/mailchimp_marketing": "3.0.80",
     "@opentelemetry/api": "1.9.1",

--- a/apps/hash-api/src/index.ts
+++ b/apps/hash-api/src/index.ts
@@ -87,6 +87,10 @@ import {
   port,
 } from "./lib/env-config";
 import { logger } from "./logger";
+import {
+  getPetrinautOptimizerOrigin,
+  setupPetrinautOptimizerHandler,
+} from "./petrinaut-optimizer/setup-petrinaut-optimizer-handler";
 import { seedOrgsAndUsers } from "./seed-data";
 import {
   setupFileDownloadProxyHandler,
@@ -747,6 +751,11 @@ const main = async () => {
   setupFileDownloadProxyHandler(app, keyv);
 
   setupAnalysisHandler(app, keyv);
+
+  setupPetrinautOptimizerHandler(app, {
+    logger,
+    origin: getPetrinautOptimizerOrigin(),
+  });
 
   setupTelemetryHandler(app);
   shutdown.addCleanup("Rudderstack Telemetry", async () => telemetry.flush());

--- a/apps/hash-api/src/petrinaut-optimizer/setup-petrinaut-optimizer-handler.test.ts
+++ b/apps/hash-api/src/petrinaut-optimizer/setup-petrinaut-optimizer-handler.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getPetrinautOptimizerOrigin,
+  PETRINAUT_OPTIMIZER_STATUS_PATH,
+  setupPetrinautOptimizerHandler,
+} from "./setup-petrinaut-optimizer-handler";
+
+import type {
+  Express,
+  Request,
+  Response as ExpressResponse,
+} from "express";
+
+const logger = { warn: () => undefined };
+
+type Handler = (request: Request, response: ExpressResponse) => Promise<void>;
+
+const callHandler = async ({
+  authenticated = true,
+  fetchImpl,
+  origin,
+}: {
+  authenticated?: boolean;
+  fetchImpl?: (input: string | URL, init?: RequestInit) => Promise<Response>;
+  origin: URL | null;
+}) => {
+  let handler: Handler | undefined;
+  let registeredPath: string | undefined;
+  const app = {
+    get: (path: string, routeHandler: Handler) => {
+      registeredPath = path;
+      handler = routeHandler;
+    },
+  } as unknown as Express;
+
+  setupPetrinautOptimizerHandler(app, { fetchImpl, logger, origin });
+
+  let statusCode = 200;
+  let body: unknown;
+  const response = {
+    json: (value: unknown) => {
+      body = value;
+      return response;
+    },
+    status: (value: number) => {
+      statusCode = value;
+      return response;
+    },
+  } as unknown as ExpressResponse;
+  const request = {
+    user: authenticated ? ({} as NonNullable<Request["user"]>) : undefined,
+  } as Request;
+
+  await handler?.(request, response);
+
+  return { body, registeredPath, statusCode };
+};
+
+describe("getPetrinautOptimizerOrigin", () => {
+  it("allows the optimizer to be unconfigured", () => {
+    expect(getPetrinautOptimizerOrigin({})).toBeNull();
+  });
+
+  it("constructs an HTTP origin from the configured host and port", () => {
+    expect(
+      getPetrinautOptimizerOrigin({
+        HASH_PETRINAUT_OPT_HOST: "petrinaut-opt",
+        HASH_PETRINAUT_OPT_PORT: "4004",
+      })?.href,
+    ).toBe("http://petrinaut-opt:4004/");
+  });
+
+  it("rejects partial configuration", () => {
+    expect(() =>
+      getPetrinautOptimizerOrigin({ HASH_PETRINAUT_OPT_HOST: "localhost" }),
+    ).toThrow("must be set together");
+  });
+});
+
+describe(PETRINAUT_OPTIMIZER_STATUS_PATH, () => {
+  it("requires authentication", async () => {
+    const result = await callHandler({ authenticated: false, origin: null });
+
+    expect(result).toEqual({
+      body: { error: "Authentication required" },
+      registeredPath: PETRINAUT_OPTIMIZER_STATUS_PATH,
+      statusCode: 401,
+    });
+  });
+
+  it("returns 503 when the optimizer is not configured", async () => {
+    const result = await callHandler({ origin: null });
+
+    expect(result).toEqual({
+      body: { error: "Petrinaut optimizer is not configured" },
+      registeredPath: PETRINAUT_OPTIMIZER_STATUS_PATH,
+      statusCode: 503,
+    });
+  });
+
+  it("forwards the optimizer status", async () => {
+    const requestedUrls: string[] = [];
+    const result = await callHandler({
+      origin: new URL("http://petrinaut-opt:4004"),
+      fetchImpl: async (input) => {
+        requestedUrls.push(input.toString());
+        return Response.json({ phase: "idle", detail: null });
+      },
+    });
+
+    expect(result).toEqual({
+      body: { phase: "idle", detail: null },
+      registeredPath: PETRINAUT_OPTIMIZER_STATUS_PATH,
+      statusCode: 200,
+    });
+    expect(requestedUrls).toEqual(["http://petrinaut-opt:4004/status"]);
+  });
+});

--- a/apps/hash-api/src/petrinaut-optimizer/setup-petrinaut-optimizer-handler.test.ts
+++ b/apps/hash-api/src/petrinaut-optimizer/setup-petrinaut-optimizer-handler.test.ts
@@ -6,11 +6,7 @@ import {
   setupPetrinautOptimizerHandler,
 } from "./setup-petrinaut-optimizer-handler";
 
-import type {
-  Express,
-  Request,
-  Response as ExpressResponse,
-} from "express";
+import type { Express, Request, Response as ExpressResponse } from "express";
 
 const logger = { warn: () => undefined };
 
@@ -115,5 +111,18 @@ describe(PETRINAUT_OPTIMIZER_STATUS_PATH, () => {
       statusCode: 200,
     });
     expect(requestedUrls).toEqual(["http://petrinaut-opt:4004/status"]);
+  });
+
+  it("rejects an invalid optimizer status", async () => {
+    const result = await callHandler({
+      origin: new URL("http://petrinaut-opt:4004"),
+      fetchImpl: async () => Response.json({ phase: "unknown" }),
+    });
+
+    expect(result).toEqual({
+      body: { error: "Petrinaut optimizer is unavailable" },
+      registeredPath: PETRINAUT_OPTIMIZER_STATUS_PATH,
+      statusCode: 503,
+    });
   });
 });

--- a/apps/hash-api/src/petrinaut-optimizer/setup-petrinaut-optimizer-handler.ts
+++ b/apps/hash-api/src/petrinaut-optimizer/setup-petrinaut-optimizer-handler.ts
@@ -1,0 +1,95 @@
+import type { Express } from "express";
+
+export const PETRINAUT_OPTIMIZER_STATUS_PATH =
+  "/api/petrinaut-optimizer/status";
+
+const STATUS_REQUEST_TIMEOUT_MS = 5_000;
+
+type Fetch = (
+  input: string | URL,
+  init?: RequestInit,
+) => Promise<Response>;
+
+type WarningLogger = {
+  warn: (message: string, metadata?: Record<string, unknown>) => void;
+};
+
+type PetrinautOptimizerHandlerOptions = {
+  origin: URL | null;
+  fetchImpl?: Fetch;
+  logger: WarningLogger;
+};
+
+/**
+ * Resolve the private optimizer origin from the environment.
+ *
+ * Both variables may be omitted for local NodeAPI development. Supplying only
+ * one is treated as a configuration error rather than silently constructing an
+ * unusable URL.
+ */
+export const getPetrinautOptimizerOrigin = (
+  environment: NodeJS.ProcessEnv = process.env,
+): URL | null => {
+  const host = environment.HASH_PETRINAUT_OPT_HOST;
+  const portValue = environment.HASH_PETRINAUT_OPT_PORT;
+
+  if (!host && !portValue) {
+    return null;
+  }
+  if (!host || !portValue) {
+    throw new Error(
+      "HASH_PETRINAUT_OPT_HOST and HASH_PETRINAUT_OPT_PORT must be set together",
+    );
+  }
+
+  const port = Number(portValue);
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    throw new Error("HASH_PETRINAUT_OPT_PORT must be an integer from 1 to 65535");
+  }
+
+  const urlHost =
+    host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
+  return new URL(`http://${urlHost}:${port}`);
+};
+
+/**
+ * Mount the first NodeAPI-to-optimizer integration point.
+ *
+ * This intentionally exposes only the optimizer's lightweight status payload.
+ * The optimization request and streaming contracts will be added separately.
+ */
+export const setupPetrinautOptimizerHandler = (
+  app: Express,
+  { origin, fetchImpl = fetch, logger }: PetrinautOptimizerHandlerOptions,
+) => {
+  app.get(PETRINAUT_OPTIMIZER_STATUS_PATH, async (req, res) => {
+    if (!req.user) {
+      res.status(401).json({ error: "Authentication required" });
+      return;
+    }
+
+    if (!origin) {
+      res.status(503).json({ error: "Petrinaut optimizer is not configured" });
+      return;
+    }
+
+    try {
+      const upstreamResponse = await fetchImpl(new URL("/status", origin), {
+        headers: { accept: "application/json" },
+        signal: AbortSignal.timeout(STATUS_REQUEST_TIMEOUT_MS),
+      });
+
+      if (!upstreamResponse.ok) {
+        throw new Error(
+          `Petrinaut optimizer returned status ${upstreamResponse.status}`,
+        );
+      }
+
+      const status: unknown = await upstreamResponse.json();
+      res.json(status);
+    } catch (error) {
+      logger.warn("Could not reach Petrinaut optimizer", { error });
+      res.status(503).json({ error: "Petrinaut optimizer is unavailable" });
+    }
+  });
+};

--- a/apps/hash-api/src/petrinaut-optimizer/setup-petrinaut-optimizer-handler.ts
+++ b/apps/hash-api/src/petrinaut-optimizer/setup-petrinaut-optimizer-handler.ts
@@ -1,3 +1,4 @@
+import type { paths } from "@local/petrinaut-optimizer-types";
 import type { Express } from "express";
 
 export const PETRINAUT_OPTIMIZER_STATUS_PATH =
@@ -5,10 +6,45 @@ export const PETRINAUT_OPTIMIZER_STATUS_PATH =
 
 const STATUS_REQUEST_TIMEOUT_MS = 5_000;
 
-type Fetch = (
-  input: string | URL,
-  init?: RequestInit,
-) => Promise<Response>;
+type PetrinautOptimizerStatus =
+  paths["/status"]["get"]["responses"][200]["content"]["application/json"];
+
+const PETRINAUT_OPTIMIZER_PHASES = [
+  "idle",
+  "running",
+  "done",
+  "error",
+] as const satisfies readonly NonNullable<PetrinautOptimizerStatus["phase"]>[];
+
+const isPetrinautOptimizerPhase = (
+  value: unknown,
+): value is NonNullable<PetrinautOptimizerStatus["phase"]> =>
+  typeof value === "string" &&
+  PETRINAUT_OPTIMIZER_PHASES.some((phase) => phase === value);
+
+const isPetrinautOptimizerStatus = (
+  value: unknown,
+): value is PetrinautOptimizerStatus => {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const {
+    detail,
+    phase,
+    updated_at: updatedAt,
+  } = value as Record<string, unknown>;
+
+  return (
+    isPetrinautOptimizerPhase(phase) &&
+    (detail === undefined || detail === null || typeof detail === "string") &&
+    (updatedAt === undefined ||
+      updatedAt === null ||
+      typeof updatedAt === "string")
+  );
+};
+
+type Fetch = (input: string | URL, init?: RequestInit) => Promise<Response>;
 
 type WarningLogger = {
   warn: (message: string, metadata?: Record<string, unknown>) => void;
@@ -44,7 +80,9 @@ export const getPetrinautOptimizerOrigin = (
 
   const port = Number(portValue);
   if (!Number.isInteger(port) || port < 1 || port > 65_535) {
-    throw new Error("HASH_PETRINAUT_OPT_PORT must be an integer from 1 to 65535");
+    throw new Error(
+      "HASH_PETRINAUT_OPT_PORT must be an integer from 1 to 65535",
+    );
   }
 
   const urlHost =
@@ -86,6 +124,11 @@ export const setupPetrinautOptimizerHandler = (
       }
 
       const status: unknown = await upstreamResponse.json();
+      if (!isPetrinautOptimizerStatus(status)) {
+        throw new Error(
+          "Petrinaut optimizer returned an invalid status payload",
+        );
+      }
       res.json(status);
     } catch (error) {
       logger.warn("Could not reach Petrinaut optimizer", { error });

--- a/yarn.lock
+++ b/yarn.lock
@@ -524,6 +524,7 @@ __metadata:
     "@local/hash-graph-client": "workspace:*"
     "@local/hash-graph-sdk": "workspace:*"
     "@local/hash-isomorphic-utils": "workspace:*"
+    "@local/petrinaut-optimizer-types": "workspace:*"
     "@local/status": "workspace:*"
     "@local/tsconfig": "workspace:*"
     "@mailchimp/mailchimp_marketing": "npm:3.0.80"
@@ -8695,7 +8696,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@local/petrinaut-optimizer-types@workspace:libs/@local/petrinaut-optimizer-types":
+"@local/petrinaut-optimizer-types@workspace:*, @local/petrinaut-optimizer-types@workspace:libs/@local/petrinaut-optimizer-types":
   version: 0.0.0-use.local
   resolution: "@local/petrinaut-optimizer-types@workspace:libs/@local/petrinaut-optimizer-types"
   dependencies:


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Add the first minimal NodeAPI integration point for the Petrinaut optimizer service. This intentionally starts with an authenticated status request so the service configuration, handler placement, upstream call, validation, and failure behavior can be reviewed before introducing optimization streaming.

## 🔗 Related links

- Stacked on [#9038](https://github.com/hashintel/hash/pull/9038)
- [#9038](https://github.com/hashintel/hash/pull/9038) is stacked on the service contract in [#9042](https://github.com/hashintel/hash/pull/9042)
- [#9042](https://github.com/hashintel/hash/pull/9042) is stacked on the Dockerfile in [#9031](https://github.com/hashintel/hash/pull/9031)

## 🚫 Blocked by

- [ ] [#9038](https://github.com/hashintel/hash/pull/9038)

## 🔍 What does this change?

- Adds `GET /api/petrinaut-optimizer/status` to the HASH NodeAPI.
- Requires an authenticated HASH user.
- Calls the optimizer container status endpoint.
- Reads the private service address from `HASH_PETRINAUT_OPT_HOST` and `HASH_PETRINAUT_OPT_PORT`.
- Uses the generated `/status` response contract from `@local/petrinaut-optimizer-types`.
- Keeps upstream JSON unknown until its phase and optional fields pass runtime validation.
- Allows both variables to be absent for local NodeAPI development, returning 503 until configured, while rejecting partial or invalid configuration.
- Applies a five-second upstream timeout and returns a generic 503 when the service is unavailable or returns an invalid status payload.
- Adds focused coverage for configuration, authentication, registration, status validation, and forwarding.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] require changes to docs which **are made** as part of this PR

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

- This PR exposes status only; optimization request forwarding and NDJSON streaming are added in the following integration PR.

## 🐾 Next steps

- Add the generated optimization request/event contract to this authenticated boundary.
- Stream NDJSON results through NodeAPI with cancellation, backpressure, timeouts, and concurrency limits.
- Wire the optimizer into local Compose and deployment configuration.

## 🛡 What tests cover this?

- Focused NodeAPI handler suite: 7 tests
- Full HASH API TypeScript check
- Generated optimizer type build/typecheck

## ❓ How to test this?

1. Configure `HASH_PETRINAUT_OPT_HOST` and `HASH_PETRINAUT_OPT_PORT` for the NodeAPI.
2. Start the Petrinaut optimizer service and HASH NodeAPI.
3. As an authenticated user, request `GET /api/petrinaut-optimizer/status`.
4. Confirm a valid optimizer status payload is returned.
5. Stop, unconfigure, or return an invalid payload from the optimizer and confirm the endpoint returns 503.

## 📹 Demo

Not applicable; this is the initial backend integration endpoint.
