### PR TITLE
FE-1220: Harden and document Petrinaut optimization execution isolation

### DIFF
--- a/apps/petrinaut-opt/README.md
+++ b/apps/petrinaut-opt/README.md
@@ -214,6 +214,20 @@ Bootstrap lives in `src/telemetry.py` and runs once when the app is created. A
 misconfigured collector is logged and swallowed so it never stops the API from
 serving.
 
+## Security and isolation
+
+The execution path, its trust boundaries, per-layer mitigations, required
+deployment configuration, and the V8-sandbox decision are documented in
+[`docs/threat-model.md`](./docs/threat-model.md).
+
+Isolation-related environment variables (all optional):
+
+| Variable                               | Default      | Meaning                                                                                                                                                                                                                                     |
+| -------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `HASH_PETRINAUT_OPT_CLI_CPU_SECONDS`   | `900`        | `RLIMIT_CPU` applied to each CLI process (Linux only); `0` disables.                                                                                                                                                                        |
+| `HASH_PETRINAUT_OPT_CLI_MEMORY_BYTES`  | `2147483648` | `RLIMIT_AS` applied to each CLI process (Linux only); `0` disables. This — not the Node heap cap — is the resident-memory bound per CLI.                                                                                                    |
+| `HASH_PETRINAUT_OPT_CLI_MAX_PROCESSES` | `256`        | `RLIMIT_NPROC` set on each CLI process (Linux only); `0` disables. Linux checks it against the real UID's **total** task count (uvicorn, tini, and all concurrent CLIs share the `petrinaut` user), so size it against total service tasks. |
+
 ## Development
 
 From `apps/petrinaut-opt`:

--- a/apps/petrinaut-opt/docker/Dockerfile
+++ b/apps/petrinaut-opt/docker/Dockerfile
@@ -95,6 +95,12 @@ ENV PATH="/opt/venv/bin:${PATH}" \
 
 WORKDIR /app
 
+# tini reaps any CLI descendants that outlive their process group; uvicorn as
+# PID 1 would leave them as zombies.
+RUN apt-get update && \
+    apt-get install --yes --no-install-recommends tini && \
+    rm -rf /var/lib/apt/lists/*
+
 # Node is the only runtime from the Node image needed by the compiled CLI.
 COPY --from=node-runtime /usr/local/bin/node /usr/local/bin/node
 COPY --from=python-deps /opt/venv /opt/venv
@@ -117,5 +123,7 @@ EXPOSE 4004
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=5 \
     CMD ["python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:4004/health', timeout=4).close()"]
+
+ENTRYPOINT ["tini", "--"]
 
 CMD ["python", "-m", "uvicorn", "src.optimization_api:app", "--host", "0.0.0.0", "--port", "4004"]

--- a/apps/petrinaut-opt/docs/threat-model.md
+++ b/apps/petrinaut-opt/docs/threat-model.md
@@ -1,0 +1,173 @@
+# Petrinaut optimization execution: threat model and isolation
+
+This document threat-models the Petrinaut optimization execution path and
+records the isolation properties each layer provides, what still relies on
+deployment configuration outside this repository, and why an additional V8
+sandbox is currently not required.
+
+## Execution path
+
+```text
+HASH client
+  │  POST   /api/petrinaut-optimizer/optimize/runs   (create → run id)
+  │  GET    …/optimize/runs/{id}/events?cursor=N     (attach / re-attach)
+  │  DELETE …/optimize/runs/{id}                     (explicit cancel)
+  │  all authenticated and rate-limited
+  ▼
+NodeAPI (apps/hash-api) — stateless proxy
+  │  proxies the same three routes, forwards the caller's account as
+  │  `x-hash-account-id`, and converts the optimizer's SSE to NDJSON
+  ▼
+Petrinaut Optimizer (apps/petrinaut-opt, FastAPI + Optuna)
+  │  a run is detached: it outlives the connection that created it
+  │  spawn `petrinaut serve --optimization-stdin --stdio`
+  │  JSON-lines over stdin/stdout, one CLI process per study
+  ▼
+Petrinaut CLI (libs/@hashintel/petrinaut-cli, Node)
+     compiles and runs the embedded model; executes manifest-authored
+     code (metrics/dynamics via the restricted HIR pipeline; scenario
+     expressions via sandboxed `new Function` until the Scenario HIR
+     lands, see FE-1219)
+```
+
+Because runs are detached, losing a connection no longer ends a study. A run
+ends only when it completes, is cancelled, exceeds its wall-clock ceiling, or
+is reclaimed after the detach-grace period with no consumer attached — which
+is what bounds slot occupancy in the tables below.
+
+## Attacker model
+
+The primary attacker is an **authenticated HASH user submitting a malicious
+optimization manifest**. The manifest embeds a full model snapshot including
+code strings that the CLI ultimately executes. Secondary concerns are a
+compromised or buggy client holding streams open, and lateral movement from a
+compromised CLI process.
+
+Assets to protect:
+
+- the NodeAPI process and its credentials (database, Kratos/Hydra, vault);
+- the optimizer service's availability (4 concurrent studies per instance);
+- other tenants' data — nothing tenant-specific is mounted into the optimizer
+  container, so this reduces to protecting the host and network;
+- the host and cluster the containers run on.
+
+## Threats and mitigations by layer
+
+### NodeAPI (`apps/hash-api/src/petrinaut-optimizer/`)
+
+| Threat                                  | Mitigation                                                                                                                                                                                                                                                                                        |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Unauthenticated access                  | Global auth middleware; handler returns 401 without `request.user`.                                                                                                                                                                                                                               |
+| Request flooding                        | `express-rate-limit` 10/min per account or IP on create/cancel, with a separate 60/min bucket for re-attaches (429 + `Retry-After`). Per-account single-flight and the concurrent-study cap are enforced upstream by the optimizer (below), not here.                                             |
+| Oversized payloads                      | 8 MiB serialized-body cap (413).                                                                                                                                                                                                                                                                  |
+| Malformed manifests                     | Strict zod manifest schema (`petrinautOptimizationManifestSchema`) with bounded work limits (≤ 100k steps/trial, ≤ 5M total steps, ≤ 1k trials).                                                                                                                                                  |
+| Stalled clients holding proxy resources | Response-start (30 s), idle (5 min), and overall (15 min) deadlines end one **attachment**; the backpressure wait is bound to the same abort signal. Ending an attachment no longer ends the run, so study-slot occupancy is bounded by the optimizer's ceiling and detach-grace reaping instead. |
+
+### Optimizer service (`apps/petrinaut-opt`)
+
+| Threat                              | Mitigation                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Oversized manifests                 | ASGI middleware caps bodies at 8 MiB, including chunked transfer.                                                                                                                                                                                                                                                                                                                                                                                                         |
+| Study-slot exhaustion               | Admission cap of 4 concurrent studies plus per-account single-flight, both keyed on the `x-hash-account-id` the proxy forwards (429 + `Retry-After`). A slot is held for the run's lifetime and released by an idempotent cleanup on completion, cancellation, ceiling expiry, or detach-grace reaping (`HASH_PETRINAUT_OPT_DETACH_GRACE_SECONDS`, default 300 s with no consumer attached).                                                                              |
+| Cross-account access to a run       | Attach and cancel resolve a run only within the caller's account tag; a run belonging to another account answers 404 rather than revealing its existence. A second attachment supersedes the first (terminal `event: superseded`) so a stolen cursor cannot silently shadow the owner's stream.                                                                                                                                                                           |
+| Runaway studies                     | Per-response protocol read timeout (240 s), bootstrap timeout (25 s), a hard cap of 1,000 trials per description, and a study wall-clock ceiling (`HASH_PETRINAUT_OPT_MAX_STUDY_SECONDS`, default 900 s) that terminates the run and its CLI.                                                                                                                                                                                                                             |
+| Credential exposure to model code   | The CLI child environment is an allowlist (`PATH`, `LANG`, `LC_ALL`, `NO_COLOR`, `TZ`, plus `PETRINAUT_CLI_NODE_OPTIONS` → `NODE_OPTIONS`); parent credentials are never forwarded.                                                                                                                                                                                                                                                                                       |
+| Surviving subprocesses              | The CLI is spawned with `start_new_session=True` (own session/process group). Cancellation and timeouts signal the **whole group** immediately (`SIGTERM` → `SIGKILL`); every close path ends with a `SIGKILL` sweep of the group, so descendants that remain in the CLI's session/process group cannot outlive the study. `tini` runs as PID 1 to reap orphans once they exit. A descendant that calls `setsid()`/`setpgid()` escapes the sweep (see limitations below). |
+| CPU / memory exhaustion by the CLI  | `resource.prlimit` (Linux) bounds the CLI process: `RLIMIT_CPU` (`HASH_PETRINAUT_OPT_CLI_CPU_SECONDS`, default 900 s), `RLIMIT_AS` (`HASH_PETRINAUT_OPT_CLI_MEMORY_BYTES`, default 2 GiB), `RLIMIT_NPROC` (`HASH_PETRINAUT_OPT_CLI_MAX_PROCESSES`, default 256, a per-real-UID fork-bomb bound — see limitations below). Node's `--max-old-space-size=768` additionally caps the V8 heap (but not `ArrayBuffer`/native allocations — `RLIMIT_AS` is the resident bound).  |
+| Protocol abuse by a compromised CLI | 8 MiB protocol line cap, id-matched responses, strict response validation; protocol violations tear the study down promptly.                                                                                                                                                                                                                                                                                                                                              |
+
+Known limitations at this layer:
+
+- `prlimit` is applied from the parent immediately after spawn, so the child
+  runs unbounded for microseconds; container-level limits are the backstop.
+- The group `SIGKILL` sweep runs after the group leader is reaped; the pgid
+  could in principle be recycled in that window. Inside the container's pid
+  namespace this is negligible, and the sweep ignores `PermissionError`.
+- The group sweep only reaches descendants still in the CLI's process group:
+  one that calls `setsid()`/`setpgid()` escapes it and runs until its
+  inherited `RLIMIT_CPU` or the container's `pidsLimit`/teardown stops it
+  (`tini` reaps it only once it exits, it does not kill live orphans).
+  Manifest-authored JS cannot spawn processes at all (`--permission` without
+  `--allow-child-process`/`--allow-worker`), so this applies only after a
+  native permission-model escape.
+- `RLIMIT_NPROC` is checked against the **real UID's total task count**
+  (processes and threads) — shared by uvicorn, tini, and all concurrent CLIs,
+  which all run as `petrinaut` — not against one CLI's own descendants. Size
+  it against total service tasks; a fork bomb in one study is contained but
+  can starve sibling studies' thread creation (contained cross-study DoS),
+  for which the container-level `pidsLimit` is the backstop.
+- The in-memory admission counter is per-instance; running multiple optimizer
+  replicas multiplies the effective study limit.
+- `/status` is unauthenticated and enumerates run ids and phases (no user
+  data). It must not be exposed outside the service network.
+
+### Petrinaut CLI (container + process posture)
+
+| Threat                                  | Mitigation                                                                                                                                                                                                                                                                                                                                                  |
+| --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Filesystem access from model code       | Node permission model: `--permission --allow-fs-read=/opt/petrinaut-cli --allow-fs-read=/usr/local/bin/petrinaut` — reads restricted to the CLI's own tree, **no** filesystem write permission granted; `--no-addons` blocks native modules; `--no-global-search-paths` and `--disable-proto=throw` reduce ambient surface.                                 |
+| Privilege escalation                    | Dedicated non-root `petrinaut` system user; `umask 0o077` on the child.                                                                                                                                                                                                                                                                                     |
+| Arbitrary code execution from manifests | Model metrics, dynamics, lambdas, and kernels are compiled through the restricted HIR pipeline (TypeScript-lowered, typechecked, compiler-emitted). Scenario parameter overrides and initial-state expressions still execute via `new Function` behind a best-effort sandbox — this is the remaining raw-code path that the Scenario HIR (FE-1219) removes. |
+| Network egress from model code          | **Not restricted by the Node permission model.** Until the Scenario HIR lands, egress control relies on deployment-level network policy (see below).                                                                                                                                                                                                        |
+
+## Required deployment configuration (outside this repository)
+
+ECS task definitions for `petrinaut-opt` live outside this repository. The
+following settings are required for the isolation model to hold and must be
+captured there:
+
+1. `readonlyRootFilesystem: true` — the image is compatible (the service
+   writes nothing; run locally with `docker run --read-only`). Provide a
+   tmpfs mount for `/tmp` if Node requires it.
+2. Task-level CPU and memory limits sized for up to 4 concurrent studies.
+   Each CLI's resident memory is bounded only by `RLIMIT_AS`
+   (`HASH_PETRINAUT_OPT_CLI_MEMORY_BYTES`, default 2 GiB) —
+   `--max-old-space-size` caps only the V8 heap, not `ArrayBuffer`/native
+   allocations — so size task memory at roughly _concurrent studies ×
+   `RLIMIT_AS`_ plus the service's own footprint, or lower
+   `HASH_PETRINAUT_OPT_CLI_MEMORY_BYTES` so four times the limit fits the
+   task.
+3. An egress security group that denies all outbound traffic except any
+   destinations the service itself requires (it requires none today) — this
+   is the only network-level control on manifest-authored code until the
+   Scenario HIR removes raw execution.
+4. `pidsLimit` (or equivalent) as a container-level backstop to
+   `RLIMIT_NPROC`.
+5. No credentials or secrets in the task environment beyond what the service
+   itself needs (it needs none today); the CLI child never inherits them
+   regardless, but defence in depth applies.
+
+## Decision: no additional V8 sandbox for now
+
+We considered wrapping manifest-authored code in a dedicated V8 isolate
+sandbox (e.g. `isolated-vm`) or a separate JS runtime. Decision: **not now**,
+because:
+
+1. The hot code surfaces (metrics, dynamics, lambdas, kernels) already run
+   through the restricted HIR compiler — only compiler-emitted source is
+   instantiated, and code that cannot be lowered fails compilation.
+2. The remaining raw surface (scenario expressions) is being replaced by the
+   Scenario HIR (FE-1219), which removes unrestricted `new Function`
+   execution entirely rather than containing it.
+3. The CLI already runs as an isolated, non-root, allowlist-environment,
+   fs-read-restricted, resource-limited, promptly-killable process inside a
+   dedicated container — a compromised CLI has no credentials, no writable
+   filesystem beyond tmpfs, and (with the required egress policy) no network.
+4. `isolated-vm`-style sandboxes require native addons, which the CLI
+   deliberately blocks (`--no-addons`), and they carry their own maintenance
+   and escape-surface costs.
+
+Revisit this decision if raw user-authored JavaScript execution is ever
+reintroduced on the server path, or if the CLI gains network-dependent
+features that preclude a deny-all egress policy.
+
+## Residual risks
+
+- Scenario expressions execute as raw JavaScript in the CLI process until
+  FE-1219 lands (bounded by the container, user, filesystem, resource-limit,
+  and network layers above).
+- Network egress from the CLI is unconstrained until the deployment-level
+  egress policy is applied.
+- Per-instance admission limits do not aggregate across replicas.
+- A malicious manifest can still burn its full CPU/wall-clock allowance per
+  study (bounded denial of service within the admission cap).

--- a/apps/petrinaut-opt/src/petrinaut_client.py
+++ b/apps/petrinaut-opt/src/petrinaut_client.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import math
 import os
 import select
@@ -14,13 +15,74 @@ import time
 from collections.abc import Callable, Mapping, Sequence
 from typing import Any
 
+try:
+    import resource
+except ImportError:  # pragma: no cover - resource is Unix-only
+    resource = None  # type: ignore[assignment]
+
+
+log = logging.getLogger("pn_client")
 
 MAX_MANIFEST_BYTES = 8 * 1024 * 1024
 MAX_PROTOCOL_LINE_BYTES = 8 * 1024 * 1024
 BOOTSTRAP_TIMEOUT_SECONDS = 25
 PROTOCOL_READ_TIMEOUT_SECONDS = 240
 PROCESS_SHUTDOWN_TIMEOUT_SECONDS = 5
+DEFAULT_CLI_CPU_SECONDS = 900
+DEFAULT_CLI_MEMORY_BYTES = 2 * 1024 * 1024 * 1024
+DEFAULT_CLI_MAX_PROCESSES = 256
 _STDERR_DRAIN_CHUNK_BYTES = 64 * 1024
+
+
+def _limit_from_environment(name: str, default: int) -> int:
+    """Read one non-negative integer limit; zero disables the limit."""
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        log.warning("ignoring non-integer %s=%r", name, raw)
+        return default
+    return max(0, value)
+
+
+def _apply_child_resource_limits(process_id: int) -> None:
+    """Bound the CLI's CPU time, address space, and process count.
+
+    Uses ``resource.prlimit`` (Linux only) so the limits are applied from the
+    parent without a fork-unsafe ``preexec_fn``. The child runs unbounded for
+    the instants before this call; container-level limits remain the outer
+    backstop. On platforms without ``prlimit`` (e.g. macOS development) the
+    limits are skipped. Note that Linux checks ``RLIMIT_NPROC`` against the
+    real UID's total task count — shared by every process of the service
+    user — not against this child's own descendants.
+    """
+    prlimit = getattr(resource, "prlimit", None) if resource is not None else None
+    if prlimit is None:
+        return
+    limits = (
+        ("RLIMIT_CPU", "HASH_PETRINAUT_OPT_CLI_CPU_SECONDS", DEFAULT_CLI_CPU_SECONDS),
+        ("RLIMIT_AS", "HASH_PETRINAUT_OPT_CLI_MEMORY_BYTES", DEFAULT_CLI_MEMORY_BYTES),
+        (
+            "RLIMIT_NPROC",
+            "HASH_PETRINAUT_OPT_CLI_MAX_PROCESSES",
+            DEFAULT_CLI_MAX_PROCESSES,
+        ),
+    )
+    for limit_name, environment_name, default in limits:
+        value = _limit_from_environment(environment_name, default)
+        if value <= 0:
+            continue
+        try:
+            prlimit(process_id, getattr(resource, limit_name), (value, value))
+        except (OSError, ValueError) as error:
+            log.warning(
+                "could not apply %s=%d to the Petrinaut CLI: %s",
+                limit_name,
+                value,
+                error,
+            )
 
 
 def _child_environment() -> dict[str, str]:
@@ -128,6 +190,9 @@ class PetrinautModel:
                     f"failed to start the Petrinaut CLI: {error}"
                 ) from error
             self._process = process
+
+        if isinstance(process, subprocess.Popen):
+            _apply_child_resource_limits(process.pid)
 
         if process.stdin is None or process.stdout is None or process.stderr is None:
             self.close(graceful=False)
@@ -368,6 +433,25 @@ class PetrinautModel:
         else:
             process.kill()
 
+    @staticmethod
+    def _sweep_process_group(process: Any) -> None:
+        """Kill any CLI descendants that outlived the CLI process itself.
+
+        The graceful shutdown path never signals the group, and the escalation
+        path stops once the group leader exits, so grandchildren that ignored
+        or never received a signal would otherwise survive and reparent to
+        PID 1. Only real child processes are swept — signalling an arbitrary
+        test-double pid would hit unrelated processes.
+        """
+        if not isinstance(process, subprocess.Popen):
+            return
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError):
+            pass
+        except OSError:
+            pass
+
     def close(self, *, graceful: bool = True) -> None:
         """Terminate the owned CLI process; safe to call repeatedly.
 
@@ -404,6 +488,7 @@ class PetrinautModel:
                     process.wait(timeout=PROCESS_SHUTDOWN_TIMEOUT_SECONDS)
                 except subprocess.TimeoutExpired:
                     pass
+        self._sweep_process_group(process)
         for stream in (process.stdout, process.stderr):
             if stream is not None and not stream.closed:
                 try:

--- a/apps/petrinaut-opt/tests/test_petrinaut_client.py
+++ b/apps/petrinaut-opt/tests/test_petrinaut_client.py
@@ -47,6 +47,18 @@ class FakeProcess:
         self.returncode = -9
 
 
+def _disable_cli_resource_limits(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Isolate real-subprocess tests from the host's task budget.
+
+    ``RLIMIT_NPROC`` is a per-real-UID bound on Linux, so applying the
+    production default to a test child forks it against every task the
+    invoking user already owns.
+    """
+    monkeypatch.setenv("HASH_PETRINAUT_OPT_CLI_CPU_SECONDS", "0")
+    monkeypatch.setenv("HASH_PETRINAUT_OPT_CLI_MEMORY_BYTES", "0")
+    monkeypatch.setenv("HASH_PETRINAUT_OPT_CLI_MAX_PROCESSES", "0")
+
+
 def test_bootstraps_an_opaque_manifest_and_uses_optimization_methods(
     optimization_manifest: dict,
     optimization_description: dict,
@@ -123,6 +135,7 @@ def test_bootstrap_timeout_terminates_a_stuck_process(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(petrinaut_client, "PROCESS_SHUTDOWN_TIMEOUT_SECONDS", 0.05)
+    _disable_cli_resource_limits(monkeypatch)
     script = "import sys, time; sys.stdin.readline(); time.sleep(60)"
     model = PetrinautModel(
         optimization_manifest,
@@ -142,6 +155,7 @@ def test_protocol_timeout_terminates_a_stuck_process(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(petrinaut_client, "PROCESS_SHUTDOWN_TIMEOUT_SECONDS", 0.05)
+    _disable_cli_resource_limits(monkeypatch)
     script = """
 import sys
 import time
@@ -273,10 +287,133 @@ def test_prompt_close_signals_the_group_before_any_shutdown_wait(
     assert events == ["killpg:SIGTERM", "wait"]
 
 
+def test_close_sweeps_grandchildren_from_the_process_group(
+    optimization_manifest: dict,
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Even a graceful shutdown must not leave CLI descendants running."""
+    _disable_cli_resource_limits(monkeypatch)
+    heartbeat = tmp_path / "heartbeat"
+    grandchild_code = (
+        "import pathlib, time\n"
+        f"path = pathlib.Path({str(heartbeat)!r})\n"
+        "while True:\n"
+        "    path.write_text(str(time.monotonic()))\n"
+        "    time.sleep(0.02)\n"
+    )
+    script = (
+        "import subprocess, sys\n"
+        "sys.stdin.readline()\n"
+        f"subprocess.Popen([sys.executable, '-c', {grandchild_code!r}])\n"
+        'sys.stderr.write("Petrinaut stdio ready for optimization\\n")\n'
+        "sys.stderr.flush()\n"
+        "sys.stdin.readline()\n"
+    )
+    model = PetrinautModel(
+        optimization_manifest,
+        command=(sys.executable, "-c", script),
+    )
+    model.start()
+    deadline = time.monotonic() + 2
+    while not heartbeat.exists() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert heartbeat.exists(), "the grandchild never started"
+
+    # Graceful path: the direct child exits on stdin EOF, so without the
+    # process-group sweep the grandchild would keep running.
+    model.close()
+
+    time.sleep(0.1)
+    last_heartbeat = heartbeat.read_text()
+    time.sleep(0.3)
+    assert heartbeat.read_text() == last_heartbeat
+
+
+def test_start_applies_resource_limits_to_real_processes(
+    optimization_manifest: dict,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    limited_pids: list[int] = []
+    monkeypatch.setattr(
+        petrinaut_client,
+        "_apply_child_resource_limits",
+        limited_pids.append,
+    )
+    script = (
+        "import sys\n"
+        "sys.stdin.readline()\n"
+        'sys.stderr.write("Petrinaut stdio ready for optimization\\n")\n'
+        "sys.stderr.flush()\n"
+        "sys.stdin.readline()\n"
+    )
+    model = PetrinautModel(
+        optimization_manifest,
+        command=(sys.executable, "-c", script),
+    )
+    model.start()
+    process = model._process
+    assert process is not None
+
+    model.close(graceful=False)
+
+    assert limited_pids == [process.pid]
+
+
+def test_resource_limits_read_overrides_and_skip_disabled_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[int, int, tuple[int, int]]] = []
+
+    class FakeResource:
+        RLIMIT_CPU = 101
+        RLIMIT_AS = 102
+        RLIMIT_NPROC = 103
+
+        @staticmethod
+        def prlimit(pid: int, limit: int, bounds: tuple[int, int]) -> None:
+            calls.append((pid, limit, bounds))
+
+    monkeypatch.setattr(petrinaut_client, "resource", FakeResource)
+    monkeypatch.setenv("HASH_PETRINAUT_OPT_CLI_CPU_SECONDS", "60")
+    monkeypatch.setenv("HASH_PETRINAUT_OPT_CLI_MEMORY_BYTES", "0")
+    monkeypatch.delenv("HASH_PETRINAUT_OPT_CLI_MAX_PROCESSES", raising=False)
+
+    petrinaut_client._apply_child_resource_limits(4242)
+
+    assert calls == [
+        (4242, FakeResource.RLIMIT_CPU, (60, 60)),
+        (
+            4242,
+            FakeResource.RLIMIT_NPROC,
+            (
+                petrinaut_client.DEFAULT_CLI_MAX_PROCESSES,
+                petrinaut_client.DEFAULT_CLI_MAX_PROCESSES,
+            ),
+        ),
+    ]
+
+
+def test_resource_limits_ignore_non_integer_overrides(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HASH_PETRINAUT_OPT_CLI_CPU_SECONDS", "soon")
+
+    assert (
+        petrinaut_client._limit_from_environment(
+            "HASH_PETRINAUT_OPT_CLI_CPU_SECONDS",
+            petrinaut_client.DEFAULT_CLI_CPU_SECONDS,
+        )
+        == petrinaut_client.DEFAULT_CLI_CPU_SECONDS
+    )
+
+
 def test_prompt_close_terminates_a_busy_process_quickly(
     optimization_manifest: dict,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A mid-trial CLI never notices stdin EOF, so cancellation must signal."""
+    _disable_cli_resource_limits(monkeypatch)
     script = """
 import sys
 import time

--- a/libs/@hashintel/petrinaut-cli/OPTIMIZATION_INTEGRATION.md
+++ b/libs/@hashintel/petrinaut-cli/OPTIMIZATION_INTEGRATION.md
@@ -130,6 +130,28 @@ and returns the objective value:
 Use one CLI process with a single Optuna worker, or start an independent CLI
 process for each parallel worker.
 
+### Cancellation and shutdown
+
+The protocol has no cancel method, and the CLI handles requests serially and
+synchronously: it only observes stdin EOF _between_ requests, and it registers
+no signal handlers in stdio mode. Parents must therefore shut the CLI down as
+follows:
+
+- **After a completed study** (the CLI is idle): close stdin and wait briefly —
+  the CLI exits on EOF.
+- **To cancel a busy CLI** (a trial is executing): signal the process
+  immediately; do not wait for EOF, which a mid-trial CLI never notices.
+  Because the default signal dispositions are intact, `SIGTERM` terminates the
+  CLI even mid-trial.
+- Spawn the CLI in its own process group (e.g. `start_new_session=True`) and
+  signal the **group**, escalating `SIGTERM` → `SIGKILL`, so descendants that
+  remain in the CLI's process group are terminated with it.
+
+The production parent (`apps/petrinaut-opt`) implements this contract,
+including a final `SIGKILL` sweep of the process group on every shutdown path
+and OS-level resource limits on the CLI process; see
+`apps/petrinaut-opt/docs/threat-model.md`.
+
 ## Python wrapper with Optuna
 
 This minimal wrapper starts the CLI with a manifest file and implements the


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Bounds what the Petrinaut CLI subprocess can do, and writes down the isolation model the optimizer service depends on. A malicious optimization manifest can no longer leave descendants running after its study ends, and each CLI process is capped on CPU time, address space, and process count.

## 🔗 Related links

- [FE-1220](https://linear.app/hash/issue/FE-1220/harden-and-document-petrinaut-optimization-execution-isolation) — this issue
- [FE-1217](https://linear.app/hash/issue/FE-1217/harden-petrinaut-optimization-execution-and-streaming) — parent hardening issue
- [SRE-830](https://linear.app/hash/issue/SRE-830) — the out-of-repo ECS task settings this documents as required

## 🚫 Blocked by

- [ ] #9066 — layer 2 of a 3-PR stack (`#9066 → this → #9060`)

## 🔍 What does this change?

- `petrinaut_client.py`: a `SIGKILL` sweep of the CLI's process group on every close path, so descendants cannot outlive the study; `resource.prlimit` (Linux) bounds each CLI process via `RLIMIT_CPU` / `RLIMIT_AS` / `RLIMIT_NPROC`, configurable through `HASH_PETRINAUT_OPT_CLI_*` (`0` disables).
- `docker/Dockerfile`: `tini` as PID 1, so any orphan that escapes the sweep is reaped instead of becoming a zombie under uvicorn.
- `docs/threat-model.md` (new): the execution path, per-layer mitigations, the required out-of-repo deployment configuration, and the documented decision that container/process isolation is sufficient — no additional V8 sandbox.
- `README.md`: the security/isolation section and the CLI limit environment variables.
- `OPTIMIZATION_INTEGRATION.md`: the CLI cancellation/shutdown contract that parents must implement.

**Dropped during the rebase:** this branch originally added a study wall-clock ceiling to the legacy `stream_all`/`stream_best` generators. `main` now bounds detached runs via `HASH_PETRINAUT_OPT_MAX_STUDY_SECONDS` (FE-1224), and #9066 below this in the stack deletes those generators entirely — so that part would have been written and then deleted.

The threat model is written against the **current** architecture rather than the one this branch was first drafted on: runs are detached and outlive their connections, ownership is enforced in the optimizer by account tag (a foreign run answers 404 so ids cannot be probed), and study-slot occupancy is bounded by the wall-clock ceiling plus detach-grace reaping instead of by connection deadlines. Each claim was checked against the code.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] require changes to docs which **are made** as part of this PR

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

- `RLIMIT_NPROC` is enforced by Linux against the service user's *total* task count, not this child's descendants; container-level `pidsLimit` (SRE-830) is the real backstop.
- `prlimit` is applied from the parent immediately after spawn, so the child is briefly unbounded; container limits remain the outer bound.
- A descendant that calls `setsid()`/`setpgid()` leaves the CLI's process group and escapes the sweep — documented in the threat model's limitations.
- Task-level settings (read-only rootfs, memory sizing, deny-all egress, `pidsLimit`) live in the out-of-repo infra and are tracked in SRE-830.

## 🛡 What tests cover this?

`apps/petrinaut-opt`: **93 pytest** green on this layer — including the process-group sweep verified with a real grandchild process (mutation-checked: removing the sweep fails the test), `prlimit` application and env parsing, and the prompt-termination paths.

## ❓ How to test this?

1. `cd apps/petrinaut-opt && uv run pytest`
2. Build the image and confirm `tini` is PID 1: `docker build --file apps/petrinaut-opt/docker/Dockerfile --tag petrinaut-opt:local .` then `docker run --rm petrinaut-opt:local ps -o pid,comm` (or inspect the entrypoint).
3. Start a run, note the CLI's pid, kill the study, and confirm no descendant of that process group survives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
