### PR TITLE
SRE-769: Publish crates via OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,3 +94,64 @@ jobs:
           path: |
             /home/runner/.npm/_logs/
             **/.turbo/*.log
+
+  publish-rust:
+    name: Publish (Rust)
+    runs-on: ubuntu-24.04
+    if: github.repository == 'hashintel/hash'
+    environment: main
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 2
+
+      - name: Determine crates to publish
+        id: crates
+        run: |
+          PACKAGES=""
+          while IFS= read -r file; do
+            if [[ -n "$file" ]]; then
+              PACKAGE_NAME=$(yq '.package.name' -p toml -oy "$file")
+              if [[ "$PACKAGE_NAME" == "null" ]]; then
+                continue
+              fi
+
+              if [[ "$(yq '.package.publish' -p toml -oy "$file")" == "false" ]]; then
+                continue
+              fi
+
+              if [[ "$(yq '.package.publish.workspace' -p toml -oy "$file")" == "true" ]]; then
+                if [[ "$(yq '.workspace.package.publish' -p toml -oy "Cargo.toml")" == "false" ]]; then
+                  continue
+                fi
+              fi
+
+              OLD_VERSION=$(git show HEAD^:"$file" | yq '.package.version' -p toml)
+              if [[ "$OLD_VERSION" == "null" ]]; then
+                continue
+              fi
+              NEW_VERSION=$(yq '.package.version' -p toml -oy "$file")
+              if [[ "$OLD_VERSION" == "$NEW_VERSION" ]]; then
+                continue
+              fi
+
+              PACKAGES="$PACKAGES -p $PACKAGE_NAME"
+            fi
+          done <<< "$(find . -name 'Cargo.toml' -type f | sed 's|\./||')"
+
+          echo "packages=${PACKAGES# }" | tee -a "$GITHUB_OUTPUT"
+
+      - name: Authenticate with crates.io
+        id: auth
+        if: steps.crates.outputs.packages != ''
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+
+      - name: Publish
+        if: steps.crates.outputs.packages != ''
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: cargo publish --all-features --no-verify ${{ steps.crates.outputs.packages }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -343,9 +343,9 @@ jobs:
             var/logs
 
   publish-rust:
-    name: Publish (Rust)
+    name: Publish dry run (Rust)
     needs: [setup]
-    if: needs.setup.outputs.publish-rust != '[]'
+    if: needs.setup.outputs.publish-rust != '[]' && (github.event_name == 'pull_request' || github.event_name == 'merge_group')
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout source code
@@ -362,18 +362,8 @@ jobs:
           PACKAGES=$(echo "$PUBLISH_PACKAGES" | jq -r '.[]' | while read -r pkg; do echo -n "-p $pkg "; done)
           echo "packages=$PACKAGES" | tee -a "$GITHUB_OUTPUT"
 
-      - name: Login
-        run: |
-          [[ -n "${{ secrets.CARGO_REGISTRY_TOKEN }}" ]]
-          cargo login "${{ secrets.CARGO_REGISTRY_TOKEN }}"
-
       - name: Publish (dry run)
-        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
         run: cargo publish --all-features --dry-run --no-verify ${{ steps.flags.outputs.packages }}
-
-      - name: Publish
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: cargo publish --all-features --no-verify ${{ steps.flags.outputs.packages }}
 
   passed:
     name: Tests passed


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Publishes crates to crates.io via OIDC trusted publishing instead of the long-lived `CARGO_REGISTRY_TOKEN` secret. The registry then only accepts tokens minted by the `release.yml` workflow inside the `main` environment, so publishing requires both registry-side configuration and the gated workflow.

## 🔗 Related links

- [SRE-769](https://linear.app/hash/issue/SRE-769) _(internal)_
- [crates.io trusted publishing](https://crates.io/docs/trusted-publishing)

## 🔍 What does this change?

- `release.yml`: new `publish-rust` job — detects version-bumped publishable crates (same detection as `test.yml`), exchanges the GitHub OIDC token for a 30-minute crates.io token via `rust-lang/crates-io-auth-action`, and publishes. Runs in the `main` environment with `id-token: write`.
- `test.yml`: the publish job becomes dry-run-only (`pull_request`/`merge_group`), renamed to `Publish dry run (Rust)`. The `cargo login` step is gone — dry runs need no authentication, which also unbreaks fork PRs that bump a crate version.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph