### PR TITLE
H-6717: Dashboard config and refresh improvements

### DIFF
--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/infer-metadata-from-document-action/generate-proposed-entities-and-claims.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/infer-metadata-from-document-action/generate-proposed-entities-and-claims.ts
@@ -8,6 +8,7 @@ import {
   systemDataTypes,
   systemEntityTypes,
   systemLinkEntityTypes,
+  systemPropertyTypes,
 } from "@local/hash-isomorphic-utils/ontology-type-ids";
 
 import { getFlowContext } from "../../shared/get-flow-context.js";
@@ -157,7 +158,9 @@ export const generateDocumentProposedEntitiesAndCreateClaims = async ({
       authorProperties["https://hash.ai/@h/types/property-type/email/"] = [
         email,
       ];
-      authorPropertyMetadata.value[systemDataTypes.email.dataTypeBaseUrl] = {
+      authorPropertyMetadata.value[
+        systemPropertyTypes.email.propertyTypeBaseUrl
+      ] = {
         value: [
           {
             metadata: {

--- a/apps/hash-api/src/analysis/analyses/dashboards.test.ts
+++ b/apps/hash-api/src/analysis/analyses/dashboards.test.ts
@@ -267,6 +267,19 @@ describe("dashboardItemData analysis", () => {
     });
   });
 
+  it("allows a new Temporal run for an explicit recompute without an artifact", async () => {
+    const result = await resolve({
+      itemUuid: ITEM_UUID,
+      recompute: true,
+    });
+
+    expect(result.status).toBe("computing");
+    expect(workflowStart.mock.calls[0]![1]).toMatchObject({
+      workflowId: `compute-dashboard-item-${WEB_ID}-${configHash}`,
+      workflowIdReusePolicy: "ALLOW_DUPLICATE",
+    });
+  });
+
   it("does not compute without a web machine", async () => {
     mockedGetWebMachineId.mockResolvedValue(null);
 
@@ -312,13 +325,13 @@ describe("dashboardItemData analysis", () => {
     );
   });
 
-  it("recomputes even a fresh artifact when force is set", async () => {
+  it("recomputes even a fresh artifact when explicitly requested", async () => {
     artifactLastModified = new Date();
     artifactMetadata = Buffer.from(
       JSON.stringify({ generationDurationMs: 5_000 }),
     );
 
-    const result = await resolve({ itemUuid: ITEM_UUID, force: true });
+    const result = await resolve({ itemUuid: ITEM_UUID, recompute: true });
 
     expect(result.status).toBe("computing");
     expect(result.metadata).toMatchObject({
@@ -326,11 +339,17 @@ describe("dashboardItemData analysis", () => {
       isRefreshing: true,
     });
     expect(workflowStart).toHaveBeenCalledTimes(1);
+    expect(workflowStart.mock.calls[0]![1].workflowIdReusePolicy).toBe(
+      "ALLOW_DUPLICATE",
+    );
   });
 
-  it("waits for a forced refresh to supersede the previous artifact", async () => {
+  it("waits for a recompute to supersede the previous artifact", async () => {
     artifactLastModified = new Date();
-    const initialResult = await resolve({ itemUuid: ITEM_UUID, force: true });
+    const initialResult = await resolve({
+      itemUuid: ITEM_UUID,
+      recompute: true,
+    });
     const refreshAfter = initialResult.metadata?.refreshAfter as string;
 
     const waitingResult = await resolve({ itemUuid: ITEM_UUID, refreshAfter });

--- a/apps/hash-api/src/analysis/analyses/dashboards.ts
+++ b/apps/hash-api/src/analysis/analyses/dashboards.ts
@@ -111,14 +111,15 @@ const createAnalysisMetadata = ({
 
 /**
  * Start the (idempotent) compute workflow for a dashboard item configuration.
- * The workflow id is derived from the config hash and source artifact version,
- * so concurrent requests for the same computation deduplicate. A terminal
- * execution is never silently replaced: its result is inspected and failures
- * are surfaced to the caller.
+ * The workflow id is derived from the config hash, source artifact version,
+ * so concurrent requests for the same computation deduplicate. Explicit user
+ * recomputations allow Temporal to create a new run under that stable workflow
+ * id; normal resolution never silently replaces a terminal execution.
  */
 const startComputeWorkflow = async (params: {
   ctx: AnalysisResolutionContext;
   configHash: string;
+  recompute: boolean;
   sourceArtifactLastModified: Date | null;
   structuralQuery: unknown;
   pythonScript: string;
@@ -128,6 +129,7 @@ const startComputeWorkflow = async (params: {
   const {
     ctx,
     configHash,
+    recompute,
     sourceArtifactLastModified,
     structuralQuery,
     pythonScript,
@@ -164,9 +166,11 @@ const startComputeWorkflow = async (params: {
           } satisfies ComputeDashboardItemDataWorkflowParams,
         ],
         workflowId,
-        workflowIdReusePolicy: WorkflowIdReusePolicy.REJECT_DUPLICATE,
-        // A failed script must not repeatedly create paid sandboxes. Retrying
-        // requires a changed configuration or source artifact version.
+        workflowIdReusePolicy: recompute
+          ? WorkflowIdReusePolicy.ALLOW_DUPLICATE
+          : WorkflowIdReusePolicy.REJECT_DUPLICATE,
+        // A failed script must not automatically create more paid sandboxes.
+        // Only an explicit recompute may create a new Temporal run.
         retry: { maximumAttempts: 1 },
       },
     );
@@ -202,11 +206,11 @@ const startComputeWorkflow = async (params: {
 /**
  * Resolve a dashboard item's chart data: serve the cached artifact keyed by a
  * hash of the item's (query, script) configuration, computing it server-side
- * via a Temporal workflow when missing, forced, or stale.
+ * via a Temporal workflow when missing, explicitly recomputed, or stale.
  *
  * Args:
  * - `itemUuid` (required): entity uuid of the DashboardItem within the web
- * - `force` (optional boolean): recompute even if a fresh artifact exists
+ * - `recompute` (optional boolean): explicitly start a new computation
  */
 const dashboardItemData: NamedAnalysis = {
   name: "dashboardItemData",
@@ -217,7 +221,7 @@ const dashboardItemData: NamedAnalysis = {
         "Argument 'itemUuid' must be a valid entity uuid",
       );
     }
-    const force = ctx.args.force === true;
+    const recompute = ctx.args.recompute === true;
     const refreshAfter =
       typeof ctx.args.refreshAfter === "string"
         ? new Date(ctx.args.refreshAfter)
@@ -311,15 +315,16 @@ const dashboardItemData: NamedAnalysis = {
       metadataStorageKey,
     );
 
-    const waitingForForcedRefresh =
+    const waitingForRecompute =
       refreshAfter !== null &&
       (!lastModified || lastModified.getTime() <= refreshAfter.getTime());
 
-    if (!lastModified || force || waitingForForcedRefresh) {
+    if (!lastModified || recompute || waitingForRecompute) {
       const sourceArtifactLastModified = refreshAfter ?? lastModified;
       const workflowState = await startComputeWorkflow({
         ctx,
         configHash,
+        recompute,
         sourceArtifactLastModified,
         structuralQuery,
         pythonScript,
@@ -371,6 +376,7 @@ const dashboardItemData: NamedAnalysis = {
       startComputeWorkflow({
         ctx,
         configHash,
+        recompute: false,
         sourceArtifactLastModified: lastModified,
         structuralQuery,
         pythonScript,

--- a/apps/hash-frontend/src/pages/dashboard/[dashboard-id].page.tsx
+++ b/apps/hash-frontend/src/pages/dashboard/[dashboard-id].page.tsx
@@ -14,6 +14,7 @@ import {
   mergePropertyObjectAndMetadata,
 } from "@local/hash-graph-sdk/entity";
 import {
+  getPrimaryChartType,
   type ChartConfig,
   type ChartType,
   type DashboardGridLayout,
@@ -253,6 +254,8 @@ const DashboardPage: NextPageWithLayout = () => {
       const itemProps = simplifyProperties(itemEntity.properties);
       const itemEntityId = itemEntity.metadata.recordId.entityId;
       const linkEntityId = link.metadata.recordId.entityId;
+      const chartConfig =
+        (itemProps.chartConfiguration as ChartConfig | undefined) ?? null;
 
       items.push({
         entityId: itemEntityId,
@@ -261,9 +264,11 @@ const DashboardPage: NextPageWithLayout = () => {
         userGoal: itemProps.goal,
         structuralQuery: normalizeStructuralQuery(itemProps.structuralQuery),
         pythonScript: itemProps.pythonScript ?? null,
-        chartType: (itemProps.chartType as ChartType | undefined) ?? null,
-        chartConfig:
-          (itemProps.chartConfiguration as ChartConfig | undefined) ?? null,
+        chartType:
+          (chartConfig && getPrimaryChartType(chartConfig)) ??
+          (itemProps.chartType as ChartType | undefined) ??
+          null,
+        chartConfig,
         gridPosition: (itemProps.gridPosition as GridPosition | undefined) ?? {
           i: itemEntityId,
           x: 0,

--- a/apps/hash-frontend/src/pages/dashboard/[dashboard-id].page/dashboard-grid/dashboard-item.tsx
+++ b/apps/hash-frontend/src/pages/dashboard/[dashboard-id].page/dashboard-grid/dashboard-item.tsx
@@ -128,7 +128,7 @@ export const DashboardItem = ({
   });
 
   const handleRefreshClick = useCallback(() => {
-    refresh({ force: true });
+    refresh();
   }, [refresh]);
 
   const handleRetryClick = useCallback(() => {

--- a/apps/hash-frontend/src/pages/dashboard/[dashboard-id].page/dashboard-grid/dashboard-item/dashboard-item-content.tsx
+++ b/apps/hash-frontend/src/pages/dashboard/[dashboard-id].page/dashboard-grid/dashboard-item/dashboard-item-content.tsx
@@ -1,6 +1,7 @@
 import { Box, CircularProgress, Typography } from "@mui/material";
 
 import { Button } from "@hashintel/ds-components";
+import { getPrimaryChartType } from "@local/hash-isomorphic-utils/dashboard-types";
 
 import { ChartRenderer } from "./dashboard-item-content/chart-renderer";
 import { WorldMapRenderer } from "./dashboard-item-content/world-map-renderer";
@@ -170,33 +171,6 @@ export const DashboardItemContent = ({
         );
       }
 
-      if (!chartType || !chartData) {
-        return (
-          <CenteredMessage>
-            <Typography
-              variant="smallTextParagraphs"
-              sx={{
-                color: ({ palette }) => palette.gray[70],
-                textAlign: "center",
-              }}
-            >
-              Missing chart configuration
-            </Typography>
-          </CenteredMessage>
-        );
-      }
-
-      if (chartType === "map" && isPositionData(chartData)) {
-        return (
-          <WorldMapRenderer
-            flights={chartData}
-            onFlightClick={onEntityClick}
-            hoveredEntityId={hoveredEntityId}
-            onHoveredEntityChange={onHoveredEntityChange}
-          />
-        );
-      }
-
       if (!chartConfig) {
         return (
           <CenteredMessage>
@@ -213,9 +187,54 @@ export const DashboardItemContent = ({
         );
       }
 
+      if (!chartData) {
+        return (
+          <CenteredMessage>
+            <Typography
+              variant="smallTextParagraphs"
+              sx={{
+                color: ({ palette }) => palette.gray[70],
+                textAlign: "center",
+              }}
+            >
+              Missing chart data
+            </Typography>
+          </CenteredMessage>
+        );
+      }
+
+      const resolvedChartType = getPrimaryChartType(chartConfig) ?? chartType;
+
+      if (!resolvedChartType) {
+        return (
+          <CenteredMessage>
+            <Typography
+              variant="smallTextParagraphs"
+              sx={{
+                color: ({ palette }) => palette.gray[70],
+                textAlign: "center",
+              }}
+            >
+              Chart configuration must contain at least one series
+            </Typography>
+          </CenteredMessage>
+        );
+      }
+
+      if (resolvedChartType === "map" && isPositionData(chartData)) {
+        return (
+          <WorldMapRenderer
+            flights={chartData}
+            onFlightClick={onEntityClick}
+            hoveredEntityId={hoveredEntityId}
+            onHoveredEntityChange={onHoveredEntityChange}
+          />
+        );
+      }
+
       return (
         <ChartRenderer
-          chartType={chartType}
+          chartType={resolvedChartType}
           chartData={chartData}
           chartConfig={chartConfig}
           onEntityClick={onEntityClick}

--- a/apps/hash-frontend/src/pages/dashboard/hooks/use-dashboard-item-config.ts
+++ b/apps/hash-frontend/src/pages/dashboard/hooks/use-dashboard-item-config.ts
@@ -1,7 +1,10 @@
 import { useApolloClient, useMutation } from "@apollo/client";
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { normalizeStructuralQuery } from "@local/hash-isomorphic-utils/dashboard-types";
+import {
+  getPrimaryChartType,
+  normalizeStructuralQuery,
+} from "@local/hash-isomorphic-utils/dashboard-types";
 import {
   configureDashboardItemFlowDefinition,
   refineDashboardItemFlowDefinition,
@@ -65,6 +68,18 @@ const initialState: ConfigState = {
   isLoading: false,
   error: null,
   flowRunId: null,
+};
+
+const configurationReadyPatch: PropertyPatchOperation = {
+  op: "add",
+  path: [systemPropertyTypes.configurationStatus.propertyTypeBaseUrl],
+  property: {
+    value: "ready",
+    metadata: {
+      dataTypeId:
+        "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1",
+    },
+  },
 };
 
 export type DashboardItemInitialValues = {
@@ -153,6 +168,15 @@ export const useDashboardItemConfig = ({
   });
 
   const [state, setState] = useState<ConfigState>(seededStateRef.current);
+  const persistedConfigurationRef = useRef({
+    structuralQuery: seededStateRef.current.structuralQuery,
+    pythonScript: seededStateRef.current.pythonScript,
+    chartType:
+      (seededStateRef.current.chartConfig &&
+        getPrimaryChartType(seededStateRef.current.chartConfig)) ??
+      seededStateRef.current.chartType,
+    chartConfig: seededStateRef.current.chartConfig,
+  });
   const pollIntervalRef = useRef<NodeJS.Timeout | null>(null);
   const generationActiveRef = useRef(false);
   const generationFinalizingRef = useRef(false);
@@ -842,6 +866,7 @@ export const useDashboardItemConfig = ({
       setState((prev) => ({ ...prev, isLoading: true, error: null }));
 
       try {
+        const persistedConfiguration = persistedConfigurationRef.current;
         await updateEntity({
           variables: {
             entityUpdate: {
@@ -860,11 +885,17 @@ export const useDashboardItemConfig = ({
                     },
                   },
                 } as unknown as PropertyPatchOperation,
+                ...(persistedConfiguration.pythonScript !== null &&
+                persistedConfiguration.chartType &&
+                persistedConfiguration.chartConfig
+                  ? [configurationReadyPatch]
+                  : []),
               ],
             },
           },
         });
 
+        persistedConfiguration.structuralQuery = structuralQuery;
         setState((prev) => ({ ...prev, structuralQuery, isLoading: false }));
       } catch (err) {
         const error =
@@ -886,6 +917,7 @@ export const useDashboardItemConfig = ({
       setState((prev) => ({ ...prev, isLoading: true, error: null }));
 
       try {
+        const persistedConfiguration = persistedConfigurationRef.current;
         await updateEntity({
           variables: {
             entityUpdate: {
@@ -902,11 +934,17 @@ export const useDashboardItemConfig = ({
                     },
                   },
                 },
+                ...(persistedConfiguration.structuralQuery &&
+                persistedConfiguration.chartType &&
+                persistedConfiguration.chartConfig
+                  ? [configurationReadyPatch]
+                  : []),
               ],
             },
           },
         });
 
+        persistedConfiguration.pythonScript = pythonScript;
         setState((prev) => ({ ...prev, pythonScript, isLoading: false }));
       } catch (err) {
         const error =
@@ -928,11 +966,28 @@ export const useDashboardItemConfig = ({
       setState((prev) => ({ ...prev, isLoading: true, error: null }));
 
       try {
+        const chartType = getPrimaryChartType(chartConfig);
+        if (!chartType) {
+          throw new Error("Chart config must contain at least one series");
+        }
+
+        const persistedConfiguration = persistedConfigurationRef.current;
         await updateEntity({
           variables: {
             entityUpdate: {
               entityId: await ensureEntityId(),
               propertyPatches: [
+                {
+                  op: "add" as const,
+                  path: [systemPropertyTypes.chartType.propertyTypeBaseUrl],
+                  property: {
+                    value: chartType,
+                    metadata: {
+                      dataTypeId:
+                        "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1",
+                    },
+                  },
+                },
                 {
                   op: "add" as const,
                   path: [
@@ -946,12 +1001,23 @@ export const useDashboardItemConfig = ({
                     },
                   },
                 },
+                ...(persistedConfiguration.structuralQuery &&
+                persistedConfiguration.pythonScript !== null
+                  ? [configurationReadyPatch]
+                  : []),
               ],
             },
           },
         });
 
-        setState((prev) => ({ ...prev, chartConfig, isLoading: false }));
+        persistedConfiguration.chartType = chartType;
+        persistedConfiguration.chartConfig = chartConfig;
+        setState((prev) => ({
+          ...prev,
+          chartType,
+          chartConfig,
+          isLoading: false,
+        }));
       } catch (err) {
         const error =
           err instanceof Error ? err : new Error("Failed to save chart config");

--- a/apps/hash-frontend/src/pages/dashboard/hooks/use-dashboard-item-config.ts
+++ b/apps/hash-frontend/src/pages/dashboard/hooks/use-dashboard-item-config.ts
@@ -966,10 +966,12 @@ export const useDashboardItemConfig = ({
       setState((prev) => ({ ...prev, isLoading: true, error: null }));
 
       try {
+
         const chartType = getPrimaryChartType(chartConfig);
         if (!chartType) {
-          throw new Error("Chart config must contain at least one series");
+          throw new Error("Chart config must contain at least one series with a valid type");
         }
+
 
         const persistedConfiguration = persistedConfigurationRef.current;
         await updateEntity({

--- a/apps/hash-frontend/src/pages/dashboard/hooks/use-dashboard-item-config.ts
+++ b/apps/hash-frontend/src/pages/dashboard/hooks/use-dashboard-item-config.ts
@@ -966,10 +966,11 @@ export const useDashboardItemConfig = ({
       setState((prev) => ({ ...prev, isLoading: true, error: null }));
 
       try {
-
         const chartType = getPrimaryChartType(chartConfig);
         if (!chartType) {
-          throw new Error("Chart config must contain at least one series with a valid type");
+          throw new Error(
+            "Chart config must contain at least one series with a valid type",
+          );
         }
 
         const persistedConfiguration = persistedConfigurationRef.current;

--- a/apps/hash-frontend/src/pages/dashboard/hooks/use-dashboard-item-config.ts
+++ b/apps/hash-frontend/src/pages/dashboard/hooks/use-dashboard-item-config.ts
@@ -972,7 +972,6 @@ export const useDashboardItemConfig = ({
           throw new Error("Chart config must contain at least one series with a valid type");
         }
 
-
         const persistedConfiguration = persistedConfigurationRef.current;
         await updateEntity({
           variables: {

--- a/apps/hash-frontend/src/pages/dashboard/hooks/use-dashboard-item-data.ts
+++ b/apps/hash-frontend/src/pages/dashboard/hooks/use-dashboard-item-data.ts
@@ -29,7 +29,7 @@ export type DashboardItemDataState = {
   isRefreshing: boolean;
   estimatedProgress: number | null;
   /** Re-fetch, optionally forcing a server-side recompute */
-  refresh: (options?: { force?: boolean }) => void;
+  refresh: () => void;
 };
 
 /**
@@ -64,12 +64,12 @@ export const useDashboardItemData = (params: {
   const requestGenerationRef = useRef(0);
 
   const fetchData = useCallback(
-    async (force: boolean) => {
+    async (recompute: boolean) => {
       const generation = ++requestGenerationRef.current;
 
       setLoading(true);
       setError(null);
-      setIsRefreshing(force);
+      setIsRefreshing(recompute);
       setEstimatedProgress(null);
       const generationStartedAt = Date.now();
 
@@ -87,8 +87,8 @@ export const useDashboardItemData = (params: {
               webId,
               args: {
                 itemUuid,
-                // Only force on the first request; polls just check status.
-                ...(force && attempt === 0 ? { force: true } : {}),
+                // Recompute is a command; later requests only poll its status.
+                ...(recompute && attempt === 0 ? { recompute: true } : {}),
                 ...(refreshAfter ? { refreshAfter } : {}),
               },
             },
@@ -188,12 +188,9 @@ export const useDashboardItemData = (params: {
     };
   }, [configurationKey, enabled, fetchData]);
 
-  const refresh = useCallback(
-    (options?: { force?: boolean }) => {
-      void fetchData(options?.force ?? false);
-    },
-    [fetchData],
-  );
+  const refresh = useCallback(() => {
+    void fetchData(true);
+  }, [fetchData]);
 
   return {
     data,

--- a/libs/@local/hash-isomorphic-utils/src/chart-config-validation.ts
+++ b/libs/@local/hash-isomorphic-utils/src/chart-config-validation.ts
@@ -26,6 +26,10 @@ export const getChartConfigProblems = (
   const problems: string[] = [];
   const typedConfig = config as ChartConfig;
 
+  if (typedConfig.series.length === 0) {
+    problems.push("series must contain at least one chart series");
+  }
+
   if (dataKeys.length > 0) {
     if (!dataKeys.includes(typedConfig.categoryKey)) {
       problems.push(

--- a/libs/@local/hash-isomorphic-utils/src/dashboard-types.ts
+++ b/libs/@local/hash-isomorphic-utils/src/dashboard-types.ts
@@ -214,6 +214,16 @@ export type ChartConfig = {
 };
 
 /**
+ * Returns the chart-level type implied by the primary series.
+ *
+ * The series configuration is the source of truth because it supports mixed
+ * chart types, whereas the separately stored chart type is only a summary.
+ */
+export const getPrimaryChartType = (
+  chartConfig: ChartConfig,
+): ChartType | null => chartConfig.series[0]?.type ?? null;
+
+/**
  * Display defaults shared by the chart editor and renderer.
  *
  * ECharts has its own defaults, so optional values must be resolved before


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Fix some bugs and improve behaviour related to the custom dashboard page:

1. Better handling of users manually defining chart config (as opposed to using the AI generation feature)
2. Improve cache-busting behaviour of users clicking to regenerate the chart

Also fix a bug in the document inference flow where patching an email was referring to the wrong property key.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->
<!-- Libraries inside of the `@local` directory are always internal libraries which have no need for publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

