### PR TITLE
FE-1229: Temporarily fix Petrinaut Panda specificity

### DIFF
--- a/.changeset/boost-petrinaut-panda-specificity.md
+++ b/.changeset/boost-petrinaut-panda-specificity.md
@@ -1,0 +1,5 @@
+---
+"@hashintel/petrinaut": patch
+---
+
+Ensure Petrinaut's Panda utility styles override independently generated host utilities.

--- a/libs/@hashintel/petrinaut/package.json
+++ b/libs/@hashintel/petrinaut/package.json
@@ -91,6 +91,8 @@
     "jsdom": "24.1.3",
     "oxlint": "1.63.0",
     "oxlint-tsgolint": "0.22.1",
+    "postcss": "8.5.16",
+    "postcss-selector-parser": "7.1.1",
     "react": "19.2.6",
     "react-dom": "19.2.6",
     "rolldown": "1.1.2",

--- a/libs/@hashintel/petrinaut/postcss.config.cjs
+++ b/libs/@hashintel/petrinaut/postcss.config.cjs
@@ -1,5 +1,0 @@
-module.exports = {
-  plugins: {
-    "@pandacss/dev/postcss": {},
-  },
-};

--- a/libs/@hashintel/petrinaut/postcss.config.mjs
+++ b/libs/@hashintel/petrinaut/postcss.config.mjs
@@ -1,0 +1,7 @@
+import panda from "@pandacss/dev/postcss";
+
+import boostPandaSpecificity from "./scripts/boost-panda-specificity.mjs";
+
+export default {
+  plugins: [panda(), boostPandaSpecificity()],
+};

--- a/libs/@hashintel/petrinaut/scripts/boost-panda-specificity.mjs
+++ b/libs/@hashintel/petrinaut/scripts/boost-panda-specificity.mjs
@@ -1,0 +1,68 @@
+import selectorParser from "postcss-selector-parser";
+
+const PANDA_SPECIFICITY_BOOST = ":not(#\\#)";
+const MINIMUM_EXISTING_BOOSTS = 4;
+const TARGET_BOOSTS = 6;
+
+/**
+ * Raise Petrinaut's Panda utility selectors above the independently generated
+ * HASH Panda bundle. This is intentionally limited to selectors already in
+ * Panda's highest emitted layer (four or more boosts), preserving the relative
+ * specificity of reset, base, token, and recipe layers.
+ *
+ * This is an integration workaround while Petrinaut and its consumers produce
+ * separate, polyfilled cascade-layer bundles. Remove it once those styles are
+ * generated together or otherwise share a single cascade-layer contract.
+ *
+ * @returns {import("postcss").Plugin}
+ */
+const boostPandaSpecificity = () => {
+  const processor = selectorParser((root) => {
+    root.each((selector) => {
+      /** @type {import("postcss-selector-parser").Pseudo[]} */
+      const boosts = [];
+
+      selector.walkPseudos((pseudo) => {
+        if (
+          pseudo.parent === selector &&
+          pseudo.toString() === PANDA_SPECIFICITY_BOOST
+        ) {
+          boosts.push(pseudo);
+        }
+      });
+
+      if (
+        boosts.length < MINIMUM_EXISTING_BOOSTS ||
+        boosts.length >= TARGET_BOOSTS
+      ) {
+        return;
+      }
+
+      let anchor = boosts[boosts.length - 1];
+      const boostTemplate = boosts[0];
+      const parent = anchor.parent;
+
+      while (boosts.length < TARGET_BOOSTS) {
+        const boost = boostTemplate.clone();
+        parent.insertAfter(anchor, boost);
+        anchor = boost;
+        boosts.push(boost);
+      }
+    });
+  });
+
+  return {
+    postcssPlugin: "petrinaut-boost-panda-specificity",
+    Rule(rule) {
+      if (!rule.selector.includes(PANDA_SPECIFICITY_BOOST)) {
+        return;
+      }
+
+      // PostCSS plugins transform their rule nodes in place.
+      // eslint-disable-next-line no-param-reassign
+      rule.selector = processor.processSync(rule.selector);
+    },
+  };
+};
+
+export default boostPandaSpecificity;

--- a/libs/@hashintel/petrinaut/scripts/boost-panda-specificity.test.ts
+++ b/libs/@hashintel/petrinaut/scripts/boost-panda-specificity.test.ts
@@ -1,0 +1,46 @@
+import postcss from "postcss";
+import { describe, expect, it } from "vitest";
+
+import boostPandaSpecificity from "./boost-panda-specificity.mjs";
+
+const process = async (css: string) =>
+  (
+    await postcss([boostPandaSpecificity()]).process(css, {
+      from: undefined,
+    })
+  ).css;
+
+describe("boostPandaSpecificity", () => {
+  it("raises Panda utility selectors from four boosts to six", async () => {
+    const input = ".op_1:not(#\\#):not(#\\#):not(#\\#):not(#\\#){opacity:1}";
+
+    await expect(process(input)).resolves.toBe(
+      ".op_1:not(#\\#):not(#\\#):not(#\\#):not(#\\#):not(#\\#):not(#\\#){opacity:1}",
+    );
+  });
+
+  it("adds boosts before a pseudo-element", async () => {
+    const input =
+      '.content:not(#\\#):not(#\\#):not(#\\#):not(#\\#)::after{content:""}';
+
+    await expect(process(input)).resolves.toBe(
+      '.content:not(#\\#):not(#\\#):not(#\\#):not(#\\#):not(#\\#):not(#\\#)::after{content:""}',
+    );
+  });
+
+  it("does not change lower Panda layers or non-Panda selectors", async () => {
+    const input = [
+      ".recipe:not(#\\#):not(#\\#):not(#\\#){display:flex}",
+      ".vendor:hover{opacity:1}",
+    ].join("\n");
+
+    await expect(process(input)).resolves.toBe(input);
+  });
+
+  it("leaves selectors that already have six boosts unchanged", async () => {
+    const input =
+      ".op_1:not(#\\#):not(#\\#):not(#\\#):not(#\\#):not(#\\#):not(#\\#){opacity:1}";
+
+    await expect(process(input)).resolves.toBe(input);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -7010,6 +7010,8 @@ __metadata:
     monaco-editor: "npm:0.55.1"
     oxlint: "npm:1.63.0"
     oxlint-tsgolint: "npm:0.22.1"
+    postcss: "npm:8.5.16"
+    postcss-selector-parser: "npm:7.1.1"
     react: "npm:19.2.6"
     react-dom: "npm:19.2.6"
     react-markdown: "npm:10.1.0"
@@ -35728,7 +35730,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.3.11, postcss@npm:^8.4.14, postcss@npm:^8.4.33, postcss@npm:^8.5.15, postcss@npm:^8.5.16, postcss@npm:^8.5.3, postcss@npm:^8.5.6":
+"postcss@npm:8.5.16, postcss@npm:^8.3.11, postcss@npm:^8.4.14, postcss@npm:^8.4.33, postcss@npm:^8.5.15, postcss@npm:^8.5.16, postcss@npm:^8.5.3, postcss@npm:^8.5.6":
   version: 8.5.16
   resolution: "postcss@npm:8.5.16"
   dependencies:


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Temporarily fix Petrinaut styles being overridden by the independently generated HASH Panda CSS bundle.

> [!IMPORTANT]
> This is an intentionally temporary compatibility fix. It hard-codes a higher specificity for Petrinaut's top Panda layer so the optimization UI works correctly in HASH today. The proper solution is to unify the HASH and Petrinaut Panda generation/layer contract; that work is tracked in [FE-1228](https://linear.app/hash/issue/FE-1228/unify-panda-css-generation-for-hash-and-petrinaut).

Implementation ticket: [FE-1229](https://linear.app/hash/issue/FE-1229/temporarily-fix-petrinaut-styles-overridden-by-hash-panda-css)

## 🔍 What does this change?

- Adds a PostCSS transform that raises Petrinaut's highest-layer Panda utility selectors from four or five specificity boosts to six.
- Leaves lower Panda layers and non-Panda/vendor CSS unchanged.
- Adds regression tests for ordinary selectors, pseudo-elements, lower layers, and idempotency.
- Adds a patch changeset for `@hashintel/petrinaut`.

## Root cause

HASH and Petrinaut currently load independently generated, polyfilled Panda CSS bundles in the same document. HASH utility selectors receive five synthetic `:not(#\#)` specificity boosts, while Petrinaut utilities receive four. HASH therefore overrides Petrinaut's conditional and component-level styles regardless of stylesheet order.

This caused the optimization parameter expansion to remain collapsed and drawer top-padding overrides to fail, offsetting sticky headers.

## Follow-up

[FE-1228](https://linear.app/hash/issue/FE-1228/unify-panda-css-generation-for-hash-and-petrinaut) tracks the architectural fix and removal of this workaround.

## 🛡 What tests cover this?

- `yarn workspace @hashintel/petrinaut exec vitest run scripts/boost-panda-specificity.test.ts`
- `yarn workspace @hashintel/petrinaut lint:eslint`
- `yarn workspace @hashintel/petrinaut lint:tsc`
- `yarn workspace @hashintel/petrinaut build`
- `yarn constraints`
- Targeted formatting check

The production build was also inspected to confirm the affected utility and conditional selectors contain six specificity boosts.