### PR TITLE
SRE-844: Fix span semantics in Node API instrumentation

### DIFF
--- a/apps/hash-api/src/auth/create-auth-handlers.ts
+++ b/apps/hash-api/src/auth/create-auth-handlers.ts
@@ -141,6 +141,15 @@ export const getUserAndSession = async ({
   session?: Session;
   user?: User;
 }> => {
+  // Kratos resolves a session from a cookie or a session token, so asking
+  // without either can only be answered with a 401. The auth middleware runs
+  // for every request that reaches it, including paths matching no route at
+  // all, so callers with no credentials — health checks, webhooks, cookie-less
+  // API clients — would otherwise pay a round trip to learn that.
+  if (!cookie && !sessionToken) {
+    return {};
+  }
+
   const authentication = { actorId: systemAccountId };
 
   const kratosSession = await kratosFrontendApi

--- a/apps/hash-api/src/graphql/create-apollo-server.ts
+++ b/apps/hash-api/src/graphql/create-apollo-server.ts
@@ -9,6 +9,8 @@ import {
 import { KeyvAdapter } from "@apollo/utils.keyvadapter";
 import { expressMiddleware } from "@as-integrations/express5";
 import { makeExecutableSchema } from "@graphql-tools/schema";
+import { context } from "@opentelemetry/api";
+import { getRPCMetadata } from "@opentelemetry/core";
 import * as Sentry from "@sentry/node";
 
 import { schema } from "@local/hash-isomorphic-utils/graphql/type-defs/schema";
@@ -121,6 +123,44 @@ const statsPlugin = ({
   },
 });
 
+/** Same keys `@opentelemetry/instrumentation-graphql` uses on its own spans. */
+const graphqlOperationNameAttribute = "graphql.operation.name";
+const graphqlOperationTypeAttribute = "graphql.operation.type";
+
+const maxOperationNameLength = 128;
+
+/**
+ * Record the GraphQL operation on the HTTP server span, which carries the same
+ * name for every GraphQL request and is what Tempo's processors read.
+ *
+ * An attribute rather than the span name, because operation names come from the
+ * client and a name would let a caller mint a metric series per request.
+ * `getRPCMetadata` yields the server span rather than whichever span is
+ * innermost here.
+ */
+const tracingPlugin = (): ApolloServerPlugin<GraphQLContext> => ({
+  requestDidStart: async () => ({
+    didResolveOperation: async ({ operationName, operation }) => {
+      const span = getRPCMetadata(context.active())?.span;
+      if (!span) {
+        return;
+      }
+      const operationType = operation?.operation;
+      if (operationType) {
+        span.setAttribute(graphqlOperationTypeAttribute, operationType);
+      }
+      if (operationName) {
+        // Length is otherwise bounded only by the request body limit, and
+        // `/graphql` answers unauthenticated requests.
+        span.setAttribute(
+          graphqlOperationNameAttribute,
+          operationName.slice(0, maxOperationNameLength),
+        );
+      }
+    },
+  }),
+});
+
 export interface CreateApolloServerParams {
   graphApi: GraphApi;
   cache: Keyv;
@@ -182,6 +222,7 @@ export const createApolloServer = async ({
 }`,
           }),
       statsPlugin({ statsd }),
+      tracingPlugin(),
       ApolloServerPluginDrainHttpServer({ httpServer }),
     ],
   });

--- a/apps/hash-api/src/instrument.mjs
+++ b/apps/hash-api/src/instrument.mjs
@@ -77,7 +77,6 @@ Sentry.init({
     process.env.ENVIRONMENT ||
     (isProdEnv ? "production" : "development"),
   sendDefaultPii: true,
-  tracesSampleRate: isProdEnv ? 1.0 : 0,
   // Skip Sentry's tracer setup only when our v2 provider actually
   // registered. Gating on `otlpEndpoint` instead would skip Sentry's
   // setup whenever the env var is set even if our bootstrap threw,

--- a/libs/@local/hash-backend-utils/src/opentelemetry.test.ts
+++ b/libs/@local/hash-backend-utils/src/opentelemetry.test.ts
@@ -1,13 +1,21 @@
-import { type Span, trace } from "@opentelemetry/api";
+import {
+  type Span,
+  type SpanStatus,
+  SpanStatusCode,
+  trace,
+} from "@opentelemetry/api";
 import { describe, expect, it } from "vitest";
 
 import {
   createHttpInstrumentation,
+  EXPECTED_CLIENT_STATUS_ATTRIBUTE,
+  httpExpectedClientStatusHook,
   httpRequestSpanNameHook,
+  isExpectedClientStatus,
   resolvePeerService,
 } from "./opentelemetry.js";
 
-import type { ClientRequest, IncomingMessage } from "node:http";
+import type { ClientRequest, IncomingMessage, ServerResponse } from "node:http";
 
 describe("resolvePeerService", () => {
   it("matches exact hosts to their service label", () => {
@@ -130,6 +138,113 @@ describe("httpRequestSpanNameHook", () => {
     httpRequestSpanNameHook(span, { method: "GET" } as IncomingMessage);
 
     expect(updates).toEqual([]);
+  });
+});
+
+describe("isExpectedClientStatus", () => {
+  it("matches the Kratos session lookup on its expected outcomes", () => {
+    for (const statusCode of [401, 403]) {
+      expect(
+        isExpectedClientStatus({
+          method: "GET",
+          path: "/sessions/whoami",
+          statusCode,
+        }),
+      ).toBe(true);
+    }
+  });
+
+  it("requires method, path and status to line up", () => {
+    for (const args of [
+      { method: "GET", path: "/sessions/whoami", statusCode: 500 },
+      { method: "GET", path: "/v1/chat/completions", statusCode: 401 },
+      { method: "DELETE", path: "/sessions/whoami", statusCode: 401 },
+      { method: undefined, path: "/sessions/whoami", statusCode: 401 },
+      { method: "GET", path: "/sessions/whoami", statusCode: undefined },
+    ]) {
+      expect(isExpectedClientStatus(args)).toBe(false);
+    }
+  });
+});
+
+describe("httpExpectedClientStatusHook", () => {
+  const makeSpan = (): {
+    span: Span;
+    statuses: SpanStatus[];
+    attributes: Record<string, unknown>;
+  } => {
+    const statuses: SpanStatus[] = [];
+    const attributes: Record<string, unknown> = {};
+    const noopSpan = trace.getTracer("test").startSpan("noop");
+    const span: Span = Object.assign(noopSpan, {
+      setStatus: (status: SpanStatus) => {
+        statuses.push(status);
+        return span;
+      },
+      setAttribute: (key: string, value: unknown) => {
+        attributes[key] = value;
+        return span;
+      },
+    });
+    return { span, statuses, attributes };
+  };
+
+  const outgoing = (path: string) => ({ method: "GET", path }) as ClientRequest;
+
+  const answeredWith = (statusCode: number) =>
+    ({ statusCode }) as IncomingMessage;
+
+  it("marks an expected client-side failure as successful", () => {
+    const { span, statuses, attributes } = makeSpan();
+    httpExpectedClientStatusHook(
+      span,
+      outgoing("/sessions/whoami?tokenize=true"),
+      answeredWith(401),
+    );
+    expect(statuses).toStrictEqual([{ code: SpanStatusCode.OK }]);
+    expect(attributes).toStrictEqual({
+      [EXPECTED_CLIENT_STATUS_ATTRIBUTE]: true,
+    });
+  });
+
+  it("leaves genuine client-side failures erroring", () => {
+    const { span, statuses } = makeSpan();
+    httpExpectedClientStatusHook(
+      span,
+      outgoing("/sessions/whoami"),
+      answeredWith(500),
+    );
+    expect(statuses).toStrictEqual([]);
+  });
+
+  // The fixture carries `path` because Express defines it as a getter on the
+  // request — without the direction guard the rule would match here.
+  it("does not touch server spans", () => {
+    const { span, statuses } = makeSpan();
+    httpExpectedClientStatusHook(
+      span,
+      {
+        method: "GET",
+        url: "/sessions/whoami",
+        path: "/sessions/whoami",
+      } as IncomingMessage & { path: string },
+      { statusCode: 401, setHeader: () => {} } as unknown as ServerResponse,
+    );
+    expect(statuses).toStrictEqual([]);
+  });
+});
+
+// Dropping either line from the factory would leave every hook test above green
+// while the behaviour disappeared in all three services.
+describe("createHttpInstrumentation hook wiring", () => {
+  it("ships both hooks", () => {
+    const config = createHttpInstrumentation(
+      "http://localhost:4317",
+    ).getConfig();
+    expect(config.requestHook).toBe(httpRequestSpanNameHook);
+    expect(config.applyCustomAttributesOnSpan).toBe(
+      httpExpectedClientStatusHook,
+    );
   });
 });
 

--- a/libs/@local/hash-backend-utils/src/opentelemetry.ts
+++ b/libs/@local/hash-backend-utils/src/opentelemetry.ts
@@ -8,7 +8,7 @@
  * Returns a teardown function that must run during graceful shutdown so
  * pending spans / log records / metric points are flushed before exit.
  */
-import { metrics } from "@opentelemetry/api";
+import { metrics, SpanStatusCode } from "@opentelemetry/api";
 import { logs } from "@opentelemetry/api-logs";
 import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-grpc";
 import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-grpc";
@@ -37,6 +37,7 @@ import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 import type { Instrumentation } from "@opentelemetry/instrumentation";
 import type { Resource } from "@opentelemetry/resources";
 import type { SpanExporter } from "@opentelemetry/sdk-trace-base";
+import type { IncomingMessage, ServerResponse } from "node:http";
 
 const traceTimeoutMs = 5000;
 const metricExportIntervalMs = 30_000;
@@ -168,6 +169,82 @@ export const httpRequestSpanNameHook: NonNullable<
 };
 
 /**
+ * Outbound requests where a status is a defined outcome of the operation rather
+ * than a failed call. semconv marks every client-side 4xx as an error, which is
+ * wrong for a call whose purpose is to ask a question that may be answered with
+ * "no".
+ *
+ * Matching is host-independent, so any dependency answering that method and
+ * path with one of those statuses counts as expected.
+ */
+interface ExpectedClientStatusRule {
+  method: string;
+  path: string;
+  statuses: readonly number[];
+}
+
+const EXPECTED_CLIENT_STATUS_RULES: readonly ExpectedClientStatusRule[] = [
+  // Kratos session lookup: 401 is "no session", 403 is "AAL1 where AAL2 is
+  // required". Callers treat both as an anonymous request.
+  { method: "GET", path: "/sessions/whoami", statuses: [401, 403] },
+];
+
+export const isExpectedClientStatus = ({
+  method,
+  path,
+  statusCode,
+}: {
+  method: string | undefined;
+  path: string | undefined;
+  statusCode: number | undefined;
+}): boolean =>
+  EXPECTED_CLIENT_STATUS_RULES.some(
+    (rule) =>
+      rule.method === method &&
+      rule.path === path &&
+      statusCode !== undefined &&
+      rule.statuses.includes(statusCode),
+  );
+
+/** The hook is handed both directions and `SpanKind` is not passed to it. */
+const isServerResponse = (
+  response: IncomingMessage | ServerResponse,
+): response is ServerResponse => "setHeader" in response;
+
+/**
+ * Marks a span whose error status {@link httpExpectedClientStatusHook} rewrote.
+ * Needed because `parseResponseStatus` never yields `OK`, so without it `OK` on
+ * a client span silently selects exactly the suppressed failures.
+ */
+export const EXPECTED_CLIENT_STATUS_ATTRIBUTE = "hash.expected_client_status";
+
+/**
+ * `applyCustomAttributesOnSpan` marking {@link EXPECTED_CLIENT_STATUS_RULES} as
+ * successful, so Tempo's `service_graphs` processor stops counting them against
+ * the edge to that dependency.
+ *
+ * `OK` rather than clearing the status, because the SDK drops `setStatus` with
+ * `UNSET`.
+ */
+export const httpExpectedClientStatusHook: NonNullable<
+  HttpInstrumentationConfig["applyCustomAttributesOnSpan"]
+> = (span, request, response) => {
+  if (isServerResponse(response)) {
+    return;
+  }
+  const rawPath = "path" in request ? request.path : undefined;
+  const isExpected = isExpectedClientStatus({
+    method: "method" in request ? request.method : undefined,
+    path: typeof rawPath === "string" ? rawPath.split("?")[0] : undefined,
+    statusCode: response.statusCode,
+  });
+  if (isExpected) {
+    span.setAttribute(EXPECTED_CLIENT_STATUS_ATTRIBUTE, true);
+    span.setStatus({ code: SpanStatusCode.OK });
+  }
+};
+
+/**
  * Default OTLP/gRPC port. Used when the configured endpoint URL does not
  * carry an explicit port (e.g. `http://collector` resolves via gRPC default).
  */
@@ -194,17 +271,20 @@ const otlpPortFromEndpoint = (otlpEndpoint: string): number => {
  *   every batch. The port is derived from `otlpEndpoint` so a non-default
  *   collector port (e.g. `:4318` for OTLP/HTTP) still gets ignored.
  * - Names spans `METHOD /path` via {@link httpRequestSpanNameHook}.
+ * - Marks expected client-side failures as successful via
+ *   {@link httpExpectedClientStatusHook}.
  *
  * Pass `extra` to merge per-service options (e.g. `ignoreIncomingPaths`).
- * `ignoreOutgoingRequestHook` and `requestHook` are intentionally not
- * mergeable here — callers needing different shapes should construct
- * `HttpInstrumentation` directly.
+ * `ignoreOutgoingRequestHook`, `requestHook` and
+ * `applyCustomAttributesOnSpan` are intentionally not mergeable here —
+ * callers needing different shapes should construct `HttpInstrumentation`
+ * directly.
  */
 export const createHttpInstrumentation = (
   otlpEndpoint: string,
   extra: Omit<
     HttpInstrumentationConfig,
-    "ignoreOutgoingRequestHook" | "requestHook"
+    "applyCustomAttributesOnSpan" | "ignoreOutgoingRequestHook" | "requestHook"
   > = {},
 ): HttpInstrumentation => {
   const otlpPort = otlpPortFromEndpoint(otlpEndpoint);
@@ -217,6 +297,7 @@ export const createHttpInstrumentation = (
       // and the exporter's own outbound traffic slips through.
       Number(options.port) === otlpPort,
     requestHook: httpRequestSpanNameHook,
+    applyCustomAttributesOnSpan: httpExpectedClientStatusHook,
   });
 };
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The Node API was reporting 4xx responses as span errors, so internet-scanner noise and the expected 401s from the session check counted against the availability signal, and the Node API → Kratos edge in the service graph rendered as failing.

Two causes, both addressed here. Sentry was authoring the HTTP server spans instead of our OpenTelemetry instrumentation, and Sentry marks a 4xx server response as an error where semconv leaves it unset. Separately, a session lookup that legitimately answers "no session" is a defined outcome of that operation rather than a failed call, but semconv marks every client-side 4xx as an error.

## 🔗 Related links

- [SRE-844](https://linear.app/hash/issue/SRE-844/fix-span-semantics-in-node-api-instrumentation-4xx-errors-scanner-span) _(internal)_

## 🚫 Blocked by

- Nothing

## 🔍 What does this change?

- Removes `tracesSampleRate` from `Sentry.init`. Any value — `0` included, because the check is for nullish — switches on Sentry's server-span and performance integrations, and those write into the globally registered tracer provider, which is ours. `skipOpenTelemetrySetup` meanwhile keeps those spans from ever reaching Sentry, so their only effect was to put Sentry's status semantics into Tempo. Sentry keeps error reporting, breadcrumbs and request isolation, all of which are ungated.
- Adds a rule table of outbound requests where a status is a defined outcome rather than a failure, and an `applyCustomAttributesOnSpan` hook that marks matches successful. Currently one entry: Kratos `GET /sessions/whoami` with 401 (no session) or 403 (AAL1 where AAL2 is required), both of which `getUserAndSession` already treats as an anonymous request.
- Tags those rewrites with `hash.expected_client_status`. `parseResponseStatus` never yields `OK` on its own, so without the attribute an `OK` client span would silently select exactly the suppressed failures, and the Tempo config would have nothing to exclude on.
- Short-circuits `getUserAndSession` when there is neither a cookie nor a session token, which Kratos can only answer with a 401. The auth middleware runs before routing, so requests without credentials — health checks, webhooks, cookie-less API clients, and anything hitting a path that matches no route — previously paid that round trip.
- Records `graphql.operation.name` and `graphql.operation.type` on the HTTP server span. Every GraphQL request shares one server span name, which is what Tempo's `span_metrics` and `service_graphs` processors read, so per-operation views could not be built from them. An attribute rather than the span name, because operation names come from the client and a name would let a caller mint a metric series per request — turning it into a metric dimension stays a decision in the Tempo config, where cardinality is controlled centrally.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

- The ticket's third item — a normalized span name for unmatched routes — is **not** addressed. Server span names come from our own `httpRequestSpanNameHook`, which uses the raw path; the OpenTelemetry default would be `{method}`, upgraded to `{method} {http.route}` once a route is known. `http.route` is never set, because `@opentelemetry/instrumentation-express` does not patch under this app's ESM entrypoint and produces no spans at all. Fixing that touches the process bootstrap and is worth its own change. Until then, path cardinality can also be bounded collector- or Tempo-side without code.
- Rule matching is host-independent, so any dependency answering `GET /sessions/whoami` with 401 or 403 would count as expected. Deliberate, because the same service answers under a different hostname per environment, but worth knowing before adding entries.
- `@apps/hash-ai-worker-ts` and `@apps/hash-integration-worker` still set `tracesSampleRate`. They serve no inbound HTTP, so they have no server spans and the symptom cannot occur there; what remains is Sentry's performance integrations running alongside ours. Left alone deliberately — a naive removal would make `Sentry.startSpan` in the Temporal activity interceptor non-recording.

## 🐾 Next steps

- Confirm on staging whether the reported error ratio actually drops. If it is derived from span status it will; if it is derived from a query over `http.status_code`, the remaining fix is in the SLO definition rather than in this code.
- Decide whether to adopt the OpenTelemetry default for server span names, which requires the Express instrumentation to work first.

## 🛡 What tests cover this?

- New unit tests in `libs/@local/hash-backend-utils/src/opentelemetry.test.ts` cover the rule predicate (expected outcomes, and that method, path and status must all line up), the hook (rewrite plus attribute, genuine failures left erroring, server spans untouched), and that `createHttpInstrumentation` actually ships both hooks — the last one because dropping that wiring would leave every other test green while the behaviour disappeared in all three services.
- The `Sentry.init` change and the Apollo plugin are bootstrap and framework wiring; both were verified against a running instance by reading the resulting spans out of Tempo rather than by test.

## ❓ How to test this?

1. Bring up the observability profile and the API: `yarn compose up -d` with the `observability` profile, then `yarn workspace @apps/hash-api dev`. Set `NODE_API_SENTRY_DSN` so Sentry is actually enabled — without a DSN its integrations never take over and the old behaviour is invisible.
2. Hit a path that matches no route, without a cookie: `curl -i localhost:5001/does-not-exist`.
3. Hit the session check through the Kratos proxy: `curl -i localhost:5001/auth/sessions/whoami`.
4. Send a named GraphQL operation: `curl -s -X POST localhost:5001/graphql -H 'content-type: application/json' -d '{"operationName":"Probe","query":"query Probe { __typename }"}'`.
5. Open the traces in Grafana on `localhost:3001` (allow a few seconds for ingest) and confirm: the server spans come from `@opentelemetry/instrumentation-http` rather than `@sentry/node`; a 404 server span has no error status; the Kratos client span for the 401 is `OK` and carries `hash.expected_client_status`; step 2 produces no Kratos client span at all; and the `POST /graphql` server span carries the operation attributes.

## 📹 Demo

Not applicable — no user-facing surface.
