### PR TITLE
FE-425: Prevent link buttons from being draggable

### DIFF
--- a/apps/hash-frontend/src/pages/notes.page/editable-quick-note.tsx
+++ b/apps/hash-frontend/src/pages/notes.page/editable-quick-note.tsx
@@ -361,6 +361,7 @@ export const EditableQuickNote: FunctionComponent<{
                   </IconButton>
                 ) : (
                   <Link
+                    draggable={false}
                     href={constructPageRelativeUrl({
                       workspaceShortname: authenticatedUser.shortname!,
                       pageEntityUuid: extractEntityUuidFromEntityId(

--- a/apps/hash-frontend/src/pages/shared/copyable-ontology-chip.tsx
+++ b/apps/hash-frontend/src/pages/shared/copyable-ontology-chip.tsx
@@ -71,7 +71,7 @@ export const CopyableOntologyChip: FunctionComponent<{
         </ButtonBase>
       </Tooltip>
       {!hideOpenInNew && (
-        <Link href={versionedUrl} target="_blank">
+        <Link href={versionedUrl} target="_blank" draggable={false}>
           <IconButton
             sx={{
               padding: 0,

--- a/apps/hash-frontend/src/pages/shared/settings-layout/settings-sidebar.tsx
+++ b/apps/hash-frontend/src/pages/shared/settings-layout/settings-sidebar.tsx
@@ -148,6 +148,7 @@ const SidebarItem = ({
           color={itemColor}
           href={item.href}
           level={level}
+          draggable={false}
         >
           {item.label}
         </ItemLink>

--- a/apps/hash-frontend/src/pages/supply-chain/shared/action-buttons.tsx
+++ b/apps/hash-frontend/src/pages/supply-chain/shared/action-buttons.tsx
@@ -94,6 +94,7 @@ export const BriefLink = ({
       href={href}
       className={cx(briefLinkStyle, className)}
       target="_blank"
+      draggable={false}
       onClick={onClick}
     >
       <Icon name="fileLines" size="xs" />

--- a/apps/hash-frontend/src/shared/layout/layout-with-header/account-dropdown.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-header/account-dropdown.tsx
@@ -123,6 +123,7 @@ export const AccountDropdown: FunctionComponent<AccountDropdownProps> = ({
         <Link
           href={`/@${authenticatedUser.shortname}`}
           noLinkStyle
+          draggable={false}
           sx={{
             [`&:hover .${typographyClasses.root}`]: {
               color: ({ palette }) => palette.blue[70],

--- a/apps/hash-frontend/src/shared/layout/layout-with-header/notifications-dropdown.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-header/notifications-dropdown.tsx
@@ -26,7 +26,7 @@ export const NotificationsDropdown: FunctionComponent = () => {
 
   return (
     <Tooltip title="Notifications" placement="bottom">
-      <Link noLinkStyle href={href}>
+      <Link noLinkStyle href={href} draggable={false}>
         <HeaderIconButtonWithCount
           icon={
             <FontAwesomeIcon

--- a/apps/hash-frontend/src/shared/layout/layout-with-header/page-header.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-header/page-header.tsx
@@ -98,7 +98,7 @@ export const PageHeader: FunctionComponent = () => {
                 <ActionsDropdown />
                 <NotificationsDropdown />
                 <Tooltip title="Actions" placement="bottom">
-                  <Link noLinkStyle href="/actions">
+                  <Link noLinkStyle href="/actions" draggable={false}>
                     <HeaderIconButtonWithCount
                       icon={
                         <CheckRegularIcon

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar/account-entities-list.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar/account-entities-list.tsx
@@ -179,7 +179,12 @@ export const AccountEntitiesList: FunctionComponent<
               setSortType={setSortType}
               activeSortType={sortType}
             />
-            <Link tabIndex={-1} href="/new/entity" noLinkStyle>
+            <Link
+              tabIndex={-1}
+              href="/new/entity"
+              noLinkStyle
+              draggable={false}
+            >
               <Tooltip title="Create new entity " sx={{ left: 5 }}>
                 <IconButton
                   data-testid="create-entity-btn"

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar/account-entity-type-list.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar/account-entity-type-list.tsx
@@ -136,7 +136,12 @@ export const AccountEntityTypeList: FunctionComponent<
               setSortType={setSortType}
               activeSortType={sortType}
             />
-            <Link tabIndex={-1} href="/new/types/entity-type" noLinkStyle>
+            <Link
+              tabIndex={-1}
+              href="/new/types/entity-type"
+              noLinkStyle
+              draggable={false}
+            >
               <Tooltip title="Create new entity type" sx={{ left: 5 }}>
                 <IconButton
                   data-testid="create-entity-type-btn"

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar/account-page-list/page-tree-item.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar/account-page-list/page-tree-item.tsx
@@ -105,6 +105,7 @@ export const PageTreeItem = forwardRef<HTMLAnchorElement, PageTreeItemProps>(
           noLinkStyle
           href={pagePath}
           tabIndex={0}
+          draggable={false}
           sx={({ palette, transitions }) => ({
             ...style,
             display: "flex",

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar/shared/entity-or-type-sidebar-item.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar/shared/entity-or-type-sidebar-item.tsx
@@ -92,6 +92,7 @@ export const EntityOrTypeSidebarItem: FunctionComponent<{
         tabIndex={-1}
         sx={{ flex: 1 }}
         noLinkStyle
+        draggable={false}
         href={href ?? baseUrl}
         flex={1}
       >

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar/shared/view-all-link.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar/shared/view-all-link.tsx
@@ -13,7 +13,7 @@ export const ViewAllLink: FunctionComponent<{
   children: ReactNode;
 }> = ({ href, sx, children }) => {
   return (
-    <Link href={href} noLinkStyle tabIndex={-1} sx={sx}>
+    <Link href={href} noLinkStyle tabIndex={-1} draggable={false} sx={sx}>
       <Typography
         variant="smallTextLabels"
         sx={({ palette }) => ({

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar/top-nav-link.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar/top-nav-link.tsx
@@ -35,6 +35,7 @@ export const TopNavLink: FunctionComponent<NavLinkProps> = ({
       <Link
         href={href}
         noLinkStyle
+        draggable={false}
         sx={[
           ({ palette, transitions, spacing }) => ({
             display: "flex",

--- a/apps/hash-frontend/src/shared/ui/menu-item.tsx
+++ b/apps/hash-frontend/src/shared/ui/menu-item.tsx
@@ -25,7 +25,7 @@ export const MenuItem = forwardRef<HTMLLIElement | null, MenuItemProps>(
 
     if (href) {
       return (
-        <Link noLinkStyle href={href}>
+        <Link noLinkStyle href={href} draggable={false}>
           {Component}
         </Link>
       );

--- a/apps/hash-frontend/src/shared/ui/tab-link.tsx
+++ b/apps/hash-frontend/src/shared/ui/tab-link.tsx
@@ -38,6 +38,7 @@ export const TabLink: FunctionComponent<TabLinkProps> = ({
     value={value}
     onClick={onClick}
     href={href}
+    draggable={false}
     component={Link}
     label={
       <Typography

--- a/libs/@hashintel/design-system/src/button.tsx
+++ b/libs/@hashintel/design-system/src/button.tsx
@@ -85,6 +85,8 @@ const Button: ForwardRefRenderFunction<HTMLButtonElement, ButtonProps> = (
       },
       ...(Array.isArray(sx) ? sx : [sx]),
     ]}
+    // buttons rendered as anchors shouldn't have the browser's native link dragging
+    {...(props.href !== undefined ? { draggable: false } : {})}
     {...props}
     ref={ref}
   >

--- a/libs/@hashintel/design-system/src/icon-button.tsx
+++ b/libs/@hashintel/design-system/src/icon-button.tsx
@@ -13,6 +13,10 @@ export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
     return (
       <MuiIconButton
         ref={ref}
+        // buttons rendered as anchors shouldn't have the browser's native link dragging
+        {...("href" in props && props.href !== undefined
+          ? { draggable: false }
+          : {})}
         {...props}
         sx={[
           {

--- a/libs/@hashintel/ds-components/src/components/Button/button.tsx
+++ b/libs/@hashintel/ds-components/src/components/Button/button.tsx
@@ -244,6 +244,7 @@ export const Button = (props: ButtonProps) => {
         download={isInactive ? undefined : props.download || undefined}
         tabIndex={isInactive ? -1 : props.tabIndex}
         aria-label={props["aria-label"] ?? (!children ? tooltip : undefined)}
+        draggable={false}
       >
         {content}
       </a>


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Prevent link buttons from being draggable, as browsers by default make anything with an href draggable.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change
