### PR TITLE
H-6736: Support campaign-based QA measurement, update low sample and outlier exclusion logic

### DIFF
--- a/apps/hash-frontend/src/pages/supply-chain/shared/docs/docs-modal/docs-content/settings.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/docs/docs-modal/docs-content/settings.tsx
@@ -68,13 +68,12 @@ export const settingsSection: DocSectionDef = {
             </SettingRow>
           </Anchor>
           <Anchor id="outliers">
-            <SettingRow name="Exclude outliers">
-              Excludes values falling significantly outside the normal
-              distribution. This is done by computing the interquartile range
-              (IQR), i.e. the values falling between 25% and 75% of
-              observations, and then excluding any values which are greater than
-              1.5x IQR above the third quartile or less than 1.5x IQR below the
-              first quartile (aka Tukey fences).
+            <SettingRow name="Exclude outliers from mean">
+              Excludes outliers from every mean shown. Specifically, this
+              excludes values outside the Tukey fences (removing values which
+              fall greater than 1.5x the interquartile range below Q1 or greater
+              than 1.5x the interquartile range above Q3). Does not affect the
+              median, percentiles (P75, P95) or minimum and maximum.
             </SettingRow>
           </Anchor>
 

--- a/apps/hash-frontend/src/pages/supply-chain/shared/docs/docs-modal/docs-content/site-overview.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/docs/docs-modal/docs-content/site-overview.tsx
@@ -137,7 +137,7 @@ export const siteOverviewSection: DocSectionDef = {
           <P>
             Dwell rows remain visible even when Exclude low samples is on,
             because a small number of high-value waits can still explain real
-            carrying cost. Low-sample dwell rows are labelled.
+            carrying cost. Low and limited-sample dwell rows are labelled.
           </P>
         </>
       ),
@@ -260,8 +260,8 @@ export const siteOverviewSection: DocSectionDef = {
             </LI>
             <LI>
               <Term>Exclude low samples</Term> &mdash; hide Planning and Trend
-              rows with fewer than 10 observations, so rankings are not
-              dominated by noisy single-event steps.
+              rows with fewer than 5 observations. Rows with 5&ndash;9
+              observations remain visible with a "limited" sample badge.
             </LI>
           </UL>
           <P>

--- a/apps/hash-frontend/src/pages/supply-chain/shared/docs/docs-modal/docs-content/step-detail.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/docs/docs-modal/docs-content/step-detail.tsx
@@ -82,11 +82,11 @@ export const stepDetailDoc: DocEntry = {
           <Term>Time range</Term> buttons (3m, 6m, 12) filter the panel.
         </LI>
         <LI>
-          <Term>Outlier count</Term> appears in the header when the Exclude
-          outliers setting removes timing observations from the current step.
-          See{" "}
+          <Term>Outlier count</Term> appears in the header when values are
+          excluded from the mean. The raw observations and percentile statistics
+          remain unchanged. See{" "}
           <CrossRef to={{ section: "settings", sub: "outliers" }}>
-            Exclude outliers
+            Exclude outliers from mean
           </CrossRef>
           .
         </LI>

--- a/apps/hash-frontend/src/pages/supply-chain/shared/docs/docs-modal/docs-content/step-qa.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/docs/docs-modal/docs-content/step-qa.tsx
@@ -8,19 +8,18 @@ export const qaDoc: DocEntry = {
   render: () => (
     <>
       <Lead>
-        QA hold measures the time a finished batch waits between production
+        QA hold measures the time a production campaign waits between production
         completion and QA release &mdash; the quality inspection and hold
         period.
       </Lead>
       <P>
-        <Term>What it measures:</Term> production receipt (the batch is complete
-        and received into inventory) to QA release (the batch passes inspection
-        and is cleared for use). One observation per finished-good batch.
+        <Term>What it measures:</Term> the time between a production campaign
+        finishing and the associated QA release. The full 'data' table also
+        shows the time between each batch's production finish and QA release.
       </P>
       <P>
-        <Term>Time filtering:</Term> observations are anchored to the
-        production-receipt date, so the selected window picks batches that
-        completed production inside that period.
+        <Term>Time filtering:</Term> observations are anchored to the campaign
+        end date.
       </P>
       <P>
         The wait that follows QA release &mdash; from release to dispatch

--- a/apps/hash-frontend/src/pages/supply-chain/shared/header-actions.test.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/header-actions.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { OutlierContext } from "./cost";
+import { AnalysisSettingsPanel } from "./header-actions";
+import { MeasureContext } from "./measure-context";
+import { TimeRangeContext } from "./time-range-context";
+
+vi.mock("@hashintel/ds-components", () => ({
+  Icon: () => null,
+  NumberInput: () => <input readOnly />,
+}));
+
+describe("AnalysisSettingsPanel", () => {
+  afterEach(cleanup);
+
+  it("allows the mean outlier policy to change under non-mean headline measures", () => {
+    const setExcludeOutliers = vi.fn();
+
+    render(
+      <TimeRangeContext.Provider
+        value={{ timeRange: "12m", setTimeRange: vi.fn() }}
+      >
+        <MeasureContext.Provider
+          value={{ measure: "p95", setMeasure: vi.fn() }}
+        >
+          <OutlierContext.Provider
+            value={{ excludeOutliers: true, setExcludeOutliers }}
+          >
+            <AnalysisSettingsPanel />
+          </OutlierContext.Provider>
+        </MeasureContext.Provider>
+      </TimeRangeContext.Provider>,
+    );
+
+    const checkbox = screen.getByRole("checkbox", {
+      name: "Exclude outliers from mean",
+    });
+    expect(checkbox).toHaveProperty("checked", true);
+    expect(checkbox).toHaveProperty("disabled", false);
+    fireEvent.click(checkbox);
+    expect(setExcludeOutliers).toHaveBeenCalledWith(false);
+  });
+});

--- a/apps/hash-frontend/src/pages/supply-chain/shared/header-actions.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/header-actions.tsx
@@ -293,7 +293,7 @@ export const AnalysisSettingsPanel = ({
               checked={excludeOutliers}
               onChange={(event) => setExcludeOutliers(event.target.checked)}
             />
-            Exclude outliers
+            Exclude outliers from mean
           </label>
           {children}
         </div>

--- a/apps/hash-frontend/src/pages/supply-chain/shared/node-badges.test.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/node-badges.test.ts
@@ -55,20 +55,20 @@ describe("node R:/C: badge recompute from shipped series", () => {
     expect(windowed.yield_summary?.median).toBe(88);
   });
 
-  it("drops outliers from the yield series under the outlier rule", () => {
+  it("does not apply the timing mean rule to yield observations", () => {
     const withOutlier: NodeYieldSeries = {
       reference: 95,
       observations: [...yieldSeries.observations, obs("2026-05", 5)],
     };
     const node = makeNode({ type: "production", yield_series: withOutlier });
     const selected = applyOutlierSelectionToNode(node, true);
-    // The 5% point is far below the others' IQR fence and is dropped.
+    // Yield remains raw: the setting applies only to timing means.
     expect(
       selected.yield_series?.observations.some(
         (observation) => observation.value === 5,
       ),
-    ).toBe(false);
+    ).toBe(true);
     const windowed = windowGraphNodeToRange(selected, "12m");
-    expect(windowed.yield_summary?.n).toBe(4);
+    expect(windowed.yield_summary?.n).toBe(5);
   });
 });

--- a/apps/hash-frontend/src/pages/supply-chain/shared/normalize-contract.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/normalize-contract.ts
@@ -104,10 +104,8 @@ function buildMonthlyFromObservations(obs: Observation[]): MonthlyBucket[] {
 }
 
 /**
- * Single-source records derive. When a step ships only the canonical
- * `detail_rows` (+ `value_col`/`ref_date_col`) and no precomputed timing series,
- * rehydrate observations/durations/monthly/stats from the rows. A strict no-op
- * whenever `observations` are already present.
+ * Single-source records derive. Campaign rows are the canonical timing source
+ * when present; detail rows remain batch evidence and the v1.2 fallback.
  */
 function ensureTimingSeriesStats<
   T extends {
@@ -223,13 +221,15 @@ function fillMonthlyTiming(
 export function deriveTimingFromRecords(step: StepDetail): StepDetail;
 export function deriveTimingFromRecords(step: StepDetailWire): StepDetailWire;
 export function deriveTimingFromRecords(step: StepDetailWire): StepDetailWire {
+  const campaignRows =
+    step.timing_grain === "campaign" ? step.campaign_rows?.rows : undefined;
   const existingObservations = step.observations ?? [];
-  if (existingObservations.length > 0) {
+  if (!campaignRows?.length && existingObservations.length > 0) {
     return step;
   }
   const valueCol = step.value_col;
   const dateCol = step.ref_date_col;
-  const rows = step.detail_rows?.rows;
+  const rows = campaignRows?.length ? campaignRows : step.detail_rows?.rows;
   if (!valueCol || !dateCol || !rows || rows.length === 0) {
     return step;
   }

--- a/apps/hash-frontend/src/pages/supply-chain/shared/observation-labels.test.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/observation-labels.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { countNoun, countTooltip } from "./observation-labels";
+import { countNoun, countTooltip, shortCountLabel } from "./observation-labels";
 
 describe("campaign observation labels", () => {
   const qaCampaign = {
@@ -12,6 +12,7 @@ describe("campaign observation labels", () => {
 
   it("labels campaign-grain QA timing observations as campaigns", () => {
     expect(countNoun(qaCampaign)).toBe("campaigns");
+    expect(shortCountLabel(7, qaCampaign)).toBe("7 campaigns");
     expect(
       countTooltip({ ...qaCampaign, count: 7, rangeLabel: "12m" }),
     ).toContain("7 campaigns in the last 12 months");

--- a/apps/hash-frontend/src/pages/supply-chain/shared/observation-labels.test.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/observation-labels.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { countNoun, countTooltip } from "./observation-labels";
+
+describe("campaign observation labels", () => {
+  const qaCampaign = {
+    id: "prod_to_qa",
+    label: "Production to QA",
+    type: "qa_hold" as const,
+    timingGrain: "campaign" as const,
+  };
+
+  it("labels campaign-grain QA timing observations as campaigns", () => {
+    expect(countNoun(qaCampaign)).toBe("campaigns");
+    expect(
+      countTooltip({ ...qaCampaign, count: 7, rangeLabel: "12m" }),
+    ).toContain("7 campaigns in the last 12 months");
+  });
+
+  it("keeps yield and consumption terminology ahead of timing grain", () => {
+    expect(countNoun({ ...qaCampaign, dimension: "yield" })).toBe(
+      "production orders",
+    );
+    expect(
+      countNoun({
+        ...qaCampaign,
+        dimension: "consumption",
+        selectedComponent: true,
+      }),
+    ).toBe("component events");
+  });
+});

--- a/apps/hash-frontend/src/pages/supply-chain/shared/observation-labels.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/observation-labels.ts
@@ -8,12 +8,14 @@ interface CountContext {
   type: StepType;
   dimension?: CountDimension;
   selectedComponent?: boolean;
+  timingGrain?: "campaign" | null;
 }
 
 interface CountTooltipContext extends CountContext {
   count: number;
   rangeLabel?: string | null;
   nBatches?: number | null;
+  nCampaigns?: number | null;
   nMovements?: number | null;
 }
 
@@ -33,6 +35,9 @@ export function countNoun(ctx: CountContext): string {
   }
   if (ctx.dimension === "supplier") {
     return "schedule lines";
+  }
+  if (ctx.timingGrain === "campaign") {
+    return "campaigns";
   }
   return "events";
 }
@@ -80,7 +85,9 @@ export function dateAnchorLabel(ctx: CountContext): string {
     case "production":
       return "schedule start";
     case "qa_hold":
-      return "production receipt date";
+      return ctx.timingGrain === "campaign"
+        ? "campaign reference date"
+        : "production receipt date";
     case "post_qa_ship":
       return "QA release date";
     case "transit":
@@ -114,7 +121,9 @@ function eventMethodology(ctx: CountContext): string {
     case "production":
       return "each production schedule campaign contributes one duration event.";
     case "qa_hold":
-      return "each finished-good batch contributes one QA-hold event.";
+      return ctx.timingGrain === "campaign"
+        ? "each campaign contributes one timing observation; batch rows are supporting evidence."
+        : "each finished-good batch contributes one QA-hold event.";
     case "post_qa_ship":
       return "each dispatch (customer delivery or hub transfer) contributes one post-QA dwell event.";
     case "transit":
@@ -130,6 +139,9 @@ export function countTooltip(ctx: CountTooltipContext): string {
   const label = shortCountLabel(ctx.count, ctx);
   const period = rangeLabel(ctx.rangeLabel);
   const base = `${label} in ${period}. Filtered by ${dateAnchorLabel(ctx)}; ${eventMethodology(ctx)}`;
+  if (ctx.nCampaigns != null && ctx.nBatches != null) {
+    return `${base} All-time source coverage: ${ctx.nCampaigns} campaigns across ${ctx.nBatches} batches.`;
+  }
   if (ctx.nBatches != null && ctx.nMovements != null) {
     return `${base} All-time source coverage: ${ctx.nBatches} batches, ${ctx.nMovements} movements.`;
   }

--- a/apps/hash-frontend/src/pages/supply-chain/shared/outlier-selection.test.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/outlier-selection.test.ts
@@ -10,10 +10,10 @@ import {
   applyOutlierSelectionToNode,
   applyOutlierSelectionToStep,
 } from "./outlier-selection";
+import { computeStats } from "./stats";
 
-// Characterization tests for the client-side Tukey 1.5x IQR outlier rule.
-// Behaviour pinned here MUST survive the contract refactor (the selected-view
-// semantics stay even as the duplicated outlier paths were collapsed).
+// Regression tests for mean-only client-side Tukey 1.5x IQR filtering.
+// Raw observations, counts, and percentile statistics remain unchanged.
 
 describe("applyOutlierSelectionToStep", () => {
   // One clear high outlier (100) far beyond the Tukey upper fence.
@@ -30,10 +30,14 @@ describe("applyOutlierSelectionToStep", () => {
       obs("2026-04", 100),
     ]);
 
-  it("drops out-of-fence points and recomputes stats when excluding outliers", () => {
+  it("filters only the mean while retaining raw observations and percentiles", () => {
     const selected = applyOutlierSelectionToStep(withOutlier(), true);
-    expect(selected.durations).toEqual([10, 11, 12, 13, 14, 15, 16, 17]);
-    expect(selected.stats.n).toBe(8);
+    expect(selected.durations).toEqual([10, 11, 12, 13, 14, 15, 16, 17, 100]);
+    expect(selected.observations).toHaveLength(9);
+    expect(selected.stats.n).toBe(9);
+    expect(selected.stats.mean).toBe(13.5);
+    expect(selected.stats.p95).toBe(withOutlier().stats.p95);
+    expect(selected.stats.max).toBe(100);
     expect(selected.excluded_count).toBe(1);
     expect(selected.excluded_pct).toBeCloseTo(100 / 9, 1);
   });
@@ -82,12 +86,13 @@ describe("applyOutlierSelectionToStep", () => {
     // Headline untouched, secondary loses its outlier.
     expect(selected.stats.n).toBe(4);
     expect(selected.excluded_count).toBe(0);
-    expect(selected.complete_timing?.stats.n).toBe(8);
+    expect(selected.complete_timing?.stats.n).toBe(9);
+    expect(selected.complete_timing?.stats.max).toBe(200);
     expect(
       selected.complete_timing?.observations.map(
         (observation) => observation.value,
       ),
-    ).not.toContain(200);
+    ).toContain(200);
   });
 
   it("leaves complete_timing untouched when including outliers", () => {
@@ -102,9 +107,6 @@ describe("applyOutlierSelectionToStep", () => {
 });
 
 describe("applyOutlierSelectionToNode", () => {
-  // Shipped v1 data carries a single base series (no raw_*/filtered_*), so today
-  // both toggle states return the base series untouched. The fixture uses a tight
-  // distribution so this invariant also holds once Tukey IQR filtering lands.
   it("returns the base series when including outliers", () => {
     const out = applyOutlierSelectionToNode(makeNode(), false);
     expect(out.observations?.map((observation) => observation.value)).toEqual([
@@ -117,5 +119,28 @@ describe("applyOutlierSelectionToNode", () => {
     expect(out.observations?.map((observation) => observation.value)).toEqual([
       10, 12, 11, 13,
     ]);
+  });
+
+  it("keeps raw P95 while filtering an outlier from the mean", () => {
+    const observations = [
+      obs("2026-01", 10),
+      obs("2026-01", 11),
+      obs("2026-02", 12),
+      obs("2026-02", 13),
+      obs("2026-03", 14),
+      obs("2026-03", 15),
+      obs("2026-04", 16),
+      obs("2026-04", 17),
+      obs("2026-04", 100),
+    ];
+    const node = makeNode({
+      observations,
+      stats: computeStats(observations.map((observation) => observation.value)),
+    });
+    const selected = applyOutlierSelectionToNode(node, true);
+
+    expect(selected.stats.p95).toBe(node.stats.p95);
+    expect(selected.observations).toHaveLength(9);
+    expect(selected.mean_observations).toHaveLength(8);
   });
 });

--- a/apps/hash-frontend/src/pages/supply-chain/shared/outlier-selection.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/outlier-selection.ts
@@ -1,15 +1,11 @@
 import { computeIqrFences, partitionByFences } from "./outlier-selection/iqr";
-import { computeStats, percentileOf, round } from "./stats";
+import { computeStats, round } from "./stats";
 
 import type {
   GraphNode,
   StepDetail,
   Observation,
   MonthlyBucket,
-  StepStats,
-  YieldData,
-  ConsumptionData,
-  ComponentConsumption,
   TimingSeries,
 } from "./types";
 
@@ -17,17 +13,15 @@ import type {
  * Apply the client-side Tukey 1.5x IQR outlier rule to a graph node.
  *
  * When `excludeOutliers` is true, fences are computed from the shipped
- * `observations`, out-of-bound points are dropped, and `stats`/`monthly` are
- * recomputed from the kept series (cost columns on each monthly bucket are
- * preserved -- inventory kg-days are independent of duration outliers).
+ * `observations`, and only the overall/monthly mean is recomputed from kept
+ * points. Raw observations, sample size and percentile statistics are retained.
  * `excluded_count`/`excluded_pct` describe the full-series exclusion. When
  * false (or with too few points), the base series is returned unchanged.
  */
 
 /**
- * Recompute per-month timing values (mean/median/n) from a kept observation set,
- * preserving each bucket's non-timing columns (kg-days, qty, variance). Months
- * with no kept observations keep their bucket with null timing and `n = 0`.
+ * Recompute only the per-month mean from kept observations. Median, sample size,
+ * percentile inputs and non-timing columns remain raw.
  */
 function rebuildMonthlyTiming(
   original: MonthlyBucket[],
@@ -49,7 +43,7 @@ function rebuildMonthlyTiming(
   return original.map((bucket) => {
     const vals = byMonth.get(bucket.month);
     if (!vals || vals.length === 0) {
-      return { ...bucket, mean: null, median: null, n: 0 };
+      return { ...bucket, mean: null };
     }
     const sorted = [...vals].sort((left, right) => left - right);
     return {
@@ -57,24 +51,10 @@ function rebuildMonthlyTiming(
       mean: round(
         sorted.reduce((left, right) => left + right, 0) / sorted.length,
       ),
-      median: round(percentileOf(sorted, 50)),
-      n: sorted.length,
     };
   });
 }
 
-/** Drop Tukey-IQR outliers from a bare observation array (over its own values). */ function outlierFilterObservations(
-  obs: Observation[],
-): Observation[] {
-  if (obs.length === 0) {
-    return obs;
-  }
-  const { kept } = partitionByFences(
-    obs,
-    computeIqrFences(obs.map((observation) => observation.value)),
-  );
-  return kept;
-}
 /**
  * A series shaped like the per-family blocks shipped on a step
  * (`yield_data`, `consumption_data.aggregate`, each consumption component):
@@ -98,8 +78,11 @@ function rebuildMonthlyTiming(
     );
     if (excluded.length > 0) {
       timing = {
-        stats: computeStats(kept.map((observation) => observation.value)),
-        observations: kept,
+        mean_observations: kept,
+        stats: {
+          ...node.stats,
+          mean: computeStats(kept.map((observation) => observation.value)).mean,
+        },
         monthly: node.monthly
           ? rebuildMonthlyTiming(node.monthly, kept)
           : node.monthly,
@@ -110,22 +93,6 @@ function rebuildMonthlyTiming(
   return {
     ...node,
     ...timing,
-    yield_series: node.yield_series
-      ? {
-          ...node.yield_series,
-          observations: outlierFilterObservations(
-            node.yield_series.observations,
-          ),
-        }
-      : node.yield_series,
-    consumption_series: node.consumption_series
-      ? {
-          ...node.consumption_series,
-          observations: outlierFilterObservations(
-            node.consumption_series.observations,
-          ),
-        }
-      : node.consumption_series,
     excluded_count: excludedCount,
     excluded_pct:
       observations.length > 0
@@ -133,60 +100,10 @@ function rebuildMonthlyTiming(
         : 0,
   };
 }
-interface SeriesLike {
-  values: number[];
-  observations: Observation[];
-  monthly: MonthlyBucket[];
-  stats: StepStats;
-}
-/**
- * Drop Tukey-IQR outliers from one family series (computed over its own value
- * distribution) and recompute `values`/`stats`/`monthly` from the kept points.
- * Returns the series unchanged when there is nothing to exclude. Non-timing
- * monthly columns (kg-days, qty, variance) are preserved via the spread in
- * {@link rebuildMonthlyTiming}.
- */ function applyOutlierToSeries<T extends SeriesLike>(series: T): T {
-  const observations = series.observations;
-  if (observations.length === 0) {
-    return series;
-  }
-  const { kept, excluded } = partitionByFences(
-    observations,
-    computeIqrFences(observations.map((observation) => observation.value)),
-  );
-  if (excluded.length === 0) {
-    return series;
-  }
-  const values = kept.map((observation) => observation.value);
-  return {
-    ...series,
-    values,
-    observations: kept,
-    monthly: rebuildMonthlyTiming(series.monthly, kept),
-    stats: computeStats(values),
-  };
-}
-/** Outlier-filter the yield series (receipt-ratio %) in place of its raw points. */ function applyOutlierToYield(
-  yd: YieldData,
-): YieldData {
-  return applyOutlierToSeries(yd);
-}
-/**
- * Outlier-filter the consumption block: each component series and the aggregate
- * series are partitioned independently. Downstream windowing recomputes the
- * aggregate `weighted_variance_pct` from whatever observations remain, so
- * dropping outlier points here makes that window-aware metric outlier-aware too.
- */ function applyOutlierToConsumption(cd: ConsumptionData): ConsumptionData {
-  const components = cd.components.map((column) =>
-    applyOutlierToSeries<ComponentConsumption>(column),
-  );
-  const aggregate = applyOutlierToSeries(cd.aggregate);
-  return { ...cd, components, aggregate };
-}
 /**
  * Outlier-filter a secondary {@link TimingSeries} (e.g. procurement's
  * full-receipt lead time) over its own value distribution, recomputing
- * `monthly`/`stats` from the kept points. Returned unchanged when there is
+ * only its mean from the kept points. Returned unchanged when there is
  * nothing to exclude. Independent of the headline series so the two can have
  * different fences.
  */ function applyOutlierToTimingSeries(ts: TimingSeries): TimingSeries {
@@ -203,9 +120,12 @@ interface SeriesLike {
   }
   return {
     ...ts,
-    observations: kept,
+    mean_observations: kept,
     monthly: rebuildMonthlyTiming(ts.monthly, kept),
-    stats: computeStats(kept.map((observation) => observation.value)),
+    stats: {
+      ...ts.stats,
+      mean: computeStats(kept.map((observation) => observation.value)).mean,
+    },
   };
 }
 /** Step-level counterpart of {@link applyOutlierSelectionToNode}. */ export function applyOutlierSelectionToStep(
@@ -228,10 +148,9 @@ interface SeriesLike {
     if (excluded.length > 0) {
       const values = kept.map((observation) => observation.value);
       timing = {
-        durations: values,
-        observations: kept,
+        mean_observations: kept,
         monthly: rebuildMonthlyTiming(step.monthly, kept),
-        stats: computeStats(values),
+        stats: { ...step.stats, mean: computeStats(values).mean },
       };
       excludedCount = excluded.length;
     }
@@ -239,12 +158,6 @@ interface SeriesLike {
   return {
     ...step,
     ...timing,
-    yield_data: step.yield_data
-      ? applyOutlierToYield(step.yield_data)
-      : step.yield_data,
-    consumption_data: step.consumption_data
-      ? applyOutlierToConsumption(step.consumption_data)
-      : step.consumption_data,
     complete_timing: step.complete_timing
       ? applyOutlierToTimingSeries(step.complete_timing)
       : step.complete_timing,

--- a/apps/hash-frontend/src/pages/supply-chain/shared/period-trends.test.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/period-trends.test.ts
@@ -204,6 +204,32 @@ describe("period helpers anchored to a fixed clock", () => {
     expect(threshold.pctChange).toBeCloseTo(-70, 6);
   });
 
+  it("uses filtered mean values without reducing raw sample counts", () => {
+    const node = siteNode({
+      observations: [
+        obs("2025-07", 10),
+        obs("2025-08", 10),
+        obs("2025-09", 1000),
+        obs("2026-01", 20),
+        obs("2026-02", 20),
+        obs("2026-03", 2000),
+      ],
+      mean_observations: [
+        obs("2025-07", 10),
+        obs("2025-08", 10),
+        obs("2026-01", 20),
+        obs("2026-02", 20),
+      ],
+    });
+
+    const trend = computeTimingTrend(node, "6m", "mean");
+
+    expect(trend.previousValue).toBe(10);
+    expect(trend.currentValue).toBe(20);
+    expect(trend.previousN).toBe(3);
+    expect(trend.currentN).toBe(3);
+  });
+
   it("computeCostTrend totals carrying cost across windows", () => {
     const node = siteNode({
       cost: cost(100),
@@ -277,5 +303,17 @@ describe("period helpers anchored to a fixed clock", () => {
     expect(filteredDeltas.medianPctChange).toBeCloseTo(-96.03960396039604, 6);
     expect(filteredDeltas.previousStats?.mean).toBe(10);
     expect(filteredDeltas.statDeltas.mean).toBeCloseTo(100, 6);
+  });
+
+  it("leaves a period mean and its delta empty when no kept values remain", () => {
+    const observations = [obs("2025-07", 10), obs("2026-01", 20)];
+    const deltas = computePeriodDeltas(
+      observations,
+      "6m",
+      observations.slice(0, 1),
+    );
+
+    expect(deltas.previousStats?.mean).toBe(10);
+    expect(deltas.statDeltas.mean).toBeNull();
   });
 });

--- a/apps/hash-frontend/src/pages/supply-chain/shared/period-trends.test.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/period-trends.test.ts
@@ -251,7 +251,7 @@ describe("period helpers anchored to a fixed clock", () => {
     expect(deltas.previousRange).not.toBeNull();
   });
 
-  it("computePeriodDeltas can compare an outlier-filtered historical series", () => {
+  it("filters the mean delta while retaining raw percentile deltas", () => {
     const step = stepFrom([
       fixtureObs("2025-07", 10),
       fixtureObs("2025-08", 10),
@@ -265,11 +265,17 @@ describe("period helpers anchored to a fixed clock", () => {
     const selected = applyOutlierSelectionToStep(step, true);
 
     const rawDeltas = computePeriodDeltas(step.observations, "6m");
-    const filteredDeltas = computePeriodDeltas(selected.observations, "6m");
+    const filteredDeltas = computePeriodDeltas(
+      selected.observations,
+      "6m",
+      selected.mean_observations,
+    );
 
     expect(rawDeltas.previousStats?.median).toBe(505);
     expect(rawDeltas.medianPctChange).toBeCloseTo(-96.03960396039604, 6);
-    expect(filteredDeltas.previousStats?.median).toBe(10);
-    expect(filteredDeltas.medianPctChange).toBeCloseTo(100, 6);
+    expect(filteredDeltas.previousStats?.median).toBe(505);
+    expect(filteredDeltas.medianPctChange).toBeCloseTo(-96.03960396039604, 6);
+    expect(filteredDeltas.previousStats?.mean).toBe(10);
+    expect(filteredDeltas.statDeltas.mean).toBeCloseTo(100, 6);
   });
 });

--- a/apps/hash-frontend/src/pages/supply-chain/shared/period-trends.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/period-trends.ts
@@ -127,19 +127,24 @@ export function computeTimingTrend(
   timeRange: TimeRange,
   measure: BaseMeasure = "median",
 ): TimingTrend {
+  const observations = node.observations ?? [];
   const trend = computeTrend(
     measure === "mean"
-      ? (node.mean_observations ?? node.observations ?? [])
-      : (node.observations ?? []),
+      ? (node.mean_observations ?? observations)
+      : observations,
     timeRange,
     measure,
   );
+  const sampleTrend =
+    measure === "mean" && node.mean_observations != null
+      ? computeTrend(observations, timeRange, measure)
+      : trend;
   return {
     pctChange: trend.pctChange,
     currentValue: trend.currentValue,
     previousValue: trend.previousValue,
-    currentN: trend.currentN,
-    previousN: trend.previousN,
+    currentN: sampleTrend.currentN,
+    previousN: sampleTrend.previousN,
   };
 }
 
@@ -239,18 +244,21 @@ export function computePeriodDeltas(
     currentMeanValues.length > 0
       ? currentMeanValues.reduce((sum, value) => sum + value, 0) /
         currentMeanValues.length
-      : 0;
+      : null;
   prevStats.mean =
     previousMeanValues.length > 0
       ? previousMeanValues.reduce((sum, value) => sum + value, 0) /
         previousMeanValues.length
-      : 0;
+      : null;
 
-  const pctDelta = (curr: number, prev: number) => {
-    if (prev === 0) {
+  const pctDelta = (
+    currentValue: number | null,
+    previousValue: number | null,
+  ) => {
+    if (currentValue == null || previousValue == null || previousValue === 0) {
       return null;
     }
-    return ((curr - prev) / prev) * 100;
+    return ((currentValue - previousValue) / previousValue) * 100;
   };
 
   const hasPrev = prevStats.n > 0;
@@ -282,10 +290,7 @@ export function computePeriodDeltas(
 
   const statDeltas: Record<string, number | null> = {};
   for (const key of keys) {
-    statDeltas[key] = pctDelta(
-      currentStats[key] as number,
-      prevStats[key] as number,
-    );
+    statDeltas[key] = pctDelta(currentStats[key], prevStats[key]);
   }
 
   return {

--- a/apps/hash-frontend/src/pages/supply-chain/shared/period-trends.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/period-trends.ts
@@ -127,7 +127,13 @@ export function computeTimingTrend(
   timeRange: TimeRange,
   measure: BaseMeasure = "median",
 ): TimingTrend {
-  const trend = computeTrend(node.observations ?? [], timeRange, measure);
+  const trend = computeTrend(
+    measure === "mean"
+      ? (node.mean_observations ?? node.observations ?? [])
+      : (node.observations ?? []),
+    timeRange,
+    measure,
+  );
   return {
     pctChange: trend.pctChange,
     currentValue: trend.currentValue,
@@ -202,6 +208,7 @@ export interface PeriodComparison {
 export function computePeriodDeltas(
   observations: Observation[],
   range: TimeRange,
+  meanObservations: Observation[] = observations,
 ): PeriodComparison {
   const { currentFrom, previousFrom, previousTo } = periodCutoffs(range);
 
@@ -219,6 +226,25 @@ export function computePeriodDeltas(
   const prevStats = computeStats(
     prevObs.map((observation) => observation.value),
   );
+  const currentMeanValues = meanObservations
+    .filter((observation) => observation.date.slice(0, 7) >= currentFrom)
+    .map((observation) => observation.value);
+  const previousMeanValues = meanObservations
+    .filter((observation) => {
+      const month = observation.date.slice(0, 7);
+      return month >= previousFrom && month <= previousTo;
+    })
+    .map((observation) => observation.value);
+  currentStats.mean =
+    currentMeanValues.length > 0
+      ? currentMeanValues.reduce((sum, value) => sum + value, 0) /
+        currentMeanValues.length
+      : 0;
+  prevStats.mean =
+    previousMeanValues.length > 0
+      ? previousMeanValues.reduce((sum, value) => sum + value, 0) /
+        previousMeanValues.length
+      : 0;
 
   const pctDelta = (curr: number, prev: number) => {
     if (prev === 0) {

--- a/apps/hash-frontend/src/pages/supply-chain/shared/range-filter.test.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/range-filter.test.ts
@@ -9,6 +9,8 @@ import {
 import {
   filterGraphNodeByDateRange,
   filterStepByDateRange,
+  windowGraphNodeToRange,
+  windowStepToRange,
 } from "./range-filter";
 
 describe("filterStepByDateRange", () => {
@@ -79,6 +81,20 @@ describe("filterStepByDateRange", () => {
     expect(out.complete_timing?.stats.n).toBe(1);
     expect(out.complete_timing?.stats.median).toBe(26);
   });
+
+  it("leaves empty kept means null while retaining raw windowed points", () => {
+    const step = stepFrom([obs("2026-04", 13)]);
+    step.mean_observations = [obs("2026-01", 10)];
+    step.complete_timing = timingSeriesFrom([obs("2026-04", 26)]);
+    step.complete_timing.mean_observations = [obs("2026-01", 20)];
+
+    const out = windowStepToRange(step, "3m");
+
+    expect(out.stats.n).toBe(1);
+    expect(out.stats.mean).toBeNull();
+    expect(out.complete_timing?.stats.n).toBe(1);
+    expect(out.complete_timing?.stats.mean).toBeNull();
+  });
 });
 
 describe("filterGraphNodeByDateRange", () => {
@@ -131,5 +147,18 @@ describe("filterGraphNodeByDateRange", () => {
     expect(out.mean_observations).toBeUndefined();
     expect(out.stats.mean).toBe(1.8);
     expect(out.stats.p95).toBe(3.5);
+  });
+
+  it("leaves an empty kept node mean null while retaining raw points", () => {
+    const out = windowGraphNodeToRange(
+      makeNode({
+        observations: [obs("2026-04", 13)],
+        mean_observations: [obs("2026-01", 10)],
+      }),
+      "3m",
+    );
+
+    expect(out.stats.n).toBe(1);
+    expect(out.stats.mean).toBeNull();
   });
 });

--- a/apps/hash-frontend/src/pages/supply-chain/shared/range-filter.test.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/range-filter.test.ts
@@ -44,6 +44,25 @@ describe("filterStepByDateRange", () => {
     ]);
   });
 
+  it("computes the mean fence over full history before windowing", () => {
+    const step = stepFrom([
+      obs("2026-01", 2),
+      obs("2026-02", 2),
+      obs("2026-03", 3),
+      obs("2026-03", 4),
+      obs("2026-03", 5),
+      obs("2026-04", 1),
+      obs("2026-05", 1),
+      obs("2026-06", 1),
+      obs("2026-06", 4),
+    ]);
+    const out = filterStepByDateRange(step, "3m", true);
+
+    expect(out.observations).toHaveLength(4);
+    expect(out.stats.mean).toBe(1.8);
+    expect(out.stats.p95).toBe(3.5);
+  });
+
   it("windows the secondary complete_timing series to the cutoff too", () => {
     const step = tightStep();
     step.complete_timing = timingSeriesFrom([
@@ -85,5 +104,32 @@ describe("filterGraphNodeByDateRange", () => {
     expect(out.monthly?.map((month) => month.month)).toEqual(["2026-04"]);
     expect(out.stats.n).toBe(1);
     expect(out.stats.median).toBe(13);
+  });
+
+  it("computes the node mean fence over full history before windowing", () => {
+    const observations = [
+      obs("2026-01", 2),
+      obs("2026-02", 2),
+      obs("2026-03", 3),
+      obs("2026-03", 4),
+      obs("2026-03", 5),
+      obs("2026-04", 1),
+      obs("2026-05", 1),
+      obs("2026-06", 1),
+      obs("2026-06", 4),
+    ];
+    const out = filterGraphNodeByDateRange(
+      makeNode({
+        observations,
+        stats: stepFrom(observations).stats,
+      }),
+      "3m",
+      true,
+    );
+
+    expect(out.observations).toHaveLength(4);
+    expect(out.mean_observations).toBeUndefined();
+    expect(out.stats.mean).toBe(1.8);
+    expect(out.stats.p95).toBe(3.5);
   });
 });

--- a/apps/hash-frontend/src/pages/supply-chain/shared/range-filter.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/range-filter.ts
@@ -308,12 +308,32 @@ export function applyProcurementBasisToStep(
  */
 
 function filterTimingSeries(ts: TimingSeries, cutoff: string): TimingSeries {
-  const { observations, monthly, stats } = filterObservationsByCutoff(
-    ts.observations,
-    ts.monthly,
-    cutoff,
+  const {
+    observations,
+    monthly,
+    stats: rawStats,
+  } = filterObservationsByCutoff(ts.observations, ts.monthly, cutoff);
+  const meanObservations = ts.mean_observations?.filter(
+    (observation) => observation.date.slice(0, 7) >= cutoff,
   );
-  return { ...ts, observations, monthly, stats };
+  const stats =
+    meanObservations == null
+      ? rawStats
+      : {
+          ...rawStats,
+          mean: computeStats(
+            meanObservations.map((observation) => observation.value),
+          ).mean,
+        };
+  return {
+    ...ts,
+    observations,
+    ...(meanObservations == null
+      ? {}
+      : { mean_observations: meanObservations }),
+    monthly,
+    stats,
+  };
 }
 
 /**
@@ -335,7 +355,19 @@ function filterTimingSeries(ts: TimingSeries, cutoff: string): TimingSeries {
     (observation: Observation) => observation.date.slice(0, 7) >= cutoff,
   );
   const values = filtered.map((observation: Observation) => observation.value);
-  const stats = computeStats(values);
+  const meanObservations = selectedStep.mean_observations?.filter(
+    (observation: Observation) => observation.date.slice(0, 7) >= cutoff,
+  );
+  const rawStats = computeStats(values);
+  const stats =
+    meanObservations == null
+      ? rawStats
+      : {
+          ...rawStats,
+          mean: computeStats(
+            meanObservations.map((observation) => observation.value),
+          ).mean,
+        };
   const filteredMonthly: MonthlyBucket[] = selectedStep.monthly.filter(
     (month) => month.month >= cutoff,
   );
@@ -352,6 +384,9 @@ function filterTimingSeries(ts: TimingSeries, cutoff: string): TimingSeries {
     ...selectedStep,
     durations: values,
     observations: filtered,
+    ...(meanObservations == null
+      ? {}
+      : { mean_observations: meanObservations }),
     monthly: filteredMonthly,
     stats,
     cost: selectedStep.cost,
@@ -470,7 +505,19 @@ export function windowGraphNodeToRange(
     (observation: Observation) => observation.date.slice(0, 7) >= cutoff,
   );
   const values = filtered.map((observation: Observation) => observation.value);
-  const stats = computeStats(values);
+  const meanObservations = selectedNode.mean_observations?.filter(
+    (observation: Observation) => observation.date.slice(0, 7) >= cutoff,
+  );
+  const rawStats = computeStats(values);
+  const stats =
+    meanObservations == null
+      ? rawStats
+      : {
+          ...rawStats,
+          mean: computeStats(
+            meanObservations.map((observation) => observation.value),
+          ).mean,
+        };
   const filteredMonthly = (selectedNode.monthly ?? []).filter(
     (month) => month.month >= cutoff,
   );
@@ -487,6 +534,9 @@ export function windowGraphNodeToRange(
     ...selectedNode,
     stats,
     observations: filtered,
+    ...(meanObservations == null
+      ? {}
+      : { mean_observations: meanObservations }),
     monthly: filteredMonthly,
     cost: selectedNode.cost,
     pct_exceeding_plan: pctExceedingForObservations(

--- a/apps/hash-frontend/src/pages/supply-chain/shared/range-filter.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/range-filter.ts
@@ -91,6 +91,14 @@ function filterObservationsByCutoff(
   };
 }
 
+function meanForObservations(observations: Observation[]): number | null {
+  if (observations.length === 0) {
+    return null;
+  }
+  return computeStats(observations.map((observation) => observation.value))
+    .mean;
+}
+
 function filterYieldData(yd: YieldData, cutoff: string): YieldData {
   const row = filterObservationsByCutoff(yd.observations, yd.monthly, cutoff);
   return {
@@ -321,9 +329,7 @@ function filterTimingSeries(ts: TimingSeries, cutoff: string): TimingSeries {
       ? rawStats
       : {
           ...rawStats,
-          mean: computeStats(
-            meanObservations.map((observation) => observation.value),
-          ).mean,
+          mean: meanForObservations(meanObservations),
         };
   return {
     ...ts,
@@ -364,9 +370,7 @@ function filterTimingSeries(ts: TimingSeries, cutoff: string): TimingSeries {
       ? rawStats
       : {
           ...rawStats,
-          mean: computeStats(
-            meanObservations.map((observation) => observation.value),
-          ).mean,
+          mean: meanForObservations(meanObservations),
         };
   const filteredMonthly: MonthlyBucket[] = selectedStep.monthly.filter(
     (month) => month.month >= cutoff,
@@ -514,9 +518,7 @@ export function windowGraphNodeToRange(
       ? rawStats
       : {
           ...rawStats,
-          mean: computeStats(
-            meanObservations.map((observation) => observation.value),
-          ).mean,
+          mean: meanForObservations(meanObservations),
         };
   const filteredMonthly = (selectedNode.monthly ?? []).filter(
     (month) => month.month >= cutoff,

--- a/apps/hash-frontend/src/pages/supply-chain/shared/records-derive.test.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/records-derive.test.ts
@@ -73,6 +73,33 @@ function recordsOnlyWireStep(
 }
 
 describe("deriveTimingFromRecords", () => {
+  it("uses campaign_rows as canonical QA observations while retaining batch evidence", () => {
+    const step = recordsOnlyStep({
+      type: "qa_hold",
+      timing_grain: "campaign",
+      n_campaigns: 2,
+      n_batches: 5,
+      campaign_rows: {
+        columns: detailRows.columns,
+        rows: [
+          { consumption_date: "2026-01-12", dwell_days: 4 },
+          { consumption_date: "2026-02-15", dwell_days: 8 },
+        ],
+      },
+      observations: [{ date: "2025-01-01", value: 999 }],
+    });
+
+    const out = ensureStepStats(step);
+    expect(out.observations).toEqual([
+      { date: "2026-01-12", value: 4 },
+      { date: "2026-02-15", value: 8 },
+    ]);
+    expect(out.stats.n).toBe(2);
+    expect(out.detail_rows).toBe(detailRows);
+    expect(out.n_campaigns).toBe(2);
+    expect(out.n_batches).toBe(5);
+  });
+
   it("rehydrates observations/durations/monthly/stats from detail_rows", () => {
     const derived = deriveTimingFromRecords(recordsOnlyStep());
     expect(
@@ -202,6 +229,32 @@ describe("deriveTimingFromRecords", () => {
       expect(out.monthly.length).toBeGreaterThan(0);
     },
   );
+
+  it("uses detail_rows as the explicit v1.2 fallback for campaign timing", () => {
+    const step = recordsOnlyStep({
+      type: "qa_hold",
+      timing_grain: "campaign",
+      campaign_rows: null,
+      detail_rows: {
+        columns: [],
+        rows: [
+          { campaign_date: "2026-04-01", qa_days: 4 },
+          { campaign_date: "2026-05-01", qa_days: 8 },
+        ],
+      },
+      ref_date_col: "campaign_date",
+      value_col: "qa_days",
+    });
+
+    const out = ensureStepStats(step);
+
+    expect(out.observations).toEqual([
+      { date: "2026-04-01", value: 4 },
+      { date: "2026-05-01", value: 8 },
+    ]);
+    expect(out.durations).toEqual([4, 8]);
+    expect(out.stats.n).toBe(2);
+  });
 
   it("derives procurement timing as one first/full observation per PO", () => {
     const step = recordsOnlyStep({

--- a/apps/hash-frontend/src/pages/supply-chain/shared/sample-confidence.test.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/sample-confidence.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  combinedSampleTier,
+  isExcludedLowSample,
+  sampleTier,
+} from "./sample-confidence";
+
+describe("sample confidence", () => {
+  it.each([
+    [0, "none"],
+    [1, "low"],
+    [4, "low"],
+    [5, "limited"],
+    [9, "limited"],
+    [10, "good"],
+  ] as const)("classifies %i observations as %s", (count, expected) => {
+    expect(sampleTier(count)).toBe(expected);
+  });
+
+  it("uses the weakest populated period", () => {
+    expect(combinedSampleTier(8, 3)).toBe("low");
+    expect(combinedSampleTier(12, 7)).toBe("limited");
+    expect(combinedSampleTier(12, 0)).toBe("good");
+  });
+
+  it("excludes only the low tier", () => {
+    expect(isExcludedLowSample(4)).toBe(true);
+    expect(isExcludedLowSample(5)).toBe(false);
+    expect(isExcludedLowSample(9)).toBe(false);
+  });
+});

--- a/apps/hash-frontend/src/pages/supply-chain/shared/sample-confidence.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/sample-confidence.ts
@@ -1,0 +1,40 @@
+export const LOW_SAMPLE_MIN = 5;
+export const GOOD_SAMPLE_MIN = 10;
+
+export type SampleTier = "none" | "low" | "limited" | "good";
+
+export const sampleTier = (count: number): SampleTier => {
+  if (count <= 0) {
+    return "none";
+  }
+  if (count < LOW_SAMPLE_MIN) {
+    return "low";
+  }
+  if (count < GOOD_SAMPLE_MIN) {
+    return "limited";
+  }
+  return "good";
+};
+
+/** Return the weakest populated tier across current/previous periods. */
+export const combinedSampleTier = (
+  ...counts: (number | null | undefined)[]
+): SampleTier => {
+  const tiers = counts
+    .filter((count): count is number => count != null && count > 0)
+    .map(sampleTier);
+  if (tiers.includes("low")) {
+    return "low";
+  }
+  if (tiers.includes("limited")) {
+    return "limited";
+  }
+  if (tiers.includes("good")) {
+    return "good";
+  }
+  return "none";
+};
+
+/** The "exclude low samples" setting retains limited (5–9) samples. */
+export const isExcludedLowSample = (count: number): boolean =>
+  count < LOW_SAMPLE_MIN;

--- a/apps/hash-frontend/src/pages/supply-chain/shared/step-detail-panel.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/step-detail-panel.tsx
@@ -25,7 +25,6 @@ import { useDocs } from "./docs/use-docs";
 import { useSupplierPerformanceEnabled } from "./feature-flags";
 import { LoadingState, ErrorState } from "./load-state";
 import { MaterialTag } from "./material-tag";
-import { useBaseMeasure, type BaseMeasure } from "./measure-context";
 import { applyOutlierSelectionToStep } from "./outlier-selection";
 import { computePeriodDeltas } from "./period-trends";
 import { useProcurementBasis } from "./procurement-basis-context";
@@ -71,6 +70,7 @@ import { recomputeSupplierBlock } from "./supplier-otif";
 import { TIME_RANGE_OPTIONS, timeRangeLongLabel } from "./time-range";
 import { useTimeRange } from "./time-range-context";
 
+import type { BaseMeasure } from "./measure-context";
 import type {
   StepDetail as StepDetailType,
   StepStats,
@@ -404,8 +404,6 @@ export const StepDetailPanel = ({
   );
   const dataTableRef = useRef<DataTableSectionHandle>(null);
   const { excludeOutliers } = useOutlierSetting();
-  const { measure } = useBaseMeasure();
-  const effectiveMeasure = measureOverride ?? measure;
   const { basis: procurementBasis } = useProcurementBasis();
   const { products } = useRegistry();
   const supplierPerformanceEnabled = useSupplierPerformanceEnabled();

--- a/apps/hash-frontend/src/pages/supply-chain/shared/step-detail-panel.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/step-detail-panel.tsx
@@ -25,6 +25,7 @@ import { useDocs } from "./docs/use-docs";
 import { useSupplierPerformanceEnabled } from "./feature-flags";
 import { LoadingState, ErrorState } from "./load-state";
 import { MaterialTag } from "./material-tag";
+import { useBaseMeasure, type BaseMeasure } from "./measure-context";
 import { applyOutlierSelectionToStep } from "./outlier-selection";
 import { computePeriodDeltas } from "./period-trends";
 import { useProcurementBasis } from "./procurement-basis-context";
@@ -70,7 +71,6 @@ import { recomputeSupplierBlock } from "./supplier-otif";
 import { TIME_RANGE_OPTIONS, timeRangeLongLabel } from "./time-range";
 import { useTimeRange } from "./time-range-context";
 
-import type { BaseMeasure } from "./measure-context";
 import type {
   StepDetail as StepDetailType,
   StepStats,
@@ -404,6 +404,8 @@ export const StepDetailPanel = ({
   );
   const dataTableRef = useRef<DataTableSectionHandle>(null);
   const { excludeOutliers } = useOutlierSetting();
+  const { measure } = useBaseMeasure();
+  const effectiveMeasure = measureOverride ?? measure;
   const { basis: procurementBasis } = useProcurementBasis();
   const { products } = useRegistry();
   const supplierPerformanceEnabled = useSupplierPerformanceEnabled();
@@ -603,8 +605,14 @@ export const StepDetailPanel = ({
     return comparisonStep.observations;
   }, [comparisonStep, dimension, selectedComponent]);
   const periodComparison = useMemo(() => {
-    return computePeriodDeltas(comparisonObservations, timeRange);
-  }, [comparisonObservations, timeRange]);
+    return computePeriodDeltas(
+      comparisonObservations,
+      timeRange,
+      dimension === "timing"
+        ? (comparisonStep?.mean_observations ?? comparisonObservations)
+        : comparisonObservations,
+    );
+  }, [comparisonObservations, comparisonStep, dimension, timeRange]);
   const selectedComponentReconciliationCount = useMemo(() => {
     if (
       dimension !== "consumption" ||
@@ -839,7 +847,7 @@ export const StepDetailPanel = ({
                       <span className={strongText}>
                         {filteredStep.excluded_count}
                       </span>{" "}
-                      outliers excluded
+                      excluded from mean
                     </span>
                   </span>
                 )}

--- a/apps/hash-frontend/src/pages/supply-chain/shared/step-detail-panel/distribution-chart.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/step-detail-panel/distribution-chart.tsx
@@ -379,6 +379,7 @@ export const DistributionChart = ({
                 type: step.type,
                 dimension,
                 selectedComponent: selectedComponent != null,
+                timingGrain: step.timing_grain,
               })}`,
               "Count",
             ]}

--- a/apps/hash-frontend/src/pages/supply-chain/shared/step-detail-panel/step-detail-primitives.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/step-detail-panel/step-detail-primitives.tsx
@@ -434,6 +434,7 @@ export const ObservationCount = ({
     id: step.id,
     label: step.label,
     type: step.type,
+    timingGrain: step.timing_grain,
     dimension,
     selectedComponent,
   });
@@ -446,11 +447,13 @@ export const ObservationCount = ({
         id: step.id,
         label: step.label,
         type: step.type,
+        timingGrain: step.timing_grain,
         dimension,
         selectedComponent,
         count,
         rangeLabel: timeRange,
         nBatches: step.n_batches,
+        nCampaigns: step.n_campaigns,
         nMovements: step.n_movements,
       })}
     >

--- a/apps/hash-frontend/src/pages/supply-chain/shared/step-detail-panel/time-series-chart.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/step-detail-panel/time-series-chart.tsx
@@ -181,6 +181,7 @@ export const TimeSeriesChart = ({
                 type: step.type,
                 dimension,
                 selectedComponent: selectedComponent != null,
+                timingGrain: step.timing_grain,
               });
               const base =
                 count != null ? `${_label}: ${count} ${noun}` : String(_label);

--- a/apps/hash-frontend/src/pages/supply-chain/shared/step-detail-panel/timing-metrics.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/step-detail-panel/timing-metrics.tsx
@@ -323,7 +323,13 @@ export const KeyMetricsRow = ({
                 ? `${formatNumber(pep, { maximumFractionDigits: 0 })}%`
                 : "–"}
             </span>
-            {pep != null && <span className={badge}>of batches</span>}
+            {pep != null && (
+              <span className={badge}>
+                {step.timing_grain === "campaign"
+                  ? "of campaigns"
+                  : "of batches"}
+              </span>
+            )}
           </div>
         </div>
 

--- a/apps/hash-frontend/src/pages/supply-chain/shared/types.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/types.ts
@@ -201,6 +201,9 @@ export interface GraphNode {
   cost: CostData | null;
   material_value?: MaterialValueData | null;
   observations?: Observation[];
+  /** Client-derived Tukey-kept timing points used only for mean trends. */
+  mean_observations?: Observation[];
+  timing_grain?: "campaign" | null;
   /** Client-side cache of combined procurement node observations from the wire. */
   procurement_observations?: ProcurementNodeObservation[];
   monthly?: MonthlyBucket[];
@@ -209,6 +212,7 @@ export interface GraphNode {
   /** Client-computed exclusion rate (%) under the current outlier setting. */
   excluded_pct?: number;
   n_batches?: number;
+  n_campaigns?: number;
   n_movements?: number;
   /** Recomputed client-side from `yield_series` under window + outlier; not shipped by the generator. */
   yield_summary?: YieldSummary | null;
@@ -472,6 +476,8 @@ export interface ProcurementNodeObservation {
 export interface TimingSeries {
   label?: string;
   observations: Observation[];
+  /** Client-derived Tukey-kept timing points used only for mean calculations. */
+  mean_observations?: Observation[];
   monthly: MonthlyBucket[];
   stats: StepStats;
 }
@@ -614,6 +620,8 @@ export interface StepDetail {
   type: StepType;
   durations: number[];
   observations: Observation[];
+  /** Client-derived Tukey-kept timing points used only for mean trends. */
+  mean_observations?: Observation[];
   monthly: MonthlyBucket[];
   stats: StepStats;
   /** Client-computed by the Tukey IQR outlier selection (lib/utils); not shipped by the generator. */
@@ -626,12 +634,18 @@ export interface StepDetail {
   pct_exceeding_plan?: number | null;
   cost: CostData | null;
   material_value?: MaterialValueData | null;
+  /** Observation grain for timing. Campaign timing is one canonical QA observation per campaign. */
+  timing_grain?: "campaign" | null;
+  /**
+   * Canonical campaign-level timing records. When present these take precedence
+   * over `detail_rows`, which remains the underlying batch evidence.
+   */
+  campaign_rows?: DetailRows | null;
   detail_rows?: DetailRows | null;
   ref_date_col?: string | null;
   /**
-   * Canonical value column within `detail_rows.rows`. With `ref_date_col`, the
-   * timing series (observations/durations/monthly/stats) is fully derivable from
-   * `detail_rows` on load.
+   * Canonical value column within the selected timing rows. Campaign timing
+   * derives from `campaign_rows`; legacy timing derives from `detail_rows`.
    */
   value_col?: string | null;
   /**
@@ -646,6 +660,7 @@ export interface StepDetail {
    * the inactive first/last receipt basis after deriving both from detail rows.
    */
   complete_timing?: TimingSeries | null;
+  n_campaigns?: number;
   n_batches?: number;
   n_movements?: number;
   yield_data?: YieldData | null;

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/opportunity.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/opportunity.tsx
@@ -16,7 +16,6 @@ import { useDocs } from "../shared/docs/use-docs";
 import { buildCsvContent, downloadCsv } from "../shared/export-utils";
 import { useSupplierPerformanceEnabled } from "../shared/feature-flags";
 import { ErrorState, SupplyChainAppSkeleton } from "../shared/load-state";
-import { useBaseMeasure } from "../shared/measure-context";
 import { ensureNodeStats } from "../shared/normalize-contract";
 import { countNoun } from "../shared/observation-labels";
 import { applyOutlierSelectionToStep } from "../shared/outlier-selection";
@@ -1549,7 +1548,6 @@ export const OpportunityBrief = ({
   const { timeRange } = useTimeRange();
   const { setAnalysisSettings, waccRate, storageCost } = useCostParams();
   const { excludeOutliers } = useOutlierSetting();
-  const { measure } = useBaseMeasure();
   const { basis: procurementBasis } = useProcurementBasis();
   const supplierPerformanceEnabled = useSupplierPerformanceEnabled();
   const [siteSummary, setSiteSummary] = useState<SiteSummary | null>(null);
@@ -1664,15 +1662,7 @@ export const OpportunityBrief = ({
       ),
       products: node.products,
     };
-  }, [
-    nodes,
-    stepId,
-    productId,
-    timeRange,
-    excludeOutliers,
-    measure,
-    procurementBasis,
-  ]);
+  }, [nodes, stepId, productId, timeRange, excludeOutliers, procurementBasis]);
 
   // Each consuming product's own (pre-dedup) node for this material/step, so the
   // brief can report per-product BOM membership and E2E binding leverage that the
@@ -1711,7 +1701,7 @@ export const OpportunityBrief = ({
       applyProcurementBasisToStep(step, procurementBasis),
       excludeOutliers,
     );
-  }, [step, excludeOutliers, measure, procurementBasis]);
+  }, [step, excludeOutliers, procurementBasis]);
 
   const filteredStep = useMemo(() => {
     if (!step) {
@@ -1723,7 +1713,7 @@ export const OpportunityBrief = ({
       excludeOutliers,
       procurementBasis,
     );
-  }, [step, timeRange, excludeOutliers, measure, procurementBasis]);
+  }, [step, timeRange, excludeOutliers, procurementBasis]);
 
   const brief = useMemo(() => {
     if (!filteredStep || !historicalStep) {

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/opportunity.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/opportunity.tsx
@@ -16,7 +16,9 @@ import { useDocs } from "../shared/docs/use-docs";
 import { buildCsvContent, downloadCsv } from "../shared/export-utils";
 import { useSupplierPerformanceEnabled } from "../shared/feature-flags";
 import { ErrorState, SupplyChainAppSkeleton } from "../shared/load-state";
+import { useBaseMeasure } from "../shared/measure-context";
 import { ensureNodeStats } from "../shared/normalize-contract";
+import { countNoun } from "../shared/observation-labels";
 import { applyOutlierSelectionToStep } from "../shared/outlier-selection";
 import {
   computePeriodDeltas,
@@ -602,13 +604,14 @@ function formatTrendSummary(
     previousN: number;
   },
   range: TimeRange,
+  observationNoun: string,
 ): string {
   if (
     trend.pctChange == null ||
     trend.currentValue == null ||
     trend.previousValue == null
   ) {
-    return `No comparison (${formatNumber(trend.currentN)} current / ${formatNumber(trend.previousN)} previous samples)`;
+    return `No comparison (${formatNumber(trend.currentN)} current / ${formatNumber(trend.previousN)} previous ${observationNoun})`;
   }
   return `${formatNumber(trend.currentValue, { maximumFractionDigits: 1 })}d vs ${formatNumber(trend.previousValue, { maximumFractionDigits: 1 })}d previous ${range} (${formatDeviation(trend.pctChange)})`;
 }
@@ -859,8 +862,10 @@ const DwellExecutiveSummary = ({
 
 const PlanningExecutiveSummary = ({
   brief,
+  observationNoun,
 }: {
   brief: PlanningOpportunityBrief;
+  observationNoun: string;
 }) => {
   return (
     <div className={grid4}>
@@ -891,7 +896,7 @@ const PlanningExecutiveSummary = ({
       />
 
       <MetricCard
-        label="Batches exceeding plan"
+        label={`${observationNoun} exceeding plan`}
         value={formatExceedingPlan(brief)}
         tone={(brief.pctExceedingPlan ?? 0) > 20 ? "bad" : "neutral"}
       />
@@ -1544,6 +1549,7 @@ export const OpportunityBrief = ({
   const { timeRange } = useTimeRange();
   const { setAnalysisSettings, waccRate, storageCost } = useCostParams();
   const { excludeOutliers } = useOutlierSetting();
+  const { measure } = useBaseMeasure();
   const { basis: procurementBasis } = useProcurementBasis();
   const supplierPerformanceEnabled = useSupplierPerformanceEnabled();
   const [siteSummary, setSiteSummary] = useState<SiteSummary | null>(null);
@@ -1658,7 +1664,15 @@ export const OpportunityBrief = ({
       ),
       products: node.products,
     };
-  }, [nodes, stepId, productId, timeRange, excludeOutliers, procurementBasis]);
+  }, [
+    nodes,
+    stepId,
+    productId,
+    timeRange,
+    excludeOutliers,
+    measure,
+    procurementBasis,
+  ]);
 
   // Each consuming product's own (pre-dedup) node for this material/step, so the
   // brief can report per-product BOM membership and E2E binding leverage that the
@@ -1697,7 +1711,7 @@ export const OpportunityBrief = ({
       applyProcurementBasisToStep(step, procurementBasis),
       excludeOutliers,
     );
-  }, [step, excludeOutliers, procurementBasis]);
+  }, [step, excludeOutliers, measure, procurementBasis]);
 
   const filteredStep = useMemo(() => {
     if (!step) {
@@ -1709,7 +1723,7 @@ export const OpportunityBrief = ({
       excludeOutliers,
       procurementBasis,
     );
-  }, [step, timeRange, excludeOutliers, procurementBasis]);
+  }, [step, timeRange, excludeOutliers, measure, procurementBasis]);
 
   const brief = useMemo(() => {
     if (!filteredStep || !historicalStep) {
@@ -1811,10 +1825,23 @@ export const OpportunityBrief = ({
     siteNode?.products ??
     products.filter((product) => product.id === productId);
   const isDwellBrief = brief.kind === "dwell";
+  const observationNoun = countNoun({
+    id: filteredStep.id,
+    label: filteredStep.label,
+    type: filteredStep.type,
+    dimension: "timing",
+    timingGrain: filteredStep.timing_grain,
+  });
+  const observationLabel =
+    observationNoun.charAt(0).toUpperCase() + observationNoun.slice(1);
   const ranking = computeBriefRanking(rollups, stepId, isDwellBrief);
 
   // Headline period-over-period trends for median / P95 / cost (newest vs prior window).
-  const periodCmp = computePeriodDeltas(historicalStep.observations, timeRange);
+  const periodCmp = computePeriodDeltas(
+    historicalStep.observations,
+    timeRange,
+    historicalStep.mean_observations ?? historicalStep.observations,
+  );
   const prevStats = periodCmp.previousStats;
   const costCmp = isDwellBrief
     ? computeCostComparison(
@@ -1974,10 +2001,10 @@ export const OpportunityBrief = ({
                 label="Analysis assumptions"
                 value={
                   isDwellBrief
-                    ? `${formatNumber(waccRate * 100, { maximumFractionDigits: 0 })}% WACC, ${formatNumber(storageCost, { maximumFractionDigits: 3 })}${filteredStep.cost?.currency ? ` ${filteredStep.cost.currency}` : ""}/t/day storage, ${excludeOutliers ? "outliers excluded" : "outliers included"}`
+                    ? `${formatNumber(waccRate * 100, { maximumFractionDigits: 0 })}% WACC, ${formatNumber(storageCost, { maximumFractionDigits: 3 })}${filteredStep.cost?.currency ? ` ${filteredStep.cost.currency}` : ""}/t/day storage, ${excludeOutliers ? "outliers excluded from mean" : "raw mean"}`
                     : excludeOutliers
-                      ? "outliers excluded"
-                      : "outliers included"
+                      ? "outliers excluded from mean"
+                      : "raw mean"
                 }
               />
             </div>
@@ -2016,7 +2043,7 @@ export const OpportunityBrief = ({
           />
 
           <MetricCard
-            label="Observations"
+            label={observationLabel}
             value={formatNumber(filteredStep.stats.n)}
           />
 
@@ -2038,7 +2065,10 @@ export const OpportunityBrief = ({
           {isDwellBrief ? (
             <DwellExecutiveSummary brief={brief} timeRange={timeRange} />
           ) : (
-            <PlanningExecutiveSummary brief={brief} />
+            <PlanningExecutiveSummary
+              brief={brief}
+              observationNoun={observationLabel}
+            />
           )}
         </BriefSection>
 
@@ -2132,10 +2162,10 @@ export const OpportunityBrief = ({
 
             <StatTable
               rows={[
-                ["Samples", formatNumber(filteredStep.stats.n)],
+                [observationLabel, formatNumber(filteredStep.stats.n)],
                 [
                   "Trend vs previous period",
-                  formatTrendSummary(brief.trend, timeRange),
+                  formatTrendSummary(brief.trend, timeRange, observationNoun),
                 ],
 
                 [
@@ -2146,10 +2176,10 @@ export const OpportunityBrief = ({
                 ],
 
                 [
-                  "Outliers excluded",
+                  "Excluded from mean only",
                   filteredStep.excluded_count == null
                     ? "-"
-                    : formatNumber(filteredStep.excluded_count),
+                    : `${formatNumber(filteredStep.excluded_count)} ${observationNoun}; percentiles use all ${formatNumber(filteredStep.stats.n)}`,
                 ],
 
                 [

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/opportunity/opportunity-utils.test.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/opportunity/opportunity-utils.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { applyOutlierSelectionToStep } from "../../shared/outlier-selection";
 import {
   buildDwellOpportunityBrief,
   buildPlanningOpportunityBrief,
@@ -148,6 +149,43 @@ describe("opportunity brief helpers", () => {
     expect(brief.recommendedActions[0]?.text).toContain(
       "longest normalized durations",
     );
+  });
+
+  it("keeps the raw P95 opportunity invariant under mean-only Tukey filtering", () => {
+    const raw = step({
+      plan: 20,
+      durations: [10, 11, 12, 13, 14, 15, 16, 17, 100],
+      observations: [
+        { date: "2026-01-01", value: 10 },
+        { date: "2026-01-02", value: 11 },
+        { date: "2026-01-03", value: 12 },
+        { date: "2026-01-04", value: 13 },
+        { date: "2026-01-05", value: 14 },
+        { date: "2026-01-06", value: 15 },
+        { date: "2026-01-07", value: 16 },
+        { date: "2026-01-08", value: 17 },
+        { date: "2026-01-09", value: 100 },
+      ],
+      stats: {
+        ...baseStats,
+        n: 9,
+        mean: 22,
+        median: 14,
+        p95: 66.8,
+        max: 100,
+      },
+    });
+    const meanFiltered = applyOutlierSelectionToStep(raw, true);
+
+    const brief = buildPlanningOpportunityBrief(
+      meanFiltered,
+      meanFiltered,
+      "12m",
+    );
+
+    expect(meanFiltered.stats.mean).toBe(13.5);
+    expect(brief.p95Days).toBe(raw.stats.p95);
+    expect(brief.p95DeviationPct).toBeCloseTo(234, 6);
   });
 
   it("labels conservative planning candidates as tighten opportunities", () => {

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/opportunity/opportunity-utils.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/opportunity/opportunity-utils.ts
@@ -7,6 +7,7 @@ import {
 } from "../../shared/cost";
 import { computeTrend, computePeriodDeltas } from "../../shared/period-trends";
 import { summarizeProcurementPlanning } from "../../shared/procurement-planning";
+import { sampleTier } from "../../shared/sample-confidence";
 import { percentileOf } from "../../shared/stats";
 import { recomputeSupplierBlock } from "../../shared/supplier-otif";
 import {
@@ -265,7 +266,6 @@ export interface PlanningOpportunityBrief {
   tailTrendNote: string | null;
 }
 
-const LOW_SAMPLE_N = 10;
 const WARNING_SAMPLE_N = 30;
 const STALE_OBSERVATION_DAYS = 60;
 
@@ -638,10 +638,11 @@ function buildEvidenceFlags(
   },
 ): EvidenceFlag[] {
   const flags: EvidenceFlag[] = [];
-  if (step.stats.n > 0 && step.stats.n < LOW_SAMPLE_N) {
+  const currentTier = sampleTier(step.stats.n);
+  if (currentTier === "low" || currentTier === "limited") {
     flags.push({
-      severity: "warning",
-      label: "Low sample",
+      severity: currentTier === "low" ? "warning" : "info",
+      label: currentTier === "low" ? "Low sample" : "Limited sample",
       detail: `Only ${formatNumber(step.stats.n)} observations are in the selected period.`,
     });
   }
@@ -660,10 +661,12 @@ function buildEvidenceFlags(
         "Potential cost impact cannot be calculated without a material unit cost.",
     });
   }
-  if (options.trend.previousN > 0 && options.trend.previousN < LOW_SAMPLE_N) {
+  const previousTier = sampleTier(options.trend.previousN);
+  if (previousTier === "low" || previousTier === "limited") {
     flags.push({
       severity: "info",
-      label: "Trend sample",
+      label:
+        previousTier === "low" ? "Low trend sample" : "Limited trend sample",
       detail: `Previous comparison period has ${formatNumber(options.trend.previousN)} observations.`,
     });
   }
@@ -758,7 +761,8 @@ function buildConfidence(
   const hasLowConfidenceWarning = flags.some(
     (flag) => flag.severity === "warning" && flag.label !== "Stale recent data",
   );
-  if (step.stats.n < LOW_SAMPLE_N || hasLowConfidenceWarning) {
+  const tier = sampleTier(step.stats.n);
+  if (tier === "low" || tier === "none" || hasLowConfidenceWarning) {
     return {
       label: "Low",
       caveats,

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product.tsx
@@ -519,11 +519,7 @@ export const Overview = ({
           return endDate != null && endDate.slice(0, 7) >= cutoff;
         })
       : bt.batches;
-    const filteredBT = recomputeBatchTimelines(
-      filteredBatches,
-      bt,
-      excludeOutliers,
-    );
+    const filteredBT = recomputeBatchTimelines(filteredBatches, bt, false);
     return {
       ...graph,
       nodes: filteredNodes,

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product.tsx
@@ -519,7 +519,11 @@ export const Overview = ({
           return endDate != null && endDate.slice(0, 7) >= cutoff;
         })
       : bt.batches;
-    const filteredBT = recomputeBatchTimelines(filteredBatches, bt, false);
+    const filteredBT = recomputeBatchTimelines(
+      filteredBatches,
+      bt,
+      excludeOutliers,
+    );
     return {
       ...graph,
       nodes: filteredNodes,
@@ -798,6 +802,7 @@ export const Overview = ({
             <E2EWhatIf
               graph={filteredGraph}
               timeRange={timeRange}
+              excludeOutliers={excludeOutliers}
               onCollapse={() => setPipelineExpanded(false)}
               onStepDrill={onStepSelect}
               activeSegments={activeSegments}

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product/e2e-what-if.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product/e2e-what-if.tsx
@@ -3,12 +3,7 @@ import { useCallback, useMemo, useState } from "react";
 import { Button } from "@hashintel/ds-components";
 import { css } from "@hashintel/ds-helpers/css";
 
-import {
-  formatCost,
-  formatNumber,
-  useCostParams,
-  useOutlierSetting,
-} from "../../shared/cost";
+import { formatCost, formatNumber, useCostParams } from "../../shared/cost";
 import { BindingLever } from "./e2e-what-if/binding-lever";
 import { KpiTile } from "./e2e-what-if/what-if-kpis";
 import { PipelineHeader } from "./shared/pipeline-header";
@@ -123,7 +118,6 @@ export const E2EWhatIf = ({
   onActiveRouteChange,
 }: E2EWhatIfProps) => {
   const { waccRate, storageCost } = useCostParams();
-  const { excludeOutliers } = useOutlierSetting();
 
   const setActiveRoute = onActiveRouteChange;
   // Levers store CAP days: missing entries or caps at the step's max mean
@@ -157,7 +151,7 @@ export const E2EWhatIf = ({
         leverDefs,
         activeRoute || null,
         { waccRate, storageCost },
-        { windowMonths, activeSegments, excludeOutliers },
+        { windowMonths, activeSegments },
       ),
     [
       graph.nodes,
@@ -169,7 +163,6 @@ export const E2EWhatIf = ({
       storageCost,
       windowMonths,
       activeSegments,
-      excludeOutliers,
     ],
   );
 

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product/e2e-what-if.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product/e2e-what-if.tsx
@@ -21,6 +21,7 @@ import type { GraphData } from "../../shared/types";
 interface E2EWhatIfProps {
   graph: GraphData;
   timeRange: TimeRange;
+  excludeOutliers: boolean;
   onCollapse: () => void;
   onStepDrill: (stepId: string) => void;
   /** Segments currently included in totals, KPIs and the lever list. */
@@ -110,6 +111,7 @@ const kpiGrid = css({
 export const E2EWhatIf = ({
   graph,
   timeRange,
+  excludeOutliers,
   onCollapse,
   onStepDrill,
   activeSegments,
@@ -151,7 +153,7 @@ export const E2EWhatIf = ({
         leverDefs,
         activeRoute || null,
         { waccRate, storageCost },
-        { windowMonths, activeSegments },
+        { windowMonths, activeSegments, excludeOutliers },
       ),
     [
       graph.nodes,
@@ -163,6 +165,7 @@ export const E2EWhatIf = ({
       storageCost,
       windowMonths,
       activeSegments,
+      excludeOutliers,
     ],
   );
 

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product/recompute-batch-timelines.test.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product/recompute-batch-timelines.test.ts
@@ -68,4 +68,35 @@ describe("recomputeBatchTimelines", () => {
       50, 50, 0, 0,
     ]);
   });
+
+  it("excludes outliers from means without changing other statistics", () => {
+    const durations = [10, 11, 12, 13, 14, 15, 16, 17, 100];
+    const batches = durations.map((duration, index) =>
+      batch({
+        batch: `B${index + 1}`,
+        seg_proc_to_prodstart: duration,
+        total_days: duration,
+      }),
+    );
+
+    const { timelines, pipeline } = recomputeBatchTimelines(
+      batches,
+      batchTimelines(batches),
+      true,
+    );
+
+    expect(timelines.segments?.seg_proc_to_prodstart).toMatchObject({
+      mean: 13.5,
+      median: 14,
+      p25: 12,
+      p75: 16,
+      n: 9,
+    });
+    expect(pipeline.direct?.stages[0]).toMatchObject({
+      mean: 13.5,
+      median: 14,
+    });
+    expect(pipeline.direct?.total_mean).toBe(13.5);
+    expect(pipeline.direct?.total_median).toBe(14);
+  });
 });

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product/recompute-batch-timelines.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product/recompute-batch-timelines.ts
@@ -12,46 +12,48 @@ import type {
 /**
  * Summary statistics for one batch segment over a filtered batch set.
  * Uses nearest-rank percentiles (no interpolation/rounding) so the pipeline
- * waterfall matches the backend's batch-timeline numbers. `excludeOutliers`
- * is supplied only for the mean view; when set, each segment's per-batch values
- * are trimmed with the shared Tukey 1.5x IQR rule before its display statistics
- * are recomputed.
+ * waterfall matches the backend's batch-timeline numbers. When
+ * `excludeOutliers` is set, only the mean excludes values outside the shared
+ * Tukey 1.5x IQR fences; the sample size, median and percentiles continue to
+ * describe the full series.
  */
 function segStats(
   batches: BatchRow[],
   key: BatchSegmentKey,
   excludeOutliers: boolean,
 ): BatchTimelineSegment | null {
-  let vals = batches
+  const values = batches
     .map((batch) => batch[key])
     .filter(
       (value): value is number => value != null && value >= 0 && value <= 730,
     );
-  if (vals.length === 0) {
+  if (values.length === 0) {
     return null;
   }
+  let meanValues = values;
   if (excludeOutliers) {
-    const fences = computeIqrFences(vals);
+    const fences = computeIqrFences(values);
     if (fences) {
-      vals = vals.filter(
+      meanValues = values.filter(
         (value) => value >= fences.lower && value <= fences.upper,
       );
     }
-    if (vals.length === 0) {
+    if (meanValues.length === 0) {
       return null;
     }
   }
-  vals.sort((left, right) => left - right);
-  const mean = vals.reduce((sum, value) => sum + value, 0) / vals.length;
-  const midpoint = Math.floor(vals.length / 2);
-  const upper = vals[midpoint];
+  values.sort((left, right) => left - right);
+  const mean =
+    meanValues.reduce((sum, value) => sum + value, 0) / meanValues.length;
+  const midpoint = Math.floor(values.length / 2);
+  const upper = values[midpoint];
   if (upper === undefined) {
     throw new Error("Segment statistics were missing a midpoint value");
   }
   const median =
-    vals.length % 2 === 0
+    values.length % 2 === 0
       ? (() => {
-          const lower = vals[midpoint - 1];
+          const lower = values[midpoint - 1];
           if (lower === undefined) {
             throw new Error(
               "Segment statistics were missing a lower midpoint value",
@@ -60,12 +62,12 @@ function segStats(
           return (lower + upper) / 2;
         })()
       : upper;
-  const p25 = vals[Math.floor(vals.length * 0.25)];
-  const p75 = vals[Math.floor(vals.length * 0.75)];
+  const p25 = values[Math.floor(values.length * 0.25)];
+  const p75 = values[Math.floor(values.length * 0.75)];
   if (p25 === undefined || p75 === undefined) {
     throw new Error("Segment statistics percentile value missing");
   }
-  return { label: "", mean, median, p25, p75, n: vals.length };
+  return { label: "", mean, median, p25, p75, n: values.length };
 }
 
 /** Pipeline stages in display order: segment key, label, and step type. */

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product/recompute-batch-timelines.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product/recompute-batch-timelines.ts
@@ -12,10 +12,10 @@ import type {
 /**
  * Summary statistics for one batch segment over a filtered batch set.
  * Uses nearest-rank percentiles (no interpolation/rounding) so the pipeline
- * waterfall matches the backend's batch-timeline numbers. When `excludeOutliers`
- * is set, the segment's per-batch values are first trimmed with the shared
- * Tukey 1.5x IQR rule (same definition as the node/step series) so the
- * waterfall + E2E totals honour the outlier toggle.
+ * waterfall matches the backend's batch-timeline numbers. `excludeOutliers`
+ * is supplied only for the mean view; when set, each segment's per-batch values
+ * are trimmed with the shared Tukey 1.5x IQR rule before its display statistics
+ * are recomputed.
  */
 function segStats(
   batches: BatchRow[],

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product/shared/step-card.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product/shared/step-card.tsx
@@ -700,6 +700,7 @@ export const StepCard = ({ node, onClick, timeRange }: StepCardProps) => {
                   id: node.id,
                   label: node.label,
                   type: node.type,
+                  timingGrain: node.timing_grain,
                 })}
               </span>
             </Tooltip>

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product/shared/step-card.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product/shared/step-card.tsx
@@ -28,6 +28,7 @@ import {
   planSourceLabel,
   pctChangeTooltip,
 } from "../../../shared/planning-param";
+import { sampleTier } from "../../../shared/sample-confidence";
 // Local portal tooltip retained for the box-plot popover only: it renders rich
 // content `bare` (no dark-pill chrome), which the ds `Tooltip` can't express.
 import { Tooltip as RichTooltip } from "../../../shared/tooltip";
@@ -515,7 +516,8 @@ export const StepCard = ({ node, onClick, timeRange }: StepCardProps) => {
     return (diff / plan) * 100;
   }, [plan, hasData, measureValue]);
   const eventCount = node.observations?.length ?? node.stats.n;
-  const isLowSample = node.stats.n > 0 && node.stats.n < 10;
+  const sampleLevel = sampleTier(node.stats.n);
+  const hasSampleWarning = sampleLevel === "low" || sampleLevel === "limited";
   return (
     <button
       type="button"
@@ -675,23 +677,25 @@ export const StepCard = ({ node, onClick, timeRange }: StepCardProps) => {
             <Tooltip
               openDelay="fast"
               content={
-                isLowSample
-                  ? "Low sample count"
+                hasSampleWarning
+                  ? `${sampleLevel === "low" ? "Low" : "Limited"} sample count`
                   : node.source
-                    ? `${countTooltip({ id: node.id, label: node.label, type: node.type, count: eventCount, rangeLabel: timeRange, nBatches: node.n_batches, nMovements: node.n_movements })}\nSource: ${node.source.label}${node.source.filter ? ` (filter ${node.source.filter})` : ""}`
+                    ? `${countTooltip({ id: node.id, label: node.label, type: node.type, timingGrain: node.timing_grain, count: eventCount, rangeLabel: timeRange, nBatches: node.n_batches, nCampaigns: node.n_campaigns, nMovements: node.n_movements })}\nSource: ${node.source.label}${node.source.filter ? ` (filter ${node.source.filter})` : ""}`
                     : countTooltip({
                         id: node.id,
                         label: node.label,
                         type: node.type,
+                        timingGrain: node.timing_grain,
                         count: eventCount,
                         rangeLabel: timeRange,
                         nBatches: node.n_batches,
+                        nCampaigns: node.n_campaigns,
                         nMovements: node.n_movements,
                       })
               }
             >
               <span className={countLabel}>
-                {isLowSample && <WarningTriangleIcon />}
+                {hasSampleWarning && <WarningTriangleIcon />}
                 {shortCountLabel(eventCount, {
                   id: node.id,
                   label: node.label,

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product/whatif.test.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product/whatif.test.ts
@@ -115,6 +115,42 @@ function baseBatch(overrides: Partial<BatchRow>): BatchRow {
   };
 }
 
+describe("aggregateSimulation (outlier policy)", () => {
+  it("excludes outliers from means without changing medians", () => {
+    const batches = [10, 11, 12, 13, 14, 15, 16, 17, 100].map(
+      (duration, index) =>
+        baseBatch({
+          batch: `B${index + 1}`,
+          seg_qa_to_customer: duration,
+        }),
+    );
+
+    const result = aggregateSimulation(
+      [],
+      batches,
+      {},
+      [],
+      null,
+      {
+        waccRate: 0.1,
+        storageCost: 0.336,
+      },
+      {
+        excludeOutliers: true,
+      },
+    );
+
+    expect(result.baselineMean).toBe(13.5);
+    expect(result.simulatedMean).toBe(13.5);
+    expect(result.baselineMedian).toBe(14);
+    expect(result.simulatedMedian).toBe(14);
+    expect(
+      result.simulatedStagesMean.find((stage) => stage.type === "transit")
+        ?.mean,
+    ).toBe(13.5);
+  });
+});
+
 function baseNode(overrides: Partial<GraphNode>): GraphNode {
   return {
     id: "ship",

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product/whatif.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product/whatif.ts
@@ -1,8 +1,4 @@
 import { computePeriodCost } from "../../shared/cost";
-import {
-  computeIqrFences,
-  type IqrFences,
-} from "../../shared/outlier-selection/iqr";
 
 import type {
   BatchRow,
@@ -687,48 +683,15 @@ export function aggregateSimulation(
   options: {
     windowMonths?: number;
     activeSegments?: Set<SegmentId>;
-    excludeOutliers?: boolean;
   } = {},
 ): SimulationResult {
   const windowMonths = options.windowMonths ?? 12;
   const activeSegments = options.activeSegments;
-  const excludeOutliers = options.excludeOutliers ?? false;
   const isActive = (step: SegmentId) =>
     !activeSegments || activeSegments.has(step);
   const routeBatches = routeCode
     ? batches.filter((batch) => batch.route === routeCode)
     : batches;
-
-  // When outliers are excluded, trim each segment with the same Tukey 1.5x IQR
-  // rule the waterfall uses (recompute-batch-timelines.segStats), so the KPI
-  // baseline/simulated totals stay consistent with the waterfall bars instead
-  // of including points the bars dropped.
-  const segFence = (
-    pick: (b: BatchRow) => number | null | undefined,
-  ): IqrFences | null => {
-    const vals = routeBatches
-      .map(pick)
-      .filter(
-        (value): value is number =>
-          typeof value === "number" && value >= 0 && value <= 730,
-      );
-    return computeIqrFences(vals);
-  };
-  const fences = excludeOutliers
-    ? {
-        procToPS: segFence((batch) => batch.seg_proc_to_prodstart),
-        prodStartToFinish: segFence(
-          (batch) => batch.seg_prodstart_to_prodfinish,
-        ),
-        prodFinishToQa: segFence((batch) => batch.seg_prodfinish_to_qa),
-        qaToCustomer: segFence((batch) => batch.seg_qa_to_customer),
-      }
-    : null;
-  const within = (
-    value: number,
-    fraction: IqrFences | null | undefined,
-  ): boolean =>
-    !fraction || (value >= fraction.lower && value <= fraction.upper);
 
   // The `capLevers` Record is keyed on stepId with an absolute cap in days.
   // Missing entries, entries for hidden levers, and caps at/above the step max
@@ -776,10 +739,7 @@ export function aggregateSimulation(
 
   const baselineTotals: number[] = [];
   const simulatedTotals: number[] = [];
-  // Per-segment buckets only collect rows where the batch's baseline for
-  // that segment is non-null and within the outlier band -- matching the
-  // baseline waterfall's segStats semantics so the dashed simulated bars
-  // overlay cleanly when no levers are active.
+  // Per-segment buckets collect every valid raw batch value.
   const segs = {
     procToPS: [] as number[],
     prodStartToFinish: [] as number[],
@@ -821,43 +781,25 @@ export function aggregateSimulation(
     let baselineTotal = 0;
     let simulatedTotal = 0;
     // Skip a segment's contribution when its legend chip is toggled off. The
-    // per-segment validity band (`inRange`) and, when active, the Tukey IQR
-    // fence (`within`) both apply per-segment, so a batch can still contribute
-    // its other valid segments even when one is excluded.
-    if (
-      isActive("procurement") &&
-      inRange(procToPSRaw) &&
-      within(procToPSRaw, fences?.procToPS)
-    ) {
+    // validity band applies independently per segment.
+    if (isActive("procurement") && inRange(procToPSRaw)) {
       segs.procToPS.push(procToPSRaw);
       baselineTotal += procToPSRaw;
       simulatedTotal += procToPSRaw;
     }
-    if (
-      isActive("production") &&
-      inRange(prodStartToFinishRaw) &&
-      within(prodStartToFinishRaw, fences?.prodStartToFinish)
-    ) {
+    if (isActive("production") && inRange(prodStartToFinishRaw)) {
       const sim2 = Math.max(0, prodStartToFinishRaw - prodSegmentReduction);
       segs.prodStartToFinish.push(sim2);
       baselineTotal += prodStartToFinishRaw;
       simulatedTotal += sim2;
     }
-    if (
-      isActive("qa_hold") &&
-      inRange(prodFinishToQaRaw) &&
-      within(prodFinishToQaRaw, fences?.prodFinishToQa)
-    ) {
+    if (isActive("qa_hold") && inRange(prodFinishToQaRaw)) {
       const sim2 = Math.max(0, prodFinishToQaRaw - qaHoldReduction);
       segs.prodFinishToQa.push(sim2);
       baselineTotal += prodFinishToQaRaw;
       simulatedTotal += sim2;
     }
-    if (
-      isActive("transit") &&
-      inRange(qaToCustomerRaw) &&
-      within(qaToCustomerRaw, fences?.qaToCustomer)
-    ) {
+    if (isActive("transit") && inRange(qaToCustomerRaw)) {
       const sim2 = Math.max(0, qaToCustomerRaw - postQaReduction);
       segs.qaToCustomer.push(sim2);
       baselineTotal += qaToCustomerRaw;

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product/whatif.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product/whatif.ts
@@ -1,4 +1,5 @@
 import { computePeriodCost } from "../../shared/cost";
+import { computeIqrFences } from "../../shared/outlier-selection/iqr";
 
 import type {
   BatchRow,
@@ -534,11 +535,18 @@ function simulateBatch(
   };
 }
 
-function mean(values: number[]): number | null {
+function mean(values: number[], excludeOutliers = false): number | null {
   if (values.length === 0) {
     return null;
   }
-  return values.reduce((sum, value) => sum + value, 0) / values.length;
+  const fences = excludeOutliers ? computeIqrFences(values) : null;
+  const meanValues = fences
+    ? values.filter((value) => value >= fences.lower && value <= fences.upper)
+    : values;
+  if (meanValues.length === 0) {
+    return null;
+  }
+  return meanValues.reduce((sum, value) => sum + value, 0) / meanValues.length;
 }
 
 function median(sortedAsc: number[]): number | null {
@@ -683,10 +691,12 @@ export function aggregateSimulation(
   options: {
     windowMonths?: number;
     activeSegments?: Set<SegmentId>;
+    excludeOutliers?: boolean;
   } = {},
 ): SimulationResult {
   const windowMonths = options.windowMonths ?? 12;
   const activeSegments = options.activeSegments;
+  const excludeOutliers = options.excludeOutliers ?? false;
   const isActive = (step: SegmentId) =>
     !activeSegments || activeSegments.has(step);
   const routeBatches = routeCode
@@ -822,8 +832,8 @@ export function aggregateSimulation(
     (left, right) => left - right,
   );
 
-  const baselineMean = mean(baselineTotals);
-  const simulatedMean = mean(simulatedTotals);
+  const baselineMean = mean(baselineTotals, excludeOutliers);
+  const simulatedMean = mean(simulatedTotals, excludeOutliers);
   const daysSaved =
     baselineMean != null && simulatedMean != null
       ? Math.max(0, baselineMean - simulatedMean)
@@ -839,10 +849,10 @@ export function aggregateSimulation(
   const sortedSegMedian = (vals: number[]) =>
     [...vals].sort((left, right) => left - right);
   const simulatedStagesMean = buildStages(
-    mean(segs.procToPS) ?? 0,
-    mean(segs.prodStartToFinish) ?? 0,
-    mean(segs.prodFinishToQa) ?? 0,
-    mean(segs.qaToCustomer) ?? 0,
+    mean(segs.procToPS, excludeOutliers) ?? 0,
+    mean(segs.prodStartToFinish, excludeOutliers) ?? 0,
+    mean(segs.prodFinishToQa, excludeOutliers) ?? 0,
+    mean(segs.qaToCustomer, excludeOutliers) ?? 0,
     activeSegments,
   );
   const simulatedStagesMedian = buildStages(

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/dwell-table.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/dwell-table.tsx
@@ -8,6 +8,7 @@ import {
   selectStat,
   useBaseMeasure,
 } from "../../shared/measure-context";
+import { sampleTier } from "../../shared/sample-confidence";
 import { siteNodeKey } from "../../shared/site-node-key";
 import {
   deriveStatusActionState,
@@ -20,12 +21,7 @@ import { ColumnHeader } from "./shared/column-header";
 import { siteNodeDisplayLabel, sortRows } from "./shared/helpers";
 import { LowSampleBadge } from "./shared/low-sample-badge";
 import { ProductTags } from "./shared/product-tags";
-import {
-  LOW_SAMPLE_N,
-  type DwellRow,
-  type SortKey,
-  type SortDir,
-} from "./shared/row-types";
+import { type DwellRow, type SortKey, type SortDir } from "./shared/row-types";
 import * as threshold from "./shared/table-styles";
 import { useStepTableView } from "./shared/use-step-table-view";
 
@@ -263,14 +259,15 @@ export const DwellTable = ({
               </td>
               <td className={cx(threshold.tdRight, threshold.valueMuted)}>
                 <span className={threshold.sampleCell}>
-                  {row.stats.n > 0 && row.stats.n < LOW_SAMPLE_N && (
-                    <span className={threshold.badgeWrap}>
-                      <LowSampleBadge
-                        label="low"
-                        title={`Current period has ${row.stats.n} observations`}
-                      />
-                    </span>
-                  )}
+                  {sampleTier(row.stats.n) !== "none" &&
+                    sampleTier(row.stats.n) !== "good" && (
+                      <span className={threshold.badgeWrap}>
+                        <LowSampleBadge
+                          label={sampleTier(row.stats.n)}
+                          title={`Current period has ${row.stats.n} observations`}
+                        />
+                      </span>
+                    )}
                   <span>{formatNumber(row.stats.n)}</span>
                 </span>
               </td>

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/opportunities-table.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/opportunities-table.tsx
@@ -129,6 +129,10 @@ const sampleGood = css({
   color: "status.success.fg.body",
   bg: "status.success.bg.subtle",
 });
+const sampleLimited = css({
+  color: "status.warning.fg.body",
+  bg: "status.warning.bg.subtle",
+});
 const sampleBad = css({
   color: "status.error.fg.body",
   bg: "status.error.bg.subtle",
@@ -300,6 +304,9 @@ function sampleTooltip(opportunity: SiteOpportunity) {
 function sampleClass(label: string): string {
   if (label === "Good sample") {
     return sampleGood;
+  }
+  if (label === "Limited sample") {
+    return sampleLimited;
   }
   return sampleBad;
 }
@@ -659,7 +666,13 @@ export const OpportunitiesTable = ({
                               sampleClass(opportunity.confidenceLabel),
                             )}
                           >
-                            {opportunity.confidenceLabel}
+                            {opportunity.confidenceLabel === "Low sample"
+                              ? "low"
+                              : opportunity.confidenceLabel === "Limited sample"
+                                ? "limited"
+                                : opportunity.confidenceLabel === "Good sample"
+                                  ? "good"
+                                  : opportunity.confidenceLabel}
                           </span>
                         </Tooltip>
                       </td>

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/opportunities.test.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/opportunities.test.ts
@@ -234,6 +234,29 @@ describe("buildSiteOpportunities", () => {
         ?.confidenceLabel,
     ).toBe("Good sample");
   });
+
+  it("distinguishes low and limited current samples", () => {
+    const opportunities = build({
+      planningRows: [
+        planning({
+          id: "low",
+          stats: stats({ n: 4, median: 8, p95: 13 }),
+        }),
+        planning({
+          id: "limited",
+          stats: stats({ n: 5, median: 8, p95: 13 }),
+        }),
+        planning({
+          id: "good",
+          stats: stats({ n: 10, median: 8, p95: 13 }),
+        }),
+      ],
+    });
+
+    expect(opportunities.map(({ confidenceLabel }) => confidenceLabel)).toEqual(
+      ["Low sample", "Limited sample", "Good sample"],
+    );
+  });
 });
 
 describe("status helpers", () => {

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/opportunities.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/opportunities.ts
@@ -1,8 +1,8 @@
 import { formatCost, formatNumber } from "../../shared/cost";
 import { procurementStepDisplayLabel } from "../../shared/procurement-planning-ui";
+import { combinedSampleTier } from "../../shared/sample-confidence";
 import { siteNodeKey } from "../../shared/site-node-key";
 import { siteNodeDisplayLabel } from "./shared/helpers";
-import { LOW_SAMPLE_N } from "./shared/row-types";
 
 import type { StatusOption } from "../../shared/status";
 import type { TimeRange } from "../../shared/time-range";
@@ -84,23 +84,26 @@ function confidenceLabel(
   if (!hasRequiredData) {
     return "Low sample";
   }
-  if (
-    currentN < LOW_SAMPLE_N ||
-    (includePrevious &&
-      previousN != null &&
-      previousN > 0 &&
-      previousN < LOW_SAMPLE_N)
-  ) {
+  const tier = combinedSampleTier(currentN, includePrevious ? previousN : null);
+  if (tier === "low" || tier === "none") {
     return "Low sample";
+  }
+  if (tier === "limited") {
+    return "Limited sample";
   }
   return "Good sample";
 }
 
-function sampleLabel(currentN: number, previousN?: number | null): string {
+function sampleLabel(
+  currentN: number,
+  previousN?: number | null,
+  timingGrain?: "campaign" | null,
+): string {
+  const noun = timingGrain === "campaign" ? "Campaigns" : "Samples";
   if (previousN == null || previousN <= 0) {
-    return `Samples ${formatNumber(currentN)}`;
+    return `${noun} ${formatNumber(currentN)}`;
   }
-  return `Samples ${formatNumber(currentN)}; prev ${formatNumber(previousN)}`;
+  return `${noun} ${formatNumber(currentN)}; prev ${formatNumber(previousN)}`;
 }
 
 function opportunityTitle(row: SiteNode): string {
@@ -137,7 +140,7 @@ function planningOpportunity(
     impactValue: `${p95DeviationPct > 0 ? "+" : ""}${formatNumber(p95DeviationPct, { maximumFractionDigits: 0 })}%`,
     impactTone: kind === "planning_over" ? "danger" : "success",
     evidence: `Plan ${formatNumber(plan, { maximumFractionDigits: 0 })}d; median ${formatNumber(row.stats.median, { maximumFractionDigits: 1 })}d; P95 ${formatNumber(row.stats.p95, { maximumFractionDigits: 1 })}d`,
-    sampleLabel: sampleLabel(row.stats.n),
+    sampleLabel: sampleLabel(row.stats.n, null, row.timing_grain),
     currentSampleN: row.stats.n,
     confidenceLabel: confidenceLabel(row.stats.n, null, true, false),
     score: Math.abs(p95DeviationPct),
@@ -188,7 +191,7 @@ export function buildSiteOpportunities({
       impactValue: formatCost(row.periodCost, currency, { compact: true }),
       impactTone: "danger",
       evidence: `${formatNumber(days, { maximumFractionDigits: 1 })}d observed; ${formatNumber(row.stats.p95, { maximumFractionDigits: 1 })}d P95`,
-      sampleLabel: sampleLabel(row.stats.n),
+      sampleLabel: sampleLabel(row.stats.n, null, row.timing_grain),
       currentSampleN: row.stats.n,
       confidenceLabel: confidenceLabel(
         row.stats.n,

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/planning-table.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/planning-table.tsx
@@ -12,6 +12,7 @@ import {
 } from "../../shared/measure-context";
 import { PlanningWarningIndicator } from "../../shared/planning-warning-indicator";
 import { procurementStepDisplayLabel } from "../../shared/procurement-planning-ui";
+import { combinedSampleTier } from "../../shared/sample-confidence";
 import { siteNodeKey } from "../../shared/site-node-key";
 import {
   deriveStatusActionState,
@@ -26,7 +27,6 @@ import { siteNodeDisplayLabel, sortPlanningRows } from "./shared/helpers";
 import { LowSampleBadge } from "./shared/low-sample-badge";
 import { ProductTags } from "./shared/product-tags";
 import {
-  LOW_SAMPLE_N,
   type PlanningRow,
   type SortKey,
   type SortDir,
@@ -62,13 +62,6 @@ function planningStepLabel(row: PlanningRow): string {
     : label;
 }
 
-function isLowSample(row: PlanningRow): boolean {
-  return (
-    (row.stats.n > 0 && row.stats.n < LOW_SAMPLE_N) ||
-    (row.previousTrendN > 0 && row.previousTrendN < LOW_SAMPLE_N)
-  );
-}
-
 const PlanningSampleTooltip = ({
   currentN,
   previousN,
@@ -78,17 +71,9 @@ const PlanningSampleTooltip = ({
 }) => {
   return (
     <span>
-      {currentN > 0 && currentN < LOW_SAMPLE_N
-        ? `Current period has ${currentN} observations`
-        : ""}
-      {currentN > 0 &&
-      currentN < LOW_SAMPLE_N &&
-      previousN > 0 &&
-      previousN < LOW_SAMPLE_N
-        ? "; "
-        : ""}
-      {previousN > 0 && previousN < LOW_SAMPLE_N
-        ? `Previous comparison period has ${previousN} observations`
+      Current period has {currentN} observations
+      {previousN > 0
+        ? `; previous comparison period has ${previousN} observations`
         : ""}
     </span>
   );
@@ -317,6 +302,10 @@ export const PlanningTable = ({
             const deviationPct = row.deviationPct;
             const hasDeviation = deviationPct != null;
             const isOver = deviationPct != null && deviationPct > 0;
+            const sampleLevel = combinedSampleTier(
+              row.stats.n,
+              row.previousTrendN,
+            );
             return (
               <tr
                 key={siteNodeKey(row)}
@@ -403,10 +392,10 @@ export const PlanningTable = ({
                 >
                   <span className={threshold.stackedCell}>
                     <TrendIndicator pctChange={row.trendPct} />
-                    {isLowSample(row) && (
+                    {(sampleLevel === "low" || sampleLevel === "limited") && (
                       <span className={threshold.badgeWrap}>
                         <LowSampleBadge
-                          label="low sample"
+                          label={`${sampleLevel} sample`}
                           title={
                             <PlanningSampleTooltip
                               currentN={row.stats.n}

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/shared/helpers.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/shared/helpers.ts
@@ -3,7 +3,11 @@ import { formatMonth } from "../../../shared/chart-format";
 import { computeMonthlyCost, formatNumber } from "../../../shared/cost";
 import { type BaseMeasure, selectStat } from "../../../shared/measure-context";
 import {
-  LOW_SAMPLE_N,
+  combinedSampleTier,
+  isExcludedLowSample,
+  sampleTier,
+} from "../../../shared/sample-confidence";
+import {
   type DwellRow,
   type PlanningRow,
   type SortKey,
@@ -20,7 +24,7 @@ import type {
 // ── Sample / formatting helpers ────────────────────────────────────────────
 
 export function hasEnoughSample(count: number): boolean {
-  return count >= LOW_SAMPLE_N;
+  return !isExcludedLowSample(count);
 }
 
 export function colorForOtif(otif: number | null): string {
@@ -41,15 +45,17 @@ export function lowSampleBadges(
   previousN?: number | null,
 ): Array<{ label: string; title: string }> {
   const badges: Array<{ label: string; title: string }> = [];
-  if (currentN > 0 && currentN < LOW_SAMPLE_N) {
+  const currentTier = sampleTier(currentN);
+  if (currentTier === "low" || currentTier === "limited") {
     badges.push({
-      label: "low sample",
+      label: `${currentTier} sample`,
       title: `Current period has ${currentN} observations`,
     });
   }
-  if (previousN != null && previousN > 0 && previousN < LOW_SAMPLE_N) {
+  const previousTier = combinedSampleTier(previousN);
+  if (previousTier === "low" || previousTier === "limited") {
     badges.push({
-      label: "low sample prev",
+      label: `${previousTier} sample prev`,
       title: `Previous comparison period has ${previousN} observations`,
     });
   }

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/shared/low-sample-badge.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/shared/low-sample-badge.tsx
@@ -1,5 +1,5 @@
 import { Tooltip } from "@hashintel/ds-components";
-import { css } from "@hashintel/ds-helpers/css";
+import { css, cx } from "@hashintel/ds-helpers/css";
 
 import type { ReactNode } from "react";
 
@@ -9,18 +9,25 @@ const badge = css({
   borderRadius: "sm",
   borderWidth: "1px",
   borderStyle: "solid",
-  borderColor: "status.warning.bd.subtle",
-  bg: "status.warning.bg.subtle",
   px: "1.5",
   py: "[1px]",
   textStyle: "xxs",
   fontWeight: "medium",
   lineHeight: "none",
-  color: "status.warning.fg.body",
   whiteSpace: "nowrap",
 });
+const low = css({
+  borderColor: "status.error.bd.subtle",
+  bg: "status.error.bg.subtle",
+  color: "status.error.fg.body",
+});
+const limited = css({
+  borderColor: "status.warning.bd.subtle",
+  bg: "status.warning.bg.subtle",
+  color: "status.warning.fg.body",
+});
 
-/** Amber pill flagging a row whose sample size is below the reliable threshold. */
+/** Sample-size pill: red for low, amber for limited. */
 export const LowSampleBadge = ({
   label,
   title,
@@ -30,7 +37,9 @@ export const LowSampleBadge = ({
 }) => {
   return (
     <Tooltip content={title} openDelay="fast">
-      <span className={badge}>{label}</span>
+      <span className={cx(badge, label.startsWith("low") ? low : limited)}>
+        {label}
+      </span>
     </Tooltip>
   );
 };

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/shared/row-types.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/shared/row-types.ts
@@ -1,7 +1,5 @@
 import type { SiteNode } from "../../../shared/types";
 
-export const LOW_SAMPLE_N = 10;
-
 export type Tab = "dwell" | "planning" | "trends" | "suppliers";
 
 export type SortKey =

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/trend-table.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/trend-table.tsx
@@ -9,6 +9,10 @@ import {
   selectStat,
   useBaseMeasure,
 } from "../../shared/measure-context";
+import {
+  combinedSampleTier,
+  type SampleTier,
+} from "../../shared/sample-confidence";
 import { siteNodeKey } from "../../shared/site-node-key";
 import {
   deriveStatusActionState,
@@ -21,12 +25,7 @@ import { ColumnHeader } from "./shared/column-header";
 import { siteNodeDisplayLabel, sortTrendRows } from "./shared/helpers";
 import { LowSampleBadge } from "./shared/low-sample-badge";
 import { ProductTags } from "./shared/product-tags";
-import {
-  LOW_SAMPLE_N,
-  type SortDir,
-  type SortKey,
-  type TrendRow,
-} from "./shared/row-types";
+import { type SortDir, type SortKey, type TrendRow } from "./shared/row-types";
 import * as threshold from "./shared/table-styles";
 import { useStepTableView } from "./shared/use-step-table-view";
 
@@ -96,11 +95,8 @@ const TrendValue = ({
   );
 };
 
-function isLowSample(row: TrendRow): boolean {
-  return (
-    (row.stats.n > 0 && row.stats.n < LOW_SAMPLE_N) ||
-    (row.previousTrendN > 0 && row.previousTrendN < LOW_SAMPLE_N)
-  );
+function rowSampleTier(row: TrendRow): SampleTier {
+  return combinedSampleTier(row.stats.n, row.previousTrendN);
 }
 
 const TrendSampleTooltip = ({
@@ -288,10 +284,11 @@ export const TrendTable = ({
               </td>
               <td className={cx(threshold.tdRight, threshold.valueMuted)}>
                 <span className={threshold.sampleCell}>
-                  {isLowSample(row) && (
+                  {(rowSampleTier(row) === "low" ||
+                    rowSampleTier(row) === "limited") && (
                     <span className={threshold.badgeWrap}>
                       <LowSampleBadge
-                        label="low"
+                        label={rowSampleTier(row)}
                         title={
                           <TrendSampleTooltip
                             currentN={row.stats.n}

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/use-site-overview-rows.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/use-site-overview-rows.ts
@@ -19,8 +19,8 @@ import {
   summarizeProcurementPlanning,
 } from "../../shared/procurement-planning";
 import {
-  windowGraphNodeToRange,
   applyProcurementBasisToNode,
+  filterGraphNodeByDateRange,
 } from "../../shared/range-filter";
 import {
   totalSiteDwellCost,
@@ -124,11 +124,16 @@ export function useSiteOverviewRows({
   }, [dedupedNodes, excludeOutliers, procurementBasis]);
 
   const filteredNodes = useMemo((): SiteNode[] => {
-    return historicalNodes.map((count) => ({
-      ...windowGraphNodeToRange(count, timeRange),
+    return dedupedNodes.map((count) => ({
+      ...filterGraphNodeByDateRange(
+        count,
+        timeRange,
+        excludeOutliers,
+        procurementBasis,
+      ),
       products: count.products,
     }));
-  }, [historicalNodes, timeRange]);
+  }, [dedupedNodes, excludeOutliers, procurementBasis, timeRange]);
 
   const historicalNodesByKey = useMemo(() => {
     return new Map(historicalNodes.map((count) => [siteNodeKey(count), count]));


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The PR is primarily aimed at supporting a production campaign-based measurement of QA hold, whereby a single observation is produced per production campaign, rather than an observation per batch. The rationale being that the actual time for QA testing starts when the campaign is finished, and earlier batches in the campaign aren't on hold for QA, they're on hold for the entire production to be complete.

Because this massively reduces the number of observations for production -> QA release, the PR also includes some rethinking of the 'exclude low samples' logic (most campaigns become 'low sample'). Instead, a 'low sample' is now `< 5` (was `< 10`), and we introduce a new 'limited' sample tier at `5-9` which isn't excluded when the box is checked, but is shown with a badge.

Finally, the 'exclude outliers' logic is updated to only apply when calculating the mean. It previously applied to everything, but the median is already resistant to outliers, and the P95 (which drives planning parameter mismatch observations) should include the tail (and excluding outliers from the P95 when you have a population of e.g. a lot of 2 day QA release observations, and then a sizeable minority of 5 day QA release, leads to less informative results).

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->
<!-- Libraries inside of the `@local` directory are always internal libraries which have no need for publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
