### PR TITLE
FE-1236: Add right inset to Simulation Settings scenario row and parameters list

### DIFF
--- a/.changeset/petrinaut-settings-right-padding.md
+++ b/.changeset/petrinaut-settings-right-padding.md
@@ -1,0 +1,5 @@
+---
+"@hashintel/petrinaut": patch
+---
+
+Add a small right inset to the Simulation Settings scenario picker row and parameters list so their controls don't hug the column edge.

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/BottomPanel/subviews/simulation-settings.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/BottomPanel/subviews/simulation-settings.tsx
@@ -39,6 +39,9 @@ const scenarioRowStyle = css({
   alignItems: "center",
   gap: "2",
   flexShrink: 0,
+  // Small right inset so the action buttons don't hug the column edge,
+  // matching the parameters list below.
+  paddingRight: "2",
 });
 
 const scenarioLabelStyle = css({
@@ -181,6 +184,8 @@ const parametersListStyle = css({
   // End padding: scrolls with the content, giving the last row breathing
   // room without reserving fixed space below the list.
   paddingBottom: "3",
+  // Small right inset so row values don't hug the scrollbar/column edge.
+  paddingRight: "2",
 });
 
 // Plain rows separated by hairline dividers, matching the sidebar's

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/BottomPanel/subviews/simulation-settings.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/BottomPanel/subviews/simulation-settings.tsx
@@ -184,19 +184,21 @@ const parametersListStyle = css({
   // End padding: scrolls with the content, giving the last row breathing
   // room without reserving fixed space below the list.
   paddingBottom: "3",
+  // Small right inset so row values don't hug the scrollbar/column edge.
+  paddingRight: "2",
 });
 
 // Plain rows separated by hairline dividers, matching the sidebar's
 // parameter list, rather than card-like boxes. A small horizontal inset
-// keeps the name and value off the column edges (the right inset also keeps
-// values clear of the scrollbar); the divider still spans the full width.
+// nudges the name and value off the row edges; the divider still spans the
+// full width.
 const parameterRowStyle = css({
   display: "flex",
   alignItems: "center",
   justifyContent: "space-between",
   gap: "4",
   paddingY: "2",
-  paddingX: "2",
+  paddingX: "0.5",
   borderBottomWidth: "thin",
   borderBottomColor: "neutral.a25",
   "&:last-child": {

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/BottomPanel/subviews/simulation-settings.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/BottomPanel/subviews/simulation-settings.tsx
@@ -184,18 +184,19 @@ const parametersListStyle = css({
   // End padding: scrolls with the content, giving the last row breathing
   // room without reserving fixed space below the list.
   paddingBottom: "3",
-  // Small right inset so row values don't hug the scrollbar/column edge.
-  paddingRight: "2",
 });
 
 // Plain rows separated by hairline dividers, matching the sidebar's
-// parameter list, rather than card-like boxes.
+// parameter list, rather than card-like boxes. A small horizontal inset
+// keeps the name and value off the column edges (the right inset also keeps
+// values clear of the scrollbar); the divider still spans the full width.
 const parameterRowStyle = css({
   display: "flex",
   alignItems: "center",
   justifyContent: "space-between",
   gap: "4",
   paddingY: "2",
+  paddingX: "2",
   borderBottomWidth: "thin",
   borderBottomColor: "neutral.a25",
   "&:last-child": {

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/BottomPanel/subviews/simulation-settings.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/BottomPanel/subviews/simulation-settings.tsx
@@ -198,7 +198,7 @@ const parameterRowStyle = css({
   justifyContent: "space-between",
   gap: "4",
   paddingY: "2",
-  paddingX: "0.5",
+  paddingX: "1",
   borderBottomWidth: "thin",
   borderBottomColor: "neutral.a25",
   "&:last-child": {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

A small visual follow-up to #9074: in the Simulation Settings subview, the scenario picker row and the parameters list sit flush against the left column's right edge. This adds a small right inset so their controls have breathing room and line up with each other.

## 🔗 Related links

- [FE-1236](https://linear.app/hash/issue/FE-1236/add-right-inset-to-simulation-settings-scenario-row-and-parameters) _(internal)_

## 🔍 What does this change?

- `scenarioRowStyle`: add `paddingRight: 2` (8px) so the edit/create/manage buttons don't hug the column edge.
- `parametersListStyle`: add `paddingRight: 2` (8px) so row values don't hug the scrollbar/column edge. It scrolls with the content, like the existing bottom inset.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] modifies an **npm**-publishable library and **I have added a changeset file(s)**

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- Style-only; covered by the existing petrinaut unit tests (no behavioural change).

## ❓ How to test this?

1. Open the `Petrinaut → Default` story, load the "Supply Chain Profit" example, open the bottom panel's **Simulation Settings** tab.
2. Note the scenario picker's action buttons and the parameter row values now sit slightly inset from the right edge, aligned with each other.
