### PR TITLE
SRE-924: Mint the release token from a Vault-held key

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -257,16 +257,18 @@ jobs:
         id: secrets
         uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
         with:
-          # Address and Access credentials come from the job's environment:
-          # `pull-request` resolves to the staging Vault, `main` to production.
-          # Each instance holds only its own tier's token, so the role name and
-          # the path carry no tier — the instance is the tier.
-          url: ${{ vars.VAULT_ADDR }}
+          # Named per tier so each value lives once, at the organization. The
+          # condition repeats the one on `environment` above, and a mismatch
+          # cannot reach the wrong tier: the role binds the environment claim,
+          # so credentials for one instance never authenticate against the
+          # other. Each instance holds only its own tier's token, so the role
+          # name and the path carry no tier — the instance is the tier.
+          url: ${{ github.ref == 'refs/heads/main' && vars.VAULT_PROD_ADDR || vars.VAULT_STAGE_ADDR }}
           method: jwt
           role: ci-hash-sentry
           extraHeaders: |
-            CF-Access-Client-Id: ${{ vars.CF_ACCESS_CLIENT_ID }}
-            CF-Access-Client-Secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+            CF-Access-Client-Id: ${{ github.ref == 'refs/heads/main' && vars.CF_ACCESS_PROD_CLIENT_ID || vars.CF_ACCESS_STAGE_CLIENT_ID }}
+            CF-Access-Client-Secret: ${{ github.ref == 'refs/heads/main' && secrets.CF_ACCESS_PROD_CLIENT_SECRET || secrets.CF_ACCESS_STAGE_CLIENT_SECRET }}
           secrets: |
             ci/data/sentry/sourcemaps auth_token | SENTRY_AUTH_TOKEN
 

--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -40,16 +40,15 @@ on:
           - lookup
           - full
 
-permissions:
-  actions: read
-  contents: read
-  id-token: write
+permissions: {}
 
 jobs:
   validate:
     name: Validate
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -62,9 +61,15 @@ jobs:
 
   renovate:
     name: Dependencies
-    uses: hashintel/.github/.github/workflows/housekeeping-dependencies.yml@9957be5b132761d8b54dea2eb3166f417ebacaf9 # main
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    uses: hashintel/.github/.github/workflows/housekeeping-dependencies.yml@89ff06bc761f0c0491d87a766eccce5aae6190ea # main
     with:
       repoCache: ${{ inputs.repoCache || 'enabled' }}
       logLevel: ${{ inputs.logLevel || 'info' }}
       overrideSchedule: ${{ inputs.overrideSchedule || false }}
       dryRun: ${{ inputs.dryRun || 'disabled' }}
+    secrets:
+      CF_ACCESS_STAGE_CLIENT_SECRET: ${{ secrets.CF_ACCESS_STAGE_CLIENT_SECRET }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,8 @@ jobs:
           app-id: "4497272"
           transit-key: github-app-hash-release
           repository: ${{ github.repository }}
-          cf-access-client-id: ${{ vars.CF_ACCESS_CLIENT_ID }}
-          cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+          cf-access-client-id: ${{ vars.CF_ACCESS_PROD_CLIENT_ID }}
+          cf-access-client-secret: ${{ secrets.CF_ACCESS_PROD_CLIENT_SECRET }}
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,30 +11,21 @@ jobs:
   release:
     runs-on: ubuntu-latest
     if: github.repository == 'hashintel/hash'
+    environment: main
     permissions:
       id-token: write
 
     steps:
-      - name: Authenticate Vault
-        id: secrets
-        uses: hashicorp/vault-action@4c06c5ccf5c0761b6029f56cfb1dcf5565918a3b # v3.4.0
-        with:
-          # The legacy Vault, still holding the GitHub App credentials. Inline
-          # for the same reason as in bench.yml — this job has no environment,
-          # so `vars.VAULT_ADDR` would not resolve to a tier.
-          url: https://vault.blockprotocol.org
-          method: jwt
-          role: dev
-          secrets: |
-            automation/data/pipelines/hash/dev github_worker_app_id | GITHUB_WORKER_APP_ID ;
-            automation/data/pipelines/hash/dev github_worker_app_private_key | GITHUB_WORKER_APP_PRIVATE_KEY ;
-
       - name: Get token
         id: app-token
-        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        uses: hashintel/.github/.github/actions/github-app-token@6784697ebabfa119d36ab0a335cfdad3555d9e4f # unmerged — re-pin to main
         with:
-          app-id: ${{ steps.secrets.outputs.GITHUB_WORKER_APP_ID }}
-          private-key: ${{ steps.secrets.outputs.GITHUB_WORKER_APP_PRIVATE_KEY }}
+          vault-address: ${{ vars.VAULT_ADDR }}
+          vault-role: ci-hash-release
+          app-id: "4497272"
+          transit-key: github-app-hash-release
+          cf-access-client-id: ${{ vars.CF_ACCESS_CLIENT_ID }}
+          cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Get token
         id: app-token
-        uses: hashintel/.github/.github/actions/github-app-token@6235da521f7054945cf1ff9967708d40c745c6b4 # unmerged — re-pin to the merged SHA, not @main
+        uses: hashintel/.github/.github/actions/github-app-token@89ff06bc761f0c0491d87a766eccce5aae6190ea # main
         with:
           vault-address: ${{ vars.VAULT_ADDR }}
           vault-role: ci-hash-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,12 +18,13 @@ jobs:
     steps:
       - name: Get token
         id: app-token
-        uses: hashintel/.github/.github/actions/github-app-token@6784697ebabfa119d36ab0a335cfdad3555d9e4f # unmerged — re-pin to main
+        uses: hashintel/.github/.github/actions/github-app-token@6235da521f7054945cf1ff9967708d40c745c6b4 # unmerged — re-pin to main
         with:
           vault-address: ${{ vars.VAULT_ADDR }}
           vault-role: ci-hash-release
           app-id: "4497272"
           transit-key: github-app-hash-release
+          repository: ${{ github.repository }}
           cf-access-client-id: ${{ vars.CF_ACCESS_CLIENT_ID }}
           cf-access-client-secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Get token
         id: app-token
-        uses: hashintel/.github/.github/actions/github-app-token@6235da521f7054945cf1ff9967708d40c745c6b4 # unmerged — re-pin to main
+        uses: hashintel/.github/.github/actions/github-app-token@6235da521f7054945cf1ff9967708d40c745c6b4 # unmerged — re-pin to the merged SHA, not @main
         with:
           vault-address: ${{ vars.VAULT_ADDR }}
           vault-role: ci-hash-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         id: app-token
         uses: hashintel/.github/.github/actions/github-app-token@89ff06bc761f0c0491d87a766eccce5aae6190ea # main
         with:
-          vault-address: ${{ vars.VAULT_ADDR }}
+          vault-address: ${{ vars.VAULT_PROD_ADDR }}
           vault-role: ci-hash-release
           app-id: "4497272"
           transit-key: github-app-hash-release


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The release job read a GitHub App's private key out of the legacy Vault and
minted an installation token with no repository scope, using an App that also
carries `workflows: write`. It now signs as a dedicated release App whose key
never leaves Vault, and the token it gets is scoped to this repository.

## 🔗 Related links

- hashintel/.github#95 — the composite action this uses
- hashintel/internal-infra#321 — the transit mount, key and role _(internal)_

## 🚫 Blocked by

- [ ] hashintel/.github#95, because the action is pinned to a commit on that branch

## 🔍 What does this change?

- `release.yml` drops the `vault-action` secret read and `create-github-app-token`
  in favour of `hashintel/.github/.github/actions/github-app-token`, which has
  Vault sign the App JWT
- the job now declares `environment: main`, which is what resolves the production
  Vault address, and puts the environment claim in the OIDC token so the Vault
  role can bind it
- authenticates as the `hash-release` App (four permissions) rather than
  `hash-worker` (nine)

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

The action is pinned to an unmerged commit of hashintel/.github#95, marked in
place with `# unmerged — re-pin to main`. It has to be re-pinned once that PR
merges, and this PR must not merge before then.

## 🐾 Next steps

Once a release run is green, the App key can be revoked in the App settings.

## 🛡 What tests cover this?

- None automated. The JWT assembly was verified against the GitHub API, and the
  imported key was verified byte-for-byte against its PEM.

## ❓ How to test this?

1. Merge hashintel/.github#95 and re-pin the action to main
2. Push to `main`
3. Confirm the release job obtains a token and changesets runs; a mismatched role,
   claim or key fails visibly at the Vault login or the App JWT exchange
