### PR TITLE
SRE-901: Stop handing CI more Vault reach than it uses

### DIFF
--- a/.github/actions/install-sccache/action.yml
+++ b/.github/actions/install-sccache/action.yml
@@ -12,7 +12,6 @@ runs:
       id: secrets
       uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
       with:
-        exportToken: true
         url: ${{ inputs.vault_address }}
         method: jwt
         role: dev

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -163,7 +163,6 @@ jobs:
         if: github.event.pull_request.head.repo.full_name == github.repository
         uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
         with:
-          exportToken: true
           url: ${{ env.VAULT_ADDR }}
           method: jwt
           role: dev
@@ -380,7 +379,6 @@ jobs:
         if: github.event.pull_request.head.repo.full_name == github.repository
         uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
         with:
-          exportToken: true
           url: ${{ env.VAULT_ADDR }}
           method: jwt
           role: dev

--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -42,7 +42,7 @@ on:
 
 permissions:
   actions: read
-  contents: write
+  contents: read
   id-token: write
 
 jobs:
@@ -68,4 +68,3 @@ jobs:
       logLevel: ${{ inputs.logLevel || 'info' }}
       overrideSchedule: ${{ inputs.overrideSchedule || false }}
       dryRun: ${{ inputs.dryRun || 'disabled' }}
-    secrets: inherit


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Three grants in CI that are not used. The hash-side half of SRE-901, which was assumed done in the first pass and never shipped.

## 🔗 Related links

- [SRE-901](https://linear.app/hash/issue/SRE-901/harden-the-centralized-renovate-workflow-against-compromised-actions) _(internal)_
- hashintel/.github#93 — the reusable-workflow half, merged

## 🚫 Blocked by

None.

## 🔍 What does this change?

- **`exportToken: true` removed** from `install-sccache` and both `bench.yml` call sites. It has no consumers: `VAULT_TOKEN` appears nowhere in `.github/` except as `VAULT_TOKEN: ""`, clearing it back out
- **`secrets: inherit` removed** from the `renovate` job. The reusable workflow reads no `secrets.*` — it takes the Vault address from `vars.VAULT_ADDR`
- **`contents: write` → `read`.** Renovate commits through the API with the App token (`RENOVATE_PLATFORM_COMMIT: enabled`), so the workflow's own token does not need it

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

- The five `VAULT_TOKEN: ""` lines are now redundant. Left in place deliberately; happy to strip them if preferred.
- `install-sccache` still authenticates with the broad `dev` role. Narrowing that is Terraform work, tracked in Linear.

## 🐾 Next steps

- Tracked in Linear.

## 🛡 What tests cover this?

- `actionlint` runs in `lint.yml` and covers the YAML.
- Verified by grep rather than CI: no reference to `VAULT_TOKEN`, `vaultToken` or `steps.secrets.outputs.vault*` anywhere in `.github/`, which is what makes the `exportToken` removal safe. Same for `secrets.*` in the reusable workflow.

## ❓ How to test this?

1. `bench.yml` — the Vault step still resolves its three fields and the upload step works
2. Any workflow using `install-tools` with sccache — the four `SCCACHE_*` values arrive and the server starts
3. Trigger `Housekeeping` manually and confirm Renovate still opens and updates PRs

## 📹 Demo

Not applicable, CI-only change.
