### PR TITLE
SRE-909: Gate fresh package releases for seven days

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -8,7 +8,7 @@ _.file                        = [".env", ".env.local"]
 [settings]
 idiomatic_version_file_enable_tools = ["rust"]
 lockfile                            = true
-minimum_release_age                 = "5d"
+minimum_release_age                 = "7d"
 
 [tools]
 # Basic tools

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -13,4 +13,4 @@ nmMode: hardlinks-local
 # node-modules is slower during the linking step but works.
 nodeLinker: node-modules
 
-npmMinimalAgeGate: 5d
+npmMinimalAgeGate: 7d


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Raises both release-age gates from five to seven days, following Semgrep's guidance on how long malicious npm releases typically survive before takedown. Follow-up to #9186; keeps `hash` consistent with hashintel/internal-sites#215.

## 🔗 Related links

- [SRE-909](https://linear.app/hash/issue/SRE-909/harden-dependency-installs-in-internal-and-internal-sites) _(internal)_

## 🔍 What does this change?

- `.yarnrc.yml`: `npmMinimalAgeGate` 5d → 7d
- `.config/mise/config.toml`: `minimum_release_age` 5d → 7d

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- None; CI's own installs exercise both gates.

## ❓ How to test this?

1. CI `yarn install --immutable` and `mise install --locked` pass unchanged — the gates only affect newly resolved versions, not the pinned ones.
