### PR TITLE
BE-702: Compile sorted entity reads as keys-first statements

### DIFF
--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
@@ -606,10 +606,9 @@ where
             .change_context(QueryError)?;
 
         compiler.set_limit(params.limit);
-        // The entity read path vouches for the fetch-keys-then-hydrate preconditions: its
-        // hydration joins are foreign-key-total and the distinct key pins all row-multiplying
-        // columns.
-        compiler.set_statement_shape(StatementShape::FetchKeysThenHydrate);
+        // The entity read path vouches for the keys-first preconditions: its hydration joins
+        // are foreign-key-total and the distinct key pins all row-multiplying columns.
+        compiler.set_statement_shape(StatementShape::KeysFirst);
 
         let cursor_parameters = params.sorting.encode().change_context(QueryError)?;
         let cursor_indices = params

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
@@ -108,7 +108,8 @@ use crate::store::{
             summary::{Deduplication, EntitySummaryQuery},
         },
         query::{
-            Distinctness, PostgresRecord as _, PostgresSorting as _, SelectCompiler, bulk_insert,
+            Distinctness, PostgresRecord as _, PostgresSorting as _, SelectCompiler,
+            StatementShape, bulk_insert,
             rows::{
                 EntityDraftRow, EntityEdgeRow, EntityEditionRow, EntityIdRow, EntityIsOfTypeRow,
                 EntityTemporalMetadataRow, PostgresRow as _,
@@ -605,6 +606,10 @@ where
             .change_context(QueryError)?;
 
         compiler.set_limit(params.limit);
+        // The entity read path vouches for the fetch-keys-then-hydrate preconditions: its
+        // hydration joins are foreign-key-total and the distinct key pins all row-multiplying
+        // columns.
+        compiler.set_statement_shape(StatementShape::FetchKeysThenHydrate);
 
         let cursor_parameters = params.sorting.encode().change_context(QueryError)?;
         let cursor_indices = params

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
@@ -607,8 +607,14 @@ where
 
         compiler.set_limit(params.limit);
         // The entity read path vouches for the keys-first preconditions: its hydration joins
-        // are foreign-key-total and the distinct key pins all row-multiplying columns.
-        compiler.set_statement_shape(StatementShape::KeysFirst);
+        // always match their key row (foreign keys, and the write paths maintaining
+        // `entity_edition_cache` in the same transaction) and the distinct key pins all
+        // row-multiplying columns.
+        //
+        // TODO(BE-618): revisit the embedding shape once the distance query is index-backed.
+        if !compiler.has_embeddings_filter() {
+            compiler.set_statement_shape(StatementShape::KeysFirst);
+        }
 
         let cursor_parameters = params.sorting.encode().change_context(QueryError)?;
         let cursor_indices = params

--- a/libs/@local/graph/postgres-store/src/store/postgres/pool.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/pool.rs
@@ -163,6 +163,11 @@ pub trait AsClient: Send + Sync {
 impl AsClient for Object {
     type Client = Client;
 
+    // Deref-coercing to the raw `tokio_postgres::Client` bypasses deadpool's statement cache,
+    // so every query is re-prepared and Postgres plans it with the actual parameter values.
+    // The statement-shape strategy in the query compiler relies on that per-execution custom
+    // planning: a cached prepared statement would switch to a generic plan after a few
+    // executions and pick its plan blind to the parameters.
     fn as_client(&self) -> &Self::Client {
         self
     }

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/ast/expression/function.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/ast/expression/function.rs
@@ -48,6 +48,96 @@ pub enum Function {
     Now,
 }
 
+/// Direct-child traversal for [`Expression::visit`] and [`Expression::visit_mut`].
+///
+/// [`Expression::visit`]: super::Expression::visit
+/// [`Expression::visit_mut`]: super::Expression::visit_mut
+impl Function {
+    pub(super) fn for_each_child(&self, visitor: &mut dyn FnMut(&Expression)) {
+        match self {
+            Self::Min(expr)
+            | Self::Max(expr)
+            | Self::JsonAgg(expr)
+            | Self::JsonExtractText(expr)
+            | Self::JsonExtractAsText(expr, _)
+            | Self::JsonScalar(expr)
+            | Self::ToJson(expr)
+            | Self::Lower(expr)
+            | Self::Upper(expr)
+            | Self::LowerInc(expr)
+            | Self::UpperInc(expr)
+            | Self::LowerInf(expr)
+            | Self::UpperInf(expr)
+            | Self::ExtractEpochMs(expr) => visitor(expr),
+            Self::JsonContains(lhs, rhs)
+            | Self::JsonPathQueryFirst(lhs, rhs)
+            | Self::Coalesce(lhs, rhs) => {
+                visitor(lhs);
+                visitor(rhs);
+            }
+            Self::JsonExtractPath(exprs)
+            | Self::JsonBuildArray(exprs)
+            | Self::Unnest(exprs)
+            | Self::ArrayLiteral {
+                elements: exprs, ..
+            } => {
+                for expr in exprs {
+                    visitor(expr);
+                }
+            }
+            Self::JsonBuildObject(pairs) => {
+                for (key, value) in pairs {
+                    visitor(key);
+                    visitor(value);
+                }
+            }
+            Self::Now => {}
+        }
+    }
+
+    pub(super) fn for_each_child_mut(&mut self, visitor: &mut dyn FnMut(&mut Expression)) {
+        match self {
+            Self::Min(expr)
+            | Self::Max(expr)
+            | Self::JsonAgg(expr)
+            | Self::JsonExtractText(expr)
+            | Self::JsonExtractAsText(expr, _)
+            | Self::JsonScalar(expr)
+            | Self::ToJson(expr)
+            | Self::Lower(expr)
+            | Self::Upper(expr)
+            | Self::LowerInc(expr)
+            | Self::UpperInc(expr)
+            | Self::LowerInf(expr)
+            | Self::UpperInf(expr)
+            | Self::ExtractEpochMs(expr) => visitor(expr),
+            Self::JsonContains(lhs, rhs)
+            | Self::JsonPathQueryFirst(lhs, rhs)
+            | Self::Coalesce(lhs, rhs) => {
+                visitor(lhs);
+                visitor(rhs);
+            }
+            Self::JsonExtractPath(exprs)
+            | Self::JsonBuildArray(exprs)
+            | Self::Unnest(exprs)
+            | Self::ArrayLiteral {
+                elements: exprs, ..
+            } => {
+                for expr in exprs {
+                    visitor(expr);
+                }
+            }
+            Self::JsonBuildObject(pairs) => {
+                for (key, value) in pairs {
+                    visitor(key);
+                    visitor(value);
+                }
+            }
+            Self::Now => {}
+        }
+    }
+}
+
 impl Transpile for Function {
     #[expect(
         clippy::too_many_lines,

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/ast/expression/function.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/ast/expression/function.rs
@@ -1,4 +1,7 @@
-use core::fmt::{self, Write as _};
+use core::{
+    fmt::{self, Write as _},
+    ops::ControlFlow,
+};
 
 use hash_graph_store::filter::PathToken;
 
@@ -53,7 +56,10 @@ pub enum Function {
 /// [`Expression::visit`]: super::Expression::visit
 /// [`Expression::visit_mut`]: super::Expression::visit_mut
 impl Function {
-    pub(super) fn for_each_child(&self, visitor: &mut dyn FnMut(&Expression)) {
+    pub(super) fn for_each_child<B>(
+        &self,
+        visitor: &mut impl FnMut(&Expression) -> ControlFlow<B>,
+    ) -> ControlFlow<B> {
         match self {
             Self::Min(expr)
             | Self::Max(expr)
@@ -72,8 +78,8 @@ impl Function {
             Self::JsonContains(lhs, rhs)
             | Self::JsonPathQueryFirst(lhs, rhs)
             | Self::Coalesce(lhs, rhs) => {
-                visitor(lhs);
-                visitor(rhs);
+                visitor(lhs)?;
+                visitor(rhs)
             }
             Self::JsonExtractPath(exprs)
             | Self::JsonBuildArray(exprs)
@@ -82,20 +88,25 @@ impl Function {
                 elements: exprs, ..
             } => {
                 for expr in exprs {
-                    visitor(expr);
+                    visitor(expr)?;
                 }
+                ControlFlow::Continue(())
             }
             Self::JsonBuildObject(pairs) => {
                 for (key, value) in pairs {
-                    visitor(key);
-                    visitor(value);
+                    visitor(key)?;
+                    visitor(value)?;
                 }
+                ControlFlow::Continue(())
             }
-            Self::Now => {}
+            Self::Now => ControlFlow::Continue(()),
         }
     }
 
-    pub(super) fn for_each_child_mut(&mut self, visitor: &mut dyn FnMut(&mut Expression)) {
+    pub(super) fn for_each_child_mut<B>(
+        &mut self,
+        visitor: &mut impl FnMut(&mut Expression) -> ControlFlow<B>,
+    ) -> ControlFlow<B> {
         match self {
             Self::Min(expr)
             | Self::Max(expr)
@@ -114,8 +125,8 @@ impl Function {
             Self::JsonContains(lhs, rhs)
             | Self::JsonPathQueryFirst(lhs, rhs)
             | Self::Coalesce(lhs, rhs) => {
-                visitor(lhs);
-                visitor(rhs);
+                visitor(lhs)?;
+                visitor(rhs)
             }
             Self::JsonExtractPath(exprs)
             | Self::JsonBuildArray(exprs)
@@ -124,16 +135,18 @@ impl Function {
                 elements: exprs, ..
             } => {
                 for expr in exprs {
-                    visitor(expr);
+                    visitor(expr)?;
                 }
+                ControlFlow::Continue(())
             }
             Self::JsonBuildObject(pairs) => {
                 for (key, value) in pairs {
-                    visitor(key);
-                    visitor(value);
+                    visitor(key)?;
+                    visitor(value)?;
                 }
+                ControlFlow::Continue(())
             }
-            Self::Now => {}
+            Self::Now => ControlFlow::Continue(()),
         }
     }
 }

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/ast/expression/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/ast/expression/mod.rs
@@ -407,6 +407,127 @@ impl Expression {
     }
 }
 
+/// Expression-tree traversal.
+///
+/// Both visitors run in pre-order (the expression itself before its children) and do not
+/// descend into [`Expression::Select`] subqueries: statement-level structures own their
+/// traversal. Callers that care about subqueries match on the variant themselves.
+impl Expression {
+    /// Calls `visitor` for this expression and every nested sub-expression.
+    pub fn visit(&self, visitor: &mut impl FnMut(&Self)) {
+        visitor(self);
+        self.for_each_child(&mut |child| child.visit(visitor));
+    }
+
+    /// Calls `visitor` mutably for this expression and every nested sub-expression.
+    pub fn visit_mut(&mut self, visitor: &mut impl FnMut(&mut Self)) {
+        visitor(self);
+        self.for_each_child_mut(&mut |child| child.visit_mut(visitor));
+    }
+
+    fn for_each_child(&self, visitor: &mut dyn FnMut(&Self)) {
+        match self {
+            Self::ColumnReference(_) | Self::Parameter(_) | Self::Constant(_) | Self::Select(_) => {
+            }
+            Self::Function(function) => function.for_each_child(visitor),
+            Self::Window(expr, window) => {
+                visitor(expr);
+                for partition in &*window.partition_by {
+                    visitor(partition);
+                }
+            }
+            Self::Cast(expr, _)
+            | Self::FieldAccess { expr, .. }
+            | Self::ArrayElement { expr, .. }
+            | Self::Grouped(expr) => visitor(expr),
+            Self::Row(exprs) => {
+                for expr in exprs {
+                    visitor(expr);
+                }
+            }
+            Self::CaseWhen {
+                conditions,
+                else_result,
+            } => {
+                for (condition, result) in conditions {
+                    visitor(condition);
+                    visitor(result);
+                }
+                if let Some(else_result) = else_result {
+                    visitor(else_result);
+                }
+            }
+            Self::Unary(unary) => visitor(&unary.expr),
+            Self::Binary(binary) => {
+                visitor(&binary.left);
+                visitor(&binary.right);
+            }
+            Self::Variadic(variadic) => {
+                for expr in &variadic.exprs {
+                    visitor(expr);
+                }
+            }
+            Self::StartsWith(lhs, rhs)
+            | Self::EndsWith(lhs, rhs)
+            | Self::ContainsSegment(lhs, rhs) => {
+                visitor(lhs);
+                visitor(rhs);
+            }
+        }
+    }
+
+    fn for_each_child_mut(&mut self, visitor: &mut dyn FnMut(&mut Self)) {
+        match self {
+            Self::ColumnReference(_) | Self::Parameter(_) | Self::Constant(_) | Self::Select(_) => {
+            }
+            Self::Function(function) => function.for_each_child_mut(visitor),
+            Self::Window(expr, window) => {
+                visitor(expr);
+                for partition in &mut *window.partition_by {
+                    visitor(partition);
+                }
+            }
+            Self::Cast(expr, _)
+            | Self::FieldAccess { expr, .. }
+            | Self::ArrayElement { expr, .. }
+            | Self::Grouped(expr) => visitor(expr),
+            Self::Row(exprs) => {
+                for expr in exprs {
+                    visitor(expr);
+                }
+            }
+            Self::CaseWhen {
+                conditions,
+                else_result,
+            } => {
+                for (condition, result) in conditions {
+                    visitor(condition);
+                    visitor(result);
+                }
+                if let Some(else_result) = else_result {
+                    visitor(else_result);
+                }
+            }
+            Self::Unary(unary) => visitor(&mut unary.expr),
+            Self::Binary(binary) => {
+                visitor(&mut binary.left);
+                visitor(&mut binary.right);
+            }
+            Self::Variadic(variadic) => {
+                for expr in &mut variadic.exprs {
+                    visitor(expr);
+                }
+            }
+            Self::StartsWith(lhs, rhs)
+            | Self::EndsWith(lhs, rhs)
+            | Self::ContainsSegment(lhs, rhs) => {
+                visitor(lhs);
+                visitor(rhs);
+            }
+        }
+    }
+}
+
 impl Transpile for Expression {
     fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match self {

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/ast/expression/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/ast/expression/mod.rs
@@ -5,8 +5,11 @@ mod unary;
 mod variadic;
 mod window;
 
-use core::fmt::{
-    Display, Formatter, Write as _, {self},
+use core::{
+    fmt::{
+        Display, Formatter, Write as _, {self},
+    },
+    ops::ControlFlow,
 };
 
 pub use self::{
@@ -409,32 +412,43 @@ impl Expression {
 
 /// Expression-tree traversal.
 ///
-/// Both visitors run in pre-order (the expression itself before its children) and do not
-/// descend into [`Expression::Select`] subqueries: statement-level structures own their
-/// traversal. Callers that care about subqueries match on the variant themselves.
+/// Both visitors run in pre-order (the expression itself before its children) and do not descend
+/// into [`Expression::Select`] subqueries: statement-level structures own their traversal. A
+/// visitor with no answer for the tables hiding inside a subquery matches on the variant and
+/// breaks.
 impl Expression {
-    /// Calls `visitor` for this expression and every nested sub-expression.
-    pub fn visit(&self, visitor: &mut impl FnMut(&Self)) {
-        visitor(self);
-        self.for_each_child(&mut |child| child.visit(visitor));
+    /// Calls `visitor` for this expression and every nested sub-expression, stopping at the first
+    /// [`ControlFlow::Break`].
+    pub fn visit<B>(&self, visitor: &mut impl FnMut(&Self) -> ControlFlow<B>) -> ControlFlow<B> {
+        visitor(self)?;
+        self.for_each_child(&mut |child| child.visit(visitor))
     }
 
-    /// Calls `visitor` mutably for this expression and every nested sub-expression.
-    pub fn visit_mut(&mut self, visitor: &mut impl FnMut(&mut Self)) {
-        visitor(self);
-        self.for_each_child_mut(&mut |child| child.visit_mut(visitor));
+    /// Calls `visitor` mutably for this expression and every nested sub-expression, stopping at
+    /// the first [`ControlFlow::Break`].
+    pub fn visit_mut<B>(
+        &mut self,
+        visitor: &mut impl FnMut(&mut Self) -> ControlFlow<B>,
+    ) -> ControlFlow<B> {
+        visitor(self)?;
+        self.for_each_child_mut(&mut |child| child.visit_mut(visitor))
     }
 
-    fn for_each_child(&self, visitor: &mut dyn FnMut(&Self)) {
+    fn for_each_child<B>(
+        &self,
+        visitor: &mut impl FnMut(&Self) -> ControlFlow<B>,
+    ) -> ControlFlow<B> {
         match self {
             Self::ColumnReference(_) | Self::Parameter(_) | Self::Constant(_) | Self::Select(_) => {
+                ControlFlow::Continue(())
             }
             Self::Function(function) => function.for_each_child(visitor),
             Self::Window(expr, window) => {
-                visitor(expr);
+                visitor(expr)?;
                 for partition in &*window.partition_by {
-                    visitor(partition);
+                    visitor(partition)?;
                 }
+                ControlFlow::Continue(())
             }
             Self::Cast(expr, _)
             | Self::FieldAccess { expr, .. }
@@ -442,50 +456,58 @@ impl Expression {
             | Self::Grouped(expr) => visitor(expr),
             Self::Row(exprs) => {
                 for expr in exprs {
-                    visitor(expr);
+                    visitor(expr)?;
                 }
+                ControlFlow::Continue(())
             }
             Self::CaseWhen {
                 conditions,
                 else_result,
             } => {
                 for (condition, result) in conditions {
-                    visitor(condition);
-                    visitor(result);
+                    visitor(condition)?;
+                    visitor(result)?;
                 }
                 if let Some(else_result) = else_result {
-                    visitor(else_result);
+                    visitor(else_result)?;
                 }
+                ControlFlow::Continue(())
             }
             Self::Unary(unary) => visitor(&unary.expr),
             Self::Binary(binary) => {
-                visitor(&binary.left);
-                visitor(&binary.right);
+                visitor(&binary.left)?;
+                visitor(&binary.right)
             }
             Self::Variadic(variadic) => {
                 for expr in &variadic.exprs {
-                    visitor(expr);
+                    visitor(expr)?;
                 }
+                ControlFlow::Continue(())
             }
             Self::StartsWith(lhs, rhs)
             | Self::EndsWith(lhs, rhs)
             | Self::ContainsSegment(lhs, rhs) => {
-                visitor(lhs);
-                visitor(rhs);
+                visitor(lhs)?;
+                visitor(rhs)
             }
         }
     }
 
-    fn for_each_child_mut(&mut self, visitor: &mut dyn FnMut(&mut Self)) {
+    fn for_each_child_mut<B>(
+        &mut self,
+        visitor: &mut impl FnMut(&mut Self) -> ControlFlow<B>,
+    ) -> ControlFlow<B> {
         match self {
             Self::ColumnReference(_) | Self::Parameter(_) | Self::Constant(_) | Self::Select(_) => {
+                ControlFlow::Continue(())
             }
             Self::Function(function) => function.for_each_child_mut(visitor),
             Self::Window(expr, window) => {
-                visitor(expr);
+                visitor(expr)?;
                 for partition in &mut *window.partition_by {
-                    visitor(partition);
+                    visitor(partition)?;
                 }
+                ControlFlow::Continue(())
             }
             Self::Cast(expr, _)
             | Self::FieldAccess { expr, .. }
@@ -493,36 +515,39 @@ impl Expression {
             | Self::Grouped(expr) => visitor(expr),
             Self::Row(exprs) => {
                 for expr in exprs {
-                    visitor(expr);
+                    visitor(expr)?;
                 }
+                ControlFlow::Continue(())
             }
             Self::CaseWhen {
                 conditions,
                 else_result,
             } => {
                 for (condition, result) in conditions {
-                    visitor(condition);
-                    visitor(result);
+                    visitor(condition)?;
+                    visitor(result)?;
                 }
                 if let Some(else_result) = else_result {
-                    visitor(else_result);
+                    visitor(else_result)?;
                 }
+                ControlFlow::Continue(())
             }
             Self::Unary(unary) => visitor(&mut unary.expr),
             Self::Binary(binary) => {
-                visitor(&mut binary.left);
-                visitor(&mut binary.right);
+                visitor(&mut binary.left)?;
+                visitor(&mut binary.right)
             }
             Self::Variadic(variadic) => {
                 for expr in &mut variadic.exprs {
-                    visitor(expr);
+                    visitor(expr)?;
                 }
+                ControlFlow::Continue(())
             }
             Self::StartsWith(lhs, rhs)
             | Self::EndsWith(lhs, rhs)
             | Self::ContainsSegment(lhs, rhs) => {
-                visitor(lhs);
-                visitor(rhs);
+                visitor(lhs)?;
+                visitor(rhs)
             }
         }
     }

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/compile/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/compile/mod.rs
@@ -2,7 +2,7 @@
 mod tests;
 
 use alloc::borrow::Cow;
-use core::iter::once;
+use core::{iter::once, ops::ControlFlow};
 use std::collections::{HashMap, HashSet};
 
 use error_stack::{Report, bail, ensure};
@@ -117,6 +117,25 @@ pub enum StatementShape {
     FencedKeysFirst,
 }
 
+impl StatementShape {
+    /// The value the shape is recorded under as `statement.shape`.
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::SinglePass => "single_pass",
+            Self::KeysFirst => "keys_first",
+            Self::FencedKeysFirst => "fenced_keys_first",
+        }
+    }
+
+    /// The fence the shape puts on the key query's plan.
+    const fn materialization(self) -> Option<Materialization> {
+        match self {
+            Self::SinglePass | Self::KeysFirst => None,
+            Self::FencedKeysFirst => Some(Materialization::Materialized),
+        }
+    }
+}
+
 /// Why a keys-first [`StatementShape`] degraded to a single-pass statement.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 enum ShapeFallback {
@@ -131,13 +150,40 @@ enum ShapeFallback {
     OpaqueExpression,
     /// A fanning-out join inside the key query would eat into `LIMIT n` with duplicates.
     ToManyKeyJoin,
-    /// A right or full outer hydration join would generate rows the key query never saw,
-    /// which the missing `WHERE` clause of the hydration statement cannot filter out again.
-    GeneratingHydrationJoin,
+    /// A right or full outer join generates rows its left side never had, which neither side of
+    /// the split can carry: in the key query they hold `NULL` keys that no hydration join
+    /// matches, and in the hydration statement they are rows the page never selected.
+    GeneratingJoin,
     /// The statement reads nothing from the key query, leaving the CTE without columns.
     NoKeyColumns,
     /// A carried CTE already uses one of the names the split reserves for its own CTEs.
     CteNameCollision,
+    /// Two key columns claim the same output name, which leaves every reference to it
+    /// ambiguous. Prefixing a shared column name with its table can land on a name another
+    /// column already carries unprefixed.
+    KeyColumnNameCollision,
+}
+
+impl ShapeFallback {
+    /// Logs the degradation, warning for the reasons that lose a shape the caller opted into.
+    fn log(self) {
+        match self {
+            // Unpaged statements have nothing to split, and fanning-out joins are structural
+            // for whole query families (link queries filter through one on every request) —
+            // neither is an anomaly worth a warning.
+            Self::Unlimited | Self::Unsorted | Self::ToManyKeyJoin => {
+                tracing::debug!(fallback = ?self, "compiling a single-pass statement");
+            }
+            Self::AsteriskSelect
+            | Self::OpaqueExpression
+            | Self::GeneratingJoin
+            | Self::NoKeyColumns
+            | Self::CteNameCollision
+            | Self::KeyColumnNameCollision => {
+                tracing::warn!(fallback = ?self, "falling back to a single-pass statement");
+            }
+        }
+    }
 }
 
 /// A join collected during compilation. The `FROM` tree is assembled from these records in
@@ -208,53 +254,60 @@ impl From<NullOrdering> for NullsOrder {
     }
 }
 
-/// Collects the table names referenced by `expression` into `tables`.
+/// A subquery expression, whose column references stay invisible to [`Expression::visit`].
 ///
-/// Sets `opaque` when the expression contains a subquery, whose references stay invisible to
-/// [`Expression::visit`].
+/// The break value of the collectors below, which the caller turns into
+/// [`ShapeFallback::OpaqueExpression`].
+struct Opaque;
+
+/// Collects the table names `expression` references into `tables`, breaking at a subquery.
 fn collect_referenced_tables(
     expression: &Expression,
     tables: &mut HashSet<TableName<'static>>,
-    opaque: &mut bool,
-) {
+) -> ControlFlow<Opaque> {
     expression.visit(&mut |node| {
+        if matches!(node, Expression::Select(_)) {
+            return ControlFlow::Break(Opaque);
+        }
         if let Expression::ColumnReference(column) = node
             && let Some(correlation) = &column.correlation
         {
             tables.insert(correlation.name.clone());
         }
-        if matches!(node, Expression::Select(_)) {
-            *opaque = true;
-        }
-    });
+        ControlFlow::Continue(())
+    })
 }
 
-/// Collects the columns `expression` reads from any of the `key_tables`, deduplicated and in
-/// first-seen order.
-///
-/// Sets `opaque` when the expression contains a subquery, whose references stay invisible to
-/// [`Expression::visit`].
-fn collect_key_columns(
-    expression: &Expression,
-    key_tables: &HashSet<TableName<'static>>,
-    columns: &mut Vec<(TableName<'static>, ColumnName<'static>)>,
-    seen: &mut HashSet<(TableName<'static>, ColumnName<'static>)>,
-    opaque: &mut bool,
-) {
-    expression.visit(&mut |node| {
-        if let Expression::ColumnReference(column) = node
-            && let Some(correlation) = &column.correlation
-            && key_tables.contains(&correlation.name)
-        {
-            let key = (correlation.name.clone(), column.name.clone());
-            if seen.insert(key.clone()) {
-                columns.push(key);
+/// The columns read from a set of key-query tables, deduplicated and in first-seen order.
+#[derive(Default)]
+struct KeyColumns {
+    columns: Vec<(TableName<'static>, ColumnName<'static>)>,
+    seen: HashSet<(TableName<'static>, ColumnName<'static>)>,
+}
+
+impl KeyColumns {
+    /// Adds every column `expression` reads from one of the `key_tables`, breaking at a subquery.
+    fn collect(
+        &mut self,
+        expression: &Expression,
+        key_tables: &HashSet<TableName<'static>>,
+    ) -> ControlFlow<Opaque> {
+        expression.visit(&mut |node| {
+            if matches!(node, Expression::Select(_)) {
+                return ControlFlow::Break(Opaque);
             }
-        }
-        if matches!(node, Expression::Select(_)) {
-            *opaque = true;
-        }
-    });
+            if let Expression::ColumnReference(column) = node
+                && let Some(correlation) = &column.correlation
+                && key_tables.contains(&correlation.name)
+            {
+                let key = (correlation.name.clone(), column.name.clone());
+                if self.seen.insert(key.clone()) {
+                    self.columns.push(key);
+                }
+            }
+            ControlFlow::Continue(())
+        })
+    }
 }
 
 /// The join split for the keys-first [`StatementShape`]s.
@@ -277,28 +330,39 @@ struct KeyColumnRewriter<'r> {
 impl<'r> KeyColumnRewriter<'r> {
     /// Assigns each key column its natural name. Every column name shared between source
     /// tables gets prefixed with its aliased table name instead.
+    ///
+    /// Reports [`ShapeFallback::KeyColumnNameCollision`] when that leaves two columns sharing
+    /// an output name.
     fn new(
         tables: &'r HashSet<TableName<'static>>,
         key_columns: &[(TableName<'static>, ColumnName<'static>)],
-    ) -> Self {
+    ) -> Result<Self, ShapeFallback> {
         let mut name_users = HashMap::<&ColumnName<'static>, usize>::new();
         for (_, column) in key_columns {
             *name_users.entry(column).or_default() += 1;
         }
-        Self {
-            tables,
-            outputs: key_columns
-                .iter()
-                .map(|(table, column)| {
-                    let output = if name_users.get(column).is_some_and(|users| *users > 1) {
-                        ColumnName::from(format!("{}_{}", table.as_str(), column.as_str()))
-                    } else {
-                        column.clone()
-                    };
-                    ((table.clone(), column.clone()), output)
-                })
-                .collect(),
+
+        let outputs: HashMap<_, _> = key_columns
+            .iter()
+            .map(|(table, column)| {
+                let output = if name_users.get(column).is_some_and(|users| *users > 1) {
+                    ColumnName::from(format!("{}_{}", table.as_str(), column.as_str()))
+                } else {
+                    column.clone()
+                };
+                ((table.clone(), column.clone()), output)
+            })
+            .collect();
+
+        // A prefixed name can land on one another column already carries: `b` and `d` sharing a
+        // `c` produce `b_c`, which a `b_c` column elsewhere also claims. Unreachable while table
+        // aliases end in `_<condition>_<depth>_<number>`, but nothing enforces that, and the
+        // symptom would be an ambiguous column reference at execution time.
+        if outputs.values().collect::<HashSet<_>>().len() != outputs.len() {
+            return Err(ShapeFallback::KeyColumnNameCollision);
         }
+
+        Ok(Self { tables, outputs })
     }
 
     /// The output column name assigned to a key-query source column.
@@ -316,7 +380,7 @@ impl<'r> KeyColumnRewriter<'r> {
     /// output column, qualified with `target` (or bare when `target` is [`None`]).
     fn rewrite(&self, expression: &Expression, target: Option<&TableName<'static>>) -> Expression {
         let mut expression = expression.clone();
-        expression.visit_mut(&mut |node| {
+        let ControlFlow::Continue(()) = expression.visit_mut(&mut |node| {
             if let Expression::ColumnReference(column) = node
                 && let Some(correlation) = &column.correlation
                 && self.tables.contains(&correlation.name)
@@ -324,6 +388,7 @@ impl<'r> KeyColumnRewriter<'r> {
                 column.name = self.output(&correlation.name, &column.name).clone();
                 column.correlation = target.cloned().map(TableReference::from);
             }
+            ControlFlow::<!>::Continue(())
         });
         expression
     }
@@ -709,54 +774,23 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
         fields(statement.shape = tracing::field::Empty)
     )]
     pub fn compile(&self) -> (String, &[&'p (dyn ToSql + Sync)]) {
-        let statement = match self.shape {
+        let (shape, statement) = match self.shape {
             StatementShape::SinglePass => {
-                tracing::Span::current().record("statement.shape", "single_pass");
-                self.single_pass_statement()
+                (StatementShape::SinglePass, self.single_pass_statement())
             }
-            StatementShape::KeysFirst => self.keys_first_or_fallback("keys_first", None),
-            StatementShape::FencedKeysFirst => self
-                .keys_first_or_fallback("fenced_keys_first", Some(Materialization::Materialized)),
-        };
-        (statement.transpile_to_string(), &self.artifacts.parameters)
-    }
-
-    /// Compiles the keys-first split, degrading to the single-pass layout with a logged
-    /// reason when the statement does not qualify.
-    fn keys_first_or_fallback(
-        &self,
-        shape: &'static str,
-        materialization: Option<Materialization>,
-    ) -> SelectStatement {
-        match self.fetch_keys_then_hydrate_statement(materialization) {
-            Ok(statement) => {
-                tracing::Span::current().record("statement.shape", shape);
-                statement
-            }
-            Err(fallback) => {
-                tracing::Span::current().record("statement.shape", "single_pass");
-                // An unpaged statement simply has nothing to split. Every other reason
-                // silently loses the shape the caller opted into and deserves a warning.
-                match fallback {
-                    // Unpaged statements have nothing to split, and fanning-out joins are
-                    // structural for whole query families (link queries filter through one on
-                    // every request) — neither is an anomaly worth a warning.
-                    ShapeFallback::Unlimited
-                    | ShapeFallback::Unsorted
-                    | ShapeFallback::ToManyKeyJoin => {
-                        tracing::debug!(?fallback, "compiling a single-pass statement");
-                    }
-                    ShapeFallback::AsteriskSelect
-                    | ShapeFallback::OpaqueExpression
-                    | ShapeFallback::GeneratingHydrationJoin
-                    | ShapeFallback::NoKeyColumns
-                    | ShapeFallback::CteNameCollision => {
-                        tracing::warn!(?fallback, "falling back to a single-pass statement");
+            shape @ (StatementShape::KeysFirst | StatementShape::FencedKeysFirst) => {
+                match self.fetch_keys_then_hydrate_statement(shape.materialization()) {
+                    Ok(statement) => (shape, statement),
+                    Err(fallback) => {
+                        fallback.log();
+                        (StatementShape::SinglePass, self.single_pass_statement())
                     }
                 }
-                self.single_pass_statement()
             }
-        }
+        };
+
+        tracing::Span::current().record("statement.shape", shape.as_str());
+        (statement.transpile_to_string(), &self.artifacts.parameters)
     }
 
     /// Lays out the statement as one flat `SELECT` over all joins.
@@ -799,7 +833,7 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
 
         let partition = self.partition_key_query_joins()?;
         let key_columns = self.collect_key_query_columns(&partition)?;
-        let rewriter = KeyColumnRewriter::new(&partition.tables, &key_columns);
+        let rewriter = KeyColumnRewriter::new(&partition.tables, &key_columns)?;
         let limited = TableName::from("limited");
 
         let mut common_table_expressions: Vec<CommonTableExpression> = self
@@ -846,8 +880,18 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
     /// closed transitively over the join conditions (a join's `ON` clause only references
     /// earlier joins, so one reverse pass suffices).
     fn partition_key_query_joins(&self) -> Result<KeyQueryPartition<'_>, ShapeFallback> {
+        // Checked before the split, because neither share can carry a generating join and
+        // which share it lands in is an accident of what the filters happen to reference.
+        if self
+            .artifacts
+            .joins
+            .iter()
+            .any(|join| matches!(join.join_type, JoinType::RightOuter | JoinType::FullOuter))
+        {
+            return Err(ShapeFallback::GeneratingJoin);
+        }
+
         let mut required = HashSet::new();
-        let mut opaque = false;
         for expression in self
             .conditions
             .iter()
@@ -858,7 +902,9 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
             )
             .chain(self.sort_by.iter().map(|sort| &sort.expression))
         {
-            collect_referenced_tables(expression, &mut required, &mut opaque);
+            if collect_referenced_tables(expression, &mut required).is_break() {
+                return Err(ShapeFallback::OpaqueExpression);
+            }
         }
 
         let mut in_key_query = vec![false; self.artifacts.joins.len()];
@@ -866,12 +912,11 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
             if required.contains(&join.table.aliased_name(join.alias)) {
                 *slot = true;
                 for condition in &join.conditions {
-                    collect_referenced_tables(condition, &mut required, &mut opaque);
+                    if collect_referenced_tables(condition, &mut required).is_break() {
+                        return Err(ShapeFallback::OpaqueExpression);
+                    }
                 }
             }
-        }
-        if opaque {
-            return Err(ShapeFallback::OpaqueExpression);
         }
 
         let mut key_joins = Vec::new();
@@ -885,12 +930,6 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
         }
         if key_joins.iter().any(|join| join.to_many) {
             return Err(ShapeFallback::ToManyKeyJoin);
-        }
-        if hydrated_joins
-            .iter()
-            .any(|join| matches!(join.join_type, JoinType::RightOuter | JoinType::FullOuter))
-        {
-            return Err(ShapeFallback::GeneratingHydrationJoin);
         }
 
         let tables = once(R::base_table().aliased_name(Alias::default()))
@@ -914,9 +953,7 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
         &self,
         partition: &KeyQueryPartition<'_>,
     ) -> Result<Vec<(TableName<'static>, ColumnName<'static>)>, ShapeFallback> {
-        let mut key_columns = Vec::new();
-        let mut seen = HashSet::new();
-        let mut opaque = false;
+        let mut key_columns = KeyColumns::default();
         for expression in self
             .sort_by
             .iter()
@@ -933,16 +970,12 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
                     .flat_map(|join| join.conditions.iter()),
             )
         {
-            collect_key_columns(
-                expression,
-                &partition.tables,
-                &mut key_columns,
-                &mut seen,
-                &mut opaque,
-            );
-        }
-        if opaque {
-            return Err(ShapeFallback::OpaqueExpression);
+            if key_columns
+                .collect(expression, &partition.tables)
+                .is_break()
+            {
+                return Err(ShapeFallback::OpaqueExpression);
+            }
         }
         if self
             .selects
@@ -951,10 +984,11 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
         {
             return Err(ShapeFallback::AsteriskSelect);
         }
-        if key_columns.is_empty() {
-            return Err(ShapeFallback::NoKeyColumns);
+        if key_columns.columns.is_empty() {
+            Err(ShapeFallback::NoKeyColumns)
+        } else {
+            Ok(key_columns.columns)
         }
-        Ok(key_columns)
     }
 
     /// Builds the `roots` CTE: the key-query columns under the full filter and cursor

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/compile/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/compile/mod.rs
@@ -85,30 +85,40 @@ pub enum Distinctness {
 }
 
 /// How [`SelectCompiler::compile`] lays out the statement.
+///
+/// Both keys-first shapes filter, sort, and limit a narrow key set in CTEs and hydrate the
+/// wide projection only for the surviving rows. They fall back to [`SinglePass`] for every
+/// [`ShapeFallback`] reason; the fallback is logged, since it silently loses the shape the
+/// caller opted into.
+///
+/// Callers opting into a keys-first shape vouch for two preconditions the compiler cannot
+/// check. `INNER` hydration joins must always match their key row (foreign-key-total joins
+/// do), and the key query must produce at most one row per `DISTINCT ON` group. Both hold
+/// for the entity read path, whose distinct key pins all row-multiplying columns. Violating
+/// either returns short or shifted pages compared to [`SinglePass`].
+///
+/// [`SinglePass`]: Self::SinglePass
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
 pub enum StatementShape {
     /// One flat `SELECT` over all joins.
     #[default]
     SinglePass,
-    /// Filters a narrow key set inside a `MATERIALIZED` CTE, sorts and limits it outside the
-    /// fence, then hydrates the wide projection only for the surviving rows.
+    /// The keys-first split with the planner left free.
+    ///
+    /// The CTEs stay inlinable, so the planner may serve the ordering demand from an index
+    /// and abort early. A misestimated filter can still bait it into an ordered scan that
+    /// never fills the limit.
+    KeysFirst,
+    /// The keys-first split behind a `MATERIALIZED` fence.
     ///
     /// The materialization fences the planner: the key query is planned without the outer
-    /// statement's ordering demand, which prevents ordered-pipeline bets built on unreliable
-    /// row estimates. Falls back to [`SinglePass`] for every [`ShapeFallback`] reason. The
-    /// fallback is logged, since it silently loses the shape the caller opted into.
-    ///
-    /// Callers opting in vouch for two preconditions the compiler cannot check. `INNER`
-    /// hydration joins must always match their key row (foreign-key-total joins do), and the
-    /// key query must produce at most one row per `DISTINCT ON` group. Both hold for the
-    /// entity read path, whose distinct key pins all row-multiplying columns. Violating
-    /// either returns short or shifted pages compared to [`SinglePass`].
-    ///
-    /// [`SinglePass`]: Self::SinglePass
-    FetchKeysThenHydrate,
+    /// ordering demand, which prevents ordered-pipeline bets built on unreliable row
+    /// estimates. In exchange the whole filtered set is computed, no matter how early an
+    /// index could have stopped.
+    FencedKeysFirst,
 }
 
-/// Why [`StatementShape::FetchKeysThenHydrate`] degraded to a single-pass statement.
+/// Why a keys-first [`StatementShape`] degraded to a single-pass statement.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 enum ShapeFallback {
     /// Without a limit the planner never bets on an ordered pipeline, so there is nothing to
@@ -246,7 +256,7 @@ fn collect_key_columns(
     });
 }
 
-/// The join split for [`StatementShape::FetchKeysThenHydrate`].
+/// The join split for the keys-first [`StatementShape`]s.
 struct KeyQueryPartition<'j> {
     /// The joins the key query filters and sorts through, in creation order.
     key_joins: Vec<&'j CompiledJoin>,
@@ -703,38 +713,44 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
                 tracing::Span::current().record("statement.shape", "single_pass");
                 self.single_pass_statement()
             }
-            StatementShape::FetchKeysThenHydrate => {
-                match self.fetch_keys_then_hydrate_statement() {
-                    Ok(statement) => {
-                        tracing::Span::current()
-                            .record("statement.shape", "fetch_keys_then_hydrate");
-                        statement
-                    }
-                    Err(fallback) => {
-                        tracing::Span::current().record("statement.shape", "single_pass");
-                        // An unpaged statement simply has nothing to fence. Every other reason
-                        // silently loses the shape the caller opted into and deserves a warning.
-                        match fallback {
-                            ShapeFallback::Unlimited | ShapeFallback::Unsorted => {
-                                tracing::debug!(?fallback, "compiling a single-pass statement");
-                            }
-                            ShapeFallback::AsteriskSelect
-                            | ShapeFallback::OpaqueExpression
-                            | ShapeFallback::ToManyKeyJoin
-                            | ShapeFallback::GeneratingHydrationJoin
-                            | ShapeFallback::NoKeyColumns => {
-                                tracing::warn!(
-                                    ?fallback,
-                                    "falling back to a single-pass statement"
-                                );
-                            }
-                        }
-                        self.single_pass_statement()
-                    }
-                }
-            }
+            StatementShape::KeysFirst => self.keys_first_or_fallback("keys_first", None),
+            StatementShape::FencedKeysFirst => self
+                .keys_first_or_fallback("fenced_keys_first", Some(Materialization::Materialized)),
         };
         (statement.transpile_to_string(), &self.artifacts.parameters)
+    }
+
+    /// Compiles the keys-first split, degrading to the single-pass layout with a logged
+    /// reason when the statement does not qualify.
+    fn keys_first_or_fallback(
+        &self,
+        shape: &'static str,
+        materialization: Option<Materialization>,
+    ) -> SelectStatement {
+        match self.fetch_keys_then_hydrate_statement(materialization) {
+            Ok(statement) => {
+                tracing::Span::current().record("statement.shape", shape);
+                statement
+            }
+            Err(fallback) => {
+                tracing::Span::current().record("statement.shape", "single_pass");
+                // An unpaged statement simply has nothing to split. Every other reason
+                // silently loses the shape the caller opted into and deserves a warning.
+                match fallback {
+                    ShapeFallback::Unlimited | ShapeFallback::Unsorted => {
+                        tracing::debug!(?fallback, "compiling a single-pass statement");
+                    }
+                    ShapeFallback::AsteriskSelect
+                    | ShapeFallback::OpaqueExpression
+                    | ShapeFallback::ToManyKeyJoin
+                    | ShapeFallback::GeneratingHydrationJoin
+                    | ShapeFallback::NoKeyColumns => {
+                        tracing::warn!(?fallback, "falling back to a single-pass statement");
+                    }
+                }
+                self.single_pass_statement()
+            }
+        }
     }
 
     /// Lays out the statement as one flat `SELECT` over all joins.
@@ -762,9 +778,12 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
             .build()
     }
 
-    /// Lays out the statement as [`StatementShape::FetchKeysThenHydrate`], or reports why the
-    /// statement does not qualify.
-    fn fetch_keys_then_hydrate_statement(&self) -> Result<SelectStatement, ShapeFallback> {
+    /// Lays out the statement as the keys-first split, fenced when `materialization` says so,
+    /// or reports why the statement does not qualify.
+    fn fetch_keys_then_hydrate_statement(
+        &self,
+        materialization: Option<Materialization>,
+    ) -> Result<SelectStatement, ShapeFallback> {
         let Some(limit) = self.limit else {
             return Err(ShapeFallback::Unlimited);
         };
@@ -788,7 +807,12 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
                 .all(|cte| cte.name.as_str() != "roots" && cte.name.as_str() != "limited"),
             "carried CTE names must not collide with the fence CTEs"
         );
-        common_table_expressions.push(self.key_query_cte(&partition, &key_columns, &rewriter));
+        common_table_expressions.push(self.key_query_cte(
+            &partition,
+            &key_columns,
+            &rewriter,
+            materialization,
+        ));
         common_table_expressions.push(self.page_cte(&rewriter, limit));
 
         Ok(SelectStatement::builder()
@@ -928,12 +952,13 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
     }
 
     /// Builds the `roots` CTE: the key-query columns under the full filter and cursor
-    /// conditions, `MATERIALIZED` to fence its plan from the outer ordering demand.
+    /// conditions, `MATERIALIZED` on demand to fence its plan from the outer ordering demand.
     fn key_query_cte(
         &self,
         partition: &KeyQueryPartition<'_>,
         key_columns: &[(TableName<'static>, ColumnName<'static>)],
         rewriter: &KeyColumnRewriter<'_>,
+        materialization: Option<Materialization>,
     ) -> CommonTableExpression {
         CommonTableExpression::builder()
             .name("roots")
@@ -958,7 +983,7 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
                     .from(Self::joined_table(partition.key_joins.iter().copied()))
                     .maybe_where_clause(self.where_condition()),
             )
-            .materialization(Materialization::Materialized)
+            .maybe_materialization(materialization)
             .build()
     }
 

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/compile/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/compile/mod.rs
@@ -137,6 +137,8 @@ enum ShapeFallback {
     GeneratingHydrationJoin,
     /// The statement reads nothing from the key query, leaving the CTE without columns.
     NoKeyColumns,
+    /// A carried CTE already uses one of the names the split reserves for its own CTEs.
+    CteNameCollision,
 }
 
 /// A join collected during compilation. The `FROM` tree is assembled from these records in
@@ -737,14 +739,19 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
                 // An unpaged statement simply has nothing to split. Every other reason
                 // silently loses the shape the caller opted into and deserves a warning.
                 match fallback {
-                    ShapeFallback::Unlimited | ShapeFallback::Unsorted => {
+                    // Unpaged statements have nothing to split, and fanning-out joins are
+                    // structural for whole query families (link queries filter through one on
+                    // every request) — neither is an anomaly worth a warning.
+                    ShapeFallback::Unlimited
+                    | ShapeFallback::Unsorted
+                    | ShapeFallback::ToManyKeyJoin => {
                         tracing::debug!(?fallback, "compiling a single-pass statement");
                     }
                     ShapeFallback::AsteriskSelect
                     | ShapeFallback::OpaqueExpression
-                    | ShapeFallback::ToManyKeyJoin
                     | ShapeFallback::GeneratingHydrationJoin
-                    | ShapeFallback::NoKeyColumns => {
+                    | ShapeFallback::NoKeyColumns
+                    | ShapeFallback::CteNameCollision => {
                         tracing::warn!(?fallback, "falling back to a single-pass statement");
                     }
                 }
@@ -801,12 +808,12 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
             .as_ref()
             .map(|with| with.common_table_expressions.to_vec())
             .unwrap_or_default();
-        debug_assert!(
-            common_table_expressions
-                .iter()
-                .all(|cte| cte.name.as_str() != "roots" && cte.name.as_str() != "limited"),
-            "carried CTE names must not collide with the fence CTEs"
-        );
+        if common_table_expressions
+            .iter()
+            .any(|cte| matches!(cte.name.as_str(), "roots" | "limited"))
+        {
+            return Err(ShapeFallback::CteNameCollision);
+        }
         common_table_expressions.push(self.key_query_cte(
             &partition,
             &key_columns,
@@ -1193,6 +1200,12 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
     #[must_use]
     pub const fn has_to_many_join(&self) -> bool {
         self.artifacts.has_to_many_join
+    }
+
+    /// Whether an embeddings distance filter was compiled into the statement.
+    #[must_use]
+    pub const fn has_embeddings_filter(&self) -> bool {
+        self.artifacts.has_embeddings_filter
     }
 
     /// Compiles a [`Filter`] to an [`Expression`].

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/compile/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/compile/mod.rs
@@ -689,14 +689,29 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
     }
 
     /// Transpiles the statement into SQL and the parameter to be passed to a prepared statement.
-    #[instrument(level = "info", skip_all)]
+    ///
+    /// Records the effective [`StatementShape`] on the span as `statement.shape`, which is the
+    /// place to check whether a fence request actually engaged.
+    #[instrument(
+        level = "info",
+        skip_all,
+        fields(statement.shape = tracing::field::Empty)
+    )]
     pub fn compile(&self) -> (String, &[&'p (dyn ToSql + Sync)]) {
         let statement = match self.shape {
-            StatementShape::SinglePass => self.single_pass_statement(),
+            StatementShape::SinglePass => {
+                tracing::Span::current().record("statement.shape", "single_pass");
+                self.single_pass_statement()
+            }
             StatementShape::FetchKeysThenHydrate => {
                 match self.fetch_keys_then_hydrate_statement() {
-                    Ok(statement) => statement,
+                    Ok(statement) => {
+                        tracing::Span::current()
+                            .record("statement.shape", "fetch_keys_then_hydrate");
+                        statement
+                    }
                     Err(fallback) => {
+                        tracing::Span::current().record("statement.shape", "single_pass");
                         // An unpaged statement simply has nothing to fence. Every other reason
                         // silently loses the shape the caller opted into and deserves a warning.
                         match fallback {

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/compile/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/compile/mod.rs
@@ -87,9 +87,8 @@ pub enum Distinctness {
 /// How [`SelectCompiler::compile`] lays out the statement.
 ///
 /// Both keys-first shapes filter, sort, and limit a narrow key set in CTEs and hydrate the
-/// wide projection only for the surviving rows. They fall back to [`SinglePass`] for every
-/// [`ShapeFallback`] reason; the fallback is logged, since it silently loses the shape the
-/// caller opted into.
+/// wide projection only for the surviving rows. They fall back to [`SinglePass`]; the fallback is
+/// logged, since it silently loses the shape the caller opted into.
 ///
 /// Callers opting into a keys-first shape vouch for two preconditions the compiler cannot
 /// check. `INNER` hydration joins must always match their key row (foreign-key-total joins

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/compile/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/compile/mod.rs
@@ -19,7 +19,9 @@ use postgres_types::ToSql;
 use tracing::instrument;
 use type_system::knowledge::Entity;
 
-use super::ast::{ColumnReference, JoinType, TableName, TableReference};
+use super::ast::{
+    ColumnName, ColumnReference, JoinType, Materialization, TableName, TableReference,
+};
 use crate::store::postgres::query::{
     Alias, Column, CommonTableExpression, EqualityOperator, Expression, FromItem, Function,
     GroupByClause, GroupingElement, Identifier, NonEmptyVec, NullsOrder, OrderByClause,
@@ -82,12 +84,88 @@ pub enum Distinctness {
     Distinct,
 }
 
-/// A join emitted into the statement, mirrored so the compiler can reuse joins and allocate
-/// fresh alias numbers without reading the statement tree back.
+/// How [`SelectCompiler::compile`] lays out the statement.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
+pub enum StatementShape {
+    /// One flat `SELECT` over all joins.
+    #[default]
+    SinglePass,
+    /// Filters a narrow key set inside a `MATERIALIZED` CTE, sorts and limits it outside the
+    /// fence, then hydrates the wide projection only for the surviving rows.
+    ///
+    /// The materialization fences the planner: the key query is planned without the outer
+    /// statement's ordering demand, which prevents ordered-pipeline bets built on unreliable
+    /// row estimates. Falls back to [`SinglePass`] for every [`ShapeFallback`] reason. The
+    /// fallback is logged, since it silently loses the shape the caller opted into.
+    ///
+    /// Callers opting in vouch for two preconditions the compiler cannot check. `INNER`
+    /// hydration joins must always match their key row (foreign-key-total joins do), and the
+    /// key query must produce at most one row per `DISTINCT ON` group. Both hold for the
+    /// entity read path, whose distinct key pins all row-multiplying columns. Violating
+    /// either returns short or shifted pages compared to [`SinglePass`].
+    ///
+    /// [`SinglePass`]: Self::SinglePass
+    FetchKeysThenHydrate,
+}
+
+/// Why [`StatementShape::FetchKeysThenHydrate`] degraded to a single-pass statement.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+enum ShapeFallback {
+    /// Without a limit the planner never bets on an ordered pipeline, so there is nothing to
+    /// fence off.
+    Unlimited,
+    /// Without sort keys there is no ordering demand to fence off.
+    Unsorted,
+    /// An asterisk select cannot be split into key and hydration columns.
+    AsteriskSelect,
+    /// A subquery expression may reference tables invisibly to the classifier.
+    OpaqueExpression,
+    /// A fanning-out join inside the key query would eat into `LIMIT n` with duplicates.
+    ToManyKeyJoin,
+    /// A right or full outer hydration join would generate rows the key query never saw,
+    /// which the missing `WHERE` clause of the hydration statement cannot filter out again.
+    GeneratingHydrationJoin,
+    /// The statement reads nothing from the key query, leaving the CTE without columns.
+    NoKeyColumns,
+}
+
+/// A join collected during compilation. The `FROM` tree is assembled from these records in
+/// [`SelectCompiler::compile`], so the compiler can reuse joins and allocate fresh alias
+/// numbers without reading a statement tree back.
 struct CompiledJoin {
     table: Table,
     alias: Alias,
+    join_type: JoinType,
+    source: JoinSource,
     conditions: Vec<Expression>,
+    /// Whether any relation using this join can fan out the driving rows.
+    ///
+    /// Unlike [`CompilerArtifacts::has_to_many_join`], which is tracked per relation, this
+    /// marks the individual joins so they can be classified separately.
+    to_many: bool,
+}
+
+impl CompiledJoin {
+    /// The `FROM` item this join scans, aliased as [`table`](Self::table) at
+    /// [`alias`](Self::alias).
+    fn source_item(&self) -> FromItem<'static> {
+        let alias = self.table.aliased_name(self.alias);
+        match &self.source {
+            JoinSource::Table => FromItem::table(self.table).alias(alias).build(),
+            JoinSource::Subquery(statement) => FromItem::subquery((**statement).clone())
+                .alias(alias)
+                .build(),
+        }
+    }
+}
+
+/// What a [`CompiledJoin`] scans.
+enum JoinSource {
+    /// The aliased [`table`](CompiledJoin::table) itself.
+    Table,
+    /// A derived table standing in for the plain table. The embeddings distance filter swaps
+    /// its join over to the aggregated distance subquery.
+    Subquery(Box<SelectStatement>),
 }
 
 /// One keyset-pagination sort key.
@@ -119,13 +197,134 @@ impl From<NullOrdering> for NullsOrder {
     }
 }
 
+/// Collects the table names referenced by `expression` into `tables`.
+///
+/// Sets `opaque` when the expression contains a subquery, whose references stay invisible to
+/// [`Expression::visit`].
+fn collect_referenced_tables(
+    expression: &Expression,
+    tables: &mut HashSet<TableName<'static>>,
+    opaque: &mut bool,
+) {
+    expression.visit(&mut |node| {
+        if let Expression::ColumnReference(column) = node
+            && let Some(correlation) = &column.correlation
+        {
+            tables.insert(correlation.name.clone());
+        }
+        if matches!(node, Expression::Select(_)) {
+            *opaque = true;
+        }
+    });
+}
+
+/// Collects the columns `expression` reads from any of the `key_tables`, deduplicated and in
+/// first-seen order.
+///
+/// Sets `opaque` when the expression contains a subquery, whose references stay invisible to
+/// [`Expression::visit`].
+fn collect_key_columns(
+    expression: &Expression,
+    key_tables: &HashSet<TableName<'static>>,
+    columns: &mut Vec<(TableName<'static>, ColumnName<'static>)>,
+    seen: &mut HashSet<(TableName<'static>, ColumnName<'static>)>,
+    opaque: &mut bool,
+) {
+    expression.visit(&mut |node| {
+        if let Expression::ColumnReference(column) = node
+            && let Some(correlation) = &column.correlation
+            && key_tables.contains(&correlation.name)
+        {
+            let key = (correlation.name.clone(), column.name.clone());
+            if seen.insert(key.clone()) {
+                columns.push(key);
+            }
+        }
+        if matches!(node, Expression::Select(_)) {
+            *opaque = true;
+        }
+    });
+}
+
+/// The join split for [`StatementShape::FetchKeysThenHydrate`].
+struct KeyQueryPartition<'j> {
+    /// The joins the key query filters and sorts through, in creation order.
+    key_joins: Vec<&'j CompiledJoin>,
+    /// The joins the hydration statement re-applies to the page, in creation order.
+    hydrated_joins: Vec<&'j CompiledJoin>,
+    /// The aliased names of the base table and every key-query join.
+    tables: HashSet<TableName<'static>>,
+}
+
+/// Rewrites references to key-query tables into references to the key query's output columns.
+struct KeyColumnRewriter<'r> {
+    tables: &'r HashSet<TableName<'static>>,
+    /// Output column name per key-query source column.
+    outputs: HashMap<(TableName<'static>, ColumnName<'static>), ColumnName<'static>>,
+}
+
+impl<'r> KeyColumnRewriter<'r> {
+    /// Assigns each key column its natural name. Every column name shared between source
+    /// tables gets prefixed with its aliased table name instead.
+    fn new(
+        tables: &'r HashSet<TableName<'static>>,
+        key_columns: &[(TableName<'static>, ColumnName<'static>)],
+    ) -> Self {
+        let mut name_users = HashMap::<&ColumnName<'static>, usize>::new();
+        for (_, column) in key_columns {
+            *name_users.entry(column).or_default() += 1;
+        }
+        Self {
+            tables,
+            outputs: key_columns
+                .iter()
+                .map(|(table, column)| {
+                    let output = if name_users.get(column).is_some_and(|users| *users > 1) {
+                        ColumnName::from(format!("{}_{}", table.as_str(), column.as_str()))
+                    } else {
+                        column.clone()
+                    };
+                    ((table.clone(), column.clone()), output)
+                })
+                .collect(),
+        }
+    }
+
+    /// The output column name assigned to a key-query source column.
+    fn output(
+        &self,
+        table: &TableName<'static>,
+        column: &ColumnName<'static>,
+    ) -> &ColumnName<'static> {
+        self.outputs
+            .get(&(table.clone(), column.clone()))
+            .expect("every key-table column is collected before it is rewritten")
+    }
+
+    /// Replaces every reference to a key-query table with a reference to the corresponding
+    /// output column, qualified with `target` (or bare when `target` is [`None`]).
+    fn rewrite(&self, expression: &Expression, target: Option<&TableName<'static>>) -> Expression {
+        let mut expression = expression.clone();
+        expression.visit_mut(&mut |node| {
+            if let Expression::ColumnReference(column) = node
+                && let Some(correlation) = &column.correlation
+                && self.tables.contains(&correlation.name)
+            {
+                column.name = self.output(&correlation.name, &column.name).clone();
+                column.correlation = target.cloned().map(TableReference::from);
+            }
+        });
+        expression
+    }
+}
+
 type TableHook<'p, 'q, T> = fn(&mut SelectCompiler<'p, 'q, T>, Alias) -> Vec<Expression>;
 type ColumnHook<'p, 'q, T> = fn(&mut SelectCompiler<'p, 'q, T>, Expression) -> Expression;
 
 pub struct SelectCompiler<'p, 'q: 'p, T: QueryRecord> {
+    shape: StatementShape,
     distinct_on: Vec<Expression>,
     selects: Vec<SelectExpression>,
-    from: Option<FromItem<'static>>,
     with: Option<WithClause>,
     conditions: Vec<Expression>,
     cursor: Vec<CursorKey>,
@@ -183,13 +382,9 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
         }
 
         Self {
+            shape: StatementShape::default(),
             distinct_on: Vec::new(),
             selects: Vec::new(),
-            from: Some(
-                FromItem::table(R::base_table())
-                    .alias(R::base_table().aliased_name(Alias::default()))
-                    .build(),
-            ),
             with: None,
             conditions: Vec::new(),
             cursor: Vec::new(),
@@ -231,6 +426,12 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
 
     pub const fn set_limit(&mut self, limit: usize) {
         self.limit = Some(limit);
+    }
+
+    /// Requests a statement layout, see [`StatementShape`] for the semantics and the
+    /// preconditions callers vouch for.
+    pub const fn set_statement_shape(&mut self, shape: StatementShape) {
+        self.shape = shape;
     }
 
     fn time_index(&mut self, temporal_axes: &'p QueryTemporalAxes, time_axis: TimeAxis) -> usize {
@@ -490,6 +691,39 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
     /// Transpiles the statement into SQL and the parameter to be passed to a prepared statement.
     #[instrument(level = "info", skip_all)]
     pub fn compile(&self) -> (String, &[&'p (dyn ToSql + Sync)]) {
+        let statement = match self.shape {
+            StatementShape::SinglePass => self.single_pass_statement(),
+            StatementShape::FetchKeysThenHydrate => {
+                match self.fetch_keys_then_hydrate_statement() {
+                    Ok(statement) => statement,
+                    Err(fallback) => {
+                        // An unpaged statement simply has nothing to fence. Every other reason
+                        // silently loses the shape the caller opted into and deserves a warning.
+                        match fallback {
+                            ShapeFallback::Unlimited | ShapeFallback::Unsorted => {
+                                tracing::debug!(?fallback, "compiling a single-pass statement");
+                            }
+                            ShapeFallback::AsteriskSelect
+                            | ShapeFallback::OpaqueExpression
+                            | ShapeFallback::ToManyKeyJoin
+                            | ShapeFallback::GeneratingHydrationJoin
+                            | ShapeFallback::NoKeyColumns => {
+                                tracing::warn!(
+                                    ?fallback,
+                                    "falling back to a single-pass statement"
+                                );
+                            }
+                        }
+                        self.single_pass_statement()
+                    }
+                }
+            }
+        };
+        (statement.transpile_to_string(), &self.artifacts.parameters)
+    }
+
+    /// Lays out the statement as one flat `SELECT` over all joins.
+    fn single_pass_statement(&self) -> SelectStatement {
         let simple = SimpleSelect::builder()
             .maybe_quantifier(
                 NonEmptyVec::try_from(self.distinct_on.clone())
@@ -497,24 +731,329 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
                     .map(SelectQuantifier::DistinctOn),
             )
             .selects(self.selects.clone())
-            .maybe_from(self.from.clone())
+            .from(Self::joined_table(&self.artifacts.joins))
             .maybe_where_clause(self.where_condition())
             .build();
 
-        (
-            SelectStatement::builder()
-                .maybe_with(self.with.clone())
-                .select_clause(simple)
-                .maybe_order_by(
-                    NonEmptyVec::try_from(self.sort_by.clone())
-                        .ok()
-                        .map(|sort_by| OrderByClause::builder().sort_by(sort_by).build()),
+        SelectStatement::builder()
+            .maybe_with(self.with.clone())
+            .select_clause(simple)
+            .maybe_order_by(
+                NonEmptyVec::try_from(self.sort_by.clone())
+                    .ok()
+                    .map(|sort_by| OrderByClause::builder().sort_by(sort_by).build()),
+            )
+            .maybe_limit(self.limit)
+            .build()
+    }
+
+    /// Lays out the statement as [`StatementShape::FetchKeysThenHydrate`], or reports why the
+    /// statement does not qualify.
+    fn fetch_keys_then_hydrate_statement(&self) -> Result<SelectStatement, ShapeFallback> {
+        let Some(limit) = self.limit else {
+            return Err(ShapeFallback::Unlimited);
+        };
+        if self.sort_by.is_empty() {
+            return Err(ShapeFallback::Unsorted);
+        }
+
+        let partition = self.partition_key_query_joins()?;
+        let key_columns = self.collect_key_query_columns(&partition)?;
+        let rewriter = KeyColumnRewriter::new(&partition.tables, &key_columns);
+        let limited = TableName::from("limited");
+
+        let mut common_table_expressions: Vec<CommonTableExpression> = self
+            .with
+            .as_ref()
+            .map(|with| with.common_table_expressions.to_vec())
+            .unwrap_or_default();
+        debug_assert!(
+            common_table_expressions
+                .iter()
+                .all(|cte| cte.name.as_str() != "roots" && cte.name.as_str() != "limited"),
+            "carried CTE names must not collide with the fence CTEs"
+        );
+        common_table_expressions.push(self.key_query_cte(&partition, &key_columns, &rewriter));
+        common_table_expressions.push(self.page_cte(&rewriter, limit));
+
+        Ok(SelectStatement::builder()
+            .with(
+                WithClause::builder()
+                    .recursive(self.with.as_ref().is_some_and(|with| with.recursive))
+                    .common_table_expressions(
+                        NonEmptyVec::try_from(common_table_expressions)
+                            .expect("the key and page CTEs were pushed above"),
+                    )
+                    .build(),
+            )
+            .select_clause(self.hydration_select(&partition, &rewriter, &limited))
+            .order_by(
+                OrderByClause::builder()
+                    .sort_by(self.rewritten_sort(&rewriter, Some(&limited)))
+                    .build(),
+            )
+            .limit(limit)
+            .build())
+    }
+
+    /// Splits the collected joins into the key query's and the hydration statement's share.
+    /// The key query takes everything referenced by a filter, the cursor, or a sort key,
+    /// closed transitively over the join conditions (a join's `ON` clause only references
+    /// earlier joins, so one reverse pass suffices).
+    fn partition_key_query_joins(&self) -> Result<KeyQueryPartition<'_>, ShapeFallback> {
+        let mut required = HashSet::new();
+        let mut opaque = false;
+        for expression in self
+            .conditions
+            .iter()
+            .chain(
+                self.cursor
+                    .iter()
+                    .flat_map(|key| once(&key.expression).chain(key.value.as_ref())),
+            )
+            .chain(self.sort_by.iter().map(|sort| &sort.expression))
+        {
+            collect_referenced_tables(expression, &mut required, &mut opaque);
+        }
+
+        let mut in_key_query = vec![false; self.artifacts.joins.len()];
+        for (slot, join) in in_key_query.iter_mut().zip(&self.artifacts.joins).rev() {
+            if required.contains(&join.table.aliased_name(join.alias)) {
+                *slot = true;
+                for condition in &join.conditions {
+                    collect_referenced_tables(condition, &mut required, &mut opaque);
+                }
+            }
+        }
+        if opaque {
+            return Err(ShapeFallback::OpaqueExpression);
+        }
+
+        let mut key_joins = Vec::new();
+        let mut hydrated_joins = Vec::new();
+        for (join, in_key_query) in self.artifacts.joins.iter().zip(&in_key_query) {
+            if *in_key_query {
+                key_joins.push(join);
+            } else {
+                hydrated_joins.push(join);
+            }
+        }
+        if key_joins.iter().any(|join| join.to_many) {
+            return Err(ShapeFallback::ToManyKeyJoin);
+        }
+        if hydrated_joins
+            .iter()
+            .any(|join| matches!(join.join_type, JoinType::RightOuter | JoinType::FullOuter))
+        {
+            return Err(ShapeFallback::GeneratingHydrationJoin);
+        }
+
+        let tables = once(R::base_table().aliased_name(Alias::default()))
+            .chain(
+                key_joins
+                    .iter()
+                    .map(|join| join.table.aliased_name(join.alias)),
+            )
+            .collect();
+
+        Ok(KeyQueryPartition {
+            key_joins,
+            hydrated_joins,
+            tables,
+        })
+    }
+
+    /// Collects every column the hydration statement reads from a key-query table, in
+    /// first-seen order. Each becomes an output column of the key query.
+    fn collect_key_query_columns(
+        &self,
+        partition: &KeyQueryPartition<'_>,
+    ) -> Result<Vec<(TableName<'static>, ColumnName<'static>)>, ShapeFallback> {
+        let mut key_columns = Vec::new();
+        let mut seen = HashSet::new();
+        let mut opaque = false;
+        for expression in self
+            .sort_by
+            .iter()
+            .map(|sort| &sort.expression)
+            .chain(self.distinct_on.iter())
+            .chain(self.selects.iter().filter_map(|select| match select {
+                SelectExpression::Expression { expression, .. } => Some(expression),
+                SelectExpression::Asterisk(_) => None,
+            }))
+            .chain(
+                partition
+                    .hydrated_joins
+                    .iter()
+                    .flat_map(|join| join.conditions.iter()),
+            )
+        {
+            collect_key_columns(
+                expression,
+                &partition.tables,
+                &mut key_columns,
+                &mut seen,
+                &mut opaque,
+            );
+        }
+        if opaque {
+            return Err(ShapeFallback::OpaqueExpression);
+        }
+        if self
+            .selects
+            .iter()
+            .any(|select| matches!(select, SelectExpression::Asterisk(_)))
+        {
+            return Err(ShapeFallback::AsteriskSelect);
+        }
+        if key_columns.is_empty() {
+            return Err(ShapeFallback::NoKeyColumns);
+        }
+        Ok(key_columns)
+    }
+
+    /// Builds the `roots` CTE: the key-query columns under the full filter and cursor
+    /// conditions, `MATERIALIZED` to fence its plan from the outer ordering demand.
+    fn key_query_cte(
+        &self,
+        partition: &KeyQueryPartition<'_>,
+        key_columns: &[(TableName<'static>, ColumnName<'static>)],
+        rewriter: &KeyColumnRewriter<'_>,
+    ) -> CommonTableExpression {
+        CommonTableExpression::builder()
+            .name("roots")
+            .statement(
+                SimpleSelect::builder()
+                    .selects(
+                        key_columns
+                            .iter()
+                            .map(|(table, column)| {
+                                let output = rewriter.output(table, column);
+                                SelectExpression::Expression {
+                                    expression: Expression::ColumnReference(ColumnReference {
+                                        correlation: Some(TableReference::from(table.clone())),
+                                        name: column.clone(),
+                                    }),
+                                    output_name: (output != column)
+                                        .then(|| Identifier::from(output.as_str().to_owned())),
+                                }
+                            })
+                            .collect::<Vec<_>>(),
+                    )
+                    .from(Self::joined_table(partition.key_joins.iter().copied()))
+                    .maybe_where_clause(self.where_condition()),
+            )
+            .materialization(Materialization::Materialized)
+            .build()
+    }
+
+    /// Builds the `limited` CTE: the sorted and limited page of `roots`.
+    fn page_cte(&self, rewriter: &KeyColumnRewriter<'_>, limit: usize) -> CommonTableExpression {
+        CommonTableExpression::builder()
+            .name("limited")
+            .statement(
+                SelectStatement::builder()
+                    .select_clause(
+                        SimpleSelect::builder()
+                            .selects(vec![SelectExpression::Asterisk(None)])
+                            .from(FromItem::table(TableName::from("roots")).build()),
+                    )
+                    .order_by(
+                        OrderByClause::builder()
+                            .sort_by(self.rewritten_sort(rewriter, None))
+                            .build(),
+                    )
+                    .limit(limit)
+                    .build(),
+            )
+            .build()
+    }
+
+    /// Builds the hydration `SELECT`: the original projection and `DISTINCT ON` over
+    /// `limited` plus the hydration joins, with all key-query references rewritten.
+    fn hydration_select(
+        &self,
+        partition: &KeyQueryPartition<'_>,
+        rewriter: &KeyColumnRewriter<'_>,
+        limited: &TableName<'static>,
+    ) -> SimpleSelect {
+        let mut from = FromItem::table(limited.clone()).build();
+        for join in &partition.hydrated_joins {
+            from = from
+                .join(join.join_type, join.source_item())
+                .on(join
+                    .conditions
+                    .iter()
+                    .map(|condition| rewriter.rewrite(condition, Some(limited)))
+                    .collect::<Vec<_>>())
+                .build();
+        }
+
+        SimpleSelect::builder()
+            .maybe_quantifier(
+                NonEmptyVec::try_from(
+                    self.distinct_on
+                        .iter()
+                        .map(|expression| rewriter.rewrite(expression, Some(limited)))
+                        .collect::<Vec<_>>(),
                 )
-                .maybe_limit(self.limit)
-                .build()
-                .transpile_to_string(),
-            &self.artifacts.parameters,
+                .ok()
+                .map(SelectQuantifier::DistinctOn),
+            )
+            .selects(
+                self.selects
+                    .iter()
+                    .map(|select| match select {
+                        SelectExpression::Expression {
+                            expression,
+                            output_name,
+                        } => SelectExpression::Expression {
+                            expression: rewriter.rewrite(expression, Some(limited)),
+                            output_name: output_name.clone(),
+                        },
+                        SelectExpression::Asterisk(_) => {
+                            unreachable!(
+                                "asterisk selects were ruled out while collecting the key columns"
+                            )
+                        }
+                    })
+                    .collect::<Vec<_>>(),
+            )
+            .from(from)
+            .build()
+    }
+
+    /// The statement's sort keys with their key-query references rewritten.
+    fn rewritten_sort(
+        &self,
+        rewriter: &KeyColumnRewriter<'_>,
+        target: Option<&TableName<'static>>,
+    ) -> NonEmptyVec<SortBy> {
+        NonEmptyVec::try_from(
+            self.sort_by
+                .iter()
+                .map(|sort| SortBy {
+                    expression: rewriter.rewrite(&sort.expression, target),
+                    direction: sort.direction,
+                    nulls: sort.nulls,
+                })
+                .collect::<Vec<_>>(),
         )
+        .expect("the sort keys were checked to be non-empty")
+    }
+
+    /// Assembles the `FROM` tree from the base table and the given joins.
+    fn joined_table<'j>(joins: impl IntoIterator<Item = &'j CompiledJoin>) -> FromItem<'static> {
+        let mut from = FromItem::table(R::base_table())
+            .alias(R::base_table().aliased_name(Alias::default()))
+            .build();
+        for join in joins {
+            from = from
+                .join(join.join_type, join.source_item())
+                .on(join.conditions.clone())
+                .build();
+        }
+        from
     }
 
     /// Combines the collected filter conditions and the keyset-pagination continuation into the
@@ -760,11 +1299,7 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
                         .aliased(path_alias),
                     );
 
-                    if let Some(FromItem::JoinOn {
-                        right: last_from, ..
-                    }) = self.from.as_mut()
-                        && let Some(last_join) = self.artifacts.joins.last()
-                    {
+                    if let Some(last_join) = self.artifacts.joins.last_mut() {
                         // The rewrite below replaces the topmost join with the distance
                         // subquery, which is only sound when that join is the embeddings join
                         // resolved for this path. A reused embeddings join buried under later
@@ -823,7 +1358,7 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
                             | Table::Reference(_) => unreachable!(),
                         };
 
-                        **last_from = FromItem::subquery(
+                        last_join.source = JoinSource::Subquery(Box::new(SelectStatement::from(
                             SimpleSelect::builder()
                                 .selects(
                                     select_columns
@@ -863,9 +1398,10 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
                                         ),
                                     ),
                                 ),
-                        )
-                        .alias(last_join.table.aliased_name(last_join.alias))
-                        .build();
+                        )));
+                        // The grouped subquery emits exactly one row per join key, so the
+                        // original relation's fan-out no longer applies.
+                        last_join.to_many = false;
                         self.artifacts.has_embeddings_filter = true;
                     }
 
@@ -1526,6 +2062,9 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
     /// Joining the tables attempts to deduplicate join operations. As soon as a new filter was
     /// compiled, each subsequent call will result in a new join-chain.
     ///
+    /// Every condition a join is created with references only the join itself and earlier
+    /// joins, which [`Self::partition_key_query_joins`] relies on for its single reverse pass.
+    ///
     /// [`Relation`]: super::table::Relation
     #[instrument(level = "debug", skip_all)]
     fn add_join_statements<'f: 'q>(&mut self, path: &R::QueryPath<'f>) -> Alias
@@ -1563,10 +2102,10 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
                 };
                 let mut conditions = foreign_key_reference.conditions(current_alias, join_alias);
 
-                let mut found = false;
+                let mut found = None;
                 let mut max_number = 0;
 
-                for existing in self.artifacts.joins.iter().rev() {
+                for (existing_index, existing) in self.artifacts.joins.iter().enumerate().rev() {
                     // Check for exact match to reuse existing join
                     if existing.table.name() == join_table.name() && existing.alias == join_alias {
                         // We only need to check the join conditions, not the join type or
@@ -1576,7 +2115,7 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
                             // We already have a join statement for this column, so we can reuse
                             // it.
                             current_alias = existing.alias;
-                            found = true;
+                            found = Some(existing_index);
                             break;
                         }
                     }
@@ -1590,8 +2129,16 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
                     }
                 }
 
-                // If we didn't find an exact match but found alias conflicts, update the alias
-                if !found {
+                if let Some(existing_index) = found {
+                    // A fanning-out relation taints the reused join as well.
+                    if relation.is_to_many() {
+                        self.artifacts
+                            .joins
+                            .get_mut(existing_index)
+                            .expect("the reuse index originates from enumerating the joins")
+                            .to_many = true;
+                    }
+                } else {
                     if max_number > 0 {
                         join_alias.number = max_number;
                         // Recalculate conditions with the updated alias
@@ -1605,24 +2152,13 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
                         conditions.extend(hook(self, join_alias));
                     }
 
-                    self.from = Some(
-                        self.from
-                            .take()
-                            .expect(
-                                "Tried to join on a `SELECT` statement without a `FROM` statement",
-                            )
-                            .join(
-                                join_type,
-                                FromItem::table(join_table)
-                                    .alias(join_table.aliased_name(join_alias)),
-                            )
-                            .on(conditions.clone())
-                            .build(),
-                    );
                     self.artifacts.joins.push(CompiledJoin {
                         table: join_table,
                         alias: join_alias,
+                        join_type,
+                        source: JoinSource::Table,
                         conditions,
+                        to_many: relation.is_to_many(),
                     });
                 }
             }

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/compile/tests.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/compile/tests.rs
@@ -2449,6 +2449,11 @@ fn fetch_keys_then_hydrate_carries_existing_ctes() {
     );
 }
 
+// No query path compiles to a right outer join today: `ReferenceTable::target_relation` is the
+// only source of one, and every chain reaching it passes an outer join first, which converts all
+// later hops to left outer joins. Both tests below therefore plant the join type by hand — the
+// guard is a fence against that structure changing.
+
 #[test]
 fn fetch_keys_then_hydrate_generating_hydration_join_falls_back() {
     use super::{CompiledJoin, JoinSource};
@@ -2463,9 +2468,7 @@ fn fetch_keys_then_hydrate_generating_hydration_join_falls_back() {
     compiler.set_limit(10);
     compiler.set_statement_shape(StatementShape::FencedKeysFirst);
 
-    // No query path compiles to a right outer join today, since the join chains convert
-    // every hop after the first outer one to a left outer join. The guard is a fence against
-    // that changing, so the join is planted directly.
+    // Nothing references the join, so it would land in the hydration statement.
     compiler.artifacts.joins.push(CompiledJoin {
         table: Table::EntityEditions,
         alias: Alias {
@@ -2481,7 +2484,48 @@ fn fetch_keys_then_hydrate_generating_hydration_join_falls_back() {
 
     assert_eq!(
         compiler.fetch_keys_then_hydrate_statement(None).map(|_| ()),
-        Err(ShapeFallback::GeneratingHydrationJoin)
+        Err(ShapeFallback::GeneratingJoin)
+    );
+}
+
+#[test]
+fn fetch_keys_then_hydrate_generating_key_join_falls_back() {
+    use crate::store::postgres::query::JoinType;
+
+    let mut compiler = SelectCompiler::<Entity>::new(None, true);
+    compiler.add_distinct_selection_with_ordering(
+        &EntityQueryPath::Uuid,
+        Distinctness::Distinct,
+        Some((Ordering::Ascending, None)),
+    );
+
+    // The filter puts the `entity_editions` join into the key query's share.
+    let json_path = JsonPath::from_path_tokens(vec![PathToken::Field(Cow::Borrowed(
+        r#"$."https://blockprotocol.org/@alice/types/property-type/name/""#,
+    ))]);
+    let filter = Filter::Equal(
+        FilterExpression::Path {
+            path: EntityQueryPath::Properties(Some(json_path)),
+        },
+        FilterExpression::Parameter {
+            parameter: Parameter::Text(Cow::Borrowed("Bob")),
+            convert: None,
+        },
+    );
+    compiler.add_filter(&filter).expect("Failed to add filter");
+    compiler.set_limit(10);
+    compiler.set_statement_shape(StatementShape::FencedKeysFirst);
+
+    let join = compiler
+        .artifacts
+        .joins
+        .first_mut()
+        .expect("the property filter should have joined the editions table");
+    join.join_type = JoinType::RightOuter;
+
+    assert_eq!(
+        compiler.fetch_keys_then_hydrate_statement(None).map(|_| ()),
+        Err(ShapeFallback::GeneratingJoin)
     );
 }
 
@@ -2549,7 +2593,8 @@ fn key_column_rewriter_disambiguates_collisions() {
         (TableName::from("second"), ColumnName::from("web_id")),
         (TableName::from("first"), ColumnName::from("entity_uuid")),
     ];
-    let rewriter = KeyColumnRewriter::new(&tables, &key_columns);
+    let rewriter = KeyColumnRewriter::new(&tables, &key_columns)
+        .expect("the disambiguated names should not collide");
 
     assert_eq!(
         rewriter
@@ -2568,6 +2613,34 @@ fn key_column_rewriter_disambiguates_collisions() {
             .output(&TableName::from("first"), &ColumnName::from("entity_uuid"))
             .as_str(),
         "entity_uuid"
+    );
+}
+
+#[test]
+fn key_column_rewriter_rejects_colliding_output_names() {
+    use std::collections::HashSet;
+
+    use super::KeyColumnRewriter;
+    use crate::store::postgres::query::ast::{ColumnName, TableName};
+
+    let tables: HashSet<TableName<'static>> = [
+        TableName::from("first"),
+        TableName::from("second"),
+        TableName::from("third"),
+    ]
+    .into();
+
+    // `web_id` is shared, so both users get prefixed — and `first_web_id` is what the third
+    // table's column is already called.
+    let key_columns = vec![
+        (TableName::from("first"), ColumnName::from("web_id")),
+        (TableName::from("second"), ColumnName::from("web_id")),
+        (TableName::from("third"), ColumnName::from("first_web_id")),
+    ];
+
+    assert_eq!(
+        KeyColumnRewriter::new(&tables, &key_columns).map(|_| ()),
+        Err(ShapeFallback::KeyColumnNameCollision)
     );
 }
 

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/compile/tests.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/compile/tests.rs
@@ -2084,6 +2084,63 @@ fn fetch_keys_then_hydrate_entity_query() {
 }
 
 #[test]
+fn filter_joined_tables_stay_out_of_the_key_projection() {
+    let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
+    let pinned_timestamp = temporal_axes.pinned_timestamp();
+    let mut compiler = SelectCompiler::<Entity>::new(Some(&temporal_axes), true);
+
+    // Mirrors the read path's order: filters first, selections after. The archived filter
+    // and the properties projection then join `entity_editions` under separate aliases, so
+    // the wide columns stay out of the key query.
+    let filter = Filter::Equal(
+        FilterExpression::Path {
+            path: EntityQueryPath::Archived,
+        },
+        FilterExpression::Parameter {
+            parameter: Parameter::Boolean(false),
+            convert: None,
+        },
+    );
+    compiler.add_filter(&filter).expect("Failed to add filter");
+    compiler.add_distinct_selection_with_ordering(
+        &EntityQueryPath::Uuid,
+        Distinctness::Distinct,
+        Some((Ordering::Ascending, None)),
+    );
+    compiler.add_selection_path(&EntityQueryPath::Properties(None));
+    compiler.set_limit(10);
+    compiler.set_statement_shape(StatementShape::KeysFirst);
+
+    test_compilation(
+        &compiler,
+        r#"
+        WITH "roots" AS (SELECT "entity_temporal_metadata_0_0_0"."entity_uuid", "entity_temporal_metadata_0_0_0"."entity_edition_id"
+        FROM "entity_temporal_metadata" AS "entity_temporal_metadata_0_0_0"
+        INNER JOIN "entity_editions" AS "entity_editions_0_1_0"
+          ON "entity_editions_0_1_0"."entity_edition_id" = "entity_temporal_metadata_0_0_0"."entity_edition_id"
+        WHERE ("entity_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ)
+          AND ("entity_temporal_metadata_0_0_0"."decision_time" && $2)
+          AND ("entity_editions_0_1_0"."archived" = $3)),
+        "limited" AS (SELECT *
+        FROM "roots"
+        ORDER BY "entity_uuid" ASC
+        LIMIT 10)
+        SELECT DISTINCT ON("limited"."entity_uuid") "limited"."entity_uuid", "entity_editions_1_1_0"."properties"
+        FROM "limited"
+        INNER JOIN "entity_editions" AS "entity_editions_1_1_0"
+          ON "entity_editions_1_1_0"."entity_edition_id" = "limited"."entity_edition_id"
+        ORDER BY "limited"."entity_uuid" ASC
+        LIMIT 10
+        "#,
+        &[
+            &pinned_timestamp,
+            &temporal_axes.variable_interval(),
+            &false,
+        ],
+    );
+}
+
+#[test]
 fn keys_first_omits_the_fence() {
     let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
     let pinned_timestamp = temporal_axes.pinned_timestamp();

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/compile/tests.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/compile/tests.rs
@@ -2054,7 +2054,7 @@ fn fetch_keys_then_hydrate_entity_query() {
     );
     compiler.add_filter(&filter).expect("Failed to add filter");
     compiler.set_limit(10);
-    compiler.set_statement_shape(StatementShape::FetchKeysThenHydrate);
+    compiler.set_statement_shape(StatementShape::FencedKeysFirst);
 
     test_compilation(
         &compiler,
@@ -2084,6 +2084,43 @@ fn fetch_keys_then_hydrate_entity_query() {
 }
 
 #[test]
+fn keys_first_omits_the_fence() {
+    let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
+    let pinned_timestamp = temporal_axes.pinned_timestamp();
+    let mut compiler = SelectCompiler::<Entity>::new(Some(&temporal_axes), true);
+    compiler.add_distinct_selection_with_ordering(
+        &EntityQueryPath::Uuid,
+        Distinctness::Distinct,
+        Some((Ordering::Ascending, None)),
+    );
+    compiler.add_selection_path(&EntityQueryPath::Properties(None));
+    compiler.set_limit(10);
+    compiler.set_statement_shape(StatementShape::KeysFirst);
+
+    // Same split as the fenced shape, but the CTE stays inlinable for the planner.
+    test_compilation(
+        &compiler,
+        r#"
+        WITH "roots" AS (SELECT "entity_temporal_metadata_0_0_0"."entity_uuid", "entity_temporal_metadata_0_0_0"."entity_edition_id"
+        FROM "entity_temporal_metadata" AS "entity_temporal_metadata_0_0_0"
+        WHERE ("entity_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ)
+          AND ("entity_temporal_metadata_0_0_0"."decision_time" && $2)),
+        "limited" AS (SELECT *
+        FROM "roots"
+        ORDER BY "entity_uuid" ASC
+        LIMIT 10)
+        SELECT DISTINCT ON("limited"."entity_uuid") "limited"."entity_uuid", "entity_editions_0_1_0"."properties"
+        FROM "limited"
+        INNER JOIN "entity_editions" AS "entity_editions_0_1_0"
+          ON "entity_editions_0_1_0"."entity_edition_id" = "limited"."entity_edition_id"
+        ORDER BY "limited"."entity_uuid" ASC
+        LIMIT 10
+        "#,
+        &[&pinned_timestamp, &temporal_axes.variable_interval()],
+    );
+}
+
+#[test]
 fn fetch_keys_then_hydrate_requires_sort_and_limit() {
     let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
 
@@ -2094,9 +2131,9 @@ fn fetch_keys_then_hydrate_requires_sort_and_limit() {
         Distinctness::Distinct,
         Some((Ordering::Ascending, None)),
     );
-    compiler.set_statement_shape(StatementShape::FetchKeysThenHydrate);
+    compiler.set_statement_shape(StatementShape::FencedKeysFirst);
     assert_eq!(
-        compiler.fetch_keys_then_hydrate_statement().map(|_| ()),
+        compiler.fetch_keys_then_hydrate_statement(None).map(|_| ()),
         Err(ShapeFallback::Unlimited)
     );
     let (unlimited, _) = compiler.compile();
@@ -2108,9 +2145,9 @@ fn fetch_keys_then_hydrate_requires_sort_and_limit() {
     let mut compiler = SelectCompiler::<Entity>::new(Some(&temporal_axes), true);
     compiler.add_selection_path(&EntityQueryPath::Uuid);
     compiler.set_limit(10);
-    compiler.set_statement_shape(StatementShape::FetchKeysThenHydrate);
+    compiler.set_statement_shape(StatementShape::FencedKeysFirst);
     assert_eq!(
-        compiler.fetch_keys_then_hydrate_statement().map(|_| ()),
+        compiler.fetch_keys_then_hydrate_statement(None).map(|_| ()),
         Err(ShapeFallback::Unsorted)
     );
     let (unsorted, _) = compiler.compile();
@@ -2129,9 +2166,9 @@ fn fetch_keys_then_hydrate_asterisk_falls_back() {
         Some((Ordering::Ascending, None)),
     );
     compiler.set_limit(10);
-    compiler.set_statement_shape(StatementShape::FetchKeysThenHydrate);
+    compiler.set_statement_shape(StatementShape::FencedKeysFirst);
     assert_eq!(
-        compiler.fetch_keys_then_hydrate_statement().map(|_| ()),
+        compiler.fetch_keys_then_hydrate_statement(None).map(|_| ()),
         Err(ShapeFallback::AsteriskSelect)
     );
     let (asterisk, _) = compiler.compile();
@@ -2167,9 +2204,9 @@ fn fetch_keys_then_hydrate_to_many_filter_falls_back() {
     );
     compiler.add_filter(&filter).expect("Failed to add filter");
     compiler.set_limit(10);
-    compiler.set_statement_shape(StatementShape::FetchKeysThenHydrate);
+    compiler.set_statement_shape(StatementShape::FencedKeysFirst);
     assert_eq!(
-        compiler.fetch_keys_then_hydrate_statement().map(|_| ()),
+        compiler.fetch_keys_then_hydrate_statement(None).map(|_| ()),
         Err(ShapeFallback::ToManyKeyJoin)
     );
     let (to_many, _) = compiler.compile();
@@ -2195,7 +2232,7 @@ fn fetch_keys_then_hydrate_sorts_across_joins() {
     );
     compiler.add_selection_path(&EntityQueryPath::Properties(None));
     compiler.set_limit(10);
-    compiler.set_statement_shape(StatementShape::FetchKeysThenHydrate);
+    compiler.set_statement_shape(StatementShape::FencedKeysFirst);
 
     test_compilation(
         &compiler,
@@ -2241,7 +2278,7 @@ fn fetch_keys_then_hydrate_with_cursor() {
         .expect("the cursor selection should compile");
     compiler.add_selection_path(&EntityQueryPath::Properties(None));
     compiler.set_limit(10);
-    compiler.set_statement_shape(StatementShape::FetchKeysThenHydrate);
+    compiler.set_statement_shape(StatementShape::FencedKeysFirst);
 
     // The keyset continuation belongs to the key query, so pages after the first stay fenced.
     test_compilation(
@@ -2275,7 +2312,7 @@ fn fetch_keys_then_hydrate_embedding_distance() {
         .add_filter(&filter)
         .expect("the embedding filter should compile");
     compiler.set_limit(3);
-    compiler.set_statement_shape(StatementShape::FetchKeysThenHydrate);
+    compiler.set_statement_shape(StatementShape::FencedKeysFirst);
 
     // The grouped distance subquery emits one row per entity, so it may drive the key query.
     test_compilation(
@@ -2328,7 +2365,7 @@ fn fetch_keys_then_hydrate_carries_existing_ctes() {
         ))
         .expect("Failed to add filter");
     compiler.set_limit(5);
-    compiler.set_statement_shape(StatementShape::FetchKeysThenHydrate);
+    compiler.set_statement_shape(StatementShape::FencedKeysFirst);
 
     // The latest-version CTE shadows `ontology_ids` and has to stay ahead of the fence CTEs.
     test_compilation(
@@ -2367,7 +2404,7 @@ fn fetch_keys_then_hydrate_generating_hydration_join_falls_back() {
         Some((Ordering::Ascending, None)),
     );
     compiler.set_limit(10);
-    compiler.set_statement_shape(StatementShape::FetchKeysThenHydrate);
+    compiler.set_statement_shape(StatementShape::FencedKeysFirst);
 
     // No query path compiles to a right outer join today, since the join chains convert
     // every hop after the first outer one to a left outer join. The guard is a fence against
@@ -2386,7 +2423,7 @@ fn fetch_keys_then_hydrate_generating_hydration_join_falls_back() {
     });
 
     assert_eq!(
-        compiler.fetch_keys_then_hydrate_statement().map(|_| ()),
+        compiler.fetch_keys_then_hydrate_statement(None).map(|_| ()),
         Err(ShapeFallback::GeneratingHydrationJoin)
     );
 }
@@ -2433,10 +2470,10 @@ fn fetch_keys_then_hydrate_reused_to_many_join_falls_back() {
     ]);
     compiler.add_filter(&filter).expect("Failed to add filter");
     compiler.set_limit(10);
-    compiler.set_statement_shape(StatementShape::FetchKeysThenHydrate);
+    compiler.set_statement_shape(StatementShape::FencedKeysFirst);
 
     assert_eq!(
-        compiler.fetch_keys_then_hydrate_statement().map(|_| ()),
+        compiler.fetch_keys_then_hydrate_statement(None).map(|_| ()),
         Err(ShapeFallback::ToManyKeyJoin)
     );
 }

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/compile/tests.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/compile/tests.rs
@@ -28,9 +28,10 @@ use type_system::{
 };
 use uuid::Uuid;
 
+use super::ShapeFallback;
 use crate::store::postgres::query::{
     Distinctness, PostgresRecord, SelectCompiler, SelectExpression, SelectStatement, SimpleSelect,
-    Transpile as _, compile::SelectCompilerError, test_helper::trim_whitespace,
+    StatementShape, Transpile as _, compile::SelectCompilerError, test_helper::trim_whitespace,
 };
 
 #[track_caller]
@@ -2022,6 +2023,457 @@ fn entity_cursor_pagination() {
         LIMIT 10
         "#,
         &[&uuid, &pinned_timestamp, &temporal_axes.variable_interval()],
+    );
+}
+
+#[test]
+fn fetch_keys_then_hydrate_entity_query() {
+    let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
+    let pinned_timestamp = temporal_axes.pinned_timestamp();
+    let mut compiler = SelectCompiler::<Entity>::new(Some(&temporal_axes), true);
+    compiler.add_distinct_selection_with_ordering(
+        &EntityQueryPath::Uuid,
+        Distinctness::Distinct,
+        Some((Ordering::Ascending, None)),
+    );
+    compiler.add_distinct_selection_with_ordering(
+        &EntityQueryPath::DecisionTime,
+        Distinctness::Distinct,
+        Some((Ordering::Descending, Some(NullOrdering::Last))),
+    );
+    compiler.add_selection_path(&EntityQueryPath::Properties(None));
+
+    let filter = Filter::Equal(
+        FilterExpression::Path {
+            path: EntityQueryPath::DraftId,
+        },
+        FilterExpression::Parameter {
+            parameter: Parameter::Uuid(Uuid::nil()),
+            convert: None,
+        },
+    );
+    compiler.add_filter(&filter).expect("Failed to add filter");
+    compiler.set_limit(10);
+    compiler.set_statement_shape(StatementShape::FetchKeysThenHydrate);
+
+    test_compilation(
+        &compiler,
+        r#"
+        WITH "roots" AS MATERIALIZED (SELECT "entity_temporal_metadata_0_0_0"."entity_uuid", "entity_temporal_metadata_0_0_0"."decision_time", "entity_temporal_metadata_0_0_0"."entity_edition_id"
+        FROM "entity_temporal_metadata" AS "entity_temporal_metadata_0_0_0"
+        WHERE ("entity_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ)
+          AND ("entity_temporal_metadata_0_0_0"."decision_time" && $2)
+          AND ("entity_temporal_metadata_0_0_0"."draft_id" = $3)),
+        "limited" AS (SELECT *
+        FROM "roots"
+        ORDER BY "entity_uuid" ASC, "decision_time" DESC NULLS LAST
+        LIMIT 10)
+        SELECT DISTINCT ON("limited"."entity_uuid", "limited"."decision_time") "limited"."entity_uuid", "limited"."decision_time", "entity_editions_0_1_0"."properties"
+        FROM "limited"
+        INNER JOIN "entity_editions" AS "entity_editions_0_1_0"
+          ON "entity_editions_0_1_0"."entity_edition_id" = "limited"."entity_edition_id"
+        ORDER BY "limited"."entity_uuid" ASC, "limited"."decision_time" DESC NULLS LAST
+        LIMIT 10
+        "#,
+        &[
+            &pinned_timestamp,
+            &temporal_axes.variable_interval(),
+            &Uuid::nil(),
+        ],
+    );
+}
+
+#[test]
+fn fetch_keys_then_hydrate_requires_sort_and_limit() {
+    let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
+
+    // Sorted but unlimited: nothing to fence off, the layout stays single-pass.
+    let mut compiler = SelectCompiler::<Entity>::new(Some(&temporal_axes), true);
+    compiler.add_distinct_selection_with_ordering(
+        &EntityQueryPath::Uuid,
+        Distinctness::Distinct,
+        Some((Ordering::Ascending, None)),
+    );
+    compiler.set_statement_shape(StatementShape::FetchKeysThenHydrate);
+    assert_eq!(
+        compiler.fetch_keys_then_hydrate_statement().map(|_| ()),
+        Err(ShapeFallback::Unlimited)
+    );
+    let (unlimited, _) = compiler.compile();
+    compiler.set_statement_shape(StatementShape::SinglePass);
+    let (single_pass, _) = compiler.compile();
+    assert_eq!(unlimited, single_pass);
+
+    // Limited but unsorted: same story.
+    let mut compiler = SelectCompiler::<Entity>::new(Some(&temporal_axes), true);
+    compiler.add_selection_path(&EntityQueryPath::Uuid);
+    compiler.set_limit(10);
+    compiler.set_statement_shape(StatementShape::FetchKeysThenHydrate);
+    assert_eq!(
+        compiler.fetch_keys_then_hydrate_statement().map(|_| ()),
+        Err(ShapeFallback::Unsorted)
+    );
+    let (unsorted, _) = compiler.compile();
+    compiler.set_statement_shape(StatementShape::SinglePass);
+    let (single_pass, _) = compiler.compile();
+    assert_eq!(unsorted, single_pass);
+}
+
+#[test]
+fn fetch_keys_then_hydrate_asterisk_falls_back() {
+    let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
+    let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes), true);
+    compiler.add_distinct_selection_with_ordering(
+        &EntityQueryPath::Uuid,
+        Distinctness::Distinct,
+        Some((Ordering::Ascending, None)),
+    );
+    compiler.set_limit(10);
+    compiler.set_statement_shape(StatementShape::FetchKeysThenHydrate);
+    assert_eq!(
+        compiler.fetch_keys_then_hydrate_statement().map(|_| ()),
+        Err(ShapeFallback::AsteriskSelect)
+    );
+    let (asterisk, _) = compiler.compile();
+    compiler.set_statement_shape(StatementShape::SinglePass);
+    let (single_pass, _) = compiler.compile();
+    assert_eq!(asterisk, single_pass);
+}
+
+#[test]
+fn fetch_keys_then_hydrate_to_many_filter_falls_back() {
+    let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
+    let mut compiler = SelectCompiler::<Entity>::new(Some(&temporal_axes), true);
+    compiler.add_distinct_selection_with_ordering(
+        &EntityQueryPath::Uuid,
+        Distinctness::Distinct,
+        Some((Ordering::Ascending, None)),
+    );
+
+    // Filtering through a link edge joins fanning-out relations into the key query, whose
+    // duplicates would eat into `LIMIT n`.
+    let filter = Filter::Equal(
+        FilterExpression::Path {
+            path: EntityQueryPath::EntityEdge {
+                edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
+                path: Box::new(EntityQueryPath::Uuid),
+                direction: EdgeDirection::Incoming,
+            },
+        },
+        FilterExpression::Parameter {
+            parameter: Parameter::Uuid(Uuid::nil()),
+            convert: None,
+        },
+    );
+    compiler.add_filter(&filter).expect("Failed to add filter");
+    compiler.set_limit(10);
+    compiler.set_statement_shape(StatementShape::FetchKeysThenHydrate);
+    assert_eq!(
+        compiler.fetch_keys_then_hydrate_statement().map(|_| ()),
+        Err(ShapeFallback::ToManyKeyJoin)
+    );
+    let (to_many, _) = compiler.compile();
+    compiler.set_statement_shape(StatementShape::SinglePass);
+    let (single_pass, _) = compiler.compile();
+    assert_eq!(to_many, single_pass);
+}
+
+#[test]
+fn fetch_keys_then_hydrate_sorts_across_joins() {
+    let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
+    let pinned_timestamp = temporal_axes.pinned_timestamp();
+    let mut compiler = SelectCompiler::<Entity>::new(Some(&temporal_axes), true);
+    compiler.add_distinct_selection_with_ordering(
+        &EntityQueryPath::CreatedAtTransactionTime,
+        Distinctness::Distinct,
+        Some((Ordering::Descending, Some(NullOrdering::Last))),
+    );
+    compiler.add_distinct_selection_with_ordering(
+        &EntityQueryPath::Uuid,
+        Distinctness::Distinct,
+        Some((Ordering::Ascending, None)),
+    );
+    compiler.add_selection_path(&EntityQueryPath::Properties(None));
+    compiler.set_limit(10);
+    compiler.set_statement_shape(StatementShape::FetchKeysThenHydrate);
+
+    test_compilation(
+        &compiler,
+        r#"
+        WITH "roots" AS MATERIALIZED (SELECT "entity_ids_0_1_0"."created_at_transaction_time", "entity_temporal_metadata_0_0_0"."entity_uuid", "entity_temporal_metadata_0_0_0"."entity_edition_id"
+        FROM "entity_temporal_metadata" AS "entity_temporal_metadata_0_0_0"
+        INNER JOIN "entity_ids" AS "entity_ids_0_1_0"
+          ON "entity_ids_0_1_0"."web_id" = "entity_temporal_metadata_0_0_0"."web_id"
+         AND "entity_ids_0_1_0"."entity_uuid" = "entity_temporal_metadata_0_0_0"."entity_uuid"
+        WHERE ("entity_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ)
+          AND ("entity_temporal_metadata_0_0_0"."decision_time" && $2)),
+        "limited" AS (SELECT *
+        FROM "roots"
+        ORDER BY "created_at_transaction_time" DESC NULLS LAST, "entity_uuid" ASC
+        LIMIT 10)
+        SELECT DISTINCT ON("limited"."created_at_transaction_time", "limited"."entity_uuid") "limited"."created_at_transaction_time", "limited"."entity_uuid", "entity_editions_0_1_0"."properties"
+        FROM "limited"
+        INNER JOIN "entity_editions" AS "entity_editions_0_1_0"
+          ON "entity_editions_0_1_0"."entity_edition_id" = "limited"."entity_edition_id"
+        ORDER BY "limited"."created_at_transaction_time" DESC NULLS LAST, "limited"."entity_uuid" ASC
+        LIMIT 10
+        "#,
+        &[&pinned_timestamp, &temporal_axes.variable_interval()],
+    );
+}
+
+#[test]
+fn fetch_keys_then_hydrate_with_cursor() {
+    let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
+    let pinned_timestamp = temporal_axes.pinned_timestamp();
+    let mut compiler = SelectCompiler::<Entity>::new(Some(&temporal_axes), true);
+
+    let uuid = Uuid::nil();
+    let parameter = compiler.add_parameter(&uuid);
+    compiler
+        .add_cursor_selection(
+            &EntityQueryPath::Uuid,
+            core::convert::identity,
+            Some(parameter),
+            Ordering::Ascending,
+            None,
+        )
+        .expect("the cursor selection should compile");
+    compiler.add_selection_path(&EntityQueryPath::Properties(None));
+    compiler.set_limit(10);
+    compiler.set_statement_shape(StatementShape::FetchKeysThenHydrate);
+
+    // The keyset continuation belongs to the key query, so pages after the first stay fenced.
+    test_compilation(
+        &compiler,
+        r#"
+        WITH "roots" AS MATERIALIZED (SELECT "entity_temporal_metadata_0_0_0"."entity_uuid", "entity_temporal_metadata_0_0_0"."entity_edition_id"
+        FROM "entity_temporal_metadata" AS "entity_temporal_metadata_0_0_0"
+        WHERE ("entity_temporal_metadata_0_0_0"."transaction_time" @> $2::TIMESTAMPTZ)
+          AND ("entity_temporal_metadata_0_0_0"."decision_time" && $3)
+          AND ("entity_temporal_metadata_0_0_0"."entity_uuid" > $1)),
+        "limited" AS (SELECT *
+        FROM "roots"
+        ORDER BY "entity_uuid" ASC
+        LIMIT 10)
+        SELECT DISTINCT ON("limited"."entity_uuid") "limited"."entity_uuid", "entity_editions_0_1_0"."properties"
+        FROM "limited"
+        INNER JOIN "entity_editions" AS "entity_editions_0_1_0"
+          ON "entity_editions_0_1_0"."entity_edition_id" = "limited"."entity_edition_id"
+        ORDER BY "limited"."entity_uuid" ASC
+        LIMIT 10
+        "#,
+        &[&uuid, &pinned_timestamp, &temporal_axes.variable_interval()],
+    );
+}
+
+#[test]
+fn fetch_keys_then_hydrate_embedding_distance() {
+    let mut compiler = SelectCompiler::<Entity>::new(None, false);
+    let filter = embedding_distance_filter();
+    compiler
+        .add_filter(&filter)
+        .expect("the embedding filter should compile");
+    compiler.set_limit(3);
+    compiler.set_statement_shape(StatementShape::FetchKeysThenHydrate);
+
+    // The grouped distance subquery emits one row per entity, so it may drive the key query.
+    test_compilation(
+        &compiler,
+        r#"
+        WITH "roots" AS MATERIALIZED (SELECT "entity_embeddings_0_1_0"."distance"
+        FROM "entity_temporal_metadata" AS "entity_temporal_metadata_0_0_0"
+        LEFT OUTER JOIN (SELECT "entity_embeddings"."web_id", "entity_embeddings"."entity_uuid", MIN("entity_embeddings"."embedding" <=> $1) AS "distance"
+        FROM "entity_embeddings"
+        GROUP BY "entity_embeddings"."web_id", "entity_embeddings"."entity_uuid") AS "entity_embeddings_0_1_0"
+          ON "entity_embeddings_0_1_0"."web_id" = "entity_temporal_metadata_0_0_0"."web_id"
+         AND "entity_embeddings_0_1_0"."entity_uuid" = "entity_temporal_metadata_0_0_0"."entity_uuid"
+        WHERE ("entity_temporal_metadata_0_0_0"."draft_id" IS NULL)
+          AND ("entity_embeddings_0_1_0"."distance" <= $2)),
+        "limited" AS (SELECT *
+        FROM "roots"
+        ORDER BY "distance" ASC
+        LIMIT 3)
+        SELECT DISTINCT ON("limited"."distance") "limited"."distance"
+        FROM "limited"
+        ORDER BY "limited"."distance" ASC
+        LIMIT 3
+        "#,
+        &[
+            &Embedding::from(vec![0.0; 1536]),
+            &Real::from_natural(5, -1),
+        ],
+    );
+}
+
+#[test]
+fn fetch_keys_then_hydrate_carries_existing_ctes() {
+    let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
+    let pinned_timestamp = temporal_axes.pinned_timestamp();
+    let mut compiler = SelectCompiler::<DataTypeWithMetadata>::new(Some(&temporal_axes), false);
+    compiler.add_distinct_selection_with_ordering(
+        &DataTypeQueryPath::Version,
+        Distinctness::Distinct,
+        Some((Ordering::Descending, None)),
+    );
+    compiler
+        .add_filter(&Filter::Equal(
+            FilterExpression::Path {
+                path: DataTypeQueryPath::Version,
+            },
+            FilterExpression::Parameter {
+                parameter: Parameter::Text(Cow::Borrowed("latest")),
+                convert: None,
+            },
+        ))
+        .expect("Failed to add filter");
+    compiler.set_limit(5);
+    compiler.set_statement_shape(StatementShape::FetchKeysThenHydrate);
+
+    // The latest-version CTE shadows `ontology_ids` and has to stay ahead of the fence CTEs.
+    test_compilation(
+        &compiler,
+        r#"
+        WITH "ontology_ids" AS (SELECT *, MAX("ontology_ids_0_0_0"."version") OVER (PARTITION BY "ontology_ids_0_0_0"."base_url") AS "latest_version"
+        FROM "ontology_ids" AS "ontology_ids_0_0_0"),
+        "roots" AS MATERIALIZED (SELECT "ontology_ids_0_1_0"."version"
+        FROM "ontology_temporal_metadata" AS "ontology_temporal_metadata_0_0_0"
+        INNER JOIN "ontology_ids" AS "ontology_ids_0_1_0"
+          ON "ontology_ids_0_1_0"."ontology_id" = "ontology_temporal_metadata_0_0_0"."ontology_id"
+        WHERE ("ontology_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ)
+          AND ("ontology_ids_0_1_0"."version" = "ontology_ids_0_1_0"."latest_version")),
+        "limited" AS (SELECT *
+        FROM "roots"
+        ORDER BY "version" DESC
+        LIMIT 5)
+        SELECT DISTINCT ON("limited"."version") "limited"."version"
+        FROM "limited"
+        ORDER BY "limited"."version" DESC
+        LIMIT 5
+        "#,
+        &[&pinned_timestamp],
+    );
+}
+
+#[test]
+fn fetch_keys_then_hydrate_generating_hydration_join_falls_back() {
+    use super::{CompiledJoin, JoinSource};
+    use crate::store::postgres::query::{Alias, JoinType, Table};
+
+    let mut compiler = SelectCompiler::<Entity>::new(None, true);
+    compiler.add_distinct_selection_with_ordering(
+        &EntityQueryPath::Uuid,
+        Distinctness::Distinct,
+        Some((Ordering::Ascending, None)),
+    );
+    compiler.set_limit(10);
+    compiler.set_statement_shape(StatementShape::FetchKeysThenHydrate);
+
+    // No query path compiles to a right outer join today, since the join chains convert
+    // every hop after the first outer one to a left outer join. The guard is a fence against
+    // that changing, so the join is planted directly.
+    compiler.artifacts.joins.push(CompiledJoin {
+        table: Table::EntityEditions,
+        alias: Alias {
+            condition_index: 0,
+            chain_depth: 1,
+            number: 0,
+        },
+        join_type: JoinType::RightOuter,
+        source: JoinSource::Table,
+        conditions: Vec::new(),
+        to_many: false,
+    });
+
+    assert_eq!(
+        compiler.fetch_keys_then_hydrate_statement().map(|_| ()),
+        Err(ShapeFallback::GeneratingHydrationJoin)
+    );
+}
+
+#[test]
+fn fetch_keys_then_hydrate_reused_to_many_join_falls_back() {
+    let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
+    let mut compiler = SelectCompiler::<Entity>::new(Some(&temporal_axes), true);
+    compiler.add_distinct_selection_with_ordering(
+        &EntityQueryPath::Uuid,
+        Distinctness::Distinct,
+        Some((Ordering::Ascending, None)),
+    );
+
+    // Both conditions share one filter index, so the second reuses the first's link join and
+    // the fan-out taint has to stick to the reused join.
+    let filter = Filter::All(vec![
+        Filter::Equal(
+            FilterExpression::Path {
+                path: EntityQueryPath::EntityEdge {
+                    edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
+                    path: Box::new(EntityQueryPath::Uuid),
+                    direction: EdgeDirection::Incoming,
+                },
+            },
+            FilterExpression::Parameter {
+                parameter: Parameter::Uuid(Uuid::nil()),
+                convert: None,
+            },
+        ),
+        Filter::Equal(
+            FilterExpression::Path {
+                path: EntityQueryPath::EntityEdge {
+                    edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
+                    path: Box::new(EntityQueryPath::WebId),
+                    direction: EdgeDirection::Incoming,
+                },
+            },
+            FilterExpression::Parameter {
+                parameter: Parameter::Uuid(Uuid::nil()),
+                convert: None,
+            },
+        ),
+    ]);
+    compiler.add_filter(&filter).expect("Failed to add filter");
+    compiler.set_limit(10);
+    compiler.set_statement_shape(StatementShape::FetchKeysThenHydrate);
+
+    assert_eq!(
+        compiler.fetch_keys_then_hydrate_statement().map(|_| ()),
+        Err(ShapeFallback::ToManyKeyJoin)
+    );
+}
+
+#[test]
+fn key_column_rewriter_disambiguates_collisions() {
+    use std::collections::HashSet;
+
+    use super::KeyColumnRewriter;
+    use crate::store::postgres::query::ast::{ColumnName, TableName};
+
+    let tables: HashSet<TableName<'static>> =
+        [TableName::from("first"), TableName::from("second")].into();
+    let key_columns = vec![
+        (TableName::from("first"), ColumnName::from("web_id")),
+        (TableName::from("second"), ColumnName::from("web_id")),
+        (TableName::from("first"), ColumnName::from("entity_uuid")),
+    ];
+    let rewriter = KeyColumnRewriter::new(&tables, &key_columns);
+
+    assert_eq!(
+        rewriter
+            .output(&TableName::from("first"), &ColumnName::from("web_id"))
+            .as_str(),
+        "first_web_id"
+    );
+    assert_eq!(
+        rewriter
+            .output(&TableName::from("second"), &ColumnName::from("web_id"))
+            .as_str(),
+        "second_web_id"
+    );
+    assert_eq!(
+        rewriter
+            .output(&TableName::from("first"), &ColumnName::from("entity_uuid"))
+            .as_str(),
+        "entity_uuid"
     );
 }
 

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/mod.rs
@@ -40,7 +40,7 @@ pub use self::{
         TableReference, TableSample, UnaryExpression, UnaryOperator, VariadicExpression,
         VariadicOperator, WindowDefinition, WithClause, bulk_insert,
     },
-    compile::{Distinctness, SelectCompiler, SelectCompilerError},
+    compile::{Distinctness, SelectCompiler, SelectCompilerError, StatementShape},
     postgres_type::PostgresType,
     table::{Alias, Column, ForeignKeyReference, JsonField, ReferenceTable, Relation, Table},
 };


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Sorted and limited entity reads now compile as a keys-first statement: a narrow key query carries the filters, cursor, and sort, and the wide projection is hydrated only for the rows that survive the `LIMIT`. This keeps the planner's ability to serve the ordering from an index while it sorts and spools far narrower rows, and it is the structural groundwork for optimizing the entity read path against known query shapes.

Grounded in the created-at sort incident: the pathological plan was reproduced locally against a 700k-entity seed and the shape trade-offs were measured with result-set-equivalence checks on every variant (see the Slack thread for the discussion).

## 🔗 Related links

- [BE-702](https://linear.app/hash/issue/BE-702) _(internal)_ — the driving ticket
- [BE-598](https://linear.app/hash/issue/BE-598) _(internal)_ — the investigation this implements
- [Slack: entities-page performance & sort keys](https://hashintel.slack.com/archives/C022217GAHF/p1784220011668439) _(internal)_ — incident context, measurements, and the follow-up direction
- [Slack: entities table loading behaviour](https://hashintel.slack.com/archives/C022217GAHF/p1783687778077499) _(internal)_

## 🚫 Blocked by

- [x] #9033

## 🔍 What does this change?

- `StatementShape` on the `SelectCompiler`: `SinglePass` (default, unchanged) | `KeysFirst` | `FencedKeysFirst`. The keys-first shapes compile into a key CTE (filters + cursor + sort columns), a page CTE (`ORDER BY` + `LIMIT`), and a hydration `SELECT` with all key-table references rewritten; the fenced variant adds `AS MATERIALIZED` to shield the key query from the outer ordering demand.
- Join classification by use (filters/cursor/sort keys, closed transitively over the join conditions) splits the collected joins into the key query's and the hydration's share; the `FROM` tree is now assembled in `compile()` from that bookkeeping.
- Statements that cannot be split degrade to `SinglePass` with a logged `ShapeFallback` reason; the effective shape is recorded on the `compile` span as `statement.shape`. Both the shape's materialization and its span value live on `StatementShape`, so a shape cannot be recorded under a fence it was not compiled with.
- The guards that reject a split are total rather than reasoned per side: any right or full outer join anywhere disqualifies the statement, and colliding key-column output names are rejected instead of surfacing as an ambiguous column reference at execution time.
- Pre-order `Expression::visit`/`visit_mut` walkers on the AST returning `ControlFlow`, so the classification stops at the first subquery it cannot see through instead of flagging one and checking after the walk. Used by the classification and the reference rewriting.
- `read_entities_impl` opts into `KeysFirst` for sorted entity reads; embedding-distance queries stay on `SinglePass` (`TODO(BE-618)`).
- A note on `AsClient for Object` documents that bypassing the pool's statement cache keeps every query on a custom plan — the shape strategy relies on parameter-aware planning.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

- `FencedKeysFirst` has no production caller yet; it is exercised by the compile tests and reserved as an escalation shape.
- Statement texts for sorted entity reads change shape, so `pg_stat_statements` fingerprints reset for those queries.

## 🐾 Next steps

- Distinguish include- from exclude-type filters on the entity read path: inclusion lists are GIN-indexable and estimable, and the entities page can derive them from the type summary it already fetches (see the Slack thread).
- [BE-709](https://linear.app/hash/issue/BE-709) _(internal)_ — `Visitor`/`VisitorMut` traits over the whole SQL AST, which is what the expression walkers here should eventually become. Statement-level traversal is what unlocks parameter offsetting for statement composition, alias rewriting as a single pass, and seeing into subqueries well enough to drop `ShapeFallback::OpaqueExpression`; expression-level traversal on its own reaches none of them.

## 🛡 What tests cover this?

- Golden compile tests for both keys-first shapes: sort keys across joins, cursor continuation inside the key CTE, embedding-distance queries, carried CTEs, and filter-joined tables staying out of the key projection
- Fallback tests asserting the specific `ShapeFallback` reason plus byte-equality with the single-pass output, covering a generating join on either side of the split and a key-column output-name collision. Neither is reachable through a query path today, so both plant the offending join type or column name directly — the guards are fences against the surrounding structure changing.
- The full `hash-graph-integration` postgres suite (including all sorting/pagination tests) against a migrated database with `KeysFirst` active
- Result-set-equivalence checks (row-set fingerprints) of every measured variant against a 700k-entity seed

## ❓ How to test this?

1. `cargo nextest run --package hash-graph-postgres-store --lib`
2. With a migrated local database: `cargo nextest run --package hash-graph-integration --test postgres`

## 📹 Demo

```sql
WITH "roots" AS (SELECT "entity_ids_0_1_0"."created_at_transaction_time", "entity_temporal_metadata_0_0_0"."entity_uuid", "entity_temporal_metadata_0_0_0"."entity_edition_id"
FROM "entity_temporal_metadata" AS "entity_temporal_metadata_0_0_0"
INNER JOIN "entity_ids" AS "entity_ids_0_1_0" ON ...
WHERE ...),
"limited" AS (SELECT * FROM "roots" ORDER BY "created_at_transaction_time" ASC LIMIT 500)
SELECT DISTINCT ON("limited"."created_at_transaction_time", ...) ..., "entity_editions_1_1_0"."properties"
FROM "limited"
INNER JOIN "entity_editions" AS "entity_editions_1_1_0" ON "entity_editions_1_1_0"."entity_edition_id" = "limited"."entity_edition_id"
ORDER BY "limited"."created_at_transaction_time" ASC LIMIT 500
```
