### PR TITLE
FE-1224: Add detached, reconnectable optimization runs to the Petrinaut optimizer

### DIFF
--- a/apps/petrinaut-opt/README.md
+++ b/apps/petrinaut-opt/README.md
@@ -85,6 +85,12 @@ failures, completion, disconnect, or detached-run cancellation/reaping.
 `GET /status` retains the 100 most recent runs so process memory cannot grow
 without bound.
 
+Detached runs reject descriptions above 1,000 trials and, by default, stop
+after 900 seconds (`HASH_PETRINAUT_OPT_MAX_STUDY_SECONDS`); invalid values use
+the default and zero disables the wall-clock limit. Their event log is retained
+for the detach-grace period and an attachment cursor is clamped to the current
+log, so malformed resume requests cannot suppress later terminal events.
+
 Optimization request bodies are limited to 8 MiB, including chunked bodies.
 
 ## CLI protocol

--- a/apps/petrinaut-opt/README.md
+++ b/apps/petrinaut-opt/README.md
@@ -17,6 +17,10 @@ forwarded unchanged to the CLI.
 - `POST /optimize/all` streams every finished trial.
 - `POST /optimize/best` streams the best-so-far result after each finished
   trial. No data frame is emitted until at least one trial completes.
+- `POST /optimize/runs` starts a detached run and returns its id. Attach or
+  reattach to its replayable event stream with
+  `GET /optimize/runs/{run_id}/events`; `DELETE /optimize/runs/{run_id}`
+  cancels it.
 
 The response is `text/event-stream`. Existing frame bodies are preserved:
 
@@ -47,10 +51,10 @@ every 30 seconds:
 SSE clients ignore comment frames, while load balancers and proxies see traffic
 before their idle timeout.
 
-Streams are not resumable: they do not emit event IDs or replay missed trials.
-If the caller disconnects, the service stops that study and releases its CLI;
-the caller must submit a new optimization request rather than reconnect with
-`Last-Event-ID`.
+The streaming endpoints are not resumable: disconnecting stops that study and
+releases its CLI. Detached-run event streams are resumable: every frame has an
+event id, buffered frames can be replayed using `Last-Event-ID` (or `cursor`),
+and disconnecting an attachment does not stop the run.
 
 Each response has an `X-Optimization-Run-ID` header for status queries:
 
@@ -77,8 +81,9 @@ optimization manifests, user-authored code, or raw request bodies.
 
 The process admits at most four active optimizations. Additional requests
 receive HTTP 429, and slots are released after initialization failures, stream
-failures, completion, or disconnect. `GET /status` retains the 100 most recent
-runs so process memory cannot grow without bound.
+failures, completion, disconnect, or detached-run cancellation/reaping.
+`GET /status` retains the 100 most recent runs so process memory cannot grow
+without bound.
 
 Optimization request bodies are limited to 8 MiB, including chunked bodies.
 

--- a/apps/petrinaut-opt/openapi/openapi.json
+++ b/apps/petrinaut-opt/openapi/openapi.json
@@ -253,7 +253,7 @@
     },
     "/optimize/runs": {
       "post": {
-        "description": "Start a detached optimization run and return its run id immediately.\n\nThe run keeps optimizing with no consumer attached; its admission slot is\nheld until the run completes, fails, is cancelled via\n``DELETE /optimize/runs/{run_id}``, or is reaped after the detach grace\nperiod without an attached consumer.",
+        "description": "Start a detached run that remains available for later SSE attachment.",
         "operationId": "post_optimize_runs_optimize_runs_post",
         "requestBody": {
           "content": {
@@ -280,7 +280,7 @@
                 }
               }
             },
-            "description": "The detached optimization run was admitted and started in the background; consume its Server-Sent Events via GET /optimize/runs/{run_id}/events"
+            "description": "A detached optimization run was started"
           },
           "413": {
             "description": "The optimization manifest exceeds 8 MiB"
@@ -315,7 +315,7 @@
     },
     "/optimize/runs/{run_id}": {
       "delete": {
-        "description": "Cancel a detached run; idempotent once the run is terminal.\n\nReturns after the run's CLI is closed, its terminal frame is appended,\nand its admission slot is released.",
+        "description": "Cancel a detached run and wait for its resources to be released.",
         "operationId": "delete_optimize_run_optimize_runs__run_id__delete",
         "parameters": [
           {
@@ -330,7 +330,7 @@
         ],
         "responses": {
           "204": {
-            "description": "The run was cancelled (or had already reached a terminal state); when this call stopped it, the event log's terminal frame is `event: cancelled`"
+            "description": "The optimization run was cancelled"
           },
           "404": {
             "description": "No optimization run with this id is registered"
@@ -351,7 +351,7 @@
     },
     "/optimize/runs/{run_id}/events": {
       "get": {
-        "description": "Attach to a detached run's SSE log, replaying frames past the cursor.\n\n``cursor`` defaults to the ``Last-Event-ID`` header (the query parameter\nwins), then to 0 \u2014 a full replay. Disconnecting never affects the run.",
+        "description": "Attach to a detached run and replay events after the supplied cursor.",
         "operationId": "get_optimize_run_events_optimize_runs__run_id__events_get",
         "parameters": [
           {
@@ -390,7 +390,7 @@
                 }
               }
             },
-            "description": "Server-Sent Events attachment to a detached optimization run. Every frame carries an `id: <seq>` line (seq starts at 1); buffered frames with seq > cursor are replayed, then new frames are live-tailed with `: heartbeat` comments roughly every 30 seconds. The terminal frame is `event: done` (completed), an ERROR data frame (study failure), or `event: cancelled` (cancelled or reaped). If the run is already terminal the response closes after the replay. Disconnecting does not affect the run; a newer attachment supersedes this one."
+            "description": "A replayable Server-Sent Events attachment. Terminal frames are `event: done`, an ERROR data frame, or `event: cancelled`."
           },
           "404": {
             "description": "No optimization run with this id is registered"

--- a/apps/petrinaut-opt/openapi/openapi.json
+++ b/apps/petrinaut-opt/openapi/openapi.json
@@ -251,6 +251,164 @@
         "summary": "Post Optimize Best"
       }
     },
+    "/optimize/runs": {
+      "post": {
+        "description": "Start a detached optimization run and return its run id immediately.\n\nThe run keeps optimizing with no consumer attached; its admission slot is\nheld until the run completes, fails, is cancelled via\n``DELETE /optimize/runs/{run_id}``, or is reaped after the detach grace\nperiod without an attached consumer.",
+        "operationId": "post_optimize_runs_optimize_runs_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "title": "Optimization Manifest",
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "title": "Response Post Optimize Runs Optimize Runs Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "The detached optimization run was admitted and started in the background; consume its Server-Sent Events via GET /optimize/runs/{run_id}/events"
+          },
+          "413": {
+            "description": "The optimization manifest exceeds 8 MiB"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "429": {
+            "description": "The service is already at its study limit",
+            "headers": {
+              "Retry-After": {
+                "description": "Seconds to wait before retrying the study",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "The CLI or optimization study could not initialize"
+          }
+        },
+        "summary": "Post Optimize Runs"
+      }
+    },
+    "/optimize/runs/{run_id}": {
+      "delete": {
+        "description": "Cancel a detached run; idempotent once the run is terminal.\n\nReturns after the run's CLI is closed, its terminal frame is appended,\nand its admission slot is released.",
+        "operationId": "delete_optimize_run_optimize_runs__run_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "run_id",
+            "required": true,
+            "schema": {
+              "title": "Run Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "The run was cancelled (or had already reached a terminal state); when this call stopped it, the event log's terminal frame is `event: cancelled`"
+          },
+          "404": {
+            "description": "No optimization run with this id is registered"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Optimize Run"
+      }
+    },
+    "/optimize/runs/{run_id}/events": {
+      "get": {
+        "description": "Attach to a detached run's SSE log, replaying frames past the cursor.\n\n``cursor`` defaults to the ``Last-Event-ID`` header (the query parameter\nwins), then to 0 \u2014 a full replay. Disconnecting never affects the run.",
+        "operationId": "get_optimize_run_events_optimize_runs__run_id__events_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "run_id",
+            "required": true,
+            "schema": {
+              "title": "Run Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/event-stream": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Server-Sent Events attachment to a detached optimization run. Every frame carries an `id: <seq>` line (seq starts at 1); buffered frames with seq > cursor are replayed, then new frames are live-tailed with `: heartbeat` comments roughly every 30 seconds. The terminal frame is `event: done` (completed), an ERROR data frame (study failure), or `event: cancelled` (cancelled or reaped). If the run is already terminal the response closes after the replay. Disconnecting does not affect the run; a newer attachment supersedes this one."
+          },
+          "404": {
+            "description": "No optimization run with this id is registered"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Optimize Run Events"
+      }
+    },
     "/status": {
       "get": {
         "description": "Return a snapshot of every optimization run's status.",

--- a/apps/petrinaut-opt/src/optimization_api.py
+++ b/apps/petrinaut-opt/src/optimization_api.py
@@ -56,7 +56,13 @@ _CREATE_RUN_RESPONSES = {
     500: _SSE_RESPONSES[500],
 }
 _RUN_EVENTS_RESPONSES = {
-    200: {"description": "A replayable Server-Sent Events attachment"},
+    200: {
+        "description": (
+            "A replayable Server-Sent Events attachment. Terminal frames are "
+            "`event: done`, an ERROR data frame, or `event: cancelled`."
+        ),
+        "content": {"text/event-stream": {"schema": {"type": "string"}}},
+    },
     404: {"description": "No optimization run with this id is registered"},
 }
 _DELETE_RUN_RESPONSES = {
@@ -449,6 +455,14 @@ async def get_optimize_run_events(
     if cursor is None:
         cursor = _cursor_from_last_event_id(request)
     epoch = run.begin_attachment()
+
+    async def detach_if_never_started() -> None:
+        # A consumer that aborts before the body iterator ever starts would
+        # otherwise stay marked attached and shield the run from the reaper.
+        # This must be async: Starlette runs sync background callables in a
+        # threadpool, where end_attachment's get_running_loop() would fail.
+        run.end_attachment(epoch)
+
     return StreamingResponse(
         attachment_event_stream(
             run,
@@ -463,7 +477,7 @@ async def get_optimize_run_events(
             "X-Accel-Buffering": "no",
             "X-Optimization-Run-ID": run_id,
         },
-        background=BackgroundTask(run.end_attachment, epoch),
+        background=BackgroundTask(detach_if_never_started),
     )
 
 

--- a/apps/petrinaut-opt/src/optimization_api.py
+++ b/apps/petrinaut-opt/src/optimization_api.py
@@ -7,17 +7,18 @@ import asyncio
 import logging
 import os
 import threading
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from contextlib import asynccontextmanager, suppress
 from pathlib import Path
 from typing import Any
 
 from dotenv import load_dotenv
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import FastAPI, HTTPException, Query, Request, Response
 from fastapi.responses import JSONResponse, StreamingResponse
 from starlette.background import BackgroundTask
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
+from src.optimization_runs import OptimizationRunRegistry, attachment_event_stream
 from src.petrinaut_client import PetrinautModel
 from src.petrinaut_optimizer import PetrinautOptimizer
 from src.telemetry import flush_telemetry, setup_telemetry
@@ -30,7 +31,7 @@ log = logging.getLogger("pn_api")
 MAX_REQUEST_BODY_BYTES = 8 * 1024 * 1024
 MAX_ACTIVE_OPTIMIZATIONS = 4
 RETRY_AFTER_SECONDS = 30
-_OPTIMIZATION_PATHS = {"/optimize/all", "/optimize/best"}
+_OPTIMIZATION_PATHS = {"/optimize/all", "/optimize/best", "/optimize/runs"}
 _SSE_RESPONSES = {
     200: {
         "description": "Server-Sent Events optimization stream",
@@ -47,6 +48,20 @@ _SSE_RESPONSES = {
         },
     },
     500: {"description": "The CLI or optimization study could not initialize"},
+}
+_CREATE_RUN_RESPONSES = {
+    201: {"description": "A detached optimization run was started"},
+    413: _SSE_RESPONSES[413],
+    429: _SSE_RESPONSES[429],
+    500: _SSE_RESPONSES[500],
+}
+_RUN_EVENTS_RESPONSES = {
+    200: {"description": "A replayable Server-Sent Events attachment"},
+    404: {"description": "No optimization run with this id is registered"},
+}
+_DELETE_RUN_RESPONSES = {
+    204: {"description": "The optimization run was cancelled"},
+    404: {"description": "No optimization run with this id is registered"},
 }
 
 
@@ -106,17 +121,21 @@ class RequestBodyLimitMiddleware:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
-    """Initialize the run-scoped status registry."""
+    """Initialize the status registry and detached-run engine."""
     app.state.statuses = StatusStore()
     app.state.optimization_admission_lock = asyncio.Lock()
     app.state.active_optimizations = 0
+    app.state.optimization_runs = OptimizationRunRegistry()
     try:
         yield
     finally:
-        # Flush buffered spans/metrics/logs on graceful shutdown so a SIGTERM
-        # (e.g. `docker stop`) does not drop whatever the batch processors have
-        # queued.
-        flush_telemetry()
+        try:
+            await app.state.optimization_runs.shutdown()
+        finally:
+            # Flush buffered spans/metrics/logs on graceful shutdown so a SIGTERM
+            # (e.g. `docker stop`) does not drop whatever the batch processors have
+            # queued.
+            flush_telemetry()
 
 
 app = FastAPI(title="Petrinaut optimization Python API", lifespan=lifespan)
@@ -166,6 +185,10 @@ async def _acquire_optimization_slot(
                 headers={"Retry-After": str(RETRY_AFTER_SECONDS)},
             )
         app.state.active_optimizations += 1
+
+
+def _request_correlation(request: Request) -> dict[str, str | None]:
+    return {"request_id": request.headers.get("x-hash-request-id")}
 
 
 async def _release_optimization_slot(app: FastAPI) -> None:
@@ -283,18 +306,13 @@ def _initialization_error(
     )
 
 
-@app.post(
-    "/optimize/all",
-    response_class=StreamingResponse,
-    responses=_SSE_RESPONSES,
-)
-async def post_optimize_all(
+async def _admit_and_initialize_run(
     request: Request,
     optimization_manifest: dict[str, Any],
-) -> StreamingResponse:
-    """Stream one SSE data frame for every completed Optuna trial."""
-    request_id = request.headers.get("x-hash-request-id")
-    await _acquire_optimization_slot(request.app, request_id=request_id)
+) -> tuple[str, PetrinautOptimizer, dict[str, str | None]]:
+    """Admit and initialize one optimizer, releasing its slot on failure."""
+    correlation = _request_correlation(request)
+    await _acquire_optimization_slot(request.app, request_id=correlation["request_id"])
     try:
         run_id = request.app.state.statuses.create().run_id
     except BaseException:
@@ -317,8 +335,24 @@ async def post_optimize_all(
                 await asyncio.to_thread(optimizer.pn_model.close, graceful=False)
         await asyncio.shield(_release_optimization_slot(request.app))
         raise _initialization_error(
-            request.app, run_id, error, request_id=request_id
+            request.app, run_id, error, request_id=correlation["request_id"]
         ) from error
+    return run_id, optimizer, correlation
+
+
+@app.post(
+    "/optimize/all",
+    response_class=StreamingResponse,
+    responses=_SSE_RESPONSES,
+)
+async def post_optimize_all(
+    request: Request,
+    optimization_manifest: dict[str, Any],
+) -> StreamingResponse:
+    """Stream one SSE data frame for every completed Optuna trial."""
+    run_id, optimizer, _correlation = await _admit_and_initialize_run(
+        request, optimization_manifest
+    )
 
     cleanup = _create_admitted_run_cleanup(request.app, optimizer)
     return StreamingResponse(
@@ -346,32 +380,9 @@ async def post_optimize_best(
     optimization_manifest: dict[str, Any],
 ) -> StreamingResponse:
     """Stream the best-so-far SSE data frame after every completed trial."""
-    request_id = request.headers.get("x-hash-request-id")
-    await _acquire_optimization_slot(request.app, request_id=request_id)
-    try:
-        run_id = request.app.state.statuses.create().run_id
-    except BaseException:
-        await asyncio.shield(_release_optimization_slot(request.app))
-        raise
-    optimizer: PetrinautOptimizer | None = None
-    try:
-        optimizer = await _initialize_admitted_optimizer(
-            request.app, optimization_manifest
-        )
-        set_status(
-            request.app,
-            run_id,
-            phase=Phase.running,
-            detail="Petrinaut CLI and Optimization Model initialized",
-        )
-    except Exception as error:
-        if optimizer is not None:
-            with suppress(Exception):
-                await asyncio.to_thread(optimizer.pn_model.close, graceful=False)
-        await asyncio.shield(_release_optimization_slot(request.app))
-        raise _initialization_error(
-            request.app, run_id, error, request_id=request_id
-        ) from error
+    run_id, optimizer, _correlation = await _admit_and_initialize_run(
+        request, optimization_manifest
+    )
 
     cleanup = _create_admitted_run_cleanup(request.app, optimizer)
     return StreamingResponse(
@@ -387,6 +398,90 @@ async def post_optimize_best(
         },
         background=BackgroundTask(cleanup),
     )
+
+
+@app.post("/optimize/runs", status_code=201, responses=_CREATE_RUN_RESPONSES)
+async def post_optimize_runs(
+    request: Request,
+    optimization_manifest: dict[str, Any],
+    response: Response,
+) -> dict[str, str]:
+    """Start a detached run that remains available for later SSE attachment."""
+    run_id, optimizer, correlation = await _admit_and_initialize_run(
+        request, optimization_manifest
+    )
+    cleanup = _create_admitted_run_cleanup(request.app, optimizer)
+    request.app.state.optimization_runs.create_run(
+        request.app,
+        run_id=run_id,
+        optimizer=optimizer,
+        cleanup=cleanup,
+        correlation=correlation,
+    )
+    response.headers["X-Optimization-Run-ID"] = run_id
+    return {"run_id": run_id}
+
+
+def _cursor_from_last_event_id(request: Request) -> int:
+    raw = request.headers.get("last-event-id")
+    if raw is None:
+        return 0
+    try:
+        return max(0, int(raw.strip()))
+    except ValueError:
+        return 0
+
+
+@app.get(
+    "/optimize/runs/{run_id}/events",
+    response_class=StreamingResponse,
+    responses=_RUN_EVENTS_RESPONSES,
+)
+async def get_optimize_run_events(
+    run_id: str,
+    request: Request,
+    cursor: int | None = Query(default=None, ge=0),
+) -> StreamingResponse:
+    """Attach to a detached run and replay events after the supplied cursor."""
+    run = request.app.state.optimization_runs.get(run_id)
+    if run is None:
+        raise HTTPException(404, f"optimization run not found: {run_id}")
+    if cursor is None:
+        cursor = _cursor_from_last_event_id(request)
+    epoch = run.begin_attachment()
+    return StreamingResponse(
+        attachment_event_stream(
+            run,
+            cursor=cursor,
+            epoch=epoch,
+            request=request,
+            correlation=_request_correlation(request),
+        ),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+            "X-Optimization-Run-ID": run_id,
+        },
+        background=BackgroundTask(run.end_attachment, epoch),
+    )
+
+
+@app.delete(
+    "/optimize/runs/{run_id}", status_code=204, responses=_DELETE_RUN_RESPONSES
+)
+async def delete_optimize_run(run_id: str, request: Request) -> Response:
+    """Cancel a detached run and wait for its resources to be released."""
+    run = request.app.state.optimization_runs.get(run_id)
+    if run is None:
+        raise HTTPException(404, f"optimization run not found: {run_id}")
+    if run.request_cancel("cancelled by client request"):
+        log.info(
+            "optimization run cancellation requested",
+            extra={"event": "run_cancel_requested", "run_id": run_id, **_request_correlation(request)},
+        )
+    await run.finished.wait()
+    return Response(status_code=204)
 
 
 @app.get("/status")

--- a/apps/petrinaut-opt/src/optimization_runs.py
+++ b/apps/petrinaut-opt/src/optimization_runs.py
@@ -1,0 +1,395 @@
+#!/usr/bin/env python3
+"""Detached, reconnectable optimization runs.
+
+A detached run owns one admitted optimizer/CLI pair and drives its study from
+a background task, appending every SSE frame body to an in-memory event log
+instead of an HTTP response. Consumers attach — and re-attach — over
+``GET /optimize/runs/{run_id}/events`` with a cursor; disconnecting a consumer
+does not affect the run. The admission slot's lifetime equals the run's
+lifetime: the idempotent cleanup (prompt CLI close plus slot release) runs
+when the run reaches a terminal state or is cancelled/reaped, never when a
+consumer detaches.
+
+The event log needs no explicit cap: it holds one frame per completed trial
+plus a handful of control frames, and the optimization manifest contract caps
+a study at 1000 trials, so a run's log is naturally bounded.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
+from contextlib import suppress
+from enum import Enum
+from typing import Any
+
+from src.utils import Phase, set_status
+
+log = logging.getLogger("pn_runs")
+
+DETACH_GRACE_ENVIRONMENT_VARIABLE = "HASH_PETRINAUT_OPT_DETACH_GRACE_SECONDS"
+DEFAULT_DETACH_GRACE_SECONDS = 300.0
+SSE_HEARTBEAT_SECONDS = 30
+_TAIL_POLL_SECONDS = 0.1
+# The single terminal frame appended when a run is cancelled (client DELETE,
+# orphan reaping, or service shutdown). Documented in the README and OpenAPI
+# responses; NodeAPI distinguishes it from a study failure's ERROR data frame.
+CANCELLED_FRAME = "event: cancelled\ndata: {}\n\n"
+
+
+def detach_grace_seconds_from_environment() -> float:
+    """Read the orphan grace period; invalid values fall back to the default.
+
+    A value of zero or below disables the orphan reaper (terminal-run log
+    retention then falls back to the default period).
+    """
+    raw = os.environ.get(DETACH_GRACE_ENVIRONMENT_VARIABLE, "").strip()
+    if not raw:
+        return DEFAULT_DETACH_GRACE_SECONDS
+    try:
+        return float(raw)
+    except ValueError:
+        return DEFAULT_DETACH_GRACE_SECONDS
+
+
+class RunState(str, Enum):
+    running = "running"
+    completed = "completed"
+    failed = "failed"
+    cancelled = "cancelled"
+
+
+class OptimizationRun:
+    """One detached optimization run and its replayable event log.
+
+    Every mutation happens on the event loop thread (the pump's ``on_event``
+    callback, the endpoints, and the registry), so plain attributes suffice;
+    the worker thread only reaches the loop via ``call_soon_threadsafe``
+    inside the optimizer.
+    """
+
+    def __init__(
+        self,
+        *,
+        run_id: str,
+        optimizer: Any,
+        cleanup: Callable[[], Awaitable[None]],
+        correlation: Mapping[str, str | None] | None = None,
+    ) -> None:
+        loop = asyncio.get_running_loop()
+        self.run_id = run_id
+        self.optimizer = optimizer
+        self.cleanup = cleanup
+        self.correlation: dict[str, str | None] = dict(correlation or {})
+        self.state = RunState.running
+        # (seq, SSE frame body); seq starts at 1 and increments by one, so the
+        # frame with sequence number ``seq`` lives at index ``seq - 1``.
+        self.events: list[tuple[int, str]] = []
+        self.attached = False
+        self.attachment_epoch = 0
+        self.created_at = loop.time()
+        # Grace also counts from creation, before the first attachment.
+        self.last_detached_at = loop.time()
+        self.terminal_at: float | None = None
+        self.cancel_requested = asyncio.Event()
+        self.cancel_reason = "optimization run cancelled"
+        self.finished = asyncio.Event()
+        self.task: asyncio.Task[None] | None = None
+        self._changed = asyncio.Event()
+
+    def append_event(self, frame: str) -> int:
+        """Append one SSE frame body and wake waiting tails."""
+        seq = len(self.events) + 1
+        self.events.append((seq, frame))
+        self._wake()
+        return seq
+
+    def request_cancel(self, reason: str) -> bool:
+        """Ask the pump to stop; False when already requested or terminal."""
+        if self.cancel_requested.is_set() or self.state is not RunState.running:
+            return False
+        self.cancel_reason = reason
+        self.cancel_requested.set()
+        return True
+
+    def begin_attachment(self) -> int:
+        """Register a new consumer, superseding any previous attachment."""
+        self.attachment_epoch += 1
+        self.attached = True
+        # Wake the superseded tail so it observes the epoch change promptly.
+        self._wake()
+        return self.attachment_epoch
+
+    def end_attachment(self, epoch: int) -> None:
+        """Mark the consumer gone; stale epochs are ignored. Idempotent."""
+        if epoch != self.attachment_epoch or not self.attached:
+            return
+        self.attached = False
+        self.last_detached_at = asyncio.get_running_loop().time()
+
+    def mark_terminal(self, state: RunState) -> None:
+        self.state = state
+        self.terminal_at = asyncio.get_running_loop().time()
+        self.finished.set()
+        self._wake()
+
+    def _wake(self) -> None:
+        """Wake every waiting tail; each wait round gets a fresh event."""
+        changed = self._changed
+        self._changed = asyncio.Event()
+        changed.set()
+
+    async def wait_for_change(self, timeout: float) -> None:
+        """Wait until the run appends, terminates, or is superseded."""
+        waiter = self._changed
+        with suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(waiter.wait(), timeout)
+
+
+async def attachment_event_stream(
+    run: OptimizationRun,
+    *,
+    cursor: int,
+    epoch: int,
+    request: Any,
+    correlation: Mapping[str, str | None] | None = None,
+) -> AsyncIterator[str]:
+    """Replay buffered frames with seq > cursor, then live-tail new ones.
+
+    Every frame carries an ``id: <seq>`` line so a consumer can re-attach
+    with ``?cursor=<seq>`` (or ``Last-Event-ID``). The stream ends when the
+    run's log is terminal and fully replayed, when a newer attachment
+    supersedes this one, or when the consumer disconnects — none of which
+    affect the run itself. Comment heartbeats are sent while tailing.
+    """
+    log_context = {**(correlation or {}), "run_id": run.run_id}
+    loop = asyncio.get_running_loop()
+    next_index = 0
+    next_heartbeat = loop.time() + SSE_HEARTBEAT_SECONDS
+    log.info(
+        "consumer attached to optimization run",
+        extra={"event": "run_attached", "cursor": cursor, **log_context},
+    )
+    try:
+        while True:
+            while next_index < len(run.events):
+                seq, frame = run.events[next_index]
+                next_index += 1
+                if seq <= cursor:
+                    continue
+                yield f"id: {seq}\n{frame}"
+                next_heartbeat = loop.time() + SSE_HEARTBEAT_SECONDS
+            if run.state is not RunState.running and next_index >= len(run.events):
+                return
+            if epoch != run.attachment_epoch:
+                log.info(
+                    "optimization run attachment superseded",
+                    extra={"event": "run_attachment_superseded", **log_context},
+                )
+                return
+            if await request.is_disconnected():
+                return
+            await run.wait_for_change(_TAIL_POLL_SECONDS)
+            if loop.time() >= next_heartbeat:
+                yield ": heartbeat\n\n"
+                next_heartbeat = loop.time() + SSE_HEARTBEAT_SECONDS
+    finally:
+        run.end_attachment(epoch)
+        log.info(
+            "consumer detached from optimization run",
+            extra={"event": "run_detached", **log_context},
+        )
+
+
+class OptimizationRunRegistry:
+    """All detached runs, plus the reaper that bounds their lifetimes.
+
+    The reaper cancels a running run with no attached consumer for the detach
+    grace period, and drops a terminal run's log after the retention period
+    (the StatusStore keeps the status row as before).
+    """
+
+    def __init__(
+        self,
+        *,
+        detach_grace_seconds: float | None = None,
+        retention_seconds: float | None = None,
+    ) -> None:
+        self.detach_grace_seconds = (
+            detach_grace_seconds_from_environment()
+            if detach_grace_seconds is None
+            else detach_grace_seconds
+        )
+        if retention_seconds is not None:
+            self.retention_seconds = retention_seconds
+        elif self.detach_grace_seconds > 0:
+            self.retention_seconds = self.detach_grace_seconds
+        else:
+            self.retention_seconds = DEFAULT_DETACH_GRACE_SECONDS
+        self._runs: dict[str, OptimizationRun] = {}
+        self._reaper_task: asyncio.Task[None] | None = None
+
+    def get(self, run_id: str) -> OptimizationRun | None:
+        return self._runs.get(run_id)
+
+    def runs(self) -> list[OptimizationRun]:
+        return list(self._runs.values())
+
+    def create_run(
+        self,
+        app: Any,
+        *,
+        run_id: str,
+        optimizer: Any,
+        cleanup: Callable[[], Awaitable[None]],
+        correlation: Mapping[str, str | None] | None = None,
+    ) -> OptimizationRun:
+        """Register a run and start the background pump driving its study."""
+        run = OptimizationRun(
+            run_id=run_id,
+            optimizer=optimizer,
+            cleanup=cleanup,
+            correlation=correlation,
+        )
+        self._runs[run_id] = run
+        run.task = asyncio.create_task(
+            self._drive_run(app, run), name=f"petrinaut-run-{run_id}"
+        )
+        self._ensure_reaper()
+        return run
+
+    async def _drive_run(self, app: Any, run: OptimizationRun) -> None:
+        """Pump one run to a terminal state, then release its resources."""
+        state = RunState.failed
+        cancellation: asyncio.CancelledError | None = None
+        try:
+            state = RunState(
+                await run.optimizer.pump_events(
+                    app,
+                    run.run_id,
+                    run.optimizer.n_trials,
+                    on_event=run.append_event,
+                    cancel_event=run.cancel_requested,
+                    correlation=run.correlation,
+                )
+            )
+        except asyncio.CancelledError as error:
+            # Service shutdown cancels the pump task; the pump's own finally
+            # already closed the CLI on its way out.
+            state = RunState.cancelled
+            cancellation = error
+        except Exception as error:
+            # Backstop only: the pump reports study failures itself. The raw
+            # message may quote user content, so log its type only.
+            log.error(
+                "optimization run pump failed",
+                extra={
+                    "event": "run_pump_failed",
+                    "run_id": run.run_id,
+                    "error_type": type(error).__name__,
+                    **run.correlation,
+                },
+            )
+            run.append_event(
+                'data: {"state": "ERROR", "message": "optimization run failed"}\n\n'
+            )
+            with suppress(Exception):
+                set_status(
+                    app,
+                    run.run_id,
+                    phase=Phase.error,
+                    detail="optimization run failed",
+                )
+        finally:
+            try:
+                if state is RunState.cancelled:
+                    run.append_event(CANCELLED_FRAME)
+                    with suppress(Exception):
+                        set_status(
+                            app,
+                            run.run_id,
+                            phase=Phase.idle,
+                            detail=run.cancel_reason,
+                        )
+                    log.info(
+                        "optimization run cancelled",
+                        extra={
+                            "event": "run_cancelled",
+                            "run_id": run.run_id,
+                            "detail": run.cancel_reason,
+                            **run.correlation,
+                        },
+                    )
+                await asyncio.shield(run.cleanup())
+            finally:
+                run.mark_terminal(state)
+        if cancellation is not None:
+            raise cancellation
+
+    def _ensure_reaper(self) -> None:
+        if self._reaper_task is None or self._reaper_task.done():
+            self._reaper_task = asyncio.create_task(
+                self._reap_loop(), name="petrinaut-run-reaper"
+            )
+
+    @property
+    def _tick_seconds(self) -> float:
+        horizons = [self.retention_seconds]
+        if self.detach_grace_seconds > 0:
+            horizons.append(self.detach_grace_seconds)
+        return max(0.01, min(1.0, min(horizons) / 10))
+
+    async def _reap_loop(self) -> None:
+        while True:
+            await asyncio.sleep(self._tick_seconds)
+            now = asyncio.get_running_loop().time()
+            for run in self.runs():
+                if run.state is RunState.running:
+                    if (
+                        self.detach_grace_seconds > 0
+                        and not run.attached
+                        and now - run.last_detached_at >= self.detach_grace_seconds
+                        and run.request_cancel(
+                            "no attached consumer within the detach grace period"
+                        )
+                    ):
+                        log.warning(
+                            "optimization run reaped: no attached consumer",
+                            extra={
+                                "event": "run_reaped",
+                                "run_id": run.run_id,
+                                "detach_grace_seconds": self.detach_grace_seconds,
+                                **run.correlation,
+                            },
+                        )
+                elif (
+                    run.terminal_at is not None
+                    and now - run.terminal_at >= self.retention_seconds
+                ):
+                    del self._runs[run.run_id]
+                    log.info(
+                        "optimization run log expired",
+                        extra={
+                            "event": "run_expired",
+                            "run_id": run.run_id,
+                            **run.correlation,
+                        },
+                    )
+
+    async def shutdown(self) -> None:
+        """Cancel the reaper and every pump; used by the app's lifespan."""
+        tasks: list[asyncio.Task[None]] = []
+        if self._reaper_task is not None:
+            self._reaper_task.cancel()
+            tasks.append(self._reaper_task)
+            self._reaper_task = None
+        for run in self.runs():
+            if run.task is not None and not run.task.done():
+                if not run.cancel_requested.is_set():
+                    run.cancel_reason = "service shutting down"
+                run.task.cancel()
+                tasks.append(run.task)
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)

--- a/apps/petrinaut-opt/src/optimization_runs.py
+++ b/apps/petrinaut-opt/src/optimization_runs.py
@@ -10,15 +10,17 @@ lifetime: the idempotent cleanup (prompt CLI close plus slot release) runs
 when the run reaches a terminal state or is cancelled/reaped, never when a
 consumer detaches.
 
-The event log needs no explicit cap: it holds one frame per completed trial
-plus a handful of control frames, and the optimization manifest contract caps
-a study at 1000 trials, so a run's log is naturally bounded.
+The event log holds one frame per completed trial plus a handful of control
+frames; it is bounded because the optimizer itself rejects study descriptions
+above ``MAX_STUDY_TRIALS`` (1000) trials — mirroring the optimization
+manifest contract — rather than trusting the CLI's reported trial count.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
+import math
 import os
 from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from contextlib import suppress
@@ -43,15 +45,19 @@ def detach_grace_seconds_from_environment() -> float:
     """Read the orphan grace period; invalid values fall back to the default.
 
     A value of zero or below disables the orphan reaper (terminal-run log
-    retention then falls back to the default period).
+    retention then falls back to the default period). Invalid and non-finite
+    values (``inf``, ``nan``, overflowing literals) fall back to the default.
     """
     raw = os.environ.get(DETACH_GRACE_ENVIRONMENT_VARIABLE, "").strip()
     if not raw:
         return DEFAULT_DETACH_GRACE_SECONDS
     try:
-        return float(raw)
+        value = float(raw)
     except ValueError:
         return DEFAULT_DETACH_GRACE_SECONDS
+    if not math.isfinite(value):
+        return DEFAULT_DETACH_GRACE_SECONDS
+    return value
 
 
 class RunState(str, Enum):
@@ -166,6 +172,11 @@ async def attachment_event_stream(
     """
     log_context = {**(correlation or {}), "run_id": run.run_id}
     loop = asyncio.get_running_loop()
+    # A cursor pointing past the end of the log would otherwise also filter
+    # out every frame appended after attaching — including the terminal one.
+    # Clamping is safe: sequence numbers are dense, append-only, and never
+    # truncated, so nothing past the current length can have been delivered.
+    cursor = min(cursor, len(run.events))
     next_index = 0
     next_heartbeat = loop.time() + SSE_HEARTBEAT_SECONDS
     log.info(
@@ -264,6 +275,10 @@ class OptimizationRunRegistry:
         """Pump one run to a terminal state, then release its resources."""
         state = RunState.failed
         cancellation: asyncio.CancelledError | None = None
+        # The pump records its outcome right before returning — ahead of its
+        # cancellable CLI-shutdown finally — so a cancellation landing in
+        # that teardown window cannot relabel an already-decided study.
+        recorded_outcomes: list[str] = []
         try:
             state = RunState(
                 await run.optimizer.pump_events(
@@ -272,13 +287,20 @@ class OptimizationRunRegistry:
                     run.optimizer.n_trials,
                     on_event=run.append_event,
                     cancel_event=run.cancel_requested,
+                    on_outcome=recorded_outcomes.append,
                     correlation=run.correlation,
                 )
             )
         except asyncio.CancelledError as error:
             # Service shutdown cancels the pump task; the pump's own finally
-            # already closed the CLI on its way out.
-            state = RunState.cancelled
+            # already closed the CLI on its way out. Keep a decided outcome:
+            # its terminal frame is already in the log, and appending a
+            # cancelled frame after it would corrupt the replay.
+            state = (
+                RunState(recorded_outcomes[0])
+                if recorded_outcomes
+                else RunState.cancelled
+            )
             cancellation = error
         except Exception as error:
             # Backstop only: the pump reports study failures itself. The raw

--- a/apps/petrinaut-opt/src/petrinaut_optimizer.py
+++ b/apps/petrinaut-opt/src/petrinaut_optimizer.py
@@ -281,6 +281,109 @@ class PetrinautOptimizer:
         worker.start()
         return worker, study_span
 
+    @staticmethod
+    def _trial_payload(
+        _study: optuna.Study, trial: optuna.trial.FrozenTrial
+    ) -> dict[str, Any]:
+        return {
+            "step": trial.number,
+            "params": dict(trial.params),
+            "init_state": {},
+            "metric": trial.value,
+            "state": trial.state.name,
+        }
+
+    async def pump_events(
+        self,
+        app: Any,
+        run_id: str,
+        n_trials: int,
+        *,
+        on_event: Callable[[str], Any],
+        cancel_event: asyncio.Event,
+        correlation: Mapping[str, str | None] | None = None,
+    ) -> str:
+        """Run a detached study and append its frames to the supplied event log."""
+        log_context = {**(correlation or {}), "run_id": run_id}
+        if not self.lock.acquire(blocking=False):
+            on_event('event: error\ndata: {"message": "already running"}\n\n')
+            return "failed"
+
+        set_status(app, run_id, phase=Phase.running, detail="optimization running")
+        log.info(
+            "optimization study started",
+            extra={"event": "study_started", "trials": n_trials, **log_context},
+        )
+        loop = asyncio.get_running_loop()
+        events: asyncio.Queue[dict[str, Any] | object] = asyncio.Queue()
+        stop_flag = threading.Event()
+
+        def callback(study: optuna.Study, trial: optuna.trial.FrozenTrial) -> None:
+            loop.call_soon_threadsafe(events.put_nowait, self._trial_payload(study, trial))
+            if stop_flag.is_set():
+                study.stop()
+
+        worker, study_span = self._start_study_worker(
+            n_trials=n_trials, callback=callback, events=events, loop=loop
+        )
+        completed = False
+        try:
+            while True:
+                if cancel_event.is_set():
+                    stop_flag.set()
+                    log.info(
+                        "optimization run cancelled, stopping study",
+                        extra={"event": "study_cancelled", **log_context},
+                    )
+                    return "cancelled"
+                try:
+                    item = await asyncio.wait_for(
+                        events.get(), timeout=_DISCONNECT_POLL_SECONDS
+                    )
+                except asyncio.TimeoutError:
+                    continue
+                if item is _SENTINEL:
+                    set_status(app, run_id, phase=Phase.done, detail="optimization completed")
+                    completed = True
+                    log.info(
+                        "optimization study completed",
+                        extra={"event": "study_completed", "trials": n_trials, **log_context},
+                    )
+                    on_event("event: done\ndata: {}\n\n")
+                    return "completed"
+                event = cast(dict[str, Any], item)
+                if event.get("state") == "ERROR":
+                    set_status(
+                        app,
+                        run_id,
+                        phase=Phase.error,
+                        detail=cast(str, event.get("message")),
+                    )
+                    log.warning(
+                        "optimization study failed",
+                        extra={"event": "study_failed", **log_context},
+                    )
+                    on_event(f"data: {json.dumps(event)}\n\n")
+                    return "failed"
+                on_event(f"data: {json.dumps(event)}\n\n")
+        finally:
+            stop_flag.set()
+            try:
+                await asyncio.to_thread(self.pn_model.close, graceful=completed)
+                await asyncio.to_thread(worker.join, _WORKER_SHUTDOWN_TIMEOUT_SECONDS)
+                if worker.is_alive():
+                    log.error(
+                        "Petrinaut optimizer worker did not stop after CLI shutdown",
+                        extra={"event": "worker_join_timeout", **log_context},
+                    )
+            finally:
+                self.lock.release()
+                try:
+                    study_span.set_attribute("optuna.study.best_value", self.study.best_value)
+                except ValueError:
+                    pass
+                study_span.end()
+
     async def stream_all(
         self, request: Request, run_id: str, n_trials: int
     ) -> AsyncIterator[str]:

--- a/apps/petrinaut-opt/src/petrinaut_optimizer.py
+++ b/apps/petrinaut-opt/src/petrinaut_optimizer.py
@@ -7,6 +7,7 @@ import asyncio
 import json
 import logging
 import math
+import os
 import queue
 import threading
 from collections.abc import AsyncIterator, Callable, Mapping
@@ -32,12 +33,37 @@ SAMPLERS = {
 }
 DEFAULT_STUDY_NAME = "opt_study"
 SSE_HEARTBEAT_SECONDS = 30
+# The service-side mirror of the optimization manifest's trial cap; it also
+# bounds every run's in-memory event log to one frame per trial plus a
+# handful of control frames, even against a CLI reporting a huge study.
+MAX_STUDY_TRIALS = 1000
+MAX_STUDY_SECONDS_ENVIRONMENT_VARIABLE = "HASH_PETRINAUT_OPT_MAX_STUDY_SECONDS"
+DEFAULT_MAX_STUDY_SECONDS = 900.0
 _DISCONNECT_POLL_SECONDS = 0.1
 _WORKER_SHUTDOWN_TIMEOUT_SECONDS = 12
 _SENTINEL = object()
 
 Scalar: TypeAlias = int | float | bool
 ParameterDescriptor: TypeAlias = Mapping[str, Any]
+
+
+def max_study_seconds_from_environment() -> float:
+    """Read the detached-study wall-clock ceiling in seconds.
+
+    Defaults to ``DEFAULT_MAX_STUDY_SECONDS``; a value of zero or below
+    disables the ceiling. Invalid and non-finite values (``inf``, ``nan``,
+    overflowing literals) fall back to the default.
+    """
+    raw = os.environ.get(MAX_STUDY_SECONDS_ENVIRONMENT_VARIABLE, "").strip()
+    if not raw:
+        return DEFAULT_MAX_STUDY_SECONDS
+    try:
+        value = float(raw)
+    except ValueError:
+        return DEFAULT_MAX_STUDY_SECONDS
+    if not math.isfinite(value):
+        return DEFAULT_MAX_STUDY_SECONDS
+    return value
 
 
 def _finite_number(value: Any, name: str) -> float:
@@ -73,6 +99,10 @@ def _parse_description(
     n_trials = study.get("trials")
     if isinstance(n_trials, bool) or not isinstance(n_trials, int) or n_trials < 1:
         raise ValueError("optimization.describe study.trials must be positive")
+    if n_trials > MAX_STUDY_TRIALS:
+        raise ValueError(
+            f"optimization.describe study.trials must not exceed {MAX_STUDY_TRIALS}"
+        )
     seed = study.get("seed")
     if isinstance(seed, bool) or not isinstance(seed, int) or seed < 0:
         raise ValueError(
@@ -236,11 +266,16 @@ class PetrinautOptimizer:
 
     def _start_study_worker(
         self,
-        *,
-        n_trials: int,
-        callback: Callable[[optuna.Study, optuna.trial.FrozenTrial], None],
-        events: asyncio.Queue[dict[str, Any] | object],
         loop: asyncio.AbstractEventLoop,
+        events: asyncio.Queue[dict[str, Any] | object],
+        stop_flag: threading.Event | None = None,
+        n_trials: int | None = None,
+        payload_builder: (
+            Callable[[optuna.Study, optuna.trial.FrozenTrial], dict[str, Any] | None]
+            | None
+        ) = None,
+        *,
+        callback: Callable[[optuna.Study, optuna.trial.FrozenTrial], None] | None = None,
     ) -> tuple[threading.Thread, Span]:
         """Run the study on a worker thread that inherits the request's context.
 
@@ -250,6 +285,21 @@ class PetrinautOptimizer:
         span. The returned ``optimization.study`` span is the parent of those
         trial spans; the caller must ``end()`` it once the stream is torn down.
         """
+        if n_trials is None:
+            raise ValueError("n_trials is required")
+        if callback is None:
+            if stop_flag is None or payload_builder is None:
+                raise ValueError("callback or detached-run callback inputs are required")
+
+            def callback(
+                study: optuna.Study, trial: optuna.trial.FrozenTrial
+            ) -> None:
+                payload = payload_builder(study, trial)
+                if payload is not None:
+                    loop.call_soon_threadsafe(events.put_nowait, payload)
+                if stop_flag.is_set():
+                    study.stop()
+
         study_span = tracer.start_span("optimization.study")
         study_span.set_attribute("optuna.study.trials", n_trials)
         study_span.set_attribute("optuna.study.direction", self.direction)
@@ -301,12 +351,15 @@ class PetrinautOptimizer:
         *,
         on_event: Callable[[str], Any],
         cancel_event: asyncio.Event,
+        on_outcome: Callable[[str], Any] | None = None,
         correlation: Mapping[str, str | None] | None = None,
     ) -> str:
-        """Run a detached study and append its frames to the supplied event log."""
+        """Run a bounded detached study and append its frames to the event log."""
         log_context = {**(correlation or {}), "run_id": run_id}
+        record_outcome = on_outcome if on_outcome is not None else lambda _outcome: None
         if not self.lock.acquire(blocking=False):
             on_event('event: error\ndata: {"message": "already running"}\n\n')
+            record_outcome("failed")
             return "failed"
 
         set_status(app, run_id, phase=Phase.running, detail="optimization running")
@@ -323,8 +376,16 @@ class PetrinautOptimizer:
             if stop_flag.is_set():
                 study.stop()
 
-        worker, study_span = self._start_study_worker(
-            n_trials=n_trials, callback=callback, events=events, loop=loop
+        started = self._start_study_worker(
+            loop, events, stop_flag, n_trials, self._trial_payload
+        )
+        if isinstance(started, tuple):
+            worker, study_span = started
+        else:
+            worker, study_span = started, None
+        max_study_seconds = max_study_seconds_from_environment()
+        study_deadline = (
+            loop.time() + max_study_seconds if max_study_seconds > 0 else None
         )
         completed = False
         try:
@@ -335,7 +396,32 @@ class PetrinautOptimizer:
                         "optimization run cancelled, stopping study",
                         extra={"event": "study_cancelled", **log_context},
                     )
+                    record_outcome("cancelled")
                     return "cancelled"
+                if study_deadline is not None and loop.time() >= study_deadline:
+                    stop_flag.set()
+                    if events.empty():
+                        message = (
+                            "optimization study exceeded its "
+                            f"{max_study_seconds:g} second execution limit"
+                        )
+                        set_status(app, run_id, phase=Phase.error, detail=message)
+                        log.warning(
+                            "optimization study timed out",
+                            extra={
+                                "event": "study_timeout",
+                                "max_study_seconds": max_study_seconds,
+                                "trials": n_trials,
+                                **log_context,
+                            },
+                        )
+                        payload = {"state": "ERROR", "message": message}
+                        on_event(f"data: {json.dumps(payload)}\n\n")
+                        record_outcome("failed")
+                        return "failed"
+                    # Items are still queued — possibly the completion
+                    # sentinel — so keep draining: a study that actually
+                    # finished within the limit is reported as completed.
                 try:
                     item = await asyncio.wait_for(
                         events.get(), timeout=_DISCONNECT_POLL_SECONDS
@@ -350,6 +436,7 @@ class PetrinautOptimizer:
                         extra={"event": "study_completed", "trials": n_trials, **log_context},
                     )
                     on_event("event: done\ndata: {}\n\n")
+                    record_outcome("completed")
                     return "completed"
                 event = cast(dict[str, Any], item)
                 if event.get("state") == "ERROR":
@@ -364,6 +451,7 @@ class PetrinautOptimizer:
                         extra={"event": "study_failed", **log_context},
                     )
                     on_event(f"data: {json.dumps(event)}\n\n")
+                    record_outcome("failed")
                     return "failed"
                 on_event(f"data: {json.dumps(event)}\n\n")
         finally:
@@ -378,11 +466,14 @@ class PetrinautOptimizer:
                     )
             finally:
                 self.lock.release()
-                try:
-                    study_span.set_attribute("optuna.study.best_value", self.study.best_value)
-                except ValueError:
-                    pass
-                study_span.end()
+                if study_span is not None:
+                    try:
+                        study_span.set_attribute(
+                            "optuna.study.best_value", self.study.best_value
+                        )
+                    except ValueError:
+                        pass
+                    study_span.end()
 
     async def stream_all(
         self, request: Request, run_id: str, n_trials: int
@@ -419,7 +510,7 @@ class PetrinautOptimizer:
                 study.stop()
 
         worker, study_span = self._start_study_worker(
-            n_trials=n_trials, callback=callback, events=events, loop=loop
+            loop, events, n_trials=n_trials, callback=callback
         )
         next_heartbeat = loop.time() + SSE_HEARTBEAT_SECONDS
         completed = False
@@ -551,7 +642,7 @@ class PetrinautOptimizer:
                 study.stop()
 
         worker, study_span = self._start_study_worker(
-            n_trials=n_trials, callback=callback, events=events, loop=loop
+            loop, events, n_trials=n_trials, callback=callback
         )
         next_heartbeat = loop.time() + SSE_HEARTBEAT_SECONDS
         completed = False

--- a/apps/petrinaut-opt/src/telemetry.py
+++ b/apps/petrinaut-opt/src/telemetry.py
@@ -42,7 +42,7 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor, SpanExporter
 
 _DEFAULT_SERVICE_NAME = "Petrinaut Optimizer"
 _DEFAULT_PROTOCOL = "grpc"
-_SERVICE_LOGGER_NAMES = ("pn_api", "pn_optimize", "pn_telemetry")
+_SERVICE_LOGGER_NAMES = ("pn_api", "pn_optimize", "pn_runs", "pn_telemetry")
 _FASTAPI_EXCLUDED_URLS = r"status$"
 
 log = logging.getLogger("pn_telemetry")

--- a/apps/petrinaut-opt/tests/test_optimization_api.py
+++ b/apps/petrinaut-opt/tests/test_optimization_api.py
@@ -3,13 +3,16 @@ from __future__ import annotations
 import asyncio
 import logging
 import threading
+import time
+from collections.abc import Callable
 from typing import Any
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from src import optimization_api
+from src import optimization_api, optimization_runs
+from src.optimization_runs import CANCELLED_FRAME, RunState
 
 
 class FakeOptimizer:
@@ -463,3 +466,482 @@ def test_openapi_exposes_post_sse_paths_with_an_untyped_json_body() -> None:
             "text/event-stream"
         ]["schema"]
         assert stream_schema["type"] == "string"
+
+
+class ScriptedDetachedOptimizer:
+    """Pump-driven double for detached-run endpoint tests.
+
+    Emits one data frame, optionally holds (releasable from the test thread,
+    cancellable through the run), then finishes with a second data frame and
+    the done frame — mirroring the real engine's frame bodies.
+    """
+
+    n_trials = 2
+
+    def __init__(self, *, hold: bool = False) -> None:
+        self.pn_model = RecordingModel()
+        self.hold = hold
+        self.release = threading.Event()
+
+    async def pump_events(
+        self,
+        _app: Any,
+        _run_id: str,
+        _n_trials: int,
+        *,
+        on_event: Callable[[str], Any],
+        cancel_event: asyncio.Event,
+        correlation: Any = None,
+    ) -> str:
+        on_event(
+            'data: {"step": 0, "params": {"rate": 1.0}, '
+            '"init_state": {}, "metric": 2.0, "state": "COMPLETE"}\n\n'
+        )
+        while self.hold and not self.release.is_set():
+            if cancel_event.is_set():
+                self.pn_model.close(graceful=False)
+                return "cancelled"
+            await asyncio.sleep(0.005)
+        on_event(
+            'data: {"step": 1, "params": {"rate": 1.5}, '
+            '"init_state": {}, "metric": 3.0, "state": "COMPLETE"}\n\n'
+        )
+        on_event("event: done\ndata: {}\n\n")
+        self.pn_model.close(graceful=True)
+        return "completed"
+
+
+def _wait_until(predicate: Callable[[], bool], timeout: float = 2.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.01)
+    raise AssertionError("condition not met within the timeout")
+
+
+def _event_ids(text: str) -> list[int]:
+    return [
+        int(line.removeprefix("id: "))
+        for line in text.splitlines()
+        if line.startswith("id: ")
+    ]
+
+
+class _AttachedConsumerRequest:
+    """Request double for direct attachment calls; connected until closed."""
+
+    def __init__(self, app: FastAPI) -> None:
+        self.app = app
+        self.headers: dict[str, str] = {}
+
+    async def is_disconnected(self) -> bool:
+        return False
+
+
+async def _start_detached_run(
+    optimization_manifest: dict,
+    *,
+    detach_grace_seconds: float = 300,
+) -> tuple[FastAPI, str]:
+    """Create a detached run through the real endpoint, direct-call style.
+
+    The TestClient transport buffers whole response bodies, so tests that
+    must read a live SSE attachment incrementally call the endpoints
+    directly and drive ``body_iterator`` themselves.
+    """
+    test_app = optimization_api.app
+    test_app.state.statuses = optimization_api.StatusStore()
+    test_app.state.optimization_admission_lock = asyncio.Lock()
+    test_app.state.active_optimizations = 0
+    test_app.state.optimization_runs = optimization_runs.OptimizationRunRegistry(
+        detach_grace_seconds=detach_grace_seconds
+    )
+    scope = {
+        "type": "http",
+        "app": test_app,
+        "method": "POST",
+        "path": "/optimize/runs",
+        "headers": [],
+        "query_string": b"",
+    }
+    request = optimization_api.Request(scope)
+    payload = await optimization_api.post_optimize_runs(
+        request, optimization_manifest, optimization_api.Response()
+    )
+    return test_app, payload["run_id"]
+
+
+async def _attach(test_app: FastAPI, run_id: str, cursor: int | None = None) -> Any:
+    response = await optimization_api.get_optimize_run_events(
+        run_id,
+        _AttachedConsumerRequest(test_app),  # type: ignore[arg-type]
+        cursor=cursor,
+    )
+    return response.body_iterator
+
+
+def _frame_ids(frames: list[str]) -> list[int]:
+    return [
+        int(frame.split("\n", 1)[0].removeprefix("id: "))
+        for frame in frames
+        if frame.startswith("id: ")
+    ]
+
+
+def test_create_detached_run_returns_201_and_holds_the_slot_until_terminal(
+    optimization_manifest: dict,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    optimizer = ScriptedDetachedOptimizer(hold=True)
+    monkeypatch.setattr(
+        optimization_api, "initialize_optimizer", lambda _manifest, **_kwargs: optimizer
+    )
+
+    with TestClient(optimization_api.app) as client:
+        response = client.post("/optimize/runs", json=optimization_manifest)
+        assert response.status_code == 201
+        run_id = response.json()["run_id"]
+        assert response.headers["x-optimization-run-id"] == run_id
+        # No consumer is attached, yet the slot stays held by the run.
+        assert optimization_api.app.state.active_optimizations == 1
+        run = optimization_api.app.state.optimization_runs.get(run_id)
+        assert run is not None
+        assert run.state is RunState.running
+
+        optimizer.release.set()
+        _wait_until(
+            lambda: optimization_api.app.state.active_optimizations == 0
+        )
+        _wait_until(lambda: run.state is RunState.completed)
+        # The pump closed the CLI gracefully; the idempotent run cleanup adds
+        # its prompt close, which the real adapter treats as a no-op.
+        assert optimizer.pn_model.close_calls == [True, False]
+
+
+def test_attach_replays_buffered_events_then_tails_live_ones(
+    optimization_manifest: dict,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    optimizer = ScriptedDetachedOptimizer(hold=True)
+    monkeypatch.setattr(
+        optimization_api, "initialize_optimizer", lambda _manifest, **_kwargs: optimizer
+    )
+
+    async def scenario() -> list[str]:
+        test_app, run_id = await _start_detached_run(optimization_manifest)
+        registry = test_app.state.optimization_runs
+        try:
+            response = await optimization_api.get_optimize_run_events(
+                run_id,
+                _AttachedConsumerRequest(test_app),  # type: ignore[arg-type]
+                cursor=None,
+            )
+            assert response.headers["x-optimization-run-id"] == run_id
+            assert response.media_type == "text/event-stream"
+            stream = response.body_iterator
+            frames = [await anext(stream)]
+            # The buffered first trial replays before any live event.
+            assert frames[0].startswith("id: 1\n")
+            optimizer.release.set()
+            async for frame in stream:
+                frames.append(frame)
+            run = registry.get(run_id)
+            assert run is not None
+            assert run.state is RunState.completed
+            assert test_app.state.active_optimizations == 0
+            return frames
+        finally:
+            await registry.shutdown()
+
+    frames = asyncio.run(scenario())
+
+    assert _frame_ids(frames) == [1, 2, 3]
+    assert frames[-1] == "id: 3\nevent: done\ndata: {}\n\n"
+
+
+def test_cursor_reattach_skips_already_seen_events(
+    optimization_manifest: dict,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    optimizer = ScriptedDetachedOptimizer()
+    monkeypatch.setattr(
+        optimization_api, "initialize_optimizer", lambda _manifest, **_kwargs: optimizer
+    )
+
+    with TestClient(optimization_api.app) as client:
+        run_id = client.post("/optimize/runs", json=optimization_manifest).json()[
+            "run_id"
+        ]
+        run = optimization_api.app.state.optimization_runs.get(run_id)
+        assert run is not None
+        _wait_until(lambda: run.state is RunState.completed)
+
+        from_cursor = client.get(f"/optimize/runs/{run_id}/events?cursor=1")
+        from_header = client.get(
+            f"/optimize/runs/{run_id}/events", headers={"Last-Event-ID": "2"}
+        )
+        cursor_wins = client.get(
+            f"/optimize/runs/{run_id}/events?cursor=0",
+            headers={"Last-Event-ID": "2"},
+        )
+
+    assert _event_ids(from_cursor.text) == [2, 3]
+    assert _event_ids(from_header.text) == [3]
+    assert _event_ids(cursor_wins.text) == [1, 2, 3]
+    assert cursor_wins.text.endswith("id: 3\nevent: done\ndata: {}\n\n")
+
+
+def test_detaching_a_consumer_does_not_cancel_the_run(
+    optimization_manifest: dict,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    optimizer = ScriptedDetachedOptimizer(hold=True)
+    monkeypatch.setattr(
+        optimization_api, "initialize_optimizer", lambda _manifest, **_kwargs: optimizer
+    )
+
+    async def scenario() -> list[str]:
+        test_app, run_id = await _start_detached_run(optimization_manifest)
+        registry = test_app.state.optimization_runs
+        try:
+            run = registry.get(run_id)
+            assert run is not None
+            stream = await _attach(test_app, run_id)
+            assert (await anext(stream)).startswith("id: 1\n")
+            # The consumer drops mid-run; the run must keep its slot and
+            # keep optimizing.
+            await stream.aclose()
+            assert run.attached is False
+            assert run.state is RunState.running
+            assert test_app.state.active_optimizations == 1
+
+            optimizer.release.set()
+            await asyncio.wait_for(run.finished.wait(), 2)
+            assert run.state is RunState.completed
+            assert test_app.state.active_optimizations == 0
+
+            # A later attachment replays the full log, then closes.
+            replay = await _attach(test_app, run_id)
+            return [frame async for frame in replay]
+        finally:
+            await registry.shutdown()
+
+    frames = asyncio.run(scenario())
+
+    assert _frame_ids(frames) == [1, 2, 3]
+    assert frames[-1] == "id: 3\nevent: done\ndata: {}\n\n"
+
+
+def test_a_second_attachment_supersedes_the_first(
+    optimization_manifest: dict,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    optimizer = ScriptedDetachedOptimizer(hold=True)
+    monkeypatch.setattr(
+        optimization_api, "initialize_optimizer", lambda _manifest, **_kwargs: optimizer
+    )
+
+    async def scenario() -> None:
+        test_app, run_id = await _start_detached_run(optimization_manifest)
+        registry = test_app.state.optimization_runs
+        try:
+            first = await _attach(test_app, run_id)
+            first_frame = await anext(first)
+            assert first_frame.startswith("id: 1\n")
+
+            second = await _attach(test_app, run_id)
+            # The superseded first stream ends without a terminal frame.
+            with pytest.raises(StopAsyncIteration):
+                await anext(first)
+            run = registry.get(run_id)
+            assert run is not None
+            assert run.attached is True
+
+            assert await anext(second) == first_frame
+            optimizer.release.set()
+            remaining = [frame async for frame in second]
+            assert _frame_ids(remaining) == [2, 3]
+        finally:
+            await registry.shutdown()
+
+    asyncio.run(scenario())
+
+
+def test_delete_cancels_a_detached_run_and_is_idempotent(
+    optimization_manifest: dict,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    optimizer = ScriptedDetachedOptimizer(hold=True)
+    monkeypatch.setattr(
+        optimization_api, "initialize_optimizer", lambda _manifest, **_kwargs: optimizer
+    )
+
+    with TestClient(optimization_api.app) as client:
+        run_id = client.post("/optimize/runs", json=optimization_manifest).json()[
+            "run_id"
+        ]
+        assert optimization_api.app.state.active_optimizations == 1
+
+        response = client.delete(f"/optimize/runs/{run_id}")
+        assert response.status_code == 204
+        run = optimization_api.app.state.optimization_runs.get(run_id)
+        assert run is not None
+        assert run.state is RunState.cancelled
+        assert run.events[-1] == (2, CANCELLED_FRAME)
+        # The pump closed the CLI promptly and the cleanup added its
+        # idempotent prompt close; neither waited for a graceful EOF.
+        assert optimizer.pn_model.close_calls == [False, False]
+        assert optimization_api.app.state.active_optimizations == 0
+
+        second = client.delete(f"/optimize/runs/{run_id}")
+        assert second.status_code == 204
+        assert optimization_api.app.state.active_optimizations == 0
+        assert optimizer.pn_model.close_calls == [False, False]
+
+        replay = client.get(f"/optimize/runs/{run_id}/events")
+
+    assert _event_ids(replay.text) == [1, 2]
+    assert replay.text.endswith(f"id: 2\n{CANCELLED_FRAME}")
+
+
+def test_the_reaper_cancels_a_run_nobody_attached_to(
+    optimization_manifest: dict,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setenv(
+        optimization_runs.DETACH_GRACE_ENVIRONMENT_VARIABLE, "0.05"
+    )
+    optimizer = ScriptedDetachedOptimizer(hold=True)
+    monkeypatch.setattr(
+        optimization_api, "initialize_optimizer", lambda _manifest, **_kwargs: optimizer
+    )
+
+    with caplog.at_level(logging.WARNING, logger="pn_runs"):
+        with TestClient(optimization_api.app) as client:
+            run_id = client.post(
+                "/optimize/runs", json=optimization_manifest
+            ).json()["run_id"]
+            run = optimization_api.app.state.optimization_runs.get(run_id)
+            assert run is not None
+            _wait_until(lambda: run.state is RunState.cancelled)
+            _wait_until(
+                lambda: optimization_api.app.state.active_optimizations == 0
+            )
+            assert run.events[-1] == (2, CANCELLED_FRAME)
+
+    reaped = next(
+        record
+        for record in caplog.records
+        if getattr(record, "event", None) == "run_reaped"
+    )
+    assert reaped.run_id == run_id
+
+
+def test_the_reaper_spares_a_run_with_an_attached_consumer(
+    optimization_manifest: dict,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    optimizer = ScriptedDetachedOptimizer(hold=True)
+    monkeypatch.setattr(
+        optimization_api, "initialize_optimizer", lambda _manifest, **_kwargs: optimizer
+    )
+
+    async def scenario() -> None:
+        test_app, run_id = await _start_detached_run(
+            optimization_manifest, detach_grace_seconds=0.05
+        )
+        registry = test_app.state.optimization_runs
+        try:
+            run = registry.get(run_id)
+            assert run is not None
+            stream = await _attach(test_app, run_id)
+            assert (await anext(stream)).startswith("id: 1\n")
+            # Stay attached well past several grace periods; the reaper must
+            # leave the run alone.
+            await asyncio.sleep(0.2)
+            assert run.state is RunState.running
+
+            optimizer.release.set()
+            remaining = [frame async for frame in stream]
+            assert _frame_ids(remaining) == [2, 3]
+            assert run.state is RunState.completed
+        finally:
+            await registry.shutdown()
+
+    asyncio.run(scenario())
+
+
+def test_unknown_detached_runs_return_404() -> None:
+    with TestClient(optimization_api.app) as client:
+        assert client.get("/optimize/runs/missing/events").status_code == 404
+        assert client.delete("/optimize/runs/missing").status_code == 404
+
+
+def test_create_detached_run_preserves_the_capacity_rejection(
+    optimization_manifest: dict,
+) -> None:
+    with TestClient(optimization_api.app) as client:
+        optimization_api.app.state.active_optimizations = (
+            optimization_api.MAX_ACTIVE_OPTIMIZATIONS
+        )
+        response = client.post("/optimize/runs", json=optimization_manifest)
+
+    assert response.status_code == 429
+    assert response.headers["retry-after"] == str(optimization_api.RETRY_AFTER_SECONDS)
+
+
+def test_create_detached_run_rejects_an_oversized_manifest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(optimization_api, "MAX_REQUEST_BODY_BYTES", 8)
+
+    with TestClient(optimization_api.app) as client:
+        response = client.post("/optimize/runs", content=b'{"long":true}')
+
+    assert response.status_code == 413
+
+
+def test_create_detached_run_reports_initialization_failure_with_the_run_id(
+    optimization_manifest: dict,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def initialize(_manifest: dict[str, Any], **_kwargs: Any) -> Any:
+        raise RuntimeError("manifest rejected by CLI")
+
+    monkeypatch.setattr(optimization_api, "initialize_optimizer", initialize)
+
+    with TestClient(optimization_api.app) as client:
+        response = client.post("/optimize/runs", json=optimization_manifest)
+        run_id = response.headers["x-optimization-run-id"]
+        assert optimization_api.app.state.active_optimizations == 0
+        assert optimization_api.app.state.optimization_runs.get(run_id) is None
+
+    assert response.status_code == 500
+    assert "manifest rejected by CLI" in response.json()["detail"]
+
+
+def test_openapi_exposes_the_detached_run_paths() -> None:
+    schema = optimization_api.app.openapi()
+
+    create = schema["paths"]["/optimize/runs"]["post"]
+    request_schema = create["requestBody"]["content"]["application/json"]["schema"]
+    assert request_schema["type"] == "object"
+    assert "201" in create["responses"]
+    assert "Retry-After" in create["responses"]["429"]["headers"]
+    assert "413" in create["responses"]
+    assert "500" in create["responses"]
+
+    events = schema["paths"]["/optimize/runs/{run_id}/events"]["get"]
+    stream_schema = events["responses"]["200"]["content"]["text/event-stream"][
+        "schema"
+    ]
+    assert stream_schema["type"] == "string"
+    assert "event: cancelled" in events["responses"]["200"]["description"]
+    assert "404" in events["responses"]
+
+    run_path = schema["paths"]["/optimize/runs/{run_id}"]
+    assert set(run_path) == {"delete"}
+    assert "204" in run_path["delete"]["responses"]
+    assert "404" in run_path["delete"]["responses"]

--- a/apps/petrinaut-opt/tests/test_optimization_api.py
+++ b/apps/petrinaut-opt/tests/test_optimization_api.py
@@ -491,8 +491,10 @@ class ScriptedDetachedOptimizer:
         *,
         on_event: Callable[[str], Any],
         cancel_event: asyncio.Event,
+        on_outcome: Callable[[str], Any] | None = None,
         correlation: Any = None,
     ) -> str:
+        record_outcome = on_outcome if on_outcome is not None else lambda _o: None
         on_event(
             'data: {"step": 0, "params": {"rate": 1.0}, '
             '"init_state": {}, "metric": 2.0, "state": "COMPLETE"}\n\n'
@@ -500,6 +502,7 @@ class ScriptedDetachedOptimizer:
         while self.hold and not self.release.is_set():
             if cancel_event.is_set():
                 self.pn_model.close(graceful=False)
+                record_outcome("cancelled")
                 return "cancelled"
             await asyncio.sleep(0.005)
         on_event(
@@ -508,6 +511,7 @@ class ScriptedDetachedOptimizer:
         )
         on_event("event: done\ndata: {}\n\n")
         self.pn_model.close(graceful=True)
+        record_outcome("completed")
         return "completed"
 
 
@@ -751,9 +755,11 @@ def test_a_second_attachment_supersedes_the_first(
             assert first_frame.startswith("id: 1\n")
 
             second = await _attach(test_app, run_id)
-            # The superseded first stream ends without a terminal frame.
+            # The superseded first stream ends without a terminal frame;
+            # bounded so a supersession regression fails fast instead of
+            # stalling until the ~30s heartbeat.
             with pytest.raises(StopAsyncIteration):
-                await anext(first)
+                await asyncio.wait_for(anext(first), timeout=1)
             run = registry.get(run_id)
             assert run is not None
             assert run.attached is True
@@ -868,6 +874,54 @@ def test_the_reaper_spares_a_run_with_an_attached_consumer(
             assert _frame_ids(remaining) == [2, 3]
             assert run.state is RunState.completed
         finally:
+            await registry.shutdown()
+
+    asyncio.run(scenario())
+
+
+def test_background_detach_covers_an_attachment_that_never_starts(
+    optimization_manifest: dict,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An aborted attach may never pull the body, skipping generator finallys.
+
+    Only the response's background task remains to end the attachment, and it
+    must run on the event loop (a sync callable would land in Starlette's
+    threadpool, where ``end_attachment``'s ``get_running_loop()`` raises) —
+    otherwise the run stays marked attached and is shielded from the reaper.
+    """
+    optimizer = ScriptedDetachedOptimizer(hold=True)
+    monkeypatch.setattr(
+        optimization_api, "initialize_optimizer", lambda _manifest, **_kwargs: optimizer
+    )
+
+    async def scenario() -> None:
+        test_app, run_id = await _start_detached_run(optimization_manifest)
+        registry = test_app.state.optimization_runs
+        try:
+            run = registry.get(run_id)
+            assert run is not None
+            response = await optimization_api.get_optimize_run_events(
+                run_id,
+                _AttachedConsumerRequest(test_app),  # type: ignore[arg-type]
+                cursor=None,
+            )
+            assert run.attached is True
+            assert response.background is not None
+
+            # The client is gone before the body iterator ever starts.
+            await response.background()
+
+            assert run.attached is False
+            # The reaper's grace clock restarts from the backstop detach.
+            assert run.last_detached_at > run.created_at
+            # A later attachment is unaffected by the stale epoch.
+            replay = await _attach(test_app, run_id)
+            assert (await anext(replay)).startswith("id: 1\n")
+            await replay.aclose()
+            await response.body_iterator.aclose()
+        finally:
+            optimizer.release.set()
             await registry.shutdown()
 
     asyncio.run(scenario())

--- a/apps/petrinaut-opt/tests/test_optimization_runs.py
+++ b/apps/petrinaut-opt/tests/test_optimization_runs.py
@@ -1,0 +1,427 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+
+from src import optimization_runs
+from src.optimization_runs import (
+    CANCELLED_FRAME,
+    DETACH_GRACE_ENVIRONMENT_VARIABLE,
+    OptimizationRun,
+    OptimizationRunRegistry,
+    RunState,
+    attachment_event_stream,
+    detach_grace_seconds_from_environment,
+)
+from src.utils import Phase, StatusStore
+
+
+FIRST_FRAME = (
+    'data: {"step": 0, "params": {"rate": 1.0}, '
+    '"init_state": {}, "metric": 2.0, "state": "COMPLETE"}\n\n'
+)
+DONE_FRAME = "event: done\ndata: {}\n\n"
+
+
+class ConnectedRequest:
+    headers: dict[str, str] = {}
+
+    async def is_disconnected(self) -> bool:
+        return False
+
+
+class DisconnectingRequest(ConnectedRequest):
+    def __init__(self) -> None:
+        self.polls = 0
+
+    async def is_disconnected(self) -> bool:
+        self.polls += 1
+        return self.polls > 1
+
+
+class HoldingPumpOptimizer:
+    """Pump double that emits one frame, then waits for cancellation."""
+
+    n_trials = 1
+
+    def __init__(self) -> None:
+        self.pump_started = asyncio.Event()
+
+    async def pump_events(
+        self,
+        _app: Any,
+        _run_id: str,
+        _n_trials: int,
+        *,
+        on_event: Any,
+        cancel_event: asyncio.Event,
+        correlation: Any = None,
+    ) -> str:
+        on_event(FIRST_FRAME)
+        self.pump_started.set()
+        await cancel_event.wait()
+        return "cancelled"
+
+
+class CompletingPumpOptimizer:
+    """Pump double that finishes immediately with a done frame."""
+
+    n_trials = 1
+
+    async def pump_events(
+        self,
+        _app: Any,
+        _run_id: str,
+        _n_trials: int,
+        *,
+        on_event: Any,
+        cancel_event: asyncio.Event,
+        correlation: Any = None,
+    ) -> str:
+        on_event(FIRST_FRAME)
+        on_event(DONE_FRAME)
+        return "completed"
+
+
+class CrashingPumpOptimizer:
+    """Pump double whose engine fails outside the study contract."""
+
+    n_trials = 1
+
+    async def pump_events(self, *_args: Any, **_kwargs: Any) -> str:
+        raise RuntimeError("pump crashed: user_secret_xyz")
+
+
+def _cleanup_recorder() -> tuple[list[int], Any]:
+    calls: list[int] = []
+
+    async def cleanup() -> None:
+        calls.append(1)
+
+    return calls, cleanup
+
+
+def _status_app_with_run() -> tuple[FastAPI, str]:
+    app = FastAPI()
+    app.state.statuses = StatusStore()
+    return app, app.state.statuses.create().run_id
+
+
+def test_detach_grace_environment_parsing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(DETACH_GRACE_ENVIRONMENT_VARIABLE, raising=False)
+    assert detach_grace_seconds_from_environment() == 300.0
+
+    monkeypatch.setenv(DETACH_GRACE_ENVIRONMENT_VARIABLE, "12.5")
+    assert detach_grace_seconds_from_environment() == 12.5
+
+    monkeypatch.setenv(DETACH_GRACE_ENVIRONMENT_VARIABLE, "not-a-number")
+    assert detach_grace_seconds_from_environment() == 300.0
+
+    monkeypatch.setenv(DETACH_GRACE_ENVIRONMENT_VARIABLE, "0")
+    assert detach_grace_seconds_from_environment() == 0.0
+
+
+def test_event_log_sequences_start_at_one_and_increment() -> None:
+    async def scenario() -> None:
+        _calls, cleanup = _cleanup_recorder()
+        run = OptimizationRun(run_id="r1", optimizer=None, cleanup=cleanup)
+        assert run.append_event(FIRST_FRAME) == 1
+        assert run.append_event(DONE_FRAME) == 2
+        assert run.events == [(1, FIRST_FRAME), (2, DONE_FRAME)]
+
+    asyncio.run(scenario())
+
+
+def test_attachment_replays_past_the_cursor_and_closes_on_terminal() -> None:
+    async def scenario() -> list[str]:
+        _calls, cleanup = _cleanup_recorder()
+        run = OptimizationRun(run_id="r1", optimizer=None, cleanup=cleanup)
+        run.append_event(FIRST_FRAME)
+        run.append_event(FIRST_FRAME)
+        run.append_event(DONE_FRAME)
+        run.mark_terminal(RunState.completed)
+
+        epoch = run.begin_attachment()
+        frames = [
+            frame
+            async for frame in attachment_event_stream(
+                run, cursor=2, epoch=epoch, request=ConnectedRequest()
+            )
+        ]
+        assert run.attached is False
+        return frames
+
+    frames = asyncio.run(scenario())
+
+    assert frames == [f"id: 3\n{DONE_FRAME}"]
+
+
+def test_attachment_tails_live_appends_after_the_replay() -> None:
+    async def scenario() -> list[str]:
+        _calls, cleanup = _cleanup_recorder()
+        run = OptimizationRun(run_id="r1", optimizer=None, cleanup=cleanup)
+        run.append_event(FIRST_FRAME)
+        epoch = run.begin_attachment()
+        stream = attachment_event_stream(
+            run, cursor=0, epoch=epoch, request=ConnectedRequest()
+        )
+        frames = [await anext(stream)]
+
+        async def append_rest() -> None:
+            run.append_event(FIRST_FRAME)
+            await asyncio.sleep(0)
+            run.append_event(DONE_FRAME)
+            run.mark_terminal(RunState.completed)
+
+        appender = asyncio.create_task(append_rest())
+        async for frame in stream:
+            frames.append(frame)
+        await appender
+        return frames
+
+    frames = asyncio.run(scenario())
+
+    assert frames == [
+        f"id: 1\n{FIRST_FRAME}",
+        f"id: 2\n{FIRST_FRAME}",
+        f"id: 3\n{DONE_FRAME}",
+    ]
+
+
+def test_a_second_attachment_supersedes_the_first() -> None:
+    async def scenario() -> None:
+        _calls, cleanup = _cleanup_recorder()
+        run = OptimizationRun(run_id="r1", optimizer=None, cleanup=cleanup)
+        run.append_event(FIRST_FRAME)
+
+        first_epoch = run.begin_attachment()
+        first_stream = attachment_event_stream(
+            run, cursor=0, epoch=first_epoch, request=ConnectedRequest()
+        )
+        assert await anext(first_stream) == f"id: 1\n{FIRST_FRAME}"
+
+        second_epoch = run.begin_attachment()
+        with pytest.raises(StopAsyncIteration):
+            await anext(first_stream)
+        # The stale attachment must not clear the newer one's attached mark.
+        assert run.attached is True
+
+        second_stream = attachment_event_stream(
+            run, cursor=0, epoch=second_epoch, request=ConnectedRequest()
+        )
+        assert await anext(second_stream) == f"id: 1\n{FIRST_FRAME}"
+        await second_stream.aclose()
+        assert run.attached is False
+
+    asyncio.run(scenario())
+
+
+def test_a_disconnected_attachment_marks_the_run_detached() -> None:
+    async def scenario() -> None:
+        _calls, cleanup = _cleanup_recorder()
+        run = OptimizationRun(run_id="r1", optimizer=None, cleanup=cleanup)
+        run.append_event(FIRST_FRAME)
+        epoch = run.begin_attachment()
+        frames = [
+            frame
+            async for frame in attachment_event_stream(
+                run, cursor=0, epoch=epoch, request=DisconnectingRequest()
+            )
+        ]
+        assert frames == [f"id: 1\n{FIRST_FRAME}"]
+        assert run.attached is False
+        assert run.state is RunState.running
+
+    asyncio.run(scenario())
+
+
+def test_registry_reaps_a_run_never_attached_within_the_grace_period(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    async def scenario() -> None:
+        app, run_id = _status_app_with_run()
+        registry = OptimizationRunRegistry(
+            detach_grace_seconds=0.05, retention_seconds=60
+        )
+        calls, cleanup = _cleanup_recorder()
+        run = registry.create_run(
+            app,
+            run_id=run_id,
+            optimizer=HoldingPumpOptimizer(),
+            cleanup=cleanup,
+            correlation={"request_id": "request-reap-1"},
+        )
+        try:
+            await asyncio.wait_for(run.finished.wait(), 2)
+            assert run.state is RunState.cancelled
+            assert run.events[-1] == (2, CANCELLED_FRAME)
+            assert calls == [1]
+            status = app.state.statuses.get(run_id)
+            assert status is not None
+            assert status.phase is Phase.idle
+        finally:
+            await registry.shutdown()
+
+    with caplog.at_level(logging.WARNING, logger="pn_runs"):
+        asyncio.run(scenario())
+
+    reaped = next(
+        record
+        for record in caplog.records
+        if getattr(record, "event", None) == "run_reaped"
+    )
+    assert reaped.request_id == "request-reap-1"
+
+
+def test_registry_does_not_reap_an_attached_run() -> None:
+    async def scenario() -> None:
+        app, run_id = _status_app_with_run()
+        registry = OptimizationRunRegistry(
+            detach_grace_seconds=0.05, retention_seconds=60
+        )
+        _calls, cleanup = _cleanup_recorder()
+        optimizer = HoldingPumpOptimizer()
+        run = registry.create_run(
+            app, run_id=run_id, optimizer=optimizer, cleanup=cleanup
+        )
+        try:
+            await asyncio.wait_for(optimizer.pump_started.wait(), 1)
+            run.begin_attachment()
+            await asyncio.sleep(0.2)
+            assert run.state is RunState.running
+        finally:
+            await registry.shutdown()
+
+    asyncio.run(scenario())
+
+
+def test_registry_keeps_disabled_grace_runs_alive() -> None:
+    async def scenario() -> None:
+        app, run_id = _status_app_with_run()
+        registry = OptimizationRunRegistry(detach_grace_seconds=0)
+        _calls, cleanup = _cleanup_recorder()
+        optimizer = HoldingPumpOptimizer()
+        run = registry.create_run(
+            app, run_id=run_id, optimizer=optimizer, cleanup=cleanup
+        )
+        try:
+            await asyncio.wait_for(optimizer.pump_started.wait(), 1)
+            await asyncio.sleep(0.1)
+            assert run.state is RunState.running
+        finally:
+            await registry.shutdown()
+
+    asyncio.run(scenario())
+
+
+def test_registry_drops_terminal_run_logs_after_the_retention_window() -> None:
+    async def scenario() -> None:
+        app, run_id = _status_app_with_run()
+        registry = OptimizationRunRegistry(
+            detach_grace_seconds=60, retention_seconds=0.05
+        )
+        _calls, cleanup = _cleanup_recorder()
+        run = registry.create_run(
+            app, run_id=run_id, optimizer=CompletingPumpOptimizer(), cleanup=cleanup
+        )
+        try:
+            await asyncio.wait_for(run.finished.wait(), 2)
+            for _ in range(200):
+                if registry.get(run_id) is None:
+                    break
+                await asyncio.sleep(0.01)
+            assert registry.get(run_id) is None
+            # The status row outlives the replay log, as before.
+            assert app.state.statuses.get(run_id) is not None
+        finally:
+            await registry.shutdown()
+
+    asyncio.run(scenario())
+
+
+def test_registry_shutdown_cancels_running_pumps() -> None:
+    async def scenario() -> None:
+        app, run_id = _status_app_with_run()
+        registry = OptimizationRunRegistry(detach_grace_seconds=0)
+        calls, cleanup = _cleanup_recorder()
+        optimizer = HoldingPumpOptimizer()
+        run = registry.create_run(
+            app, run_id=run_id, optimizer=optimizer, cleanup=cleanup
+        )
+        await asyncio.wait_for(optimizer.pump_started.wait(), 1)
+
+        await registry.shutdown()
+
+        assert run.state is RunState.cancelled
+        assert run.cancel_reason == "service shutting down"
+        assert run.events[-1] == (2, CANCELLED_FRAME)
+        assert calls == [1]
+
+    asyncio.run(scenario())
+
+
+def test_a_pump_crash_appends_a_bounded_backstop_error_frame(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    async def scenario() -> None:
+        app, run_id = _status_app_with_run()
+        registry = OptimizationRunRegistry(detach_grace_seconds=60)
+        calls, cleanup = _cleanup_recorder()
+        run = registry.create_run(
+            app, run_id=run_id, optimizer=CrashingPumpOptimizer(), cleanup=cleanup
+        )
+        try:
+            await asyncio.wait_for(run.finished.wait(), 2)
+            assert run.state is RunState.failed
+            assert run.events == [
+                (
+                    1,
+                    'data: {"state": "ERROR", '
+                    '"message": "optimization run failed"}\n\n',
+                )
+            ]
+            assert calls == [1]
+        finally:
+            await registry.shutdown()
+
+    with caplog.at_level(logging.ERROR, logger="pn_runs"):
+        asyncio.run(scenario())
+
+    failure = next(
+        record
+        for record in caplog.records
+        if getattr(record, "event", None) == "run_pump_failed"
+    )
+    assert failure.error_type == "RuntimeError"
+    # The raw pump error may quote user content, so it is never logged or
+    # replayed to consumers.
+    assert "user_secret_xyz" not in failure.getMessage()
+
+
+def test_attachment_heartbeats_while_tailing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(optimization_runs, "SSE_HEARTBEAT_SECONDS", 0.01)
+
+    async def scenario() -> list[str]:
+        _calls, cleanup = _cleanup_recorder()
+        run = OptimizationRun(run_id="r1", optimizer=None, cleanup=cleanup)
+        epoch = run.begin_attachment()
+        stream = attachment_event_stream(
+            run, cursor=0, epoch=epoch, request=ConnectedRequest()
+        )
+        frames = [await anext(stream)]
+        run.append_event(DONE_FRAME)
+        run.mark_terminal(RunState.completed)
+        async for frame in stream:
+            frames.append(frame)
+        return frames
+
+    frames = asyncio.run(scenario())
+
+    assert frames[0] == ": heartbeat\n\n"
+    assert frames[-1] == f"id: 1\n{DONE_FRAME}"

--- a/apps/petrinaut-opt/tests/test_optimization_runs.py
+++ b/apps/petrinaut-opt/tests/test_optimization_runs.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import threading
 from typing import Any
 
 import pytest
 from fastapi import FastAPI
 
 from src import optimization_runs
+from src.petrinaut_optimizer import PetrinautOptimizer
 from src.optimization_runs import (
     CANCELLED_FRAME,
     DETACH_GRACE_ENVIRONMENT_VARIABLE,
@@ -59,11 +61,14 @@ class HoldingPumpOptimizer:
         *,
         on_event: Any,
         cancel_event: asyncio.Event,
+        on_outcome: Any = None,
         correlation: Any = None,
     ) -> str:
         on_event(FIRST_FRAME)
         self.pump_started.set()
         await cancel_event.wait()
+        if on_outcome is not None:
+            on_outcome("cancelled")
         return "cancelled"
 
 
@@ -80,10 +85,46 @@ class CompletingPumpOptimizer:
         *,
         on_event: Any,
         cancel_event: asyncio.Event,
+        on_outcome: Any = None,
         correlation: Any = None,
     ) -> str:
         on_event(FIRST_FRAME)
         on_event(DONE_FRAME)
+        if on_outcome is not None:
+            on_outcome("completed")
+        return "completed"
+
+
+class CompletedThenBlockedPumpOptimizer:
+    """Pump double stuck in its (cancellable) teardown after deciding.
+
+    Mirrors the real engine's shape: the done frame is appended and the
+    outcome recorded before the CLI-shutdown ``finally`` — a cancellable
+    window in which ``registry.shutdown()`` may land its cancellation.
+    """
+
+    n_trials = 1
+
+    def __init__(self) -> None:
+        self.teardown_entered = asyncio.Event()
+
+    async def pump_events(
+        self,
+        _app: Any,
+        _run_id: str,
+        _n_trials: int,
+        *,
+        on_event: Any,
+        cancel_event: asyncio.Event,
+        on_outcome: Any = None,
+        correlation: Any = None,
+    ) -> str:
+        on_event(FIRST_FRAME)
+        on_event(DONE_FRAME)
+        if on_outcome is not None:
+            on_outcome("completed")
+        self.teardown_entered.set()
+        await asyncio.Event().wait()
         return "completed"
 
 
@@ -123,6 +164,15 @@ def test_detach_grace_environment_parsing(monkeypatch: pytest.MonkeyPatch) -> No
 
     monkeypatch.setenv(DETACH_GRACE_ENVIRONMENT_VARIABLE, "0")
     assert detach_grace_seconds_from_environment() == 0.0
+
+
+@pytest.mark.parametrize("raw", ["inf", "-inf", "nan", "1e400"])
+def test_detach_grace_rejects_non_finite_values(
+    monkeypatch: pytest.MonkeyPatch, raw: str
+) -> None:
+    """`float()` accepts inf/nan spellings, which must not become a period."""
+    monkeypatch.setenv(DETACH_GRACE_ENVIRONMENT_VARIABLE, raw)
+    assert detach_grace_seconds_from_environment() == 300.0
 
 
 def test_event_log_sequences_start_at_one_and_increment() -> None:
@@ -192,6 +242,38 @@ def test_attachment_tails_live_appends_after_the_replay() -> None:
     ]
 
 
+def test_attachment_with_a_cursor_past_the_log_end_still_tails_live_events() -> None:
+    """An out-of-range cursor must not swallow later frames or the terminal."""
+
+    async def scenario() -> list[str]:
+        _calls, cleanup = _cleanup_recorder()
+        run = OptimizationRun(run_id="r1", optimizer=None, cleanup=cleanup)
+        run.append_event(FIRST_FRAME)
+        epoch = run.begin_attachment()
+        stream = attachment_event_stream(
+            run, cursor=999, epoch=epoch, request=ConnectedRequest()
+        )
+
+        async def append_rest() -> None:
+            await asyncio.sleep(0.01)
+            run.append_event(FIRST_FRAME)
+            run.append_event(DONE_FRAME)
+            run.mark_terminal(RunState.completed)
+
+        appender = asyncio.create_task(append_rest())
+        frames = [
+            frame async for frame in stream if not frame.startswith(": heartbeat")
+        ]
+        await appender
+        return frames
+
+    frames = asyncio.run(scenario())
+
+    # The clamped cursor skips the already-buffered frame but delivers every
+    # frame appended after attaching, including the terminal one.
+    assert frames == [f"id: 2\n{FIRST_FRAME}", f"id: 3\n{DONE_FRAME}"]
+
+
 def test_a_second_attachment_supersedes_the_first() -> None:
     async def scenario() -> None:
         _calls, cleanup = _cleanup_recorder()
@@ -205,8 +287,10 @@ def test_a_second_attachment_supersedes_the_first() -> None:
         assert await anext(first_stream) == f"id: 1\n{FIRST_FRAME}"
 
         second_epoch = run.begin_attachment()
+        # Bounded so a supersession regression fails fast instead of
+        # stalling until the ~30s heartbeat.
         with pytest.raises(StopAsyncIteration):
-            await anext(first_stream)
+            await asyncio.wait_for(anext(first_stream), timeout=1)
         # The stale attachment must not clear the newer one's attached mark.
         assert run.attached is True
 
@@ -360,6 +444,87 @@ def test_registry_shutdown_cancels_running_pumps() -> None:
         assert run.cancel_reason == "service shutting down"
         assert run.events[-1] == (2, CANCELLED_FRAME)
         assert calls == [1]
+
+    asyncio.run(scenario())
+
+
+def test_shutdown_during_pump_teardown_keeps_the_decided_outcome() -> None:
+    """A cancel landing after `done` must not relabel the run as cancelled."""
+
+    async def scenario() -> None:
+        app, run_id = _status_app_with_run()
+        registry = OptimizationRunRegistry(detach_grace_seconds=0)
+        calls, cleanup = _cleanup_recorder()
+        optimizer = CompletedThenBlockedPumpOptimizer()
+        run = registry.create_run(
+            app, run_id=run_id, optimizer=optimizer, cleanup=cleanup
+        )
+        await asyncio.wait_for(optimizer.teardown_entered.wait(), 1)
+
+        await registry.shutdown()
+
+        assert run.state is RunState.completed
+        # The event log ends with the single decided terminal frame; no
+        # cancelled frame is appended after it.
+        assert run.events == [(1, FIRST_FRAME), (2, DONE_FRAME)]
+        assert calls == [1]
+
+    asyncio.run(scenario())
+
+
+class SlowCloseStudyModel:
+    """Real-optimizer model whose CLI close blocks until released."""
+
+    def __init__(self, description: dict[str, Any]) -> None:
+        self.description = description
+        self.close_started = threading.Event()
+        self.close_release = threading.Event()
+        self.close_calls: list[bool] = []
+
+    def describe_optimization(self) -> dict[str, Any]:
+        return self.description
+
+    def objective(self, _parameter_values: dict[str, Any]) -> float:
+        return 1.0
+
+    def close(self, *, graceful: bool = True) -> None:
+        self.close_started.set()
+        self.close_release.wait(timeout=2)
+        self.close_calls.append(graceful)
+
+
+def test_cancel_during_the_real_pumps_cli_close_keeps_completed(
+    optimization_description: dict,
+) -> None:
+    """The real engine records its outcome before the cancellable close."""
+
+    async def scenario() -> None:
+        app, run_id = _status_app_with_run()
+        registry = OptimizationRunRegistry(detach_grace_seconds=0)
+        calls, cleanup = _cleanup_recorder()
+        model = SlowCloseStudyModel(optimization_description)
+        optimizer = PetrinautOptimizer(model)  # type: ignore[arg-type]
+        run = registry.create_run(
+            app, run_id=run_id, optimizer=optimizer, cleanup=cleanup
+        )
+        try:
+            # The study finishes, the done frame lands, then the pump blocks
+            # in its CLI-shutdown finally; cancel it right there.
+            await asyncio.to_thread(model.close_started.wait, 2)
+            assert run.task is not None
+            run.task.cancel()
+            model.close_release.set()
+            await asyncio.gather(run.task, return_exceptions=True)
+
+            assert run.state is RunState.completed
+            assert run.events[-1][1] == DONE_FRAME
+            assert CANCELLED_FRAME not in [frame for _seq, frame in run.events]
+            assert calls == [1]
+            status = app.state.statuses.get(run_id)
+            assert status is not None
+            assert status.phase is Phase.done
+        finally:
+            await registry.shutdown()
 
     asyncio.run(scenario())
 

--- a/apps/petrinaut-opt/tests/test_petrinaut_optimizer.py
+++ b/apps/petrinaut-opt/tests/test_petrinaut_optimizer.py
@@ -184,6 +184,15 @@ def test_uses_the_cli_supplied_seed_for_deterministic_sampling(
     [
         {"direction": "up"},
         {"study": {"trials": 0, "sampler": "random", "seed": 42}},
+        # The service-side trial cap bounds every run's event log even when
+        # the CLI's reported study is huge.
+        {
+            "study": {
+                "trials": petrinaut_optimizer.MAX_STUDY_TRIALS + 1,
+                "sampler": "random",
+                "seed": 42,
+            }
+        },
         {"study": {"trials": 1, "sampler": "unknown", "seed": 42}},
         {"study": {"trials": 1, "sampler": "random", "seed": -1}},
         {
@@ -549,6 +558,180 @@ def test_pump_events_cancellation_stops_the_study_promptly(
     assert frames == []
     assert model.closed is True
     assert model.close_calls == [False]
+
+
+def test_max_study_seconds_environment_parsing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    variable = petrinaut_optimizer.MAX_STUDY_SECONDS_ENVIRONMENT_VARIABLE
+    monkeypatch.delenv(variable, raising=False)
+    assert petrinaut_optimizer.max_study_seconds_from_environment() == 900.0
+
+    monkeypatch.setenv(variable, "12.5")
+    assert petrinaut_optimizer.max_study_seconds_from_environment() == 12.5
+
+    monkeypatch.setenv(variable, "not-a-number")
+    assert petrinaut_optimizer.max_study_seconds_from_environment() == 900.0
+
+    monkeypatch.setenv(variable, "0")
+    assert petrinaut_optimizer.max_study_seconds_from_environment() == 0.0
+
+
+@pytest.mark.parametrize("raw", ["inf", "-inf", "nan", "1e400"])
+def test_max_study_seconds_rejects_non_finite_values(
+    monkeypatch: pytest.MonkeyPatch, raw: str
+) -> None:
+    monkeypatch.setenv(
+        petrinaut_optimizer.MAX_STUDY_SECONDS_ENVIRONMENT_VARIABLE, raw
+    )
+    assert petrinaut_optimizer.max_study_seconds_from_environment() == 900.0
+
+
+def test_pump_events_enforces_the_study_wall_clock_ceiling(
+    optimization_description: dict,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    optimization_description["study"]["trials"] = 1
+    monkeypatch.setenv(
+        petrinaut_optimizer.MAX_STUDY_SECONDS_ENVIRONMENT_VARIABLE, "0.05"
+    )
+    monkeypatch.setattr(petrinaut_optimizer, "_WORKER_SHUTDOWN_TIMEOUT_SECONDS", 0.01)
+    model = StubbornModel(optimization_description)
+    optimizer = PetrinautOptimizer(model)  # type: ignore[arg-type]
+    app, run_id = _status_app_with_run()
+    frames: list[str] = []
+    outcomes: list[str] = []
+
+    async def drive() -> str:
+        started_at = time.monotonic()
+        state = await optimizer.pump_events(
+            app,
+            run_id,
+            optimizer.n_trials,
+            on_event=frames.append,
+            cancel_event=asyncio.Event(),
+            on_outcome=outcomes.append,
+        )
+        assert time.monotonic() - started_at < 0.5
+        model.release.set()
+        await asyncio.sleep(0.05)
+        return state
+
+    with caplog.at_level(logging.WARNING, logger="pn_optimize"):
+        state = asyncio.run(drive())
+    status = app.state.statuses.get(run_id)
+
+    assert state == "failed"
+    assert outcomes == ["failed"]
+    assert frames == [
+        'data: {"state": "ERROR", "message": "optimization study exceeded '
+        'its 0.05 second execution limit"}\n\n'
+    ]
+    assert model.closed is True
+    assert model.close_calls == [False]
+    assert status is not None
+    assert status.phase is Phase.error
+    timeout = next(
+        record
+        for record in caplog.records
+        if getattr(record, "event", None) == "study_timeout"
+    )
+    assert timeout.run_id == run_id
+    assert timeout.max_study_seconds == 0.05
+
+
+def test_pump_events_completed_before_the_ceiling_is_not_misreported(
+    optimization_description: dict,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        petrinaut_optimizer.MAX_STUDY_SECONDS_ENVIRONMENT_VARIABLE, "5"
+    )
+    model = FakeModel(optimization_description)
+    optimizer = PetrinautOptimizer(model)  # type: ignore[arg-type]
+    app, run_id = _status_app_with_run()
+    frames: list[str] = []
+    outcomes: list[str] = []
+
+    async def drive() -> str:
+        return await optimizer.pump_events(
+            app,
+            run_id,
+            optimizer.n_trials,
+            on_event=frames.append,
+            cancel_event=asyncio.Event(),
+            on_outcome=outcomes.append,
+        )
+
+    state = asyncio.run(drive())
+
+    assert state == "completed"
+    assert outcomes == ["completed"]
+    assert frames[-1] == "event: done\ndata: {}\n\n"
+    assert all('"state": "ERROR"' not in frame for frame in frames)
+    assert model.close_calls == [True]
+
+
+def test_pump_events_drains_a_queued_completion_after_the_deadline(
+    optimization_description: dict,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A completion already queued when the ceiling lapses is still reported."""
+    optimization_description["study"]["trials"] = 1
+    monkeypatch.setenv(
+        petrinaut_optimizer.MAX_STUDY_SECONDS_ENVIRONMENT_VARIABLE, "0.000001"
+    )
+
+    def preloaded_worker(
+        self: PetrinautOptimizer,
+        _loop: asyncio.AbstractEventLoop,
+        events: asyncio.Queue,
+        _stop_flag: threading.Event,
+        _n_trials: int,
+        _payload_builder: Any,
+    ) -> threading.Thread:
+        # The study "finished" before the pump's first deadline check: both
+        # the trial payload and the sentinel are already queued.
+        events.put_nowait(
+            {
+                "step": 0,
+                "params": {"rate": 1.0},
+                "init_state": {},
+                "metric": 2.0,
+                "state": "COMPLETE",
+            }
+        )
+        events.put_nowait(petrinaut_optimizer._SENTINEL)
+        worker = threading.Thread(target=lambda: None, daemon=True)
+        worker.start()
+        return worker
+
+    monkeypatch.setattr(
+        PetrinautOptimizer, "_start_study_worker", preloaded_worker
+    )
+    model = FakeModel(optimization_description)
+    optimizer = PetrinautOptimizer(model)  # type: ignore[arg-type]
+    app, run_id = _status_app_with_run()
+    frames: list[str] = []
+
+    async def drive() -> str:
+        return await optimizer.pump_events(
+            app,
+            run_id,
+            optimizer.n_trials,
+            on_event=frames.append,
+            cancel_event=asyncio.Event(),
+        )
+
+    state = asyncio.run(drive())
+    status = app.state.statuses.get(run_id)
+
+    assert state == "completed"
+    assert frames[-1] == "event: done\ndata: {}\n\n"
+    assert all('"state": "ERROR"' not in frame for frame in frames)
+    assert status is not None
+    assert status.phase is Phase.done
 
 
 def test_disconnect_closes_cli_before_a_bounded_worker_join(

--- a/apps/petrinaut-opt/tests/test_petrinaut_optimizer.py
+++ b/apps/petrinaut-opt/tests/test_petrinaut_optimizer.py
@@ -434,6 +434,123 @@ def test_stream_error_is_terminal_and_is_not_followed_by_done(
     assert not hasattr(failure, "detail")
 
 
+def _status_app_with_run() -> tuple[FastAPI, str]:
+    app = FastAPI()
+    app.state.statuses = StatusStore()
+    return app, app.state.statuses.create().run_id
+
+
+def test_pump_events_appends_frames_and_completes(
+    optimization_description: dict,
+) -> None:
+    model = FakeModel(optimization_description)
+    optimizer = PetrinautOptimizer(model)  # type: ignore[arg-type]
+    app, run_id = _status_app_with_run()
+    frames: list[str] = []
+
+    async def drive() -> str:
+        return await optimizer.pump_events(
+            app,
+            run_id,
+            optimizer.n_trials,
+            on_event=frames.append,
+            cancel_event=asyncio.Event(),
+        )
+
+    state = asyncio.run(drive())
+    data = [
+        json.loads(frame.removeprefix("data: "))
+        for frame in frames
+        if frame.startswith("data: ")
+    ]
+
+    assert state == "completed"
+    assert frames[-1] == "event: done\ndata: {}\n\n"
+    assert len(data) == 3
+    assert all(
+        set(payload) == {"step", "params", "init_state", "metric", "state"}
+        for payload in data
+    )
+    assert model.close_calls == [True]
+    status = app.state.statuses.get(run_id)
+    assert status is not None
+    assert status.phase is Phase.done
+
+
+def test_pump_events_reports_a_study_failure_without_done(
+    optimization_description: dict,
+) -> None:
+    model = FailingModel(
+        optimization_description, PetrinautClientError("transport failed")
+    )
+    optimizer = PetrinautOptimizer(model)  # type: ignore[arg-type]
+    app, run_id = _status_app_with_run()
+    frames: list[str] = []
+
+    async def drive() -> str:
+        return await optimizer.pump_events(
+            app,
+            run_id,
+            optimizer.n_trials,
+            on_event=frames.append,
+            cancel_event=asyncio.Event(),
+        )
+
+    state = asyncio.run(drive())
+    status = app.state.statuses.get(run_id)
+
+    assert state == "failed"
+    assert json.loads(frames[-1].removeprefix("data: ")) == {
+        "state": "ERROR",
+        "message": "transport failed",
+    }
+    assert "event: done\ndata: {}\n\n" not in frames
+    assert model.close_calls == [False]
+    assert status is not None
+    assert status.phase is Phase.error
+
+
+def test_pump_events_cancellation_stops_the_study_promptly(
+    optimization_description: dict,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    optimization_description["study"]["trials"] = 1
+    monkeypatch.setattr(petrinaut_optimizer, "_WORKER_SHUTDOWN_TIMEOUT_SECONDS", 0.01)
+    model = StubbornModel(optimization_description)
+    optimizer = PetrinautOptimizer(model)  # type: ignore[arg-type]
+    app, run_id = _status_app_with_run()
+    frames: list[str] = []
+    cancel_event = asyncio.Event()
+
+    async def drive() -> str:
+        async def cancel_after_entry() -> None:
+            await asyncio.to_thread(model.entered.wait, 1)
+            cancel_event.set()
+
+        canceller = asyncio.create_task(cancel_after_entry())
+        started_at = time.monotonic()
+        state = await optimizer.pump_events(
+            app,
+            run_id,
+            optimizer.n_trials,
+            on_event=frames.append,
+            cancel_event=cancel_event,
+        )
+        assert time.monotonic() - started_at < 0.5
+        await canceller
+        model.release.set()
+        await asyncio.sleep(0.05)
+        return state
+
+    state = asyncio.run(drive())
+
+    assert state == "cancelled"
+    # The caller owns the terminal cancelled frame, so none is appended here.
+    assert frames == []
+    assert model.closed is True
+    assert model.close_calls == [False]
+
+
 def test_disconnect_closes_cli_before_a_bounded_worker_join(
     optimization_description: dict,
     monkeypatch: pytest.MonkeyPatch,

--- a/libs/@local/petrinaut-optimizer-client/src/openapi.gen.ts
+++ b/libs/@local/petrinaut-optimizer-client/src/openapi.gen.ts
@@ -64,6 +64,77 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/optimize/runs": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Post Optimize Runs
+     * @description Start a detached optimization run and return its run id immediately.
+     *
+     *     The run keeps optimizing with no consumer attached; its admission slot is
+     *     held until the run completes, fails, is cancelled via
+     *     ``DELETE /optimize/runs/{run_id}``, or is reaped after the detach grace
+     *     period without an attached consumer.
+     */
+    post: operations["post_optimize_runs_optimize_runs_post"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/optimize/runs/{run_id}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post?: never;
+    /**
+     * Delete Optimize Run
+     * @description Cancel a detached run; idempotent once the run is terminal.
+     *
+     *     Returns after the run's CLI is closed, its terminal frame is appended,
+     *     and its admission slot is released.
+     */
+    delete: operations["delete_optimize_run_optimize_runs__run_id__delete"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/optimize/runs/{run_id}/events": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get Optimize Run Events
+     * @description Attach to a detached run's SSE log, replaying frames past the cursor.
+     *
+     *     ``cursor`` defaults to the ``Last-Event-ID`` header (the query parameter
+     *     wins), then to 0 — a full replay. Disconnecting never affects the run.
+     */
+    get: operations["get_optimize_run_events_optimize_runs__run_id__events_get"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/status": {
     parameters: {
       query?: never;
@@ -286,6 +357,142 @@ export interface operations {
           [name: string]: unknown;
         };
         content?: never;
+      };
+    };
+  };
+  post_optimize_runs_optimize_runs_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          [key: string]: unknown;
+        };
+      };
+    };
+    responses: {
+      /** @description The detached optimization run was admitted and started in the background; consume its Server-Sent Events via GET /optimize/runs/{run_id}/events */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            [key: string]: string;
+          };
+        };
+      };
+      /** @description The optimization manifest exceeds 8 MiB */
+      413: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+      /** @description The service is already at its study limit */
+      429: {
+        headers: {
+          /** @description Seconds to wait before retrying the study */
+          "Retry-After"?: string;
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description The CLI or optimization study could not initialize */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  delete_optimize_run_optimize_runs__run_id__delete: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        run_id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description The run was cancelled (or had already reached a terminal state); when this call stopped it, the event log's terminal frame is `event: cancelled` */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description No optimization run with this id is registered */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  get_optimize_run_events_optimize_runs__run_id__events_get: {
+    parameters: {
+      query?: {
+        cursor?: number | null;
+      };
+      header?: never;
+      path: {
+        run_id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Server-Sent Events attachment to a detached optimization run. Every frame carries an `id: <seq>` line (seq starts at 1); buffered frames with seq > cursor are replayed, then new frames are live-tailed with `: heartbeat` comments roughly every 30 seconds. The terminal frame is `event: done` (completed), an ERROR data frame (study failure), or `event: cancelled` (cancelled or reaped). If the run is already terminal the response closes after the replay. Disconnecting does not affect the run; a newer attachment supersedes this one. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "text/event-stream": string;
+        };
+      };
+      /** @description No optimization run with this id is registered */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
       };
     };
   };


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Decouples a Petrinaut optimization study's lifetime from the HTTP connection consuming it. A run is created detached and identified by a `run_id`; consumers attach, detach, and re-attach to its event stream with a cursor, and killing the socket no longer kills the study. This is the optimizer half of the fix for the intermittent staging `network error` on long optimization streams (a mid-run transport reset currently destroys the study); cancellation becomes an explicit `DELETE` instead of being implied by disconnect.

## 🔗 Related links

- [FE-1224](https://linear.app/hash/issue/FE-1224/optimizer-detached-run-engine-with-cursored-sse-re-attachment) — this issue
- [FE-1223](https://linear.app/hash/issue/FE-1223/detached-reconnectable-petrinaut-optimization-runs-decouple-study) — parent issue holding the full contract (NodeAPI and frontend halves follow)
- [SRE-831](https://linear.app/hash/issue/SRE-831) — the suspected transport-reset root cause this architecture makes survivable

## 🚫 Blocked by

- [ ] #9057 and #9059 — this branch is built on them, so this PR's diff includes their commits until they merge (merge order: #9057 → #9059 → this)

## 🔍 What does this change?

- `POST /optimize/runs` — admits (existing 4-slot cap, 429 + `Retry-After`), starts the CLI + Optuna study in a background task owned by the run, returns `201 {"run_id"}` immediately.
- `GET /optimize/runs/{run_id}/events?cursor=N` (or `Last-Event-ID`) — SSE that replays buffered events with sequence > cursor (`id:` field carries the sequence, starting at 1), then live-tails with heartbeats. Disconnect does not affect the run; a new attachment supersedes a stale one; a terminal run replays fully then closes; 404 for unknown/expired runs.
- `DELETE /optimize/runs/{run_id}` — idempotent explicit cancel: prompt CLI close, slot release, dedicated `event: cancelled` terminal frame (also used by the reaper and shutdown).
- Slot lifetime = run lifetime; the per-run event log is bounded by the existing ≤1,000-trials manifest cap.
- Orphan reaper: a run unattached for `HASH_PETRINAUT_OPT_DETACH_GRACE_SECONDS` (default 300; ≤0 disables) is cancelled; terminal run logs are retained for the same window for replay.
- Legacy `/optimize/all` and `/optimize/best` keep their exact behavior (stream from start, cancel-on-disconnect) — their shared worker scaffolding was extracted and reused by the new engine rather than rewritten, and all 83 pre-existing tests pass unmodified.
- README "Detached runs" section; OpenAPI spec regenerated with the three new routes.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] require changes to docs which **are made** as part of this PR

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

- A run lives inside one optimizer process (the CLI is its child), so re-attachment must reach the same instance — fine at today's single replica; a persistent job architecture is the durable successor (out of scope, noted in FE-1223).
- NodeAPI does not use these routes yet — that is FE-1225, stacked on this branch.

## 🐾 Next steps

- FE-1225: NodeAPI + `@local/petrinaut-optimizer-client` proxy the create/attach/cancel routes with ownership checks.
- FE-1226: the frontend auto-reconnects with the cursor (branch ready, stacked on #9063).

## 🛡 What tests cover this?

`apps/petrinaut-opt`: 83 → **112 pytest**. New coverage: create → 201 with the slot held until terminal and released exactly once; replay + live tail with strictly increasing `id:`s; cursor and `Last-Event-ID` re-attach (query wins); post-terminal full replay then clean close; **disconnect not cancelling the run**; attachment supersession; prompt idempotent DELETE (graceful=False close, terminal frame); reaper reaping unattached runs while sparing attached ones (and disabled at ≤0); retention expiry; pump-crash backstop with redacted logging; lifespan shutdown cancelling pumps; 404/429+`Retry-After`/413/500-with-run-id; OpenAPI shape for the three routes. The OpenAPI drift gate (`yarn test:unit`) is clean.

## ❓ How to test this?

1. `cd apps/petrinaut-opt && uv run pytest`
2. With a local optimizer running (see README), `POST /optimize/runs` with the checked-in supply-chain manifest, note the `run_id`.
3. `curl -N .../optimize/runs/<run_id>/events`, kill the curl mid-run, re-run it with `?cursor=<last id seen>` — confirm the study kept running and the stream resumes after the cursor.
4. `DELETE .../optimize/runs/<run_id>` — confirm a prompt `event: cancelled` terminal frame and slot release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
