### PR TITLE
FE-1238: Send the type universe as an include list on the entities page

### DIFF
--- a/apps/hash-frontend/src/pages/shared/entities-visualizer.tsx
+++ b/apps/hash-frontend/src/pages/shared/entities-visualizer.tsx
@@ -366,7 +366,10 @@ export const EntitiesVisualizer: FunctionComponent<{
   }, [entitiesData]);
 
   useEffect(() => {
-    if (availableTypesLoading) {
+    // An errored summary yields EMPTY available types — that is ignorance, not
+    // knowledge that the selected types are gone. Pruning against it would wipe
+    // the selection whose explicit type clause keeps the page working.
+    if (availableTypesLoading || typeUniverseError) {
       return;
     }
 
@@ -433,6 +436,7 @@ export const EntitiesVisualizer: FunctionComponent<{
     isTypePinned,
     propertyFilterData,
     setFilterState,
+    typeUniverseError,
   ]);
 
   const isDisplayingFilesOnly = useMemo(
@@ -571,6 +575,14 @@ export const EntitiesVisualizer: FunctionComponent<{
     setSelectedTableRows([]);
   }, [entitiesData]);
 
+  // The universe only feeds the default view — with a pinned type or an
+  // explicit selection the main query runs on its own type clause, so a failed
+  // summary must not blank results that still load.
+  const typeUniverseBlocksResults =
+    !!typeUniverseError &&
+    !isTypePinned &&
+    filterState.type.selectedTypeIds === null;
+
   const showLoading = !subgraph || !closedMultiEntityTypesRootMap;
 
   const { totalResultCount } = visualizerData;
@@ -618,7 +630,7 @@ export const EntitiesVisualizer: FunctionComponent<{
         }
       />
       <Box ref={contentTopRef} />
-      {typeUniverseError ? (
+      {typeUniverseBlocksResults ? (
         <Stack
           gap={2}
           sx={[

--- a/apps/hash-frontend/src/pages/shared/entities-visualizer.tsx
+++ b/apps/hash-frontend/src/pages/shared/entities-visualizer.tsx
@@ -1,4 +1,4 @@
-import { Box, Stack, useTheme } from "@mui/material";
+import { Box, Stack, Typography, useTheme } from "@mui/material";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { extractBaseUrl, isBaseUrl } from "@blockprotocol/type-system";
@@ -14,6 +14,7 @@ import { useEntityTypesContextRequired } from "../../shared/entity-types-context
 import { HEADER_HEIGHT } from "../../shared/layout/layout-with-header/page-header";
 import { tableContentSx } from "../../shared/table-content";
 import { BulkActionsDropdown } from "../../shared/table-header/bulk-actions-dropdown";
+import { Button } from "../../shared/ui";
 import { useMemoCompare } from "../../shared/use-memo-compare";
 import { useAuthenticatedUser } from "./auth-info-context";
 import {
@@ -251,6 +252,22 @@ export const EntitiesVisualizer: FunctionComponent<{
     [sort],
   );
 
+  const isTypePinned = !!entityTypeBaseUrl || !!entityTypeId;
+
+  const {
+    availableEntityTypes,
+    propertyFilterData,
+    loading: availableTypesLoading,
+    typeUniverse,
+    typeUniverseError,
+    refetchTypeUniverse,
+  } = useAvailableTypes({
+    filterState,
+    internalWebs,
+    entityTypeBaseUrl,
+    entityTypeIds: entityTypeId ? [entityTypeId] : undefined,
+  });
+
   const entitiesData = useEntitiesVisualizerData({
     conversions: activeConversionsWithoutTitle
       ? typedEntries(activeConversionsWithoutTitle).map(
@@ -268,6 +285,8 @@ export const EntitiesVisualizer: FunctionComponent<{
     internalWebs,
     limit: 500,
     sort: graphSort,
+    typeUniverse,
+    typeUniverseError,
     view,
   });
 
@@ -345,19 +364,6 @@ export const EntitiesVisualizer: FunctionComponent<{
       setVisualizerData(entitiesData);
     }
   }, [entitiesData]);
-
-  const isTypePinned = !!entityTypeBaseUrl || !!entityTypeId;
-
-  const {
-    availableEntityTypes,
-    propertyFilterData,
-    loading: availableTypesLoading,
-  } = useAvailableTypes({
-    filterState,
-    internalWebs,
-    entityTypeBaseUrl,
-    entityTypeIds: entityTypeId ? [entityTypeId] : undefined,
-  });
 
   useEffect(() => {
     if (availableTypesLoading) {
@@ -612,7 +618,30 @@ export const EntitiesVisualizer: FunctionComponent<{
         }
       />
       <Box ref={contentTopRef} />
-      {showLoading ? (
+      {typeUniverseError ? (
+        <Stack
+          gap={2}
+          sx={[
+            {
+              alignItems: "center",
+              justifyContent: "center",
+              height: tableHeight,
+              width: "100%",
+            },
+            tableContentSx,
+          ]}
+        >
+          <Typography>Something went wrong loading entities.</Typography>
+          <Button
+            onClick={() => {
+              void refetchTypeUniverse();
+            }}
+            size="small"
+          >
+            Try again
+          </Button>
+        </Stack>
+      ) : showLoading ? (
         <Stack
           sx={[
             {

--- a/apps/hash-frontend/src/pages/shared/entities-visualizer/shared/build-filter.ts
+++ b/apps/hash-frontend/src/pages/shared/entities-visualizer/shared/build-filter.ts
@@ -121,11 +121,27 @@ export const buildEntitiesFilter = ({
   internalWebIds,
   pinnedEntityTypeBaseUrl,
   pinnedEntityTypeIds,
+  typeUniverse,
 }: {
   filterState: EntitiesFilterState;
   internalWebIds: WebId[];
   pinnedEntityTypeBaseUrl?: BaseUrl;
   pinnedEntityTypeIds?: VersionedUrl[];
+  /**
+   * The type universe: the entity type ids present in the current result set,
+   * as reported by `summarizeEntities` over the same web and archive scope
+   * (type selection and property filters deliberately dropped — see
+   * `useAvailableTypes`). It must stay a superset of the types the main query
+   * can return, or rows silently vanish.
+   *
+   * When there is no explicit type selection, it is sent as an include list so
+   * the query planner has an indexable, estimable type clause — the
+   * noisy-system-type exclusions alone are unestimable and provoke pathological
+   * plans. The exclusions are still applied on top: a multi-type entity can
+   * carry a noisy type alongside one from the universe, so the include list
+   * alone would not be equivalent.
+   */
+  typeUniverse?: VersionedUrl[] | null;
 }): Filter => {
   const clauses: Filter[] = [];
 
@@ -144,6 +160,21 @@ export const buildEntitiesFilter = ({
 
   if (typeClause) {
     clauses.push(typeClause);
+  } else if (typeUniverse) {
+    clauses.push(
+      typeUniverse.length
+        ? {
+            any: typeUniverse.map((entityTypeId) => ({
+              equal: [
+                { path: ["type", "versionedUrl"] },
+                { parameter: entityTypeId },
+              ],
+            })),
+          }
+        : {
+            equal: [{ path: ["type", "versionedUrl"] }, { parameter: "" }],
+          },
+    );
   }
 
   if (!isTypePinned) {

--- a/apps/hash-frontend/src/pages/shared/entities-visualizer/shared/use-available-types.ts
+++ b/apps/hash-frontend/src/pages/shared/entities-visualizer/shared/use-available-types.ts
@@ -39,6 +39,21 @@ export const useAvailableTypes = ({
   availableEntityTypes: AvailableType[];
   propertyFilterData: FilterMetadataForProperty[];
   loading: boolean;
+  /**
+   * The type universe: the entity type ids present in the current result set,
+   * or `null` while the summary has not arrived yet (or is not fetched at all,
+   * for pinned types). Feeds the include-type clause of the main entities
+   * query — see `buildEntitiesFilter`.
+   */
+  typeUniverse: VersionedUrl[] | null;
+  /**
+   * Set when the type universe cannot be provided — the summary query failed,
+   * or its response was missing the requested type ids. The main entities query
+   * stays gated in that case, so callers should surface this instead of an
+   * endless loading state.
+   */
+  typeUniverseError?: Error;
+  refetchTypeUniverse: () => Promise<unknown>;
 } => {
   const { entityTypes, entityTypeParentIds } = useEntityTypesContextRequired();
   const { dataTypes } = useDataTypesContext();
@@ -63,6 +78,8 @@ export const useAvailableTypes = ({
     return null;
   }, [entityTypeBaseUrl, entityTypeIds, entityTypes]);
 
+  // No typeUniverse here — this query defines the universe. Feeding it back in
+  // would ratchet it shut against newly appearing types.
   const filter = useMemo(
     () =>
       buildEntitiesFilter({
@@ -77,7 +94,7 @@ export const useAvailableTypes = ({
     [filterState, internalWebs],
   );
 
-  const { data, loading } = useQuery<
+  const { data, error, loading, refetch } = useQuery<
     SummarizeEntitiesQuery,
     SummarizeEntitiesQueryVariables
   >(summarizeEntitiesQuery, {
@@ -161,11 +178,41 @@ export const useAvailableTypes = ({
   const propertyFilterDataLoading =
     !dataTypes || !entityTypes || !entityTypeParentIds || !propertyTypes;
 
+  // A present-but-empty typeIds map means "genuinely zero matching entities" and
+  // yields a match-nothing clause. An ABSENT map despite includeTypeIds being
+  // requested is a broken response — coercing it to an empty universe would
+  // silently render the whole workspace as "0 entities", so it surfaces as an
+  // error instead.
+  const typeUniverse = useMemo<VersionedUrl[] | null>(() => {
+    if (!data?.summarizeEntities.typeIds) {
+      return null;
+    }
+
+    return Object.keys(data.summarizeEntities.typeIds) as VersionedUrl[];
+  }, [data]);
+
+  const typeUniverseError = useMemo<Error | undefined>(() => {
+    if (error) {
+      return error;
+    }
+
+    if (data && !data.summarizeEntities.typeIds) {
+      return new Error(
+        "summarizeEntities returned no typeIds although they were requested",
+      );
+    }
+
+    return undefined;
+  }, [data, error]);
+
   return {
     availableEntityTypes,
     propertyFilterData,
     loading: shouldFetchAvailableTypes
       ? loading || propertyFilterDataLoading
       : propertyFilterDataLoading,
+    typeUniverse,
+    typeUniverseError,
+    refetchTypeUniverse: refetch,
   };
 };

--- a/apps/hash-frontend/src/pages/shared/entities-visualizer/shared/use-available-types.ts
+++ b/apps/hash-frontend/src/pages/shared/entities-visualizer/shared/use-available-types.ts
@@ -47,10 +47,10 @@ export const useAvailableTypes = ({
    */
   typeUniverse: VersionedUrl[] | null;
   /**
-   * Set when the type universe cannot be provided — the summary query failed,
-   * or its response was missing the requested type ids. The main entities query
-   * stays gated in that case, so callers should surface this instead of an
-   * endless loading state.
+   * Set when no type universe can be provided — the summary query failed with
+   * no cached universe to fall back on, or its response was missing the
+   * requested type ids. The main entities query stays gated in that case, so
+   * callers should surface this instead of an endless loading state.
    */
   typeUniverseError?: Error;
   refetchTypeUniverse: () => Promise<unknown>;
@@ -191,7 +191,14 @@ export const useAvailableTypes = ({
     return Object.keys(data.summarizeEntities.typeIds) as VersionedUrl[];
   }, [data]);
 
+  // Only fatal when it leaves us without a universe — a failed background
+  // refresh with a cached universe still renders (slightly stale) results,
+  // which beats flipping a working page into an error state.
   const typeUniverseError = useMemo<Error | undefined>(() => {
+    if (typeUniverse !== null) {
+      return undefined;
+    }
+
     if (error) {
       return error;
     }
@@ -203,7 +210,7 @@ export const useAvailableTypes = ({
     }
 
     return undefined;
-  }, [data, error]);
+  }, [data, error, typeUniverse]);
 
   return {
     availableEntityTypes,

--- a/apps/hash-frontend/src/pages/shared/entities-visualizer/use-entities-visualizer-data.tsx
+++ b/apps/hash-frontend/src/pages/shared/entities-visualizer/use-entities-visualizer-data.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@apollo/client";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 
 import { getLatestEntityVertices, getRoots } from "@blockprotocol/graph/stdlib";
 import {
@@ -53,7 +53,15 @@ export type EntitiesVisualizerData = Partial<
    * Note that if is hasCachedContent is true, data for the given query is available before loading is complete.
    * The cached content will be replaced automatically and the value updated when the network request completes.
    */
-  refetch: () => Promise<ApolloQueryResult<QueryEntitySubgraphQuery>>;
+  /**
+   * Refetches the subgraph query only — the type universe keeps its last
+   * snapshot, so entities of types that appeared after it loaded stay hidden
+   * until the universe query itself refetches. Resolves to `undefined` without
+   * querying while the type universe is still awaited.
+   */
+  refetch: () => Promise<
+    ApolloQueryResult<QueryEntitySubgraphQuery> | undefined
+  >;
   subgraph?: Subgraph<EntityRootType<HashEntity>>;
   tableData: EntitiesTableData | null;
   totalResultCount: number | null;
@@ -70,6 +78,19 @@ export const useEntitiesVisualizerData = (params: {
   internalWebs: { webId: WebId }[];
   limit?: number;
   sort?: EntityQuerySortingRecord;
+  /**
+   * The type universe from `useAvailableTypes` — `null` while the summary is in
+   * flight, and permanently for pinned types, which never fetch it. The default
+   * (no type selection) view sends it as an include-type clause and holds its
+   * queries back until it arrives — see {@link buildEntitiesFilter}.
+   */
+  typeUniverse: VersionedUrl[] | null;
+  /**
+   * Set when the type universe failed to load. The gated queries stay skipped,
+   * but `loading` stops reporting `true` so the page can show an error state
+   * instead of an endless spinner.
+   */
+  typeUniverseError?: Error;
   view: VisualizerView;
 }): EntitiesVisualizerData => {
   const {
@@ -82,6 +103,8 @@ export const useEntitiesVisualizerData = (params: {
     internalWebs,
     limit,
     sort,
+    typeUniverse,
+    typeUniverseError,
     view,
   } = params;
 
@@ -102,9 +125,24 @@ export const useEntitiesVisualizerData = (params: {
         internalWebIds,
         pinnedEntityTypeBaseUrl: entityTypeBaseUrl,
         pinnedEntityTypeIds: entityTypeIds,
+        typeUniverse,
       }),
-    [filterState, internalWebIds, entityTypeBaseUrl, entityTypeIds],
+    [
+      filterState,
+      internalWebIds,
+      entityTypeBaseUrl,
+      entityTypeIds,
+      typeUniverse,
+    ],
   );
+
+  // TODO(BE-705): a dedicated Graph endpoint will run the summary and the page
+  //  query in one transaction, replacing this client-side coordination.
+  const awaitingTypeUniverse =
+    typeUniverse === null &&
+    !entityTypeBaseUrl &&
+    !entityTypeIds?.length &&
+    filterState.type.selectedTypeIds === null;
 
   const variables = useMemo<QueryEntitySubgraphQueryVariables>(
     () => ({
@@ -132,6 +170,7 @@ export const useEntitiesVisualizerData = (params: {
     SummarizeEntitiesQuery,
     SummarizeEntitiesQueryVariables
   >(summarizeEntitiesQuery, {
+    skip: awaitingTypeUniverse,
     variables: {
       request: {
         filter,
@@ -147,6 +186,7 @@ export const useEntitiesVisualizerData = (params: {
     QueryEntitySubgraphQueryVariables
   >(queryEntitySubgraphQuery, {
     fetchPolicy: "cache-and-network",
+    skip: awaitingTypeUniverse,
     onCompleted: (completedData) => {
       if (view === "Graph") {
         return;
@@ -169,6 +209,17 @@ export const useEntitiesVisualizerData = (params: {
     },
     variables,
   });
+
+  // Apollo's refetch punches through `skip`, and while the gate holds the built
+  // filter has no type clause at all — exactly the unestimable shape the gate
+  // exists to prevent. Drop the call instead.
+  const guardedRefetch = useCallback(async () => {
+    if (awaitingTypeUniverse) {
+      return undefined;
+    }
+
+    return refetch();
+  }, [awaitingTypeUniverse, refetch]);
 
   const hadCachedContent = useMemo(
     () =>
@@ -200,8 +251,8 @@ export const useEntitiesVisualizerData = (params: {
       ...data?.queryEntitySubgraph,
       entities,
       hadCachedContent,
-      loading,
-      refetch,
+      loading: loading || (awaitingTypeUniverse && !typeUniverseError),
+      refetch: guardedRefetch,
       subgraph,
       tableData,
       totalResultCount: summaryData?.summarizeEntities.count ?? null,
@@ -213,7 +264,9 @@ export const useEntitiesVisualizerData = (params: {
       entities,
       hadCachedContent,
       loading,
-      refetch,
+      awaitingTypeUniverse,
+      typeUniverseError,
+      guardedRefetch,
       subgraph,
       tableData,
       updateTableData,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The default view of the `/entities` page filters types only by exclusion (`ignoreNoisySystemTypesFilter`), which compiles to NOT-array-overlap chains Postgres cannot estimate — the root of the multi-second sorted-read incidents on the entities page. The page already knows the visible-type universe from the `summarizeEntities` call that feeds its filter pills, so it now sends that universe as an include-type clause the planner can index and estimate. Measured against a 700k-entity seed, the incident-shaped query drops from 5.5s to sub-millisecond with the include clause in place.

## 🔗 Related links

- [FE-1238](https://linear.app/hash/issue/FE-1238) _(internal)_ — the driving ticket
- [BE-702](https://linear.app/hash/issue/BE-702) _(internal)_ — the graph-side keys-first statement shape this complements
- [BE-705](https://linear.app/hash/issue/BE-705) _(internal)_ — follow-up: dedicated entities-page endpoint
- [Slack: entities-page performance & sort keys](https://hashintel.slack.com/archives/C022217GAHF/p1784220011668439) _(internal)_

## 🔍 What does this change?

- `buildEntitiesFilter` accepts the type universe and sends it as an `any(equal(type.versionedUrl, …))` clause when no explicit type clause exists. The noisy-system-type exclusions stay on top as the semantic recheck: a multi-type entity can carry a noisy type alongside a universe type, so the include list alone would not be result-equivalent.
- `useAvailableTypes` exposes the universe (plus an error and a refetch handle). Its own summarize query keeps the exclusion-only shape — it defines the universe and has no sort+limit, so the pathological plan shape does not apply to it.
- `useEntitiesVisualizerData` holds both the subgraph query and the count summarize back until the universe is available, reports `loading` accordingly, and guards the exposed `refetch` from punching through the gate (Apollo's refetch ignores `skip`).
- A failed universe query surfaces as an error state with a retry button instead of an endless spinner.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

- A type created between the summary and the page query stays invisible until the summary refetches. This matches what the filter UI shows anyway; `TODO(BE-705)` removes the window by running both in one transaction server-side.
- Cold loads serialize the summarize and the page query (one extra hop) — the price for never sending the unestimable filter shape.

## 🐾 Next steps

- [BE-705](https://linear.app/hash/issue/BE-705): a dedicated Graph endpoint runs the summary and the page query in one transaction, replacing this client-side coordination.

## 🛡 What tests cover this?

- The entities-visualizer area has no automated test coverage; verified via type checks, lint, and manual testing of the page (default view, type selection, pinned types, pagination).

## ❓ How to test this?

1. Open `/entities` and check the network tab: `queryEntitySubgraph` now fires after the `summarizeEntities` response and its filter carries an `any(equal(type.versionedUrl, …))` clause alongside the exclusions.
2. Filter, sort, and paginate as usual — behavior is unchanged.
3. Error path: block the summarize request (devtools request blocking) and reload — the page shows an error state with a working "Try again" button instead of an endless spinner.

## 📹 Demo

Filter shape of the default view, before → after:

```jsonc
// before: exclusions only — unestimable
{ "all": [ …, { "notEqual": [{ "path": ["type", "baseUrl"] }, …] }, ×12 ] }

// after: include universe first, exclusions kept as recheck
{ "all": [ …,
  { "any": [ { "equal": [{ "path": ["type", "versionedUrl"] }, …] }, … ] },
  { "notEqual": [{ "path": ["type", "baseUrl"] }, …] }, ×12
] }
```
