### PR TITLE
H-6715, H-6740, H-6741: Product timeline search, bulk opportunity export, show comments on status input

### DIFF
--- a/apps/hash-frontend/src/pages/supply-chain/README.md
+++ b/apps/hash-frontend/src/pages/supply-chain/README.md
@@ -105,6 +105,7 @@ product display labels, raw analysis values, or client-specific data.
 - `production_schedule_granularity_changed`
 - `production_schedule_lineage_selected`
 - `production_schedule_batch_drilled`
+- `production_schedule_identifier_searched`
 - `opportunity_marked_read`
 - `opportunity_marked_unread`
 - `wacc_changed`
@@ -115,9 +116,10 @@ product display labels, raw analysis values, or client-specific data.
 - `procurement_basis_changed`
 - `time_range_changed`
 
-Timeline interactions never send batch/order identifiers, dates, quantities,
-campaign names, or filter values. A failed optional schedule fetch is reported
-as `supply_chain_error` with interaction
+Timeline identifier search reports only whether a match was found and the
+matched identifier type. Timeline interactions never send batch/order
+identifiers, dates, quantities, campaign names, or filter values. A failed
+optional schedule fetch is reported as `supply_chain_error` with interaction
 `production_schedule_fetch_failed`.
 
 ### Status Reports

--- a/apps/hash-frontend/src/pages/supply-chain/shared/docs/docs-modal/docs-content/step-qa.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/docs/docs-modal/docs-content/step-qa.tsx
@@ -8,18 +8,22 @@ export const qaDoc: DocEntry = {
   render: () => (
     <>
       <Lead>
-        QA hold measures the time a production campaign waits between production
-        completion and QA release &mdash; the quality inspection and hold
-        period.
+        QA hold measures the quality inspection and hold period between
+        production completion and QA release.
       </Lead>
       <P>
-        <Term>What it measures:</Term> the time between a production campaign
-        finishing and the associated QA release. The full 'data' table also
-        shows the time between each batch's production finish and QA release.
+        <Term>Composite-tested materials:</Term> one observation per production
+        campaign, measured from the final batch receipt in that campaign to its
+        QA release. The full 'data' table retains each batch as supporting
+        evidence.
       </P>
       <P>
-        <Term>Time filtering:</Term> observations are anchored to the campaign
-        end date.
+        <Term>Other materials:</Term> one observation per finished-good batch,
+        measured from that batch's production receipt to its QA release.
+      </P>
+      <P>
+        <Term>Time filtering:</Term> both observation series are anchored to the
+        QA release date.
       </P>
       <P>
         The wait that follows QA release &mdash; from release to dispatch

--- a/apps/hash-frontend/src/pages/supply-chain/shared/export-utils.test.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/export-utils.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { buildCsvContent } from "./export-utils";
+
+describe("buildCsvContent", () => {
+  it("quotes and escapes multiline CSV values", () => {
+    const csv = buildCsvContent(
+      [
+        {
+          key: "comments",
+          label: "Comments",
+          source_field: null,
+          source_table: null,
+        },
+      ],
+      [{ comments: 'First line\nSecond "quoted" line' }],
+    );
+
+    expect(csv).toBe('"Comments"\n"First line\nSecond ""quoted"" line"');
+  });
+
+  it("neutralizes strings that spreadsheet applications treat as formulas", () => {
+    const csv = buildCsvContent(
+      [
+        {
+          key: "value",
+          label: "Value",
+          source_field: null,
+          source_table: null,
+        },
+      ],
+      [
+        { value: '=HYPERLINK("https://example.com")' },
+        { value: " \t+SUM(1,2)" },
+        { value: "-identifier" },
+        { value: "@author" },
+        { value: 42 },
+      ],
+    );
+
+    expect(csv).toContain(`"'=HYPERLINK(""https://example.com"")"`);
+    expect(csv).toContain(`"' \t+SUM(1,2)"`);
+    expect(csv).toContain("'-identifier");
+    expect(csv).toContain("'@author");
+    expect(csv).toContain("\n42");
+  });
+
+  it("escapes and neutralizes dynamic header metadata", () => {
+    const csv = buildCsvContent(
+      [
+        {
+          key: "value",
+          label: '=Header "name"',
+          source_field: "FIELD\nNAME",
+          source_table: "@TABLE",
+        },
+      ],
+      [{ value: "safe" }],
+    );
+
+    expect(csv).toBe(`"'=Header ""name"" (@TABLE.FIELD\nNAME)"\nsafe`);
+  });
+});

--- a/apps/hash-frontend/src/pages/supply-chain/shared/export-utils.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/export-utils.ts
@@ -1,30 +1,53 @@
 import type { DetailColumn } from "./types";
 
+const neutralizeSpreadsheetFormula = (value: string): string => {
+  let index = 0;
+  while (index < value.length && value.charCodeAt(index) <= 0x20) {
+    index += 1;
+  }
+  return index < value.length && "=+-@".includes(value[index]!)
+    ? `'${value}`
+    : value;
+};
+
+const encodeCsvValue = (
+  value: string | number | null | undefined,
+  alwaysQuote = false,
+): string => {
+  if (value == null) {
+    return "";
+  }
+  const safeValue =
+    typeof value === "string" ? neutralizeSpreadsheetFormula(value) : value;
+  const serializedValue = String(safeValue);
+  if (
+    alwaysQuote ||
+    serializedValue.includes(",") ||
+    serializedValue.includes('"') ||
+    serializedValue.includes("\n") ||
+    serializedValue.includes("\r")
+  ) {
+    return `"${serializedValue.replace(/"/g, '""')}"`;
+  }
+  return serializedValue;
+};
+
 export function buildCsvContent(
   columns: DetailColumn[],
   rows: Record<string, string | number | null>[],
 ): string {
   const headers = columns.map((col) => {
-    if (col.source_table && col.source_field) {
-      return `"${col.label} (${col.source_table}.${col.source_field})"`;
-    }
-    return `"${col.label}"`;
+    const source =
+      col.source_table && col.source_field
+        ? ` (${col.source_table}.${col.source_field})`
+        : "";
+    return encodeCsvValue(`${col.label}${source}`, true);
   });
 
   const csvRows = rows.map((row) =>
     columns
       .map((col) => {
-        const val = row[col.key];
-        if (val == null) {
-          return "";
-        }
-        if (
-          typeof val === "string" &&
-          (val.includes(",") || val.includes('"'))
-        ) {
-          return `"${val.replace(/"/g, '""')}"`;
-        }
-        return String(val);
+        return encodeCsvValue(row[col.key]);
       })
       .join(","),
   );

--- a/apps/hash-frontend/src/pages/supply-chain/shared/observation-labels.test.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/observation-labels.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, it } from "vitest";
 
-import { countNoun, countTooltip, shortCountLabel } from "./observation-labels";
+import {
+  countNoun,
+  countTooltip,
+  dateAnchorLabel,
+  effectiveTimingGrain,
+  shortCountLabel,
+} from "./observation-labels";
 
-describe("campaign observation labels", () => {
+describe("QA observation labels", () => {
   const qaCampaign = {
     id: "prod_to_qa",
     label: "Production to QA",
@@ -16,6 +22,45 @@ describe("campaign observation labels", () => {
     expect(
       countTooltip({ ...qaCampaign, count: 7, rangeLabel: "12m" }),
     ).toContain("7 campaigns in the last 12 months");
+    expect(dateAnchorLabel(qaCampaign)).toBe("QA release date");
+    expect(
+      countTooltip({
+        ...qaCampaign,
+        count: 7,
+        nCampaigns: 7,
+        nBatches: 20,
+      }),
+    ).toContain("7 campaigns across 20 batches");
+  });
+
+  it("treats omitted and explicit batch QA grain as batches", () => {
+    const omittedBatch = {
+      id: "prod_to_qa",
+      label: "Production to QA",
+      type: "qa_hold" as const,
+    };
+    const explicitBatch = {
+      ...omittedBatch,
+      timingGrain: "batch" as const,
+    };
+
+    expect(effectiveTimingGrain(omittedBatch)).toBe("batch");
+    expect(countNoun(omittedBatch)).toBe("batches");
+    expect(countNoun(explicitBatch)).toBe("batches");
+    expect(shortCountLabel(12, omittedBatch)).toBe("12 batches");
+    expect(
+      countTooltip({ ...omittedBatch, count: 12, nBatches: 30 }),
+    ).toContain("All-time source coverage: 30 batches.");
+    expect(countTooltip({ ...omittedBatch, count: 12 })).toContain(
+      "each finished-good batch contributes one QA-hold event",
+    );
+    expect(dateAnchorLabel(omittedBatch)).toBe("QA release date");
+  });
+
+  it("keeps omitted non-QA timing at generic event grain", () => {
+    const transit = { type: "transit" as const };
+    expect(effectiveTimingGrain(transit)).toBeNull();
+    expect(countNoun(transit)).toBe("events");
   });
 
   it("keeps yield and consumption terminology ahead of timing grain", () => {

--- a/apps/hash-frontend/src/pages/supply-chain/shared/observation-labels.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/observation-labels.ts
@@ -1,4 +1,4 @@
-import type { StepType } from "./types";
+import type { StepType, TimingGrain } from "./types";
 
 export type CountDimension = "timing" | "yield" | "consumption" | "supplier";
 
@@ -8,7 +8,7 @@ interface CountContext {
   type: StepType;
   dimension?: CountDimension;
   selectedComponent?: boolean;
-  timingGrain?: "campaign" | null;
+  timingGrain?: TimingGrain | null;
 }
 
 interface CountTooltipContext extends CountContext {
@@ -26,6 +26,15 @@ function isDirectShip(ctx: Pick<CountContext, "id" | "label">): boolean {
   );
 }
 
+export function effectiveTimingGrain(
+  ctx: Pick<CountContext, "type" | "timingGrain">,
+): TimingGrain | null {
+  if (ctx.timingGrain) {
+    return ctx.timingGrain;
+  }
+  return ctx.type === "qa_hold" ? "batch" : null;
+}
+
 export function countNoun(ctx: CountContext): string {
   if (ctx.dimension === "yield") {
     return "production orders";
@@ -36,8 +45,12 @@ export function countNoun(ctx: CountContext): string {
   if (ctx.dimension === "supplier") {
     return "schedule lines";
   }
-  if (ctx.timingGrain === "campaign") {
+  const grain = effectiveTimingGrain(ctx);
+  if (grain === "campaign") {
     return "campaigns";
+  }
+  if (grain === "batch") {
+    return "batches";
   }
   return "events";
 }
@@ -85,9 +98,7 @@ export function dateAnchorLabel(ctx: CountContext): string {
     case "production":
       return "schedule start";
     case "qa_hold":
-      return ctx.timingGrain === "campaign"
-        ? "campaign reference date"
-        : "production receipt date";
+      return "QA release date";
     case "post_qa_ship":
       return "QA release date";
     case "transit":
@@ -121,9 +132,9 @@ function eventMethodology(ctx: CountContext): string {
     case "production":
       return "each production schedule campaign contributes one duration event.";
     case "qa_hold":
-      return ctx.timingGrain === "campaign"
-        ? "each campaign contributes one timing observation; batch rows are supporting evidence."
-        : "each finished-good batch contributes one QA-hold event.";
+      return effectiveTimingGrain(ctx) === "campaign"
+        ? "each campaign contributes one timing observation, measured from campaign end; batch rows are supporting evidence."
+        : "each finished-good batch contributes one QA-hold event, measured from batch receipt.";
     case "post_qa_ship":
       return "each dispatch (customer delivery or hub transfer) contributes one post-QA dwell event.";
     case "transit":
@@ -139,8 +150,12 @@ export function countTooltip(ctx: CountTooltipContext): string {
   const label = shortCountLabel(ctx.count, ctx);
   const period = rangeLabel(ctx.rangeLabel);
   const base = `${label} in ${period}. Filtered by ${dateAnchorLabel(ctx)}; ${eventMethodology(ctx)}`;
-  if (ctx.nCampaigns != null && ctx.nBatches != null) {
+  const grain = effectiveTimingGrain(ctx);
+  if (grain === "campaign" && ctx.nCampaigns != null && ctx.nBatches != null) {
     return `${base} All-time source coverage: ${ctx.nCampaigns} campaigns across ${ctx.nBatches} batches.`;
+  }
+  if (grain === "batch" && ctx.nBatches != null) {
+    return `${base} All-time source coverage: ${ctx.nBatches} batches.`;
   }
   if (ctx.nBatches != null && ctx.nMovements != null) {
     return `${base} All-time source coverage: ${ctx.nBatches} batches, ${ctx.nMovements} movements.`;

--- a/apps/hash-frontend/src/pages/supply-chain/shared/records-derive.test.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/records-derive.test.ts
@@ -100,6 +100,40 @@ describe("deriveTimingFromRecords", () => {
     expect(out.n_batches).toBe(5);
   });
 
+  it("uses detail_rows as canonical observations for omitted-grain batch QA", () => {
+    const step = recordsOnlyStep({
+      type: "qa_hold",
+      timing_grain: undefined,
+      n_batches: 2,
+      campaign_rows: undefined,
+      detail_rows: {
+        columns: [],
+        rows: [
+          {
+            qa_decision_date: "2026-01-12",
+            prod_to_qa_decision_days: 4,
+          },
+          {
+            qa_decision_date: "2026-02-15",
+            prod_to_qa_decision_days: 8,
+          },
+        ],
+      },
+      ref_date_col: "qa_decision_date",
+      value_col: "prod_to_qa_decision_days",
+    });
+
+    const out = ensureStepStats(step);
+
+    expect(out.observations).toEqual([
+      { date: "2026-01-12", value: 4 },
+      { date: "2026-02-15", value: 8 },
+    ]);
+    expect(out.stats.n).toBe(2);
+    expect(out.n_batches).toBe(2);
+    expect(out.campaign_rows).toBeUndefined();
+  });
+
   it("rehydrates observations/durations/monthly/stats from detail_rows", () => {
     const derived = deriveTimingFromRecords(recordsOnlyStep());
     expect(

--- a/apps/hash-frontend/src/pages/supply-chain/shared/search-input.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/search-input.tsx
@@ -1,0 +1,44 @@
+import { TextInput } from "@hashintel/ds-components";
+import { css } from "@hashintel/ds-helpers/css";
+
+import type { ComponentProps } from "react";
+
+const searchContainer = css({
+  w: "[220px]",
+  maxW: "[40vw]",
+});
+
+type SearchInputSize = NonNullable<ComponentProps<typeof TextInput>["size"]>;
+
+export const SupplyChainSearchInput = ({
+  ariaLabel,
+  onChange,
+  placeholder = "Search...",
+  size = "md",
+  value,
+}: {
+  ariaLabel: string;
+  onChange: (query: string) => void;
+  placeholder?: string;
+  size?: SearchInputSize;
+  value: string;
+}) => {
+  return (
+    <div className={searchContainer} role="search">
+      <TextInput
+        type="search"
+        value={value}
+        size={size}
+        width="fullWidth"
+        prefix={{ iconName: "search", variant: "subtle" }}
+        clearable={{
+          clearable: value.length > 0,
+          onClear: () => onChange(""),
+        }}
+        placeholder={placeholder}
+        aria-label={ariaLabel}
+        onChange={onChange}
+      />
+    </div>
+  );
+};

--- a/apps/hash-frontend/src/pages/supply-chain/shared/status-dialog.test.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/status-dialog.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { StatusDialog } from "./status-dialog";
+
+vi.mock("@hashintel/ds-components", () => ({
+  Select: ({
+    htmlForId,
+    items,
+    onChange,
+    value,
+  }: {
+    htmlForId: string;
+    items: Array<{ value: string; text: string }>;
+    onChange: (value: string) => void;
+    value: string;
+  }) => (
+    <select
+      id={htmlForId}
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+    >
+      {items.map((item) => (
+        <option key={item.value} value={item.value}>
+          {item.text}
+        </option>
+      ))}
+    </select>
+  ),
+  usePortalContainerRef: () => null,
+}));
+
+vi.mock("./telemetry", () => ({
+  trackSupplyChainInteraction: vi.fn(),
+}));
+
+describe("StatusDialog", () => {
+  afterEach(cleanup);
+
+  it("shows previous updates in chronological order", () => {
+    render(
+      <StatusDialog
+        title="QA hold"
+        entries={[
+          {
+            at: "2026-02-02T12:00:00.000Z",
+            user: "Later user",
+            category: "Investigation update",
+            text: "Later comment",
+          },
+          {
+            at: "2026-01-01T12:00:00.000Z",
+            user: "Earlier user",
+            category: "Investigation started",
+            text: "",
+          },
+        ]}
+        inline
+        onClose={vi.fn()}
+        onSave={vi.fn()}
+      />,
+    );
+
+    const updates = screen.getAllByRole("article");
+    expect(
+      screen
+        .getByRole("region", { name: "Previous status updates" })
+        .getAttribute("tabindex"),
+    ).toBe("0");
+    expect(screen.getByRole<HTMLSelectElement>("combobox").value).toBe(
+      "Investigation update",
+    );
+    expect(updates[0]?.textContent).toContain("Earlier user");
+    expect(updates[0]?.textContent).toContain("(no comment)");
+    expect(updates[1]?.textContent).toContain("Later comment");
+  });
+
+  it("uses the selected status and validates its required comment", () => {
+    const onSave = vi.fn();
+    render(
+      <StatusDialog title="QA hold" inline onClose={vi.fn()} onSave={onSave} />,
+    );
+    expect(screen.queryByText("Previous updates")).toBeNull();
+
+    fireEvent.change(screen.getByRole("combobox", { name: "Status" }), {
+      target: { value: "Investigation concluded" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save status" }));
+
+    expect(screen.getByText("Add a comment for this status.")).toBeTruthy();
+    expect(onSave).not.toHaveBeenCalled();
+
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "Issue resolved" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save status" }));
+
+    expect(onSave).toHaveBeenCalledWith({
+      category: "Investigation concluded",
+      text: "Issue resolved",
+    });
+  });
+});

--- a/apps/hash-frontend/src/pages/supply-chain/shared/status-dialog.test.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/status-dialog.test.tsx
@@ -4,7 +4,31 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { StatusDialog } from "./status-dialog";
 
+import type { ReactNode } from "react";
+
 vi.mock("@hashintel/ds-components", () => ({
+  Button: ({
+    "aria-label": ariaLabel,
+    children,
+    className,
+    onClick,
+    type,
+  }: {
+    "aria-label"?: string;
+    children?: ReactNode;
+    className?: string;
+    onClick?: () => void;
+    type?: "button" | "reset" | "submit";
+  }) => (
+    <button
+      aria-label={ariaLabel}
+      className={className}
+      onClick={onClick}
+      type={type === "submit" ? "submit" : "button"}
+    >
+      {children}
+    </button>
+  ),
   Select: ({
     htmlForId,
     items,
@@ -86,7 +110,7 @@ describe("StatusDialog", () => {
     fireEvent.change(screen.getByRole("combobox", { name: "Status" }), {
       target: { value: "Investigation concluded" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Save status" }));
+    fireEvent.click(screen.getByRole("button", { name: "Post" }));
 
     expect(screen.getByText("Add a comment for this status.")).toBeTruthy();
     expect(onSave).not.toHaveBeenCalled();
@@ -94,7 +118,7 @@ describe("StatusDialog", () => {
     fireEvent.change(screen.getByRole("textbox"), {
       target: { value: "Issue resolved" },
     });
-    fireEvent.click(screen.getByRole("button", { name: "Save status" }));
+    fireEvent.click(screen.getByRole("button", { name: "Post" }));
 
     expect(onSave).toHaveBeenCalledWith({
       category: "Investigation concluded",

--- a/apps/hash-frontend/src/pages/supply-chain/shared/status-dialog.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/status-dialog.tsx
@@ -2,11 +2,12 @@ import { useEffect, useId, useRef, useState, type FormEvent } from "react";
 import { createPortal } from "react-dom";
 
 import {
+  Button,
   Select,
   usePortalContainerRef,
   type SelectItem,
 } from "@hashintel/ds-components";
-import { css, cx } from "@hashintel/ds-helpers/css";
+import { css } from "@hashintel/ds-helpers/css";
 
 import {
   STATUS_OPTIONS,
@@ -53,12 +54,21 @@ const headerRow = css({
   gap: "3",
 });
 const titleStyle = css({
-  textStyle: "lg",
+  textStyle: "base",
   fontWeight: "semibold",
   color: "fg.heading",
 });
-const subtitle = css({ textStyle: "xs", color: "fg.subtle" });
 const body = css({
+  display: "flex",
+  flexDirection: "column",
+});
+const historySection = css({
+  px: "5",
+  py: "4",
+  borderBottomWidth: "1px",
+  borderColor: "bd.subtle",
+});
+const statusFields = css({
   px: "5",
   py: "4",
   display: "flex",
@@ -130,34 +140,11 @@ const footer = css({
   justifyContent: "flex-end",
   gap: "2",
 });
+
 // Save is first in DOM (so it's the first tab stop after the textarea) but
 // rendered on the right via flex order; Cancel keeps the left slot.
 const saveOrder = css({ order: "1" });
 const cancelOrder = css({ order: "0" });
-const button = css({
-  display: "inline-flex",
-  alignItems: "center",
-  gap: "1",
-  borderRadius: "sm",
-  borderWidth: "1px",
-  borderStyle: "solid",
-  borderColor: "bd.subtle",
-  px: "2.5",
-  py: "1",
-  textStyle: "xs",
-  lineHeight: "none",
-  fontWeight: "medium",
-  color: "fg.muted",
-  cursor: "pointer",
-  whiteSpace: "nowrap",
-  _hover: { borderColor: "bd.strong", color: "fg.heading" },
-});
-const primaryButton = css({
-  bg: "fg.heading",
-  color: "bgSolid.min",
-  borderColor: "fg.heading",
-  _hover: { bg: "fg.muted", color: "bgSolid.min" },
-});
 
 const DEFAULT_STATUS: StatusOption = "Investigation started";
 const latestStatusCategory = (entries: readonly StatusEntry[]): StatusOption =>
@@ -270,24 +257,21 @@ export const StatusDialog = ({
         onSubmit={handleSubmit}
       >
         <div className={headerRow}>
-          <div>
-            <h2 id="status-dialog-title" className={titleStyle}>
-              Status
-            </h2>
-            <p className={subtitle}>{title}</p>
-          </div>
-          <button
-            type="button"
-            className={button}
-            aria-label="Close status"
+          <h2 id="status-dialog-title" className={titleStyle}>
+            {title}
+          </h2>
+          <Button
+            variant="ghost"
+            tone="neutral"
+            size="sm"
+            iconName="close"
+            aria-label="Close"
             onClick={handleCancel}
-          >
-            x
-          </button>
+          />
         </div>
         <div className={body}>
           {entries.length > 0 && (
-            <section>
+            <section className={historySection}>
               <div
                 className={history}
                 role="region"
@@ -322,52 +306,53 @@ export const StatusDialog = ({
               </div>
             </section>
           )}
-          <div className={fieldLabel}>
-            <label htmlFor={statusSelectId}>Status</label>
-            <Select
-              items={statusItems}
-              value={category}
-              onChange={selectCategory}
-              required
-              size="sm"
-              htmlForId={statusSelectId}
+          <div className={statusFields}>
+            <div className={fieldLabel}>
+              <label htmlFor={statusSelectId}>Status</label>
+              <Select
+                items={statusItems}
+                value={category}
+                onChange={selectCategory}
+                required
+                size="sm"
+                htmlForId={statusSelectId}
+              />
+            </div>
+            <textarea
+              ref={textareaRef}
+              className={textarea}
+              value={text}
+              onChange={(event) => {
+                setText(event.target.value);
+                if (error && event.target.value.trim()) {
+                  setError(null);
+                }
+              }}
+              placeholder="Add context, next actions, or why this is not feasible..."
+              aria-required={statusCommentRequired(category)}
+              aria-invalid={error ? true : undefined}
+              aria-describedby={error ? "status-dialog-error" : undefined}
             />
+            {error && (
+              <p id="status-dialog-error" className={errorText}>
+                {error}
+              </p>
+            )}
           </div>
-          <textarea
-            ref={textareaRef}
-            className={textarea}
-            value={text}
-            onChange={(event) => {
-              setText(event.target.value);
-              if (error && event.target.value.trim()) {
-                setError(null);
-              }
-            }}
-            placeholder="Add context, next actions, or why this is not feasible..."
-            aria-required={statusCommentRequired(category)}
-            aria-invalid={error ? true : undefined}
-            aria-describedby={error ? "status-dialog-error" : undefined}
-          />
-          {error && (
-            <p id="status-dialog-error" className={errorText}>
-              {error}
-            </p>
-          )}
         </div>
         <div className={footer}>
-          <button
-            type="submit"
-            className={cx(button, primaryButton, saveOrder)}
-          >
-            Save status
-          </button>
-          <button
+          <Button type="submit" variant="solid" size="sm" className={saveOrder}>
+            Post
+          </Button>
+          <Button
             type="button"
-            className={cx(button, cancelOrder)}
+            className={cancelOrder}
             onClick={handleCancel}
+            size="sm"
+            variant="subtle"
           >
             Cancel
-          </button>
+          </Button>
         </div>
       </form>
     </div>

--- a/apps/hash-frontend/src/pages/supply-chain/shared/status-dialog.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/status-dialog.tsx
@@ -1,12 +1,17 @@
-import { useEffect, useRef, useState, type FormEvent } from "react";
+import { useEffect, useId, useRef, useState, type FormEvent } from "react";
 import { createPortal } from "react-dom";
 
-import { usePortalContainerRef } from "@hashintel/ds-components";
+import {
+  Select,
+  usePortalContainerRef,
+  type SelectItem,
+} from "@hashintel/ds-components";
 import { css, cx } from "@hashintel/ds-helpers/css";
 
 import {
   STATUS_OPTIONS,
   statusCommentRequired,
+  type StatusEntry,
   type StatusOption,
 } from "./status";
 import { trackSupplyChainInteraction } from "./telemetry";
@@ -60,14 +65,47 @@ const body = css({
   flexDirection: "column",
   gap: "4",
 });
-const radioStack = css({ display: "flex", flexDirection: "column", gap: "2" });
-const radioLabel = css({
+const history = css({
+  display: "flex",
+  flexDirection: "column",
+  gap: "2",
+  minH: "0",
+  maxH: "[min(240px,35dvh)]",
+  flexShrink: "1",
+  overflowY: "auto",
+});
+const historyEntry = css({
+  borderWidth: "1px",
+  borderStyle: "solid",
+  borderColor: "bd.subtle",
+  borderRadius: "md",
+  px: "3",
+  py: "2",
+});
+const historyMeta = css({
   display: "flex",
   alignItems: "center",
-  gap: "2",
-  textStyle: "sm",
+  justifyContent: "space-between",
+  gap: "3",
+  textStyle: "xs",
+  color: "fg.subtle",
+});
+const historyCategory = css({
+  fontWeight: "medium",
   color: "fg.heading",
-  cursor: "pointer",
+});
+const historyComment = css({
+  mt: "1",
+  textStyle: "sm",
+  color: "fg.muted",
+  whiteSpace: "pre-wrap",
+});
+const fieldLabel = css({
+  display: "flex",
+  flexDirection: "column",
+  gap: "1",
+  textStyle: "xs",
+  color: "fg.subtle",
 });
 const textarea = css({
   minH: "28",
@@ -122,10 +160,23 @@ const primaryButton = css({
 });
 
 const DEFAULT_STATUS: StatusOption = "Investigation started";
+const latestStatusCategory = (entries: readonly StatusEntry[]): StatusOption =>
+  entries.reduce<StatusEntry | undefined>(
+    (latestEntry, entry) =>
+      !latestEntry || entry.at > latestEntry.at ? entry : latestEntry,
+    undefined,
+  )?.category ?? DEFAULT_STATUS;
+const statusItems: SelectItem<StatusOption>[] = STATUS_OPTIONS.map(
+  (option) => ({
+    value: option,
+    text: option,
+  }),
+);
 
 export interface StatusDialogProps {
   /** Subtitle shown under the heading (e.g. the step / opportunity title). */
   title: string;
+  entries?: readonly StatusEntry[];
   onClose: () => void;
   onSave: (status: { category: StatusOption; text: string }) => void;
   /**
@@ -142,18 +193,21 @@ export interface StatusDialogProps {
  */
 export const StatusDialog = ({
   title,
+  entries = [],
   onClose,
   onSave,
   inline = false,
 }: StatusDialogProps) => {
-  const [category, setCategory] = useState<StatusOption>(DEFAULT_STATUS);
+  const [category, setCategory] = useState<StatusOption>(() =>
+    latestStatusCategory(entries),
+  );
   const [text, setText] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const statusSelectId = useId();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const portalRef = usePortalContainerRef();
 
   useEffect(() => {
-    setCategory(DEFAULT_STATUS);
     setText("");
     setError(null);
     const id = requestAnimationFrame(() => {
@@ -232,19 +286,52 @@ export const StatusDialog = ({
           </button>
         </div>
         <div className={body}>
-          <div className={radioStack}>
-            {STATUS_OPTIONS.map((option) => (
-              <label key={option} className={radioLabel}>
-                <input
-                  type="radio"
-                  name="status-category"
-                  value={option}
-                  checked={category === option}
-                  onChange={() => selectCategory(option)}
-                />
-                {option}
-              </label>
-            ))}
+          {entries.length > 0 && (
+            <section>
+              <div
+                className={history}
+                role="region"
+                aria-label="Previous status updates"
+                // A bounded overflow region must be keyboard-focusable to scroll.
+                // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+                tabIndex={0}
+              >
+                {[...entries]
+                  .sort((left, right) => left.at.localeCompare(right.at))
+                  .map((entry) => (
+                    <article
+                      key={`${entry.at}-${entry.user}-${entry.category}-${entry.text}`}
+                      className={historyEntry}
+                    >
+                      <div className={historyMeta}>
+                        <span>
+                          <span className={historyCategory}>
+                            {entry.category}
+                          </span>{" "}
+                          · {entry.user}
+                        </span>
+                        <time dateTime={entry.at}>
+                          {new Date(entry.at).toLocaleString()}
+                        </time>
+                      </div>
+                      <p className={historyComment}>
+                        {entry.text || "(no comment)"}
+                      </p>
+                    </article>
+                  ))}
+              </div>
+            </section>
+          )}
+          <div className={fieldLabel}>
+            <label htmlFor={statusSelectId}>Status</label>
+            <Select
+              items={statusItems}
+              value={category}
+              onChange={selectCategory}
+              required
+              size="sm"
+              htmlForId={statusSelectId}
+            />
           </div>
           <textarea
             ref={textareaRef}
@@ -257,7 +344,7 @@ export const StatusDialog = ({
               }
             }}
             placeholder="Add context, next actions, or why this is not feasible..."
-            required={statusCommentRequired(category)}
+            aria-required={statusCommentRequired(category)}
             aria-invalid={error ? true : undefined}
             aria-describedby={error ? "status-dialog-error" : undefined}
           />

--- a/apps/hash-frontend/src/pages/supply-chain/shared/step-detail-panel/timing-metrics.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/step-detail-panel/timing-metrics.tsx
@@ -11,6 +11,7 @@ import {
   formatNumber,
 } from "../cost";
 import { useBaseMeasure, selectStat, MEASURE_LABELS } from "../measure-context";
+import { effectiveTimingGrain } from "../observation-labels";
 import { type PeriodComparison, computeCostComparison } from "../period-trends";
 import { planSourceLabel } from "../planning-param";
 import { useProcurementBasis } from "../procurement-basis-context";
@@ -325,7 +326,10 @@ export const KeyMetricsRow = ({
             </span>
             {pep != null && (
               <span className={badge}>
-                {step.timing_grain === "campaign"
+                {effectiveTimingGrain({
+                  type: step.type,
+                  timingGrain: step.timing_grain,
+                }) === "campaign"
                   ? "of campaigns"
                   : "of batches"}
               </span>

--- a/apps/hash-frontend/src/pages/supply-chain/shared/telemetry.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/telemetry.ts
@@ -3,9 +3,17 @@ import { sendTelemetry } from "../../../shared/telemetry-client";
 import type { FrontendTrackEventName } from "@local/hash-isomorphic-utils/telemetry/types";
 
 type SupplyChainTelemetryProperties = {
+  identifierType?:
+    | "batch"
+    | "production_order"
+    | "dispatch"
+    | "delivery"
+    | "shipment"
+    | "sales_order";
   interaction?: string;
   opportunityKind?: string;
   opportunityType?: string;
+  outcome?: "matched" | "no_match";
   productId?: string;
   route?: string;
   siteId?: string;

--- a/apps/hash-frontend/src/pages/supply-chain/shared/types.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/types.ts
@@ -194,6 +194,8 @@ export interface GraphNode {
   label: string;
   type: StepType;
   material: string | null;
+  /** Human-readable material description; optional only for legacy artifacts. */
+  material_name?: string | null;
   plant: string;
   stats: StepStats;
   plan: number | null;

--- a/apps/hash-frontend/src/pages/supply-chain/shared/types.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/types.ts
@@ -39,6 +39,8 @@ export type StepType =
   | "transit"
   | "destination_dwell";
 
+export type TimingGrain = "campaign" | "batch";
+
 export interface CostData {
   unit_price: number | null;
   currency: string | null;
@@ -203,7 +205,8 @@ export interface GraphNode {
   observations?: Observation[];
   /** Client-derived Tukey-kept timing points used only for mean trends. */
   mean_observations?: Observation[];
-  timing_grain?: "campaign" | null;
+  /** QA timing grain; omitted interpreted as batch. */
+  timing_grain?: TimingGrain | null;
   /** Client-side cache of combined procurement node observations from the wire. */
   procurement_observations?: ProcurementNodeObservation[];
   monthly?: MonthlyBucket[];
@@ -413,7 +416,7 @@ export interface BindingScore {
 
 export interface GraphData {
   /** Procurement planning data contract version. */
-  schema_version?: "1.2";
+  schema_version?: "1.2" | "1.3";
   analysis_settings?: AnalysisSettings | null;
   product_id: string;
   product_name: string;
@@ -614,7 +617,7 @@ export interface SiteData {
 
 export interface StepDetail {
   /** Procurement planning data contract version. */
-  schema_version?: "1.2";
+  schema_version?: "1.2" | "1.3";
   id: string;
   label: string;
   type: StepType;
@@ -634,8 +637,11 @@ export interface StepDetail {
   pct_exceeding_plan?: number | null;
   cost: CostData | null;
   material_value?: MaterialValueData | null;
-  /** Observation grain for timing. Campaign timing is one canonical QA observation per campaign. */
-  timing_grain?: "campaign" | null;
+  /**
+   * QA observation grain. Campaign timing is one observation per
+   * campaign; omitted is interpreted as batch.
+   */
+  timing_grain?: TimingGrain | null;
   /**
    * Canonical campaign-level timing records. When present these take precedence
    * over `detail_rows`, which remains the underlying batch evidence.
@@ -804,7 +810,7 @@ export interface ProcurementSupplierBlock {
  */
 export interface SiteSupplierPerformance {
   /** Procurement planning data contract version. */
-  schema_version?: "1.2";
+  schema_version?: "1.2" | "1.3";
   generated_at: string;
   overall: {
     n_lines: number;
@@ -858,7 +864,7 @@ export interface SiteSummaryRollups {
 
 /** `site/{siteId}/summary.json` — the precomputed site overview artifact. */
 export interface SiteSummary {
-  schema_version?: "1.2";
+  schema_version?: "1.2" | "1.3";
   analysis_settings?: AnalysisSettings | null;
   site_id: string;
   generated_at: string;

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product.tsx
@@ -115,6 +115,10 @@ const controlsBottomRow = css({
   alignItems: "center",
   gap: "2",
 });
+const planningLegendRow = css({
+  display: "flex",
+  justifyContent: "flex-end",
+});
 const contentBase = css({
   px: "6",
   py: "3",
@@ -669,7 +673,6 @@ export const Overview = ({
           {/* Right: primary view controls + lower-frequency settings/help. */}
           <div className={controlsCol}>
             <div className={controlsBottomRow}>
-              <PlanningParamLegend />
               <SegmentedControl
                 value={viewMode}
                 onChange={(nextViewMode) => {
@@ -713,6 +716,9 @@ export const Overview = ({
                 docContext="product"
                 productView={viewMode}
               />
+            </div>
+            <div className={planningLegendRow}>
+              <PlanningParamLegend />
             </div>
           </div>
         </div>
@@ -868,6 +874,11 @@ export const Overview = ({
               <StatusDialog
                 key={`${statusTarget.plant}-${statusTarget.id}`}
                 title={statusTarget.label}
+                entries={
+                  opportunityStatusStore.statusHistory[
+                    statusKey(productSiteId, statusTarget)
+                  ] ?? []
+                }
                 inline
                 onClose={() => setStatusTarget(null)}
                 onSave={(entry) => {
@@ -886,6 +897,11 @@ export const Overview = ({
         <StatusDialog
           key={`${statusTarget.plant}-${statusTarget.id}`}
           title={statusTarget.label}
+          entries={
+            opportunityStatusStore.statusHistory[
+              statusKey(productSiteId, statusTarget)
+            ] ?? []
+          }
           onClose={() => setStatusTarget(null)}
           onSave={(entry) => {
             opportunityStatusStore.actions.onSaveStatus(statusTarget, entry);

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product/production-schedule.test.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product/production-schedule.test.tsx
@@ -1,10 +1,17 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 import { createElement } from "react";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
 import { parseProductionSchedule } from "@local/hash-isomorphic-utils/production-schedule";
 
+import { trackSupplyChainInteraction } from "../../shared/telemetry";
 import { ProductionScheduleView } from "./production-schedule";
 
 import type {
@@ -315,7 +322,11 @@ beforeAll(() => {
   HTMLElement.prototype.scrollTo = vi.fn();
 });
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  vi.useRealTimers();
+});
 
 const selectOption = async (
   selectName: string,
@@ -926,5 +937,170 @@ describe("ProductionScheduleView", () => {
 
     expect(screen.queryByText("Dispatched as FG")).toBeNull();
     expect(screen.queryByText("Over-depleted inventory")).toBeNull();
+  });
+
+  it("selects and reveals a batch from an exact identifier search", async () => {
+    vi.useFakeTimers();
+    render(
+      createElement(ProductionScheduleView, {
+        schedule,
+        productNameByMaterial: new Map(),
+      }),
+    );
+
+    fireEvent.change(
+      screen.getByRole("searchbox", {
+        name: "Search production timeline by identifier",
+      }),
+      { target: { value: "raw-batch" } },
+    );
+    await act(() => vi.advanceTimersByTimeAsync(200));
+
+    expect(
+      screen
+        .getByRole("button", { name: "Batch raw-batch" })
+        .getAttribute("aria-pressed"),
+    ).toBe("true");
+    expect(screen.getByRole("status").textContent).toContain("Selected batch");
+
+    await act(() => vi.advanceTimersByTimeAsync(500));
+    expect(
+      vi
+        .mocked(trackSupplyChainInteraction)
+        .mock.calls.filter(
+          ([properties]) =>
+            properties.interaction ===
+            "production_schedule_identifier_searched",
+        ),
+    ).toHaveLength(1);
+    expect(
+      vi
+        .mocked(trackSupplyChainInteraction)
+        .mock.calls.find(
+          ([properties]) =>
+            properties.interaction ===
+            "production_schedule_identifier_searched",
+        )?.[0],
+    ).not.toHaveProperty("query");
+  });
+
+  it("centers the rendered matching node in both scroll directions", async () => {
+    vi.useFakeTimers();
+    render(
+      createElement(ProductionScheduleView, {
+        schedule,
+        productNameByMaterial: new Map(),
+      }),
+    );
+    const frame = screen.getByRole("region", {
+      name: "Scrollable production timeline",
+    });
+    const batch = screen.getByRole("button", { name: "Batch batch-1" });
+    Object.defineProperties(frame, {
+      clientHeight: { configurable: true, value: 600 },
+      clientWidth: { configurable: true, value: 800 },
+    });
+    frame.getBoundingClientRect = () =>
+      ({
+        bottom: 600,
+        height: 600,
+        left: 0,
+        right: 800,
+        top: 0,
+        width: 800,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }) as DOMRect;
+    batch.getBoundingClientRect = () =>
+      ({
+        bottom: 430,
+        height: 30,
+        left: 600,
+        right: 700,
+        top: 400,
+        width: 100,
+        x: 600,
+        y: 400,
+        toJSON: () => ({}),
+      }) as DOMRect;
+
+    fireEvent.change(
+      screen.getByRole("searchbox", {
+        name: "Search production timeline by identifier",
+      }),
+      { target: { value: "batch-1" } },
+    );
+    await act(() => vi.advanceTimersByTimeAsync(200));
+
+    expect(frame.scrollLeft).toBeGreaterThan(0);
+    expect(frame.scrollTop).toBeGreaterThan(0);
+  });
+
+  it("keeps a selection on no-match, then clears query and selection together", async () => {
+    vi.useFakeTimers();
+    render(
+      createElement(ProductionScheduleView, {
+        schedule,
+        productNameByMaterial: new Map(),
+      }),
+    );
+    const search = screen.getByRole("searchbox", {
+      name: "Search production timeline by identifier",
+    });
+    fireEvent.change(search, { target: { value: "raw-batch" } });
+    await act(() => vi.advanceTimersByTimeAsync(200));
+    expect(
+      screen
+        .getByRole("button", { name: "Batch raw-batch" })
+        .getAttribute("aria-pressed"),
+    ).toBe("true");
+
+    fireEvent.change(search, { target: { value: "not-present" } });
+    await act(() => vi.advanceTimersByTimeAsync(200));
+    expect(screen.getByText("No matching timeline identifier")).toBeTruthy();
+    expect(
+      screen
+        .getByRole("button", { name: "Batch raw-batch" })
+        .getAttribute("aria-pressed"),
+    ).toBe("true");
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear input" }));
+    expect(search).toHaveProperty("value", "");
+    expect(
+      screen
+        .getByRole("button", { name: "Batch raw-batch" })
+        .getAttribute("aria-pressed"),
+    ).toBe("false");
+    expect(screen.queryByText("No matching timeline identifier")).toBeNull();
+  });
+
+  it("reveals a non-product dispatch matched by identifier", async () => {
+    vi.useFakeTimers();
+    render(
+      createElement(ProductionScheduleView, {
+        schedule,
+        productNameByMaterial: new Map(),
+      }),
+    );
+
+    fireEvent.change(
+      screen.getByRole("searchbox", {
+        name: "Search production timeline by identifier",
+      }),
+      { target: { value: "dispatch-foreign-material" } },
+    );
+    await act(() => vi.advanceTimersByTimeAsync(200));
+
+    expect(
+      screen.getByRole("combobox", { name: "Lane display" }).textContent,
+    ).toContain("Lane");
+    expect(
+      screen
+        .getByRole("button", {
+          name: "Select dispatch for batch raw-batch",
+        })
+        .getAttribute("aria-pressed"),
+    ).toBe("true");
   });
 });

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product/production-schedule.test.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product/production-schedule.test.tsx
@@ -961,7 +961,7 @@ describe("ProductionScheduleView", () => {
         .getByRole("button", { name: "Batch raw-batch" })
         .getAttribute("aria-pressed"),
     ).toBe("true");
-    expect(screen.getByRole("status").textContent).toContain("Selected batch");
+    expect(screen.getByRole("status").textContent).toContain("Found batch");
 
     await act(() => vi.advanceTimersByTimeAsync(500));
     expect(
@@ -1058,7 +1058,7 @@ describe("ProductionScheduleView", () => {
 
     fireEvent.change(search, { target: { value: "not-present" } });
     await act(() => vi.advanceTimersByTimeAsync(200));
-    expect(screen.getByText("No matching timeline identifier")).toBeTruthy();
+    expect(screen.getByText("No matching batch or order")).toBeTruthy();
     expect(
       screen
         .getByRole("button", { name: "Batch raw-batch" })
@@ -1072,7 +1072,7 @@ describe("ProductionScheduleView", () => {
         .getByRole("button", { name: "Batch raw-batch" })
         .getAttribute("aria-pressed"),
     ).toBe("false");
-    expect(screen.queryByText("No matching timeline identifier")).toBeNull();
+    expect(screen.queryByText("No matching batch or order")).toBeNull();
   });
 
   it("reveals a non-product dispatch matched by identifier", async () => {

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product/production-schedule.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product/production-schedule.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 import { css } from "@hashintel/ds-helpers/css";
 
@@ -8,6 +15,7 @@ import {
   formatCalendarDay,
 } from "./production-schedule/calendar-date-axis";
 import { DispatchLane } from "./production-schedule/dispatch-lane";
+import { findScheduleIdentifierMatch } from "./production-schedule/identifier-search";
 import {
   batchLifecycleEnd,
   batchLifecycleStart,
@@ -393,10 +401,20 @@ export const ProductionScheduleView = ({
     useState<ScheduleLaneDisplay>("continuous");
   const [viewportWidth, setViewportWidth] = useState(0);
   const [selection, setSelection] = useState<ScheduleSelection | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchStatus, setSearchStatus] = useState<string | null>(null);
+  const [pendingSearchDate, setPendingSearchDate] = useState<string | null>(
+    null,
+  );
   const [collapsedFocusedMaterials, setCollapsedFocusedMaterials] = useState<
     Set<string>
   >(() => new Set());
+  const searchPreviousPresetRef = useRef<ScheduleRangePreset | null>(null);
   const selectOrToggle = (next: ScheduleSelection) => {
+    setSearchQuery("");
+    setSearchStatus(null);
+    setPendingSearchDate(null);
+    searchPreviousPresetRef.current = null;
     setCollapsedFocusedMaterials(new Set());
     setSelection((current) =>
       current && selectionIdentity(current) === selectionIdentity(next)
@@ -430,6 +448,17 @@ export const ProductionScheduleView = ({
   );
   const chartFrameRef = useRef<HTMLDivElement>(null);
   const pendingViewportCenterRef = useRef<number | "start" | null>(null);
+  const clearSelectionAndSearch = useCallback(() => {
+    setSelection(null);
+    setSearchQuery("");
+    setSearchStatus(null);
+    setPendingSearchDate(null);
+    const previousPreset = searchPreviousPresetRef.current;
+    searchPreviousPresetRef.current = null;
+    if (previousPreset) {
+      setPreset(previousPreset);
+    }
+  }, []);
 
   useEffect(() => {
     const frame = chartFrameRef.current;
@@ -446,12 +475,20 @@ export const ProductionScheduleView = ({
   useEffect(() => {
     const clearSelection = (event: globalThis.KeyboardEvent) => {
       if (event.key === "Escape") {
-        setSelection(null);
+        clearSelectionAndSearch();
       }
     };
     window.addEventListener("keydown", clearSelection);
     return () => window.removeEventListener("keydown", clearSelection);
-  }, []);
+  }, [clearSelectionAndSearch]);
+
+  useEffect(() => {
+    setSelection(null);
+    setSearchQuery("");
+    setSearchStatus(null);
+    setPendingSearchDate(null);
+    searchPreviousPresetRef.current = null;
+  }, [schedule]);
 
   const selectedRange = useMemo(
     () =>
@@ -544,6 +581,71 @@ export const ProductionScheduleView = ({
     pendingViewportCenterRef.current = null;
   }, [plotWidth]);
 
+  useLayoutEffect(() => {
+    const frame = chartFrameRef.current;
+    if (!frame || !pendingSearchDate) {
+      return;
+    }
+    const visiblePlotWidth = Math.max(1, frame.clientWidth - LABEL_WIDTH);
+    const target =
+      selection?.kind === "batch"
+        ? [
+            ...frame.querySelectorAll<HTMLElement>("[data-schedule-batch-id]"),
+          ].find(
+            (element) => element.dataset.scheduleBatchId === selection.batchId,
+          )
+        : selection?.kind === "dispatch"
+          ? [
+              ...frame.querySelectorAll<HTMLElement>(
+                "[data-schedule-dispatch-event-ids]",
+              ),
+            ].find(
+              (element) =>
+                (selection.origin === "dispatch_lane"
+                  ? element.dataset.dispatchMarkerKind ===
+                    "selected-product-lane"
+                  : element.dataset.dispatchMarkerKind !==
+                    "selected-product-lane") &&
+                element.dataset.scheduleDispatchEventIds
+                  ?.split(",")
+                  .some((eventId) => selection.eventIds.includes(eventId)),
+            )
+          : undefined;
+    const frameBounds = frame.getBoundingClientRect();
+    const targetBounds = target?.getBoundingClientRect();
+    if (targetBounds?.width) {
+      frame.scrollLeft = Math.max(
+        0,
+        frame.scrollLeft +
+          targetBounds.left -
+          (frameBounds.left + LABEL_WIDTH) -
+          (visiblePlotWidth - targetBounds.width) / 2,
+      );
+    } else {
+      const centerRatio = Math.max(
+        0,
+        Math.min(
+          1,
+          (scheduleDayNumber(pendingSearchDate) - startDay + 0.5) / dayCount,
+        ),
+      );
+      frame.scrollLeft = Math.max(
+        0,
+        centerRatio * plotWidth - visiblePlotWidth / 2,
+      );
+    }
+    if (targetBounds?.height) {
+      frame.scrollTop = Math.max(
+        0,
+        frame.scrollTop +
+          targetBounds.top -
+          frameBounds.top -
+          (frame.clientHeight - targetBounds.height) / 2,
+      );
+    }
+    setPendingSearchDate(null);
+  }, [dayCount, pendingSearchDate, plotWidth, selection, startDay]);
+
   const selectedRelated = trace.batchIds;
   const hasSelection = selection !== null;
   const dispatchLaneFocused =
@@ -632,11 +734,16 @@ export const ProductionScheduleView = ({
       ) {
         return;
       }
-      setSelection(null);
+      clearSelectionAndSearch();
     };
     frame.addEventListener("click", clearSelection);
     return () => frame.removeEventListener("click", clearSelection);
-  }, [displayedLanes.length, timelineEnd, timelineStart]);
+  }, [
+    clearSelectionAndSearch,
+    displayedLanes.length,
+    timelineEnd,
+    timelineStart,
+  ]);
 
   const trackInteraction = (interaction: string) =>
     trackSupplyChainInteraction({
@@ -644,6 +751,79 @@ export const ProductionScheduleView = ({
       productId: schedule.product_id,
       source: "production_schedule",
     });
+
+  const handleIdentifierSearch = useCallback(
+    (query: string) => {
+      const trimmedQuery = query.trim();
+      if (!trimmedQuery) {
+        return;
+      }
+      const match = findScheduleIdentifierMatch(schedule, trimmedQuery);
+      if (!match) {
+        setSearchStatus("No matching batch or order");
+        trackSupplyChainInteraction({
+          interaction: "production_schedule_identifier_searched",
+          outcome: "no_match",
+          productId: schedule.product_id,
+          source: "production_schedule",
+        });
+        return;
+      }
+      setCollapsedFocusedMaterials(new Set());
+      setSelection(match.selection);
+      if (
+        (selectedRange.start && match.date < selectedRange.start) ||
+        (selectedRange.end && match.date > selectedRange.end)
+      ) {
+        if (preset !== "all" && searchPreviousPresetRef.current == null) {
+          searchPreviousPresetRef.current = preset;
+        }
+        setPreset("all");
+      }
+      if (
+        match.selection.kind === "dispatch" &&
+        match.selection.origin === "batch_marker"
+      ) {
+        setLaneDisplay("lane");
+        setShowInventoryDwell(true);
+        setShowEventMarkers(true);
+      }
+      if (match.laneRole === "raw_material") {
+        setShowRawMaterials(true);
+      }
+      setPendingSearchDate(match.date);
+      setSearchStatus(`Found ${match.identifierType.replaceAll("_", " ")}`);
+      trackSupplyChainInteraction({
+        identifierType: match.identifierType,
+        interaction: "production_schedule_identifier_searched",
+        outcome: "matched",
+        productId: schedule.product_id,
+        source: "production_schedule",
+      });
+    },
+    [preset, schedule, selectedRange.end, selectedRange.start],
+  );
+  const identifierSearchHandlerRef = useRef(handleIdentifierSearch);
+  useEffect(() => {
+    identifierSearchHandlerRef.current = handleIdentifierSearch;
+  }, [handleIdentifierSearch]);
+  useEffect(() => {
+    if (!searchQuery) {
+      return;
+    }
+    const timeout = window.setTimeout(
+      () => identifierSearchHandlerRef.current(searchQuery),
+      200,
+    );
+    return () => window.clearTimeout(timeout);
+  }, [searchQuery]);
+
+  const handleSearchInputChange = (nextQuery: string) => {
+    setSearchQuery(nextQuery);
+    if (!nextQuery) {
+      clearSelectionAndSearch();
+    }
+  };
 
   const changeZoom = (direction: "in" | "out") => {
     const frame = chartFrameRef.current;
@@ -680,9 +860,11 @@ export const ProductionScheduleView = ({
           trackInteraction("production_schedule_lane_display_changed");
         }}
         onPresetChange={(nextPreset) => {
+          searchPreviousPresetRef.current = null;
           setPreset(nextPreset);
           trackInteraction("production_schedule_filter_changed");
         }}
+        onSearchInputChange={handleSearchInputChange}
         onShowEventMarkersChange={(showMarkers) => {
           setShowEventMarkers(showMarkers);
           trackInteraction("production_schedule_event_markers_changed");
@@ -700,6 +882,8 @@ export const ProductionScheduleView = ({
         onZoomIn={() => changeZoom("in")}
         onZoomOut={() => changeZoom("out")}
         preset={preset}
+        searchStatus={searchStatus}
+        searchValue={searchQuery}
         showEventMarkers={showEventMarkers}
         showInventoryDwell={showInventoryDwell}
         showRawMaterials={showRawMaterials}
@@ -1005,6 +1189,7 @@ export const ProductionScheduleView = ({
                               <button
                                 type="button"
                                 className={batchButton}
+                                data-schedule-batch-id={batch.id}
                                 aria-pressed={selected}
                                 aria-label={`Batch ${batch.batch ?? batch.order}${directUse?.state === "used_elsewhere" ? ", also used for other products" : ""}`}
                                 style={{
@@ -1184,6 +1369,9 @@ export const ProductionScheduleView = ({
                                     <button
                                       type="button"
                                       className={eventMarker}
+                                      data-schedule-dispatch-event-ids={clusterDispatches
+                                        .map((dispatch) => dispatch.id)
+                                        .join(",")}
                                       data-dispatch-marker-kind={
                                         dispatchedAsFinishedGood
                                           ? "finished-good"

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product/production-schedule/dispatch-lane.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product/production-schedule/dispatch-lane.tsx
@@ -199,6 +199,9 @@ export const DispatchLane = ({
                 type="button"
                 className={eventMarker}
                 data-dispatch-marker-kind="selected-product-lane"
+                data-schedule-dispatch-event-ids={clusterDispatches
+                  .map((dispatch) => dispatch.id)
+                  .join(",")}
                 aria-pressed={selected}
                 style={{
                   boxShadow: selected ? "0 0 0 2px #0f172a" : undefined,

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product/production-schedule/identifier-search.test.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product/production-schedule/identifier-search.test.ts
@@ -1,0 +1,269 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  findScheduleIdentifierMatch,
+  normalizeScheduleIdentifier,
+} from "./identifier-search";
+
+import type {
+  ProductionScheduleLegacy,
+  ProductionScheduleV12,
+  ProductionScheduleV12Batch,
+} from "../../../shared/production-schedule-types";
+
+const schedule: ProductionScheduleLegacy = {
+  schema_version: "1.1",
+  artifact_type: "production_schedule",
+  artifact_version: "1.1",
+  product_id: "product",
+  product_name: "Product",
+  product_material: "FG",
+  plant: "SITE",
+  quantity_tolerance: 0.000001,
+  source: {
+    allocations: "test",
+    cadence: "test",
+    order_outputs: "test",
+    production_windows: "test",
+  },
+  consumption_evidence: [],
+  lanes: [
+    {
+      material: "RAW",
+      name: "Raw",
+      bom_depth: 1,
+      role: "raw_material",
+      uom: "KG",
+      campaigns: [],
+      batches: [
+        {
+          id: "RAW::BATCH-7",
+          material: "RAW",
+          batch: "BATCH-7",
+          order: "00001234",
+          start: "2026-01-01",
+          end: "2026-01-02",
+          span_days: 2,
+          quantity: 10,
+          uom: "KG",
+          campaign_core: null,
+          campaign_id: null,
+          building: null,
+          start_source: "receipt_date",
+          finish_source: "receipt_date",
+          derivation: "test",
+          allocation_status: "open",
+          allocation_totals: {
+            selected: 0,
+            shared: 0,
+            other: 0,
+            open: 10,
+            unresolved: 0,
+          },
+          allocated_quantity: 0,
+          unallocated_quantity: 10,
+          allocation_tolerance: 0.000001,
+          allocation_tolerance_reason: "test",
+          allocations: [],
+        },
+      ],
+    },
+  ],
+  dispatch_events: [
+    {
+      id: "dispatch-1",
+      batch_id: "RAW::BATCH-7",
+      material: "RAW",
+      batch: "BATCH-7",
+      dispatch_date: "2026-01-03",
+      quantity: 5,
+      uom: "KG",
+      bwart: "601",
+      episode_scope: "in_episode",
+      delivery_coverage: "exact",
+      deliveries: [
+        {
+          delivery_number: "00005678",
+          delivery_item: "10",
+          shipment_number: "SHIP-9",
+          sales_order: "00009999",
+        },
+      ],
+    },
+    {
+      id: "dispatch-2",
+      batch_id: "RAW::BATCH-7",
+      material: "RAW",
+      batch: "BATCH-7",
+      dispatch_date: "2026-01-04",
+      quantity: 5,
+      uom: "KG",
+      bwart: "601",
+      episode_scope: "in_episode",
+      delivery_coverage: "exact",
+      deliveries: [
+        {
+          delivery_number: "00005679",
+          delivery_item: "10",
+          sales_order: "00009999",
+        },
+      ],
+    },
+  ],
+};
+
+const v12Batch = (
+  id: string,
+  material: string,
+  batch: string,
+): ProductionScheduleV12Batch => ({
+  id,
+  material,
+  batch,
+  order: `ORDER-${batch}`,
+  start: "2026-01-01",
+  end: "2026-01-02",
+  span_days: 2,
+  quantity: 10,
+  uom: "KG",
+  campaign_core: null,
+  campaign_id: null,
+  building: null,
+  start_source: "charge_day",
+  finish_source: "fill_day",
+  derivation: "test",
+  allocation_status: "open",
+  allocation_totals: {
+    selected: 0,
+    shared: 0,
+    other: 0,
+    open: 10,
+    unresolved: 0,
+  },
+  allocated_quantity: 0,
+  unallocated_quantity: 10,
+  allocation_tolerance: 0.000001,
+  allocation_tolerance_reason: "test",
+  timing_kind: "production_window",
+  allocation_overage_quantity: 0,
+  consumption_event_ids: [],
+  lifecycle_start: "2026-01-01",
+  lifecycle_end: "2026-01-02",
+  lifecycle_end_reason: "open",
+  lifecycle_balance_status: "balanced",
+  lifecycle_overage_quantity: 0,
+  remaining_quantity: 10,
+  last_exit_date: null,
+  lifecycle_exit_quantity: 0,
+});
+
+describe("production schedule identifier search", () => {
+  it("normalizes numeric identifiers without changing non-numeric batches", () => {
+    expect(normalizeScheduleIdentifier(" 00001234 ")).toBe("1234");
+    expect(normalizeScheduleIdentifier(" Batch-7 ")).toBe("batch-7");
+    expect(normalizeScheduleIdentifier("I-123")).toBe("i-123");
+  });
+
+  it("maps batch and production order identifiers to the batch", () => {
+    expect(findScheduleIdentifierMatch(schedule, "BATCH-7")).toMatchObject({
+      identifierType: "batch",
+      laneRole: "raw_material",
+      selection: { kind: "batch", batchId: "RAW::BATCH-7" },
+    });
+    expect(findScheduleIdentifierMatch(schedule, "1234")).toMatchObject({
+      identifierType: "production_order",
+      selection: { kind: "batch", batchId: "RAW::BATCH-7" },
+    });
+  });
+
+  it("centers a batch on its rendered production interval", () => {
+    const longLifecycleSchedule = structuredClone(schedule);
+    const longLifecycleBatch = longLifecycleSchedule.lanes[0]!.batches[0]!;
+    longLifecycleBatch.lifecycle_end = "2026-12-31";
+
+    expect(
+      findScheduleIdentifierMatch(longLifecycleSchedule, "BATCH-7")?.date,
+    ).toBe("2026-01-01");
+  });
+
+  it("maps delivery and sales orders to all matching dispatches", () => {
+    expect(findScheduleIdentifierMatch(schedule, "5678")).toMatchObject({
+      identifierType: "delivery",
+      selection: { kind: "dispatch", eventIds: ["dispatch-1"] },
+    });
+    expect(findScheduleIdentifierMatch(schedule, "9999")).toMatchObject({
+      identifierType: "sales_order",
+      selection: {
+        kind: "dispatch",
+        eventIds: ["dispatch-1", "dispatch-2"],
+      },
+    });
+  });
+
+  it("returns null for an unknown identifier", () => {
+    expect(findScheduleIdentifierMatch(schedule, "missing")).toBeNull();
+  });
+
+  it("ignores batches and dispatches outside the rendered product lineage", () => {
+    const unrelatedBatch = v12Batch("OTHER::UNRELATED", "OTHER", "UNRELATED");
+    const v12Schedule: ProductionScheduleV12 = {
+      schema_version: "1.2",
+      artifact_type: "production_schedule",
+      artifact_version: "1.2",
+      product_id: "product",
+      product_name: "Product",
+      product_material: "FG",
+      plant: "SITE",
+      quantity_tolerance: 0.000001,
+      lanes: [
+        {
+          material: "FG",
+          name: "Finished good",
+          bom_depth: 0,
+          role: "finished_good",
+          uom: "KG",
+          campaigns: [],
+          batches: [v12Batch("FG::VISIBLE", "FG", "VISIBLE")],
+        },
+        {
+          material: "OTHER",
+          name: "Unrelated",
+          bom_depth: 1,
+          role: "intermediate",
+          uom: "KG",
+          campaigns: [],
+          batches: [unrelatedBatch],
+        },
+      ],
+      consumption_events: [],
+      batch_links: [],
+      dispatch_events: [
+        {
+          id: "unrelated-dispatch",
+          batch_id: unrelatedBatch.id,
+          material: unrelatedBatch.material,
+          batch: unrelatedBatch.batch!,
+          dispatch_date: "2026-01-02",
+          quantity: 1,
+          uom: "KG",
+          bwart: "601",
+          episode_scope: "in_episode",
+          delivery_coverage: "none",
+          deliveries: [],
+        },
+      ],
+      source: {
+        production_windows: "test",
+        cadence: "test",
+        consumption_events: "test",
+        order_outputs: "test",
+        dispatches: "test",
+      },
+    };
+
+    expect(findScheduleIdentifierMatch(v12Schedule, "UNRELATED")).toBeNull();
+    expect(
+      findScheduleIdentifierMatch(v12Schedule, "unrelated-dispatch"),
+    ).toBeNull();
+  });
+});

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product/production-schedule/identifier-search.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product/production-schedule/identifier-search.ts
@@ -1,0 +1,178 @@
+import {
+  batchLifecycleStart,
+  productionScheduleRelevantBatchIds,
+  scheduleDayNumber,
+  type ScheduleSelection,
+} from "./model";
+
+import type {
+  ProductionSchedule,
+  ProductionScheduleBatch,
+  ProductionScheduleDispatchEvent,
+  ProductionScheduleRole,
+} from "../../../shared/production-schedule-types";
+
+export type ScheduleIdentifierType =
+  | "batch"
+  | "production_order"
+  | "dispatch"
+  | "delivery"
+  | "shipment"
+  | "sales_order";
+
+export interface ScheduleIdentifierMatch {
+  date: string;
+  identifierType: ScheduleIdentifierType;
+  laneRole: ProductionScheduleRole;
+  selection: ScheduleSelection;
+}
+
+export const normalizeScheduleIdentifier = (identifier: string): string => {
+  const normalized = identifier.trim().toLowerCase();
+  if (/^\d+$/.test(normalized)) {
+    return normalized.replace(/^0+(?=\d)/, "");
+  }
+  return normalized;
+};
+
+const batchDate = (batch: ProductionScheduleBatch): string => {
+  const startDate =
+    batch.timing_kind === "lifecycle_only"
+      ? batchLifecycleStart(batch)
+      : batch.start;
+  const endDate =
+    batch.timing_kind === "lifecycle_only" ? startDate : batch.end;
+  const start = scheduleDayNumber(startDate);
+  const end = scheduleDayNumber(endDate);
+  return new Date((start + Math.floor((end - start) / 2)) * 86_400_000)
+    .toISOString()
+    .slice(0, 10);
+};
+
+const matchingDispatches = (
+  schedule: ProductionSchedule,
+  query: string,
+  relevantBatchIds: ReadonlySet<string>,
+): {
+  dispatches: ProductionScheduleDispatchEvent[];
+  identifierType: ScheduleIdentifierType;
+} | null => {
+  const candidates: Array<{
+    dispatch: ProductionScheduleDispatchEvent;
+    identifierType: ScheduleIdentifierType;
+  }> = [];
+  for (const dispatch of schedule.dispatch_events ?? []) {
+    if (!relevantBatchIds.has(dispatch.batch_id)) {
+      continue;
+    }
+    if (normalizeScheduleIdentifier(dispatch.id) === query) {
+      candidates.push({ dispatch, identifierType: "dispatch" });
+    }
+    for (const delivery of dispatch.deliveries) {
+      const identifiers: Array<
+        [string | null | undefined, ScheduleIdentifierType]
+      > = [
+        [delivery.delivery_number, "delivery"],
+        [delivery.shipment_number, "shipment"],
+        [delivery.sales_order, "sales_order"],
+      ];
+      for (const [identifier, identifierType] of identifiers) {
+        if (identifier && normalizeScheduleIdentifier(identifier) === query) {
+          candidates.push({ dispatch, identifierType });
+        }
+      }
+    }
+  }
+  if (candidates.length === 0) {
+    return null;
+  }
+  const identifierType = candidates[0]!.identifierType;
+  return {
+    dispatches: [
+      ...new Map(
+        candidates
+          .filter((candidate) => candidate.identifierType === identifierType)
+          .map(({ dispatch }) => [dispatch.id, dispatch]),
+      ).values(),
+    ].sort((left, right) => left.id.localeCompare(right.id)),
+    identifierType,
+  };
+};
+
+export const findScheduleIdentifierMatch = (
+  schedule: ProductionSchedule,
+  identifier: string,
+): ScheduleIdentifierMatch | null => {
+  const query = normalizeScheduleIdentifier(identifier);
+  if (!query) {
+    return null;
+  }
+
+  const relevantBatchIds = productionScheduleRelevantBatchIds(schedule);
+  const batchCandidates: Array<{
+    batch: ProductionScheduleBatch;
+    identifierType: "batch" | "production_order";
+    laneRole: ProductionScheduleRole;
+  }> = [];
+  for (const lane of schedule.lanes) {
+    for (const batch of lane.batches) {
+      if (!relevantBatchIds.has(batch.id)) {
+        continue;
+      }
+      const batchMatches = [batch.batch, batch.id].some(
+        (value) => value && normalizeScheduleIdentifier(value) === query,
+      );
+      if (batchMatches) {
+        batchCandidates.push({
+          batch,
+          identifierType: "batch",
+          laneRole: lane.role,
+        });
+      } else if (
+        batch.order &&
+        normalizeScheduleIdentifier(batch.order) === query
+      ) {
+        batchCandidates.push({
+          batch,
+          identifierType: "production_order",
+          laneRole: lane.role,
+        });
+      }
+    }
+  }
+  const batchMatch = batchCandidates.sort((left, right) =>
+    left.batch.id.localeCompare(right.batch.id),
+  )[0];
+  if (batchMatch) {
+    return {
+      date: batchDate(batchMatch.batch),
+      identifierType: batchMatch.identifierType,
+      laneRole: batchMatch.laneRole,
+      selection: { kind: "batch", batchId: batchMatch.batch.id },
+    };
+  }
+
+  const dispatchMatch = matchingDispatches(schedule, query, relevantBatchIds);
+  const firstDispatch = dispatchMatch?.dispatches[0];
+  if (!dispatchMatch || !firstDispatch) {
+    return null;
+  }
+  const laneRole =
+    schedule.lanes.find((lane) =>
+      lane.batches.some((batch) => batch.id === firstDispatch.batch_id),
+    )?.role ?? "finished_good";
+  return {
+    date: firstDispatch.dispatch_date,
+    identifierType: dispatchMatch.identifierType,
+    laneRole,
+    selection: {
+      kind: "dispatch",
+      eventIds: dispatchMatch.dispatches.map((dispatch) => dispatch.id),
+      origin: dispatchMatch.dispatches.every(
+        (dispatch) => dispatch.material === schedule.product_material,
+      )
+        ? "dispatch_lane"
+        : "batch_marker",
+    },
+  };
+};

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product/production-schedule/toolbar.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product/production-schedule/toolbar.tsx
@@ -1,6 +1,8 @@
 import { Button, Select, type SelectItem } from "@hashintel/ds-components";
 import { css, cx } from "@hashintel/ds-helpers/css";
 
+import { SupplyChainSearchInput } from "../../../shared/search-input";
+
 import type { ScheduleRangePreset } from "./schedule-dates";
 
 const toolbar = css({
@@ -70,6 +72,13 @@ const zoomButton = css({
   bg: "[#fff]",
   _hover: { bg: "bg.subtle" },
 });
+const searchStatusStyle = css({
+  marginLeft: "1",
+  minH: "4",
+  textStyle: "xs",
+  color: "fg.subtle",
+  fontStyle: "italic",
+});
 
 type LaneDisplay = "lane" | "continuous";
 
@@ -96,12 +105,15 @@ interface ProductionScheduleToolbarProps {
   onFitZoom: () => void;
   onLaneDisplayChange: (value: LaneDisplay) => void;
   onPresetChange: (value: ScheduleRangePreset) => void;
+  onSearchInputChange: (value: string) => void;
   onShowEventMarkersChange: (value: boolean) => void;
   onShowInventoryDwellChange: (value: boolean) => void;
   onShowRawMaterialsChange: (value: boolean) => void;
   onZoomIn: () => void;
   onZoomOut: () => void;
   preset: ScheduleRangePreset;
+  searchStatus: string | null;
+  searchValue: string;
   showEventMarkers: boolean;
   showInventoryDwell: boolean;
   showRawMaterials: boolean;
@@ -118,12 +130,15 @@ export const ProductionScheduleToolbar = ({
   onFitZoom,
   onLaneDisplayChange,
   onPresetChange,
+  onSearchInputChange,
   onShowEventMarkersChange,
   onShowInventoryDwellChange,
   onShowRawMaterialsChange,
   onZoomIn,
   onZoomOut,
   preset,
+  searchStatus,
+  searchValue,
   showEventMarkers,
   showInventoryDwell,
   showRawMaterials,
@@ -257,6 +272,21 @@ export const ProductionScheduleToolbar = ({
           </label>
         </div>
       )}
+    </div>
+    <div className={field}>
+      <span>
+        Find batch or order{" "}
+        <span className={searchStatusStyle} role="status" aria-live="polite">
+          {searchStatus}
+        </span>
+      </span>
+      <SupplyChainSearchInput
+        ariaLabel="Search production timeline by identifier"
+        onChange={onSearchInputChange}
+        placeholder="Batch, order, delivery..."
+        size="sm"
+        value={searchValue}
+      />
     </div>
   </div>
 );

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product/production-schedule/tooltip-content.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/product/production-schedule/tooltip-content.tsx
@@ -271,6 +271,7 @@ const deliverySummary = (
 ): string =>
   [
     delivery.delivery_number ? `Delivery ${delivery.delivery_number}` : null,
+    delivery.sales_order ? `Sales order ${delivery.sales_order}` : null,
     delivery.customer_name ?? delivery.ship_to ?? null,
     delivery.incoterms_2
       ? `Destination ${delivery.incoterms_2}`

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site.tsx
@@ -1,10 +1,11 @@
 import { useCallback, useEffect, useState, useMemo } from "react";
 
-import { Icon } from "@hashintel/ds-components";
+import { Button } from "@hashintel/ds-components";
 import { css, cx } from "@hashintel/ds-helpers/css";
 
 import { isDwellType } from "../shared/categories";
-import { formatCost } from "../shared/cost";
+import { formatCost, useCostParams, useOutlierSetting } from "../shared/cost";
+import { downloadCsv } from "../shared/export-utils";
 import { useSupplierPerformanceEnabled } from "../shared/feature-flags";
 import {
   AnalysisSettingsPanel,
@@ -12,7 +13,9 @@ import {
 } from "../shared/header-actions";
 import { ErrorState, SupplyChainAppSkeleton } from "../shared/load-state";
 import { useLowSampleSetting } from "../shared/low-sample-context";
+import { useProcurementBasis } from "../shared/procurement-basis-context";
 import { ScopeSelect } from "../shared/scope-select";
+import { SupplyChainSearchInput } from "../shared/search-input";
 import { StatChip } from "../shared/stat-chip";
 import { statusKey } from "../shared/status";
 import { StatusDialog } from "../shared/status-dialog";
@@ -31,6 +34,7 @@ import {
 import { OpportunitiesTable } from "./site/opportunities-table";
 import { PlanningTable } from "./site/planning-table";
 import { SiteMonthlyCarryCostChart } from "./site/site-monthly-carry-cost-chart";
+import { buildSiteOverviewCsv } from "./site/site-overview-export";
 import { createSiteSearchMatchers } from "./site/site-search";
 import { SupplierTable } from "./site/supplier-table";
 import { TabButton } from "./site/tab-button";
@@ -99,101 +103,12 @@ const headerControls = css({
   gap: "2",
   flexShrink: 0,
 });
-const searchWrap = css({
+const searchControls = css({
   display: "flex",
   alignItems: "center",
+  justifyContent: "flex-end",
   gap: "2",
-  w: "[320px]",
-  maxW: "[40vw]",
-  px: "3",
-  py: "1.5",
-  borderWidth: "1px",
-  borderStyle: "solid",
-  borderColor: "bd.subtle",
-  borderRadius: "md",
-  bg: "bg.surface",
-  color: "fg.subtle",
-  transition: "colors",
-  _focusWithin: {
-    borderColor: "[#93c5fd]",
-    boxShadow: "[0 0 0 2px rgba(147, 197, 253, 0.25)]",
-  },
-  '&[data-active="true"]': {
-    bg: "[#eff6ff]",
-    borderColor: "[#2563eb]",
-    color: "[#2563eb]",
-  },
 });
-const searchInput = css({
-  flex: "1",
-  minW: "0",
-  bg: "[transparent]",
-  color: "fg.heading",
-  textStyle: "sm",
-  outline: "none",
-  _placeholder: { color: "fg.subtle" },
-});
-const clearSearchButton = css({
-  display: "inline-flex",
-  alignItems: "center",
-  justifyContent: "center",
-  w: "4",
-  h: "4",
-  flexShrink: 0,
-  color: "fg.subtle",
-  cursor: "pointer",
-  borderRadius: "sm",
-  _hover: { color: "fg.heading", bg: "bg.subtle" },
-});
-const clearSearchButtonHidden = css({
-  visibility: "hidden",
-  pointerEvents: "none",
-});
-
-const SiteSearchInput = ({
-  onChange,
-}: {
-  onChange: (query: string) => void;
-}) => {
-  const [value, setValue] = useState("");
-
-  useEffect(() => {
-    const timeout = window.setTimeout(() => onChange(value), 200);
-    return () => window.clearTimeout(timeout);
-  }, [value, onChange]);
-
-  return (
-    <div
-      className={searchWrap}
-      data-active={value ? "true" : undefined}
-      role="search"
-      style={value ? { borderColor: "#2563eb" } : undefined}
-    >
-      <Icon name="search" size="xs" />
-      <input
-        type="text"
-        value={value}
-        className={searchInput}
-        placeholder="Search..."
-        aria-label="Search site overview tables"
-        onChange={(event) => setValue(event.target.value)}
-      />
-      <button
-        type="button"
-        className={cx(clearSearchButton, !value && clearSearchButtonHidden)}
-        aria-label="Clear search"
-        disabled={!value}
-        onClick={() => {
-          setValue("");
-          onChange("");
-        }}
-      >
-        <Icon name="close" size="xs" />
-      </button>
-    </div>
-  );
-};
-
 const settingsCollapse = css({
   display: "grid",
   transition: "[grid-template-rows 180ms ease, opacity 160ms ease]",
@@ -291,10 +206,14 @@ export const SiteOverview = ({
   opportunityStatusActions = noopOpportunityStatusActions,
 }: SiteOverviewProps) => {
   const { timeRange } = useTimeRange();
+  const { currency, waccRate, storageCost } = useCostParams();
+  const { excludeOutliers } = useOutlierSetting();
+  const { basis: procurementBasis } = useProcurementBasis();
   const supplierPerformanceEnabled = useSupplierPerformanceEnabled();
   const siteSlug = siteId;
   const [tab, setTab] = useState<Tab>("dwell");
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [searchInputValue, setSearchInputValue] = useState("");
   const [searchQuery, setSearchQuery] = useState("");
   const [searchParams] = useSearchParams();
   const { excludeLowSamples, setExcludeLowSamples } = useLowSampleSetting();
@@ -311,6 +230,14 @@ export const SiteOverview = ({
     node: SiteNode;
     title: string;
   } | null>(null);
+
+  useEffect(() => {
+    const timeout = window.setTimeout(
+      () => setSearchQuery(searchInputValue),
+      200,
+    );
+    return () => window.clearTimeout(timeout);
+  }, [searchInputValue]);
 
   const openStatus = useCallback(
     (node: SiteNode, title: string) => {
@@ -402,6 +329,7 @@ export const SiteOverview = ({
   const {
     loading,
     error,
+    historicalNodes,
     summaryStats,
     siteCurrency,
     monthlyCarryCost,
@@ -416,6 +344,44 @@ export const SiteOverview = ({
     supplierMode,
     supplierPerformanceEnabled,
   });
+  const handleExport = useCallback(() => {
+    const csv = buildSiteOverviewCsv({
+      dwellRows,
+      historicalNodes,
+      planningRows,
+      settings: {
+        currency,
+        excludeLowSamples,
+        excludeOutliers,
+        procurementBasis,
+        storageCost,
+        timeRange,
+        waccRate,
+      },
+      siteId: siteSlug,
+      statusHistory: opportunityStatusHistory,
+    });
+    downloadCsv(csv, `${siteSlug}_supply_chain_${timeRange}.csv`);
+    trackSupplyChainInteraction({
+      interaction: "csv_exported",
+      siteId,
+      source: "site_overview",
+    });
+  }, [
+    dwellRows,
+    currency,
+    excludeLowSamples,
+    excludeOutliers,
+    historicalNodes,
+    opportunityStatusHistory,
+    planningRows,
+    procurementBasis,
+    siteId,
+    siteSlug,
+    storageCost,
+    timeRange,
+    waccRate,
+  ]);
   const buildBriefHref = useCallback(
     (type: "dwell" | "planning", node: SiteNode, kind?: OpportunityKind) =>
       opportunityBriefHref(siteSlug, type, node, timeRange, searchParams, kind),
@@ -584,7 +550,21 @@ export const SiteOverview = ({
                 docContext="site"
               />
             </div>
-            <SiteSearchInput onChange={setSearchQuery} />
+            <div className={searchControls}>
+              <Button
+                variant="subtle"
+                tone="neutral"
+                size="sm"
+                onClick={handleExport}
+              >
+                Export
+              </Button>
+              <SupplyChainSearchInput
+                ariaLabel="Search site overview tables"
+                onChange={setSearchInputValue}
+                value={searchInputValue}
+              />
+            </div>
           </div>
         </div>
         <div
@@ -797,6 +777,11 @@ export const SiteOverview = ({
                   selectedStepStatusTarget.title
                 }`}
                 title={selectedStepStatusTarget.title}
+                entries={
+                  opportunityStatusHistory[
+                    statusKey(siteSlug, selectedStepStatusTarget.node)
+                  ] ?? []
+                }
                 inline
                 onClose={() => setStatusTarget(null)}
                 onSave={(entry) => {
@@ -826,6 +811,10 @@ export const SiteOverview = ({
             statusTarget.title
           }`}
           title={statusTarget.title}
+          entries={
+            opportunityStatusHistory[statusKey(siteSlug, statusTarget.node)] ??
+            []
+          }
           onClose={() => setStatusTarget(null)}
           onSave={(entry) => {
             opportunityStatusActions.onSaveStatus(statusTarget.node, entry);

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site.tsx
@@ -107,7 +107,7 @@ const searchControls = css({
   display: "flex",
   alignItems: "center",
   justifyContent: "flex-end",
-  gap: "2",
+  gap: "3",
 });
 const settingsCollapse = css({
   display: "grid",
@@ -349,6 +349,7 @@ export const SiteOverview = ({
       dwellRows,
       historicalNodes,
       planningRows,
+      products,
       settings: {
         currency,
         excludeLowSamples,
@@ -375,6 +376,7 @@ export const SiteOverview = ({
     historicalNodes,
     opportunityStatusHistory,
     planningRows,
+    products,
     procurementBasis,
     siteId,
     siteSlug,
@@ -551,17 +553,15 @@ export const SiteOverview = ({
               />
             </div>
             <div className={searchControls}>
-              <Button
-                variant="subtle"
-                tone="neutral"
-                size="sm"
-                onClick={handleExport}
-              >
-                Export
+              <Button variant="subtle" size="sm" onClick={handleExport}>
+                <span className={css({ textStyle: "xs", color: "fg.subtle" })}>
+                  Export
+                </span>
               </Button>
               <SupplyChainSearchInput
                 ariaLabel="Search site overview tables"
                 onChange={setSearchInputValue}
+                size="sm"
                 value={searchInputValue}
               />
             </div>

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/opportunities.test.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/opportunities.test.ts
@@ -235,6 +235,32 @@ describe("buildSiteOpportunities", () => {
     ).toBe("Good sample");
   });
 
+  it("labels QA opportunity samples by effective timing grain", () => {
+    const opportunities = build({
+      planningRows: [
+        planning({
+          id: "qa-campaign",
+          type: "qa_hold",
+          timing_grain: "campaign",
+          stats: stats({ n: 12, median: 8, p95: 13 }),
+        }),
+        planning({
+          id: "qa-batch",
+          type: "qa_hold",
+          timing_grain: undefined,
+          stats: stats({ n: 20, median: 8, p95: 13 }),
+        }),
+      ],
+    });
+
+    expect(
+      opportunities.find(({ stepId }) => stepId === "qa-campaign")?.sampleLabel,
+    ).toBe("Campaigns 12");
+    expect(
+      opportunities.find(({ stepId }) => stepId === "qa-batch")?.sampleLabel,
+    ).toBe("Batches 20");
+  });
+
   it("distinguishes low and limited current samples", () => {
     const opportunities = build({
       planningRows: [

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/opportunities.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/opportunities.ts
@@ -1,4 +1,5 @@
 import { formatCost, formatNumber } from "../../shared/cost";
+import { effectiveTimingGrain } from "../../shared/observation-labels";
 import { procurementStepDisplayLabel } from "../../shared/procurement-planning-ui";
 import { combinedSampleTier } from "../../shared/sample-confidence";
 import { siteNodeKey } from "../../shared/site-node-key";
@@ -97,9 +98,20 @@ function confidenceLabel(
 function sampleLabel(
   currentN: number,
   previousN?: number | null,
-  timingGrain?: "campaign" | null,
+  node?: Pick<SiteNode, "type" | "timing_grain">,
 ): string {
-  const noun = timingGrain === "campaign" ? "Campaigns" : "Samples";
+  const grain = node
+    ? effectiveTimingGrain({
+        type: node.type,
+        timingGrain: node.timing_grain,
+      })
+    : null;
+  const noun =
+    grain === "campaign"
+      ? "Campaigns"
+      : grain === "batch"
+        ? "Batches"
+        : "Samples";
   if (previousN == null || previousN <= 0) {
     return `${noun} ${formatNumber(currentN)}`;
   }
@@ -140,7 +152,7 @@ function planningOpportunity(
     impactValue: `${p95DeviationPct > 0 ? "+" : ""}${formatNumber(p95DeviationPct, { maximumFractionDigits: 0 })}%`,
     impactTone: kind === "planning_over" ? "danger" : "success",
     evidence: `Plan ${formatNumber(plan, { maximumFractionDigits: 0 })}d; median ${formatNumber(row.stats.median, { maximumFractionDigits: 1 })}d; P95 ${formatNumber(row.stats.p95, { maximumFractionDigits: 1 })}d`,
-    sampleLabel: sampleLabel(row.stats.n, null, row.timing_grain),
+    sampleLabel: sampleLabel(row.stats.n, null, row),
     currentSampleN: row.stats.n,
     confidenceLabel: confidenceLabel(row.stats.n, null, true, false),
     score: Math.abs(p95DeviationPct),
@@ -191,7 +203,7 @@ export function buildSiteOpportunities({
       impactValue: formatCost(row.periodCost, currency, { compact: true }),
       impactTone: "danger",
       evidence: `${formatNumber(days, { maximumFractionDigits: 1 })}d observed; ${formatNumber(row.stats.p95, { maximumFractionDigits: 1 })}d P95`,
-      sampleLabel: sampleLabel(row.stats.n, null, row.timing_grain),
+      sampleLabel: sampleLabel(row.stats.n, null, row),
       currentSampleN: row.stats.n,
       confidenceLabel: confidenceLabel(
         row.stats.n,

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/site-overview-export.test.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/site-overview-export.test.ts
@@ -39,6 +39,7 @@ const baseNode: SiteNode = {
   label: "Raw material dwell",
   type: "raw_material_dwell",
   material: "MAT-1",
+  material_name: "Material One",
   plant: "SITE-1",
   stats,
   plan: 12,
@@ -114,6 +115,7 @@ describe("site overview export", () => {
       dwellRows: [dwellRow],
       historicalNodes: [baseNode, planningRow],
       planningRows: [planningRow],
+      products: [{ id: "product-1", material: "FG-1", name: "Product, One" }],
       settings: {
         currency: "GBP",
         excludeLowSamples: true,
@@ -132,6 +134,9 @@ describe("site overview export", () => {
     expect(rows[0]).toMatchObject({
       category: "Dwell",
       step_type: "Raw material dwell",
+      material_name: "Material One",
+      material: "MAT-1",
+      plant: "SITE-1",
       opportunity_status: "Investigating",
       latest_status_category: "Investigation update",
       mean_current: 20,
@@ -174,8 +179,16 @@ describe("site overview export", () => {
   it("orders and trims columns for spreadsheet review", () => {
     const labels = SITE_OVERVIEW_EXPORT_COLUMNS.map((column) => column.label);
 
+    expect(labels.slice(0, 5)).toEqual([
+      "Category",
+      "Step type",
+      "Material name",
+      "Material number",
+      "Plant",
+    ]);
     expect(labels).not.toEqual(
       expect.arrayContaining([
+        "Step",
         "Step ID",
         "Site",
         "Product IDs",

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/site-overview-export.test.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/site-overview-export.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  SITE_OVERVIEW_EXPORT_COLUMNS,
+  buildSiteOverviewCsv,
+  buildSiteOverviewExportRows,
+} from "./site-overview-export";
+
+import type { SiteNode, StepStats } from "../../shared/types";
+import type { DwellRow, PlanningRow } from "./shared/row-types";
+
+const stats: StepStats = {
+  n: 2,
+  mean: 15,
+  median: 15,
+  std: 5,
+  min: 10,
+  max: 20,
+  p25: 12.5,
+  p75: 17.5,
+  p85: 18.5,
+  p95: 19.5,
+};
+const currentStats: StepStats = {
+  n: 1,
+  mean: 20,
+  median: 20,
+  std: 0,
+  min: 20,
+  max: 20,
+  p25: 20,
+  p75: 20,
+  p85: 20,
+  p95: 20,
+};
+
+const baseNode: SiteNode = {
+  id: "raw_dwell_MAT-1",
+  label: "Raw material dwell",
+  type: "raw_material_dwell",
+  material: "MAT-1",
+  plant: "SITE-1",
+  stats,
+  plan: 12,
+  plan_note: "Target",
+  cost: { unit_price: 100.123, currency: "GBP" },
+  material_value: {
+    unit_cost: 50,
+    currency: "JPY",
+    unit_cost_source: "test",
+    uom: "KG",
+    monthly: [],
+  },
+  observations: [
+    { date: "2026-03-01", value: 10 },
+    { date: "2026-06-01", value: 20 },
+  ],
+  mean_observations: [
+    { date: "2026-03-01", value: 10 },
+    { date: "2026-06-01", value: 20 },
+  ],
+  products: [{ id: "product-1", name: "Product, One" }],
+};
+
+const dwellRow: DwellRow = {
+  ...baseNode,
+  stats: currentStats,
+  periodCost: 250,
+  previousPeriodCost: 200,
+  previousCostN: 1,
+  costTrendPct: 25,
+  trendPct: 100,
+  previousValue: 10,
+  previousTrendN: 1,
+};
+
+const planningRow: PlanningRow = {
+  ...baseNode,
+  id: "prod_duration_MAT-1",
+  label: "Production",
+  type: "production",
+  stats: currentStats,
+  periodMaterialValue: 5000.123,
+  deviationPct: 25,
+  trendPct: 100,
+  previousValue: 10,
+  previousTrendN: 1,
+};
+
+describe("site overview export", () => {
+  afterEach(() => vi.useRealTimers());
+
+  it("exports dwell and planning rows with every measure and status history", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-28T12:00:00.000Z"));
+    const statusHistory = {
+      "site-1::dwell::raw_dwell_MAT-1": [
+        {
+          at: "2026-07-02T10:00:00.000Z",
+          user: "Second",
+          category: "Investigation update" as const,
+          text: "Later, with comma",
+        },
+        {
+          at: "2026-07-01T10:00:00.000Z",
+          user: "First",
+          category: "Investigation started" as const,
+          text: "",
+        },
+      ],
+    };
+
+    const input = {
+      dwellRows: [dwellRow],
+      historicalNodes: [baseNode, planningRow],
+      planningRows: [planningRow],
+      settings: {
+        currency: "GBP",
+        excludeLowSamples: true,
+        excludeOutliers: true,
+        procurementBasis: "first" as const,
+        storageCost: 0.2,
+        timeRange: "3m" as const,
+        waccRate: 0.1,
+      },
+      siteId: "site-1",
+      statusHistory,
+    };
+    const rows = buildSiteOverviewExportRows(input);
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({
+      category: "Dwell",
+      step_type: "Raw material dwell",
+      opportunity_status: "Investigating",
+      latest_status_category: "Investigation update",
+      mean_current: 20,
+      mean_previous: 10,
+      mean_trend_percent: 100,
+      mean_trend_direction: "worsening",
+      mean_deviation_percent: 66.7,
+      median_current: 20,
+      p75_current: 20,
+      p95_current: 20,
+      period_dwell_cost: 250,
+      previous_period_dwell_cost: 200,
+      dwell_cost_trend_percent: 25,
+      dwell_cost_currency: "GBP",
+      analysis_currency: "GBP",
+      low_samples_excluded: "Yes",
+      unit_price: 100.123,
+      unit_price_currency: "GBP",
+      material_value_currency: "JPY",
+      previous_sample_count: 1,
+    });
+    expect(rows[0]?.comments).toContain("First");
+    expect(rows[0]?.comments?.toString().indexOf("First")).toBeLessThan(
+      rows[0]?.comments?.toString().indexOf("Second") ?? 0,
+    );
+    expect(rows[1]).toMatchObject({
+      category: "Planning",
+      period_material_value: 5000.123,
+    });
+
+    const csv = buildSiteOverviewCsv(input);
+    expect(csv).toContain("Mean current (days)");
+    expect(csv).toContain("P95 trend (%)");
+    expect(csv).toContain("Material value currency");
+    expect(csv).not.toContain("P95 current samples");
+    expect(csv).toContain('"Product, One"');
+    expect(csv).toContain("Later, with comma");
+  });
+
+  it("orders and trims columns for spreadsheet review", () => {
+    const labels = SITE_OVERVIEW_EXPORT_COLUMNS.map((column) => column.label);
+
+    expect(labels).not.toEqual(
+      expect.arrayContaining([
+        "Step ID",
+        "Site",
+        "Product IDs",
+        "Planning profile ID",
+        "Observation grain",
+      ]),
+    );
+    expect(labels.indexOf("P95 vs plan (%)")).toBe(
+      labels.indexOf("Plan (days)") + 1,
+    );
+    expect(labels.indexOf("Outliers excluded from mean")).toBe(
+      labels.indexOf("Mean vs plan (%)") + 1,
+    );
+    expect(labels.slice(-9)).toEqual([
+      "Procurement timing basis",
+      "Low samples excluded",
+      "WACC (%)",
+      "Storage cost per tonne per day",
+      "Analysis currency",
+      "Period material value",
+      "Material value currency",
+      "Unit price",
+      "Unit price currency",
+    ]);
+  });
+});

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/site-overview-export.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/site-overview-export.ts
@@ -1,0 +1,313 @@
+import { STEP_TYPE_LABELS } from "../../shared/categories";
+import { buildCsvContent } from "../../shared/export-utils";
+import { BASE_MEASURES, MEASURE_LABELS } from "../../shared/measure-context";
+import { computeTimingTrend, trendDirection } from "../../shared/period-trends";
+import { siteNodeKey } from "../../shared/site-node-key";
+import {
+  deriveStatusActionState,
+  statusKey,
+  type StatusEntry,
+  type StatusStore,
+} from "../../shared/status";
+
+import type { ProcurementBasis } from "../../shared/procurement-basis-context";
+import type { TimeRange } from "../../shared/time-range";
+import type { DetailColumn, SiteNode } from "../../shared/types";
+import type { DwellRow, PlanningRow } from "./shared/row-types";
+
+type ExportValue = string | number | null;
+type ExportRecord = Record<string, ExportValue>;
+
+export interface SiteOverviewExportSettings {
+  currency: string;
+  excludeLowSamples: boolean;
+  excludeOutliers: boolean;
+  procurementBasis: ProcurementBasis;
+  storageCost: number;
+  timeRange: TimeRange;
+  waccRate: number;
+}
+
+export interface SiteOverviewExportInput {
+  dwellRows: readonly DwellRow[];
+  historicalNodes: readonly SiteNode[];
+  planningRows: readonly PlanningRow[];
+  settings: SiteOverviewExportSettings;
+  siteId: string;
+  statusHistory: StatusStore;
+}
+
+const identityColumns = [
+  ["category", "Category"],
+  ["step_type", "Step type"],
+  ["step", "Step"],
+  ["plant", "Plant"],
+  ["material", "Material"],
+  ["product_names", "Products"],
+  ["supplier_name", "Supplier"],
+  ["supplier_id", "Supplier ID"],
+  ["receipt_basis", "Receipt basis"],
+  ["plan_match_status", "Plan match status"],
+  ["planning_source", "Planning source"],
+] as const;
+
+const analysisColumns = [["time_range", "Time range"]] as const;
+
+const planningColumns = [
+  ["plan_days", "Plan (days)"],
+  ["p95_deviation_percent", "P95 vs plan (%)"],
+  ["plan_note", "Plan note"],
+  ["observations_exceeding_plan_percent", "Observations exceeding plan (%)"],
+  ["minimum_order_quantity", "Minimum order quantity"],
+  ["minimum_order_uom", "Minimum order UOM"],
+  ["order_multiple_quantity", "Order multiple quantity"],
+  ["safety_stock_quantity", "Safety stock quantity"],
+  ["safety_stock_uom", "Safety stock UOM"],
+] as const;
+
+const costColumns = [
+  ["period_dwell_cost", "Period dwell cost"],
+  ["previous_period_dwell_cost", "Previous period dwell cost"],
+  ["dwell_cost_trend_percent", "Dwell cost trend (%)"],
+  ["dwell_cost_currency", "Dwell cost currency"],
+] as const;
+
+const qualityColumns = [
+  ["sample_count", "Sample count"],
+  ["previous_sample_count", "Previous sample count"],
+] as const;
+
+const outlierColumns = [
+  ["outliers_excluded", "Outliers excluded from mean"],
+  ["excluded_outlier_count", "Excluded outlier count"],
+  ["excluded_outlier_percent", "Excluded outlier (%)"],
+] as const;
+
+const statusColumns = [
+  ["opportunity_status", "Opportunity status"],
+  ["latest_status_category", "Latest status category"],
+  ["latest_status_at", "Latest status at"],
+  ["latest_status_author", "Latest status author"],
+  ["comments", "Comments"],
+] as const;
+
+const measureColumnEntries = BASE_MEASURES.flatMap((measure) => {
+  const label = MEASURE_LABELS[measure];
+  return [
+    [`${measure}_current`, `${label} current (days)`],
+    [`${measure}_previous`, `${label} previous (days)`],
+    [`${measure}_trend_percent`, `${label} trend (%)`],
+    [`${measure}_trend_direction`, `${label} trend direction`],
+    ...(measure === "p95"
+      ? []
+      : [[`${measure}_deviation_percent`, `${label} vs plan (%)`] as const]),
+  ] as const;
+});
+
+const exportSettingsColumns = [
+  ["procurement_basis", "Procurement timing basis"],
+  ["low_samples_excluded", "Low samples excluded"],
+  ["wacc_percent", "WACC (%)"],
+  ["storage_cost", "Storage cost per tonne per day"],
+  ["analysis_currency", "Analysis currency"],
+  ["period_material_value", "Period material value"],
+  ["material_value_currency", "Material value currency"],
+  ["unit_price", "Unit price"],
+  ["unit_price_currency", "Unit price currency"],
+] as const;
+
+const outlierColumnsIndex =
+  measureColumnEntries.findIndex(([key]) => key === "mean_deviation_percent") +
+  1;
+
+const columnEntries = [
+  ...identityColumns,
+  ...analysisColumns,
+  ...planningColumns,
+  ...costColumns,
+  ...qualityColumns,
+  ...measureColumnEntries.slice(0, outlierColumnsIndex),
+  ...outlierColumns,
+  ...measureColumnEntries.slice(outlierColumnsIndex),
+  ...statusColumns,
+  ...exportSettingsColumns,
+] as const;
+
+export const SITE_OVERVIEW_EXPORT_COLUMNS: DetailColumn[] = columnEntries.map(
+  ([key, label]) => ({
+    key,
+    label,
+    source_field: null,
+    source_table: null,
+  }),
+);
+
+const latestEntry = (
+  entries: readonly StatusEntry[] | undefined,
+): StatusEntry | null =>
+  entries
+    ? ([...entries]
+        .sort((left, right) => left.at.localeCompare(right.at))
+        .at(-1) ?? null)
+    : null;
+
+const formatComments = (entries: readonly StatusEntry[] | undefined): string =>
+  [...(entries ?? [])]
+    .sort((left, right) => left.at.localeCompare(right.at))
+    .map(
+      (entry) =>
+        `${entry.at} | ${entry.user} | ${entry.category} | ${
+          entry.text || "(no comment)"
+        }`,
+    )
+    .join("\n");
+
+const planningSourceLabel = (node: SiteNode): string | null => {
+  const source = node.planning_source;
+  if (!source) {
+    return null;
+  }
+  return [source.label, source.system, source.table]
+    .filter(Boolean)
+    .join(" | ");
+};
+
+const unroundedNumericColumns = new Set([
+  "period_material_value",
+  "unit_price",
+]);
+
+const roundExportValues = (record: ExportRecord): ExportRecord =>
+  Object.fromEntries(
+    Object.entries(record).map(([key, value]) => [
+      key,
+      typeof value === "number" && !unroundedNumericColumns.has(key)
+        ? Number(value.toFixed(1))
+        : value,
+    ]),
+  );
+
+const measureValues = (
+  node: SiteNode,
+  historicalNode: SiteNode,
+  timeRange: TimeRange,
+): ExportRecord => {
+  const values: ExportRecord = {};
+  for (const measure of BASE_MEASURES) {
+    const trend = computeTimingTrend(historicalNode, timeRange, measure);
+    const current = node.stats[measure] ?? null;
+    values[`${measure}_current`] = current;
+    values[`${measure}_previous`] = trend.previousValue;
+    values[`${measure}_trend_percent`] = trend.pctChange;
+    values[`${measure}_trend_direction`] = trendDirection(trend.pctChange);
+    values[`${measure}_deviation_percent`] =
+      node.plan != null && node.plan > 0 && current != null
+        ? ((current - node.plan) / node.plan) * 100
+        : null;
+  }
+  return values;
+};
+
+const rowToExportRecord = ({
+  category,
+  historicalNode,
+  node,
+  settings,
+  siteId,
+  statusHistory,
+}: {
+  category: "Dwell" | "Planning";
+  historicalNode: SiteNode;
+  node: DwellRow | PlanningRow;
+  settings: SiteOverviewExportSettings;
+  siteId: string;
+  statusHistory: StatusStore;
+}): ExportRecord => {
+  const entries = statusHistory[statusKey(siteId, node)];
+  const latest = latestEntry(entries);
+  const dwell = category === "Dwell" ? (node as DwellRow) : null;
+  const planning = category === "Planning" ? (node as PlanningRow) : null;
+
+  return roundExportValues({
+    category,
+    step_type: STEP_TYPE_LABELS[node.type],
+    step: node.label,
+    plant: node.plant,
+    material: node.material,
+    product_names: node.products.map((product) => product.name).join("; "),
+    supplier_name: node.supplier_name ?? null,
+    supplier_id: node.supplier_id ?? null,
+    receipt_basis: node.receipt_basis ?? null,
+    plan_match_status: node.plan_match_status ?? null,
+    planning_source: planningSourceLabel(node),
+    time_range: settings.timeRange,
+    procurement_basis: settings.procurementBasis,
+    low_samples_excluded: settings.excludeLowSamples ? "Yes" : "No",
+    outliers_excluded: settings.excludeOutliers ? "Yes" : "No",
+    wacc_percent: settings.waccRate * 100,
+    storage_cost: settings.storageCost,
+    analysis_currency: settings.currency,
+    plan_days: node.plan,
+    plan_note: node.plan_note,
+    observations_exceeding_plan_percent: node.pct_exceeding_plan ?? null,
+    period_material_value: planning?.periodMaterialValue ?? null,
+    material_value_currency: node.material_value?.currency ?? null,
+    minimum_order_quantity: node.inventory_policy?.minimum_order_qty ?? null,
+    minimum_order_uom: node.inventory_policy?.order_uom ?? null,
+    order_multiple_quantity: node.inventory_policy?.order_multiple_qty ?? null,
+    safety_stock_quantity: node.inventory_policy?.safety_stock_qty ?? null,
+    safety_stock_uom: node.inventory_policy?.safety_stock_uom ?? null,
+    unit_price: node.cost?.unit_price ?? null,
+    unit_price_currency: node.cost?.currency ?? null,
+    period_dwell_cost: dwell?.periodCost ?? null,
+    previous_period_dwell_cost: dwell?.previousPeriodCost ?? null,
+    dwell_cost_trend_percent: dwell?.costTrendPct ?? null,
+    dwell_cost_currency: node.cost?.currency ?? settings.currency,
+    sample_count: node.stats.n,
+    previous_sample_count: node.previousTrendN,
+    excluded_outlier_count: node.excluded_count ?? null,
+    excluded_outlier_percent: node.excluded_pct ?? null,
+    ...measureValues(node, historicalNode, settings.timeRange),
+    opportunity_status: deriveStatusActionState(entries).label,
+    latest_status_category: latest?.category ?? null,
+    latest_status_at: latest?.at ?? null,
+    latest_status_author: latest?.user ?? null,
+    comments: formatComments(entries),
+  });
+};
+
+export const buildSiteOverviewExportRows = ({
+  dwellRows,
+  historicalNodes,
+  planningRows,
+  settings,
+  siteId,
+  statusHistory,
+}: SiteOverviewExportInput): ExportRecord[] => {
+  const historicalNodesByKey = new Map(
+    historicalNodes.map((node) => [siteNodeKey(node), node]),
+  );
+  const exportRow = (
+    node: DwellRow | PlanningRow,
+    category: "Dwell" | "Planning",
+  ) =>
+    rowToExportRecord({
+      category,
+      historicalNode: historicalNodesByKey.get(siteNodeKey(node)) ?? node,
+      node,
+      settings,
+      siteId,
+      statusHistory,
+    });
+
+  return [
+    ...dwellRows.map((row) => exportRow(row, "Dwell")),
+    ...planningRows.map((row) => exportRow(row, "Planning")),
+  ];
+};
+
+export const buildSiteOverviewCsv = (input: SiteOverviewExportInput): string =>
+  buildCsvContent(
+    SITE_OVERVIEW_EXPORT_COLUMNS,
+    buildSiteOverviewExportRows(input),
+  );

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/site-overview-export.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/site-overview-export.ts
@@ -12,7 +12,7 @@ import {
 
 import type { ProcurementBasis } from "../../shared/procurement-basis-context";
 import type { TimeRange } from "../../shared/time-range";
-import type { DetailColumn, SiteNode } from "../../shared/types";
+import type { DetailColumn, Product, SiteNode } from "../../shared/types";
 import type { DwellRow, PlanningRow } from "./shared/row-types";
 
 type ExportValue = string | number | null;
@@ -32,6 +32,7 @@ export interface SiteOverviewExportInput {
   dwellRows: readonly DwellRow[];
   historicalNodes: readonly SiteNode[];
   planningRows: readonly PlanningRow[];
+  products: readonly Product[];
   settings: SiteOverviewExportSettings;
   siteId: string;
   statusHistory: StatusStore;
@@ -40,9 +41,9 @@ export interface SiteOverviewExportInput {
 const identityColumns = [
   ["category", "Category"],
   ["step_type", "Step type"],
-  ["step", "Step"],
+  ["material_name", "Material name"],
+  ["material", "Material number"],
   ["plant", "Plant"],
-  ["material", "Material"],
   ["product_names", "Products"],
   ["supplier_name", "Supplier"],
   ["supplier_id", "Supplier ID"],
@@ -172,6 +173,27 @@ const planningSourceLabel = (node: SiteNode): string | null => {
     .join(" | ");
 };
 
+const buildMaterialNamesByNumber = (
+  products: readonly Product[],
+  nodes: readonly SiteNode[],
+): ReadonlyMap<string, string> => {
+  const materialNames = new Map<string, string>();
+
+  for (const product of products) {
+    if (product.material && product.name.trim()) {
+      materialNames.set(product.material, product.name.trim());
+    }
+  }
+  for (const node of nodes) {
+    const materialName = node.material_name?.trim();
+    if (node.material && materialName) {
+      materialNames.set(node.material, materialName);
+    }
+  }
+
+  return materialNames;
+};
+
 const unroundedNumericColumns = new Set([
   "period_material_value",
   "unit_price",
@@ -212,6 +234,7 @@ const rowToExportRecord = ({
   category,
   historicalNode,
   node,
+  materialNamesByNumber,
   settings,
   siteId,
   statusHistory,
@@ -219,6 +242,7 @@ const rowToExportRecord = ({
   category: "Dwell" | "Planning";
   historicalNode: SiteNode;
   node: DwellRow | PlanningRow;
+  materialNamesByNumber: ReadonlyMap<string, string>;
   settings: SiteOverviewExportSettings;
   siteId: string;
   statusHistory: StatusStore;
@@ -231,9 +255,11 @@ const rowToExportRecord = ({
   return roundExportValues({
     category,
     step_type: STEP_TYPE_LABELS[node.type],
-    step: node.label,
-    plant: node.plant,
+    material_name: node.material
+      ? (materialNamesByNumber.get(node.material) ?? null)
+      : null,
     material: node.material,
+    plant: node.plant,
     product_names: node.products.map((product) => product.name).join("; "),
     supplier_name: node.supplier_name ?? null,
     supplier_id: node.supplier_id ?? null,
@@ -280,6 +306,7 @@ export const buildSiteOverviewExportRows = ({
   dwellRows,
   historicalNodes,
   planningRows,
+  products,
   settings,
   siteId,
   statusHistory,
@@ -287,6 +314,11 @@ export const buildSiteOverviewExportRows = ({
   const historicalNodesByKey = new Map(
     historicalNodes.map((node) => [siteNodeKey(node), node]),
   );
+  const materialNamesByNumber = buildMaterialNamesByNumber(products, [
+    ...historicalNodes,
+    ...dwellRows,
+    ...planningRows,
+  ]);
   const exportRow = (
     node: DwellRow | PlanningRow,
     category: "Dwell" | "Planning",
@@ -294,6 +326,7 @@ export const buildSiteOverviewExportRows = ({
     rowToExportRecord({
       category,
       historicalNode: historicalNodesByKey.get(siteNodeKey(node)) ?? node,
+      materialNamesByNumber,
       node,
       settings,
       siteId,

--- a/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/use-site-overview-rows.ts
+++ b/apps/hash-frontend/src/pages/supply-chain/supply-chain-data-shell/site/use-site-overview-rows.ts
@@ -327,6 +327,7 @@ export function useSiteOverviewRows({
   return {
     loading,
     error,
+    historicalNodes,
     filteredNodes,
     summaryStats,
     siteCurrency,

--- a/libs/@local/hash-isomorphic-utils/src/production-schedule/schema.ts
+++ b/libs/@local/hash-isomorphic-utils/src/production-schedule/schema.ts
@@ -1,6 +1,10 @@
 import { z } from "zod";
 
 const nonEmptyString = z.string().min(1);
+const canonicalNonEmptyString = nonEmptyString.refine(
+  (value) => value === value.trim(),
+  { error: "String must not have leading or trailing whitespace" },
+);
 const nullableNonEmptyString = nonEmptyString.nullable();
 const nonNegativeNumber = z.number().finite().nonnegative();
 const positiveNumber = z.number().finite().positive();
@@ -213,6 +217,7 @@ export const productionScheduleDeliverySchema = z.strictObject({
   delivery_number: nonEmptyString,
   delivery_item: nonEmptyString,
   shipment_number: nonEmptyString.optional(),
+  sales_order: canonicalNonEmptyString.optional(),
   ship_to: nonEmptyString.optional(),
   sold_to: nonEmptyString.optional(),
   customer_name: nonEmptyString.optional(),

--- a/libs/@local/hash-isomorphic-utils/src/production-schedule/validation.test.ts
+++ b/libs/@local/hash-isomorphic-utils/src/production-schedule/validation.test.ts
@@ -85,4 +85,39 @@ describe("parseProductionSchedule", () => {
       ),
     ).toThrow();
   });
+
+  it("accepts an optional sales-order number on dispatch deliveries", () => {
+    const schedule = legacySchedule();
+    schedule.dispatch_events = [
+      {
+        id: "dispatch-1",
+        batch_id: "1000::B1",
+        material: "1000",
+        batch: "B1",
+        dispatch_date: "2026-02-01",
+        quantity: 10,
+        uom: "KG",
+        bwart: "601",
+        episode_scope: "in_episode",
+        delivery_coverage: "exact",
+        deliveries: [
+          {
+            delivery_number: "DELIVERY",
+            delivery_item: "10",
+            sales_order: "SALES-ORDER",
+            quantity: 10,
+            uom: "KG",
+          },
+        ],
+      },
+    ];
+
+    expect(parseProductionSchedule(schedule, "product")).toBeTruthy();
+
+    schedule.dispatch_events[0]!.deliveries[0]!.sales_order = "";
+    expect(() => parseProductionSchedule(schedule, "product")).toThrow();
+
+    schedule.dispatch_events[0]!.deliveries[0]!.sales_order = " PADDED ";
+    expect(() => parseProductionSchedule(schedule, "product")).toThrow();
+  });
 });


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

A few UX improvements to the supply chain pages:

1. H-6715: Add an 'export' button to the site view which exports all dwell + planning rows as a CSV
2. H-6740: Add a search input to the product timeline view which focuses the input batch or order number
3. H-6741: When adding a status update, show existing comments in the modal

Also builds on #9118 to support a mix of QA release measurement techniques (i.e. not just all batch-received or all campaign-end).

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->
<!-- Libraries inside of the `@local` directory are always internal libraries which have no need for publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] require changes to docs which **are made** as part of this PR

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
