### PR TITLE
BE-618: Rank semantic searches on a quantized embedding column with per-policy-branch reads

### DIFF
--- a/libs/@local/graph/migrations/graph-migrations/v008__entity_types/up.sql
+++ b/libs/@local/graph/migrations/graph-migrations/v008__entity_types/up.sql
@@ -36,5 +36,8 @@ CREATE TABLE entity_type_constrains_link_destinations_on (
 CREATE TABLE entity_type_embeddings (
     ontology_id UUID PRIMARY KEY REFERENCES entity_types,
     embedding VECTOR(3072) NOT NULL,
-    updated_at_transaction_time TIMESTAMP WITH TIME ZONE NOT NULL
+    updated_at_transaction_time TIMESTAMP WITH TIME ZONE NOT NULL,
+    embedding_bits BIT(3072) NOT NULL GENERATED ALWAYS AS (
+        binary_quantize(embedding)::BIT(3072)
+    ) STORED
 );

--- a/libs/@local/graph/migrations/graph-migrations/v009__entities/up.sql
+++ b/libs/@local/graph/migrations/graph-migrations/v009__entities/up.sql
@@ -156,8 +156,15 @@ CREATE TABLE entity_embeddings (
     embedding VECTOR(3072) NOT NULL,
     updated_at_decision_time TIMESTAMP WITH TIME ZONE NOT NULL,
     updated_at_transaction_time TIMESTAMP WITH TIME ZONE NOT NULL,
+    embedding_bits BIT(3072) NOT NULL GENERATED ALWAYS AS (
+        binary_quantize(embedding)::BIT(3072)
+    ) STORED,
     FOREIGN KEY (web_id, entity_uuid) REFERENCES entity_ids
 );
 
 CREATE UNIQUE INDEX entity_embeddings_idx
 ON entity_embeddings (web_id, entity_uuid, property) NULLS NOT DISTINCT;
+
+-- Only the combined per-entity embedding: the per-property rows are a different space.
+CREATE INDEX entity_embeddings_hnsw
+ON entity_embeddings USING hnsw (embedding_bits bit_hamming_ops) WHERE property IS NULL;

--- a/libs/@local/graph/postgres-store/postgres_migrations/V57__entity_embedding_bits.sql
+++ b/libs/@local/graph/postgres-store/postgres_migrations/V57__entity_embedding_bits.sql
@@ -1,0 +1,12 @@
+ALTER TABLE entity_embeddings
+    ADD COLUMN embedding_bits bit(3072) NOT NULL
+    GENERATED ALWAYS AS (binary_quantize(embedding)::bit(3072)) STORED;
+
+ALTER TABLE entity_type_embeddings
+    ADD COLUMN embedding_bits bit(3072) NOT NULL
+    GENERATED ALWAYS AS (binary_quantize(embedding)::bit(3072)) STORED;
+
+-- Only the combined per-entity embedding: the per-property rows are a different space.
+CREATE INDEX entity_embeddings_hnsw ON entity_embeddings
+    USING hnsw (embedding_bits bit_hamming_ops)
+    WHERE property IS NULL;

--- a/libs/@local/graph/postgres-store/src/snapshot/entity/batch.rs
+++ b/libs/@local/graph/postgres-store/src/snapshot/entity/batch.rs
@@ -235,8 +235,26 @@ where
                     INSERT INTO entity_edge
                         SELECT * FROM entity_edge_tmp;
 
-                    INSERT INTO entity_embeddings
-                        SELECT * FROM entity_embeddings_tmp;
+                    -- The explicit list leaves out the generated `embedding_bits` column, which
+                    -- rejects inserts even when the staging table is empty.
+                    INSERT INTO entity_embeddings (
+                        web_id,
+                        entity_uuid,
+                        draft_id,
+                        property,
+                        embedding,
+                        updated_at_decision_time,
+                        updated_at_transaction_time
+                    )
+                        SELECT
+                            web_id,
+                            entity_uuid,
+                            draft_id,
+                            property,
+                            embedding,
+                            updated_at_decision_time,
+                            updated_at_transaction_time
+                        FROM entity_embeddings_tmp;
             ",
             )
             .instrument(tracing::info_span!(

--- a/libs/@local/graph/postgres-store/src/snapshot/entity/batch.rs
+++ b/libs/@local/graph/postgres-store/src/snapshot/entity/batch.rs
@@ -81,9 +81,12 @@ where
                         (LIKE entity_edge INCLUDING ALL)
                         ON COMMIT DROP;
 
+                    -- Staging holds the rows for a single copy, so it needs neither the HNSW
+                    -- index nor the quantized column derived from the vectors.
                     CREATE TEMPORARY TABLE entity_embeddings_tmp
-                        (LIKE entity_embeddings INCLUDING ALL)
+                        (LIKE entity_embeddings INCLUDING ALL EXCLUDING INDEXES)
                         ON COMMIT DROP;
+                    ALTER TABLE entity_embeddings_tmp DROP COLUMN embedding_bits;
                 ",
             )
             .instrument(tracing::info_span!(

--- a/libs/@local/graph/postgres-store/src/snapshot/ontology/entity_type/batch.rs
+++ b/libs/@local/graph/postgres-store/src/snapshot/ontology/entity_type/batch.rs
@@ -102,8 +102,18 @@ where
                     INSERT INTO entity_types
                         SELECT * FROM entity_types_tmp;
 
-                    INSERT INTO entity_type_embeddings
-                        SELECT * FROM entity_type_embeddings_tmp;
+                    -- The explicit list leaves out the generated `embedding_bits` column, which
+                    -- rejects inserts even when the staging table is empty.
+                    INSERT INTO entity_type_embeddings (
+                        ontology_id,
+                        embedding,
+                        updated_at_transaction_time
+                    )
+                        SELECT
+                            ontology_id,
+                            embedding,
+                            updated_at_transaction_time
+                        FROM entity_type_embeddings_tmp;
                 ",
             )
             .instrument(tracing::info_span!(

--- a/libs/@local/graph/postgres-store/src/snapshot/ontology/entity_type/batch.rs
+++ b/libs/@local/graph/postgres-store/src/snapshot/ontology/entity_type/batch.rs
@@ -38,6 +38,9 @@ where
                     CREATE TEMPORARY TABLE entity_type_embeddings_tmp (
                         LIKE entity_type_embeddings INCLUDING ALL
                     ) ON COMMIT DROP;
+                    -- Staging holds the rows for a single copy, so it does not need the
+                    -- quantized column derived from the vectors.
+                    ALTER TABLE entity_type_embeddings_tmp DROP COLUMN embedding_bits;
                 ",
             )
             .instrument(tracing::info_span!(

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
@@ -2,6 +2,7 @@ mod delete;
 pub(crate) mod provenance;
 mod query;
 mod read;
+mod search;
 mod summary;
 
 use alloc::borrow::Cow;
@@ -26,10 +27,9 @@ use hash_graph_store::{
         EntityQueryPath, EntityQuerySorting, EntityStore, EntityTypeRetrieval, EntityTypesError,
         EntityValidationReport, EntityValidationType, HasPermissionForEntitiesParams,
         PatchEntityParams, QueryConversion, QueryEntitiesParams, QueryEntitiesResponse,
-        QueryEntitySubgraphParams, QueryEntitySubgraphResponse, SearchEntitiesFilter,
-        SearchEntitiesParams, SearchEntitiesResponse, SummarizeEntitiesParams,
-        SummarizeEntitiesResponse, UpdateEntityEmbeddingsParams, ValidateEntityComponents,
-        ValidateEntityParams,
+        QueryEntitySubgraphParams, QueryEntitySubgraphResponse, SearchEntitiesParams,
+        SearchEntitiesResponse, SummarizeEntitiesParams, SummarizeEntitiesResponse,
+        UpdateEntityEmbeddingsParams, ValidateEntityComponents, ValidateEntityParams,
     },
     entity_type::{EntityTypeStore as _, IncludeEntityTypeOption},
     error::{
@@ -107,8 +107,8 @@ use crate::store::{
             summary::{Deduplication, EntitySummaryQuery},
         },
         query::{
-            Distinctness, PostgresRecord as _, PostgresSorting as _, QUANTIZED_RANK_OVERFETCH,
-            SelectCompiler, StatementShape, bulk_insert,
+            Distinctness, PostgresRecord as _, PostgresSorting as _, SelectCompiler,
+            StatementShape, bulk_insert,
             rows::{
                 EntityDraftRow, EntityEdgeRow, EntityEditionRow, EntityIdRow, EntityIsOfTypeRow,
                 EntityTemporalMetadataRow, PostgresRow as _,
@@ -791,253 +791,6 @@ where
         }
 
         Ok(response)
-    }
-
-    /// Reads the entities whose combined embedding is closest to `params.embedding`.
-    ///
-    /// Two reads: one statement that ranks candidates with the permission and request filters in
-    /// place and re-scores them against the full vector, then the hydration of the survivors.
-    #[tracing::instrument(level = "info", skip(self, params))]
-    #[expect(clippy::too_many_lines)]
-    async fn search_entities_impl(
-        &self,
-        actor_id: ActorEntityUuid,
-        params: SearchEntitiesParams,
-    ) -> Result<SearchEntitiesResponse, Report<QueryError>> {
-        let SearchEntitiesParams {
-            embedding,
-            maximum_semantic_distance,
-            limit,
-            include_entity_types,
-            filter:
-                SearchEntitiesFilter {
-                    entity_type_ids,
-                    web_ids,
-                    include_drafts,
-                },
-        } = params;
-
-        let policy_components = PolicyComponents::builder(self)
-            .with_actor(actor_id)
-            .with_action(ActionName::ViewEntity, MergePolicies::Yes)
-            .await
-            .change_context(QueryError)?;
-        let policy_filter = Filter::<Entity>::for_policies(
-            policy_components.extract_filter_policies(ActionName::ViewEntity),
-            policy_components.actor_id(),
-            policy_components.optimization_data(ActionName::ViewEntity),
-        );
-
-        // A search always runs against the current time and never returns archived entities.
-        let temporal_axes = QueryTemporalAxesUnresolved::live_only().resolve();
-
-        let mut request_filters = vec![Filter::Equal(
-            FilterExpression::Path {
-                path: EntityQueryPath::Archived,
-            },
-            FilterExpression::Parameter {
-                parameter: Parameter::Boolean(false),
-                convert: None,
-            },
-        )];
-        if !entity_type_ids.is_empty() {
-            request_filters.push(Filter::Any(
-                entity_type_ids
-                    .iter()
-                    .map(Filter::for_entity_by_type_id)
-                    .collect(),
-            ));
-        }
-        if !web_ids.is_empty() {
-            request_filters.push(Filter::In(
-                FilterExpression::Path {
-                    path: EntityQueryPath::WebId,
-                },
-                FilterExpressionList::ParameterList {
-                    parameters: ParameterList::WebIds(&web_ids),
-                },
-            ));
-        }
-        let request_filter = Filter::All(request_filters);
-
-        let web_id_path = EntityQueryPath::WebId;
-        let uuid_path = EntityQueryPath::Uuid;
-        let draft_id_path = EntityQueryPath::DraftId;
-        let embedding_path = EntityQueryPath::Embedding;
-
-        let mut compiler = SelectCompiler::<Entity>::new(Some(&temporal_axes), include_drafts);
-        compiler
-            .add_filter(&policy_filter)
-            .change_context(QueryError)?;
-        compiler
-            .add_filter(&request_filter)
-            .change_context(QueryError)?;
-        compiler.add_selection_path(&web_id_path);
-        compiler.add_selection_path(&uuid_path);
-        compiler.add_selection_path(&draft_id_path);
-        let embeddings_alias = compiler
-            .rank_by_quantized_distance(&embedding_path, &embedding)
-            .change_context(QueryError)?;
-        // The search compares against the combined embedding over all of an entity's properties.
-        compiler.restrict_embedding_property(embeddings_alias, None);
-        let candidate_pool = limit.saturating_mul(QUANTIZED_RANK_OVERFETCH);
-        compiler.set_limit(candidate_pool);
-
-        // An HNSW scan stops after `ef_search` tuples (default 40) regardless of the statement's
-        // limit, so it must be allowed to produce the whole candidate pool. The iterative mode
-        // resumes the walk when the filters discard candidates, or when the pool exceeds the
-        // setting's range of 1 to 1000.
-        let settings = format!(
-            "SET LOCAL hnsw.ef_search = {};
-             SET LOCAL hnsw.iterative_scan = relaxed_order;",
-            candidate_pool.clamp(1, 1000)
-        );
-        self.as_client()
-            .batch_execute(&settings)
-            .instrument(tracing::info_span!(
-                "SET",
-                otel.kind = "client",
-                db.system = "postgresql",
-                peer.service = "Postgres",
-                db.query.text = settings,
-            ))
-            .await
-            .change_context(QueryError)?;
-
-        // The candidate read ranks on the quantized embedding, so it becomes a CTE that the same
-        // statement re-scores against the full vector. Only the candidates have their out-of-line
-        // vector read that way, and the permission filter stays inside the ranking rather than
-        // being applied to its result.
-        let (candidate_statement, candidate_parameters) = compiler.compile();
-        let maximum_distance = maximum_semantic_distance.into_inner();
-
-        let mut parameters = candidate_parameters.to_vec();
-        let embedding_parameter = parameters.len() + 1;
-        parameters.push(&embedding);
-        let maximum_distance_parameter = parameters.len() + 1;
-        parameters.push(&maximum_distance);
-
-        // The candidate filters join to-many relations, so one entity can occupy several pool
-        // slots. `DISTINCT` collapses them, which requires the distance in the select list.
-        let statement = format!(
-            "WITH candidates AS ({candidate_statement})
-             SELECT DISTINCT
-                    candidates.web_id,
-                    candidates.entity_uuid,
-                    candidates.draft_id,
-                    entity_embeddings.embedding <=> ${embedding_parameter}::vector AS distance
-               FROM candidates
-               JOIN entity_embeddings
-                 ON entity_embeddings.web_id = candidates.web_id
-                AND entity_embeddings.entity_uuid = candidates.entity_uuid
-              WHERE entity_embeddings.property IS NULL
-                AND entity_embeddings.embedding <=> ${embedding_parameter}::vector <= \
-             ${maximum_distance_parameter}
-              ORDER BY distance
-              LIMIT {limit}"
-        );
-
-        let ranked = self
-            .as_client()
-            .query(&statement, &parameters)
-            .instrument(tracing::info_span!(
-                "SELECT",
-                otel.kind = "client",
-                db.system = "postgresql",
-                peer.service = "Postgres",
-                db.query.text = statement,
-            ))
-            .await
-            .change_context(QueryError)?
-            .into_iter()
-            .map(|row| EntityId {
-                web_id: row.get(0),
-                entity_uuid: row.get(1),
-                draft_id: row.get(2),
-            })
-            .collect::<Vec<_>>();
-
-        if ranked.len() < limit {
-            // Expected for actors whose filters pass few candidates: the iterative scan gives up
-            // at `hnsw.max_scan_tuples`. The event is what distinguishes that from a genuinely
-            // sparse result when a search returns fewer rows than requested.
-            tracing::debug!(
-                limit,
-                candidates = ranked.len(),
-                candidate_pool,
-                "the search returned fewer candidates than requested"
-            );
-        }
-
-        if ranked.is_empty() {
-            return Ok(SearchEntitiesResponse {
-                entities: Vec::new(),
-                closed_multi_entity_types: None,
-            });
-        }
-
-        let response = self
-            .query_entities_impl(
-                actor_id,
-                QueryEntitiesParams {
-                    filter: Filter::Any(
-                        ranked
-                            .iter()
-                            .map(|&entity_id| {
-                                let by_id = Filter::for_entity_by_entity_id(entity_id);
-                                if entity_id.draft_id.is_some() {
-                                    by_id
-                                } else {
-                                    // The shared filter leaves the draft dimension open for live
-                                    // ids, which would hydrate an entity's drafts alongside it
-                                    // when drafts are included.
-                                    Filter::All(vec![
-                                        by_id,
-                                        Filter::Not(Box::new(Filter::Exists {
-                                            path: EntityQueryPath::DraftId,
-                                        })),
-                                    ])
-                                }
-                            })
-                            .collect(),
-                    ),
-                    temporal_axes: QueryTemporalAxesUnresolved::live_only(),
-                    sorting: EntityQuerySorting {
-                        paths: vec![],
-                        cursor: None,
-                    },
-                    conversions: Vec::new(),
-                    // The filter already names exactly the entities to hydrate.
-                    limit: ranked.len(),
-                    include_drafts,
-                    include_entity_types: include_entity_types
-                        .then_some(IncludeEntityTypeOption::Closed),
-                    include_permissions: false,
-                },
-            )
-            .await?;
-
-        // Hydration does not preserve the ranking, so restore it from the candidate order. The
-        // hydration filter names exactly the ranked ids, so a row without a rank cannot occur —
-        // dropping it beats `Option`'s None-first ordering, which would put it on top.
-        let ranks = ranked
-            .iter()
-            .enumerate()
-            .map(|(rank, &entity_id)| (entity_id, rank))
-            .collect::<HashMap<_, _>>();
-        let mut entities = response.entities;
-        entities.retain(|entity| ranks.contains_key(&entity.metadata.record_id.entity_id));
-        entities.sort_by_key(|entity| {
-            ranks
-                .get(&entity.metadata.record_id.entity_id)
-                .copied()
-                .expect("the retained entities should all carry a rank")
-        });
-
-        Ok(SearchEntitiesResponse {
-            entities,
-            closed_multi_entity_types: response.closed_multi_entity_types,
-        })
     }
 
     #[tracing::instrument(level = "info", skip(self, params))]
@@ -2072,9 +1825,10 @@ where
         actor_id: ActorEntityUuid,
         params: SearchEntitiesParams,
     ) -> Result<SearchEntitiesResponse, Report<QueryError>> {
-        // The ranked read and the hydration are separate statements. Under `READ COMMITTED` each
-        // would use its own MVCC snapshot, so a write committing in between could rank an entity
-        // that the hydration no longer returns.
+        // The search issues several statements — one candidate read per policy branch, the
+        // rerank, and the hydration. Under `READ COMMITTED` each would use its own MVCC
+        // snapshot, so a write committing in between could rank an entity that the hydration no
+        // longer returns.
         let transaction = self
             .begin_read_only_transaction()
             .await

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
@@ -10,7 +10,6 @@ use std::collections::{HashMap, HashSet};
 
 use error_stack::{FutureExt as _, Report, ResultExt as _, TryReportStreamExt as _, ensure};
 use futures::{StreamExt as _, TryStreamExt as _, stream};
-use hash_codec::numeric::Real;
 use hash_graph_authorization::policies::{
     Authorized, MergePolicies, PolicyComponents, Request, RequestContext, ResourceId,
     action::ActionName,
@@ -108,8 +107,8 @@ use crate::store::{
             summary::{Deduplication, EntitySummaryQuery},
         },
         query::{
-            Distinctness, PostgresRecord as _, PostgresSorting as _, SelectCompiler,
-            StatementShape, bulk_insert,
+            Distinctness, PostgresRecord as _, PostgresSorting as _, QUANTIZED_RANK_OVERFETCH,
+            SelectCompiler, StatementShape, bulk_insert,
             rows::{
                 EntityDraftRow, EntityEdgeRow, EntityEditionRow, EntityIdRow, EntityIsOfTypeRow,
                 EntityTemporalMetadataRow, PostgresRow as _,
@@ -610,11 +609,7 @@ where
         // always match their key row (foreign keys, and the write paths maintaining
         // `entity_edition_cache` in the same transaction) and the distinct key pins all
         // row-multiplying columns.
-        //
-        // TODO(BE-618): revisit the embedding shape once the distance query is index-backed.
-        if !compiler.has_embeddings_filter() {
-            compiler.set_statement_shape(StatementShape::KeysFirst);
-        }
+        compiler.set_statement_shape(StatementShape::KeysFirst);
 
         let cursor_parameters = params.sorting.encode().change_context(QueryError)?;
         let cursor_indices = params
@@ -796,6 +791,253 @@ where
         }
 
         Ok(response)
+    }
+
+    /// Reads the entities whose combined embedding is closest to `params.embedding`.
+    ///
+    /// Two reads: one statement that ranks candidates with the permission and request filters in
+    /// place and re-scores them against the full vector, then the hydration of the survivors.
+    #[tracing::instrument(level = "info", skip(self, params))]
+    #[expect(clippy::too_many_lines)]
+    async fn search_entities_impl(
+        &self,
+        actor_id: ActorEntityUuid,
+        params: SearchEntitiesParams,
+    ) -> Result<SearchEntitiesResponse, Report<QueryError>> {
+        let SearchEntitiesParams {
+            embedding,
+            maximum_semantic_distance,
+            limit,
+            include_entity_types,
+            filter:
+                SearchEntitiesFilter {
+                    entity_type_ids,
+                    web_ids,
+                    include_drafts,
+                },
+        } = params;
+
+        let policy_components = PolicyComponents::builder(self)
+            .with_actor(actor_id)
+            .with_action(ActionName::ViewEntity, MergePolicies::Yes)
+            .await
+            .change_context(QueryError)?;
+        let policy_filter = Filter::<Entity>::for_policies(
+            policy_components.extract_filter_policies(ActionName::ViewEntity),
+            policy_components.actor_id(),
+            policy_components.optimization_data(ActionName::ViewEntity),
+        );
+
+        // A search always runs against the current time and never returns archived entities.
+        let temporal_axes = QueryTemporalAxesUnresolved::live_only().resolve();
+
+        let mut request_filters = vec![Filter::Equal(
+            FilterExpression::Path {
+                path: EntityQueryPath::Archived,
+            },
+            FilterExpression::Parameter {
+                parameter: Parameter::Boolean(false),
+                convert: None,
+            },
+        )];
+        if !entity_type_ids.is_empty() {
+            request_filters.push(Filter::Any(
+                entity_type_ids
+                    .iter()
+                    .map(Filter::for_entity_by_type_id)
+                    .collect(),
+            ));
+        }
+        if !web_ids.is_empty() {
+            request_filters.push(Filter::In(
+                FilterExpression::Path {
+                    path: EntityQueryPath::WebId,
+                },
+                FilterExpressionList::ParameterList {
+                    parameters: ParameterList::WebIds(&web_ids),
+                },
+            ));
+        }
+        let request_filter = Filter::All(request_filters);
+
+        let web_id_path = EntityQueryPath::WebId;
+        let uuid_path = EntityQueryPath::Uuid;
+        let draft_id_path = EntityQueryPath::DraftId;
+        let embedding_path = EntityQueryPath::Embedding;
+
+        let mut compiler = SelectCompiler::<Entity>::new(Some(&temporal_axes), include_drafts);
+        compiler
+            .add_filter(&policy_filter)
+            .change_context(QueryError)?;
+        compiler
+            .add_filter(&request_filter)
+            .change_context(QueryError)?;
+        compiler.add_selection_path(&web_id_path);
+        compiler.add_selection_path(&uuid_path);
+        compiler.add_selection_path(&draft_id_path);
+        let embeddings_alias = compiler
+            .rank_by_quantized_distance(&embedding_path, &embedding)
+            .change_context(QueryError)?;
+        // The search compares against the combined embedding over all of an entity's properties.
+        compiler.restrict_embedding_property(embeddings_alias, None);
+        let candidate_pool = limit.saturating_mul(QUANTIZED_RANK_OVERFETCH);
+        compiler.set_limit(candidate_pool);
+
+        // An HNSW scan stops after `ef_search` tuples (default 40) regardless of the statement's
+        // limit, so it must be allowed to produce the whole candidate pool. The iterative mode
+        // resumes the walk when the filters discard candidates, or when the pool exceeds the
+        // setting's range of 1 to 1000.
+        let settings = format!(
+            "SET LOCAL hnsw.ef_search = {};
+             SET LOCAL hnsw.iterative_scan = relaxed_order;",
+            candidate_pool.clamp(1, 1000)
+        );
+        self.as_client()
+            .batch_execute(&settings)
+            .instrument(tracing::info_span!(
+                "SET",
+                otel.kind = "client",
+                db.system = "postgresql",
+                peer.service = "Postgres",
+                db.query.text = settings,
+            ))
+            .await
+            .change_context(QueryError)?;
+
+        // The candidate read ranks on the quantized embedding, so it becomes a CTE that the same
+        // statement re-scores against the full vector. Only the candidates have their out-of-line
+        // vector read that way, and the permission filter stays inside the ranking rather than
+        // being applied to its result.
+        let (candidate_statement, candidate_parameters) = compiler.compile();
+        let maximum_distance = maximum_semantic_distance.into_inner();
+
+        let mut parameters = candidate_parameters.to_vec();
+        let embedding_parameter = parameters.len() + 1;
+        parameters.push(&embedding);
+        let maximum_distance_parameter = parameters.len() + 1;
+        parameters.push(&maximum_distance);
+
+        // The candidate filters join to-many relations, so one entity can occupy several pool
+        // slots. `DISTINCT` collapses them, which requires the distance in the select list.
+        let statement = format!(
+            "WITH candidates AS ({candidate_statement})
+             SELECT DISTINCT
+                    candidates.web_id,
+                    candidates.entity_uuid,
+                    candidates.draft_id,
+                    entity_embeddings.embedding <=> ${embedding_parameter}::vector AS distance
+               FROM candidates
+               JOIN entity_embeddings
+                 ON entity_embeddings.web_id = candidates.web_id
+                AND entity_embeddings.entity_uuid = candidates.entity_uuid
+              WHERE entity_embeddings.property IS NULL
+                AND entity_embeddings.embedding <=> ${embedding_parameter}::vector <= \
+             ${maximum_distance_parameter}
+              ORDER BY distance
+              LIMIT {limit}"
+        );
+
+        let ranked = self
+            .as_client()
+            .query(&statement, &parameters)
+            .instrument(tracing::info_span!(
+                "SELECT",
+                otel.kind = "client",
+                db.system = "postgresql",
+                peer.service = "Postgres",
+                db.query.text = statement,
+            ))
+            .await
+            .change_context(QueryError)?
+            .into_iter()
+            .map(|row| EntityId {
+                web_id: row.get(0),
+                entity_uuid: row.get(1),
+                draft_id: row.get(2),
+            })
+            .collect::<Vec<_>>();
+
+        if ranked.len() < limit {
+            // Expected for actors whose filters pass few candidates: the iterative scan gives up
+            // at `hnsw.max_scan_tuples`. The event is what distinguishes that from a genuinely
+            // sparse result when a search returns fewer rows than requested.
+            tracing::debug!(
+                limit,
+                candidates = ranked.len(),
+                candidate_pool,
+                "the search returned fewer candidates than requested"
+            );
+        }
+
+        if ranked.is_empty() {
+            return Ok(SearchEntitiesResponse {
+                entities: Vec::new(),
+                closed_multi_entity_types: None,
+            });
+        }
+
+        let response = self
+            .query_entities_impl(
+                actor_id,
+                QueryEntitiesParams {
+                    filter: Filter::Any(
+                        ranked
+                            .iter()
+                            .map(|&entity_id| {
+                                let by_id = Filter::for_entity_by_entity_id(entity_id);
+                                if entity_id.draft_id.is_some() {
+                                    by_id
+                                } else {
+                                    // The shared filter leaves the draft dimension open for live
+                                    // ids, which would hydrate an entity's drafts alongside it
+                                    // when drafts are included.
+                                    Filter::All(vec![
+                                        by_id,
+                                        Filter::Not(Box::new(Filter::Exists {
+                                            path: EntityQueryPath::DraftId,
+                                        })),
+                                    ])
+                                }
+                            })
+                            .collect(),
+                    ),
+                    temporal_axes: QueryTemporalAxesUnresolved::live_only(),
+                    sorting: EntityQuerySorting {
+                        paths: vec![],
+                        cursor: None,
+                    },
+                    conversions: Vec::new(),
+                    // The filter already names exactly the entities to hydrate.
+                    limit: ranked.len(),
+                    include_drafts,
+                    include_entity_types: include_entity_types
+                        .then_some(IncludeEntityTypeOption::Closed),
+                    include_permissions: false,
+                },
+            )
+            .await?;
+
+        // Hydration does not preserve the ranking, so restore it from the candidate order. The
+        // hydration filter names exactly the ranked ids, so a row without a rank cannot occur —
+        // dropping it beats `Option`'s None-first ordering, which would put it on top.
+        let ranks = ranked
+            .iter()
+            .enumerate()
+            .map(|(rank, &entity_id)| (entity_id, rank))
+            .collect::<HashMap<_, _>>();
+        let mut entities = response.entities;
+        entities.retain(|entity| ranks.contains_key(&entity.metadata.record_id.entity_id));
+        entities.sort_by_key(|entity| {
+            ranks
+                .get(&entity.metadata.record_id.entity_id)
+                .copied()
+                .expect("the retained entities should all carry a rank")
+        });
+
+        Ok(SearchEntitiesResponse {
+            entities,
+            closed_multi_entity_types: response.closed_multi_entity_types,
+        })
     }
 
     #[tracing::instrument(level = "info", skip(self, params))]
@@ -1830,95 +2072,19 @@ where
         actor_id: ActorEntityUuid,
         params: SearchEntitiesParams,
     ) -> Result<SearchEntitiesResponse, Report<QueryError>> {
-        let SearchEntitiesParams {
-            embedding,
-            maximum_semantic_distance,
-            limit,
-            include_entity_types,
-            filter:
-                SearchEntitiesFilter {
-                    entity_type_ids,
-                    web_ids,
-                    include_drafts,
-                },
-        } = params;
+        // The ranked read and the hydration are separate statements. Under `READ COMMITTED` each
+        // would use its own MVCC snapshot, so a write committing in between could rank an entity
+        // that the hydration no longer returns.
+        let transaction = self
+            .begin_read_only_transaction()
+            .await
+            .change_context(QueryError)?;
 
-        // TODO(BE-618): optimize the query — it scans embeddings without a vector index. A
-        //   halfvec/HNSW index needs an ANN-friendly query shape to be usable (the current
-        //   `MIN(<=>) GROUP BY` defeats it). The returned entities can also be trimmed to the
-        //   fields the search bar and inference actually use, but the query is the bottleneck.
-        let maximum_distance =
-            Real::try_from(maximum_semantic_distance.into_inner()).change_context(QueryError)?;
+        let response = transaction.search_entities_impl(actor_id, params).await?;
 
-        // The search always runs against the current time and never returns archived entities.
-        let mut filters = vec![
-            Filter::CosineDistance(
-                FilterExpression::Path {
-                    path: EntityQueryPath::Embedding,
-                },
-                FilterExpression::Parameter {
-                    parameter: Parameter::Vector(embedding),
-                    convert: None,
-                },
-                FilterExpression::Parameter {
-                    parameter: Parameter::Decimal(maximum_distance),
-                    convert: None,
-                },
-            ),
-            Filter::Equal(
-                FilterExpression::Path {
-                    path: EntityQueryPath::Archived,
-                },
-                FilterExpression::Parameter {
-                    parameter: Parameter::Boolean(false),
-                    convert: None,
-                },
-            ),
-        ];
+        transaction.commit().await.change_context(QueryError)?;
 
-        if !entity_type_ids.is_empty() {
-            filters.push(Filter::Any(
-                entity_type_ids
-                    .iter()
-                    .map(Filter::for_entity_by_type_id)
-                    .collect(),
-            ));
-        }
-        if !web_ids.is_empty() {
-            filters.push(Filter::In(
-                FilterExpression::Path {
-                    path: EntityQueryPath::WebId,
-                },
-                FilterExpressionList::ParameterList {
-                    parameters: ParameterList::WebIds(&web_ids),
-                },
-            ));
-        }
-
-        let response = self
-            .query_entities(
-                actor_id,
-                QueryEntitiesParams {
-                    filter: Filter::All(filters),
-                    temporal_axes: QueryTemporalAxesUnresolved::live_only(),
-                    sorting: EntityQuerySorting {
-                        paths: vec![],
-                        cursor: None,
-                    },
-                    conversions: Vec::new(),
-                    limit,
-                    include_drafts,
-                    include_entity_types: include_entity_types
-                        .then_some(IncludeEntityTypeOption::Closed),
-                    include_permissions: false,
-                },
-            )
-            .await?;
-
-        Ok(SearchEntitiesResponse {
-            entities: response.entities,
-            closed_multi_entity_types: response.closed_multi_entity_types,
-        })
+        Ok(response)
     }
 
     #[tracing::instrument(level = "info", skip(self, params))]

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/query.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/query.rs
@@ -145,10 +145,6 @@ impl QueryRecordDecode for Entity {
             draft_id: row.get(indices.draft_id),
         };
 
-        if let Ok(distance) = row.try_get::<_, f64>("distance") {
-            tracing::trace!(%entity_id, %distance, "Entity embedding was calculated");
-        }
-
         let property_metadata = row
             .get::<_, Option<serde_json::Value>>(indices.property_metadata)
             .map(|value| {

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/search.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/search.rs
@@ -348,8 +348,10 @@ where
         include_drafts: bool,
         include_entity_types: bool,
     ) -> Result<SearchEntitiesResponse, Report<QueryError>> {
-        let response = self
-            .query_entities_impl(
+        // The box cuts the hydration subtree out of the search future's type, whose layout
+        // otherwise overflows rustc's recursion depth.
+        let response = Box::pin(
+            self.query_entities_impl(
                 actor_id,
                 QueryEntitiesParams {
                     filter: Filter::Any(
@@ -386,8 +388,9 @@ where
                         .then_some(IncludeEntityTypeOption::Closed),
                     include_permissions: false,
                 },
-            )
-            .await?;
+            ),
+        )
+        .await?;
 
         // The hydration filter names exactly the ranked ids, so a row without a rank cannot
         // occur — dropping it beats `Option`'s None-first ordering, which would put it on top.

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/search.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/search.rs
@@ -1,0 +1,422 @@
+use std::collections::{HashMap, HashSet};
+
+use error_stack::{Report, ResultExt as _};
+use hash_graph_authorization::policies::{MergePolicies, PolicyComponents, action::ActionName};
+use hash_graph_store::{
+    entity::{
+        EntityQueryPath, EntityQuerySorting, QueryEntitiesParams, SearchEntitiesFilter,
+        SearchEntitiesParams, SearchEntitiesResponse,
+    },
+    entity_type::IncludeEntityTypeOption,
+    error::QueryError,
+    filter::{Filter, FilterExpression, FilterExpressionList, Parameter, ParameterList},
+    subgraph::temporal_axes::{QueryTemporalAxes, QueryTemporalAxesUnresolved},
+};
+use hash_graph_types::Embedding;
+use postgres_types::ToSql;
+use tokio_postgres::GenericClient as _;
+use tracing::Instrument as _;
+use type_system::{
+    knowledge::{Entity, entity::id::EntityId},
+    ontology::id::VersionedUrl,
+    principal::{actor::ActorEntityUuid, actor_group::WebId},
+};
+
+use crate::store::{
+    AsClient, PostgresStore,
+    postgres::{
+        InTransaction,
+        query::{QUANTIZED_RANK_OVERFETCH, SelectCompiler},
+    },
+};
+
+const fn empty_response() -> SearchEntitiesResponse {
+    SearchEntitiesResponse {
+        entities: Vec::new(),
+        closed_multi_entity_types: None,
+    }
+}
+
+/// The non-policy restrictions of a search.
+///
+/// A search never returns archived entities; the type and web restrictions come from the
+/// request.
+fn request_filter<'p>(
+    entity_type_ids: &'p [VersionedUrl],
+    web_ids: &'p [WebId],
+) -> Filter<'p, Entity> {
+    let mut request_filters = vec![Filter::Equal(
+        FilterExpression::Path {
+            path: EntityQueryPath::Archived,
+        },
+        FilterExpression::Parameter {
+            parameter: Parameter::Boolean(false),
+            convert: None,
+        },
+    )];
+    if !entity_type_ids.is_empty() {
+        request_filters.push(Filter::Any(
+            entity_type_ids
+                .iter()
+                .map(Filter::for_entity_by_type_id)
+                .collect(),
+        ));
+    }
+    if !web_ids.is_empty() {
+        request_filters.push(Filter::In(
+            FilterExpression::Path {
+                path: EntityQueryPath::WebId,
+            },
+            FilterExpressionList::ParameterList {
+                parameters: ParameterList::WebIds(web_ids),
+            },
+        ));
+    }
+    Filter::All(request_filters)
+}
+
+/// The statement that re-scores the candidate keys against the full vector.
+///
+/// The keys arrive as three parallel arrays, followed by the embedding and the distance
+/// threshold. The unique index on `(web_id, entity_uuid, property) NULLS NOT DISTINCT` yields
+/// at most one embedding row per candidate, so the join cannot fan out. The key columns break
+/// distance ties, which keeps the ordering deterministic.
+fn rerank_statement(limit: usize) -> String {
+    format!(
+        "WITH candidates AS (
+             SELECT *
+               FROM unnest($1::uuid[], $2::uuid[], $3::uuid[])
+                 AS candidates (web_id, entity_uuid, draft_id)
+         )
+         SELECT candidates.web_id,
+                candidates.entity_uuid,
+                candidates.draft_id,
+                entity_embeddings.embedding <=> $4::vector AS distance
+           FROM candidates
+           JOIN entity_embeddings
+             ON entity_embeddings.web_id = candidates.web_id
+            AND entity_embeddings.entity_uuid = candidates.entity_uuid
+          WHERE entity_embeddings.property IS NULL
+            AND entity_embeddings.embedding <=> $4::vector <= $5
+          ORDER BY distance, candidates.web_id, candidates.entity_uuid, candidates.draft_id
+          LIMIT {limit}"
+    )
+}
+
+impl<C> PostgresStore<C, InTransaction>
+where
+    C: AsClient,
+{
+    /// Reads the entities whose combined embedding is closest to `params.embedding`.
+    ///
+    /// The candidates rank per policy branch: a single statement over the whole permit
+    /// disjunction can span several tables, which forces the planner to materialize the visible
+    /// set instead of walking the vector index. A branch replaces that top-level disjunction
+    /// with a conjunction and gets its own key-read. The union of the branches' candidates is
+    /// re-scored against the full vector before the survivors are hydrated.
+    #[tracing::instrument(
+        level = "info",
+        skip(self, params),
+        fields(branches = tracing::field::Empty)
+    )]
+    pub(crate) async fn search_entities_impl(
+        &self,
+        actor_id: ActorEntityUuid,
+        params: SearchEntitiesParams,
+    ) -> Result<SearchEntitiesResponse, Report<QueryError>> {
+        let SearchEntitiesParams {
+            embedding,
+            maximum_semantic_distance,
+            limit,
+            include_entity_types,
+            filter:
+                SearchEntitiesFilter {
+                    entity_type_ids,
+                    web_ids,
+                    include_drafts,
+                },
+        } = params;
+
+        let policy_components = PolicyComponents::builder(self)
+            .with_actor(actor_id)
+            .with_action(ActionName::ViewEntity, MergePolicies::Yes)
+            .await
+            .change_context(QueryError)?;
+        let policy_branches = Filter::<Entity>::for_policy_branches(
+            policy_components.extract_filter_policies(ActionName::ViewEntity),
+            policy_components.actor_id(),
+            policy_components.optimization_data(ActionName::ViewEntity),
+        );
+        // The branch count is the fan-out of sequential key-reads, so a slow search with a
+        // pathological policy set stays attributable.
+        tracing::Span::current().record("branches", policy_branches.len());
+
+        if policy_branches.is_empty() {
+            return Ok(empty_response());
+        }
+
+        // A search always runs against the current time.
+        let temporal_axes = QueryTemporalAxesUnresolved::live_only().resolve();
+        let request_filter = request_filter(&entity_type_ids, &web_ids);
+
+        let candidate_pool = limit.saturating_mul(QUANTIZED_RANK_OVERFETCH);
+        self.prepare_hnsw_scan(candidate_pool).await?;
+
+        // The branches may permit overlapping sets of entities, so the candidate keys
+        // deduplicate before the rerank.
+        let mut candidates = HashSet::new();
+        for policy_branch in &policy_branches {
+            candidates.extend(
+                self.branch_candidates(
+                    policy_branch,
+                    &request_filter,
+                    &temporal_axes,
+                    include_drafts,
+                    &embedding,
+                    candidate_pool,
+                )
+                .await?,
+            );
+        }
+
+        if candidates.is_empty() {
+            return Ok(empty_response());
+        }
+
+        let ranked = self
+            .rerank_candidates(
+                &candidates,
+                &embedding,
+                maximum_semantic_distance.into_inner(),
+                limit,
+            )
+            .await?;
+
+        if ranked.len() < limit {
+            // Expected for actors whose filters pass few candidates: the iterative scan gives up
+            // at `hnsw.max_scan_tuples`. The event is what distinguishes that from a genuinely
+            // sparse result when a search returns fewer rows than requested.
+            tracing::debug!(
+                limit,
+                ranked = ranked.len(),
+                candidates = candidates.len(),
+                candidate_pool,
+                branches = policy_branches.len(),
+                "the search returned fewer results than requested"
+            );
+        }
+
+        if ranked.is_empty() {
+            return Ok(empty_response());
+        }
+
+        self.hydrate_ranked(actor_id, &ranked, include_drafts, include_entity_types)
+            .await
+    }
+
+    /// Prepares the transaction's HNSW scans to produce the whole candidate pool.
+    ///
+    /// An HNSW scan stops after `ef_search` tuples (default 40) regardless of the statement's
+    /// limit. The iterative mode resumes the walk when the filters discard candidates, or when
+    /// the pool exceeds the setting's range of 1 to 1000. `SET LOCAL` scopes the settings to
+    /// the enclosing transaction.
+    async fn prepare_hnsw_scan(&self, candidate_pool: usize) -> Result<(), Report<QueryError>> {
+        let settings = format!(
+            "SET LOCAL hnsw.ef_search = {};
+             SET LOCAL hnsw.iterative_scan = relaxed_order;",
+            candidate_pool.clamp(1, 1000)
+        );
+        self.as_client()
+            .batch_execute(&settings)
+            .instrument(tracing::info_span!(
+                "SET",
+                otel.kind = "client",
+                db.system = "postgresql",
+                peer.service = "Postgres",
+                db.query.text = settings,
+            ))
+            .await
+            .change_context(QueryError)
+    }
+
+    /// Reads one policy branch's candidate keys, ranked on the quantized embedding.
+    async fn branch_candidates(
+        &self,
+        policy_branch: &Filter<'_, Entity>,
+        request_filter: &Filter<'_, Entity>,
+        temporal_axes: &QueryTemporalAxes,
+        include_drafts: bool,
+        embedding: &Embedding<'_>,
+        candidate_pool: usize,
+    ) -> Result<Vec<EntityId>, Report<QueryError>> {
+        let web_id_path = EntityQueryPath::WebId;
+        let uuid_path = EntityQueryPath::Uuid;
+        let draft_id_path = EntityQueryPath::DraftId;
+        let embedding_path = EntityQueryPath::Embedding;
+
+        let mut compiler = SelectCompiler::<Entity>::new(Some(temporal_axes), include_drafts);
+        compiler
+            .add_filter(policy_branch)
+            .change_context(QueryError)?;
+        compiler
+            .add_filter(request_filter)
+            .change_context(QueryError)?;
+        compiler.add_selection_path(&web_id_path);
+        compiler.add_selection_path(&uuid_path);
+        compiler.add_selection_path(&draft_id_path);
+        let embeddings_alias = compiler
+            .rank_by_quantized_distance(&embedding_path, embedding)
+            .change_context(QueryError)?;
+        // The search compares against the combined embedding over all of an entity's properties.
+        compiler.restrict_embedding_property(embeddings_alias, None);
+        compiler.set_limit(candidate_pool);
+
+        let (statement, parameters) = compiler.compile();
+        Ok(self
+            .as_client()
+            .query(&statement, parameters)
+            .instrument(tracing::info_span!(
+                "SELECT",
+                otel.kind = "client",
+                db.system = "postgresql",
+                peer.service = "Postgres",
+                db.query.text = statement,
+            ))
+            .await
+            .change_context(QueryError)?
+            .into_iter()
+            .map(|row| EntityId {
+                web_id: row.get(0),
+                entity_uuid: row.get(1),
+                draft_id: row.get(2),
+            })
+            .collect())
+    }
+
+    /// Re-scores the candidates against the full vector, applying the distance threshold.
+    async fn rerank_candidates(
+        &self,
+        candidates: &HashSet<EntityId>,
+        embedding: &Embedding<'_>,
+        maximum_distance: f64,
+        limit: usize,
+    ) -> Result<Vec<EntityId>, Report<QueryError>> {
+        let mut candidate_web_ids = Vec::with_capacity(candidates.len());
+        let mut candidate_entity_uuids = Vec::with_capacity(candidates.len());
+        let mut candidate_draft_ids = Vec::with_capacity(candidates.len());
+        for entity_id in candidates {
+            candidate_web_ids.push(entity_id.web_id);
+            candidate_entity_uuids.push(entity_id.entity_uuid);
+            candidate_draft_ids.push(entity_id.draft_id);
+        }
+
+        let statement = rerank_statement(limit);
+        let parameters: [&(dyn ToSql + Sync); 5] = [
+            &candidate_web_ids,
+            &candidate_entity_uuids,
+            &candidate_draft_ids,
+            embedding,
+            &maximum_distance,
+        ];
+
+        Ok(self
+            .as_client()
+            .query(&statement, &parameters)
+            .instrument(tracing::info_span!(
+                "SELECT",
+                otel.kind = "client",
+                db.system = "postgresql",
+                peer.service = "Postgres",
+                db.query.text = statement,
+            ))
+            .await
+            .change_context(QueryError)?
+            .into_iter()
+            .map(|row| EntityId {
+                web_id: row.get(0),
+                entity_uuid: row.get(1),
+                draft_id: row.get(2),
+            })
+            .collect())
+    }
+
+    /// Hydrates the ranked entities, restoring the ranking the hydration read does not preserve.
+    async fn hydrate_ranked(
+        &self,
+        actor_id: ActorEntityUuid,
+        ranked: &[EntityId],
+        include_drafts: bool,
+        include_entity_types: bool,
+    ) -> Result<SearchEntitiesResponse, Report<QueryError>> {
+        let response = self
+            .query_entities_impl(
+                actor_id,
+                QueryEntitiesParams {
+                    filter: Filter::Any(
+                        ranked
+                            .iter()
+                            .map(|&entity_id| {
+                                let by_id = Filter::for_entity_by_entity_id(entity_id);
+                                if entity_id.draft_id.is_some() {
+                                    by_id
+                                } else {
+                                    // The shared filter leaves the draft dimension open for live
+                                    // ids, which would hydrate an entity's drafts alongside it
+                                    // when drafts are included.
+                                    Filter::All(vec![
+                                        by_id,
+                                        Filter::Not(Box::new(Filter::Exists {
+                                            path: EntityQueryPath::DraftId,
+                                        })),
+                                    ])
+                                }
+                            })
+                            .collect(),
+                    ),
+                    temporal_axes: QueryTemporalAxesUnresolved::live_only(),
+                    sorting: EntityQuerySorting {
+                        paths: vec![],
+                        cursor: None,
+                    },
+                    conversions: Vec::new(),
+                    // The filter already names exactly the entities to hydrate.
+                    limit: ranked.len(),
+                    include_drafts,
+                    include_entity_types: include_entity_types
+                        .then_some(IncludeEntityTypeOption::Closed),
+                    include_permissions: false,
+                },
+            )
+            .await?;
+
+        // The hydration filter names exactly the ranked ids, so a row without a rank cannot
+        // occur — dropping it beats `Option`'s None-first ordering, which would put it on top.
+        let ranks = ranked
+            .iter()
+            .enumerate()
+            .map(|(rank, &entity_id)| (entity_id, rank))
+            .collect::<HashMap<_, _>>();
+        let mut entities = response.entities;
+        entities.retain(|entity| ranks.contains_key(&entity.metadata.record_id.entity_id));
+        if entities.len() != ranked.len() {
+            // The hydration applies the policies a second time, so a shortfall means the branch
+            // decomposition permitted more than the combined policy filter does.
+            tracing::warn!(
+                ranked = ranked.len(),
+                hydrated = entities.len(),
+                "the hydration disagrees with the ranked candidates"
+            );
+        }
+        entities.sort_by_key(|entity| {
+            ranks
+                .get(&entity.metadata.record_id.entity_id)
+                .copied()
+                .expect("the retained entities should all carry a rank")
+        });
+
+        Ok(SearchEntitiesResponse {
+            entities,
+            closed_multi_entity_types: response.closed_multi_entity_types,
+        })
+    }
+}

--- a/libs/@local/graph/postgres-store/src/store/postgres/ontology/data_type.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/ontology/data_type.rs
@@ -1688,10 +1688,6 @@ impl QueryRecordDecode for DataTypeWithMetadata {
             version: row.get(indices.version),
         };
 
-        if let Ok(distance) = row.try_get::<_, f64>("distance") {
-            tracing::trace!(%record_id, %distance, "Data type embedding was calculated");
-        }
-
         let conversion_targets: Option<Vec<BaseUrl>> = row.get(indices.conversion_targets);
         let conversion_froms: Option<Vec<ConversionDefinition>> = row.get(indices.conversion_froms);
         let conversion_intos: Option<Vec<ConversionDefinition>> = row.get(indices.conversion_intos);

--- a/libs/@local/graph/postgres-store/src/store/postgres/ontology/entity_type.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/ontology/entity_type.rs
@@ -4,7 +4,6 @@ use std::collections::{HashMap, HashSet};
 
 use error_stack::{Report, ResultExt as _};
 use futures::{StreamExt as _, TryStreamExt as _};
-use hash_codec::numeric::Real;
 use hash_graph_authorization::policies::{
     Authorized, MergePolicies, PolicyComponents, Request, RequestContext, ResourceId,
     action::ActionName, principal::actor::AuthenticatedActor,
@@ -23,7 +22,7 @@ use hash_graph_store::{
         UpdateEntityTypeEmbeddingParams, UpdateEntityTypesParams,
     },
     error::{CheckPermissionError, InsertionError, QueryError, UpdateError},
-    filter::{Filter, FilterExpression, FilterExpressionList, Parameter, ParameterList},
+    filter::{Filter, FilterExpression, FilterExpressionList, ParameterList},
     property_type::{
         PropertyTypeStore as _, QueryPropertyTypeSubgraphParams, QueryPropertyTypesParams,
     },
@@ -74,7 +73,8 @@ use crate::store::{
         crud::{QueryIndices, QueryRecordDecode, TypedRow},
         ontology::{PostgresOntologyOwnership, read::OntologyTypeTraversalData},
         query::{
-            Distinctness, PostgresRecord, PostgresSorting, ReferenceTable, SelectCompiler, Table,
+            Distinctness, PostgresRecord, PostgresSorting, QUANTIZED_RANK_OVERFETCH,
+            ReferenceTable, SelectCompiler, Table,
         },
     },
     validation::StoreProvider,
@@ -1210,6 +1210,7 @@ where
     }
 
     #[tracing::instrument(level = "info", skip(self, params))]
+    #[expect(clippy::too_many_lines)]
     async fn search_entity_types(
         &self,
         actor_id: ActorEntityUuid,
@@ -1221,36 +1222,103 @@ where
             limit,
         } = params;
 
-        // TODO(BE-618): optimize the query — it scans embeddings without a vector index, which
-        //   needs an ANN-friendly query shape to be usable (the current `MIN(<=>) GROUP BY`
-        //   defeats it).
-        let maximum_distance =
-            Real::try_from(maximum_semantic_distance.into_inner()).change_context(QueryError)?;
-
-        let filter = Filter::CosineDistance(
-            FilterExpression::Path {
-                path: EntityTypeQueryPath::Embedding,
-            },
-            FilterExpression::Parameter {
-                parameter: Parameter::Vector(embedding),
-                convert: None,
-            },
-            FilterExpression::Parameter {
-                parameter: Parameter::Decimal(maximum_distance),
-                convert: None,
-            },
+        let policy_components = PolicyComponents::builder(self)
+            .with_actor(actor_id)
+            .with_action(ActionName::ViewEntityType, MergePolicies::Yes)
+            .await
+            .change_context(QueryError)?;
+        let policy_filter = Filter::<EntityTypeWithMetadata>::for_policies(
+            policy_components.extract_filter_policies(ActionName::ViewEntityType),
+            policy_components.optimization_data(ActionName::ViewEntityType),
         );
 
         // The search always runs against the current time.
+        let temporal_axes = QueryTemporalAxesUnresolved::live_only().resolve();
+
+        let ontology_id_path = EntityTypeQueryPath::OntologyId;
+        let embedding_path = EntityTypeQueryPath::Embedding;
+
+        let mut compiler =
+            SelectCompiler::<EntityTypeWithMetadata>::new(Some(&temporal_axes), false);
+        compiler
+            .add_filter(&policy_filter)
+            .change_context(QueryError)?;
+        compiler.add_selection_path(&ontology_id_path);
+        compiler
+            .rank_by_quantized_distance(&embedding_path, &embedding)
+            .change_context(QueryError)?;
+        let candidate_pool = limit.saturating_mul(QUANTIZED_RANK_OVERFETCH);
+        compiler.set_limit(candidate_pool);
+
+        // Same shape as the entity search: the candidate CTE ranks on the quantized embedding,
+        // the outer statement re-scores against the full vector, and `DISTINCT` collapses
+        // candidates duplicated by to-many filter joins.
+        let (candidate_statement, candidate_parameters) = compiler.compile();
+        let maximum_distance = maximum_semantic_distance.into_inner();
+
+        let mut parameters = candidate_parameters.to_vec();
+        let embedding_parameter = parameters.len() + 1;
+        parameters.push(&embedding);
+        let maximum_distance_parameter = parameters.len() + 1;
+        parameters.push(&maximum_distance);
+
+        let statement = format!(
+            "WITH candidates AS ({candidate_statement})
+             SELECT DISTINCT
+                    candidates.ontology_id,
+                    entity_type_embeddings.embedding <=> ${embedding_parameter}::vector AS distance
+               FROM candidates
+               JOIN entity_type_embeddings
+                 ON entity_type_embeddings.ontology_id = candidates.ontology_id
+              WHERE entity_type_embeddings.embedding <=> ${embedding_parameter}::vector <= \
+             ${maximum_distance_parameter}
+              ORDER BY distance
+              LIMIT {limit}"
+        );
+
+        let ranked = self
+            .as_client()
+            .query(&statement, &parameters)
+            .instrument(tracing::info_span!(
+                "SELECT",
+                otel.kind = "client",
+                db.system = "postgresql",
+                peer.service = "Postgres",
+                db.query.text = statement,
+            ))
+            .await
+            .change_context(QueryError)?
+            .into_iter()
+            .map(|row| row.get::<_, EntityTypeUuid>(0))
+            .collect::<Vec<_>>();
+
+        if ranked.len() < limit {
+            // Expected for actors whose filters pass few candidates. The event is what
+            // distinguishes that from a genuinely sparse result.
+            tracing::debug!(
+                limit,
+                candidates = ranked.len(),
+                candidate_pool,
+                "the search returned fewer candidates than requested"
+            );
+        }
+
+        if ranked.is_empty() {
+            return Ok(SearchEntityTypesResponse {
+                entity_types: Vec::new(),
+            });
+        }
+
         let response = self
             .query_entity_types(
                 actor_id,
                 QueryEntityTypesParams {
                     request: CommonQueryEntityTypesParams {
-                        filter,
+                        filter: Filter::for_entity_type_uuids(&ranked),
                         temporal_axes: QueryTemporalAxesUnresolved::live_only(),
                         after: None,
-                        limit: Some(limit),
+                        // The filter already names exactly the types to hydrate.
+                        limit: Some(ranked.len()),
                         include_count: false,
                         include_web_ids: false,
                         include_edition_created_by_ids: false,
@@ -1260,9 +1328,26 @@ where
             )
             .await?;
 
-        Ok(SearchEntityTypesResponse {
-            entity_types: response.entity_types,
-        })
+        // Hydration does not preserve the ranking, so restore it from the candidate order. The
+        // hydration filter names exactly the ranked ids, so a row without a rank cannot occur —
+        // dropping it beats `Option`'s None-first ordering, which would put it on top.
+        let ranks = ranked
+            .iter()
+            .enumerate()
+            .map(|(rank, &id)| (id, rank))
+            .collect::<HashMap<_, _>>();
+        let mut entity_types = response.entity_types;
+        entity_types.retain(|entity_type| {
+            ranks.contains_key(&EntityTypeUuid::from_url(&entity_type.schema.id))
+        });
+        entity_types.sort_by_key(|entity_type| {
+            ranks
+                .get(&EntityTypeUuid::from_url(&entity_type.schema.id))
+                .copied()
+                .expect("the retained entity types should all carry a rank")
+        });
+
+        Ok(SearchEntityTypesResponse { entity_types })
     }
 
     #[tracing::instrument(
@@ -2181,10 +2266,6 @@ impl QueryRecordDecode for EntityTypeWithMetadata {
             base_url: row.get(indices.base_url),
             version: row.get(indices.version),
         };
-
-        if let Ok(distance) = row.try_get::<_, f64>("distance") {
-            tracing::trace!(%record_id, %distance, "Entity type embedding was calculated");
-        }
 
         Self {
             schema: row.get::<_, Json<_>>(indices.schema).0,

--- a/libs/@local/graph/postgres-store/src/store/postgres/ontology/property_type.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/ontology/property_type.rs
@@ -1229,10 +1229,6 @@ impl QueryRecordDecode for PropertyTypeWithMetadata {
             version: row.get(indices.version),
         };
 
-        if let Ok(distance) = row.try_get::<_, f64>("distance") {
-            tracing::trace!(%record_id, %distance, "Property type embedding was calculated");
-        }
-
         Self {
             schema: row.get::<_, Json<_>>(indices.schema).0,
             metadata: PropertyTypeMetadata {

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/ast/expression/binary.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/ast/expression/binary.rs
@@ -55,8 +55,8 @@ pub enum BinaryOperator {
     ArrayContains,
     /// `<lhs> && <rhs>`
     Overlap,
-    /// `<lhs> <=> <rhs>`
-    CosineDistance,
+    /// `<lhs> <~> <rhs>`
+    HammingDistance,
 }
 
 impl BinaryOperator {
@@ -80,7 +80,7 @@ impl BinaryOperator {
             Self::JsonAccessAsText => " ->> ",
             Self::TimeIntervalContainsTimestamp | Self::ArrayContains => " @> ",
             Self::Overlap => " && ",
-            Self::CosineDistance => " <=> ",
+            Self::HammingDistance => " <~> ",
         };
         fmt.write_str(string)
     }
@@ -106,7 +106,7 @@ impl BinaryOperator {
             | Self::JsonAccessAsText
             | Self::ArrayContains
             | Self::Overlap
-            | Self::CosineDistance => Ok(()),
+            | Self::HammingDistance => Ok(()),
         }
     }
 }

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/ast/expression/function.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/ast/expression/function.rs
@@ -47,6 +47,13 @@ pub enum Function {
     ///
     /// Transpiles to `(extract(epoch from <expr>) * 1000)::int8` in PostgreSQL.
     ExtractEpochMs(Box<Expression>),
+    /// Reduces a vector to one bit per dimension, set when the component is positive.
+    ///
+    /// Transpiles to `binary_quantize(<expr>)` in PostgreSQL. The result is comparable with
+    /// [`BinaryOperator::HammingDistance`] against a `bit` column of the same width.
+    ///
+    /// [`BinaryOperator::HammingDistance`]: super::BinaryOperator::HammingDistance
+    BinaryQuantize(Box<Expression>),
     Unnest(Vec<Expression>),
     Now,
 }
@@ -74,7 +81,8 @@ impl Function {
             | Self::UpperInc(expr)
             | Self::LowerInf(expr)
             | Self::UpperInf(expr)
-            | Self::ExtractEpochMs(expr) => visitor(expr),
+            | Self::ExtractEpochMs(expr)
+            | Self::BinaryQuantize(expr) => visitor(expr),
             Self::JsonContains(lhs, rhs)
             | Self::JsonPathQueryFirst(lhs, rhs)
             | Self::Coalesce(lhs, rhs) => {
@@ -121,7 +129,8 @@ impl Function {
             | Self::UpperInc(expr)
             | Self::LowerInf(expr)
             | Self::UpperInf(expr)
-            | Self::ExtractEpochMs(expr) => visitor(expr),
+            | Self::ExtractEpochMs(expr)
+            | Self::BinaryQuantize(expr) => visitor(expr),
             Self::JsonContains(lhs, rhs)
             | Self::JsonPathQueryFirst(lhs, rhs)
             | Self::Coalesce(lhs, rhs) => {
@@ -276,6 +285,11 @@ impl Transpile for Function {
                 fmt.write_str("(extract(epoch from ")?;
                 expression.transpile(fmt)?;
                 fmt.write_str(") * 1000)::int8")
+            }
+            Self::BinaryQuantize(expression) => {
+                fmt.write_str("binary_quantize(")?;
+                expression.transpile(fmt)?;
+                fmt.write_char(')')
             }
             Self::Unnest(expression) => {
                 fmt.write_str("UNNEST(")?;

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/ast/expression/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/ast/expression/mod.rs
@@ -259,13 +259,25 @@ impl Expression {
         })
     }
 
+    /// Hamming distance between two `bit` expressions of equal width.
     #[must_use]
-    pub fn cosine_distance(lhs: Self, rhs: Self) -> Self {
+    pub fn hamming_distance(lhs: Self, rhs: Self) -> Self {
         Self::Binary(BinaryExpression {
-            op: BinaryOperator::CosineDistance,
+            op: BinaryOperator::HammingDistance,
             left: Box::new(lhs),
             right: Box::new(rhs),
         })
+    }
+
+    /// Reduces a vector expression to one bit per dimension.
+    ///
+    /// The argument is pinned to `vector`: `binary_quantize` is overloaded per vector type, so an
+    /// untyped parameter fails Postgres' overload resolution.
+    #[must_use]
+    pub fn binary_quantize(expression: Self) -> Self {
+        Self::Function(Function::BinaryQuantize(Box::new(
+            expression.cast(PostgresType::Vector),
+        )))
     }
 
     #[must_use]

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/compile/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/compile/mod.rs
@@ -24,14 +24,13 @@ use super::ast::{
 };
 use crate::store::postgres::query::{
     Alias, Column, CommonTableExpression, EqualityOperator, Expression, FromItem, Function,
-    GroupByClause, GroupingElement, Identifier, NonEmptyVec, NullsOrder, OrderByClause,
-    PostgresQueryPath, PostgresRecord, SelectExpression, SelectQuantifier, SelectStatement,
-    SimpleSelect, SortBy, SortDirection, Table, Transpile as _, WindowDefinition, WithClause,
+    Identifier, NonEmptyVec, NullsOrder, OrderByClause, PostgresQueryPath, PostgresRecord,
+    SelectExpression, SelectQuantifier, SelectStatement, SimpleSelect, SortBy, SortDirection,
+    Table, Transpile as _, WindowDefinition, WithClause,
     postgres_type::PostgresType,
     table::{
-        DataTypeEmbeddings, EntityEditions, EntityEmbeddings, EntityTemporalMetadata,
-        EntityTypeEmbeddings, EntityTypes, FilterColumn as _, JsonField, OntologyIds,
-        OntologyTemporalMetadata, PropertyTypeEmbeddings,
+        EntityEditions, EntityEmbeddings, EntityTemporalMetadata, EntityTypeEmbeddings,
+        EntityTypes, FilterColumn as _, JsonField, OntologyIds, OntologyTemporalMetadata,
     },
 };
 
@@ -58,8 +57,6 @@ pub struct CompilerArtifacts<'p> {
     table_info: TableInfo<'p>,
     cursor_disallowed_reason: Option<&'static str>,
     has_to_many_join: bool,
-    /// Set once an embeddings distance subquery is installed; a statement supports only one.
-    has_embeddings_filter: bool,
 }
 
 struct PathSelection {
@@ -83,6 +80,16 @@ pub enum Distinctness {
     Indistinct,
     Distinct,
 }
+
+/// Candidates a quantized ranking reads per requested result row.
+///
+/// [`rank_by_quantized_distance`] orders on the binary-quantized embedding, whose order deviates
+/// from the exact one, so callers re-score a multiple of the requested rows against the full
+/// vector to recover what the quantization misordered. The budget covers quantization alone —
+/// filters participate in the ranking itself, never in the re-scoring.
+///
+/// [`rank_by_quantized_distance`]: SelectCompiler::rank_by_quantized_distance
+pub const QUANTIZED_RANK_OVERFETCH: usize = 4;
 
 /// How [`SelectCompiler::compile`] lays out the statement.
 ///
@@ -193,7 +200,6 @@ struct CompiledJoin {
     table: Table,
     alias: Alias,
     join_type: JoinType,
-    source: JoinSource,
     conditions: Vec<Expression>,
     /// Whether any relation using this join can fan out the driving rows.
     ///
@@ -206,23 +212,10 @@ impl CompiledJoin {
     /// The `FROM` item this join scans, aliased as [`table`](Self::table) at
     /// [`alias`](Self::alias).
     fn source_item(&self) -> FromItem<'static> {
-        let alias = self.table.aliased_name(self.alias);
-        match &self.source {
-            JoinSource::Table => FromItem::table(self.table).alias(alias).build(),
-            JoinSource::Subquery(statement) => FromItem::subquery((**statement).clone())
-                .alias(alias)
-                .build(),
-        }
+        FromItem::table(self.table)
+            .alias(self.table.aliased_name(self.alias))
+            .build()
     }
-}
-
-/// What a [`CompiledJoin`] scans.
-enum JoinSource {
-    /// The aliased [`table`](CompiledJoin::table) itself.
-    Table,
-    /// A derived table standing in for the plain table. The embeddings distance filter swaps
-    /// its join over to the aggregated distance subquery.
-    Subquery(Box<SelectStatement>),
 }
 
 /// One keyset-pagination sort key.
@@ -421,16 +414,8 @@ pub struct SelectCompiler<'p, 'q: 'p, T: QueryRecord> {
 
 #[derive(Debug, derive_more::Display, derive_more::Error)]
 pub enum SelectCompilerError {
-    #[display("Cannot convert parameter for distance function")]
-    ConvertDistanceParameter,
-    #[display("Only a single embedding filter is allowed per statement")]
-    MultipleEmbeddings,
-    #[display("Only embeddings are supported for cosine distance")]
+    #[display("The column at this path has no binary-quantized form to rank on")]
     UnsupportedEmbeddingPath,
-    #[display(
-        "Cosine distance is only supported with exactly one `path` and one `parameter` expression."
-    )]
-    UnsupportedDistanceExpression,
     #[display("Cannot add a cursor: {reason}")]
     CursorDisallowed { reason: &'static str },
     #[display("Parameters with a pending conversion cannot be compiled")]
@@ -477,7 +462,6 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
                 },
                 cursor_disallowed_reason: None,
                 has_to_many_join: false,
-                has_embeddings_filter: false,
             },
             temporal_axes,
             table_hooks,
@@ -1235,23 +1219,11 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
         self.artifacts.has_to_many_join
     }
 
-    /// Whether an embeddings distance filter was compiled into the statement.
-    #[must_use]
-    pub const fn has_embeddings_filter(&self) -> bool {
-        self.artifacts.has_embeddings_filter
-    }
-
     /// Compiles a [`Filter`] to an [`Expression`].
     ///
     /// # Errors
     ///
     /// Returns an error if the filter compilation fails.
-    ///
-    /// # Panics
-    ///
-    /// Panics when an embeddings table declares no grouping columns, though the static table
-    /// list makes that unreachable.
-    #[expect(clippy::too_many_lines)]
     #[instrument(level = "debug", skip_all)]
     pub fn compile_filter<'f: 'q>(
         &mut self,
@@ -1297,216 +1269,6 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
                 self.compile_filter_expression(lhs)?.0,
                 self.compile_filter_expression(rhs)?.0,
             ),
-            Filter::CosineDistance(lhs, rhs, max) => match (lhs, rhs) {
-                (
-                    FilterExpression::Path { path },
-                    FilterExpression::Parameter { parameter, convert },
-                )
-                | (
-                    FilterExpression::Parameter { parameter, convert },
-                    FilterExpression::Path { path },
-                ) => {
-                    let _span = tracing::info_span!("compile_cosine_distance").entered();
-                    ensure!(
-                        !self.artifacts.has_embeddings_filter,
-                        SelectCompilerError::MultipleEmbeddings
-                    );
-                    // We don't support custom sorting yet and limit/cursor implicitly set an order.
-                    // We special case the distance function to allow sorting by distance, so we
-                    // need to make sure that we don't have a limit or cursor.
-
-                    self.artifacts.cursor_disallowed_reason =
-                        Some("Cannot use distance function with cursor");
-
-                    // `convert` should be `None` as we don't support parameter conversion at this
-                    // stage, yet.
-                    ensure!(
-                        convert.is_none(),
-                        SelectCompilerError::ConvertDistanceParameter
-                    );
-
-                    let path_alias = self.add_join_statements(path);
-                    let parameter_expression = self.compile_parameter(parameter).0;
-                    let maximum_expression = self.compile_filter_expression(max)?.0;
-
-                    let (embeddings_column, None) = path.terminating_column() else {
-                        bail!(SelectCompilerError::UnsupportedEmbeddingPath);
-                    };
-                    let embeddings_table = embeddings_column.table();
-                    let distance_expression = Expression::ColumnReference(
-                        match embeddings_table {
-                            Table::DataTypeEmbeddings => {
-                                Column::DataTypeEmbeddings(DataTypeEmbeddings::Distance)
-                            }
-                            Table::PropertyTypeEmbeddings => {
-                                Column::PropertyTypeEmbeddings(PropertyTypeEmbeddings::Distance)
-                            }
-                            Table::EntityTypeEmbeddings => {
-                                Column::EntityTypeEmbeddings(EntityTypeEmbeddings::Distance)
-                            }
-                            Table::EntityEmbeddings => {
-                                Column::EntityEmbeddings(EntityEmbeddings::Distance)
-                            }
-                            Table::OntologyIds
-                            | Table::OntologyTemporalMetadata
-                            | Table::OntologyOwnedMetadata
-                            | Table::OntologyExternalMetadata
-                            | Table::OntologyAdditionalMetadata
-                            | Table::DataTypes
-                            | Table::DataTypeConversions
-                            | Table::DataTypeConversionAggregation
-                            | Table::PropertyTypes
-                            | Table::EntityTypes
-                            | Table::EntityEditionCache
-                            | Table::EntityIds
-                            | Table::EntityDrafts
-                            | Table::EntityTemporalMetadata
-                            | Table::EntityEditions
-                            | Table::EntityIsOfType
-                            | Table::EntityHasLeftEntity
-                            | Table::EntityHasRightEntity
-                            | Table::EntityEdge
-                            | Table::Action
-                            | Table::ActionHierarchy
-                            | Table::Policy
-                            | Table::PolicyEdition
-                            | Table::PolicyAction
-                            | Table::UserActor
-                            | Table::MachineActor
-                            | Table::AiActor
-                            | Table::Web
-                            | Table::Team
-                            | Table::Role
-                            | Table::ActorRole
-                            | Table::Reference(_) => {
-                                bail!(SelectCompilerError::UnsupportedEmbeddingPath)
-                            }
-                        }
-                        .aliased(path_alias),
-                    );
-
-                    if let Some(last_join) = self.artifacts.joins.last_mut() {
-                        // The rewrite below replaces the topmost join with the distance
-                        // subquery, which is only sound when that join is the embeddings join
-                        // resolved for this path. A reused embeddings join buried under later
-                        // joins (created by an earlier non-distance filter on the embedding
-                        // path) cannot be rewritten.
-                        ensure!(
-                            last_join.table == embeddings_table && last_join.alias == path_alias,
-                            SelectCompilerError::MultipleEmbeddings
-                        );
-
-                        let select_columns: &[_] = match embeddings_table {
-                            Table::DataTypeEmbeddings => {
-                                &[Column::DataTypeEmbeddings(DataTypeEmbeddings::OntologyId)]
-                            }
-                            Table::PropertyTypeEmbeddings => &[Column::PropertyTypeEmbeddings(
-                                PropertyTypeEmbeddings::OntologyId,
-                            )],
-                            Table::EntityTypeEmbeddings => &[Column::EntityTypeEmbeddings(
-                                EntityTypeEmbeddings::OntologyId,
-                            )],
-                            Table::EntityEmbeddings => &[
-                                Column::EntityEmbeddings(EntityEmbeddings::WebId),
-                                Column::EntityEmbeddings(EntityEmbeddings::EntityUuid),
-                            ],
-                            Table::OntologyIds
-                            | Table::OntologyTemporalMetadata
-                            | Table::OntologyOwnedMetadata
-                            | Table::OntologyExternalMetadata
-                            | Table::OntologyAdditionalMetadata
-                            | Table::DataTypes
-                            | Table::DataTypeConversions
-                            | Table::DataTypeConversionAggregation
-                            | Table::PropertyTypes
-                            | Table::EntityTypes
-                            | Table::EntityEditionCache
-                            | Table::EntityIds
-                            | Table::EntityDrafts
-                            | Table::EntityTemporalMetadata
-                            | Table::EntityEditions
-                            | Table::EntityIsOfType
-                            | Table::EntityHasLeftEntity
-                            | Table::EntityHasRightEntity
-                            | Table::EntityEdge
-                            | Table::Action
-                            | Table::ActionHierarchy
-                            | Table::Policy
-                            | Table::PolicyEdition
-                            | Table::PolicyAction
-                            | Table::UserActor
-                            | Table::MachineActor
-                            | Table::AiActor
-                            | Table::Web
-                            | Table::Team
-                            | Table::Role
-                            | Table::ActorRole
-                            | Table::Reference(_) => unreachable!(),
-                        };
-
-                        last_join.source = JoinSource::Subquery(Box::new(SelectStatement::from(
-                            SimpleSelect::builder()
-                                .selects(
-                                    select_columns
-                                        .iter()
-                                        .map(|&column| SelectExpression::Expression {
-                                            expression: Expression::ColumnReference(column.into()),
-                                            output_name: None,
-                                        })
-                                        .chain(once(SelectExpression::Expression {
-                                            expression: Expression::Function(Function::Min(
-                                                Box::new(Expression::cosine_distance(
-                                                    Expression::ColumnReference(
-                                                        embeddings_column.into(),
-                                                    ),
-                                                    parameter_expression,
-                                                )),
-                                            )),
-                                            output_name: Some(Identifier::from("distance")),
-                                        }))
-                                        .collect::<Vec<_>>(),
-                                )
-                                .from(FromItem::table(embeddings_table))
-                                .group_by(
-                                    GroupByClause::builder().grouping_elements(
-                                        NonEmptyVec::try_from(
-                                            select_columns
-                                                .iter()
-                                                .map(|&column| {
-                                                    GroupingElement::Expressions(NonEmptyVec::from(
-                                                        Expression::ColumnReference(column.into()),
-                                                    ))
-                                                })
-                                                .collect::<Vec<_>>(),
-                                        )
-                                        .expect(
-                                            "every embeddings table groups by at least one column",
-                                        ),
-                                    ),
-                                ),
-                        )));
-                        // The grouped subquery emits exactly one row per join key, so the
-                        // original relation's fan-out no longer applies.
-                        last_join.to_many = false;
-                        self.artifacts.has_embeddings_filter = true;
-                    }
-
-                    self.sort_by.insert(
-                        0,
-                        SortBy::builder()
-                            .expression(distance_expression.clone())
-                            .direction(SortDirection::Ascending)
-                            .build(),
-                    );
-                    self.selects.push(SelectExpression::Expression {
-                        expression: distance_expression.clone(),
-                        output_name: None,
-                    });
-                    self.distinct_on.push(distance_expression.clone());
-                    Expression::less_or_equal(distance_expression, maximum_expression)
-                }
-                _ => bail!(SelectCompilerError::UnsupportedDistanceExpression),
-            },
             Filter::In(lhs, rhs) => Expression::r#in(
                 self.compile_filter_expression(lhs)?.0,
                 self.compile_filter_expression_list(rhs).0,
@@ -1639,7 +1401,6 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
             | Filter::GreaterOrEqual(..)
             | Filter::Less(..)
             | Filter::LessOrEqual(..)
-            | Filter::CosineDistance(..)
             | Filter::In(..)
             | Filter::StartsWith(..)
             | Filter::EndsWith(..)
@@ -1911,7 +1672,6 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
             | Filter::GreaterOrEqual(..)
             | Filter::Less(..)
             | Filter::LessOrEqual(..)
-            | Filter::CosineDistance(..)
             | Filter::In(..)
             | Filter::StartsWith(..)
             | Filter::EndsWith(..)
@@ -2242,7 +2002,6 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
                         table: join_table,
                         alias: join_alias,
                         join_type,
-                        source: JoinSource::Table,
                         conditions,
                         to_many: relation.is_to_many(),
                     });
@@ -2252,9 +2011,86 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
 
         current_alias
     }
+
+    /// Ranks the statement by semantic distance to `embedding`, closest first.
+    ///
+    /// The rank is computed on the binary-quantized form of the embedding at `path`, which stays
+    /// in the heap tuple where the full vector is always `TOAST`ed. Quantization makes the order
+    /// approximate: callers needing the exact order re-score the returned candidates against the
+    /// full vector. The rank only reaches an HNSW index while it stays the statement's leading
+    /// sort under a limit.
+    ///
+    /// Ranking turns the embeddings join into an `INNER JOIN` treated as one row per record, so
+    /// records without an embedding drop out of the statement. On `entity_embeddings` the
+    /// one-row property only holds once [`restrict_embedding_property`] pins an embedding space —
+    /// the returned [`Alias`] addresses the join for it.
+    ///
+    /// Ranking rules out a cursor: a keyset predicate compares the cursor columns, which the
+    /// distance order ignores.
+    ///
+    /// # Errors
+    ///
+    /// [`SelectCompilerError::UnsupportedEmbeddingPath`] if the column at `path` has no
+    /// binary-quantized form.
+    ///
+    /// # Panics
+    ///
+    /// If the embeddings join resolved for `path` is missing from the statement, which the
+    /// path's relation rules out.
+    ///
+    /// [`restrict_embedding_property`]: Self::restrict_embedding_property
+    pub fn rank_by_quantized_distance<'f: 'q>(
+        &mut self,
+        path: &R::QueryPath<'f>,
+        embedding: &'p (dyn ToSql + Sync),
+    ) -> Result<Alias, Report<SelectCompilerError>>
+    where
+        R::QueryPath<'f>: PostgresQueryPath,
+    {
+        let bits_column = match path.terminating_column() {
+            (Column::EntityEmbeddings(EntityEmbeddings::Embedding), None) => {
+                Column::EntityEmbeddings(EntityEmbeddings::EmbeddingBits)
+            }
+            (Column::EntityTypeEmbeddings(EntityTypeEmbeddings::Embedding), None) => {
+                Column::EntityTypeEmbeddings(EntityTypeEmbeddings::EmbeddingBits)
+            }
+            _ => bail!(SelectCompilerError::UnsupportedEmbeddingPath),
+        };
+
+        self.artifacts.cursor_disallowed_reason =
+            Some("Cannot use a semantic ranking with a cursor");
+
+        let alias = self.add_join_statements(path);
+
+        // The relation resolves to an outer join, which would keep records without any embedding
+        // and rank them with a NULL distance.
+        let join = self
+            .artifacts
+            .joins
+            .iter_mut()
+            .rev()
+            .find(|join| join.table.name() == bits_column.table().name() && join.alias == alias)
+            .expect("ranking on an embedding path should resolve to an embeddings join");
+        join.join_type = JoinType::Inner;
+        join.to_many = false;
+
+        let rank = Expression::hamming_distance(
+            Expression::ColumnReference(bits_column.aliased(alias)),
+            Expression::binary_quantize(self.add_parameter(embedding)),
+        );
+        self.sort_by.insert(
+            0,
+            SortBy::builder()
+                .expression(rank)
+                .direction(SortDirection::Ascending)
+                .build(),
+        );
+
+        Ok(alias)
+    }
 }
 
-/// Entity-specific methods for property masking.
+/// Entity-specific compiler extensions.
 impl<'p, 'q: 'p> SelectCompiler<'p, 'q, Entity> {
     /// Configures property masking for Entity queries.
     ///
@@ -2326,5 +2162,31 @@ impl<'p, 'q: 'p> SelectCompiler<'p, 'q, Entity> {
         } else {
             column
         }
+    }
+
+    /// Restricts the embeddings join at `alias` to one embedding space.
+    ///
+    /// `entity_embeddings` interleaves two spaces: a combined embedding over all of an entity's
+    /// properties and one embedding per property value. Distances are only comparable within one
+    /// space, so a statement ranking over the table picks a side: [`None`] selects the combined
+    /// embedding, [`Some`] the embedding of that property. Either addresses at most one row per
+    /// entity.
+    ///
+    /// `alias` is the join handle returned by [`rank_by_quantized_distance`].
+    ///
+    /// [`rank_by_quantized_distance`]: Self::rank_by_quantized_distance
+    pub fn restrict_embedding_property(
+        &mut self,
+        alias: Alias,
+        property: Option<&'p (dyn ToSql + Sync)>,
+    ) {
+        let property_column = Expression::ColumnReference(
+            Column::EntityEmbeddings(EntityEmbeddings::Property).aliased(alias),
+        );
+        let property_condition = match property {
+            Some(property) => Expression::equal(property_column, self.add_parameter(property)),
+            None => Expression::is_null(property_column),
+        };
+        self.conditions.push(property_condition);
     }
 }

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/compile/tests.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/compile/tests.rs
@@ -7,8 +7,8 @@ use hash_graph_store::{
     entity::EntityQueryPath,
     entity_type::EntityTypeQueryPath,
     filter::{
-        Filter, FilterExpression, JsonPath, Parameter, PathToken,
-        protection::PropertyProtectionFilterConfig,
+        Filter, FilterExpression, FilterExpressionList, JsonPath, Parameter, ParameterList,
+        PathToken, protection::PropertyProtectionFilterConfig,
     },
     property_type::PropertyTypeQueryPath,
     query::{NullOrdering, Ordering},
@@ -25,6 +25,7 @@ use type_system::{
         BaseUrl, DataTypeWithMetadata, EntityTypeWithMetadata, PropertyTypeWithMetadata,
         VersionedUrl,
     },
+    principal::actor_group::WebId,
 };
 use uuid::Uuid;
 
@@ -1604,44 +1605,192 @@ fn filter_entity_by_type_base_url() {
     );
 }
 
+/// A semantic read ranks candidates under the permission filter rather than filtering the ranked
+/// rows, so the statement carrying `ORDER BY … LIMIT` has to carry the permission predicate too.
+/// Were the two split across statements, the limit would cut the candidates before the permission
+/// filter saw them and a restricted actor would get too few results, and the wrong ones.
 #[test]
-fn filter_embedding_distance() {
+fn semantic_ordering_ranks_under_the_permission_filter() {
+    let permitted_webs = [WebId::new(Uuid::from_u128(1))];
+    let embedding = Embedding::from(vec![0.0; 3072]);
+
     let mut compiler = SelectCompiler::<Entity>::with_asterisk(None, false);
 
-    let filter = Filter::CosineDistance(
+    // The shape `Filter::for_policies` produces for an actor permitted a set of webs.
+    let permission_filter = Filter::In(
         FilterExpression::Path {
-            path: EntityQueryPath::Embedding,
+            path: EntityQueryPath::WebId,
         },
-        FilterExpression::Parameter {
-            parameter: Parameter::Vector(Embedding::from(vec![0.0; 1536])),
-            convert: None,
-        },
-        FilterExpression::Parameter {
-            parameter: Parameter::Decimal(Real::from_natural(5, -1)),
-            convert: None,
+        FilterExpressionList::ParameterList {
+            parameters: ParameterList::WebIds(&permitted_webs),
         },
     );
-    compiler.add_filter(&filter).expect("Failed to add filter");
+    compiler
+        .add_filter(&permission_filter)
+        .expect("the permission filter should compile");
+    let embeddings_alias = compiler
+        .rank_by_quantized_distance(&EntityQueryPath::Embedding, &embedding)
+        .expect("the embedding path should have a quantized form to rank on");
+    compiler.restrict_embedding_property(embeddings_alias, None);
+    compiler.set_limit(400);
 
     test_compilation(
         &compiler,
         r#"
-        SELECT DISTINCT ON("entity_embeddings_0_1_0"."distance") *, "entity_embeddings_0_1_0"."distance"
+        SELECT *
         FROM "entity_temporal_metadata" AS "entity_temporal_metadata_0_0_0"
-        LEFT OUTER JOIN (SELECT "entity_embeddings"."web_id", "entity_embeddings"."entity_uuid", MIN("entity_embeddings"."embedding" <=> $1) AS "distance"
-        FROM "entity_embeddings"
-        GROUP BY "entity_embeddings"."web_id", "entity_embeddings"."entity_uuid") AS "entity_embeddings_0_1_0"
+        INNER JOIN "entity_embeddings" AS "entity_embeddings_1_1_0"
+          ON "entity_embeddings_1_1_0"."web_id" = "entity_temporal_metadata_0_0_0"."web_id"
+         AND "entity_embeddings_1_1_0"."entity_uuid" = "entity_temporal_metadata_0_0_0"."entity_uuid"
+        WHERE ("entity_temporal_metadata_0_0_0"."draft_id" IS NULL)
+          AND ("entity_temporal_metadata_0_0_0"."web_id" = ANY($1))
+          AND ("entity_embeddings_1_1_0"."property" IS NULL)
+        ORDER BY "entity_embeddings_1_1_0"."embedding_bits" <~> binary_quantize(($2::vector)) ASC
+        LIMIT 400
+        "#,
+        &[&permitted_webs.as_slice(), &embedding],
+    );
+}
+
+/// The per-property embedding space is addressed by equality on the `property` column instead of
+/// its `IS NULL` row.
+#[test]
+fn semantic_ordering_selects_one_embedding_space() {
+    let embedding = Embedding::from(vec![0.0; 3072]);
+    let property = "https://example.com/@example-org/types/property-type/name/";
+
+    let mut compiler = SelectCompiler::<Entity>::with_asterisk(None, false);
+    let embeddings_alias = compiler
+        .rank_by_quantized_distance(&EntityQueryPath::Embedding, &embedding)
+        .expect("the embedding path should have a quantized form to rank on");
+    compiler.restrict_embedding_property(embeddings_alias, Some(&property));
+    compiler.set_limit(400);
+
+    test_compilation(
+        &compiler,
+        r#"
+        SELECT *
+        FROM "entity_temporal_metadata" AS "entity_temporal_metadata_0_0_0"
+        INNER JOIN "entity_embeddings" AS "entity_embeddings_0_1_0"
           ON "entity_embeddings_0_1_0"."web_id" = "entity_temporal_metadata_0_0_0"."web_id"
          AND "entity_embeddings_0_1_0"."entity_uuid" = "entity_temporal_metadata_0_0_0"."entity_uuid"
         WHERE ("entity_temporal_metadata_0_0_0"."draft_id" IS NULL)
-          AND ("entity_embeddings_0_1_0"."distance" <= $2)
-        ORDER BY "entity_embeddings_0_1_0"."distance" ASC
+          AND ("entity_embeddings_0_1_0"."property" = $2)
+        ORDER BY "entity_embeddings_0_1_0"."embedding_bits" <~> binary_quantize(($1::vector)) ASC
+        LIMIT 400
+        "#,
+        &[&embedding, &property],
+    );
+}
+
+/// `entity_type_embeddings` has no `property` column, so ranking entity types needs no space
+/// restriction.
+#[test]
+fn semantic_ordering_ranks_entity_types() {
+    let embedding = Embedding::from(vec![0.0; 3072]);
+
+    let mut compiler = SelectCompiler::<EntityTypeWithMetadata>::with_asterisk(None, false);
+    compiler
+        .rank_by_quantized_distance(&EntityTypeQueryPath::Embedding, &embedding)
+        .expect("the embedding path should have a quantized form to rank on");
+    compiler.set_limit(400);
+
+    test_compilation(
+        &compiler,
+        r#"
+        SELECT *
+        FROM "ontology_temporal_metadata" AS "ontology_temporal_metadata_0_0_0"
+        INNER JOIN "entity_type_embeddings" AS "entity_type_embeddings_0_1_0"
+          ON "entity_type_embeddings_0_1_0"."ontology_id" = "ontology_temporal_metadata_0_0_0"."ontology_id"
+        ORDER BY "entity_type_embeddings_0_1_0"."embedding_bits" <~> binary_quantize(($1::vector)) ASC
+        LIMIT 400
+        "#,
+        &[&embedding],
+    );
+}
+
+/// The exact statement the entity search issues: temporal axes, key selections, ranking, and the
+/// embedding-space restriction. The outer re-score references the CTE's columns by name, so this
+/// pins the output names and their order alongside the ranking shape.
+#[test]
+fn semantic_ordering_production_shape() {
+    let temporal_axes = QueryTemporalAxesUnresolved::live_only().resolve();
+    let pinned_timestamp = temporal_axes.pinned_timestamp();
+    let embedding = Embedding::from(vec![0.0; 3072]);
+
+    let web_id_path = EntityQueryPath::WebId;
+    let uuid_path = EntityQueryPath::Uuid;
+    let draft_id_path = EntityQueryPath::DraftId;
+
+    let mut compiler = SelectCompiler::<Entity>::new(Some(&temporal_axes), false);
+    compiler.add_selection_path(&web_id_path);
+    compiler.add_selection_path(&uuid_path);
+    compiler.add_selection_path(&draft_id_path);
+    let embeddings_alias = compiler
+        .rank_by_quantized_distance(&EntityQueryPath::Embedding, &embedding)
+        .expect("the embedding path should have a quantized form to rank on");
+    compiler.restrict_embedding_property(embeddings_alias, None);
+    compiler.set_limit(400);
+
+    test_compilation(
+        &compiler,
+        r#"
+        SELECT "entity_temporal_metadata_0_0_0"."web_id", "entity_temporal_metadata_0_0_0"."entity_uuid", "entity_temporal_metadata_0_0_0"."draft_id"
+        FROM "entity_temporal_metadata" AS "entity_temporal_metadata_0_0_0"
+        INNER JOIN "entity_embeddings" AS "entity_embeddings_0_1_0"
+          ON "entity_embeddings_0_1_0"."web_id" = "entity_temporal_metadata_0_0_0"."web_id"
+         AND "entity_embeddings_0_1_0"."entity_uuid" = "entity_temporal_metadata_0_0_0"."entity_uuid"
+        WHERE ("entity_temporal_metadata_0_0_0"."draft_id" IS NULL)
+          AND ("entity_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ)
+          AND ("entity_temporal_metadata_0_0_0"."decision_time" && $2)
+          AND ("entity_embeddings_0_1_0"."property" IS NULL)
+        ORDER BY "entity_embeddings_0_1_0"."embedding_bits" <~> binary_quantize(($3::vector)) ASC
+        LIMIT 400
         "#,
         &[
-            &Embedding::from(vec![0.0; 1536]),
-            &Real::from_natural(5, -1),
+            &pinned_timestamp,
+            &temporal_axes.variable_interval(),
+            &embedding,
         ],
     );
+}
+
+#[test]
+fn semantic_ordering_rejects_non_embedding_paths() {
+    let embedding = Embedding::from(vec![0.0; 3072]);
+
+    let mut compiler = SelectCompiler::<Entity>::with_asterisk(None, false);
+    let error = compiler
+        .rank_by_quantized_distance(&EntityQueryPath::Uuid, &embedding)
+        .expect_err("a non-embedding path should have no quantized form to rank on");
+    assert!(matches!(
+        error.current_context(),
+        SelectCompilerError::UnsupportedEmbeddingPath
+    ));
+}
+
+#[test]
+fn cursor_after_semantic_ordering_is_rejected() {
+    let embedding = Embedding::from(vec![0.0; 3072]);
+
+    let mut compiler = SelectCompiler::<Entity>::with_asterisk(None, false);
+    compiler
+        .rank_by_quantized_distance(&EntityQueryPath::Embedding, &embedding)
+        .expect("the embedding path should have a quantized form to rank on");
+
+    let error = compiler
+        .add_cursor_selection(
+            &EntityQueryPath::Uuid,
+            core::convert::identity,
+            None,
+            Ordering::Ascending,
+            None,
+        )
+        .expect_err("a cursor is not allowed after a semantic ranking");
+    assert!(matches!(
+        error.current_context(),
+        SelectCompilerError::CursorDisallowed { .. }
+    ));
 }
 
 #[test]
@@ -1900,95 +2049,6 @@ mod property_masking {
             "ORDER BY should use masked properties expression: {sql}"
         );
     }
-}
-
-fn embedding_distance_filter() -> Filter<'static, Entity> {
-    Filter::CosineDistance(
-        FilterExpression::Path {
-            path: EntityQueryPath::Embedding,
-        },
-        FilterExpression::Parameter {
-            parameter: Parameter::Vector(Embedding::from(vec![0.0; 1536])),
-            convert: None,
-        },
-        FilterExpression::Parameter {
-            parameter: Parameter::Decimal(Real::from_natural(5, -1)),
-            convert: None,
-        },
-    )
-}
-
-#[test]
-fn second_embedding_filter_is_rejected() {
-    let mut compiler = SelectCompiler::<Entity>::with_asterisk(None, false);
-    let filter = embedding_distance_filter();
-    compiler
-        .add_filter(&filter)
-        .expect("the first embedding filter should compile");
-
-    let error = compiler
-        .add_filter(&filter)
-        .expect_err("a second embedding filter should be rejected");
-    assert!(matches!(
-        error.current_context(),
-        SelectCompilerError::MultipleEmbeddings
-    ));
-}
-
-#[test]
-fn buried_embeddings_join_is_not_rewritten() {
-    let mut compiler = SelectCompiler::<Entity>::with_asterisk(None, false);
-
-    // Within one combined filter every branch shares a `condition_index`, so the distance arm
-    // reuses the embeddings join created by the `Exists` branch — buried under the properties
-    // join added in between. Rewriting the topmost join would replace the wrong one.
-    let json_path = JsonPath::from_path_tokens(vec![PathToken::Field(Cow::Borrowed("name"))]);
-    let filter = Filter::All(vec![
-        Filter::Exists {
-            path: EntityQueryPath::Embedding,
-        },
-        Filter::Equal(
-            FilterExpression::Path {
-                path: EntityQueryPath::Properties(Some(json_path)),
-            },
-            FilterExpression::Parameter {
-                parameter: Parameter::Text(Cow::Borrowed("Bob")),
-                convert: None,
-            },
-        ),
-        embedding_distance_filter(),
-    ]);
-
-    let error = compiler
-        .add_filter(&filter)
-        .expect_err("a buried embeddings join cannot be rewritten into the distance subquery");
-    assert!(matches!(
-        error.current_context(),
-        SelectCompilerError::MultipleEmbeddings
-    ));
-}
-
-#[test]
-fn cursor_after_embedding_filter_is_rejected() {
-    let mut compiler = SelectCompiler::<Entity>::with_asterisk(None, false);
-    let filter = embedding_distance_filter();
-    compiler
-        .add_filter(&filter)
-        .expect("the embedding filter should compile");
-
-    let error = compiler
-        .add_cursor_selection(
-            &EntityQueryPath::Uuid,
-            core::convert::identity,
-            None,
-            Ordering::Ascending,
-            None,
-        )
-        .expect_err("a cursor is not allowed after an embedding filter");
-    assert!(matches!(
-        error.current_context(),
-        SelectCompilerError::CursorDisallowed { .. }
-    ));
 }
 
 #[test]
@@ -2362,45 +2422,6 @@ fn fetch_keys_then_hydrate_with_cursor() {
 }
 
 #[test]
-fn fetch_keys_then_hydrate_embedding_distance() {
-    let mut compiler = SelectCompiler::<Entity>::new(None, false);
-    let filter = embedding_distance_filter();
-    compiler
-        .add_filter(&filter)
-        .expect("the embedding filter should compile");
-    compiler.set_limit(3);
-    compiler.set_statement_shape(StatementShape::FencedKeysFirst);
-
-    // The grouped distance subquery emits one row per entity, so it may drive the key query.
-    test_compilation(
-        &compiler,
-        r#"
-        WITH "roots" AS MATERIALIZED (SELECT "entity_embeddings_0_1_0"."distance"
-        FROM "entity_temporal_metadata" AS "entity_temporal_metadata_0_0_0"
-        LEFT OUTER JOIN (SELECT "entity_embeddings"."web_id", "entity_embeddings"."entity_uuid", MIN("entity_embeddings"."embedding" <=> $1) AS "distance"
-        FROM "entity_embeddings"
-        GROUP BY "entity_embeddings"."web_id", "entity_embeddings"."entity_uuid") AS "entity_embeddings_0_1_0"
-          ON "entity_embeddings_0_1_0"."web_id" = "entity_temporal_metadata_0_0_0"."web_id"
-         AND "entity_embeddings_0_1_0"."entity_uuid" = "entity_temporal_metadata_0_0_0"."entity_uuid"
-        WHERE ("entity_temporal_metadata_0_0_0"."draft_id" IS NULL)
-          AND ("entity_embeddings_0_1_0"."distance" <= $2)),
-        "limited" AS (SELECT *
-        FROM "roots"
-        ORDER BY "distance" ASC
-        LIMIT 3)
-        SELECT DISTINCT ON("limited"."distance") "limited"."distance"
-        FROM "limited"
-        ORDER BY "limited"."distance" ASC
-        LIMIT 3
-        "#,
-        &[
-            &Embedding::from(vec![0.0; 1536]),
-            &Real::from_natural(5, -1),
-        ],
-    );
-}
-
-#[test]
 fn fetch_keys_then_hydrate_carries_existing_ctes() {
     let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
     let pinned_timestamp = temporal_axes.pinned_timestamp();
@@ -2456,7 +2477,7 @@ fn fetch_keys_then_hydrate_carries_existing_ctes() {
 
 #[test]
 fn fetch_keys_then_hydrate_generating_hydration_join_falls_back() {
-    use super::{CompiledJoin, JoinSource};
+    use super::CompiledJoin;
     use crate::store::postgres::query::{Alias, JoinType, Table};
 
     let mut compiler = SelectCompiler::<Entity>::new(None, true);
@@ -2477,7 +2498,6 @@ fn fetch_keys_then_hydrate_generating_hydration_join_falls_back() {
             number: 0,
         },
         join_type: JoinType::RightOuter,
-        source: JoinSource::Table,
         conditions: Vec::new(),
         to_many: false,
     });

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/compile/tests.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/compile/tests.rs
@@ -1709,9 +1709,191 @@ fn semantic_ordering_ranks_entity_types() {
     );
 }
 
-/// The exact statement the entity search issues: temporal axes, key selections, ranking, and the
-/// embedding-space restriction. The outer re-score references the CTE's columns by name, so this
-/// pins the output names and their order alongside the ranking shape.
+/// One branch of the permit disjunction as [`Filter::for_policy_branches`] shapes it — the permit
+/// with every forbid negated — compiled together with the request filter. A branch replaces the
+/// top-level permit disjunction with a conjunction; a permit can still hold a disjunction of its
+/// own, which then stays inside the branch.
+#[test]
+fn semantic_ordering_compiles_a_policy_branch() {
+    let permitted_webs = [WebId::new(Uuid::from_u128(1))];
+    let forbidden_uuid = Uuid::from_u128(2);
+    let embedding = Embedding::from(vec![0.0; 3072]);
+
+    let mut compiler = SelectCompiler::<Entity>::with_asterisk(None, false);
+
+    let policy_branch = Filter::All(vec![
+        Filter::In(
+            FilterExpression::Path {
+                path: EntityQueryPath::WebId,
+            },
+            FilterExpressionList::ParameterList {
+                parameters: ParameterList::WebIds(&permitted_webs),
+            },
+        ),
+        Filter::Not(Box::new(Filter::Any(vec![Filter::Equal(
+            FilterExpression::Path {
+                path: EntityQueryPath::Uuid,
+            },
+            FilterExpression::Parameter {
+                parameter: Parameter::Uuid(forbidden_uuid),
+                convert: None,
+            },
+        )]))),
+    ]);
+    let request_filter = Filter::Equal(
+        FilterExpression::Path {
+            path: EntityQueryPath::Archived,
+        },
+        FilterExpression::Parameter {
+            parameter: Parameter::Boolean(false),
+            convert: None,
+        },
+    );
+
+    compiler
+        .add_filter(&policy_branch)
+        .expect("the policy branch should compile");
+    compiler
+        .add_filter(&request_filter)
+        .expect("the request filter should compile");
+    let embeddings_alias = compiler
+        .rank_by_quantized_distance(&EntityQueryPath::Embedding, &embedding)
+        .expect("the embedding path should have a quantized form to rank on");
+    compiler.restrict_embedding_property(embeddings_alias, None);
+    compiler.set_limit(400);
+
+    test_compilation(
+        &compiler,
+        r#"
+        SELECT *
+        FROM "entity_temporal_metadata" AS "entity_temporal_metadata_0_0_0"
+        INNER JOIN "entity_editions" AS "entity_editions_1_1_0"
+          ON "entity_editions_1_1_0"."entity_edition_id" = "entity_temporal_metadata_0_0_0"."entity_edition_id"
+        INNER JOIN "entity_embeddings" AS "entity_embeddings_2_1_0"
+          ON "entity_embeddings_2_1_0"."web_id" = "entity_temporal_metadata_0_0_0"."web_id"
+         AND "entity_embeddings_2_1_0"."entity_uuid" = "entity_temporal_metadata_0_0_0"."entity_uuid"
+        WHERE ("entity_temporal_metadata_0_0_0"."draft_id" IS NULL)
+          AND (("entity_temporal_metadata_0_0_0"."web_id" = ANY($1))
+          AND (NOT(("entity_temporal_metadata_0_0_0"."entity_uuid" = $2))))
+          AND ("entity_editions_1_1_0"."archived" = $3)
+          AND ("entity_embeddings_2_1_0"."property" IS NULL)
+        ORDER BY "entity_embeddings_2_1_0"."embedding_bits" <~> binary_quantize(($4::vector)) ASC
+        LIMIT 400
+        "#,
+        &[
+            &permitted_webs.as_slice(),
+            &forbidden_uuid,
+            &false,
+            &embedding,
+        ],
+    );
+}
+
+/// The branch split end to end: the policies go through [`Filter::for_policy_branches`] and
+/// every branch compiles to its own statement, so a change to the branch assembly shows up here
+/// as a changed statement.
+#[test]
+fn semantic_ordering_compiles_the_policy_branch_split() {
+    use hash_graph_authorization::policies::{
+        Effect, OptimizationData,
+        resource::{EntityResourceConstraint, ResourceConstraint},
+    };
+    use type_system::{
+        knowledge::entity::id::EntityUuid,
+        principal::actor::{ActorId, UserId},
+    };
+
+    let embedding = Embedding::from(vec![0.0; 3072]);
+    let actor_id = Some(ActorId::User(UserId::new(Uuid::from_u128(10))));
+
+    let permitted_entity = Uuid::from_u128(1);
+    let forbidden_entity = Uuid::from_u128(2);
+    let permit = ResourceConstraint::Entity(EntityResourceConstraint::Exact {
+        id: EntityUuid::new(permitted_entity),
+    });
+    let forbid = ResourceConstraint::Entity(EntityResourceConstraint::Exact {
+        id: EntityUuid::new(forbidden_entity),
+    });
+    let optimization_data = OptimizationData {
+        permitted_web_ids: vec![
+            WebId::new(Uuid::from_u128(3)),
+            WebId::new(Uuid::from_u128(4)),
+        ],
+        ..OptimizationData::default()
+    };
+
+    let branches = Filter::<Entity>::for_policy_branches(
+        [
+            (Effect::Permit, Some(&permit)),
+            (Effect::Forbid, Some(&forbid)),
+        ],
+        actor_id,
+        &optimization_data,
+    );
+    assert_eq!(
+        branches.len(),
+        2,
+        "the policies should split into an entity permit and a web permit branch"
+    );
+
+    let expectations: [(&str, &[&dyn ToSql]); 2] = [
+        (
+            r#"
+            SELECT *
+            FROM "entity_temporal_metadata" AS "entity_temporal_metadata_0_0_0"
+            INNER JOIN "entity_embeddings" AS "entity_embeddings_1_1_0"
+              ON "entity_embeddings_1_1_0"."web_id" = "entity_temporal_metadata_0_0_0"."web_id"
+             AND "entity_embeddings_1_1_0"."entity_uuid" = "entity_temporal_metadata_0_0_0"."entity_uuid"
+            WHERE ("entity_temporal_metadata_0_0_0"."draft_id" IS NULL)
+              AND (("entity_temporal_metadata_0_0_0"."entity_uuid" = $1)
+              AND (NOT(("entity_temporal_metadata_0_0_0"."entity_uuid" = $2))))
+              AND ("entity_embeddings_1_1_0"."property" IS NULL)
+            ORDER BY "entity_embeddings_1_1_0"."embedding_bits" <~> binary_quantize(($3::vector)) ASC
+            LIMIT 400
+            "#,
+            &[&permitted_entity, &forbidden_entity, &embedding],
+        ),
+        (
+            r#"
+            SELECT *
+            FROM "entity_temporal_metadata" AS "entity_temporal_metadata_0_0_0"
+            INNER JOIN "entity_embeddings" AS "entity_embeddings_1_1_0"
+              ON "entity_embeddings_1_1_0"."web_id" = "entity_temporal_metadata_0_0_0"."web_id"
+             AND "entity_embeddings_1_1_0"."entity_uuid" = "entity_temporal_metadata_0_0_0"."entity_uuid"
+            WHERE ("entity_temporal_metadata_0_0_0"."draft_id" IS NULL)
+              AND (("entity_temporal_metadata_0_0_0"."web_id" = ANY($1))
+              AND (NOT(("entity_temporal_metadata_0_0_0"."entity_uuid" = $2))))
+              AND ("entity_embeddings_1_1_0"."property" IS NULL)
+            ORDER BY "entity_embeddings_1_1_0"."embedding_bits" <~> binary_quantize(($3::vector)) ASC
+            LIMIT 400
+            "#,
+            &[
+                &optimization_data.permitted_web_ids.as_slice(),
+                &forbidden_entity,
+                &embedding,
+            ],
+        ),
+    ];
+
+    for (branch, (expected_statement, expected_parameters)) in branches.iter().zip(expectations) {
+        let mut compiler = SelectCompiler::<Entity>::with_asterisk(None, false);
+        compiler
+            .add_filter(branch)
+            .expect("the policy branch should compile");
+        let embeddings_alias = compiler
+            .rank_by_quantized_distance(&EntityQueryPath::Embedding, &embedding)
+            .expect("the embedding path should have a quantized form to rank on");
+        compiler.restrict_embedding_property(embeddings_alias, None);
+        compiler.set_limit(400);
+
+        test_compilation(&compiler, expected_statement, expected_parameters);
+    }
+}
+
+/// The statement core every branch key-read shares: temporal axes, key selections, ranking, and
+/// the embedding-space restriction. The per-branch policy and request filters are pinned
+/// separately. The key columns are read back positionally, so this pins their order alongside
+/// the ranking shape.
 #[test]
 fn semantic_ordering_production_shape() {
     let temporal_axes = QueryTemporalAxesUnresolved::live_only().resolve();

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/mod.rs
@@ -40,7 +40,9 @@ pub use self::{
         TableReference, TableSample, UnaryExpression, UnaryOperator, VariadicExpression,
         VariadicOperator, WindowDefinition, WithClause, bulk_insert,
     },
-    compile::{Distinctness, SelectCompiler, SelectCompilerError, StatementShape},
+    compile::{
+        Distinctness, QUANTIZED_RANK_OVERFETCH, SelectCompiler, SelectCompilerError, StatementShape,
+    },
     postgres_type::PostgresType,
     table::{Alias, Column, ForeignKeyReference, JsonField, ReferenceTable, Relation, Table},
 };

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/postgres_type.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/postgres_type.rs
@@ -27,6 +27,8 @@ pub enum PostgresType {
     JsonPath,
     // `pgvector` embedding vector
     Vector,
+    // bit string, transpiles without a width and is therefore unusable as a parameter cast
+    Bit,
     // `entity_edge_kind` enum
     EntityEdgeKind,
     // `edge_direction` enum
@@ -58,6 +60,7 @@ impl Transpile for PostgresType {
             Self::JsonB => fmt.write_str(Type::JSONB.name()),
             Self::JsonPath => fmt.write_str(Type::JSONPATH.name()),
             Self::Vector => fmt.write_str("vector"),
+            Self::Bit => fmt.write_str(Type::BIT.name()),
             Self::EntityEdgeKind => fmt.write_str("entity_edge_kind"),
             Self::EdgeDirection => fmt.write_str("edge_direction"),
             Self::PrincipalType => fmt.write_str("principal_type"),

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/table.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/table.rs
@@ -1024,7 +1024,6 @@ pub enum DataTypeEmbeddings {
     OntologyId,
     Embedding,
     UpdatedAtTransactionTime,
-    Distance,
 }
 
 impl DatabaseColumn<'_> for DataTypeEmbeddings {
@@ -1033,7 +1032,6 @@ impl DatabaseColumn<'_> for DataTypeEmbeddings {
             Self::OntologyId => "ontology_id".into(),
             Self::Embedding => "embedding".into(),
             Self::UpdatedAtTransactionTime => "updated_at_transaction_time".into(),
-            Self::Distance => "distance".into(),
         }
     }
 
@@ -1042,7 +1040,6 @@ impl DatabaseColumn<'_> for DataTypeEmbeddings {
             Self::OntologyId => PostgresType::Uuid,
             Self::Embedding => PostgresType::Vector,
             Self::UpdatedAtTransactionTime => PostgresType::TimestampTz,
-            Self::Distance => PostgresType::Float8,
         }
     }
 }
@@ -1053,7 +1050,6 @@ impl FilterColumn<'_> for DataTypeEmbeddings {
             Self::OntologyId => ParameterType::Uuid,
             Self::Embedding => ParameterType::Vector(Box::new(ParameterType::Decimal)),
             Self::UpdatedAtTransactionTime => ParameterType::Timestamp,
-            Self::Distance => ParameterType::Decimal,
         }
     }
 }
@@ -1096,7 +1092,6 @@ pub enum PropertyTypeEmbeddings {
     OntologyId,
     Embedding,
     UpdatedAtTransactionTime,
-    Distance,
 }
 
 impl DatabaseColumn<'_> for PropertyTypeEmbeddings {
@@ -1105,7 +1100,6 @@ impl DatabaseColumn<'_> for PropertyTypeEmbeddings {
             Self::OntologyId => "ontology_id".into(),
             Self::Embedding => "embedding".into(),
             Self::UpdatedAtTransactionTime => "updated_at_transaction_time".into(),
-            Self::Distance => "distance".into(),
         }
     }
 
@@ -1114,7 +1108,6 @@ impl DatabaseColumn<'_> for PropertyTypeEmbeddings {
             Self::OntologyId => PostgresType::Uuid,
             Self::Embedding => PostgresType::Vector,
             Self::UpdatedAtTransactionTime => PostgresType::TimestampTz,
-            Self::Distance => PostgresType::Float8,
         }
     }
 }
@@ -1125,7 +1118,6 @@ impl FilterColumn<'_> for PropertyTypeEmbeddings {
             Self::OntologyId => ParameterType::Uuid,
             Self::Embedding => ParameterType::Vector(Box::new(ParameterType::Decimal)),
             Self::UpdatedAtTransactionTime => ParameterType::Timestamp,
-            Self::Distance => ParameterType::Decimal,
         }
     }
 }
@@ -1134,8 +1126,11 @@ impl FilterColumn<'_> for PropertyTypeEmbeddings {
 pub enum EntityTypeEmbeddings {
     OntologyId,
     Embedding,
+    /// The binary-quantized [`Embedding`], one bit per dimension.
+    ///
+    /// [`Embedding`]: Self::Embedding
+    EmbeddingBits,
     UpdatedAtTransactionTime,
-    Distance,
 }
 
 impl DatabaseColumn<'_> for EntityTypeEmbeddings {
@@ -1143,8 +1138,8 @@ impl DatabaseColumn<'_> for EntityTypeEmbeddings {
         match self {
             Self::OntologyId => "ontology_id".into(),
             Self::Embedding => "embedding".into(),
+            Self::EmbeddingBits => "embedding_bits".into(),
             Self::UpdatedAtTransactionTime => "updated_at_transaction_time".into(),
-            Self::Distance => "distance".into(),
         }
     }
 
@@ -1152,8 +1147,8 @@ impl DatabaseColumn<'_> for EntityTypeEmbeddings {
         match self {
             Self::OntologyId => PostgresType::Uuid,
             Self::Embedding => PostgresType::Vector,
+            Self::EmbeddingBits => PostgresType::Bit,
             Self::UpdatedAtTransactionTime => PostgresType::TimestampTz,
-            Self::Distance => PostgresType::Float8,
         }
     }
 }
@@ -1163,8 +1158,8 @@ impl FilterColumn<'_> for EntityTypeEmbeddings {
         match self {
             Self::OntologyId => ParameterType::Uuid,
             Self::Embedding => ParameterType::Vector(Box::new(ParameterType::Decimal)),
+            Self::EmbeddingBits => ParameterType::Vector(Box::new(ParameterType::Boolean)),
             Self::UpdatedAtTransactionTime => ParameterType::Timestamp,
-            Self::Distance => ParameterType::Decimal,
         }
     }
 }
@@ -1175,10 +1170,17 @@ pub enum EntityEmbeddings {
     EntityUuid,
     DraftId,
     Embedding,
+    /// The binary-quantized [`Embedding`], one bit per dimension.
+    ///
+    /// Stored generated column. At 392 bytes it stays in the heap tuple, whereas the 12 kB
+    /// [`Embedding`] is always out-of-line, so ranking candidates on this column avoids a TOAST
+    /// read per row.
+    ///
+    /// [`Embedding`]: Self::Embedding
+    EmbeddingBits,
     Property,
     UpdatedAtTransactionTime,
     UpdatedAtDecisionTime,
-    Distance,
 }
 
 impl DatabaseColumn<'_> for EntityEmbeddings {
@@ -1188,10 +1190,10 @@ impl DatabaseColumn<'_> for EntityEmbeddings {
             Self::EntityUuid => "entity_uuid".into(),
             Self::DraftId => "draft_id".into(),
             Self::Embedding => "embedding".into(),
+            Self::EmbeddingBits => "embedding_bits".into(),
             Self::Property => "property".into(),
             Self::UpdatedAtDecisionTime => "updated_at_decision_time".into(),
             Self::UpdatedAtTransactionTime => "updated_at_transaction_time".into(),
-            Self::Distance => "distance".into(),
         }
     }
 
@@ -1199,11 +1201,11 @@ impl DatabaseColumn<'_> for EntityEmbeddings {
         match self {
             Self::WebId | Self::EntityUuid | Self::DraftId => PostgresType::Uuid,
             Self::Embedding => PostgresType::Vector,
+            Self::EmbeddingBits => PostgresType::Bit,
             Self::Property => PostgresType::Text,
             Self::UpdatedAtTransactionTime | Self::UpdatedAtDecisionTime => {
                 PostgresType::TimestampTz
             }
-            Self::Distance => PostgresType::Float8,
         }
     }
 }
@@ -1213,11 +1215,11 @@ impl FilterColumn<'_> for EntityEmbeddings {
         match self {
             Self::WebId | Self::EntityUuid | Self::DraftId => ParameterType::Uuid,
             Self::Embedding => ParameterType::Vector(Box::new(ParameterType::Decimal)),
+            Self::EmbeddingBits => ParameterType::Vector(Box::new(ParameterType::Boolean)),
             Self::Property => ParameterType::BaseUrl,
             Self::UpdatedAtTransactionTime | Self::UpdatedAtDecisionTime => {
                 ParameterType::Timestamp
             }
-            Self::Distance => ParameterType::Decimal,
         }
     }
 }

--- a/libs/@local/graph/postgres-store/tests/semantic_search/main.rs
+++ b/libs/@local/graph/postgres-store/tests/semantic_search/main.rs
@@ -2,7 +2,6 @@
 //!
 //! The suite is ignored by default: it requires a database holding real entities, embeddings,
 //! and policies, and measures rather than asserts behaviour that depends on that data.
-#![recursion_limit = "256"]
 #![expect(
     unreachable_pub,
     reason = "the shared test harness exports more than this suite consumes"

--- a/libs/@local/graph/postgres-store/tests/semantic_search/main.rs
+++ b/libs/@local/graph/postgres-store/tests/semantic_search/main.rs
@@ -1,0 +1,85 @@
+//! Exercises [`EntityStore::search_entities`] against an externally seeded database.
+//!
+//! The suite is ignored by default: it requires a database holding real entities, embeddings,
+//! and policies, and measures rather than asserts behaviour that depends on that data.
+#![expect(
+    unreachable_pub,
+    reason = "the shared test harness exports more than this suite consumes"
+)]
+
+#[path = "../common/mod.rs"]
+mod common;
+
+use hash_graph_postgres_store::store::AsClient as _;
+use hash_graph_store::{
+    entity::{EntityStore as _, SearchEntitiesFilter, SearchEntitiesParams},
+    filter::SemanticDistance,
+};
+use hash_graph_types::Embedding;
+use type_system::principal::actor::ActorEntityUuid;
+use uuid::Uuid;
+
+use self::common::DatabaseTestWrapper;
+
+#[tokio::test]
+#[ignore = "requires a seeded database with embeddings and policies"]
+async fn search_with_real_policies() {
+    let mut database = DatabaseTestWrapper::new().await;
+
+    let actor_rows = database
+        .connection
+        .as_client()
+        .query("SELECT id FROM user_actor LIMIT 2", &[])
+        .await
+        .expect("the seeded database should hold user actors");
+    let embedding = database
+        .connection
+        .as_client()
+        .query_one(
+            "SELECT embedding FROM entity_embeddings
+              WHERE property IS NULL
+              LIMIT 1",
+            &[],
+        )
+        .await
+        .expect("the seeded database should hold embeddings")
+        .get::<_, Embedding>(0)
+        .into_owned();
+
+    // The compose container caps shared memory below what a parallel plan requests.
+    database
+        .connection
+        .as_client()
+        .execute("SET max_parallel_workers_per_gather = 0", &[])
+        .await
+        .expect("disabling parallel workers should succeed");
+
+    for actor_row in actor_rows {
+        let actor_id = ActorEntityUuid::new(actor_row.get::<_, Uuid>(0));
+
+        for run in ["cold", "warm"] {
+            let started = std::time::Instant::now();
+            let response = database
+                .connection
+                .search_entities(
+                    actor_id,
+                    SearchEntitiesParams {
+                        embedding: embedding.to_owned(),
+                        maximum_semantic_distance: SemanticDistance::try_from(2.0)
+                            .expect("2.0 should be a valid cosine distance"),
+                        limit: 100,
+                        include_entity_types: false,
+                        filter: SearchEntitiesFilter::default(),
+                    },
+                )
+                .await
+                .expect("the search should succeed");
+
+            println!(
+                "actor {actor_id}: {run} search returned {count} entities in {elapsed:?}",
+                count = response.entities.len(),
+                elapsed = started.elapsed(),
+            );
+        }
+    }
+}

--- a/libs/@local/graph/store/src/filter/mod.rs
+++ b/libs/@local/graph/store/src/filter/mod.rs
@@ -135,12 +135,6 @@ pub enum Filter<'p, R: QueryRecord> {
     Less(FilterExpression<'p, R>, FilterExpression<'p, R>),
     LessOrEqual(FilterExpression<'p, R>, FilterExpression<'p, R>),
     #[serde(skip)]
-    CosineDistance(
-        FilterExpression<'p, R>,
-        FilterExpression<'p, R>,
-        FilterExpression<'p, R>,
-    ),
-    #[serde(skip)]
     In(FilterExpression<'p, R>, FilterExpressionList<'p, R>),
     StartsWith(FilterExpression<'p, R>, FilterExpression<'p, R>),
     EndsWith(FilterExpression<'p, R>, FilterExpression<'p, R>),
@@ -1240,38 +1234,6 @@ where
                 lhs.apply_parameter_conversion(data_type_provider).await?;
                 rhs.apply_parameter_conversion(data_type_provider).await?;
 
-                match (lhs, rhs) {
-                    (
-                        FilterExpression::Parameter {
-                            parameter,
-                            convert: _,
-                        },
-                        FilterExpression::Path { path },
-                    )
-                    | (
-                        FilterExpression::Path { path },
-                        FilterExpression::Parameter {
-                            parameter,
-                            convert: _,
-                        },
-                    ) => {
-                        parameter.convert_to_parameter_type(&path.expected_type())?;
-                    }
-                    (..) => {}
-                }
-            }
-            Self::CosineDistance(lhs, rhs, max) => {
-                lhs.apply_parameter_conversion(data_type_provider).await?;
-                rhs.apply_parameter_conversion(data_type_provider).await?;
-                max.apply_parameter_conversion(data_type_provider).await?;
-
-                if let FilterExpression::Parameter {
-                    parameter,
-                    convert: _,
-                } = max
-                {
-                    parameter.convert_to_parameter_type(&ParameterType::Decimal)?;
-                }
                 match (lhs, rhs) {
                     (
                         FilterExpression::Parameter {

--- a/libs/@local/graph/store/src/filter/mod.rs
+++ b/libs/@local/graph/store/src/filter/mod.rs
@@ -838,6 +838,15 @@ impl<'p> Filter<'p, EntityTypeWithMetadata> {
     }
 }
 
+/// The permit and forbid filters of a policy set, separated so they can be assembled into a
+/// single filter or into per-permit branches.
+struct PolicyFilterParts<'p> {
+    permits: Vec<Filter<'p, Entity>>,
+    forbids: Vec<Filter<'p, Entity>>,
+    blank_permit: bool,
+    blank_forbid: bool,
+}
+
 impl<'p> Filter<'p, Entity> {
     /// Creates a `Filter` to search for a specific entities, identified by its [`EntityId`].
     #[must_use]
@@ -1049,7 +1058,96 @@ impl<'p> Filter<'p, Entity> {
         actor_id: Option<ActorId>,
         optimization_data: &'p OptimizationData,
     ) -> Self {
-        // Follow the same pattern as for_policies: separate permits and forbids
+        let PolicyFilterParts {
+            permits,
+            forbids,
+            blank_permit,
+            blank_forbid,
+        } = Self::policy_filter_parts(policies, actor_id, optimization_data);
+
+        if blank_forbid {
+            return Self::Any(Vec::new()); // Blank forbid = deny all
+        }
+
+        if blank_permit {
+            if forbids.is_empty() {
+                Self::All(Vec::new()) // Allow all
+            } else {
+                Self::Not(Box::new(Self::Any(forbids))) // Allow all except forbids
+            }
+        } else {
+            match (!permits.is_empty(), !forbids.is_empty()) {
+                (false, _) => Self::Any(Vec::new()), // No permits = deny all
+                (true, false) => Self::Any(permits), // Only permits
+                (true, true) => Self::All(vec![
+                    // Both permits and forbids
+                    Self::Any(permits),
+                    Self::Not(Box::new(Self::Any(forbids))),
+                ]),
+            }
+        }
+    }
+
+    /// Creates one filter per permitted access path instead of a single disjunction.
+    ///
+    /// Each branch pairs one permit with the negation of every forbid, so the union of the
+    /// branches' results equals the result of [`Self::for_policies`] over the same policies. A
+    /// blank permit collapses the branches into a single one holding only the negated forbids,
+    /// or no constraint at all. An empty vector means the policies deny all access. Permits that
+    /// duplicate an earlier one or that cannot match any entity, such as constraints on other
+    /// resource kinds, produce no branch.
+    #[must_use]
+    pub fn for_policy_branches(
+        policies: impl IntoIterator<Item = (Effect, Option<&'p ResourceConstraint>)>,
+        actor_id: Option<ActorId>,
+        optimization_data: &'p OptimizationData,
+    ) -> Vec<Self> {
+        let PolicyFilterParts {
+            permits,
+            forbids,
+            blank_permit,
+            blank_forbid,
+        } = Self::policy_filter_parts(policies, actor_id, optimization_data);
+
+        if blank_forbid {
+            return Vec::new();
+        }
+
+        let forbid_filter = (!forbids.is_empty()).then(|| Self::Not(Box::new(Self::Any(forbids))));
+
+        if blank_permit {
+            return vec![forbid_filter.unwrap_or_else(|| Self::All(Vec::new()))];
+        }
+
+        // An unmatchable or duplicated permit contributes nothing to the union, but its branch
+        // would still cost a read
+        let mut unique_permits: Vec<Self> = Vec::with_capacity(permits.len());
+        for permit in permits {
+            if matches!(permit, Self::Any(ref filters) if filters.is_empty())
+                || unique_permits.contains(&permit)
+            {
+                continue;
+            }
+            unique_permits.push(permit);
+        }
+
+        unique_permits
+            .into_iter()
+            .map(|permit| {
+                if let Some(forbid) = &forbid_filter {
+                    Self::All(vec![permit, forbid.clone()])
+                } else {
+                    permit
+                }
+            })
+            .collect()
+    }
+
+    fn policy_filter_parts(
+        policies: impl IntoIterator<Item = (Effect, Option<&'p ResourceConstraint>)>,
+        actor_id: Option<ActorId>,
+        optimization_data: &'p OptimizationData,
+    ) -> PolicyFilterParts<'p> {
         let mut permits = Vec::new();
         let mut forbids = Vec::new();
         let mut blank_permit = false;
@@ -1057,13 +1155,19 @@ impl<'p> Filter<'p, Entity> {
         for (effect, resource) in policies {
             match (resource, effect) {
                 (None, Effect::Permit) => blank_permit = true,
-                (None, Effect::Forbid) => return Self::Any(Vec::new()), // Blank forbid = deny all
+                // A blank forbid overrides every other policy, so the remaining ones don't matter
+                (None, Effect::Forbid) => {
+                    return PolicyFilterParts {
+                        permits: Vec::new(),
+                        forbids: Vec::new(),
+                        blank_permit: false,
+                        blank_forbid: true,
+                    };
+                }
                 (Some(resource), Effect::Permit) => {
-                    // Non-optimizable permits
                     permits.push(Self::for_resource_constraint(resource, actor_id));
                 }
                 (Some(resource), Effect::Forbid) => {
-                    // All forbids
                     forbids.push(Self::for_resource_constraint(resource, actor_id));
                 }
             }
@@ -1084,7 +1188,6 @@ impl<'p> Filter<'p, Entity> {
                 ));
             }
             entity_uuids => {
-                // Use the Vec directly for the IN clause
                 permits.push(Self::In(
                     FilterExpression::Path {
                         path: EntityQueryPath::Uuid,
@@ -1111,7 +1214,6 @@ impl<'p> Filter<'p, Entity> {
                 ));
             }
             web_ids => {
-                // Use the Vec directly for the IN clause
                 permits.push(Self::In(
                     FilterExpression::Path {
                         path: EntityQueryPath::WebId,
@@ -1123,23 +1225,11 @@ impl<'p> Filter<'p, Entity> {
             }
         }
 
-        // Apply the same combination logic as for_policies
-        if blank_permit {
-            if forbids.is_empty() {
-                Self::All(Vec::new()) // Allow all
-            } else {
-                Self::Not(Box::new(Self::Any(forbids))) // Allow all except forbids
-            }
-        } else {
-            match (!permits.is_empty(), !forbids.is_empty()) {
-                (false, _) => Self::Any(Vec::new()), // No permits = deny all
-                (true, false) => Self::Any(permits), // Only permits
-                (true, true) => Self::All(vec![
-                    // Both permits and forbids
-                    Self::Any(permits),
-                    Self::Not(Box::new(Self::Any(forbids))),
-                ]),
-            }
+        PolicyFilterParts {
+            permits,
+            forbids,
+            blank_permit,
+            blank_forbid: false,
         }
     }
 
@@ -1561,15 +1651,18 @@ mod tests {
     mod policy_conversion {
         use hash_graph_authorization::policies::{
             Effect, OptimizationData, Policy, PolicyId,
-            resource::{EntityResourceConstraint, ResourceConstraint},
+            resource::{EntityResourceConstraint, EntityResourceFilter, ResourceConstraint},
         };
         use type_system::{
             knowledge::entity::{Entity, id::EntityUuid},
-            principal::actor::{ActorId, UserId},
+            principal::{
+                actor::{ActorId, UserId},
+                actor_group::WebId,
+            },
         };
         use uuid::Uuid;
 
-        use super::{Filter, FilterExpression, Parameter};
+        use super::{Filter, FilterExpression, FilterExpressionList, Parameter, ParameterList};
         use crate::entity::EntityQueryPath;
 
         /// Helper to create a complete test policy.
@@ -1834,6 +1927,509 @@ mod tests {
                     assert!(permits.is_empty(), "Blank forbid should forbid everything");
                 }
                 other => panic!("Expected Any filter, got: {other:?}"),
+            }
+        }
+
+        #[test]
+        fn branches_split_permits() {
+            let entity_uuid_1 = EntityUuid::new(Uuid::new_v4());
+            let entity_uuid_2 = EntityUuid::new(Uuid::new_v4());
+            let actor_id = Some(ActorId::User(UserId::new(Uuid::new_v4())));
+
+            let policies = [
+                create_test_policy(
+                    Effect::Permit,
+                    Some(ResourceConstraint::Entity(
+                        EntityResourceConstraint::Exact { id: entity_uuid_1 },
+                    )),
+                ),
+                create_test_policy(
+                    Effect::Permit,
+                    Some(ResourceConstraint::Entity(
+                        EntityResourceConstraint::Exact { id: entity_uuid_2 },
+                    )),
+                ),
+            ];
+
+            let optimization_data = OptimizationData::default();
+            let branches = Filter::<Entity>::for_policy_branches(
+                policies.iter().map(policy_to_tuple),
+                actor_id,
+                &optimization_data,
+            );
+
+            assert_eq!(branches.len(), 2);
+            for (branch, expected) in branches.iter().zip([entity_uuid_1, entity_uuid_2]) {
+                match branch {
+                    Filter::Equal(
+                        FilterExpression::Path {
+                            path: EntityQueryPath::Uuid,
+                        },
+                        FilterExpression::Parameter {
+                            parameter: Parameter::Uuid(uuid),
+                            ..
+                        },
+                    ) => assert_eq!(*uuid, Uuid::from(expected)),
+                    other => panic!("Expected a bare permit branch, got: {other:?}"),
+                }
+            }
+        }
+
+        #[test]
+        fn branches_carry_forbids() {
+            let permit_uuid_1 = EntityUuid::new(Uuid::new_v4());
+            let permit_uuid_2 = EntityUuid::new(Uuid::new_v4());
+            let forbid_uuid = EntityUuid::new(Uuid::new_v4());
+            let actor_id = Some(ActorId::User(UserId::new(Uuid::new_v4())));
+
+            let policies = [
+                create_test_policy(
+                    Effect::Permit,
+                    Some(ResourceConstraint::Entity(
+                        EntityResourceConstraint::Exact { id: permit_uuid_1 },
+                    )),
+                ),
+                create_test_policy(
+                    Effect::Permit,
+                    Some(ResourceConstraint::Entity(
+                        EntityResourceConstraint::Exact { id: permit_uuid_2 },
+                    )),
+                ),
+                create_test_policy(
+                    Effect::Forbid,
+                    Some(ResourceConstraint::Entity(
+                        EntityResourceConstraint::Exact { id: forbid_uuid },
+                    )),
+                ),
+            ];
+
+            let optimization_data = OptimizationData::default();
+            let branches = Filter::<Entity>::for_policy_branches(
+                policies.iter().map(policy_to_tuple),
+                actor_id,
+                &optimization_data,
+            );
+
+            // Every branch pairs its permit with the shared forbids
+            assert_eq!(branches.len(), 2);
+            for (branch, expected) in branches.iter().zip([permit_uuid_1, permit_uuid_2]) {
+                match branch {
+                    Filter::All(conditions) => {
+                        assert_eq!(conditions.len(), 2);
+                        match &conditions[0] {
+                            Filter::Equal(
+                                FilterExpression::Path {
+                                    path: EntityQueryPath::Uuid,
+                                },
+                                FilterExpression::Parameter {
+                                    parameter: Parameter::Uuid(uuid),
+                                    ..
+                                },
+                            ) => assert_eq!(*uuid, Uuid::from(expected)),
+                            other => panic!("Unexpected permit filter: {other:?}"),
+                        }
+                        match &conditions[1] {
+                            Filter::Not(inner) => match &**inner {
+                                Filter::Any(forbids) => assert_eq!(forbids.len(), 1),
+                                other => panic!("Expected Any(forbids), got: {other:?}"),
+                            },
+                            other => panic!("Expected Not(Any(forbids)), got: {other:?}"),
+                        }
+                    }
+                    other => panic!("Expected All([permit, forbids]), got: {other:?}"),
+                }
+            }
+        }
+
+        #[test]
+        fn no_branches_without_permits() {
+            let forbid_uuid = EntityUuid::new(Uuid::new_v4());
+            let actor_id = Some(ActorId::User(UserId::new(Uuid::new_v4())));
+
+            let policy = create_test_policy(
+                Effect::Forbid,
+                Some(ResourceConstraint::Entity(
+                    EntityResourceConstraint::Exact { id: forbid_uuid },
+                )),
+            );
+
+            let optimization_data = OptimizationData::default();
+            let branches = Filter::<Entity>::for_policy_branches(
+                [policy_to_tuple(&policy)],
+                actor_id,
+                &optimization_data,
+            );
+
+            assert!(
+                branches.is_empty(),
+                "policies without a permit should produce no branches"
+            );
+        }
+
+        #[test]
+        fn blank_permit_yields_single_branch() {
+            let forbid_uuid = EntityUuid::new(Uuid::new_v4());
+            let actor_id = Some(ActorId::User(UserId::new(Uuid::new_v4())));
+            let optimization_data = OptimizationData::default();
+
+            let unrestricted = create_test_policy(Effect::Permit, None);
+            let branches = Filter::<Entity>::for_policy_branches(
+                [policy_to_tuple(&unrestricted)],
+                actor_id,
+                &optimization_data,
+            );
+            match branches.as_slice() {
+                [Filter::All(conditions)] => {
+                    assert!(
+                        conditions.is_empty(),
+                        "a blank permit should yield one unconstrained branch"
+                    );
+                }
+                other => panic!("Expected a single All branch, got: {other:?}"),
+            }
+
+            let policies = [
+                create_test_policy(Effect::Permit, None),
+                create_test_policy(
+                    Effect::Forbid,
+                    Some(ResourceConstraint::Entity(
+                        EntityResourceConstraint::Exact { id: forbid_uuid },
+                    )),
+                ),
+            ];
+            let branches = Filter::<Entity>::for_policy_branches(
+                policies.iter().map(policy_to_tuple),
+                actor_id,
+                &optimization_data,
+            );
+            match branches.as_slice() {
+                [Filter::Not(inner)] => match &**inner {
+                    Filter::Any(forbids) => assert_eq!(forbids.len(), 1),
+                    other => panic!("Expected Any(forbids), got: {other:?}"),
+                },
+                other => panic!("Expected a single Not(Any(forbids)) branch, got: {other:?}"),
+            }
+        }
+
+        #[test]
+        fn blank_forbid_yields_no_branches() {
+            let permit_uuid = EntityUuid::new(Uuid::new_v4());
+            let actor_id = Some(ActorId::User(UserId::new(Uuid::new_v4())));
+
+            let policies = [
+                create_test_policy(
+                    Effect::Permit,
+                    Some(ResourceConstraint::Entity(
+                        EntityResourceConstraint::Exact { id: permit_uuid },
+                    )),
+                ),
+                create_test_policy(Effect::Forbid, None),
+            ];
+
+            let optimization_data = OptimizationData::default();
+            let branches = Filter::<Entity>::for_policy_branches(
+                policies.iter().map(policy_to_tuple),
+                actor_id,
+                &optimization_data,
+            );
+
+            assert!(
+                branches.is_empty(),
+                "a blank forbid should deny access regardless of permits"
+            );
+        }
+
+        #[test]
+        fn blank_forbid_overrides_optimization_permits() {
+            let actor_id = Some(ActorId::User(UserId::new(Uuid::new_v4())));
+            let optimization_data = OptimizationData {
+                permitted_entity_uuids: vec![EntityUuid::new(Uuid::new_v4())],
+                permitted_web_ids: vec![WebId::new(Uuid::new_v4())],
+                ..OptimizationData::default()
+            };
+            let policy = create_test_policy(Effect::Forbid, None);
+
+            let filter = Filter::<Entity>::for_policies(
+                [policy_to_tuple(&policy)],
+                actor_id,
+                &optimization_data,
+            );
+            assert!(
+                matches!(filter, Filter::Any(ref permits) if permits.is_empty()),
+                "a blank forbid should deny access regardless of optimization permits"
+            );
+
+            let branches = Filter::<Entity>::for_policy_branches(
+                [policy_to_tuple(&policy)],
+                actor_id,
+                &optimization_data,
+            );
+            assert!(
+                branches.is_empty(),
+                "a blank forbid should deny access regardless of optimization permits"
+            );
+        }
+
+        #[test]
+        fn optimization_permits_form_branches() {
+            let actor_id = Some(ActorId::User(UserId::new(Uuid::new_v4())));
+
+            let single_web = OptimizationData {
+                permitted_web_ids: vec![WebId::new(Uuid::new_v4())],
+                ..OptimizationData::default()
+            };
+            let branches =
+                Filter::<Entity>::for_policy_branches(core::iter::empty(), actor_id, &single_web);
+            match branches.as_slice() {
+                [
+                    Filter::Equal(
+                        FilterExpression::Path {
+                            path: EntityQueryPath::WebId,
+                        },
+                        FilterExpression::Parameter {
+                            parameter: Parameter::Uuid(uuid),
+                            ..
+                        },
+                    ),
+                ] => assert_eq!(*uuid, Uuid::from(single_web.permitted_web_ids[0])),
+                other => panic!("Expected a single web equality branch, got: {other:?}"),
+            }
+
+            let multiple = OptimizationData {
+                permitted_entity_uuids: vec![EntityUuid::new(Uuid::new_v4())],
+                permitted_web_ids: vec![WebId::new(Uuid::new_v4()), WebId::new(Uuid::new_v4())],
+                ..OptimizationData::default()
+            };
+            let branches =
+                Filter::<Entity>::for_policy_branches(core::iter::empty(), actor_id, &multiple);
+            match branches.as_slice() {
+                [
+                    Filter::Equal(
+                        FilterExpression::Path {
+                            path: EntityQueryPath::Uuid,
+                        },
+                        _,
+                    ),
+                    Filter::In(
+                        FilterExpression::Path {
+                            path: EntityQueryPath::WebId,
+                        },
+                        FilterExpressionList::ParameterList {
+                            parameters: ParameterList::WebIds(webs),
+                        },
+                    ),
+                ] => assert_eq!(webs.len(), 2),
+                other => panic!(
+                    "Expected an entity equality branch and a web membership branch, got: \
+                     {other:?}"
+                ),
+            }
+        }
+
+        #[test]
+        fn unmatchable_permits_form_no_branch() {
+            let actor_id = Some(ActorId::User(UserId::new(Uuid::new_v4())));
+            let matchable_uuid = EntityUuid::new(Uuid::new_v4());
+
+            let policies = [
+                create_test_policy(
+                    Effect::Permit,
+                    Some(ResourceConstraint::Entity(EntityResourceConstraint::Any {
+                        filter: EntityResourceFilter::Any {
+                            filters: Vec::new(),
+                        },
+                    })),
+                ),
+                create_test_policy(
+                    Effect::Permit,
+                    Some(ResourceConstraint::Entity(
+                        EntityResourceConstraint::Exact { id: matchable_uuid },
+                    )),
+                ),
+            ];
+
+            let optimization_data = OptimizationData::default();
+            let branches = Filter::<Entity>::for_policy_branches(
+                policies.iter().map(policy_to_tuple),
+                actor_id,
+                &optimization_data,
+            );
+
+            assert_eq!(
+                branches.len(),
+                1,
+                "a permit that cannot match should produce no branch"
+            );
+            assert!(matches!(branches[0], Filter::Equal(..)));
+        }
+
+        #[test]
+        fn duplicate_permits_form_one_branch() {
+            let actor_id = Some(ActorId::User(UserId::new(Uuid::new_v4())));
+            let entity_uuid = EntityUuid::new(Uuid::new_v4());
+
+            let duplicate = || {
+                create_test_policy(
+                    Effect::Permit,
+                    Some(ResourceConstraint::Entity(
+                        EntityResourceConstraint::Exact { id: entity_uuid },
+                    )),
+                )
+            };
+            let policies = [duplicate(), duplicate()];
+
+            let optimization_data = OptimizationData::default();
+            let branches = Filter::<Entity>::for_policy_branches(
+                policies.iter().map(policy_to_tuple),
+                actor_id,
+                &optimization_data,
+            );
+
+            assert_eq!(
+                branches.len(),
+                1,
+                "identical permits should collapse into one branch"
+            );
+        }
+
+        /// Evaluates the filter shapes the policy constructors emit against a synthetic entity.
+        fn filter_matches(filter: &Filter<'_, Entity>, web_id: Uuid, entity_uuid: Uuid) -> bool {
+            match filter {
+                Filter::All(filters) => filters
+                    .iter()
+                    .all(|filter| filter_matches(filter, web_id, entity_uuid)),
+                Filter::Any(filters) => filters
+                    .iter()
+                    .any(|filter| filter_matches(filter, web_id, entity_uuid)),
+                Filter::Not(inner) => !filter_matches(inner, web_id, entity_uuid),
+                Filter::Equal(
+                    FilterExpression::Path { path },
+                    FilterExpression::Parameter {
+                        parameter: Parameter::Uuid(uuid),
+                        ..
+                    },
+                ) => match path {
+                    EntityQueryPath::Uuid => *uuid == entity_uuid,
+                    EntityQueryPath::WebId => *uuid == web_id,
+                    other => panic!("the evaluator should cover the path {other:?}"),
+                },
+                Filter::In(
+                    FilterExpression::Path { path },
+                    FilterExpressionList::ParameterList { parameters },
+                ) => match (path, parameters) {
+                    (EntityQueryPath::Uuid, ParameterList::EntityUuids(uuids)) => {
+                        uuids.iter().any(|uuid| Uuid::from(*uuid) == entity_uuid)
+                    }
+                    (EntityQueryPath::WebId, ParameterList::WebIds(webs)) => {
+                        webs.iter().any(|web| Uuid::from(*web) == web_id)
+                    }
+                    other => panic!("the evaluator should cover the expression {other:?}"),
+                },
+                other => panic!("the evaluator should cover the filter {other:?}"),
+            }
+        }
+
+        /// The union of the branches must select the same entities as the combined filter, for
+        /// every combination of blank and specific permits, forbids, and optimization data.
+        #[test]
+        fn branch_union_matches_for_policies() {
+            let actor_id = Some(ActorId::User(UserId::new(Uuid::from_u128(100))));
+
+            let webs = [Uuid::from_u128(1), Uuid::from_u128(2), Uuid::from_u128(3)];
+            let entities = [
+                Uuid::from_u128(11),
+                Uuid::from_u128(12),
+                Uuid::from_u128(13),
+                Uuid::from_u128(14),
+            ];
+
+            let permit_sets: [&[Uuid]; 3] = [&[], &entities[..1], &entities[..2]];
+            let web_sets: [&[Uuid]; 3] = [&[], &webs[..1], &webs[..2]];
+            let uuid_sets: [&[Uuid]; 2] = [&[], &entities[2..3]];
+
+            for blank_permit in [false, true] {
+                for permit_uuids in permit_sets {
+                    for blank_forbid in [false, true] {
+                        for forbid_uuid in [None, Some(entities[1])] {
+                            for opt_webs in web_sets {
+                                for opt_uuids in uuid_sets {
+                                    let mut policies = Vec::new();
+                                    if blank_permit {
+                                        policies.push(create_test_policy(Effect::Permit, None));
+                                    }
+                                    for &uuid in permit_uuids {
+                                        policies.push(create_test_policy(
+                                            Effect::Permit,
+                                            Some(ResourceConstraint::Entity(
+                                                EntityResourceConstraint::Exact {
+                                                    id: EntityUuid::new(uuid),
+                                                },
+                                            )),
+                                        ));
+                                    }
+                                    if let Some(uuid) = forbid_uuid {
+                                        policies.push(create_test_policy(
+                                            Effect::Forbid,
+                                            Some(ResourceConstraint::Entity(
+                                                EntityResourceConstraint::Exact {
+                                                    id: EntityUuid::new(uuid),
+                                                },
+                                            )),
+                                        ));
+                                    }
+                                    if blank_forbid {
+                                        policies.push(create_test_policy(Effect::Forbid, None));
+                                    }
+
+                                    let optimization_data = OptimizationData {
+                                        permitted_entity_uuids: opt_uuids
+                                            .iter()
+                                            .copied()
+                                            .map(EntityUuid::new)
+                                            .collect(),
+                                        permitted_web_ids: opt_webs
+                                            .iter()
+                                            .copied()
+                                            .map(WebId::new)
+                                            .collect(),
+                                        ..OptimizationData::default()
+                                    };
+
+                                    let combined = Filter::<Entity>::for_policies(
+                                        policies.iter().map(policy_to_tuple),
+                                        actor_id,
+                                        &optimization_data,
+                                    );
+                                    let branches = Filter::<Entity>::for_policy_branches(
+                                        policies.iter().map(policy_to_tuple),
+                                        actor_id,
+                                        &optimization_data,
+                                    );
+
+                                    for &web_id in &webs {
+                                        for &entity_uuid in &entities {
+                                            assert_eq!(
+                                                branches.iter().any(|branch| filter_matches(
+                                                    branch,
+                                                    web_id,
+                                                    entity_uuid
+                                                )),
+                                                filter_matches(&combined, web_id, entity_uuid),
+                                                "the branch union should match the combined \
+                                                 filter for web {web_id}, entity {entity_uuid}, \
+                                                 blank_permit={blank_permit}, \
+                                                 permits={permit_uuids:?}, \
+                                                 forbid={forbid_uuid:?}, \
+                                                 blank_forbid={blank_forbid}, \
+                                                 opt_webs={opt_webs:?}, opt_uuids={opt_uuids:?}"
+                                            );
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/libs/@local/graph/store/src/filter/protection.rs
+++ b/libs/@local/graph/store/src/filter/protection.rs
@@ -758,11 +758,6 @@ fn collect_excluded_types_recursive<'f, 'p, I: Extend<&'f PropertyFilter<'p>>>(
         | Filter::ContainsSegment(lhs, rhs) => {
             collect_from_comparison(lhs, rhs, config, excluded);
         }
-        Filter::CosineDistance(lhs, rhs, distance) => {
-            collect_from_expr(lhs, config, excluded);
-            collect_from_expr(rhs, config, excluded);
-            collect_from_expr(distance, config, excluded);
-        }
         Filter::In(expr, _) => collect_from_expr(expr, config, excluded),
         Filter::Exists { path } => collect_from_path(path, config, excluded),
     }
@@ -939,7 +934,6 @@ pub fn transform_filter<'f, 'p: 'f>(
         | Filter::GreaterOrEqual(..)
         | Filter::Less(..)
         | Filter::LessOrEqual(..)
-        | Filter::CosineDistance(..)
         | Filter::In(..)
         | Filter::StartsWith(..)
         | Filter::EndsWith(..)
@@ -1409,10 +1403,9 @@ mod tests {
     // =========================================================================
     // TODO(BE-313): Embedding (property-specific + combined)
     // =========================================================================
-    // mod embedding {
-    //     - cosine_distance_on_property_embedding_detected
-    //     - cosine_distance_on_combined_embedding_detected
-    // }
+    // Semantic ranking bypasses the `Filter` tree: `SelectCompiler::rank_by_quantized_distance`
+    // and `restrict_embedding_property` address embeddings at the compiler level, invisible to
+    // this transformation. Protecting a per-property ranking needs a check at that surface.
 
     // =========================================================================
     // Tests: Filter Transformation

--- a/tests/graph/integration/postgres/lib.rs
+++ b/tests/graph/integration/postgres/lib.rs
@@ -19,6 +19,7 @@ mod partial_updates;
 mod property_metadata;
 mod property_type;
 mod read_only;
+mod semantic_search;
 mod sorting;
 mod transaction;
 

--- a/tests/graph/integration/postgres/semantic_search.rs
+++ b/tests/graph/integration/postgres/semantic_search.rs
@@ -1,0 +1,417 @@
+//! Behavioural coverage for [`EntityStore::search_entities`].
+//!
+//! The embeddings are constructed in the first two vector components, so every cosine distance
+//! to the query is known exactly: same direction is `0`, a 60° angle is `0.5`, orthogonal is
+//! `1`, and opposite is `2`. The assertions therefore pin the full pipeline — per-branch
+//! candidate reads, cross-branch deduplication, the exact rerank, and the rank-preserving
+//! hydration — against ground truth.
+
+use std::collections::HashSet;
+
+use hash_graph_authorization::policies::{Effect, action::ActionName};
+use hash_graph_store::{
+    entity::{
+        CreateEntityParams, CreateEntityPolicyParams, EntityStore as _, SearchEntitiesFilter,
+        SearchEntitiesParams, UpdateEntityEmbeddingsParams,
+    },
+    filter::SemanticDistance,
+};
+use hash_graph_temporal_versioning::Timestamp;
+use hash_graph_test_data::{data_type, entity, entity_type, property_type};
+use hash_graph_types::{Embedding, knowledge::entity::EntityEmbedding};
+use type_system::{
+    knowledge::{
+        entity::{EntityId, provenance::ProvidedEntityEditionProvenance},
+        property::{PropertyObject, PropertyObjectWithMetadata},
+    },
+    ontology::id::{BaseUrl, OntologyTypeVersion, VersionedUrl},
+    principal::{
+        actor::{ActorEntityUuid, ActorType},
+        actor_group::WebId,
+    },
+    provenance::{OriginProvenance, OriginType},
+};
+use uuid::Uuid;
+
+use crate::{DatabaseApi, DatabaseTestWrapper};
+
+async fn seed(database: &mut DatabaseTestWrapper) -> DatabaseApi<'_> {
+    database
+        .seed(
+            [
+                data_type::VALUE_V1,
+                data_type::TEXT_V1,
+                data_type::NUMBER_V1,
+            ],
+            [
+                property_type::NAME_V1,
+                property_type::AGE_V1,
+                property_type::FAVORITE_SONG_V1,
+                property_type::FAVORITE_FILM_V1,
+                property_type::HOBBY_V1,
+                property_type::INTERESTS_V1,
+            ],
+            [
+                entity_type::LINK_V1,
+                entity_type::link::FRIEND_OF_V1,
+                entity_type::link::ACQUAINTANCE_OF_V1,
+                entity_type::PERSON_V1,
+            ],
+        )
+        .await
+        .expect("could not seed database")
+}
+
+fn person_entity_type_id() -> VersionedUrl {
+    VersionedUrl {
+        base_url: BaseUrl::new(
+            "https://blockprotocol.org/@alice/types/entity-type/person/".to_owned(),
+        )
+        .expect("couldn't construct Base URL"),
+        version: OntologyTypeVersion {
+            major: 1,
+            pre_release: None,
+        },
+    }
+}
+
+async fn create_person(
+    api: &mut DatabaseApi<'_>,
+    draft: bool,
+    policies: Vec<CreateEntityPolicyParams>,
+) -> EntityId {
+    let person: PropertyObject =
+        serde_json::from_str(entity::PERSON_ALICE_V1).expect("could not parse entity");
+
+    api.create_entity(
+        api.account_id,
+        CreateEntityParams {
+            web_id: WebId::new(api.account_id),
+            entity_uuid: None,
+            decision_time: None,
+            entity_type_ids: HashSet::from([person_entity_type_id()]),
+            properties: PropertyObjectWithMetadata::from_parts(person, None)
+                .expect("could not create property with metadata object"),
+            confidence: None,
+            link_data: None,
+            draft,
+            policies,
+            provenance: ProvidedEntityEditionProvenance {
+                actor_type: ActorType::User,
+                origin: OriginProvenance::from_empty_type(OriginType::Api),
+                sources: Vec::new(),
+            },
+            read_only: false,
+        },
+    )
+    .await
+    .expect("could not create entity")
+    .metadata
+    .record_id
+    .entity_id
+}
+
+/// A policy that permits every actor to view the entity it is attached to.
+fn public_view_policy() -> CreateEntityPolicyParams {
+    CreateEntityPolicyParams {
+        name: "semantic-search-test-public-view".to_owned(),
+        effect: Effect::Permit,
+        principal: None,
+        actions: vec![ActionName::ViewEntity],
+    }
+}
+
+/// A full-width embedding pointing along `(x, y)` in the first two components.
+#[expect(clippy::indexing_slicing)]
+fn embedding_towards(x: f32, y: f32) -> Embedding<'static> {
+    let mut vector = vec![0.0_f32; Embedding::DIM];
+    vector[0] = x;
+    vector[1] = y;
+    Embedding::from(vector)
+}
+
+fn query_embedding() -> Embedding<'static> {
+    embedding_towards(1.0, 0.0)
+}
+
+#[expect(clippy::float_arithmetic)]
+fn sixty_degrees() -> Embedding<'static> {
+    embedding_towards(0.5, 3.0_f32.sqrt() / 2.0)
+}
+
+async fn insert_embedding(
+    api: &mut DatabaseApi<'_>,
+    entity_id: EntityId,
+    embedding: Embedding<'static>,
+) {
+    api.update_entity_embeddings(
+        api.account_id,
+        UpdateEntityEmbeddingsParams {
+            entity_id,
+            embeddings: vec![EntityEmbedding {
+                property: None,
+                embedding,
+            }],
+            updated_at_transaction_time: Timestamp::now(),
+            updated_at_decision_time: Timestamp::now(),
+            reset: false,
+        },
+    )
+    .await
+    .expect("could not insert entity embedding");
+}
+
+async fn search(
+    api: &mut DatabaseApi<'_>,
+    actor_id: ActorEntityUuid,
+    filter: SearchEntitiesFilter,
+    maximum_semantic_distance: f64,
+    limit: usize,
+) -> Vec<EntityId> {
+    api.search_entities(
+        actor_id,
+        SearchEntitiesParams {
+            embedding: query_embedding(),
+            maximum_semantic_distance: SemanticDistance::try_from(maximum_semantic_distance)
+                .expect("the maximum should be a valid cosine distance"),
+            limit,
+            include_entity_types: false,
+            filter,
+        },
+    )
+    .await
+    .expect("the search should succeed")
+    .entities
+    .into_iter()
+    .map(|entity| entity.metadata.record_id.entity_id)
+    .collect()
+}
+
+fn web_filter(web_id: WebId) -> SearchEntitiesFilter {
+    SearchEntitiesFilter {
+        web_ids: vec![web_id],
+        ..SearchEntitiesFilter::default()
+    }
+}
+
+/// Four entities at the exact cosine distances `0`, `0.5`, `1`, and `2`, created in scrambled
+/// order so the ranking cannot accidentally mirror the insertion order.
+async fn seed_ranked_persons(api: &mut DatabaseApi<'_>) -> [EntityId; 4] {
+    let opposite = create_person(api, false, Vec::new()).await;
+    insert_embedding(api, opposite, embedding_towards(-1.0, 0.0)).await;
+
+    let mid = create_person(api, false, Vec::new()).await;
+    insert_embedding(api, mid, sixty_degrees()).await;
+
+    let near = create_person(api, false, Vec::new()).await;
+    insert_embedding(api, near, embedding_towards(1.0, 0.0)).await;
+
+    let far = create_person(api, false, Vec::new()).await;
+    insert_embedding(api, far, embedding_towards(0.0, 1.0)).await;
+
+    [near, mid, far, opposite]
+}
+
+#[tokio::test]
+async fn ranks_by_exact_distance() {
+    let mut database = DatabaseTestWrapper::new().await;
+    let mut api = seed(&mut database).await;
+    let actor = api.account_id;
+    let own_web = WebId::new(actor);
+
+    let [near, mid, far, opposite] = seed_ranked_persons(&mut api).await;
+
+    let results = search(&mut api, actor, web_filter(own_web), 2.0, 10).await;
+    assert_eq!(
+        results,
+        [near, mid, far, opposite],
+        "the results should be ordered by ascending cosine distance"
+    );
+}
+
+#[tokio::test]
+async fn applies_the_distance_threshold() {
+    let mut database = DatabaseTestWrapper::new().await;
+    let mut api = seed(&mut database).await;
+    let actor = api.account_id;
+    let own_web = WebId::new(actor);
+
+    let [near, mid, _far, _opposite] = seed_ranked_persons(&mut api).await;
+
+    let results = search(&mut api, actor, web_filter(own_web), 0.75, 10).await;
+    assert_eq!(
+        results,
+        [near, mid],
+        "entities beyond the distance threshold should be cut"
+    );
+}
+
+#[tokio::test]
+async fn respects_the_limit() {
+    let mut database = DatabaseTestWrapper::new().await;
+    let mut api = seed(&mut database).await;
+    let actor = api.account_id;
+    let own_web = WebId::new(actor);
+
+    let [near, mid, _far, _opposite] = seed_ranked_persons(&mut api).await;
+
+    let results = search(&mut api, actor, web_filter(own_web), 2.0, 2).await;
+    assert_eq!(
+        results,
+        [near, mid],
+        "the limit should keep the nearest entities"
+    );
+}
+
+#[tokio::test]
+async fn isolates_actors() {
+    let mut database = DatabaseTestWrapper::new().await;
+    let mut api = seed(&mut database).await;
+    let actor = api.account_id;
+    let own_web = WebId::new(actor);
+
+    let visible = create_person(&mut api, false, Vec::new()).await;
+    insert_embedding(&mut api, visible, embedding_towards(1.0, 0.0)).await;
+    let second = create_person(&mut api, false, Vec::new()).await;
+    insert_embedding(&mut api, second, embedding_towards(0.0, 1.0)).await;
+
+    let results = search(&mut api, actor, web_filter(own_web), 2.0, 10).await;
+    assert_eq!(results, [visible, second]);
+
+    // The machine actor has no access to the owner's web, so the search must not surface its
+    // entities no matter what else it returns.
+    let outsider = api.create_machine("semantic-search-outsider").await;
+    let results = search(
+        &mut api,
+        outsider.into(),
+        SearchEntitiesFilter::default(),
+        2.0,
+        10,
+    )
+    .await;
+    assert!(
+        !results.contains(&visible) && !results.contains(&second),
+        "an actor without web access should not see the web's entities"
+    );
+}
+
+#[tokio::test]
+async fn deduplicates_overlapping_policy_branches() {
+    let mut database = DatabaseTestWrapper::new().await;
+    let mut api = seed(&mut database).await;
+    let actor = api.account_id;
+    let own_web = WebId::new(actor);
+
+    // The owner sees this entity through the web permit AND through the entity-scoped policy,
+    // so it ranks in two branches and must still appear exactly once.
+    let public = create_person(&mut api, false, vec![public_view_policy()]).await;
+    insert_embedding(&mut api, public, embedding_towards(1.0, 0.0)).await;
+    let private = create_person(&mut api, false, Vec::new()).await;
+    insert_embedding(&mut api, private, sixty_degrees()).await;
+
+    let results = search(&mut api, actor, web_filter(own_web), 2.0, 10).await;
+    assert_eq!(
+        results,
+        [public, private],
+        "overlapping permits should not duplicate an entity"
+    );
+
+    // The entity-scoped policy has no principal constraint, so it permits the outsider as well —
+    // but only for that one entity.
+    let outsider = api.create_machine("semantic-search-outsider").await;
+    let results = search(
+        &mut api,
+        outsider.into(),
+        SearchEntitiesFilter::default(),
+        2.0,
+        10,
+    )
+    .await;
+    assert!(
+        results.contains(&public),
+        "the entity-scoped permit should make the entity visible to any actor"
+    );
+    assert!(
+        !results.contains(&private),
+        "the web's other entities should stay invisible"
+    );
+    assert_eq!(
+        results.iter().filter(|&&id| id == public).count(),
+        1,
+        "the entity should appear exactly once"
+    );
+}
+
+#[tokio::test]
+async fn excludes_drafts_unless_requested() {
+    let mut database = DatabaseTestWrapper::new().await;
+    let mut api = seed(&mut database).await;
+    let actor = api.account_id;
+    let own_web = WebId::new(actor);
+
+    let draft = create_person(&mut api, true, Vec::new()).await;
+    insert_embedding(&mut api, draft, embedding_towards(1.0, 0.0)).await;
+    let live = create_person(&mut api, false, Vec::new()).await;
+    insert_embedding(&mut api, live, sixty_degrees()).await;
+
+    let results = search(&mut api, actor, web_filter(own_web), 2.0, 10).await;
+    assert_eq!(results, [live], "drafts should be excluded by default");
+
+    let results = search(
+        &mut api,
+        actor,
+        SearchEntitiesFilter {
+            include_drafts: true,
+            ..web_filter(own_web)
+        },
+        2.0,
+        10,
+    )
+    .await;
+    assert_eq!(
+        results,
+        [draft, live],
+        "requesting drafts should rank them alongside live entities"
+    );
+}
+
+#[tokio::test]
+async fn restricts_to_requested_types_and_webs() {
+    let mut database = DatabaseTestWrapper::new().await;
+    let mut api = seed(&mut database).await;
+    let actor = api.account_id;
+    let own_web = WebId::new(actor);
+
+    let person = create_person(&mut api, false, Vec::new()).await;
+    insert_embedding(&mut api, person, embedding_towards(1.0, 0.0)).await;
+
+    let results = search(
+        &mut api,
+        actor,
+        web_filter(WebId::new(Uuid::new_v4())),
+        2.0,
+        10,
+    )
+    .await;
+    assert!(
+        results.is_empty(),
+        "a foreign web restriction should exclude the entity"
+    );
+
+    let results = search(
+        &mut api,
+        actor,
+        SearchEntitiesFilter {
+            entity_type_ids: vec![person_entity_type_id()],
+            ..web_filter(own_web)
+        },
+        2.0,
+        10,
+    )
+    .await;
+    assert_eq!(
+        results,
+        [person],
+        "the type restriction should keep matching entities"
+    );
+}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Top-nav semantic search took 16s+ locally (BE-618). The generic filter path sorted all entities by exact cosine distance before cutting to the limit, and the cross-table permission disjunction forced the planner to materialize the whole visible set.

This PR makes the search index-driven: entities are ranked on a new binary-quantized embedding column via a partial HNSW index, permission policies are decomposed into one conjunctive branch per permit (each individually plannable), and the candidates are re-scored against the full vector before hydration. Measurements and query plans are documented in BE-618.

## 🔗 Related links

- [BE-618](https://linear.app/hash/issue/BE-618) — the investigation
- [BE-735](https://linear.app/hash/issue/BE-735) — follow-up merging the per-branch reads into one statement (stacked PR, to be merged together with this one)
- [BE-734](https://linear.app/hash/issue/BE-734) — follow-up collapsing structurally identical web permits
- [BE-732](https://linear.app/hash/issue/BE-732) — production embedding backfill (only 31k of 726k prod entities have embeddings)

## 🚫 Blocked by

- Nothing. The BE-735 follow-up PR is stacked on this branch and follows it into `main`.

## 🔍 What does this change?

**Commit 1 — quantized ranking (`2a1ab997`):**

- Migration `V57`: generated `embedding_bits bit(3072)` column (`binary_quantize`, 392B inline vs 12kB TOASTed vector) on `entity_embeddings` and `entity_type_embeddings`, plus a partial HNSW index (`bit_hamming_ops`, `WHERE property IS NULL`) on entities; shadow migrations updated
- SQL-AST: `BinaryOperator::HammingDistance` (`<~>`), `Function::BinaryQuantize`, `PostgresType::Bit`
- `SelectCompiler::rank_by_quantized_distance` + `restrict_embedding_property`: ranks on the quantized column with an `INNER` embeddings join, forbids cursors, overfetches `limit × 4` candidates
- `search_entities` / `search_entity_types`: ranked key-read + exact `<=>` rerank with the distance threshold, then hydration with rank restore, in one `REPEATABLE READ` transaction; `SET LOCAL hnsw.ef_search` sized to the candidate pool with `iterative_scan = relaxed_order`
- `Filter::CosineDistance` removed entirely (compile arm, error variants, `Distance` pseudo-columns, keys-first gate); snapshot restore switched to explicit column lists (generated columns reject `INSERT ... SELECT *`)

**Commit 2 — policy branches (`HEAD`):**

- `Filter::for_policy_branches`: splits the permit disjunction at construction (no tree parsing), one branch per permit with all forbids conjoined; duplicate and unmatchable permits produce no branch; `for_policies` re-expressed over the same parts extraction with byte-identical output
- `search_entities_impl` moved to `knowledge/entity/search.rs` and restructured: one candidate key-read per branch, union-dedup, exact rerank over `unnest` arrays with deterministic tie-breaking, divergence warning if hydration disagrees with the ranking, branch count recorded on the tracing span
- New compile goldens (branch shape, end-to-end branch split) and a property test asserting the branch union selects the same entities as the combined filter across 144 policy configurations

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

- **Behaviour change:** results were previously exact over all entities; they are now approximate-then-exact — an entity whose quantized rank is more than `limit × 4` positions away from its exact rank can differ. The binary-quantization recall has not been measured yet.
- The per-branch reads run sequentially (N+3 round trips per search) until the stacked BE-735 PR lands.
- The candidate pool counts rows duplicated by to-many filter joins, so the effective pool can fall below `limit × 4` and miss a nearer neighbour. Deduplicating before the limit is part of BE-735, which rewrites the reads into one statement.
- Actors with many webs get one branch per web role (BE-734); duplicate policies in prod (BE-696) would each cost a read — identical permits are deduplicated at branch assembly as a stopgap.
- `search_entity_types` keeps the single-statement shape: `entity_type_embeddings` has no HNSW index yet and stays small. It also ranks and hydrates without a transaction, unlike the entity search — BE-738, which needs a trait change the compiler does not allow today.

## 🐾 Next steps

- BE-735: statement-layer `UNION` + shared parameter registry, rerank composed from the AST, single statement per search
- BE-734: collapse structurally identical web permits into `web_id = ANY(...)`
- BE-732: production embedding backfill
- Measure binary-quantization recall against exact ranking; the overfetch factor 4 is unmeasured

## 🛡 What tests cover this?

- `tests/graph/integration/postgres/semantic_search.rs` (new): 7 tests against constructed ground truth (exact cosine distances 0/0.5/1/2) — ranking with rank restore, distance threshold, limit, actor isolation, cross-branch deduplication via entity-scoped policies, draft handling, request filters
- `filter::tests::policy_conversion`: 15 unit tests incl. a property test comparing `for_policy_branches` against `for_policies` over a synthetic universe
- Compile goldens pinning the ranked statement shapes, parameters, and the branch split end to end
- `libs/@local/graph/postgres-store/tests/semantic_search/main.rs`: ignored perf harness against a seeded database (measures, does not assert)

## ❓ How to test this?

1. Run the integration tests: `cargo nextest run --package hash-graph-integration --test postgres semantic_search` (requires a freshly migrated database)
2. With a seeded database: start the graph (`cargo run --bin hash-graph -- server`) and `POST /entities/search` with an `embedding`, `maximumSemanticDistance` and `limit` — results are ordered by ascending distance
3. `EXPLAIN ANALYZE` on a branch statement shows the HNSW index driving broad branches and conventional index scans on selective ones

## 📹 Demo

Plans and measurement details are documented in the Linear issues.
