### PR TITLE
SRE-915: Resolve the Vault target from the job's environment

### DIFF
--- a/.github/actions/install-sccache/action.yml
+++ b/.github/actions/install-sccache/action.yml
@@ -2,7 +2,13 @@ name: Install sccache
 description: Setup sccache for Rust project caching
 inputs:
   vault_address:
-    description: The URL of the Vault server
+    description: The URL of the Vault server holding `ci/sccache/r2`.
+    required: true
+  cf_access_client_id:
+    description: Cloudflare Access service-token client ID for that Vault.
+    required: true
+  cf_access_client_secret:
+    description: Cloudflare Access service-token client secret for that Vault.
     required: true
 
 runs:
@@ -12,14 +18,19 @@ runs:
       id: secrets
       uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
       with:
+        # The endpoint sits behind Cloudflare Access, hence the service-token
+        # headers. Vault's own ACL still decides what the role may read.
         url: ${{ inputs.vault_address }}
         method: jwt
-        role: dev
+        role: ci-hash-sccache
+        extraHeaders: |
+          CF-Access-Client-Id: ${{ inputs.cf_access_client_id }}
+          CF-Access-Client-Secret: ${{ inputs.cf_access_client_secret }}
         secrets: |
-          infrastructure/data/github/actions/secrets sccache_r2_account_id | SCCACHE_ACCOUNT_ID ;
-          infrastructure/data/github/actions/secrets sccache_r2_bucket | SCCACHE_BUCKET ;
-          infrastructure/data/github/actions/secrets sccache_r2_access_key_id | SCCACHE_AWS_ACCESS_KEY_ID ;
-          infrastructure/data/github/actions/secrets sccache_r2_secret_access_key | SCCACHE_AWS_SECRET_ACCESS_KEY ;
+          ci/data/sccache/r2 account_id | SCCACHE_ACCOUNT_ID ;
+          ci/data/sccache/r2 bucket | SCCACHE_BUCKET ;
+          ci/data/sccache/r2 access_key_id | SCCACHE_AWS_ACCESS_KEY_ID ;
+          ci/data/sccache/r2 secret_access_key | SCCACHE_AWS_SECRET_ACCESS_KEY ;
 
     - name: Setup sccache
       uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9

--- a/.github/actions/install-tools/action.yml
+++ b/.github/actions/install-tools/action.yml
@@ -56,6 +56,7 @@ runs:
 
     - name: "Install sccache"
       if: ${{ (inputs.rust == true || inputs.rust == 'true') && (inputs.sccache == true || inputs.sccache == 'true') && inputs.cf_access_client_secret != '' }}
+      continue-on-error: true
       uses: ./.github/actions/install-sccache
       with:
         vault_address: ${{ inputs.vault_address }}

--- a/.github/actions/install-tools/action.yml
+++ b/.github/actions/install-tools/action.yml
@@ -6,8 +6,14 @@ inputs:
     description: GitHub token for authentication
     required: true
   vault_address:
-    description: The URL of the Vault server. If empty, sccache installation is skipped.
-    required: true
+    description: The URL of the Vault server holding the sccache credentials.
+    default: ""
+  cf_access_client_id:
+    description: Cloudflare Access service-token client ID for that Vault.
+    default: ""
+  cf_access_client_secret:
+    description: Cloudflare Access service-token client secret for that Vault. Empty on fork pull requests, which is what skips sccache there.
+    default: ""
   rust:
     description: Should Rust be installed? Can either be `"true"` or `true`
     default: "true"
@@ -49,7 +55,9 @@ runs:
         command: ${{ github.action_path }}/install-rust.sh
 
     - name: "Install sccache"
-      if: ${{ (inputs.rust == true || inputs.rust == 'true') && (inputs.sccache == true || inputs.sccache == 'true') && inputs.vault_address != '' }}
+      if: ${{ (inputs.rust == true || inputs.rust == 'true') && (inputs.sccache == true || inputs.sccache == 'true') && inputs.cf_access_client_secret != '' }}
       uses: ./.github/actions/install-sccache
       with:
         vault_address: ${{ inputs.vault_address }}
+        cf_access_client_id: ${{ inputs.cf_access_client_id }}
+        cf_access_client_secret: ${{ inputs.cf_access_client_secret }}

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -134,8 +134,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           vault_address: ${{ vars.VAULT_STAGE_ADDR }}
-          cf_access_client_id: ${{ vars.CF_ACCESS_CI_CLIENT_ID }}
-          cf_access_client_secret: ${{ secrets.CF_ACCESS_CI_CLIENT_SECRET }}
+          cf_access_client_id: ${{ vars.CF_ACCESS_STAGE_CLIENT_ID }}
+          cf_access_client_secret: ${{ secrets.CF_ACCESS_STAGE_CLIENT_SECRET }}
           rust: false
 
       - name: Warm up repository

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -133,7 +133,9 @@ jobs:
         uses: ./.github/actions/install-tools
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          vault_address: ${{ secrets.VAULT_ADDR }}
+          vault_address: ${{ vars.VAULT_STAGE_ADDR }}
+          cf_access_client_id: ${{ vars.CF_ACCESS_CI_CLIENT_ID }}
+          cf_access_client_secret: ${{ secrets.CF_ACCESS_CI_CLIENT_SECRET }}
           rust: false
 
       - name: Warm up repository

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -49,7 +49,9 @@ jobs:
         uses: ./.github/actions/install-tools
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          vault_address: ${{ secrets.VAULT_ADDR }}
+          vault_address: ${{ vars.VAULT_STAGE_ADDR }}
+          cf_access_client_id: ${{ vars.CF_ACCESS_CI_CLIENT_ID }}
+          cf_access_client_secret: ${{ secrets.CF_ACCESS_CI_CLIENT_SECRET }}
           rust: false
 
       - name: Determine changed packages
@@ -93,7 +95,9 @@ jobs:
         uses: ./.github/actions/install-tools
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          vault_address: ${{ secrets.VAULT_ADDR }}
+          vault_address: ${{ vars.VAULT_STAGE_ADDR }}
+          cf_access_client_id: ${{ vars.CF_ACCESS_CI_CLIENT_ID }}
+          cf_access_client_secret: ${{ secrets.CF_ACCESS_CI_CLIENT_SECRET }}
 
       - name: Prune repository
         if: github.event_name == 'pull_request'
@@ -132,7 +136,9 @@ jobs:
         uses: ./.github/actions/install-tools
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          vault_address: ${{ secrets.VAULT_ADDR }}
+          vault_address: ${{ vars.VAULT_STAGE_ADDR }}
+          cf_access_client_id: ${{ vars.CF_ACCESS_CI_CLIENT_ID }}
+          cf_access_client_secret: ${{ secrets.CF_ACCESS_CI_CLIENT_SECRET }}
 
       - name: Prune repository
         uses: ./.github/actions/prune-repository
@@ -209,7 +215,9 @@ jobs:
         uses: ./.github/actions/install-tools
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          vault_address: ${{ secrets.VAULT_ADDR }}
+          vault_address: ${{ vars.VAULT_STAGE_ADDR }}
+          cf_access_client_id: ${{ vars.CF_ACCESS_CI_CLIENT_ID }}
+          cf_access_client_secret: ${{ secrets.CF_ACCESS_CI_CLIENT_SECRET }}
 
       - name: Prune repository
         if: github.event_name == 'pull_request'
@@ -307,7 +315,9 @@ jobs:
         uses: ./.github/actions/install-tools
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          vault_address: ${{ secrets.VAULT_ADDR }}
+          vault_address: ${{ vars.VAULT_STAGE_ADDR }}
+          cf_access_client_id: ${{ vars.CF_ACCESS_CI_CLIENT_ID }}
+          cf_access_client_secret: ${{ secrets.CF_ACCESS_CI_CLIENT_SECRET }}
           sccache: false # sccache is already running in the background
 
       - name: Prune repository

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -10,8 +10,10 @@ env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: hashintel
   TURBO_CACHE: remote:rw
-
-  VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
+  # The legacy Vault, still holding `aws/creds/dev-deploy`. Inline rather than a
+  # variable because it goes away once those credentials move; `vars.VAULT_ADDR`
+  # is the per-environment one and would resolve to the wrong instance here.
+  VAULT_ADDR: https://vault.blockprotocol.org
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -50,8 +52,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           vault_address: ${{ vars.VAULT_STAGE_ADDR }}
-          cf_access_client_id: ${{ vars.CF_ACCESS_CI_CLIENT_ID }}
-          cf_access_client_secret: ${{ secrets.CF_ACCESS_CI_CLIENT_SECRET }}
+          cf_access_client_id: ${{ vars.CF_ACCESS_STAGE_CLIENT_ID }}
+          cf_access_client_secret: ${{ secrets.CF_ACCESS_STAGE_CLIENT_SECRET }}
           rust: false
 
       - name: Determine changed packages
@@ -96,8 +98,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           vault_address: ${{ vars.VAULT_STAGE_ADDR }}
-          cf_access_client_id: ${{ vars.CF_ACCESS_CI_CLIENT_ID }}
-          cf_access_client_secret: ${{ secrets.CF_ACCESS_CI_CLIENT_SECRET }}
+          cf_access_client_id: ${{ vars.CF_ACCESS_STAGE_CLIENT_ID }}
+          cf_access_client_secret: ${{ secrets.CF_ACCESS_STAGE_CLIENT_SECRET }}
 
       - name: Prune repository
         if: github.event_name == 'pull_request'
@@ -137,8 +139,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           vault_address: ${{ vars.VAULT_STAGE_ADDR }}
-          cf_access_client_id: ${{ vars.CF_ACCESS_CI_CLIENT_ID }}
-          cf_access_client_secret: ${{ secrets.CF_ACCESS_CI_CLIENT_SECRET }}
+          cf_access_client_id: ${{ vars.CF_ACCESS_STAGE_CLIENT_ID }}
+          cf_access_client_secret: ${{ secrets.CF_ACCESS_STAGE_CLIENT_SECRET }}
 
       - name: Prune repository
         uses: ./.github/actions/prune-repository
@@ -216,8 +218,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           vault_address: ${{ vars.VAULT_STAGE_ADDR }}
-          cf_access_client_id: ${{ vars.CF_ACCESS_CI_CLIENT_ID }}
-          cf_access_client_secret: ${{ secrets.CF_ACCESS_CI_CLIENT_SECRET }}
+          cf_access_client_id: ${{ vars.CF_ACCESS_STAGE_CLIENT_ID }}
+          cf_access_client_secret: ${{ secrets.CF_ACCESS_STAGE_CLIENT_SECRET }}
 
       - name: Prune repository
         if: github.event_name == 'pull_request'
@@ -316,8 +318,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           vault_address: ${{ vars.VAULT_STAGE_ADDR }}
-          cf_access_client_id: ${{ vars.CF_ACCESS_CI_CLIENT_ID }}
-          cf_access_client_secret: ${{ secrets.CF_ACCESS_CI_CLIENT_SECRET }}
+          cf_access_client_id: ${{ vars.CF_ACCESS_STAGE_CLIENT_ID }}
+          cf_access_client_secret: ${{ secrets.CF_ACCESS_STAGE_CLIENT_SECRET }}
           sccache: false # sccache is already running in the background
 
       - name: Prune repository

--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -18,8 +18,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           vault_address: ${{ vars.VAULT_STAGE_ADDR }}
-          cf_access_client_id: ${{ vars.CF_ACCESS_CI_CLIENT_ID }}
-          cf_access_client_secret: ${{ secrets.CF_ACCESS_CI_CLIENT_SECRET }}
+          cf_access_client_id: ${{ vars.CF_ACCESS_STAGE_CLIENT_ID }}
+          cf_access_client_secret: ${{ secrets.CF_ACCESS_STAGE_CLIENT_SECRET }}
 
       - name: Warm up repository
         uses: ./.github/actions/warm-up-repo

--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -17,7 +17,9 @@ jobs:
         uses: ./.github/actions/install-tools
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          vault_address: ${{ secrets.VAULT_ADDR }}
+          vault_address: ${{ vars.VAULT_STAGE_ADDR }}
+          cf_access_client_id: ${{ vars.CF_ACCESS_CI_CLIENT_ID }}
+          cf_access_client_secret: ${{ secrets.CF_ACCESS_CI_CLIENT_SECRET }}
 
       - name: Warm up repository
         uses: ./.github/actions/warm-up-repo

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -30,7 +30,9 @@ jobs:
         uses: ./.github/actions/install-tools
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          vault_address: ${{ secrets.VAULT_ADDR }}
+          vault_address: ${{ vars.VAULT_STAGE_ADDR }}
+          cf_access_client_id: ${{ vars.CF_ACCESS_CI_CLIENT_ID }}
+          cf_access_client_secret: ${{ secrets.CF_ACCESS_CI_CLIENT_SECRET }}
           rust: false
 
       - name: Determine changed packages that have codspeed
@@ -63,7 +65,9 @@ jobs:
         uses: ./.github/actions/install-tools
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          vault_address: ${{ secrets.VAULT_ADDR }}
+          vault_address: ${{ vars.VAULT_STAGE_ADDR }}
+          cf_access_client_id: ${{ vars.CF_ACCESS_CI_CLIENT_ID }}
+          cf_access_client_secret: ${{ secrets.CF_ACCESS_CI_CLIENT_SECRET }}
 
       - name: Prune repository
         uses: ./.github/actions/prune-repository

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -31,8 +31,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           vault_address: ${{ vars.VAULT_STAGE_ADDR }}
-          cf_access_client_id: ${{ vars.CF_ACCESS_CI_CLIENT_ID }}
-          cf_access_client_secret: ${{ secrets.CF_ACCESS_CI_CLIENT_SECRET }}
+          cf_access_client_id: ${{ vars.CF_ACCESS_STAGE_CLIENT_ID }}
+          cf_access_client_secret: ${{ secrets.CF_ACCESS_STAGE_CLIENT_SECRET }}
           rust: false
 
       - name: Determine changed packages that have codspeed
@@ -66,8 +66,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           vault_address: ${{ vars.VAULT_STAGE_ADDR }}
-          cf_access_client_id: ${{ vars.CF_ACCESS_CI_CLIENT_ID }}
-          cf_access_client_secret: ${{ secrets.CF_ACCESS_CI_CLIENT_SECRET }}
+          cf_access_client_id: ${{ vars.CF_ACCESS_STAGE_CLIENT_ID }}
+          cf_access_client_secret: ${{ secrets.CF_ACCESS_STAGE_CLIENT_SECRET }}
 
       - name: Prune repository
         uses: ./.github/actions/prune-repository

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,8 +56,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           vault_address: ${{ vars.VAULT_STAGE_ADDR }}
-          cf_access_client_id: ${{ vars.CF_ACCESS_CI_CLIENT_ID }}
-          cf_access_client_secret: ${{ secrets.CF_ACCESS_CI_CLIENT_SECRET }}
+          cf_access_client_id: ${{ vars.CF_ACCESS_STAGE_CLIENT_ID }}
+          cf_access_client_secret: ${{ secrets.CF_ACCESS_STAGE_CLIENT_SECRET }}
           rust: false
 
       # Service catalog: the single source of truth for build/manifest/deploy.
@@ -242,9 +242,13 @@ jobs:
     if: needs.setup.outputs.sourcemaps != '{"name":[],"include":[]}' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-24.04
     # The environment lands in the OIDC token as a claim the Vault role binds,
-    # and `main` only accepts the main branch. Picking the role in this
-    # expression is therefore no longer self-asserted.
-    environment: ${{ github.event_name == 'push' && 'main' || 'pull-request' }}
+    # and `main` only accepts the main branch. Picking the tier here is
+    # therefore not self-asserted.
+    #
+    # Keyed on the ref rather than the event, so a workflow_dispatch on main —
+    # which this workflow treats as a publishing run elsewhere — gets the same
+    # tier as a push, and a dispatch on any other branch does not.
+    environment: ${{ github.ref == 'refs/heads/main' && 'main' || 'pull-request' }}
     permissions:
       id-token: write
       contents: read
@@ -252,19 +256,19 @@ jobs:
       - name: Authenticate Vault
         id: secrets
         uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
-        env:
-          # Must stay in sync with the job's `environment:` above — the Vault
-          # role binds that value as a claim.
-          VAULT_TIER: ${{ github.event_name == 'push' && 'main' || 'pull-request' }}
         with:
-          url: ${{ vars.VAULT_STAGE_ADDR }}
+          # Address and Access credentials come from the job's environment:
+          # `pull-request` resolves to the staging Vault, `main` to production.
+          # Each instance holds only its own tier's token, so the role name and
+          # the path carry no tier — the instance is the tier.
+          url: ${{ vars.VAULT_ADDR }}
           method: jwt
-          role: ci-hash-sentry-${{ env.VAULT_TIER }}
+          role: ci-hash-sentry
           extraHeaders: |
-            CF-Access-Client-Id: ${{ vars.CF_ACCESS_CI_CLIENT_ID }}
-            CF-Access-Client-Secret: ${{ secrets.CF_ACCESS_CI_CLIENT_SECRET }}
+            CF-Access-Client-Id: ${{ vars.CF_ACCESS_CLIENT_ID }}
+            CF-Access-Client-Secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
           secrets: |
-            ci/data/sentry/${{ env.VAULT_TIER }} auth_token | SENTRY_AUTH_TOKEN
+            ci/data/sentry/sourcemaps auth_token | SENTRY_AUTH_TOKEN
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -274,8 +278,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           vault_address: ${{ vars.VAULT_STAGE_ADDR }}
-          cf_access_client_id: ${{ vars.CF_ACCESS_CI_CLIENT_ID }}
-          cf_access_client_secret: ${{ secrets.CF_ACCESS_CI_CLIENT_SECRET }}
+          cf_access_client_id: ${{ vars.CF_ACCESS_STAGE_CLIENT_ID }}
+          cf_access_client_secret: ${{ secrets.CF_ACCESS_STAGE_CLIENT_SECRET }}
 
       - name: Prune repository
         uses: ./.github/actions/prune-repository

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,7 +55,9 @@ jobs:
         uses: ./.github/actions/install-tools
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          vault_address: ${{ secrets.VAULT_ADDR }}
+          vault_address: ${{ vars.VAULT_STAGE_ADDR }}
+          cf_access_client_id: ${{ vars.CF_ACCESS_CI_CLIENT_ID }}
+          cf_access_client_secret: ${{ secrets.CF_ACCESS_CI_CLIENT_SECRET }}
           rust: false
 
       # Service catalog: the single source of truth for build/manifest/deploy.
@@ -262,7 +264,9 @@ jobs:
         uses: ./.github/actions/install-tools
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          vault_address: ${{ secrets.VAULT_ADDR }}
+          vault_address: ${{ vars.VAULT_STAGE_ADDR }}
+          cf_access_client_id: ${{ vars.CF_ACCESS_CI_CLIENT_ID }}
+          cf_access_client_secret: ${{ secrets.CF_ACCESS_CI_CLIENT_SECRET }}
 
       - name: Prune repository
         uses: ./.github/actions/prune-repository

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -241,6 +241,10 @@ jobs:
     # isn't reachable from forks.
     if: needs.setup.outputs.sourcemaps != '{"name":[],"include":[]}' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-24.04
+    # The environment lands in the OIDC token as a claim the Vault role binds,
+    # and `main` only accepts the main branch. Picking the role in this
+    # expression is therefore no longer self-asserted.
+    environment: ${{ github.event_name == 'push' && 'main' || 'pull-request' }}
     permissions:
       id-token: write
       contents: read
@@ -249,13 +253,18 @@ jobs:
         id: secrets
         uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
         env:
-          VAULT_ROLE: ${{ github.event_name == 'push' && 'prod' || 'dev' }}
+          # Must stay in sync with the job's `environment:` above — the Vault
+          # role binds that value as a claim.
+          VAULT_TIER: ${{ github.event_name == 'push' && 'main' || 'pull-request' }}
         with:
-          url: ${{ secrets.VAULT_ADDR }}
+          url: ${{ vars.VAULT_STAGE_ADDR }}
           method: jwt
-          role: ${{ env.VAULT_ROLE }}
+          role: ci-hash-sentry-${{ env.VAULT_TIER }}
+          extraHeaders: |
+            CF-Access-Client-Id: ${{ vars.CF_ACCESS_CI_CLIENT_ID }}
+            CF-Access-Client-Secret: ${{ secrets.CF_ACCESS_CI_CLIENT_SECRET }}
           secrets: |
-            automation/data/pipelines/hash/${{ env.VAULT_ROLE }} sentry_auth_token | SENTRY_AUTH_TOKEN
+            ci/data/sentry/${{ env.VAULT_TIER }} auth_token | SENTRY_AUTH_TOKEN
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,8 +34,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           vault_address: ${{ vars.VAULT_STAGE_ADDR }}
-          cf_access_client_id: ${{ vars.CF_ACCESS_CI_CLIENT_ID }}
-          cf_access_client_secret: ${{ secrets.CF_ACCESS_CI_CLIENT_SECRET }}
+          cf_access_client_id: ${{ vars.CF_ACCESS_STAGE_CLIENT_ID }}
+          cf_access_client_secret: ${{ secrets.CF_ACCESS_STAGE_CLIENT_SECRET }}
           rust: false
 
       - name: Determine changed packages
@@ -73,8 +73,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           vault_address: ${{ vars.VAULT_STAGE_ADDR }}
-          cf_access_client_id: ${{ vars.CF_ACCESS_CI_CLIENT_ID }}
-          cf_access_client_secret: ${{ secrets.CF_ACCESS_CI_CLIENT_SECRET }}
+          cf_access_client_id: ${{ vars.CF_ACCESS_STAGE_CLIENT_ID }}
+          cf_access_client_secret: ${{ secrets.CF_ACCESS_STAGE_CLIENT_SECRET }}
 
       - name: Prune repository
         uses: ./.github/actions/prune-repository
@@ -219,8 +219,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           vault_address: ${{ vars.VAULT_STAGE_ADDR }}
-          cf_access_client_id: ${{ vars.CF_ACCESS_CI_CLIENT_ID }}
-          cf_access_client_secret: ${{ secrets.CF_ACCESS_CI_CLIENT_SECRET }}
+          cf_access_client_id: ${{ vars.CF_ACCESS_STAGE_CLIENT_ID }}
+          cf_access_client_secret: ${{ secrets.CF_ACCESS_STAGE_CLIENT_SECRET }}
 
       - name: Warm up repository
         uses: ./.github/actions/warm-up-repo

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,7 +33,9 @@ jobs:
         uses: ./.github/actions/install-tools
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          vault_address: ${{ secrets.VAULT_ADDR }}
+          vault_address: ${{ vars.VAULT_STAGE_ADDR }}
+          cf_access_client_id: ${{ vars.CF_ACCESS_CI_CLIENT_ID }}
+          cf_access_client_secret: ${{ secrets.CF_ACCESS_CI_CLIENT_SECRET }}
           rust: false
 
       - name: Determine changed packages
@@ -70,7 +72,9 @@ jobs:
         uses: ./.github/actions/install-tools
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          vault_address: ${{ secrets.VAULT_ADDR }}
+          vault_address: ${{ vars.VAULT_STAGE_ADDR }}
+          cf_access_client_id: ${{ vars.CF_ACCESS_CI_CLIENT_ID }}
+          cf_access_client_secret: ${{ secrets.CF_ACCESS_CI_CLIENT_SECRET }}
 
       - name: Prune repository
         uses: ./.github/actions/prune-repository
@@ -214,7 +218,9 @@ jobs:
         uses: ./.github/actions/install-tools
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          vault_address: ${{ secrets.VAULT_ADDR }}
+          vault_address: ${{ vars.VAULT_STAGE_ADDR }}
+          cf_access_client_id: ${{ vars.CF_ACCESS_CI_CLIENT_ID }}
+          cf_access_client_secret: ${{ secrets.CF_ACCESS_CI_CLIENT_SECRET }}
 
       - name: Warm up repository
         uses: ./.github/actions/warm-up-repo

--- a/.github/workflows/publish-blocks-to-preview.yml
+++ b/.github/workflows/publish-blocks-to-preview.yml
@@ -26,7 +26,9 @@ jobs:
         uses: ./.github/actions/install-tools
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          vault_address: ${{ secrets.VAULT_ADDR }}
+          vault_address: ${{ vars.VAULT_STAGE_ADDR }}
+          cf_access_client_id: ${{ vars.CF_ACCESS_CI_CLIENT_ID }}
+          cf_access_client_secret: ${{ secrets.CF_ACCESS_CI_CLIENT_SECRET }}
 
       - name: Warm up repository
         uses: ./.github/actions/warm-up-repo
@@ -58,7 +60,9 @@ jobs:
         uses: ./.github/actions/install-tools
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          vault_address: ${{ secrets.VAULT_ADDR }}
+          vault_address: ${{ vars.VAULT_STAGE_ADDR }}
+          cf_access_client_id: ${{ vars.CF_ACCESS_CI_CLIENT_ID }}
+          cf_access_client_secret: ${{ secrets.CF_ACCESS_CI_CLIENT_SECRET }}
 
       - name: Warm up repository
         uses: ./.github/actions/warm-up-repo

--- a/.github/workflows/publish-blocks-to-preview.yml
+++ b/.github/workflows/publish-blocks-to-preview.yml
@@ -27,8 +27,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           vault_address: ${{ vars.VAULT_STAGE_ADDR }}
-          cf_access_client_id: ${{ vars.CF_ACCESS_CI_CLIENT_ID }}
-          cf_access_client_secret: ${{ secrets.CF_ACCESS_CI_CLIENT_SECRET }}
+          cf_access_client_id: ${{ vars.CF_ACCESS_STAGE_CLIENT_ID }}
+          cf_access_client_secret: ${{ secrets.CF_ACCESS_STAGE_CLIENT_SECRET }}
 
       - name: Warm up repository
         uses: ./.github/actions/warm-up-repo
@@ -61,8 +61,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           vault_address: ${{ vars.VAULT_STAGE_ADDR }}
-          cf_access_client_id: ${{ vars.CF_ACCESS_CI_CLIENT_ID }}
-          cf_access_client_secret: ${{ secrets.CF_ACCESS_CI_CLIENT_SECRET }}
+          cf_access_client_id: ${{ vars.CF_ACCESS_STAGE_CLIENT_ID }}
+          cf_access_client_secret: ${{ secrets.CF_ACCESS_STAGE_CLIENT_SECRET }}
 
       - name: Warm up repository
         uses: ./.github/actions/warm-up-repo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,10 @@ jobs:
         id: secrets
         uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
         with:
-          url: ${{ secrets.VAULT_ADDR }}
+          # The legacy Vault, still holding the GitHub App credentials. Inline
+          # for the same reason as in bench.yml — this job has no environment,
+          # so `vars.VAULT_ADDR` would not resolve to a tier.
+          url: https://vault.blockprotocol.org
           method: jwt
           role: dev
           secrets: |
@@ -42,8 +45,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           vault_address: ${{ vars.VAULT_STAGE_ADDR }}
-          cf_access_client_id: ${{ vars.CF_ACCESS_CI_CLIENT_ID }}
-          cf_access_client_secret: ${{ secrets.CF_ACCESS_CI_CLIENT_SECRET }}
+          cf_access_client_id: ${{ vars.CF_ACCESS_STAGE_CLIENT_ID }}
+          cf_access_client_secret: ${{ secrets.CF_ACCESS_STAGE_CLIENT_SECRET }}
 
       - name: Warm up repository
         uses: ./.github/actions/warm-up-repo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,9 @@ jobs:
         uses: ./.github/actions/install-tools
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          vault_address: ${{ secrets.VAULT_ADDR }}
+          vault_address: ${{ vars.VAULT_STAGE_ADDR }}
+          cf_access_client_id: ${{ vars.CF_ACCESS_CI_CLIENT_ID }}
+          cf_access_client_secret: ${{ secrets.CF_ACCESS_CI_CLIENT_SECRET }}
 
       - name: Warm up repository
         uses: ./.github/actions/warm-up-repo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,9 @@ jobs:
         uses: ./.github/actions/install-tools
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          vault_address: ${{ secrets.VAULT_ADDR }}
+          vault_address: ${{ vars.VAULT_STAGE_ADDR }}
+          cf_access_client_id: ${{ vars.CF_ACCESS_CI_CLIENT_ID }}
+          cf_access_client_secret: ${{ secrets.CF_ACCESS_CI_CLIENT_SECRET }}
           rust: false
 
       - name: Determine changed packages
@@ -122,7 +124,9 @@ jobs:
         uses: ./.github/actions/install-tools
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          vault_address: ${{ secrets.VAULT_ADDR }}
+          vault_address: ${{ vars.VAULT_STAGE_ADDR }}
+          cf_access_client_id: ${{ vars.CF_ACCESS_CI_CLIENT_ID }}
+          cf_access_client_secret: ${{ secrets.CF_ACCESS_CI_CLIENT_SECRET }}
 
       - name: Prune repository
         uses: ./.github/actions/prune-repository
@@ -219,7 +223,9 @@ jobs:
         uses: ./.github/actions/install-tools
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          vault_address: ${{ secrets.VAULT_ADDR }}
+          vault_address: ${{ vars.VAULT_STAGE_ADDR }}
+          cf_access_client_id: ${{ vars.CF_ACCESS_CI_CLIENT_ID }}
+          cf_access_client_secret: ${{ secrets.CF_ACCESS_CI_CLIENT_SECRET }}
 
       - name: Prune repository
         uses: ./.github/actions/prune-repository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,6 @@ env:
   TURBO_TEAM: hashintel
   TURBO_CACHE: remote:rw
   NEXTEST_PROFILE: ci
-  VAULT_ADDR: ${{ secrets.VAULT_ADDR }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -51,8 +50,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           vault_address: ${{ vars.VAULT_STAGE_ADDR }}
-          cf_access_client_id: ${{ vars.CF_ACCESS_CI_CLIENT_ID }}
-          cf_access_client_secret: ${{ secrets.CF_ACCESS_CI_CLIENT_SECRET }}
+          cf_access_client_id: ${{ vars.CF_ACCESS_STAGE_CLIENT_ID }}
+          cf_access_client_secret: ${{ secrets.CF_ACCESS_STAGE_CLIENT_SECRET }}
           rust: false
 
       - name: Determine changed packages
@@ -125,8 +124,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           vault_address: ${{ vars.VAULT_STAGE_ADDR }}
-          cf_access_client_id: ${{ vars.CF_ACCESS_CI_CLIENT_ID }}
-          cf_access_client_secret: ${{ secrets.CF_ACCESS_CI_CLIENT_SECRET }}
+          cf_access_client_id: ${{ vars.CF_ACCESS_STAGE_CLIENT_ID }}
+          cf_access_client_secret: ${{ secrets.CF_ACCESS_STAGE_CLIENT_SECRET }}
 
       - name: Prune repository
         uses: ./.github/actions/prune-repository
@@ -224,8 +223,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           vault_address: ${{ vars.VAULT_STAGE_ADDR }}
-          cf_access_client_id: ${{ vars.CF_ACCESS_CI_CLIENT_ID }}
-          cf_access_client_secret: ${{ secrets.CF_ACCESS_CI_CLIENT_SECRET }}
+          cf_access_client_id: ${{ vars.CF_ACCESS_STAGE_CLIENT_ID }}
+          cf_access_client_secret: ${{ secrets.CF_ACCESS_STAGE_CLIENT_SECRET }}
 
       - name: Prune repository
         uses: ./.github/actions/prune-repository


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Two CI secrets move to a dedicated `ci/` mount, each read by a role scoped to a single path: the sccache build cache and the Sentry sourcemap token.

Stacked on #9160. The Vault side is already applied.

## 🔗 Related links

- [SRE-915](https://linear.app/hash/issue/SRE-915/narrow-vault-dev-role-housekeeping-workflow) _(internal)_
- Terraform: `internal-infra#319`

## 🚫 Blocked by

- [ ] #9160

## 🔍 What does this change?

**Sentry** — the `sourcemaps` job declares a GitHub environment, and both the Vault address and the Cloudflare Access credentials resolve from it. Each instance holds only its own tier's token, so the role name and the path carry no tier. The environment is keyed on the ref, so a `workflow_dispatch` on `main` — a publishing run elsewhere in this workflow — gets the same tier as a push.

**sccache** — `install-sccache` reads `ci/data/sccache/r2` with `role: ci-hash-sccache` instead of `role: dev`, and sends Access headers. `install-tools` gained `vault_address`, `cf_access_client_id` and `cf_access_client_secret`; the sccache gate moved to the client secret, which keeps it skipped on fork pull requests.

sccache stays on explicitly pinned names rather than the environment-resolved ones: it runs in twenty jobs that declare no environment, and a shared cache should serve pull requests and `main` alike. Its install step is now `continue-on-error` — a cache must not be able to fail the build.

**Legacy** — `bench.yml` and `release.yml` still read their own secrets from the old Vault and take its address inline, because they have no environment and would otherwise resolve to the wrong instance. `test.yml` lost a `VAULT_ADDR` it no longer read.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

- The `sourcemaps` job now produces a deployment record per run, pull requests included. Accepted for one job; the same on the sccache path would mean ~20 per run.
- `account_id` and `bucket` sit in Vault alongside the two R2 keys although neither is a secret, so both are masked in logs and the sccache endpoint reads as `https://***.r2.cloudflarestorage.com`. Moving them out means two more inputs across 20 call sites, which is not worth it until endpoint debugging actually hurts.
- `bench` and `release` still read from the old Vault. Retiring it needs those two moved first.

## 🐾 Next steps

- Once merged, the repo-level `VAULT_ADDR` variable and secret are unreferenced and can go.

## 🛡 What tests cover this?

- sccache: every workflow using `install-tools` with Rust enabled exercises it. With `continue-on-error` a Vault failure no longer fails the job, so check the step's own outcome rather than the job's.
- Sentry: a pull-request run of `deploy.yml` covers one tier, a push to `main` the other.
- Verified against both applied Vaults: each role carries the expected claims, and the field names match what the actions request.
- Not covered: fork pull requests, which cannot be exercised from a same-repo branch.

## ❓ How to test this?

1. Any `Install tools` step with Rust enabled — `Retrieve secrets` succeeds and `Start sccache server` connects
2. A `deploy.yml` run with sourcemaps in the matrix — `sentry-cli login` succeeds
3. A job with `rust: false` still skips sccache

## 📹 Demo

Not applicable, CI-only change.
