### PR TITLE
feat: allow map_err like syntax on change_context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2655,7 +2655,7 @@ dependencies = [
 
 [[package]]
 name = "error-stack"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "ansi-to-html",
  "anyhow",
@@ -2668,6 +2668,7 @@ dependencies = [
  "insta",
  "owo-colors",
  "pin-project-lite",
+ "rand 0.10.1",
  "regex",
  "rustc_version",
  "serde",

--- a/libs/error-stack/Cargo.toml
+++ b/libs/error-stack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "error-stack"
-version       = "0.8.0"
+version       = "0.8.1"
 authors       = { workspace = true }
 edition       = "2021"
 rust-version  = "1.83.0"
@@ -42,6 +42,7 @@ futures-util       = { workspace = true }
 glob               = { workspace = true }
 insta              = { workspace = true, features = ["filters", "ron"] }
 owo-colors         = { workspace = true }
+rand               = { workspace = true, features = ["thread_rng"] }
 regex              = { workspace = true }
 serde              = { workspace = true, features = ["derive"] }
 supports-color     = { workspace = true }

--- a/libs/error-stack/src/report.rs
+++ b/libs/error-stack/src/report.rs
@@ -465,8 +465,8 @@ impl<C> Report<C> {
     where
         C: Send + Sync + 'static,
     {
-        if let Some(r) = self.downcast_mut::<C>() {
-            return r;
+        if let Some(report) = self.downcast_mut::<C>() {
+            return report;
         }
         // FIXME: cannot document the report here due to compiler jank
         // Panics if there isn't an attached context which matches `T`. As it's not possible

--- a/libs/error-stack/src/report.rs
+++ b/libs/error-stack/src/report.rs
@@ -457,6 +457,29 @@ impl<C> Report<C> {
         })
     }
 
+    /// Returns the current context of the `Report` as a mutable reference.
+    ///
+    /// See [`Report::current_context`] for more information.
+    #[must_use]
+    pub fn current_context_mut(&mut self) -> &mut C
+    where
+        C: Send + Sync + 'static,
+    {
+        if let Some(r) = self.downcast_mut::<C>() {
+            return r;
+        }
+        // FIXME: cannot document the report here due to compiler jank
+        // Panics if there isn't an attached context which matches `T`. As it's not possible
+        // to create a `Report` without a valid context and this method can
+        // only be called when `T` is a valid context, it's guaranteed that
+        // the context is available.
+        unreachable!(
+            "Report does not contain a context. This should not happen as a Report must \
+            always contain at least one frame.\n\n
+            Please file an issue to https://github.com/hashintel/hash/issues/new?template=bug-report-error-stack.yml"
+        )
+    }
+
     /// Converts this `Report` to an [`Error`].
     #[must_use]
     pub fn into_error(self) -> impl Error + Send + Sync + 'static

--- a/libs/error-stack/src/result.rs
+++ b/libs/error-stack/src/result.rs
@@ -57,6 +57,16 @@ pub trait ResultExt {
     where
         C: Error + Send + Sync + 'static,
         F: FnOnce() -> C;
+
+    /// Lazily changes the context of the [`Report`](error_stack::Report) inside the
+    /// [`Result`] with a mutable reference to the original error value.
+    ///
+    /// Applies [`Report::change_context`](error_stack::Report::change_context) on the [`Err`]
+    /// variant, refer to it for more information.
+    fn change_context_adaptive<C, F>(self, context: F) -> Result<Self::Ok, Report<C>>
+    where
+        C: Error + Send + Sync + 'static,
+        F: FnOnce(&mut Report<Self::Context>) -> C;
 }
 
 impl<T, E> ResultExt for Result<T, E>
@@ -132,6 +142,22 @@ where
         match self {
             Ok(value) => Ok(value),
             Err(error) => Err(error.into_report().change_context(context())),
+        }
+    }
+
+    #[track_caller]
+    fn change_context_adaptive<C, F>(self, context: F) -> Result<T, Report<C>>
+    where
+        C: Error + Send + Sync + 'static,
+        F: FnOnce(&mut Report<<E as IntoReport>::Context>) -> C,
+    {
+        match self {
+            Ok(value) => Ok(value),
+            Err(error) => {
+                let mut report = error.into_report();
+                let ctx = context(&mut report);
+                Err(report.change_context(ctx))
+            }
         }
     }
 }

--- a/libs/error-stack/tests/test_change_context.rs
+++ b/libs/error-stack/tests/test_change_context.rs
@@ -88,3 +88,29 @@ fn attach_future() {
     test_messages(&report);
     test_kinds(&report);
 }
+
+#[test]
+fn attach_result_reflect() {
+    let random_number = rand::random_range(0..u32::MAX);
+    let error = create_error()
+        .change_context(ContextA(random_number))
+        .attach_opaque(AttachmentA)
+        .change_context_adaptive(|context_a| ContextA(context_a.current_context_mut().0))
+        .attach_opaque_with(|| AttachmentB);
+    let report = error.expect_err("Not an error");
+    let kinds = remove_builtin_frames(&report)
+        .map(|frame| frame.kind())
+        .collect::<Vec<_>>();
+    match kinds[1] {
+        FrameKind::Context(context) => {
+            assert_eq!(context.downcast_ref::<ContextA>().expect("context A").0, random_number);
+        }
+        _ => panic!("must be a context"),
+    };
+    match kinds[3] {
+        FrameKind::Context(context) => {
+            assert_eq!(context.downcast_ref::<ContextA>().expect("context A").0, random_number);
+        }
+        _ => panic!("must be a context"),
+    };
+}

--- a/libs/error-stack/tests/test_change_context.rs
+++ b/libs/error-stack/tests/test_change_context.rs
@@ -103,14 +103,20 @@ fn attach_result_reflect() {
         .collect::<Vec<_>>();
     match kinds[1] {
         FrameKind::Context(context) => {
-            assert_eq!(context.downcast_ref::<ContextA>().expect("context A").0, random_number);
+            assert_eq!(
+                context.downcast_ref::<ContextA>().expect("context A").0,
+                random_number
+            );
         }
-        _ => panic!("must be a context"),
-    };
+        FrameKind::Attachment(_) => panic!("must be a context"),
+    }
     match kinds[3] {
         FrameKind::Context(context) => {
-            assert_eq!(context.downcast_ref::<ContextA>().expect("context A").0, random_number);
+            assert_eq!(
+                context.downcast_ref::<ContextA>().expect("context A").0,
+                random_number
+            );
         }
-        _ => panic!("must be a context"),
-    };
+        FrameKind::Attachment(_) => panic!("must be a context"),
+    }
 }

--- a/libs/error-stack/tests/test_conversion.rs
+++ b/libs/error-stack/tests/test_conversion.rs
@@ -57,9 +57,10 @@ fn error_with_sources() -> Result<(), OuterError> {
 
 #[test]
 fn report() {
-    let report = io_error().map_err(Report::new).expect_err("not an error");
+    let mut report = io_error().map_err(Report::new).expect_err("not an error");
     assert!(report.contains::<io::Error>());
     assert_eq!(report.current_context().kind(), io::ErrorKind::Other);
+    assert_eq!(report.current_context_mut().kind(), io::ErrorKind::Other);
 }
 
 #[test]
@@ -88,9 +89,10 @@ fn error() {
 
 #[test]
 fn into_report() {
-    let report = io_error().map_err(Report::from).expect_err("not an error");
+    let mut report = io_error().map_err(Report::from).expect_err("not an error");
     assert!(report.contains::<io::Error>());
     assert_eq!(report.current_context().kind(), io::ErrorKind::Other);
+    assert_eq!(report.current_context_mut().kind(), io::ErrorKind::Other);
 }
 
 fn returning_boxed_error() -> Result<(), Box<dyn core::error::Error + Send + Sync>> {

--- a/libs/error-stack/tests/test_conversion.rs
+++ b/libs/error-stack/tests/test_conversion.rs
@@ -3,7 +3,7 @@
 #![allow(clippy::std_instead_of_core)]
 
 use core::fmt;
-use std::{error::Error, io};
+use std::{error::Error, fmt::Display, io};
 
 #[cfg(nightly)]
 use error_stack::IntoReport;
@@ -133,4 +133,39 @@ fn never_report() {
     }
 
     let Ok(()) = ().never_report();
+}
+
+#[test]
+fn pop_resource() {
+    #[derive(Debug)]
+    struct RecoverableError {
+        // Simulate a non-trivial resource
+        resource: Option<u32>,
+    }
+
+    impl Display for RecoverableError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(
+                f,
+                "recoverable error: resource: {}",
+                self.resource
+                    .as_ref().map_or_else(|| String::from("<unavailable>"), ToString::to_string)
+            )
+        }
+    }
+
+    impl Error for RecoverableError {}
+
+    let test_number = rand::random_range(0..u32::MAX);
+    let mut report = Report::new(RecoverableError {
+        resource: Some(test_number),
+    });
+    assert_eq!(
+        report
+            .current_context_mut()
+            .resource
+            .take()
+            .expect("resource should be available"),
+        test_number
+    );
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

- Add `Report::current_context_mut` to access the internal error mutably. This is required if the caller needs to modify or extract non-Clone fields as part of error recovery.
- Add `ResultExt::change_context_adaptive` to allow `map_err` like syntax. This helps with cases of error propagation where the underlying error needs to be surfaced to the domain level in the current form or in another form.

## 🔍 What does this change?

- Added `Report::current_context_mut`
- Added `ResultExt::change_context_adaptive`

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->
<!-- Libraries inside of the `@local` directory are always internal libraries which have no need for publishing -->

This PR:

- [ ] does not modify any publishable blocks or libraries, or modifications do not need publishing
- [ ] modifies an **npm**-publishable library and **I have added a changeset file(s)**
- [x] modifies a **Cargo**-publishable library and **I have amended the version**
- [ ] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**
- [ ] modifies a **block** that will need publishing via GitHub action once merged
- [ ] I am unsure / need advice

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [ ] are internal and do not require a docs change
- [ ] are in a state where docs changes are not _yet_ required but will be
  - this is tracked in: [Insert Link Here](link)
- [x] require changes to docs which **are made** as part of this PR
- [ ] require changes to docs which are **not** made in this PR
  - _Provide more detail here_
- [ ] I am unsure / need advice

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
- [ ] affected the execution graph, and the `turbo.json`'s have been updated to reflect this
- [ ] I am unsure / need advice

## ⚠️ Known issues
- Compiler jank related to non-lexical lifetimes prevents embedding the report in case of a panic.

## 🐾 Next steps
- Re-introduce the report embedding in the `unreachable!` panic in `Report::current_context_mut`

## 🛡 What tests cover this?
<!-- What automated tests cover this? Existing ones? New ones? None? -->
- Test cases in `test_change_context.rs` and `test_conversion.rs` have been modified to cover these two functions.

## ❓ How to test this?
- Running cargo test is sufficient, as these tests are fuzzed.