### PR TITLE
FE-1218: Fix Petrinaut optimization streaming backpressure and cancellation latency

### DIFF
--- a/apps/hash-api/src/petrinaut-optimizer/create-petrinaut-optimization-handler.test.ts
+++ b/apps/hash-api/src/petrinaut-optimizer/create-petrinaut-optimization-handler.test.ts
@@ -59,16 +59,27 @@ const unexpectedFetch = async (): Promise<Response> => {
   throw new Error("Unexpected upstream request");
 };
 
+/** Mutable fake Express response the backpressure tests can drive. */
+type FakeResponse = EventEmitter & ExpressResponse & { destroyed: boolean };
+
 const callHandler = async ({
   authenticated = true,
   body,
   fetchImpl = unexpectedFetch,
+  handler,
   onRequest,
+  onResponse,
+  writeReturns,
 }: {
   authenticated?: boolean;
   body: unknown;
   fetchImpl?: (input: string | URL, init?: RequestInit) => Promise<Response>;
+  /** Reuse one handler across calls to observe its slot bookkeeping. */
+  handler?: ReturnType<typeof createPetrinautOptimizationHandler>;
   onRequest?: (request: EventEmitter) => void;
+  onResponse?: (response: FakeResponse) => void;
+  /** Decide each write's backpressure result; defaults to no backpressure. */
+  writeReturns?: (value: string) => boolean;
 }) => {
   let statusCode = 200;
   let bodyResult: unknown;
@@ -76,14 +87,25 @@ const callHandler = async ({
   const output: string[] = [];
   let headersSent = false;
   let writableEnded = false;
-  const response = Object.assign(new EventEmitter(), {
+  let writableNeedDrain = false;
+  const responseEmitter = new EventEmitter();
+  // `Object.assign` would copy getter *values*, freezing them at `false`.
+  Object.defineProperties(responseEmitter, {
+    headersSent: { get: () => headersSent },
+    writableEnded: { get: () => writableEnded },
+    writableNeedDrain: { get: () => writableNeedDrain },
+  });
+  // Clear the drain flag without registering a listener, so the tests can
+  // assert that the handler leaves no listeners of its own behind.
+  const originalEmit = responseEmitter.emit.bind(responseEmitter);
+  responseEmitter.emit = (eventName: string | symbol, ...args: unknown[]) => {
+    if (eventName === "drain") {
+      writableNeedDrain = false;
+    }
+    return originalEmit(eventName, ...args);
+  };
+  const response = Object.assign(responseEmitter, {
     destroyed: false,
-    get headersSent() {
-      return headersSent;
-    },
-    get writableEnded() {
-      return writableEnded;
-    },
     end: () => {
       writableEnded = true;
     },
@@ -107,26 +129,33 @@ const callHandler = async ({
     write: (value: string) => {
       headersSent = true;
       output.push(value);
-      return true;
+      const flushed = writeReturns?.(value) ?? true;
+      if (!flushed) {
+        writableNeedDrain = true;
+      }
+      return flushed;
     },
-  }) as unknown as ExpressResponse;
+  }) as unknown as FakeResponse;
   const request = Object.assign(new EventEmitter(), {
     body,
     user: authenticated
       ? ({ accountId: "user-1" } as NonNullable<Request["user"]>)
       : undefined,
   }) as unknown as Request;
-  const handler = createPetrinautOptimizationHandler({
-    fetchImpl,
-    logger,
-    origin: new URL("http://petrinaut-opt:4004"),
-  });
+  const activeHandler =
+    handler ??
+    createPetrinautOptimizationHandler({
+      fetchImpl,
+      logger,
+      origin: new URL("http://petrinaut-opt:4004"),
+    });
 
-  const handlerPromise = handler(request, response, () => undefined);
+  const handlerPromise = activeHandler(request, response, () => undefined);
   onRequest?.(request);
+  onResponse?.(response);
   await handlerPromise;
 
-  return { body: bodyResult, headers, output, statusCode };
+  return { body: bodyResult, headers, output, response, statusCode };
 };
 
 describe("createPetrinautOptimizationHandler", () => {
@@ -267,6 +296,240 @@ describe("createPetrinautOptimizationHandler", () => {
     expect(JSON.parse(upstreamRequest?.body ?? "null")).toEqual(
       validOptimizationInput,
     );
+  });
+
+  it("preserves an upstream busy response without a Retry-After header", async () => {
+    const result = await callHandler({
+      body: validOptimizationInput,
+      fetchImpl: async () =>
+        Response.json({ detail: "The optimizer is busy" }, { status: 429 }),
+    });
+
+    expect(result.statusCode).toBe(429);
+    expect(result.body).toEqual({ error: "Petrinaut optimizer is busy" });
+    expect(result.headers).not.toHaveProperty("Retry-After");
+  });
+
+  it("cleans up backpressure listeners and survives a late close", async () => {
+    const unhandledRejections: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) =>
+      unhandledRejections.push(reason);
+    process.on("unhandledRejection", onUnhandledRejection);
+    let activeResponse: FakeResponse | undefined;
+
+    try {
+      const upstream = [
+        'data: {"step":0,"params":{"rate":0.4},"init_state":{},"metric":2,"state":"COMPLETE"}\n\n',
+        'data: {"step":1,"params":{"rate":0.8},"init_state":{},"metric":4,"state":"COMPLETE"}\n\n',
+        "event: done\ndata: {}\n\n",
+      ].join("");
+
+      const result = await callHandler({
+        body: validOptimizationInput,
+        fetchImpl: async () =>
+          new Response(upstream, {
+            headers: { "content-type": "text/event-stream" },
+          }),
+        onResponse: (response) => {
+          activeResponse = response;
+        },
+        writeReturns: (value) => {
+          if (value.includes('"trial":0')) {
+            // Backpressure this write, then let the buffer drain shortly
+            // after the handler has started waiting.
+            setImmediate(() => activeResponse?.emit("drain"));
+            return false;
+          }
+          return true;
+        },
+      });
+
+      expect(result.statusCode).toBe(200);
+      expect(result.output).toHaveLength(4);
+      expect(result.response.listenerCount("drain")).toBe(0);
+      expect(result.response.listenerCount("close")).toBe(0);
+
+      // The response closing after completion must not trip the listener
+      // that lost the earlier drain/close race.
+      result.response.emit("close");
+      await new Promise(setImmediate);
+      expect(unhandledRejections).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onUnhandledRejection);
+    }
+  });
+
+  it("stops a backpressured stream when the client closes and frees the slot", async () => {
+    const handler = createPetrinautOptimizationHandler({
+      fetchImpl: async (_input, init) =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(
+                new TextEncoder().encode(
+                  'data: {"step":0,"params":{"rate":0.4},"init_state":{},"metric":2,"state":"COMPLETE"}\n\n',
+                ),
+              );
+              init?.signal?.addEventListener(
+                "abort",
+                () =>
+                  controller.error(new DOMException("Aborted", "AbortError")),
+                { once: true },
+              );
+            },
+          }),
+          { headers: { "content-type": "text/event-stream" } },
+        ),
+      logger,
+      origin: new URL("http://petrinaut-opt:4004"),
+    });
+    let activeResponse: FakeResponse | undefined;
+
+    const first = await callHandler({
+      body: validOptimizationInput,
+      handler,
+      onResponse: (response) => {
+        activeResponse = response;
+      },
+      writeReturns: (value) => {
+        if (value.includes('"trial":0')) {
+          setImmediate(() => {
+            if (activeResponse) {
+              activeResponse.destroyed = true;
+              activeResponse.emit("close");
+            }
+          });
+          return false;
+        }
+        return true;
+      },
+    });
+
+    expect(first.statusCode).toBe(200);
+    expect(first.response.listenerCount("drain")).toBe(0);
+    expect(first.response.listenerCount("close")).toBe(0);
+
+    // The same user must be admitted again: the slot was released.
+    const second = await callHandler({
+      body: validOptimizationInput,
+      handler,
+      writeReturns: (value) => {
+        if (value.includes('"trial":0')) {
+          setImmediate(() => {
+            activeResponse!.destroyed = true;
+            activeResponse!.emit("close");
+          });
+          return false;
+        }
+        return true;
+      },
+      onResponse: (response) => {
+        activeResponse = response;
+      },
+    });
+    expect(second.statusCode).toBe(200);
+    expect(second.body).toBeUndefined();
+  });
+
+  it("breaks a backpressured wait on timeout instead of holding the slot", async () => {
+    vi.useFakeTimers();
+
+    try {
+      const handler = createPetrinautOptimizationHandler({
+        fetchImpl: async (_input, init) =>
+          new Response(
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.enqueue(
+                  new TextEncoder().encode(
+                    'data: {"step":0,"params":{"rate":0.4},"init_state":{},"metric":2,"state":"COMPLETE"}\n\n',
+                  ),
+                );
+                init?.signal?.addEventListener(
+                  "abort",
+                  () =>
+                    controller.error(new DOMException("Aborted", "AbortError")),
+                  { once: true },
+                );
+              },
+            }),
+            { headers: { "content-type": "text/event-stream" } },
+          ),
+        logger,
+        origin: new URL("http://petrinaut-opt:4004"),
+      });
+
+      const firstPromise = callHandler({
+        body: validOptimizationInput,
+        handler,
+        // The client never drains and never disconnects.
+        writeReturns: (value) => !value.includes('"trial":0'),
+      });
+
+      // The 5 minute idle timeout aborts the stalled stream.
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(5 * 60_000 + 1_000);
+      const first = await firstPromise;
+
+      expect(first.statusCode).toBe(200);
+      expect(first.output.at(-1)).toContain('"code":"optimization_timeout"');
+      expect(first.response.writableEnded).toBe(true);
+      expect(first.response.listenerCount("drain")).toBe(0);
+      expect(first.response.listenerCount("close")).toBe(0);
+      // Heartbeats must not stuff a buffer that already needs draining.
+      expect(first.output.filter((frame) => frame === "\n")).toHaveLength(0);
+
+      // The user slot must be free again after the timeout teardown.
+      const secondPromise = callHandler({
+        body: validOptimizationInput,
+        handler,
+        writeReturns: (value) => !value.includes('"trial":0'),
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(5 * 60_000 + 1_000);
+      const second = await secondPromise;
+      expect(second.statusCode).toBe(200);
+      expect(second.body).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps a single terminal event when a timeout hits the final write", async () => {
+    vi.useFakeTimers();
+
+    try {
+      const upstream = [
+        'data: {"step":0,"params":{"rate":0.4},"init_state":{},"metric":2,"state":"COMPLETE"}\n\n',
+        "event: done\ndata: {}\n\n",
+      ].join("");
+
+      const resultPromise = callHandler({
+        body: validOptimizationInput,
+        fetchImpl: async () =>
+          new Response(upstream, {
+            headers: { "content-type": "text/event-stream" },
+          }),
+        // The final complete event is committed to the buffer, but the
+        // client never drains it before the idle timeout fires.
+        writeReturns: (value) => !value.includes('"type":"complete"'),
+      });
+
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(5 * 60_000 + 1_000);
+      const result = await resultPromise;
+
+      const terminalEvents = result.output.filter(
+        (frame) =>
+          frame.includes('"type":"complete"') ||
+          frame.includes('"type":"error"'),
+      );
+      expect(terminalEvents).toHaveLength(1);
+      expect(terminalEvents[0]).toContain('"type":"complete"');
+      expect(result.response.writableEnded).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("aborts disconnected requests and releases the user slot", async () => {

--- a/apps/hash-api/src/petrinaut-optimizer/create-petrinaut-optimization-handler.ts
+++ b/apps/hash-api/src/petrinaut-optimizer/create-petrinaut-optimization-handler.ts
@@ -111,7 +111,11 @@ const createOptimizationRequestLifecycle = (
       clearTimeout(responseStartTimeout);
       resetIdleTimeout();
       downstreamHeartbeat = setInterval(() => {
-        if (!response.destroyed && !response.writableEnded) {
+        if (
+          !response.destroyed &&
+          !response.writableEnded &&
+          !response.writableNeedDrain
+        ) {
           // Blank NDJSON lines are transport heartbeats, not domain events.
           response.write("\n");
         }
@@ -140,20 +144,54 @@ const summarizeValidationIssues = (
 const writeOptimizationEvent = async (
   response: ExpressResponse,
   event: PetrinautOptimizationEvent,
+  signal: AbortSignal,
 ): Promise<void> => {
   // This is schema-validated NDJSON served with `nosniff`, never HTML.
   // nosemgrep: javascript.express.security.audit.xss.direct-response-write.direct-response-write
-  if (!response.write(`${JSON.stringify(event)}\n`)) {
-    if (response.destroyed || response.writableEnded) {
-      throw new Error("The optimization client disconnected");
-    }
+  if (response.write(`${JSON.stringify(event)}\n`)) {
+    return;
+  }
+  if (response.destroyed || response.writableEnded) {
+    throw new Error("The optimization client disconnected");
+  }
+  if (signal.aborted) {
+    throw new Error("The optimization request was aborted");
+  }
+  // Aborting this controller removes whichever listeners lost the race, so a
+  // backpressured stream cannot accumulate `drain`/`close` listeners and the
+  // loser can never surface a late unhandled rejection.
+  const waitCleanup = new AbortController();
+  try {
     await Promise.race([
-      once(response, "drain"),
-      once(response, "close").then(() => {
+      once(response, "drain", { signal: waitCleanup.signal }),
+      once(response, "close", { signal: waitCleanup.signal }).then(() => {
         throw new Error("The optimization client disconnected");
       }),
+      once(signal, "abort", { signal: waitCleanup.signal }).then(() => {
+        throw new Error("The optimization request was aborted");
+      }),
     ]);
+  } finally {
+    waitCleanup.abort();
   }
+};
+
+/**
+ * Write a final event without waiting for backpressure to clear.
+ *
+ * Teardown must never block on a stalled client, so this write is
+ * best-effort: the response ends immediately afterwards either way.
+ */
+const writeTerminalOptimizationEventBestEffort = (
+  response: ExpressResponse,
+  event: PetrinautOptimizationEvent,
+): void => {
+  if (response.destroyed || response.writableEnded) {
+    return;
+  }
+  // This is schema-validated NDJSON served with `nosniff`, never HTML.
+  // nosemgrep: javascript.express.security.audit.xss.direct-response-write.direct-response-write
+  response.write(`${JSON.stringify(event)}\n`);
 };
 
 /** Forward canonical optimization events as NDJSON. */
@@ -161,12 +199,17 @@ const forwardOptimizationEvents = async (
   events: AsyncIterable<PetrinautOptimizationEvent>,
   response: ExpressResponse,
   markTerminalEvent: () => void,
+  signal: AbortSignal,
 ): Promise<void> => {
   for await (const event of events) {
-    await writeOptimizationEvent(response, event);
+    const backpressureWait = writeOptimizationEvent(response, event, signal);
     if (event.type === "complete" || event.type === "error") {
+      // The write is committed synchronously even when the buffer is full,
+      // so the stream contains its terminal event regardless of how the
+      // backpressure wait settles — an abort must not append a second one.
       markTerminalEvent();
     }
+    await backpressureWait;
   }
 };
 
@@ -258,6 +301,7 @@ export const createPetrinautOptimizationHandler = ({
         upstreamEvents,
         response,
         lifecycle.markTerminalEvent,
+        lifecycle.signal,
       );
       response.end();
     } catch (error) {
@@ -288,7 +332,7 @@ export const createPetrinautOptimizationHandler = ({
       }
       if (!lifecycle.state.terminalEventSent) {
         try {
-          await writeOptimizationEvent(response, {
+          writeTerminalOptimizationEventBestEffort(response, {
             type: "error",
             code: lifecycle.state.timeoutKind
               ? "optimization_timeout"

--- a/apps/petrinaut-opt/openapi/openapi.json
+++ b/apps/petrinaut-opt/openapi/openapi.json
@@ -176,7 +176,15 @@
             "description": "Validation Error"
           },
           "429": {
-            "description": "The service is already at its study limit"
+            "description": "The service is already at its study limit",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds to wait before retrying the study",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           },
           "500": {
             "description": "The CLI or optimization study could not initialize"
@@ -226,7 +234,15 @@
             "description": "Validation Error"
           },
           "429": {
-            "description": "The service is already at its study limit"
+            "description": "The service is already at its study limit",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds to wait before retrying the study",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           },
           "500": {
             "description": "The CLI or optimization study could not initialize"

--- a/apps/petrinaut-opt/src/optimization_api.py
+++ b/apps/petrinaut-opt/src/optimization_api.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 
 import asyncio
 import os
-from collections.abc import AsyncIterator
+import threading
+from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager, suppress
 from pathlib import Path
 from typing import Any
@@ -13,6 +14,7 @@ from typing import Any
 from dotenv import load_dotenv
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
+from starlette.background import BackgroundTask
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from src.petrinaut_client import PetrinautModel
@@ -24,6 +26,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
 load_dotenv(REPO_ROOT / ".env")
 MAX_REQUEST_BODY_BYTES = 8 * 1024 * 1024
 MAX_ACTIVE_OPTIMIZATIONS = 4
+RETRY_AFTER_SECONDS = 30
 _OPTIMIZATION_PATHS = {"/optimize/all", "/optimize/best"}
 _SSE_RESPONSES = {
     200: {
@@ -31,7 +34,15 @@ _SSE_RESPONSES = {
         "content": {"text/event-stream": {"schema": {"type": "string"}}},
     },
     413: {"description": "The optimization manifest exceeds 8 MiB"},
-    429: {"description": "The service is already at its study limit"},
+    429: {
+        "description": "The service is already at its study limit",
+        "headers": {
+            "Retry-After": {
+                "description": "Seconds to wait before retrying the study",
+                "schema": {"type": "string"},
+            },
+        },
+    },
     500: {"description": "The CLI or optimization study could not initialize"},
 }
 
@@ -129,6 +140,7 @@ async def _acquire_optimization_slot(app: FastAPI) -> None:
                 detail=(
                     "The optimizer is already running its maximum number of studies"
                 ),
+                headers={"Retry-After": str(RETRY_AFTER_SECONDS)},
             )
         app.state.active_optimizations += 1
 
@@ -148,26 +160,72 @@ async def _initialize_admitted_optimizer(
     try:
         return await asyncio.shield(initializer)
     except asyncio.CancelledError:
+        # Backstop for a second cancellation racing the recovery below: once
+        # the initializer finishes, close whatever CLI it started even if no
+        # coroutine is left awaiting it. close() is idempotent, so the
+        # awaited recovery close and this callback can coexist.
+        def _close_abandoned_optimizer(task: asyncio.Task[PetrinautOptimizer]) -> None:
+            if task.cancelled() or task.exception() is not None:
+                return
+            threading.Thread(
+                target=task.result().pn_model.close,
+                kwargs={"graceful": False},
+                daemon=True,
+                name="petrinaut-abandoned-cli-close",
+            ).start()
+
+        initializer.add_done_callback(_close_abandoned_optimizer)
         optimizer: PetrinautOptimizer | None = None
         try:
             with suppress(Exception, asyncio.CancelledError):
                 optimizer = await asyncio.shield(initializer)
             if optimizer is not None:
                 with suppress(Exception):
-                    await asyncio.to_thread(optimizer.pn_model.close)
+                    await asyncio.to_thread(
+                        optimizer.pn_model.close, graceful=False
+                    )
         finally:
             await asyncio.shield(_release_optimization_slot(app))
         raise
 
 
-async def _stream_with_admission_slot(
-    app: FastAPI, stream: AsyncIterator[str]
+def _create_admitted_run_cleanup(
+    app: FastAPI, optimizer: PetrinautOptimizer
+) -> Callable[[], Awaitable[None]]:
+    """Build the idempotent teardown for one admitted optimization run.
+
+    The teardown runs from the stream wrapper's ``finally`` on every consumed
+    stream, and again as the response's background task: when a client aborts
+    before the response body is ever pulled, the never-started generators skip
+    their ``finally`` blocks entirely, which would otherwise leak both the
+    admission slot and a live CLI process.
+    """
+    cleaned_up = False
+
+    async def cleanup() -> None:
+        nonlocal cleaned_up
+        if cleaned_up:
+            return
+        cleaned_up = True
+        try:
+            # No-op when the stream already closed the CLI; prompt when the
+            # stream generators never ran at all.
+            with suppress(Exception):
+                await asyncio.to_thread(optimizer.pn_model.close, graceful=False)
+        finally:
+            await _release_optimization_slot(app)
+
+    return cleanup
+
+
+async def _stream_with_cleanup(
+    stream: AsyncIterator[str], cleanup: Callable[[], Awaitable[None]]
 ) -> AsyncIterator[str]:
     try:
         async for frame in stream:
             yield frame
     finally:
-        await asyncio.shield(_release_optimization_slot(app))
+        await asyncio.shield(cleanup())
 
 
 def _initialization_error(app: FastAPI, run_id: str, error: Exception) -> HTTPException:
@@ -214,14 +272,15 @@ async def post_optimize_all(
     except Exception as error:
         if optimizer is not None:
             with suppress(Exception):
-                await asyncio.to_thread(optimizer.pn_model.close)
+                await asyncio.to_thread(optimizer.pn_model.close, graceful=False)
         await asyncio.shield(_release_optimization_slot(request.app))
         raise _initialization_error(request.app, run_id, error) from error
 
+    cleanup = _create_admitted_run_cleanup(request.app, optimizer)
     return StreamingResponse(
-        _stream_with_admission_slot(
-            request.app,
+        _stream_with_cleanup(
             optimizer.stream_all(request, run_id=run_id, n_trials=optimizer.n_trials),
+            cleanup,
         ),
         media_type="text/event-stream",
         headers={
@@ -229,6 +288,7 @@ async def post_optimize_all(
             "X-Accel-Buffering": "no",
             "X-Optimization-Run-ID": run_id,
         },
+        background=BackgroundTask(cleanup),
     )
 
 
@@ -262,14 +322,15 @@ async def post_optimize_best(
     except Exception as error:
         if optimizer is not None:
             with suppress(Exception):
-                await asyncio.to_thread(optimizer.pn_model.close)
+                await asyncio.to_thread(optimizer.pn_model.close, graceful=False)
         await asyncio.shield(_release_optimization_slot(request.app))
         raise _initialization_error(request.app, run_id, error) from error
 
+    cleanup = _create_admitted_run_cleanup(request.app, optimizer)
     return StreamingResponse(
-        _stream_with_admission_slot(
-            request.app,
+        _stream_with_cleanup(
             optimizer.stream_best(request, run_id=run_id, n_trials=optimizer.n_trials),
+            cleanup,
         ),
         media_type="text/event-stream",
         headers={
@@ -277,6 +338,7 @@ async def post_optimize_best(
             "X-Accel-Buffering": "no",
             "X-Optimization-Run-ID": run_id,
         },
+        background=BackgroundTask(cleanup),
     )
 
 

--- a/apps/petrinaut-opt/src/petrinaut_client.py
+++ b/apps/petrinaut-opt/src/petrinaut_client.py
@@ -130,7 +130,7 @@ class PetrinautModel:
             self._process = process
 
         if process.stdin is None or process.stdout is None or process.stderr is None:
-            self.close()
+            self.close(graceful=False)
             raise PetrinautClientError("the Petrinaut CLI pipes are unavailable")
 
         try:
@@ -143,14 +143,14 @@ class PetrinautModel:
                 description="Petrinaut optimization bootstrap",
             ).strip()
         except (BrokenPipeError, OSError, ValueError, PetrinautClientError) as error:
-            self.close()
+            self.close(graceful=False)
             raise PetrinautClientError(
                 "failed to bootstrap the Petrinaut CLI"
             ) from error
 
         if not status.startswith("Petrinaut stdio ready"):
             details = status.strip() or f"process exited with code {process.poll()}"
-            self.close()
+            self.close(graceful=False)
             raise PetrinautClientError(
                 f"Petrinaut failed to load the optimization manifest: {details}"
             )
@@ -268,7 +268,7 @@ class PetrinautModel:
                 description="Petrinaut protocol response",
             )
         except PetrinautProtocolError:
-            self.close()
+            self.close(graceful=False)
             raise
         except (
             BrokenPipeError,
@@ -276,20 +276,20 @@ class PetrinautModel:
             ValueError,
             PetrinautClientError,
         ) as error:
-            self.close()
+            self.close(graceful=False)
             raise PetrinautClientError(
                 "failed to communicate with the Petrinaut CLI"
             ) from error
 
         if not line:
-            self.close()
+            self.close(graceful=False)
             raise PetrinautClientError(
                 f"the Petrinaut CLI exited without a response (code {process.poll()})"
             )
         try:
             return self._parse_response(line, request_id)
         except PetrinautProtocolError:
-            self.close()
+            self.close(graceful=False)
             raise
 
     @staticmethod
@@ -323,7 +323,7 @@ class PetrinautModel:
         """Return the CLI-owned Optuna study and parameter description."""
         result = self._exchange("optimization.describe")
         if not isinstance(result, dict):
-            self.close()
+            self.close(graceful=False)
             raise PetrinautProtocolError(
                 "optimization.describe returned a non-object result"
             )
@@ -336,7 +336,7 @@ class PetrinautModel:
             {"parameterValues": dict(parameter_values)},
         )
         if not isinstance(result, dict):
-            self.close()
+            self.close(graceful=False)
             raise PetrinautProtocolError(
                 "optimization.evaluate returned a non-object result"
             )
@@ -368,8 +368,16 @@ class PetrinautModel:
         else:
             process.kill()
 
-    def close(self) -> None:
-        """Terminate the owned CLI process; safe to call repeatedly."""
+    def close(self, *, graceful: bool = True) -> None:
+        """Terminate the owned CLI process; safe to call repeatedly.
+
+        A busy CLI only observes stdin EOF between protocol requests, so the
+        graceful EOF wait is reserved for shutdowns after a study finished and
+        the CLI is idle. Cancellation, timeouts, and failure paths must pass
+        ``graceful=False`` so the process group is signalled immediately and
+        optimizer capacity is released promptly instead of after the full
+        shutdown timeout.
+        """
         with self._state_lock:
             process = self._process
             self._process = None
@@ -381,19 +389,21 @@ class PetrinautModel:
                 process.stdin.close()
             except (BrokenPipeError, OSError, ValueError):
                 pass
-        if process.poll() is None:
+        if process.poll() is None and graceful:
             try:
                 process.wait(timeout=PROCESS_SHUTDOWN_TIMEOUT_SECONDS)
             except subprocess.TimeoutExpired:
-                self._signal_process(process, signal.SIGTERM)
+                pass
+        if process.poll() is None:
+            self._signal_process(process, signal.SIGTERM)
+            try:
+                process.wait(timeout=PROCESS_SHUTDOWN_TIMEOUT_SECONDS)
+            except subprocess.TimeoutExpired:
+                self._signal_process(process, signal.SIGKILL)
                 try:
                     process.wait(timeout=PROCESS_SHUTDOWN_TIMEOUT_SECONDS)
                 except subprocess.TimeoutExpired:
-                    self._signal_process(process, signal.SIGKILL)
-                    try:
-                        process.wait(timeout=PROCESS_SHUTDOWN_TIMEOUT_SECONDS)
-                    except subprocess.TimeoutExpired:
-                        pass
+                    pass
         for stream in (process.stdout, process.stderr):
             if stream is not None and not stream.closed:
                 try:

--- a/apps/petrinaut-opt/src/petrinaut_optimizer.py
+++ b/apps/petrinaut-opt/src/petrinaut_optimizer.py
@@ -269,6 +269,7 @@ class PetrinautOptimizer:
         worker = threading.Thread(target=run, daemon=True)
         worker.start()
         next_heartbeat = loop.time() + SSE_HEARTBEAT_SECONDS
+        completed = False
 
         try:
             while True:
@@ -299,6 +300,7 @@ class PetrinautOptimizer:
                         phase=Phase.done,
                         detail="optimization completed",
                     )
+                    completed = True
                     yield "event: done\ndata: {}\n\n"
                     break
                 event = cast(dict[str, Any], item)
@@ -315,7 +317,10 @@ class PetrinautOptimizer:
         finally:
             stop_flag.set()
             try:
-                await asyncio.to_thread(self.pn_model.close)
+                # Only a study that ran to completion left the CLI idle enough
+                # for the graceful EOF shutdown; every other exit (disconnect,
+                # error, cancellation) terminates the process group promptly.
+                await asyncio.to_thread(self.pn_model.close, graceful=completed)
                 await asyncio.to_thread(worker.join, _WORKER_SHUTDOWN_TIMEOUT_SECONDS)
                 if worker.is_alive():
                     log.error(
@@ -373,6 +378,7 @@ class PetrinautOptimizer:
         worker = threading.Thread(target=run, daemon=True)
         worker.start()
         next_heartbeat = loop.time() + SSE_HEARTBEAT_SECONDS
+        completed = False
 
         try:
             while True:
@@ -403,6 +409,7 @@ class PetrinautOptimizer:
                         phase=Phase.done,
                         detail="optimization completed",
                     )
+                    completed = True
                     yield "event: done\ndata: {}\n\n"
                     break
                 event = cast(dict[str, Any], item)
@@ -419,7 +426,10 @@ class PetrinautOptimizer:
         finally:
             stop_flag.set()
             try:
-                await asyncio.to_thread(self.pn_model.close)
+                # Only a study that ran to completion left the CLI idle enough
+                # for the graceful EOF shutdown; every other exit (disconnect,
+                # error, cancellation) terminates the process group promptly.
+                await asyncio.to_thread(self.pn_model.close, graceful=completed)
                 await asyncio.to_thread(worker.join, _WORKER_SHUTDOWN_TIMEOUT_SECONDS)
                 if worker.is_alive():
                     log.error(

--- a/apps/petrinaut-opt/tests/test_optimization_api.py
+++ b/apps/petrinaut-opt/tests/test_optimization_api.py
@@ -195,12 +195,39 @@ def test_rejects_studies_above_the_process_local_limit(
         response = client.post("/optimize/all", json=optimization_manifest)
 
     assert response.status_code == 429
+    assert response.headers["retry-after"] == str(optimization_api.RETRY_AFTER_SECONDS)
+
+
+class RecordingModel:
+    """Track how the CLI adapter is shut down."""
+
+    def __init__(self) -> None:
+        self.close_calls: list[bool] = []
+
+    def close(self, *, graceful: bool = True) -> None:
+        self.close_calls.append(graceful)
+
+
+def _admitted_test_app(active_optimizations: int) -> FastAPI:
+    test_app = FastAPI()
+    test_app.state.optimization_admission_lock = asyncio.Lock()
+    test_app.state.active_optimizations = active_optimizations
+    return test_app
+
+
+def _optimizer_with_recording_model() -> FakeOptimizer:
+    optimizer = FakeOptimizer()
+    optimizer.pn_model = RecordingModel()  # type: ignore[attr-defined]
+    return optimizer
 
 
 def test_releases_admission_slot_when_a_stream_fails() -> None:
-    test_app = FastAPI()
-    test_app.state.optimization_admission_lock = asyncio.Lock()
-    test_app.state.active_optimizations = 1
+    test_app = _admitted_test_app(active_optimizations=1)
+    optimizer = _optimizer_with_recording_model()
+    cleanup = optimization_api._create_admitted_run_cleanup(
+        test_app,
+        optimizer,  # type: ignore[arg-type]
+    )
 
     async def failing_stream():
         raise RuntimeError("stream failed")
@@ -208,14 +235,73 @@ def test_releases_admission_slot_when_a_stream_fails() -> None:
 
     async def consume() -> None:
         with pytest.raises(RuntimeError, match="stream failed"):
-            async for _frame in optimization_api._stream_with_admission_slot(
-                test_app, failing_stream()
+            async for _frame in optimization_api._stream_with_cleanup(
+                failing_stream(), cleanup
             ):
                 pass
 
     asyncio.run(consume())
 
     assert test_app.state.active_optimizations == 0
+    assert optimizer.pn_model.close_calls == [False]  # type: ignore[attr-defined]
+
+
+def test_admitted_run_cleanup_releases_the_slot_exactly_once() -> None:
+    test_app = _admitted_test_app(active_optimizations=1)
+    optimizer = _optimizer_with_recording_model()
+    cleanup = optimization_api._create_admitted_run_cleanup(
+        test_app,
+        optimizer,  # type: ignore[arg-type]
+    )
+
+    async def run_twice() -> None:
+        await cleanup()
+        await cleanup()
+
+    asyncio.run(run_twice())
+
+    assert test_app.state.active_optimizations == 0
+    assert optimizer.pn_model.close_calls == [False]  # type: ignore[attr-defined]
+
+
+def test_background_cleanup_covers_a_stream_that_never_starts(
+    optimization_manifest: dict,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An aborted response may never pull the body, skipping generator finallys."""
+    optimizer = _optimizer_with_recording_model()
+    monkeypatch.setattr(
+        optimization_api, "initialize_optimizer", lambda _manifest: optimizer
+    )
+
+    async def abandon_response() -> None:
+        test_app = optimization_api.app
+        test_app.state.statuses = optimization_api.StatusStore()
+        test_app.state.optimization_admission_lock = asyncio.Lock()
+        test_app.state.active_optimizations = 0
+        scope = {
+            "type": "http",
+            "app": test_app,
+            "method": "POST",
+            "path": "/optimize/all",
+            "headers": [],
+            "query_string": b"",
+        }
+        request = optimization_api.Request(scope)
+        response = await optimization_api.post_optimize_all(
+            request, optimization_manifest
+        )
+
+        assert test_app.state.active_optimizations == 1
+        assert response.background is not None
+        # The client is gone before the body iterator is ever started; only
+        # the background task remains to release the slot and the CLI.
+        await response.background()
+        assert test_app.state.active_optimizations == 0
+
+    asyncio.run(abandon_response())
+
+    assert optimizer.pn_model.close_calls == [False]  # type: ignore[attr-defined]
 
 
 def test_cancellation_during_initialization_closes_cli_and_releases_slot(
@@ -231,7 +317,8 @@ def test_cancellation_during_initialization_closes_cli_and_releases_slot(
     class ClosableModel:
         closed = False
 
-        def close(self) -> None:
+        def close(self, *, graceful: bool = True) -> None:
+            assert graceful is False
             self.closed = True
 
     optimizer = FakeOptimizer()
@@ -259,6 +346,50 @@ def test_cancellation_during_initialization_closes_cli_and_releases_slot(
     asyncio.run(cancel_initialization())
 
     assert optimizer.pn_model.closed is True  # type: ignore[attr-defined]
+    assert test_app.state.active_optimizations == 0
+
+
+def test_second_cancellation_still_closes_an_abandoned_cli(
+    optimization_manifest: dict,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cancel racing the init-cancel recovery must not orphan the CLI."""
+    test_app = _admitted_test_app(active_optimizations=1)
+    optimizer = _optimizer_with_recording_model()
+    started = threading.Event()
+    finish = threading.Event()
+
+    def initialize(_manifest: dict[str, Any]) -> FakeOptimizer:
+        started.set()
+        finish.wait(timeout=2)
+        return optimizer
+
+    monkeypatch.setattr(optimization_api, "initialize_optimizer", initialize)
+
+    async def cancel_twice() -> None:
+        task = asyncio.create_task(
+            optimization_api._initialize_admitted_optimizer(
+                test_app, optimization_manifest
+            )
+        )
+        await asyncio.to_thread(started.wait, 1)
+        task.cancel()
+        # Let the task enter its recovery await before cancelling again.
+        await asyncio.sleep(0.05)
+        task.cancel()
+        finish.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        # The abandoned CLI is closed by the initializer's done-callback,
+        # which hands off to a daemon thread.
+        for _ in range(100):
+            if optimizer.pn_model.close_calls:  # type: ignore[attr-defined]
+                return
+            await asyncio.sleep(0.01)
+
+    asyncio.run(cancel_twice())
+
+    assert optimizer.pn_model.close_calls == [False]  # type: ignore[attr-defined]
     assert test_app.state.active_optimizations == 0
 
 

--- a/apps/petrinaut-opt/tests/test_petrinaut_client.py
+++ b/apps/petrinaut-opt/tests/test_petrinaut_client.py
@@ -241,6 +241,63 @@ def test_close_signals_the_isolated_process_group(
     ]
 
 
+def test_prompt_close_signals_the_group_before_any_shutdown_wait(
+    optimization_manifest: dict,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = FakeProcess([])
+    process.pid = 12345
+    events: list[str] = []
+
+    def wait(*, timeout: float | None = None) -> int:
+        events.append("wait")
+        process.returncode = -signal.SIGTERM
+        return process.returncode
+
+    process.wait = wait  # type: ignore[method-assign]
+    monkeypatch.setattr(
+        petrinaut_client.os,
+        "killpg",
+        lambda _pid, sent_signal: events.append(
+            f"killpg:{signal.Signals(sent_signal).name}"
+        ),
+    )
+    model = PetrinautModel(
+        optimization_manifest,
+        popen_factory=lambda *_args, **_kwargs: process,
+    )
+    model.start()
+
+    model.close(graceful=False)
+
+    assert events == ["killpg:SIGTERM", "wait"]
+
+
+def test_prompt_close_terminates_a_busy_process_quickly(
+    optimization_manifest: dict,
+) -> None:
+    """A mid-trial CLI never notices stdin EOF, so cancellation must signal."""
+    script = """
+import sys
+import time
+sys.stdin.readline()
+sys.stderr.write("Petrinaut stdio ready for optimization\\n")
+sys.stderr.flush()
+while True:
+    time.sleep(0.1)
+"""
+    model = PetrinautModel(
+        optimization_manifest,
+        command=(sys.executable, "-c", script),
+    )
+    model.start()
+
+    started_at = time.monotonic()
+    model.close(graceful=False)
+
+    assert time.monotonic() - started_at < 2
+
+
 def test_cli_error_during_evaluation_is_recoverable(
     optimization_manifest: dict,
 ) -> None:

--- a/apps/petrinaut-opt/tests/test_petrinaut_optimizer.py
+++ b/apps/petrinaut-opt/tests/test_petrinaut_optimizer.py
@@ -23,6 +23,7 @@ class FakeModel:
         self.description = description
         self.evaluations: list[dict[str, Any]] = []
         self.closed = False
+        self.close_calls: list[bool] = []
 
     def describe_optimization(self) -> dict[str, Any]:
         return self.description
@@ -35,8 +36,9 @@ class FakeModel:
             + int(parameter_values["enabled"])
         )
 
-    def close(self) -> None:
+    def close(self, *, graceful: bool = True) -> None:
         self.closed = True
+        self.close_calls.append(graceful)
 
 
 class SlowModel(FakeModel):
@@ -241,6 +243,7 @@ def test_stream_all_preserves_the_existing_sse_frame_shape(
         set(payload["params"]) == {"rate", "count", "enabled"} for payload in data
     )
     assert model.closed is True
+    assert model.close_calls == [True]
 
 
 def test_stream_best_preserves_the_existing_sse_frame_shape(
@@ -272,6 +275,7 @@ def test_stream_best_preserves_the_existing_sse_frame_shape(
     assert all(payload["state"] == "COMPLETE" for payload in data)
     assert all(payload["init_state"] == {} for payload in data)
     assert model.closed is True
+    assert model.close_calls == [True]
 
 
 def test_stream_sends_comment_heartbeats_while_a_trial_is_running(
@@ -336,6 +340,7 @@ def test_stream_error_is_terminal_and_is_not_followed_by_done(
     assert status is not None
     assert status.phase is Phase.error
     assert model.closed is True
+    assert model.close_calls == [False]
 
 
 def test_disconnect_closes_cli_before_a_bounded_worker_join(
@@ -369,5 +374,6 @@ def test_disconnect_closes_cli_before_a_bounded_worker_join(
 
     assert frames == []
     assert model.closed is True
+    assert model.close_calls == [False]
     assert status is not None
     assert status.phase is Phase.idle

--- a/libs/@local/petrinaut-optimizer-client/src/open-optimization-stream.test.ts
+++ b/libs/@local/petrinaut-optimizer-client/src/open-optimization-stream.test.ts
@@ -96,6 +96,41 @@ describe("openPetrinautOptimizationStream", () => {
     });
   });
 
+  it("preserves the busy status and Retry-After of an optimizer 429", async () => {
+    const result = openPetrinautOptimizationStream({
+      endpoint: "/optimize/all",
+      fetchImpl: async () =>
+        Response.json(
+          {
+            detail:
+              "The optimizer is already running its maximum number of studies",
+          },
+          { status: 429, headers: { "retry-after": "30" } },
+        ),
+      input,
+    });
+
+    await expect(result).rejects.toBeInstanceOf(PetrinautOptimizerHttpError);
+    await expect(result).rejects.toMatchObject({
+      message: "The optimizer is already running its maximum number of studies",
+      retryAfter: "30",
+      status: 429,
+    });
+  });
+
+  it("reports a null Retry-After when the optimizer 429 omits the header", async () => {
+    const result = openPetrinautOptimizationStream({
+      endpoint: "/optimize/all",
+      fetchImpl: async () => Response.json({ detail: "busy" }, { status: 429 }),
+      input,
+    });
+
+    await expect(result).rejects.toMatchObject({
+      retryAfter: null,
+      status: 429,
+    });
+  });
+
   it("falls back to the upstream status for an unstructured error", async () => {
     await expect(
       openPetrinautOptimizationStream({

--- a/libs/@local/petrinaut-optimizer-client/src/openapi.gen.ts
+++ b/libs/@local/petrinaut-optimizer-client/src/openapi.gen.ts
@@ -216,6 +216,8 @@ export interface operations {
       /** @description The service is already at its study limit */
       429: {
         headers: {
+          /** @description Seconds to wait before retrying the study */
+          "Retry-After"?: string;
           [name: string]: unknown;
         };
         content?: never;
@@ -272,6 +274,8 @@ export interface operations {
       /** @description The service is already at its study limit */
       429: {
         headers: {
+          /** @description Seconds to wait before retrying the study */
+          "Retry-After"?: string;
           [name: string]: unknown;
         };
         content?: never;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Hardens the Petrinaut optimization streaming and cancellation path from #9040 so a slow or disconnecting client cannot leak NodeAPI listeners, promises, or optimizer capacity, and so cancelling a busy study terminates its CLI promptly. Also restores and regression-tests propagation of the optimizer's `429` / `Retry-After` through NodeAPI.

## 🔗 Related links

- [FE-1218](https://linear.app/hash/issue/FE-1218) — this issue
- [FE-1217](https://linear.app/hash/issue/FE-1217) — parent hardening issue
- [Review: orphaned close rejection after drain](https://github.com/hashintel/hash/pull/9040#discussion_r3607302778)
- [Review: cancel delays CLI kill five seconds](https://github.com/hashintel/hash/pull/9040#discussion_r3607246228)
- [Review: upstream 429 becomes gateway error](https://github.com/hashintel/hash/pull/9040#discussion_r3607246229)

## 🔍 What does this change?

- NodeAPI (`create-petrinaut-optimization-handler.ts`): races the backpressure wait against `drain`, `close`, and the request abort signal, removing the losing listeners via an internal `AbortController` — no accumulated listeners, no orphaned rejected promise, no slot held past the timeouts.
- Marks a terminal event as committed at write hand-off, so a timeout during the final backpressured write cannot append a second, contradictory terminal event; the failure-path terminal write is best-effort and never blocks teardown; heartbeats skip while the buffer needs draining.
- Optimizer (`petrinaut_client.py`): `close(graceful=False)` signals the CLI process group immediately instead of waiting up to 5s for stdin EOF a mid-trial CLI never observes; the graceful EOF wait is reserved for studies that completed normally. An idempotent per-run cleanup shared between the stream wrapper and a `StreamingResponse` background task covers a client that aborts before the body is pulled.
- Optimizer emits `Retry-After` on the `429` study-limit response (declared in the OpenAPI spec); the client preserves status + `Retry-After`, and NodeAPI passes them through.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

- This does not, by itself, fix the intermittent staging `network error` on long optimization streams — the evidence points to a max-connection-duration reset at an intermediate proxy/LB, upstream of NodeAPI. This PR removes NodeAPI as a suspect and guarantees a downstream reset frees capacity and kills the CLI promptly; the confirming logs land in #9059.

## 🛡 What tests cover this?

New/updated unit tests in `apps/hash-api`, `apps/petrinaut-opt`, and `@local/petrinaut-optimizer-client` covering: drain-first, close-first, client abort, idle timeout during backpressure, single-terminal-event, heartbeat suppression under backpressure, prompt process-group termination (fake and real subprocess), slot released exactly once (including never-started stream generators and double cancellation), and `429` / `Retry-After` propagation end to end.

## ❓ How to test this?

1. `cd apps/petrinaut-opt && uv run pytest`
2. `turbo run test:unit --filter '@apps/hash-api' --filter '@local/petrinaut-optimizer-client'`
3. Confirm the streaming/cancellation and 429 suites pass.
