### PR TITLE
FE-1381: use ds button group in petrinaut

### DIFF
--- a/libs/@hashintel/ds-components/src/components/ButtonGroup/button-group.recipe.ts
+++ b/libs/@hashintel/ds-components/src/components/ButtonGroup/button-group.recipe.ts
@@ -8,9 +8,7 @@ export const styles = cva({
   },
   variants: {
     variant: {
-      spaced: {
-        gap: "2",
-      },
+      spaced: {},
       segmented: {
         columnGap: "0",
         rowGap: "2",
@@ -45,6 +43,16 @@ export const styles = cva({
         },
       },
     },
+    // The gap between buttons in a `spaced` group, on the shared FormInputSize
+    // scale. Keys declare the variant; the gap value is set per-variant below so
+    // it only applies to `spaced`.
+    spacing: {
+      xxs: {},
+      xs: {},
+      sm: {},
+      md: {},
+      lg: {},
+    },
     alignedTo: {
       left: { justifyContent: "flex-start" },
       right: { justifyContent: "flex-end" },
@@ -54,8 +62,16 @@ export const styles = cva({
       false: { flexWrap: "wrap" },
     },
   },
+  compoundVariants: [
+    { variant: "spaced", spacing: "xxs", css: { gap: "1" } },
+    { variant: "spaced", spacing: "xs", css: { gap: "1.5" } },
+    { variant: "spaced", spacing: "sm", css: { gap: "2" } },
+    { variant: "spaced", spacing: "md", css: { gap: "2.5" } },
+    { variant: "spaced", spacing: "lg", css: { gap: "3" } },
+  ],
   defaultVariants: {
     variant: "spaced",
+    spacing: "md",
     alignedTo: "left",
     noWrap: false,
   },

--- a/libs/@hashintel/ds-components/src/components/ButtonGroup/button-group.stories.tsx
+++ b/libs/@hashintel/ds-components/src/components/ButtonGroup/button-group.stories.tsx
@@ -1,5 +1,6 @@
 import { css } from "@hashintel/ds-helpers/css";
 
+import { type FormInputSize, formInputSizes } from "../../util/form-shared";
 import { Button } from "../Button/button";
 import { ButtonGroup } from "./button-group";
 
@@ -99,9 +100,13 @@ const frameClass = css({
 const shortLabels = ["One", "Two", "Three"];
 const manyLabels = ["Alpha", "Beta", "Gamma", "Delta", "Epsilon", "Zeta"];
 
-const buttons = (labels: string[], variant: ButtonVariant = "subtle") =>
+const buttons = (
+  labels: string[],
+  variant: ButtonVariant = "subtle",
+  size?: FormInputSize,
+) =>
   labels.map((label, index) => (
-    <Button key={label} variant={variant} pressed={index === 0}>
+    <Button key={label} variant={variant} size={size} pressed={index === 0}>
       {label}
     </Button>
   ));
@@ -163,6 +168,29 @@ export const Default: Story = () => (
 );
 
 Default.parameters = {
+  controls: { disable: true },
+  actions: { disable: true },
+  interactions: { disable: true },
+};
+
+export const Spacing: Story = () => (
+  <div className={pageClass}>
+    <section className={sectionClass}>
+      <span className={sectionHeadingClass}>spaced · all spacing sizes</span>
+      <div className={compactRowsClass}>
+        {formInputSizes.map((spacing) => (
+          <Example key={spacing} framed={false} label={`spacing=${spacing}`}>
+            <ButtonGroup variant="spaced" spacing={spacing}>
+              {buttons(shortLabels, "subtle", spacing)}
+            </ButtonGroup>
+          </Example>
+        ))}
+      </div>
+    </section>
+  </div>
+);
+
+Spacing.parameters = {
   controls: { disable: true },
   actions: { disable: true },
   interactions: { disable: true },

--- a/libs/@hashintel/ds-components/src/components/ButtonGroup/button-group.tsx
+++ b/libs/@hashintel/ds-components/src/components/ButtonGroup/button-group.tsx
@@ -7,6 +7,8 @@ import { cx } from "@hashintel/ds-helpers/css";
 import { styles } from "./button-group.recipe";
 import { useSegmentedRows } from "./use-segmented-rows";
 
+import type { FormInputSize } from "../../util/form-shared";
+
 export type ButtonGroupProps = {
   className?: string;
   children?: React.ReactNode;
@@ -15,6 +17,13 @@ export type ButtonGroupProps = {
    * a single control with shared, overlapping borders.
    */
   variant?: "spaced" | "segmented";
+  /**
+   * The gap between buttons in a `spaced` group, on the shared FormInputSize
+   * scale. Has no effect on `segmented` groups, whose buttons share a border.
+   * Aligned + fitted to Button sizes with the same value, so usually should
+   * match the button size of the children.
+   */
+  spacing?: FormInputSize;
   /** Reverse the visual (and focus/tab) order of the buttons. */
   reverse?: boolean;
   /** Which edge of the available width the buttons align to. Defaults to `left`. */
@@ -27,6 +36,7 @@ export const ButtonGroup = ({
   className,
   children,
   variant = "spaced",
+  spacing = "md",
   reverse = false,
   alignedTo = "left",
   noWrap = false,
@@ -43,7 +53,7 @@ export const ButtonGroup = ({
     <div
       ref={ref}
       role="group"
-      className={cx(styles({ variant, alignedTo, noWrap }), className)}
+      className={cx(styles({ variant, spacing, alignedTo, noWrap }), className)}
     >
       {decoratedContent}
     </div>

--- a/libs/@hashintel/petrinaut/src/ui/components/walkthrough/walkthrough-dialog.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/components/walkthrough/walkthrough-dialog.tsx
@@ -1,6 +1,6 @@
 import { use, useState } from "react";
 
-import { Button, Dialog } from "@hashintel/ds-components";
+import { Button, ButtonGroup, Dialog } from "@hashintel/ds-components";
 import { css } from "@hashintel/ds-helpers/css";
 
 import {
@@ -86,6 +86,8 @@ const progressGroupStyle = css({
   display: "flex",
   alignItems: "center",
   gap: "3",
+  // Keep its content width so the full-width ButtonGroup beside it doesn't squash it.
+  flexShrink: "[0]",
 });
 
 const srOnlyStyle = css({
@@ -126,12 +128,6 @@ const dividerStyle = css({
   height: "[16px]",
   backgroundColor: "neutral.a10",
   flexShrink: "[0]",
-});
-
-const actionsStyle = css({
-  display: "flex",
-  alignItems: "center",
-  gap: "2",
 });
 
 export type WalkthroughDialogProps = {
@@ -268,7 +264,7 @@ export const WalkthroughDialog: React.FC<WalkthroughDialogProps> = ({
               </Button>
             )}
           </div>
-          <div className={actionsStyle}>
+          <ButtonGroup alignedTo="right">
             <Button
               variant="subtle"
               size="sm"
@@ -285,7 +281,7 @@ export const WalkthroughDialog: React.FC<WalkthroughDialogProps> = ({
             >
               {atLast ? "Get started" : "Next"}
             </Button>
-          </div>
+          </ButtonGroup>
         </div>
       </Dialog.Footer>
     </Dialog>

--- a/libs/@hashintel/petrinaut/src/ui/components/walkthrough/walkthrough-dialog.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/components/walkthrough/walkthrough-dialog.tsx
@@ -264,7 +264,7 @@ export const WalkthroughDialog: React.FC<WalkthroughDialogProps> = ({
               </Button>
             )}
           </div>
-          <ButtonGroup alignedTo="right">
+          <ButtonGroup alignedTo="right" spacing="sm">
             <Button
               variant="subtle"
               size="sm"

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel/interactive-tools/apply-auto-layout-widget.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel/interactive-tools/apply-auto-layout-widget.tsx
@@ -59,7 +59,7 @@ const ApplyAutoLayoutWidget = ({
         The assistant suggests running auto-layout on the net. This may
         reposition places and transitions.
       </span>
-      <ButtonGroup>
+      <ButtonGroup spacing="sm">
         <Button
           size="sm"
           variant="solid"

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel/interactive-tools/apply-auto-layout-widget.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel/interactive-tools/apply-auto-layout-widget.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@hashintel/ds-components";
+import { Button, ButtonGroup } from "@hashintel/ds-components";
 import { css } from "@hashintel/ds-helpers/css";
 import {
   aiCommandActionInputSchemas,
@@ -27,12 +27,6 @@ const widgetStyle = css({
   color: "[#0666c6]",
   fontSize: "sm",
   fontWeight: "medium",
-});
-
-const buttonsStyle = css({
-  display: "flex",
-  alignItems: "center",
-  gap: "2",
 });
 
 const summaryStyle = css({
@@ -65,7 +59,7 @@ const ApplyAutoLayoutWidget = ({
         The assistant suggests running auto-layout on the net. This may
         reposition places and transitions.
       </span>
-      <div className={buttonsStyle}>
+      <ButtonGroup>
         <Button
           size="sm"
           variant="solid"
@@ -89,7 +83,7 @@ const ApplyAutoLayoutWidget = ({
         >
           No, keep current layout
         </Button>
-      </div>
+      </ButtonGroup>
     </div>
   );
 };


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Use button group in petrinaut. I've left many button collections with their custom flex styles instead of switching to button group which is as intended - button group does not need to be used all the time.
 
## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change
