### PR TITLE
FE-1222: Classify Petrinaut optimization transport errors in the UI

### DIFF
--- a/apps/hash-frontend/src/pages/processes/[uuid].page/process-editor.tsx
+++ b/apps/hash-frontend/src/pages/processes/[uuid].page/process-editor.tsx
@@ -522,6 +522,10 @@ export const ProcessEditor = ({
          * with HASH's session, then relay the NDJSON response byte-for-byte.
          */
         void (async () => {
+          // Captured from the response headers so a transport failure that
+          // happens mid-stream stays traceable to the NodeAPI/optimizer logs.
+          let hashRequestId: string | null = null;
+          let optimizationRunId: string | null = null;
           try {
             const response = await fetch(PETRINAUT_OPTIMIZATION_API, {
               method: "POST",
@@ -531,12 +535,17 @@ export const ProcessEditor = ({
               signal: controller.signal,
             });
 
+            hashRequestId = response.headers.get("x-hash-request-id");
+            optimizationRunId = response.headers.get("x-optimization-run-id");
+
             bridge.send({
               kind: "optimizationResponseStart",
               requestId,
               ok: response.ok,
               status: response.status,
               statusText: response.statusText,
+              hashRequestId,
+              optimizationRunId,
             });
 
             if (response.body) {
@@ -556,10 +565,17 @@ export const ProcessEditor = ({
           } catch (error) {
             // An iframe-initiated abort is expected control flow.
             if (!controller.signal.aborted) {
+              // This catch only sees transport-level failures of the host's
+              // own fetch/read (a reset connection surfaces as a `TypeError`);
+              // HTTP and protocol classification happen in the iframe bridge.
               bridge.send({
                 kind: "optimizationError",
                 requestId,
-                message: error instanceof Error ? error.message : String(error),
+                category: "network",
+                message: "The optimization service connection was interrupted",
+                hashRequestId,
+                optimizationRunId,
+                errorName: error instanceof Error ? error.name : undefined,
               });
             }
           } finally {

--- a/apps/hash-frontend/src/pages/processes/[uuid]/embed.page/create-bridge-petrinaut-optimization.browser.test.ts
+++ b/apps/hash-frontend/src/pages/processes/[uuid]/embed.page/create-bridge-petrinaut-optimization.browser.test.ts
@@ -95,6 +95,8 @@ describe("createBridgePetrinautOptimization", () => {
       ok: true,
       status: 200,
       statusText: "OK",
+      hashRequestId: "req-1",
+      optimizationRunId: "run-1",
     });
     sendFromHost({
       kind: "optimizationChunk",
@@ -145,5 +147,45 @@ describe("createBridgePetrinautOptimization", () => {
           (message as { requestId?: string }).requestId === requestId,
       ),
     ).toBe(true);
+  });
+
+  it("classifies a mid-stream host error with its correlation ids", async () => {
+    const postMessage = vi
+      .spyOn(window.parent, "postMessage")
+      .mockImplementation(() => undefined);
+    const iterator = createBridgePetrinautOptimization()
+      .optimize(input)
+      [Symbol.asyncIterator]();
+
+    const firstEvent = iterator.next();
+    await vi.waitFor(() => {
+      expect(getOptimizationRequest(postMessage.mock.calls)).toBeDefined();
+    });
+    const requestId = getOptimizationRequest(postMessage.mock.calls)?.requestId;
+
+    sendFromHost({
+      kind: "optimizationResponseStart",
+      requestId,
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      hashRequestId: "req-9",
+      optimizationRunId: "run-9",
+    });
+    sendFromHost({
+      kind: "optimizationError",
+      requestId,
+      category: "network",
+      message: "The optimization service connection was interrupted",
+    });
+
+    // The bridge reclassifies the host error and backfills the correlation ids
+    // captured from the earlier response-start message.
+    await expect(firstEvent).rejects.toMatchObject({
+      name: "PetrinautOptimizationTransportError",
+      category: "network",
+      hashRequestId: "req-9",
+      optimizationRunId: "run-9",
+    });
   });
 });

--- a/apps/hash-frontend/src/pages/processes/[uuid]/embed.page/create-bridge-petrinaut-optimization.test.ts
+++ b/apps/hash-frontend/src/pages/processes/[uuid]/embed.page/create-bridge-petrinaut-optimization.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { parsePetrinautOptimizationResponse } from "./create-bridge-petrinaut-optimization";
+import {
+  parsePetrinautOptimizationResponse,
+  PetrinautOptimizationTransportError,
+} from "./create-bridge-petrinaut-optimization";
 
 const responseFromChunks = (chunks: string[], status = 200): Response => {
   const encoder = new TextEncoder();
@@ -41,28 +44,50 @@ describe("parsePetrinautOptimizationResponse", () => {
     ]);
   });
 
-  it("rejects a stream with no terminal event", async () => {
+  it("rejects a stream with no terminal event as a protocol error", async () => {
     const response = responseFromChunks([
       '{"type":"started","requestedTrials":2}\n',
     ]);
 
-    await expect(collect(response)).rejects.toThrow("without a terminal event");
+    await expect(collect(response)).rejects.toMatchObject({
+      category: "protocol",
+      message: expect.stringContaining("without a terminal event"),
+    });
   });
 
-  it("rejects data after a terminal event", async () => {
+  it("rejects data after a terminal event as a protocol error", async () => {
     const response = responseFromChunks([
       '{"type":"error","code":"failed","message":"nope","retryable":false}\n',
       '{"type":"started","requestedTrials":2}\n',
     ]);
 
-    await expect(collect(response)).rejects.toThrow("after a terminal event");
+    await expect(collect(response)).rejects.toMatchObject({
+      category: "protocol",
+      message: expect.stringContaining("after a terminal event"),
+    });
   });
 
-  it("surfaces a structured HTTP error", async () => {
+  it("surfaces a structured HTTP error with status and correlation ids", async () => {
     const response = new Response(JSON.stringify({ error: "Not configured" }), {
       status: 503,
+      headers: {
+        "x-hash-request-id": "req-1",
+        "x-optimization-run-id": "run-1",
+      },
     });
 
-    await expect(collect(response)).rejects.toThrow("Not configured");
+    const error = await collect(response).then(
+      () => null,
+      (caught: unknown) => caught,
+    );
+
+    expect(error).toBeInstanceOf(PetrinautOptimizationTransportError);
+    expect(error).toMatchObject({
+      category: "http",
+      httpStatus: 503,
+      hashRequestId: "req-1",
+      optimizationRunId: "run-1",
+      message: "Not configured",
+    });
   });
 });

--- a/apps/hash-frontend/src/pages/processes/[uuid]/embed.page/create-bridge-petrinaut-optimization.ts
+++ b/apps/hash-frontend/src/pages/processes/[uuid]/embed.page/create-bridge-petrinaut-optimization.ts
@@ -11,12 +11,52 @@ import {
   nextRequestId,
 } from "../../shared/messages";
 
+/** Classification of an optimization transport failure. */
+export type OptimizationErrorCategory =
+  | "network"
+  | "http"
+  | "protocol"
+  | "aborted";
+
+/**
+ * A classified optimization transport failure carrying the correlation ids
+ * needed to trace it to the NodeAPI and optimizer logs. Consumers build a
+ * user-facing message from `category` and progress rather than surfacing the
+ * raw `message`.
+ */
+export class PetrinautOptimizationTransportError extends Error {
+  readonly category: OptimizationErrorCategory;
+  readonly hashRequestId: string | null;
+  readonly optimizationRunId: string | null;
+  readonly httpStatus: number | null;
+
+  constructor(
+    message: string,
+    options: {
+      category: OptimizationErrorCategory;
+      hashRequestId?: string | null;
+      optimizationRunId?: string | null;
+      httpStatus?: number | null;
+    },
+  ) {
+    super(message);
+    this.name = "PetrinautOptimizationTransportError";
+    this.category = options.category;
+    this.hashRequestId = options.hashRequestId ?? null;
+    this.optimizationRunId = options.optimizationRunId ?? null;
+    this.httpStatus = options.httpStatus ?? null;
+  }
+}
+
 type PendingRequest = {
   stream: ReadableStream<Uint8Array>;
   controller: ReadableStreamDefaultController<Uint8Array>;
   resolveResponse: (response: Response) => void;
   rejectResponse: (error: Error) => void;
   responded: boolean;
+  /** Correlation ids from the response-start header, for later stream errors. */
+  hashRequestId: string | null;
+  optimizationRunId: string | null;
   clearResponseStartTimeout: () => void;
   cleanup: () => void;
 };
@@ -102,15 +142,31 @@ const ensureListener = () => {
         if (pending.responded) {
           rejectPendingRequest(
             message.requestId,
-            new Error("The optimizer sent more than one response header"),
+            new PetrinautOptimizationTransportError(
+              "The optimizer sent more than one response header",
+              { category: "protocol" },
+            ),
           );
           return;
         }
         pending.responded = true;
+        pending.hashRequestId = message.hashRequestId;
+        pending.optimizationRunId = message.optimizationRunId;
         pending.clearResponseStartTimeout();
+        const headers = new Headers({
+          "content-type": "application/x-ndjson",
+        });
+        // Carry the correlation ids on the synthesized response so the HTTP
+        // error path (`readHttpError`) can attach them too.
+        if (message.hashRequestId !== null) {
+          headers.set("x-hash-request-id", message.hashRequestId);
+        }
+        if (message.optimizationRunId !== null) {
+          headers.set("x-optimization-run-id", message.optimizationRunId);
+        }
         pending.resolveResponse(
           new Response(pending.stream, {
-            headers: { "content-type": "application/x-ndjson" },
+            headers,
             status: message.status,
             statusText: message.statusText,
           }),
@@ -129,7 +185,10 @@ const ensureListener = () => {
         if (!pending.responded) {
           rejectPendingRequest(
             message.requestId,
-            new Error("The optimizer ended before sending a response"),
+            new PetrinautOptimizationTransportError(
+              "The optimizer ended before sending a response",
+              { category: "protocol" },
+            ),
           );
           return;
         }
@@ -143,7 +202,16 @@ const ensureListener = () => {
         break;
       }
       case "optimizationError":
-        rejectPendingRequest(message.requestId, new Error(message.message));
+        rejectPendingRequest(
+          message.requestId,
+          new PetrinautOptimizationTransportError(message.message, {
+            category: message.category,
+            hashRequestId: message.hashRequestId ?? pending.hashRequestId,
+            optimizationRunId:
+              message.optimizationRunId ?? pending.optimizationRunId,
+            httpStatus: message.httpStatus,
+          }),
+        );
         break;
     }
   });
@@ -178,7 +246,10 @@ const bridgeFetch = (
     postToHost({ kind: "optimizationAbort", requestId });
     rejectPendingRequest(
       requestId,
-      new Error("The optimization service did not respond in time"),
+      new PetrinautOptimizationTransportError(
+        "The optimization service did not respond in time",
+        { category: "network" },
+      ),
     );
   }, RESPONSE_START_TIMEOUT_MS);
   const clearResponseStartTimeout = () => clearTimeout(responseStartTimeout);
@@ -190,6 +261,8 @@ const bridgeFetch = (
       resolveResponse: resolve,
       rejectResponse: reject,
       responded: false,
+      hashRequestId: null,
+      optimizationRunId: null,
       clearResponseStartTimeout,
       cleanup: () => {
         clearResponseStartTimeout();
@@ -208,7 +281,15 @@ const bridgeFetch = (
   return response;
 };
 
-const readHttpError = async (response: Response): Promise<Error> => {
+const readHttpError = async (
+  response: Response,
+): Promise<PetrinautOptimizationTransportError> => {
+  const correlation = {
+    category: "http" as const,
+    hashRequestId: response.headers.get("x-hash-request-id"),
+    optimizationRunId: response.headers.get("x-optimization-run-id"),
+    httpStatus: response.status,
+  };
   const body = await response.text();
   if (body) {
     try {
@@ -220,24 +301,29 @@ const readHttpError = async (response: Response): Promise<Error> => {
             ? json.message
             : null;
       if (message) {
-        return new Error(message);
+        return new PetrinautOptimizationTransportError(message, correlation);
       }
     } catch {
       // Fall through and include the plain response body.
     }
   }
-  return new Error(
+  return new PetrinautOptimizationTransportError(
     body ||
       `Optimization request failed with status ${response.status} ${response.statusText}`,
+    correlation,
   );
 };
+
+/** A protocol violation while decoding the optimizer's NDJSON stream. */
+const protocolError = (message: string) =>
+  new PetrinautOptimizationTransportError(message, { category: "protocol" });
 
 const parseEventLine = (line: string): PetrinautOptimizationEvent => {
   let parsed: unknown;
   try {
     parsed = JSON.parse(line);
   } catch {
-    throw new Error("The optimizer returned malformed NDJSON");
+    throw protocolError("The optimizer returned malformed NDJSON");
   }
   return petrinautOptimizationEventSchema.parse(parsed);
 };
@@ -250,7 +336,7 @@ export async function* parsePetrinautOptimizationResponse(
     throw await readHttpError(response);
   }
   if (!response.body) {
-    throw new Error("The optimizer returned an empty response body");
+    throw protocolError("The optimizer returned an empty response body");
   }
 
   const reader = response.body.getReader();
@@ -261,7 +347,7 @@ export async function* parsePetrinautOptimizationResponse(
 
   const parseAndTrack = (line: string, terminalSeen: boolean) => {
     if (terminalSeen) {
-      throw new Error("The optimizer returned data after a terminal event");
+      throw protocolError("The optimizer returned data after a terminal event");
     }
     const event = parseEventLine(line);
     return {
@@ -298,7 +384,9 @@ export async function* parsePetrinautOptimizationResponse(
       yield parsed.event;
     }
     if (!terminalEventSeen) {
-      throw new Error("The optimizer stream ended without a terminal event");
+      throw protocolError(
+        "The optimizer stream ended without a terminal event",
+      );
     }
   } finally {
     if (!reachedEnd) {

--- a/apps/hash-frontend/src/pages/processes/shared/messages.ts
+++ b/apps/hash-frontend/src/pages/processes/shared/messages.ts
@@ -185,6 +185,13 @@ export type HostToIframeMessage =
       ok: boolean;
       status: number;
       statusText: string;
+      /**
+       * NodeAPI's `x-hash-request-id` / `X-Optimization-Run-ID` response
+       * headers, forwarded so a later transport failure remains traceable to
+       * the NodeAPI and optimizer logs. Null when the header is absent.
+       */
+      hashRequestId: string | null;
+      optimizationRunId: string | null;
     }
   | {
       /** A verbatim chunk of the optimizer's NDJSON response body. */
@@ -198,10 +205,20 @@ export type HostToIframeMessage =
       requestId: string;
     }
   | {
-      /** The optimization fetch failed before or while streaming. */
+      /**
+       * The optimization fetch failed before or while streaming. `category`
+       * classifies the failure so the UI can show an actionable message
+       * instead of a raw exception string; `message` is a safe, human-readable
+       * summary that never contains internal or user-authored content.
+       */
       kind: "optimizationError";
       requestId: string;
+      category: "network" | "http" | "protocol" | "aborted";
       message: string;
+      hashRequestId?: string | null;
+      optimizationRunId?: string | null;
+      httpStatus?: number;
+      errorName?: string;
     };
 
 /**

--- a/libs/@hashintel/petrinaut/docs/optimization.md
+++ b/libs/@hashintel/petrinaut/docs/optimization.md
@@ -77,6 +77,11 @@ Closing the drawer does not stop the optimization. Use **Cancel** to abort an
 active run. Completed, cancelled, and failed records can be removed from their
 result drawer.
 
+If a run fails, the drawer explains what happened — for example, a lost
+connection reports how many of the requested trials had completed and includes
+a diagnostic identifier for support. Trials received before the failure are
+kept, and a **Retry** action starts a fresh run with the same settings.
+
 For the initial integration, an optimization is tied to its browser connection.
 Closing or reloading the page cancels the active request rather than creating a
 persistent background job.

--- a/libs/@hashintel/petrinaut/src/react/optimizations/context.ts
+++ b/libs/@hashintel/petrinaut/src/react/optimizations/context.ts
@@ -13,6 +13,20 @@ export type OptimizationStatus =
   | "error"
   | "cancelled";
 
+/** How an optimization transport failure was classified. */
+export type OptimizationErrorCategory =
+  | "network"
+  | "http"
+  | "protocol"
+  | "aborted";
+
+/** Correlation ids for tracing a failure to the NodeAPI/optimizer logs. */
+export type OptimizationErrorDiagnostics = {
+  hashRequestId: string | null;
+  optimizationRunId: string | null;
+  httpStatus: number | null;
+};
+
 export type OptimizationBest = NonNullable<
   Extract<PetrinautOptimizationEvent, { type: "complete" }>["best"]
 >;
@@ -23,6 +37,10 @@ export type OptimizationRecord = {
   createdAt: number;
   status: OptimizationStatus;
   error: string | null;
+  /** Set when a transport failure was classified; null otherwise. */
+  errorCategory: OptimizationErrorCategory | null;
+  /** Correlation ids for a classified failure, for the diagnostic UI. */
+  errorDiagnostics: OptimizationErrorDiagnostics | null;
   requestedTrials: number;
   completedTrials: number;
   prunedTrials: number;
@@ -47,6 +65,11 @@ export type OptimizationsContextValue = {
   createOptimization: (input: PetrinautOptimizationInput) => Promise<string>;
   cancelOptimization: (optimizationId: string) => void;
   removeOptimization: (optimizationId: string) => void;
+  /**
+   * Start a fresh optimization from a prior one's input (e.g. after a
+   * transport failure). Returns the new id, or null if the record is gone.
+   */
+  retryOptimization: (optimizationId: string) => Promise<string | null>;
 };
 
 const DEFAULT_CONTEXT_VALUE: OptimizationsContextValue = {
@@ -58,6 +81,7 @@ const DEFAULT_CONTEXT_VALUE: OptimizationsContextValue = {
     Promise.reject(new Error("Optimization is unavailable")),
   cancelOptimization: () => {},
   removeOptimization: () => {},
+  retryOptimization: () => Promise.resolve(null),
 };
 
 export const OptimizationsContext = createContext<OptimizationsContextValue>(

--- a/libs/@hashintel/petrinaut/src/react/optimizations/provider.test.tsx
+++ b/libs/@hashintel/petrinaut/src/react/optimizations/provider.test.tsx
@@ -158,6 +158,101 @@ describe("OptimizationsProvider", () => {
     });
   });
 
+  it("classifies a transport failure and preserves received trials", async () => {
+    class FakeTransportError extends Error {
+      category = "network" as const;
+      hashRequestId = "req-7";
+      optimizationRunId = "run-7";
+      httpStatus = null;
+    }
+    const capability: PetrinautOptimization = {
+      async *optimize() {
+        yield { type: "started", requestedTrials: 2 };
+        yield {
+          type: "trial",
+          trial: 0,
+          parameters: { infected_ratio: 0.01 },
+          objective: 0.4,
+          state: "complete",
+          best: {
+            trial: 0,
+            parameters: { infected_ratio: 0.01 },
+            objective: 0.4,
+          },
+        };
+        throw new FakeTransportError("connection interrupted");
+      },
+    };
+    const getValue = renderProvider(capability);
+
+    await act(async () => {
+      await getValue().createOptimization(input);
+    });
+
+    await waitFor(() =>
+      expect(getValue().optimizations[0]?.status).toBe("error"),
+    );
+    const optimization = getValue().optimizations[0]!;
+    // The raw exception message is replaced with an actionable, progress-aware
+    // message carrying the diagnostic id, and the received trial is kept.
+    expect(optimization.error).toBe(
+      "Connection to the optimization service was interrupted after 1 of 2 trials. Retry the optimization. (diagnostic id: run-7)",
+    );
+    expect(optimization.errorCategory).toBe("network");
+    expect(optimization.errorDiagnostics).toEqual({
+      hashRequestId: "req-7",
+      optimizationRunId: "run-7",
+      httpStatus: null,
+    });
+    expect(optimization.trials).toHaveLength(1);
+  });
+
+  it("retries a failed optimization from its original input", async () => {
+    let call = 0;
+    const capability: PetrinautOptimization = {
+      async *optimize(request) {
+        call += 1;
+        if (call === 1) {
+          throw Object.assign(new Error("interrupted"), {
+            category: "network",
+          });
+        }
+        yield {
+          type: "complete",
+          requestedTrials: request.study.trials,
+          completedTrials: 0,
+          prunedTrials: 0,
+          failedTrials: 0,
+          best: null,
+        };
+      },
+    };
+    const getValue = renderProvider(capability);
+    let failedId = "";
+
+    await act(async () => {
+      failedId = await getValue().createOptimization(input);
+    });
+    await waitFor(() =>
+      expect(getValue().optimizations[0]?.status).toBe("error"),
+    );
+
+    let retriedId: string | null = null;
+    await act(async () => {
+      retriedId = await getValue().retryOptimization(failedId);
+    });
+
+    expect(retriedId).not.toBeNull();
+    expect(retriedId).not.toBe(failedId);
+    await waitFor(() =>
+      expect(
+        getValue().optimizations.find((o) => o.id === retriedId)?.status,
+      ).toBe("complete"),
+    );
+    // The retry reuses the failed run's input, so the failed record remains.
+    expect(getValue().optimizations).toHaveLength(2);
+  });
+
   it("aborts and marks an active optimization as cancelled", async () => {
     const capability: PetrinautOptimization = {
       async *optimize(_request, options) {

--- a/libs/@hashintel/petrinaut/src/react/optimizations/provider.tsx
+++ b/libs/@hashintel/petrinaut/src/react/optimizations/provider.tsx
@@ -5,6 +5,8 @@ import { petrinautOptimizationInputSchema } from "@hashintel/petrinaut-core";
 import { useBlockWindowClose } from "../hooks/use-block-window-close";
 import { PetrinautOptimizationContext } from "../optimization-context";
 import {
+  type OptimizationErrorCategory,
+  type OptimizationErrorDiagnostics,
   isOptimizationActive,
   type OptimizationRecord,
   OptimizationsContext,
@@ -13,11 +15,82 @@ import {
 
 import type { PropsWithChildren } from "react";
 
+const ERROR_CATEGORIES = new Set<OptimizationErrorCategory>([
+  "network",
+  "http",
+  "protocol",
+  "aborted",
+]);
+
+type ClassifiedError = {
+  category: OptimizationErrorCategory;
+  diagnostics: OptimizationErrorDiagnostics;
+};
+
 function isAbortError(error: unknown): boolean {
   return (
     (error instanceof DOMException && error.name === "AbortError") ||
     (error instanceof Error && error.name === "AbortError")
   );
+}
+
+/**
+ * Read the structured fields off a classified transport error without
+ * depending on the host bridge's class: the error crosses from the app into
+ * this library, so it is duck-typed rather than matched with `instanceof`.
+ */
+function classifyError(error: unknown): ClassifiedError | null {
+  if (typeof error !== "object" || error === null) {
+    return null;
+  }
+  const candidate = error as Record<string, unknown>;
+  if (
+    typeof candidate.category !== "string" ||
+    !ERROR_CATEGORIES.has(candidate.category as OptimizationErrorCategory)
+  ) {
+    return null;
+  }
+  return {
+    category: candidate.category as OptimizationErrorCategory,
+    diagnostics: {
+      hashRequestId:
+        typeof candidate.hashRequestId === "string"
+          ? candidate.hashRequestId
+          : null,
+      optimizationRunId:
+        typeof candidate.optimizationRunId === "string"
+          ? candidate.optimizationRunId
+          : null,
+      httpStatus:
+        typeof candidate.httpStatus === "number" ? candidate.httpStatus : null,
+    },
+  };
+}
+
+/** Build a safe, actionable message from a classified failure. */
+function buildErrorMessage(
+  classified: ClassifiedError,
+  progress: { completedTrials: number; requestedTrials: number },
+): string {
+  const after = `after ${progress.completedTrials} of ${progress.requestedTrials} trials`;
+  const { httpStatus, optimizationRunId, hashRequestId } =
+    classified.diagnostics;
+  const diagnosticId = optimizationRunId ?? hashRequestId;
+  const diagnostic = diagnosticId ? ` (diagnostic id: ${diagnosticId})` : "";
+
+  switch (classified.category) {
+    case "http":
+      return `The optimization service rejected the request${
+        httpStatus === null ? "" : ` (status ${httpStatus})`
+      } ${after}. Retry the optimization.${diagnostic}`;
+    case "protocol":
+      return `The optimization stream ended unexpectedly ${after}. Retry the optimization.${diagnostic}`;
+    case "aborted":
+      return "The optimization was cancelled.";
+    case "network":
+    default:
+      return `Connection to the optimization service was interrupted ${after}. Retry the optimization.${diagnostic}`;
+  }
 }
 
 export const OptimizationsProvider = ({ children }: PropsWithChildren) => {
@@ -70,6 +143,8 @@ export const OptimizationsProvider = ({ children }: PropsWithChildren) => {
         createdAt: Date.now(),
         status: "initializing",
         error: null,
+        errorCategory: null,
+        errorDiagnostics: null,
         requestedTrials: input.study.trials,
         completedTrials: 0,
         prunedTrials: 0,
@@ -135,19 +210,35 @@ export const OptimizationsProvider = ({ children }: PropsWithChildren) => {
             }
           }
         } catch (error) {
-          patchOptimization(optimizationId, (current) => ({
-            ...current,
-            status:
-              abortController.signal.aborted || isAbortError(error)
-                ? "cancelled"
-                : "error",
-            error:
-              abortController.signal.aborted || isAbortError(error)
-                ? null
+          const classified = classifyError(error);
+          const cancelled =
+            abortController.signal.aborted ||
+            isAbortError(error) ||
+            classified?.category === "aborted";
+          patchOptimization(optimizationId, (current) => {
+            if (cancelled) {
+              return {
+                ...current,
+                status: "cancelled",
+                error: null,
+                errorCategory: null,
+                errorDiagnostics: null,
+              };
+            }
+            return {
+              ...current,
+              status: "error",
+              // A classified transport failure yields a safe, actionable
+              // message and correlation ids; anything else keeps its message.
+              error: classified
+                ? buildErrorMessage(classified, current)
                 : error instanceof Error
                   ? error.message
                   : String(error),
-          }));
+              errorCategory: classified?.category ?? null,
+              errorDiagnostics: classified?.diagnostics ?? null,
+            };
+          });
         } finally {
           abortControllersRef.current.delete(optimizationId);
         }
@@ -182,6 +273,17 @@ export const OptimizationsProvider = ({ children }: PropsWithChildren) => {
     );
   };
 
+  const retryOptimization: OptimizationsContextValue["retryOptimization"] =
+    async (optimizationId) => {
+      const existing = optimizations.find(
+        (optimization) => optimization.id === optimizationId,
+      );
+      if (!existing) {
+        return null;
+      }
+      return createOptimization(existing.input);
+    };
+
   const selectedOptimization =
     optimizations.find(
       (optimization) => optimization.id === selectedOptimizationId,
@@ -195,6 +297,7 @@ export const OptimizationsProvider = ({ children }: PropsWithChildren) => {
     createOptimization,
     cancelOptimization,
     removeOptimization,
+    retryOptimization,
   };
 
   return <OptimizationsContext value={value}>{children}</OptimizationsContext>;

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/create-optimization-drawer.test.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/create-optimization-drawer.test.tsx
@@ -209,6 +209,7 @@ const TestProviders = ({
     createOptimization,
     cancelOptimization: () => {},
     removeOptimization: () => {},
+    retryOptimization: () => Promise.resolve(null),
   };
   const drawer = (
     <OptimizationsContext value={optimizations}>

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/view-optimization-drawer.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/view-optimization-drawer.tsx
@@ -283,7 +283,8 @@ export const ViewOptimizationDrawer = ({
   onClose: () => void;
   optimization: OptimizationRecord | undefined;
 }) => {
-  const { cancelOptimization, removeOptimization } = use(OptimizationsContext);
+  const { cancelOptimization, removeOptimization, retryOptimization } =
+    use(OptimizationsContext);
 
   if (!open || !optimization) {
     return null;
@@ -370,6 +371,23 @@ export const ViewOptimizationDrawer = ({
                 onClick={() => cancelOptimization(optimization.id)}
               >
                 Cancel
+              </Button>
+            ) : null}
+            {optimization.status === "error" ? (
+              <Button
+                variant="subtle"
+                tone="neutral"
+                size="sm"
+                prefix={<Icon name="rotate" size="sm" />}
+                onClick={() => {
+                  void retryOptimization(optimization.id).then((newId) => {
+                    if (newId !== null) {
+                      onClose();
+                    }
+                  });
+                }}
+              >
+                Retry
               </Button>
             ) : null}
             <Button variant="solid" tone="neutral" size="sm" onClick={onClose}>


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When a long optimization stream is reset mid-run, the UI shows the raw `network error` — the caught `fetch`/`reader.read()` exception message forwarded verbatim. This replaces it with a classified, actionable error and threads NodeAPI's correlation ids to the UI, so a failed run is traceable to the NodeAPI and optimizer logs and the user gets a clear next step. Already-received trials are preserved and a Retry action is offered.

## 🔗 Related links

- [FE-1222](https://linear.app/hash/issue/FE-1222) — this issue
- [FE-1217](https://linear.app/hash/issue/FE-1217) — parent hardening issue
- [SRE-831](https://linear.app/hash/issue/SRE-831) — the suspected root cause (proxy/LB streaming timeout); this PR improves the experience regardless of it

## 🚫 Blocked by

- [ ] Stacked on `codex/petrinaut-optimization-frontend` (#9051)
- [ ] Relies on the `X-Optimization-Run-ID` response header NodeAPI sets in #9059 for the run-id diagnostic (degrades gracefully to null if absent)

## 🔍 What does this change?

- `messages.ts`: `optimizationResponseStart` carries the `x-hash-request-id` / `X-Optimization-Run-ID` response headers; `optimizationError` gains a `category` (`network` / `http` / `protocol` / `aborted`) plus optional correlation ids, `httpStatus`, and `errorName`.
- Host (`process-editor.tsx`): captures the correlation headers, forwards them on response-start, and classifies its own transport failures as `network` with a safe message (no raw exception text).
- Bridge (`create-bridge-petrinaut-optimization.ts`): a new `PetrinautOptimizationTransportError` carries the structured fields; non-ok responses are classified `http` (with status + correlation ids), protocol violations `protocol`, and the response-start timeout `network`; correlation ids captured at response-start backfill a later stream error.
- Provider (`provider.tsx`): builds a safe, progress-aware message ("Connection to the optimization service was interrupted after N of M trials. Retry the optimization. (diagnostic id: …)"), keeps the received trials, stores `errorCategory` / `errorDiagnostics` on the record, and adds `retryOptimization` to start a fresh run from the failed one's input. The error type crosses the app→lib boundary, so it is duck-typed rather than matched with `instanceof`.
- View drawer: a **Retry** action on a failed run.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] require changes to docs which **are made** as part of this PR

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- `create-bridge-petrinaut-optimization.test.ts`: protocol classification (no-terminal, data-after-terminal) and the HTTP path carrying status + correlation ids.
- `create-bridge-petrinaut-optimization.browser.test.ts`: a mid-stream host error is reclassified and backfilled with the response-start correlation ids.
- `provider.test.tsx`: a classified transport failure yields the composed message + preserved trials + `errorCategory`/`errorDiagnostics`; `retryOptimization` starts a fresh run from the original input.
- `messages.test.ts`, `create-optimization-drawer.test.tsx`: kept green with the extended message and context shapes.

All four suites pass (`@hashintel/petrinaut` react + UI optimization tests; `@apps/hash-frontend` bridge + messages tests).

## ❓ How to test this?

1. Check out the branch / open the deployment.
2. Start a long optimization and interrupt the connection (or let a proxy reset it) so the stream drops mid-run.
3. Confirm the result drawer shows a classified message with the trial progress and a diagnostic id, the already-received trials remain listed, and a **Retry** button starts a fresh run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
