### PR TITLE
FE-1231: Share a fixed simulation seed between interactive Play and optimization runs

### DIFF
--- a/.changeset/shared-simulation-seed.md
+++ b/.changeset/shared-simulation-seed.md
@@ -1,0 +1,6 @@
+---
+"@hashintel/petrinaut-core": patch
+"@hashintel/petrinaut": patch
+---
+
+Use a shared fixed seed (`PETRINAUT_DEFAULT_SEED`) for interactive simulation and optimization runs, so playing a simulation reproduces an optimization trial given the same configuration.

--- a/libs/@hashintel/petrinaut-core/src/index.ts
+++ b/libs/@hashintel/petrinaut-core/src/index.ts
@@ -190,6 +190,7 @@ export type {
 
 // --- Simulation ---
 export {
+  PETRINAUT_DEFAULT_SEED,
   addAllMonteCarloMetricValues,
   createMonteCarloExperiment,
   createMonteCarloMetricHistogramAccumulator,

--- a/libs/@hashintel/petrinaut-core/src/simulation/api.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/api.ts
@@ -13,6 +13,13 @@ export type SimulationState =
   | "Complete"
   | "Error";
 
+/**
+ * Default RNG seed shared by interactive simulation and optimization runs, so
+ * a simulation played in the editor reproduces an optimization trial given the
+ * same model, scenario parameter values, dt, and max time.
+ */
+export const PETRINAUT_DEFAULT_SEED = 1234;
+
 export type BackpressureConfig = {
   /** Maximum frames the worker can compute ahead before waiting for ack. */
   maxFramesAhead?: number;

--- a/libs/@hashintel/petrinaut-core/src/simulation/index.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/index.ts
@@ -17,6 +17,7 @@ export type {
   SimulationState,
   WorkerFactory,
 } from "./api";
+export { PETRINAUT_DEFAULT_SEED } from "./api";
 export {
   addAllMonteCarloMetricValues,
   createMonteCarloExperiment,

--- a/libs/@hashintel/petrinaut/docs/simulation.md
+++ b/libs/@hashintel/petrinaut/docs/simulation.md
@@ -53,7 +53,7 @@ The numerical method for integrating differential equations. Currently only **Eu
 
 Press **Play** in the bottom toolbar. The simulation:
 
-1. Initializes with a fresh random seed (single-run simulations re-seed each time you press Play, so two consecutive runs of the same stochastic model produce different trajectories), the current dt, and parameter values.
+1. Initializes with a fixed random seed, the current dt, and parameter values. The seed is the same one used by [optimization](optimization.md) trials, so pressing Play twice with the same configuration reproduces the same trajectory, and a single run can reproduce an optimization trial given the same scenario parameter values, dt, and max time.
 2. Computes frames in a background Web Worker.
 3. Streams frames to the UI for playback.
 

--- a/libs/@hashintel/petrinaut/src/react/playback/provider.tsx
+++ b/libs/@hashintel/petrinaut/src/react/playback/provider.tsx
@@ -3,6 +3,7 @@ import { use, useEffect, useRef, useState } from "react";
 import {
   createPlayback,
   getPlayModeBackpressure,
+  PETRINAUT_DEFAULT_SEED,
   type ComputePlayMode,
   type Playback,
   type PlaybackSpeed,
@@ -247,7 +248,9 @@ export const PlaybackProvider: React.FC<PlaybackProviderProps> = ({
       }
       const initialization = (async () => {
         await initialize({
-          seed: Date.now(),
+          // Fixed seed shared with optimization runs so an interactive run
+          // reproduces an optimization trial given the same configuration.
+          seed: PETRINAUT_DEFAULT_SEED,
           dt: dtRef.current,
           maxFramesAhead: cfg.maxFramesAhead,
           batchSize: cfg.batchSize,

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/create-optimization-drawer.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/create-optimization-drawer.tsx
@@ -12,6 +12,7 @@ import {
 } from "@hashintel/ds-components";
 import { css } from "@hashintel/ds-helpers/css";
 import {
+  PETRINAUT_DEFAULT_SEED,
   PETRINAUT_OPTIMIZATION_MAX_STEPS_PER_TRIAL,
   PETRINAUT_OPTIMIZATION_MAX_TOTAL_STEPS,
   PETRINAUT_OPTIMIZATION_MAX_TRIALS,
@@ -180,7 +181,6 @@ const directionOptions = [
   { value: "minimize", label: "Minimize" },
 ];
 
-const OPTIMIZATION_SEED = 1234;
 const OPTIMIZATION_SAMPLER = "tpe" as const;
 const DEFAULT_DT = 0.1;
 const CUSTOM_OBJECTIVE_METRIC_NAME = "Custom objective";
@@ -470,7 +470,7 @@ export function buildPetrinautOptimizationInput({
     },
     scenario: { id: scenario.id, parameterBindings },
     objective: { metricId: metric.id, direction },
-    execution: { seed: OPTIMIZATION_SEED, dt, maxTime },
+    execution: { seed: PETRINAUT_DEFAULT_SEED, dt, maxTime },
     study: { trials: optimizationSteps, sampler: OPTIMIZATION_SAMPLER },
   });
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Make the RNG seed used by Petrinaut's interactive simulation (the Play button in Simulate mode) the same as the one used by optimization trials. Previously, each Play re-seeded with `Date.now()`, so an interactive run could never reproduce an optimization trial; optimization trials always run with a fixed seed of `1234`.

Both values feed the same engine entry point (`buildSimulation({ seed })` → the initial LCG `rngState`), so with a shared constant, playing a simulation in the editor reproduces an optimization trial given the same scenario parameter values, dt, and max time.

## 🔗 Related links

- [FE-1231](https://linear.app/hash/issue/FE-1231/petrinaut-share-a-fixed-simulation-seed-between-interactive-play-and) _(internal)_

## 🔍 What does this change?

- Adds `PETRINAUT_DEFAULT_SEED = 1234` to `@hashintel/petrinaut-core` (`simulation/api.ts`), exported from the package root.
- The playback provider now initializes interactive runs with the shared constant instead of `Date.now()`. This also fixes `Date.now()` exceeding the engine's documented `MAX_SEED` (2³¹ − 1) bound.
- The create-optimization drawer's local `OPTIMIZATION_SEED = 1234` is replaced by the shared constant, so the two paths cannot drift apart.
- Updates `libs/@hashintel/petrinaut/docs/simulation.md` to describe the fixed-seed behaviour (the previous text documented per-Play re-seeding).
- Adds a changeset (patch) for both packages.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] modifies an **npm**-publishable library and **I have added a changeset file(s)**

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] require changes to docs which **are made** as part of this PR

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

- Behaviour change: pressing Play twice on the same stochastic configuration now reproduces the identical trajectory (previously each Play produced a different one). Monte Carlo experiments keep their own user-editable seed field for varied draws.
- Exact trial reproduction additionally requires `maxTime` to be a multiple of `dt`: `model.run` clamps the final step's dt to the remaining time, while the interactive worker loop steps with fixed dt and stops once it passes `maxTime`. Left out of scope here.

## 🐾 Next steps

- Optionally align the interactive worker's final-step handling with `model.run`'s dt clamping (see Known issues).

## 🛡 What tests cover this?

- Existing unit tests for both packages pass (`turbo run test:unit --filter '@hashintel/petrinaut-core' --filter '@hashintel/petrinaut'`). No test asserted the previous `Date.now()` seeding, so none needed updating.

## ❓ How to test this?

1. Checkout the branch and run the Petrinaut demo (`yarn dev` in `libs/@hashintel/petrinaut`).
2. Load a stochastic example model, press Play, note the trajectory; reset and press Play again.
3. Confirm the two runs produce identical trajectories (previously they differed).

## 📹 Demo

Not applicable — no visual change; the seed is not surfaced in the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
