### PR TITLE
H-6711: Supply chain site overview search and filters, and dwell cost distribution chart

### DIFF
--- a/apps/hash-frontend/src/pages/supply-chain/shared/categories.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/categories.ts
@@ -74,13 +74,13 @@ export const STEP_TYPE_ORDER: StepType[] = [
 /** Human-readable labels for each finer step type (used by the Step column filter). */
 export const STEP_TYPE_LABELS: Record<StepType, string> = {
   procurement: "Procurement",
-  raw_material_dwell: "Raw material",
+  raw_material_dwell: "Raw material dwell",
   production: "Production",
-  intermediate_dwell: "Intermediate",
+  intermediate_dwell: "Intermediate dwell",
   qa_hold: "QA hold",
-  post_qa_ship: "QA to Ship",
+  post_qa_ship: "QA to Ship dwell",
   transit: "Transit",
-  destination_dwell: "Destination",
+  destination_dwell: "Destination dwell",
 };
 
 export const PIPELINE_COLORS: Record<string, string> = {

--- a/apps/hash-frontend/src/pages/supply-chain/shared/docs/docs-modal/docs-content/site-overview.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/docs/docs-modal/docs-content/site-overview.tsx
@@ -69,9 +69,8 @@ export const siteOverviewSection: DocSectionDef = {
           </P>
           <P>
             Sort and filter the table from its column headers: <Term>Type</Term>{" "}
-            filters by opportunity kind (hiding a kind removes its whole
-            section), <Term>Opportunity</Term> sorts by title and filters by
-            product, and <Term>Status</Term> sorts and filters by the
+            filters by step type, <Term>Opportunity</Term> sorts by title and
+            filters by product, and <Term>Status</Term> sorts and filters by the
             investigation state.
           </P>
           <H4>Investigation workflow</H4>
@@ -232,6 +231,12 @@ export const siteOverviewSection: DocSectionDef = {
             alongside one site-wide control.
           </Lead>
           <UL>
+            <LI>
+              <Term>Site search</Term> &mdash; type in the search box below the
+              settings and help buttons to filter opportunities and every detail
+              tab by step, product, material, location or supplier. Section and
+              tab counts update with the results.
+            </LI>
             <LI>
               <Term>Column sort</Term> &mdash; click a sortable column header to
               sort by it, and click again to reverse the direction.

--- a/apps/hash-frontend/src/pages/supply-chain/shared/docs/docs-modal/docs-content/step-detail.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/docs/docs-modal/docs-content/step-detail.tsx
@@ -36,7 +36,9 @@ export const stepDetailDoc: DocEntry = {
         <LI>
           <Term>Distribution</Term> shows the spread of observations for the
           active time range and dimension. Use it to distinguish one-off tails
-          from broad shifts in the whole series.
+          from broad shifts in the whole series. On dwell steps, switch between
+          duration and event value using the standard dwell-cost calculation
+          (kg-days with WACC and storage-cost assumptions).
         </LI>
         <LI>
           <Term>Monthly trend</Term> shows change over time. Selecting a month

--- a/apps/hash-frontend/src/pages/supply-chain/shared/header-actions.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/header-actions.tsx
@@ -52,6 +52,7 @@ const settingsWrap = css({
   borderColor: "bd.subtle",
   pt: "3",
   display: "flex",
+  flexWrap: "wrap",
   alignItems: "center",
   justifyContent: "flex-end",
   gap: "4",
@@ -94,6 +95,13 @@ const sharedFields = css({
   justifyContent: "flex-end",
   gap: "3",
 });
+const fieldGroup = css({
+  display: "inline-flex",
+  alignItems: "center",
+  gap: "3",
+  flexShrink: "0",
+  whiteSpace: "nowrap",
+});
 const fieldLabel = css({
   display: "flex",
   alignItems: "center",
@@ -115,14 +123,6 @@ const measureSelect = css({
   py: "0.5",
   cursor: "pointer",
 });
-const extraFields = css({
-  display: "flex",
-  flexWrap: "wrap",
-  alignItems: "center",
-  justifyContent: "flex-end",
-  gap: "3",
-});
-
 export const HeaderActionButtons = ({
   settingsOpen,
   onSettingsToggle,
@@ -196,92 +196,100 @@ export const AnalysisSettingsPanel = ({
         )}
       </div>
       <div className={sharedFields}>
-        <span className={fieldLabel}>
-          WACC
-          <NumberInput
-            value={Math.round(waccRate * 100)}
-            min={1}
-            max={50}
-            step={1}
-            size="xs"
-            align="center"
-            width="fitContent"
-            onChange={(value) => {
-              if (value != null && value > 0 && value <= 50) {
-                setWaccRate(value / 100);
+        <div className={fieldGroup}>
+          <span className={fieldLabel}>
+            WACC
+            <NumberInput
+              value={Math.round(waccRate * 100)}
+              min={1}
+              max={50}
+              step={1}
+              size="xs"
+              align="center"
+              width="fitContent"
+              onChange={(value) => {
+                if (value != null && value > 0 && value <= 50) {
+                  setWaccRate(value / 100);
+                }
+              }}
+              aria-label="WACC percent"
+            />
+            %
+          </span>
+          <span className={fieldLabel}>
+            Storage
+            <NumberInput
+              value={storageCost}
+              min={0.001}
+              max={10}
+              step={0.01}
+              size="xs"
+              align="center"
+              width="fitContent"
+              onChange={(value) => {
+                if (value != null && value > 0 && value <= 10) {
+                  setStorageCost(value);
+                }
+              }}
+              aria-label="Storage cost per tonne per day"
+            />
+            {currency}/t/d
+          </span>
+        </div>
+        <div className={fieldGroup}>
+          <label className={fieldLabel}>
+            Measure
+            <select
+              className={measureSelect}
+              value={measure}
+              onChange={(event) =>
+                setMeasure(event.target.value as BaseMeasure)
               }
-            }}
-            aria-label="WACC percent"
-          />
-          %
-        </span>
-        <span className={fieldLabel}>
-          Storage
-          <NumberInput
-            value={storageCost}
-            min={0.001}
-            max={10}
-            step={0.01}
-            size="xs"
-            align="center"
-            width="fitContent"
-            onChange={(value) => {
-              if (value != null && value > 0 && value <= 10) {
-                setStorageCost(value);
+              aria-label="Base timing measure"
+            >
+              {BASE_MEASURES.map((measureOption) => (
+                <option key={measureOption} value={measureOption}>
+                  {MEASURE_LABELS[measureOption]}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className={fieldLabel}>
+            Procurement
+            <select
+              className={measureSelect}
+              value={basis}
+              onChange={(event) =>
+                setBasis(event.target.value as ProcurementBasis)
               }
-            }}
-            aria-label="Storage cost per tonne per day"
-          />
-          {currency}/t/d
-        </span>
-        <label className={fieldLabel}>
-          Measure
-          <select
-            className={measureSelect}
-            value={measure}
-            onChange={(event) => setMeasure(event.target.value as BaseMeasure)}
-            aria-label="Base timing measure"
-          >
-            {BASE_MEASURES.map((month) => (
-              <option key={month} value={month}>
-                {MEASURE_LABELS[month]}
-              </option>
-            ))}
-          </select>
-        </label>
-        <label className={fieldLabel}>
-          Procurement
-          <select
-            className={measureSelect}
-            value={basis}
-            onChange={(event) =>
-              setBasis(event.target.value as ProcurementBasis)
-            }
-            aria-label="Procurement lead-time basis"
-          >
-            {PROCUREMENT_BASES.map((basisOption) => (
-              <option key={basisOption} value={basisOption}>
-                {PROCUREMENT_BASIS_LABELS[basisOption]}
-              </option>
-            ))}
-          </select>
-        </label>
+              aria-label="Procurement lead-time basis"
+            >
+              {PROCUREMENT_BASES.map((basisOption) => (
+                <option key={basisOption} value={basisOption}>
+                  {PROCUREMENT_BASIS_LABELS[basisOption]}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
         <SegmentedControl
           value={timeRange}
           onChange={setTimeRange}
           options={TIME_RANGE_OPTIONS}
         />
 
-        <label className={fieldLabel}>
-          <input
-            type="checkbox"
-            checked={excludeOutliers}
-            onChange={(event) => setExcludeOutliers(event.target.checked)}
-          />
-          Exclude outliers
-        </label>
+        <div className={fieldGroup}>
+          <label className={fieldLabel}>
+            <input
+              type="checkbox"
+              checked={excludeOutliers}
+              onChange={(event) => setExcludeOutliers(event.target.checked)}
+            />
+            Exclude outliers
+          </label>
+          {children}
+        </div>
       </div>
-      {children != null && <div className={extraFields}>{children}</div>}
     </div>
   );
 };

--- a/apps/hash-frontend/src/pages/supply-chain/shared/step-detail-panel/distribution-chart.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/step-detail-panel/distribution-chart.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import {
   BarChart,
   Bar,
@@ -12,9 +12,12 @@ import {
 
 import { css } from "@hashintel/ds-helpers/css";
 
+import { isDwellType } from "../categories";
 import { chartTheme } from "../chart-theme";
-import { formatNumber } from "../cost";
+import { formatCost, formatNumber, useCostParams } from "../cost";
 import { countNoun } from "../observation-labels";
+import { SegmentedControl } from "../segmented-control";
+import { dwellCostDistributionValues } from "./distribution-chart/dwell-cost-distribution";
 
 import type { StepDetail } from "../types";
 
@@ -29,6 +32,12 @@ const chartTitle = css({
   fontWeight: "medium",
   color: "fg.max",
   lineHeight: "[20px]",
+});
+const chartHeader = css({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  gap: "3",
 });
 const emptyText = css({ textStyle: "sm", color: "fg.subtle" });
 
@@ -46,7 +55,10 @@ type Bin = {
   isLast: boolean;
   count: number;
   label: string;
+  axisLabel: string;
 };
+
+type DwellDistributionMeasure = "duration" | "value";
 
 function niceStep(rawStep: number): number {
   const mag = 10 ** Math.floor(Math.log10(rawStep));
@@ -63,7 +75,10 @@ function niceStep(rawStep: number): number {
   return 10 * mag;
 }
 
-function buildBins(values: number[]): { bins: Bin[]; binCount: number } {
+function buildBins(
+  values: number[],
+  valueFormatter?: (value: number) => string,
+): { bins: Bin[]; binCount: number } {
   const filtered = values.filter((day): day is number => Number.isFinite(day));
   if (filtered.length === 0) {
     return { bins: [], binCount: 0 };
@@ -73,7 +88,8 @@ function buildBins(values: number[]): { bins: Bin[]; binCount: number } {
   const max = Math.max(...filtered);
   const range = max - min;
   if (range === 0) {
-    const label = formatNumber(min, { maximumFractionDigits: 0 });
+    const label =
+      valueFormatter?.(min) ?? formatNumber(min, { maximumFractionDigits: 0 });
     return {
       bins: [
         {
@@ -82,6 +98,7 @@ function buildBins(values: number[]): { bins: Bin[]; binCount: number } {
           isLast: true,
           count: filtered.length,
           label,
+          axisLabel: label,
         },
       ],
 
@@ -101,8 +118,10 @@ function buildBins(values: number[]): { bins: Bin[]; binCount: number } {
   const count = Math.round((niceMax - niceMin) / step);
 
   const useDecimals = step < 1;
-  const fmt = (value: number) =>
-    formatNumber(value, { maximumFractionDigits: useDecimals ? 1 : 0 });
+  const fmt =
+    valueFormatter ??
+    ((value: number) =>
+      formatNumber(value, { maximumFractionDigits: useDecimals ? 1 : 0 }));
 
   const histogram: Bin[] = [];
   for (let index = 0; index < count; index++) {
@@ -119,6 +138,7 @@ function buildBins(values: number[]): { bins: Bin[]; binCount: number } {
       isLast,
       count: column,
       label,
+      axisLabel: fmt(start),
     });
   }
 
@@ -130,6 +150,10 @@ export const DistributionChart = ({
   dimension = "timing",
   selectedComponent,
 }: DistributionChartProps) => {
+  const { waccRate, storageCost } = useCostParams();
+  const [dwellMeasure, setDwellMeasure] =
+    useState<DwellDistributionMeasure>("duration");
+  const isDwellTiming = dimension === "timing" && isDwellType(step.type);
   const { bins, binCount, refValue, title } = useMemo(() => {
     if (dimension === "yield" && step.yield_data) {
       const { bins: right2, binCount: bc } = buildBins(step.yield_data.values);
@@ -160,29 +184,63 @@ export const DistributionChart = ({
           : "Aggregate consumption variance distribution",
       };
     }
-    const { bins: right, binCount: bc } = buildBins(step.durations);
+    const values =
+      isDwellTiming && dwellMeasure === "value"
+        ? dwellCostDistributionValues(step, waccRate, storageCost)
+        : step.durations;
+    const isValueDistribution = isDwellTiming && dwellMeasure === "value";
+    const { bins: right, binCount: bc } = buildBins(
+      values,
+      isValueDistribution
+        ? (value) =>
+            formatCost(value, step.cost?.currency ?? null, { compact: true })
+        : undefined,
+    );
     return {
       bins: right,
       binCount: bc,
-      refValue: step.plan,
-      title: "Duration distribution",
+      refValue: isValueDistribution ? null : step.plan,
+      title: isDwellTiming ? "Distribution" : "Duration distribution",
     };
-  }, [step, dimension, selectedComponent]);
+  }, [
+    step,
+    dimension,
+    selectedComponent,
+    isDwellTiming,
+    dwellMeasure,
+    waccRate,
+    storageCost,
+  ]);
 
   if (bins.length === 0) {
     return (
       <div className={chartWrap}>
-        <h3 className={chartTitle}>{title}</h3>
+        <div className={chartHeader}>
+          <h3 className={chartTitle}>{title}</h3>
+          {isDwellTiming && (
+            <SegmentedControl
+              value={dwellMeasure}
+              onChange={setDwellMeasure}
+              options={[
+                { value: "duration", label: "Duration" },
+                { value: "value", label: "Value" },
+              ]}
+            />
+          )}
+        </div>
         <p className={emptyText}>
-          {dimension === "consumption" && selectedComponent
-            ? "No in-range matched variance data available"
-            : "No data available"}
+          {isDwellTiming && dwellMeasure === "value"
+            ? "No cost data available"
+            : dimension === "consumption" && selectedComponent
+              ? "No in-range matched variance data available"
+              : "No data available"}
         </p>
       </div>
     );
   }
 
   const hasRef = refValue != null && (dimension !== "timing" || refValue > 0);
+  const isValueDistribution = isDwellTiming && dwellMeasure === "value";
   const rv = refValue ?? 0;
   const refIdx = hasRef
     ? bins.findIndex(
@@ -239,8 +297,23 @@ export const DistributionChart = ({
 
   return (
     <div className={chartWrap}>
-      <h3 className={chartTitle}>{title}</h3>
-      <ResponsiveContainer width="100%" height={380}>
+      <div className={chartHeader}>
+        <h3 className={chartTitle}>{title}</h3>
+        {isDwellTiming && (
+          <SegmentedControl
+            value={dwellMeasure}
+            onChange={setDwellMeasure}
+            options={[
+              { value: "duration", label: "Duration" },
+              { value: "value", label: "Value" },
+            ]}
+          />
+        )}
+      </div>
+      <ResponsiveContainer
+        width="100%"
+        height={isValueDistribution ? 440 : 380}
+      >
         <BarChart
           data={bins}
           margin={{ top: 10, right: 10, bottom: 5, left: 5 }}
@@ -251,9 +324,30 @@ export const DistributionChart = ({
               fontSize: 10,
               fill: chartTheme.axis.tickStrong,
               letterSpacing: 0.2,
+              ...(isValueDistribution
+                ? { angle: -90, textAnchor: "end" as const }
+                : {}),
             }}
+            tickFormatter={(label: string) =>
+              isValueDistribution
+                ? (bins.find((bin) => bin.label === label)?.axisLabel ?? label)
+                : label
+            }
             tickLine={false}
             axisLine={{ stroke: chartTheme.axis.line, strokeWidth: 0.5 }}
+            interval={isValueDistribution ? 0 : undefined}
+            height={isValueDistribution ? 110 : 30}
+            label={
+              isValueDistribution
+                ? {
+                    value: `Dwell cost (${step.cost?.currency ?? "USD"})`,
+                    position: "insideBottom",
+                    offset: -2,
+                    fontSize: 11,
+                    fill: chartTheme.axis.tick,
+                  }
+                : undefined
+            }
           />
 
           <YAxis

--- a/apps/hash-frontend/src/pages/supply-chain/shared/step-detail-panel/distribution-chart/dwell-cost-distribution.test.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/step-detail-panel/distribution-chart/dwell-cost-distribution.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { dwellCostDistributionValues } from "./dwell-cost-distribution";
+
+import type { StepDetail } from "../../types";
+
+describe("dwellCostDistributionValues", () => {
+  it("applies WACC and storage cost to each selected event's kg-days", () => {
+    const step = {
+      cost: { unit_price: 365, currency: "GBP" },
+      ref_date_col: "exit_date",
+      value_col: "dwell_days",
+      observations: [
+        { date: "2026-06-01", value: 5 },
+        { date: "2026-06-03", value: 8 },
+      ],
+      detail_rows: {
+        columns: [],
+        rows: [
+          { exit_date: "2026-06-01", dwell_days: 5, kg_days: 100 },
+          { exit_date: "2026-06-02", dwell_days: 50, kg_days: 999 },
+          { exit_date: "2026-06-03", dwell_days: 8, kg_days: 240 },
+        ],
+      },
+    } as unknown as StepDetail;
+
+    // Rate per kg-day = 365 × (10% / 365) + 400 / 1,000 = 0.5.
+    expect(dwellCostDistributionValues(step, 0.1, 400)).toEqual([50, 120]);
+  });
+
+  it("returns no values when unit price or row-level kg-days are unavailable", () => {
+    const step = {
+      cost: { unit_price: null, currency: "GBP" },
+      ref_date_col: "exit_date",
+      value_col: "dwell_days",
+      observations: [{ date: "2026-06-01", value: 5 }],
+      detail_rows: {
+        columns: [],
+        rows: [{ exit_date: "2026-06-01", dwell_days: 5 }],
+      },
+    } as unknown as StepDetail;
+
+    expect(dwellCostDistributionValues(step, 0.1, 0.4)).toEqual([]);
+  });
+});

--- a/apps/hash-frontend/src/pages/supply-chain/shared/step-detail-panel/distribution-chart/dwell-cost-distribution.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/step-detail-panel/distribution-chart/dwell-cost-distribution.ts
@@ -1,0 +1,61 @@
+import { computeMonthlyCost } from "../../cost";
+
+import type { StepDetail } from "../../types";
+
+function numberValue(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function observationKey(date: string, value: number): string {
+  return `${date.slice(0, 10)}::${value}`;
+}
+
+export function dwellCostDistributionValues(
+  step: StepDetail,
+  waccRate: number,
+  storageCost: number,
+): number[] {
+  const detailRows = step.detail_rows;
+  const dateColumn = step.ref_date_col;
+  const valueColumn = step.value_col;
+  if (!detailRows || !dateColumn || !valueColumn) {
+    return [];
+  }
+
+  const remainingObservations = new Map<string, number>();
+  for (const observation of step.observations) {
+    const key = observationKey(observation.date, observation.value);
+    remainingObservations.set(key, (remainingObservations.get(key) ?? 0) + 1);
+  }
+
+  return detailRows.rows.flatMap((row) => {
+    const date = row[dateColumn];
+    const duration = numberValue(row[valueColumn]);
+    const kgDays = numberValue(row.kg_days);
+    if (typeof date !== "string" || duration == null || kgDays == null) {
+      return [];
+    }
+
+    const key = observationKey(date, duration);
+    const remaining = remainingObservations.get(key) ?? 0;
+    if (remaining === 0) {
+      return [];
+    }
+    remainingObservations.set(key, remaining - 1);
+
+    const cost = computeMonthlyCost(
+      kgDays,
+      step.cost?.unit_price,
+      waccRate,
+      storageCost,
+    );
+    return cost == null ? [] : [cost];
+  });
+}

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useState, useMemo } from "react";
+import { useCallback, useEffect, useState, useMemo } from "react";
 
+import { Icon } from "@hashintel/ds-components";
 import { css, cx } from "@hashintel/ds-helpers/css";
 
 import { isDwellType } from "../shared/categories";
@@ -30,6 +31,7 @@ import {
 import { OpportunitiesTable } from "./site/opportunities-table";
 import { PlanningTable } from "./site/planning-table";
 import { SiteMonthlyCarryCostChart } from "./site/site-monthly-carry-cost-chart";
+import { createSiteSearchMatchers } from "./site/site-search";
 import { SupplierTable } from "./site/supplier-table";
 import { TabButton } from "./site/tab-button";
 import { TrendTable } from "./site/trend-table";
@@ -90,6 +92,108 @@ const controlsRow = css({
   gap: "2",
   flexShrink: 0,
 });
+const headerControls = css({
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "flex-end",
+  gap: "2",
+  flexShrink: 0,
+});
+const searchWrap = css({
+  display: "flex",
+  alignItems: "center",
+  gap: "2",
+  w: "[320px]",
+  maxW: "[40vw]",
+  px: "3",
+  py: "1.5",
+  borderWidth: "1px",
+  borderStyle: "solid",
+  borderColor: "bd.subtle",
+  borderRadius: "md",
+  bg: "bg.surface",
+  color: "fg.subtle",
+  transition: "colors",
+  _focusWithin: {
+    borderColor: "[#93c5fd]",
+    boxShadow: "[0 0 0 2px rgba(147, 197, 253, 0.25)]",
+  },
+  '&[data-active="true"]': {
+    bg: "[#eff6ff]",
+    borderColor: "[#2563eb]",
+    color: "[#2563eb]",
+  },
+});
+const searchInput = css({
+  flex: "1",
+  minW: "0",
+  bg: "[transparent]",
+  color: "fg.heading",
+  textStyle: "sm",
+  outline: "none",
+  _placeholder: { color: "fg.subtle" },
+});
+const clearSearchButton = css({
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  w: "4",
+  h: "4",
+  flexShrink: 0,
+  color: "fg.subtle",
+  cursor: "pointer",
+  borderRadius: "sm",
+  _hover: { color: "fg.heading", bg: "bg.subtle" },
+});
+const clearSearchButtonHidden = css({
+  visibility: "hidden",
+  pointerEvents: "none",
+});
+
+const SiteSearchInput = ({
+  onChange,
+}: {
+  onChange: (query: string) => void;
+}) => {
+  const [value, setValue] = useState("");
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => onChange(value), 200);
+    return () => window.clearTimeout(timeout);
+  }, [value, onChange]);
+
+  return (
+    <div
+      className={searchWrap}
+      data-active={value ? "true" : undefined}
+      role="search"
+      style={value ? { borderColor: "#2563eb" } : undefined}
+    >
+      <Icon name="search" size="xs" />
+      <input
+        type="text"
+        value={value}
+        className={searchInput}
+        placeholder="Search..."
+        aria-label="Search site overview tables"
+        onChange={(event) => setValue(event.target.value)}
+      />
+      <button
+        type="button"
+        className={cx(clearSearchButton, !value && clearSearchButtonHidden)}
+        aria-label="Clear search"
+        disabled={!value}
+        onClick={() => {
+          setValue("");
+          onChange("");
+        }}
+      >
+        <Icon name="close" size="xs" />
+      </button>
+    </div>
+  );
+};
+
 const settingsCollapse = css({
   display: "grid",
   gridTemplateRows: "0fr",
@@ -192,6 +296,7 @@ export const SiteOverview = ({
   const siteSlug = siteId;
   const [tab, setTab] = useState<Tab>("dwell");
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
   const [searchParams] = useSearchParams();
   const { excludeLowSamples, setExcludeLowSamples } = useLowSampleSetting();
   const [selectedStep, setSelectedStep] = useState<{
@@ -281,7 +386,7 @@ export const SiteOverview = ({
     key: SortKey;
     dir: SortDir;
   } | null>({ key: "impact", dir: "desc" });
-  const [oppTypeHidden, setOppTypeHidden] = useState<Set<OpportunityKind>>(
+  const [oppTypeHidden, setOppTypeHidden] = useState<Set<StepType>>(
     () => new Set(),
   );
   const [oppProductHidden, setOppProductHidden] = useState<Set<string>>(
@@ -317,7 +422,7 @@ export const SiteOverview = ({
       opportunityBriefHref(siteSlug, type, node, timeRange, searchParams, kind),
     [searchParams, siteSlug, timeRange],
   );
-  const opportunities = useMemo(
+  const generatedOpportunities = useMemo(
     () =>
       buildSiteOpportunities({
         siteId: siteSlug,
@@ -335,6 +440,30 @@ export const SiteOverview = ({
       siteCurrency,
       buildBriefHref,
     ],
+  );
+  const searchMatchers = useMemo(
+    () => createSiteSearchMatchers(searchQuery),
+    [searchQuery],
+  );
+  const filteredDwellRows = useMemo(
+    () => dwellRows.filter(searchMatchers.siteNode),
+    [dwellRows, searchMatchers],
+  );
+  const filteredPlanningRows = useMemo(
+    () => planningRows.filter(searchMatchers.siteNode),
+    [planningRows, searchMatchers],
+  );
+  const filteredTrendRows = useMemo(
+    () => trendRows.filter(searchMatchers.siteNode),
+    [trendRows, searchMatchers],
+  );
+  const filteredSupplierRows = useMemo(
+    () => supplierRows.filter(searchMatchers.supplier),
+    [supplierRows, searchMatchers],
+  );
+  const opportunities = useMemo(
+    () => generatedOpportunities.filter(searchMatchers.opportunity),
+    [generatedOpportunities, searchMatchers],
   );
 
   const overPlanCount = useMemo(
@@ -379,14 +508,7 @@ export const SiteOverview = ({
   );
 
   const revealOverPlanOpportunities = useCallback(() => {
-    setOppTypeHidden((hiddenKinds) => {
-      if (!hiddenKinds.has("planning_over")) {
-        return hiddenKinds;
-      }
-      const nextHiddenKinds = new Set(hiddenKinds);
-      nextHiddenKinds.delete("planning_over");
-      return nextHiddenKinds;
-    });
+    setOppTypeHidden(new Set());
     setOppSectionRevealRequest((previousRequest) => ({
       kind: "planning_over",
       requestId: (previousRequest?.requestId ?? 0) + 1,
@@ -446,21 +568,24 @@ export const SiteOverview = ({
               )}
             </div>
           </div>
-          <div className={controlsRow}>
-            <HeaderActionButtons
-              settingsOpen={settingsOpen}
-              onSettingsToggle={() => {
-                trackSupplyChainInteraction({
-                  interaction: settingsOpen
-                    ? "settings_closed"
-                    : "settings_opened",
-                  siteId,
-                  source: "site_overview",
-                });
-                setSettingsOpen((open) => !open);
-              }}
-              docContext="site"
-            />
+          <div className={headerControls}>
+            <div className={controlsRow}>
+              <HeaderActionButtons
+                settingsOpen={settingsOpen}
+                onSettingsToggle={() => {
+                  trackSupplyChainInteraction({
+                    interaction: settingsOpen
+                      ? "settings_closed"
+                      : "settings_opened",
+                    siteId,
+                    source: "site_overview",
+                  });
+                  setSettingsOpen((open) => !open);
+                }}
+                docContext="site"
+              />
+            </div>
+            <SiteSearchInput onChange={setSearchQuery} />
           </div>
         </div>
         <div
@@ -523,7 +648,7 @@ export const SiteOverview = ({
                   setTab("dwell");
                 }}
                 label="Dwell Time / Cost"
-                count={dwellRows.length}
+                count={filteredDwellRows.length}
               />
 
               <TabButton
@@ -537,7 +662,7 @@ export const SiteOverview = ({
                   setTab("planning");
                 }}
                 label="Planning Parameters"
-                count={planningRows.length}
+                count={filteredPlanningRows.length}
               />
 
               <TabButton
@@ -551,7 +676,7 @@ export const SiteOverview = ({
                   setTab("trends");
                 }}
                 label="Trend"
-                count={trendRows.length}
+                count={filteredTrendRows.length}
               />
 
               {supplierPerformanceEnabled && (
@@ -566,7 +691,7 @@ export const SiteOverview = ({
                     setTab("suppliers");
                   }}
                   label="Supplier Performance"
-                  count={supplierRows.length}
+                  count={filteredSupplierRows.length}
                 />
               )}
             </div>
@@ -575,7 +700,7 @@ export const SiteOverview = ({
           {/* Detail tables */}
           {tab === "dwell" && (
             <DwellTable
-              rows={dwellRows}
+              rows={filteredDwellRows}
               siteId={siteSlug}
               sort={dwellSort}
               onSort={setDwellSort}
@@ -594,7 +719,7 @@ export const SiteOverview = ({
           )}
           {tab === "planning" && (
             <PlanningTable
-              rows={planningRows}
+              rows={filteredPlanningRows}
               siteId={siteSlug}
               sort={planSort}
               onSort={setPlanSort}
@@ -615,7 +740,7 @@ export const SiteOverview = ({
           )}
           {tab === "trends" && (
             <TrendTable
-              rows={trendRows}
+              rows={filteredTrendRows}
               siteId={siteSlug}
               sort={trendSort}
               onSort={setTrendSort}
@@ -632,7 +757,7 @@ export const SiteOverview = ({
           )}
           {supplierPerformanceEnabled && tab === "suppliers" && (
             <SupplierTable
-              rows={supplierRows}
+              rows={filteredSupplierRows}
               sort={supplierSort}
               onSort={setSupplierSort}
               onRowClick={(value) =>

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/opportunities-table.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/opportunities-table.tsx
@@ -4,6 +4,7 @@ import { Tooltip } from "@hashintel/ds-components";
 import { css, cx } from "@hashintel/ds-helpers/css";
 
 import { StatusActionButton } from "../../shared/action-buttons";
+import { STEP_TYPE_LABELS, STEP_TYPE_ORDER } from "../../shared/categories";
 import { PlanningWarningIndicator } from "../../shared/planning-warning-indicator";
 import {
   compareStatusLabels,
@@ -20,7 +21,7 @@ import { ColumnHeader } from "./shared/column-header";
 import { ProductTags } from "./shared/product-tags";
 import * as threshold from "./shared/table-styles";
 
-import type { SiteNode } from "../../shared/types";
+import type { SiteNode, StepType } from "../../shared/types";
 import type { OpportunityKind, SiteOpportunity } from "./opportunities";
 import type { SortDir, SortKey } from "./shared/row-types";
 
@@ -210,9 +211,6 @@ const OPPORTUNITY_SECTIONS: OpportunitySection[] = [
   { id: "planning_under", label: "Under plan", kinds: ["planning_under"] },
 ];
 
-const kindLabel = (kind: OpportunityKind): string =>
-  OPPORTUNITY_SECTIONS.find((section) => section.id === kind)?.label ?? kind;
-
 interface OpportunitiesTableProps {
   opportunities: SiteOpportunity[];
   /** Route site slug; scopes status keys to the global store. */
@@ -222,8 +220,8 @@ interface OpportunitiesTableProps {
   onStatus: (node: SiteNode, title: string) => void;
   sort: { key: SortKey; dir: SortDir } | null;
   onSort: (next: { key: SortKey; dir: SortDir }) => void;
-  typeHidden: Set<OpportunityKind>;
-  onTypeHiddenChange: (next: Set<OpportunityKind>) => void;
+  typeHidden: Set<StepType>;
+  onTypeHiddenChange: (next: Set<StepType>) => void;
   productHidden: Set<string>;
   onProductHiddenChange: (next: Set<string>) => void;
   statusHidden: Set<StatusActionLabel>;
@@ -389,14 +387,14 @@ export const OpportunitiesTable = ({
   );
 
   const typeFilter = useMemo(() => {
-    const values = OPPORTUNITY_SECTIONS.map((section) => section.id).filter(
-      (kind) => opportunities.some((opportunity) => opportunity.kind === kind),
+    const values = STEP_TYPE_ORDER.filter((stepType) =>
+      opportunities.some((opportunity) => opportunity.node.type === stepType),
     );
-    return buildColumnFilter<OpportunityKind>({
-      header: "Type",
+    return buildColumnFilter<StepType>({
+      header: "Step type",
       values,
-      labelOf: kindLabel,
-      counts: countBy(opportunities, (opportunity) => opportunity.kind),
+      labelOf: (stepType) => STEP_TYPE_LABELS[stepType],
+      counts: countBy(opportunities, (opportunity) => opportunity.node.type),
       hidden: typeHidden,
       onHiddenChange: onTypeHiddenChange,
       searchable: false,
@@ -447,12 +445,11 @@ export const OpportunitiesTable = ({
     const passesStatus = (opportunity: SiteOpportunity) =>
       !statusHidden.has(statusOf(opportunity));
 
-    return OPPORTUNITY_SECTIONS.filter(
-      (section) => !typeHidden.has(section.id),
-    ).map((section) => {
+    return OPPORTUNITY_SECTIONS.map((section) => {
       const items = opportunities.filter(
         (opportunity) =>
           section.kinds.includes(opportunity.kind) &&
+          !typeHidden.has(opportunity.node.type) &&
           passesProduct(opportunity) &&
           passesStatus(opportunity),
       );

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/site-search.test.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/site-search.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { siteNodeMatchesSearch, supplierMatchesSearch } from "./site-search";
+
+import type { SiteNode, VendorOtifStats } from "../../shared/types";
+
+const node = {
+  id: "raw_dwell_123",
+  label: "Raw ingredients at Bristol",
+  type: "raw_material_dwell",
+  material: "MAT-123",
+  plant: "Bristol",
+  products: [{ id: "PROD-1", name: "Vitamin tablets" }],
+} as SiteNode;
+
+describe("site overview search", () => {
+  it("matches step labels, types, materials, and products", () => {
+    expect(siteNodeMatchesSearch(node, "ingredients")).toBe(true);
+    expect(siteNodeMatchesSearch(node, "raw material dwell")).toBe(true);
+    expect(siteNodeMatchesSearch(node, "mat-123 vitamin")).toBe(true);
+    expect(siteNodeMatchesSearch(node, "transit")).toBe(false);
+  });
+
+  it("matches supplier names, identifiers, and materials", () => {
+    const supplier = {
+      vendor_id: "V-42",
+      vendor_name: "Acme Ingredients",
+      materials: [{ matnr: "RM-7", name: "Citric acid" }],
+    } as VendorOtifStats;
+
+    expect(supplierMatchesSearch(supplier, "acme rm-7")).toBe(true);
+    expect(supplierMatchesSearch(supplier, "citric")).toBe(true);
+    expect(supplierMatchesSearch(supplier, "other")).toBe(false);
+  });
+});

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/site-search.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/site-search.ts
@@ -1,0 +1,98 @@
+import { STEP_TYPE_LABELS } from "../../shared/categories";
+
+import type { SiteNode, VendorOtifStats } from "../../shared/types";
+import type { SiteOpportunity } from "./opportunities";
+
+function searchTerms(query: string): string[] {
+  return query.trim().toLocaleLowerCase().split(/\s+/).filter(Boolean);
+}
+
+function matchesSearchText(
+  terms: string[],
+  values: Array<string | null | undefined>,
+): boolean {
+  if (terms.length === 0) {
+    return true;
+  }
+
+  const searchableText = values
+    .filter((value): value is string => value != null)
+    .join(" ")
+    .toLocaleLowerCase();
+
+  return terms.every((term) => searchableText.includes(term));
+}
+
+function siteNodeMatchesTerms(node: SiteNode, terms: string[]): boolean {
+  return matchesSearchText(terms, [
+    node.id,
+    node.label,
+    node.material,
+    node.plant,
+    node.supplier_id,
+    node.supplier_name,
+    node.receipt_basis,
+    STEP_TYPE_LABELS[node.type],
+    ...node.products.flatMap((product) => [product.id, product.name]),
+  ]);
+}
+
+function opportunityMatchesTerms(
+  opportunity: SiteOpportunity,
+  terms: string[],
+): boolean {
+  return matchesSearchText(terms, [
+    opportunity.title,
+    opportunity.typeLabel,
+    opportunity.impactLabel,
+    opportunity.impactValue,
+    opportunity.evidence,
+    STEP_TYPE_LABELS[opportunity.node.type],
+    opportunity.node.id,
+    opportunity.node.material,
+    opportunity.node.plant,
+    ...opportunity.products.flatMap((product) => [product.id, product.name]),
+  ]);
+}
+
+function supplierMatchesTerms(
+  supplier: VendorOtifStats,
+  terms: string[],
+): boolean {
+  return matchesSearchText(terms, [
+    supplier.vendor_id,
+    supplier.vendor_name,
+    ...(supplier.materials?.flatMap((material) => [
+      material.matnr,
+      material.name,
+    ]) ?? []),
+  ]);
+}
+
+interface SiteSearchMatchers {
+  siteNode: (node: SiteNode) => boolean;
+  opportunity: (opportunity: SiteOpportunity) => boolean;
+  supplier: (supplier: VendorOtifStats) => boolean;
+}
+
+export function createSiteSearchMatchers(query: string): SiteSearchMatchers {
+  const terms = searchTerms(query);
+  return {
+    siteNode: (node: SiteNode) => siteNodeMatchesTerms(node, terms),
+    opportunity: (opportunity: SiteOpportunity) =>
+      opportunityMatchesTerms(opportunity, terms),
+    supplier: (supplier: VendorOtifStats) =>
+      supplierMatchesTerms(supplier, terms),
+  };
+}
+
+export function siteNodeMatchesSearch(node: SiteNode, query: string): boolean {
+  return siteNodeMatchesTerms(node, searchTerms(query));
+}
+
+export function supplierMatchesSearch(
+  supplier: VendorOtifStats,
+  query: string,
+): boolean {
+  return supplierMatchesTerms(supplier, searchTerms(query));
+}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

A few UX improvements to the supply chain pages:

1. Search input on the site overview to filter rows
2. Improve filters on opportunities table
3. For dwell nodes, allow switching between a chart showing distribution of event (a) duration and (b) cost

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->
<!-- Libraries inside of the `@local` directory are always internal libraries which have no need for publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
