### PR TITLE
FE-1204: Fix org avatars to be square

### DIFF
--- a/apps/hash-frontend/src/pages/@/[shortname].page/profile-page-header.tsx
+++ b/apps/hash-frontend/src/pages/@/[shortname].page/profile-page-header.tsx
@@ -69,6 +69,7 @@ export const ProfilePageHeader: FunctionComponent<{
                   profile.kind === "user" ? profile.displayName : profile.name
                 }
                 size={leftColumnWidth}
+                borderRadius={profile.kind === "org" ? "12px" : undefined}
                 sx={{
                   position: "relative",
                   top: avatarTopOffset,

--- a/apps/hash-frontend/src/pages/flows.page.tsx
+++ b/apps/hash-frontend/src/pages/flows.page.tsx
@@ -70,6 +70,7 @@ type FlowSummary = Subtype<
       avatarUrl?: string;
       name: string;
       shortname: string;
+      isOrg: boolean;
     };
     name: string;
     uuid: string;
@@ -158,6 +159,7 @@ const FlowsPageContent = () => {
               avatarUrl: "/hash-logo-black.png",
               name: "HASH",
               shortname: "hash",
+              isOrg: true,
             },
             name: flowDefinition.name,
             /**

--- a/apps/hash-frontend/src/pages/shared/flow-tables.tsx
+++ b/apps/hash-frontend/src/pages/shared/flow-tables.tsx
@@ -42,10 +42,12 @@ export const FlowTableWebChip = ({
   avatarUrl,
   name,
   shortname,
+  isOrg,
 }: {
   avatarUrl?: string;
   name: string;
   shortname: string;
+  isOrg: boolean;
 }) => (
   <Link href={`/@${shortname}`} noLinkStyle>
     <Stack
@@ -61,7 +63,12 @@ export const FlowTableWebChip = ({
         transition: transitions.create("border"),
       })}
     >
-      <Avatar src={avatarUrl} title={name} size={14} />
+      <Avatar
+        src={avatarUrl}
+        title={name}
+        size={14}
+        borderRadius={isOrg ? "4px" : undefined}
+      />
       <Typography
         component="span"
         sx={{

--- a/apps/hash-frontend/src/pages/shared/web-selector.tsx
+++ b/apps/hash-frontend/src/pages/shared/web-selector.tsx
@@ -94,6 +94,7 @@ export const WebSelector = ({
                   : undefined
               }
               title={name}
+              borderRadius="4px"
             />
           ),
           label: name,

--- a/apps/hash-frontend/src/pages/workers.page/flow-run-table.tsx
+++ b/apps/hash-frontend/src/pages/workers.page/flow-run-table.tsx
@@ -120,6 +120,7 @@ type WorkerSummary = Subtype<
       avatarUrl?: string;
       name: string;
       shortname: string;
+      isOrg: boolean;
     };
     name: string;
     status: SimpleFlowRunStatus;
@@ -341,6 +342,7 @@ export const FlowRunTable = ({ flowDefinitionIdFilter }: FlowRunTableProps) => {
                 ],
               name: authenticatedUser.displayName ?? "Unknown",
               shortname: authenticatedUser.shortname ?? "unknown",
+              isOrg: false,
             };
           } else {
             const org = authenticatedUser.memberOf.find(
@@ -356,6 +358,7 @@ export const FlowRunTable = ({ flowDefinitionIdFilter }: FlowRunTableProps) => {
                 ],
               name: org.name,
               shortname: org.shortname,
+              isOrg: true,
             };
           }
           webByWebId[webId] = web;

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar/workspace-switcher.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar/workspace-switcher.tsx
@@ -36,7 +36,11 @@ export const WorkspaceSwitcher = () => {
   const { activeWorkspaceWebId, updateActiveWorkspaceWebId } =
     useActiveWorkspace();
 
-  const activeWorkspace = useMemo<{ name: string; avatarSrc?: string }>(() => {
+  const activeWorkspace = useMemo<{
+    name: string;
+    avatarSrc?: string;
+    isOrg: boolean;
+  }>(() => {
     if (activeWorkspaceWebId === authenticatedUser.accountId) {
       return {
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- @todo how to handle empty displayName
@@ -46,6 +50,7 @@ export const WorkspaceSwitcher = () => {
               authenticatedUser.hasAvatar.imageEntity.properties,
             )
           : undefined,
+        isOrg: false,
       };
     } else {
       const { org: activeOrg } =
@@ -61,11 +66,12 @@ export const WorkspaceSwitcher = () => {
                 activeOrg.hasAvatar.imageEntity.properties,
               )
             : undefined,
+          isOrg: true,
         };
       }
     }
 
-    return { name: "User" };
+    return { name: "User", isOrg: false };
   }, [activeWorkspaceWebId, authenticatedUser]);
 
   const workspaceList = useMemo(() => {
@@ -80,6 +86,7 @@ export const WorkspaceSwitcher = () => {
               authenticatedUser.hasAvatar.imageEntity.properties,
             )
           : undefined,
+        isOrg: false,
       },
       ...authenticatedUser.memberOf.map(
         ({ org: { webId, name, memberships, hasAvatar } }) => ({
@@ -90,6 +97,7 @@ export const WorkspaceSwitcher = () => {
           avatarSrc: hasAvatar
             ? getImageUrlFromEntityProperties(hasAvatar.imageEntity.properties)
             : undefined,
+          isOrg: true,
         }),
       ),
     ];
@@ -114,7 +122,7 @@ export const WorkspaceSwitcher = () => {
             size={22}
             src={activeWorkspace.avatarSrc}
             title={activeWorkspace.name}
-            borderRadius="4px"
+            borderRadius={activeWorkspace.isOrg ? "4px" : undefined}
           />
           <Typography
             sx={{
@@ -147,7 +155,7 @@ export const WorkspaceSwitcher = () => {
         }}
         autoFocus={false}
       >
-        {workspaceList.map(({ title, subText, webId, avatarSrc }) => (
+        {workspaceList.map(({ title, subText, webId, avatarSrc, isOrg }) => (
           <MenuItem
             key={webId}
             selected={webId === activeWorkspaceWebId}
@@ -157,14 +165,20 @@ export const WorkspaceSwitcher = () => {
             }}
           >
             <ListItemAvatar
-              sx={{
-                [`&.${listItemAvatarClasses.root}`]: { borderRadius: "6px" },
-              }}
+              sx={
+                isOrg
+                  ? {
+                      [`&.${listItemAvatarClasses.root}`]: {
+                        borderRadius: "6px",
+                      },
+                    }
+                  : undefined
+              }
             >
               <Avatar
                 src={avatarSrc}
                 size={26}
-                borderRadius="4px"
+                borderRadius={isOrg ? "4px" : undefined}
                 title={
                   webId === authenticatedUser.accountId
                     ? authenticatedUser.displayName

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar/workspace-switcher.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar/workspace-switcher.tsx
@@ -3,6 +3,7 @@ import {
   Box,
   Divider,
   ListItemAvatar,
+  listItemAvatarClasses,
   ListItemText,
   Menu,
   Tooltip,
@@ -113,6 +114,7 @@ export const WorkspaceSwitcher = () => {
             size={22}
             src={activeWorkspace.avatarSrc}
             title={activeWorkspace.name}
+            borderRadius="4px"
           />
           <Typography
             sx={{
@@ -154,10 +156,15 @@ export const WorkspaceSwitcher = () => {
               popupState.close();
             }}
           >
-            <ListItemAvatar>
+            <ListItemAvatar
+              sx={{
+                [`&.${listItemAvatarClasses.root}`]: { borderRadius: "6px" },
+              }}
+            >
               <Avatar
                 src={avatarSrc}
-                size={34}
+                size={26}
+                borderRadius="4px"
                 title={
                   webId === authenticatedUser.accountId
                     ? authenticatedUser.displayName


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Updates avatars for organizations to be square. This updates the workspace switcher, as well as the profile pages for organizations. See screenshots below:

<img width="1342" height="507" alt="Screenshot 2026-07-27 at 12 39 06" src="https://github.com/user-attachments/assets/aeddc507-e700-48ca-ab4f-32d6f74b6e0f" />
<img width="278" height="286" alt="Screenshot 2026-07-27 at 12 37 22" src="https://github.com/user-attachments/assets/5e550932-a3e4-4569-859f-d6a66d1d49c1" />

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change
