### PR TITLE
BE-332: Add fail-closed request authentication to the Graph REST API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3558,6 +3558,7 @@ dependencies = [
  "harpc-tower",
  "harpc-types",
  "hash-codec",
+ "hash-graph-authentication",
  "hash-graph-authorization",
  "hash-graph-embeddings",
  "hash-graph-postgres-store",
@@ -3606,7 +3607,15 @@ dependencies = [
 name = "hash-graph-authentication"
 version = "0.0.0"
 dependencies = [
+ "derive_more",
+ "error-stack",
+ "hash-status",
+ "http 1.4.2",
  "simple-mermaid",
+ "tokio",
+ "tracing",
+ "type-system",
+ "uuid",
 ]
 
 [[package]]

--- a/apps/hash-graph/docs/dependency-diagram.mmd
+++ b/apps/hash-graph/docs/dependency-diagram.mmd
@@ -14,101 +14,105 @@ graph TD
     2[<a href="../hash_codec/index.html">hash-codec</a>]
     3[<a href="../hash_codegen/index.html">hash-codegen</a>]
     4[<a href="../hash_graph_api/index.html">hash-graph-api</a>]
-    5[<a href="../hash_graph_authorization/index.html">hash-graph-authorization</a>]
-    6[<a href="../hash_graph_embeddings/index.html">hash-graph-embeddings</a>]
-    7[<a href="../hash_graph_migrations/index.html">hash-graph-migrations</a>]
-    8[<a href="../hash_graph_migrations_macros/index.html">hash-graph-migrations-macros</a>]
-    9[<a href="../hash_graph_postgres_store/index.html">hash-graph-postgres-store</a>]
-    10[<a href="../hash_graph_store/index.html">hash-graph-store</a>]
-    11[<a href="../hash_graph_temporal_versioning/index.html">hash-graph-temporal-versioning</a>]
-    12[<a href="../hash_graph_type_defs/index.html">hash-graph-type-defs</a>]
-    13[<a href="../hash_graph_type_fetcher/index.html">hash-graph-type-fetcher</a>]
-    14[<a href="../hash_graph_types/index.html">hash-graph-types</a>]
-    15[<a href="../hash_graph_validation/index.html">hash-graph-validation</a>]
-    16[<a href="../harpc_client/index.html">harpc-client</a>]
-    17[<a href="../harpc_codec/index.html">harpc-codec</a>]
-    18[<a href="../harpc_net/index.html">harpc-net</a>]
-    19[<a href="../harpc_server/index.html">harpc-server</a>]
-    20[<a href="../harpc_system/index.html">harpc-system</a>]
-    21[<a href="../harpc_tower/index.html">harpc-tower</a>]
-    22[<a href="../harpc_types/index.html">harpc-types</a>]
-    23[<a href="../harpc_wire_protocol/index.html">harpc-wire-protocol</a>]
-    24[<a href="../hashql_ast/index.html">hashql-ast</a>]
-    25[<a href="../hashql_compiletest/index.html">hashql-compiletest</a>]
-    26[<a href="../hashql_core/index.html">hashql-core</a>]
-    27[<a href="../hashql_diagnostics/index.html">hashql-diagnostics</a>]
-    28[<a href="../hashql_eval/index.html">hashql-eval</a>]
-    29[<a href="../hashql_hir/index.html">hashql-hir</a>]
-    30[<a href="../hashql_macros/index.html">hashql-macros</a>]
-    31[<a href="../hashql_mir/index.html">hashql-mir</a>]
-    32[<a href="../hashql_syntax_jexpr/index.html">hashql-syntax-jexpr</a>]
-    33[<a href="../hash_status/index.html">hash-status</a>]
-    34[<a href="../hash_telemetry/index.html">hash-telemetry</a>]
-    35[<a href="../hash_temporal_client/index.html">hash-temporal-client</a>]
-    36[<a href="../darwin_kperf/index.html">darwin-kperf</a>]
-    37[<a href="../darwin_kperf_criterion/index.html">darwin-kperf-criterion</a>]
-    38[<a href="../darwin_kperf_events/index.html">darwin-kperf-events</a>]
-    39[<a href="../darwin_kperf_sys/index.html">darwin-kperf-sys</a>]
-    40[<a href="../error_stack/index.html">error-stack</a>]
-    41[<a href="../hash_graph_test_data/index.html">hash-graph-test-data</a>]
+    5[<a href="../hash_graph_authentication/index.html">hash-graph-authentication</a>]
+    6[<a href="../hash_graph_authorization/index.html">hash-graph-authorization</a>]
+    7[<a href="../hash_graph_embeddings/index.html">hash-graph-embeddings</a>]
+    8[<a href="../hash_graph_migrations/index.html">hash-graph-migrations</a>]
+    9[<a href="../hash_graph_migrations_macros/index.html">hash-graph-migrations-macros</a>]
+    10[<a href="../hash_graph_postgres_store/index.html">hash-graph-postgres-store</a>]
+    11[<a href="../hash_graph_store/index.html">hash-graph-store</a>]
+    12[<a href="../hash_graph_temporal_versioning/index.html">hash-graph-temporal-versioning</a>]
+    13[<a href="../hash_graph_type_defs/index.html">hash-graph-type-defs</a>]
+    14[<a href="../hash_graph_type_fetcher/index.html">hash-graph-type-fetcher</a>]
+    15[<a href="../hash_graph_types/index.html">hash-graph-types</a>]
+    16[<a href="../hash_graph_validation/index.html">hash-graph-validation</a>]
+    17[<a href="../harpc_client/index.html">harpc-client</a>]
+    18[<a href="../harpc_codec/index.html">harpc-codec</a>]
+    19[<a href="../harpc_net/index.html">harpc-net</a>]
+    20[<a href="../harpc_server/index.html">harpc-server</a>]
+    21[<a href="../harpc_system/index.html">harpc-system</a>]
+    22[<a href="../harpc_tower/index.html">harpc-tower</a>]
+    23[<a href="../harpc_types/index.html">harpc-types</a>]
+    24[<a href="../harpc_wire_protocol/index.html">harpc-wire-protocol</a>]
+    25[<a href="../hashql_ast/index.html">hashql-ast</a>]
+    26[<a href="../hashql_compiletest/index.html">hashql-compiletest</a>]
+    27[<a href="../hashql_core/index.html">hashql-core</a>]
+    28[<a href="../hashql_diagnostics/index.html">hashql-diagnostics</a>]
+    29[<a href="../hashql_eval/index.html">hashql-eval</a>]
+    30[<a href="../hashql_hir/index.html">hashql-hir</a>]
+    31[<a href="../hashql_macros/index.html">hashql-macros</a>]
+    32[<a href="../hashql_mir/index.html">hashql-mir</a>]
+    33[<a href="../hashql_syntax_jexpr/index.html">hashql-syntax-jexpr</a>]
+    34[<a href="../hash_status/index.html">hash-status</a>]
+    35[<a href="../hash_telemetry/index.html">hash-telemetry</a>]
+    36[<a href="../hash_temporal_client/index.html">hash-temporal-client</a>]
+    37[<a href="../darwin_kperf/index.html">darwin-kperf</a>]
+    38[<a href="../darwin_kperf_criterion/index.html">darwin-kperf-criterion</a>]
+    39[<a href="../darwin_kperf_events/index.html">darwin-kperf-events</a>]
+    40[<a href="../darwin_kperf_sys/index.html">darwin-kperf-sys</a>]
+    41[<a href="../error_stack/index.html">error-stack</a>]
+    42[<a href="../hash_graph_test_data/index.html">hash-graph-test-data</a>]
     0 --> 4
-    1 --> 11
-    1 -.-> 41
+    1 --> 12
+    1 -.-> 42
     2 -.-> 3
-    2 --> 23
-    4 --> 12
+    2 --> 24
+    4 --> 5
     4 --> 13
-    4 --> 19
-    4 --> 28
-    4 --> 32
+    4 --> 14
+    4 --> 20
+    4 --> 29
+    4 --> 33
     5 --> 1
-    6 --> 14
-    6 -.-> 37
-    7 --> 8
-    7 --> 34
-    9 --> 6
-    9 --> 7
-    9 -.-> 9
-    9 --> 15
-    9 --> 33
-    10 --> 5
-    10 --> 14
-    10 --> 35
-    11 --> 2
-    12 --> 33
-    13 --> 10
-    14 -.-> 41
-    15 -.-> 41
-    16 --> 20
-    17 --> 22
-    17 --> 40
-    18 --> 2
-    18 -.-> 17
-    18 --> 17
-    19 -.-> 1
-    19 -.-> 16
-    20 --> 21
-    21 -.-> 18
-    21 --> 18
-    23 -.-> 22
-    23 --> 22
-    23 --> 40
-    24 -.-> 25
-    25 --> 28
-    25 --> 32
-    26 --> 2
-    26 --> 27
-    26 --> 30
-    26 -.-> 37
-    28 --> 9
-    28 --> 31
-    29 -.-> 25
-    31 --> 29
-    32 --> 24
-    32 --> 26
-    34 --> 40
-    35 --> 1
-    36 --> 38
-    36 --> 39
-    37 --> 36
-    41 --> 10
+    5 --> 34
+    6 --> 1
+    7 --> 15
+    7 -.-> 38
+    8 --> 9
+    8 --> 35
+    10 --> 7
+    10 --> 8
+    10 -.-> 10
+    10 --> 16
+    10 --> 34
+    11 --> 6
+    11 --> 15
+    11 --> 36
+    12 --> 2
+    13 --> 34
+    14 --> 11
+    15 -.-> 42
+    16 -.-> 42
+    17 --> 21
+    18 --> 23
+    18 --> 41
+    19 --> 2
+    19 -.-> 18
+    19 --> 18
+    20 -.-> 1
+    20 -.-> 17
+    21 --> 22
+    22 -.-> 19
+    22 --> 19
+    24 -.-> 23
+    24 --> 23
+    24 --> 41
+    25 -.-> 26
+    26 --> 29
+    26 --> 33
+    27 --> 2
+    27 --> 28
+    27 --> 31
+    27 -.-> 38
+    29 --> 10
+    29 --> 32
+    30 -.-> 26
+    32 --> 30
+    33 --> 25
+    33 --> 27
+    35 --> 41
+    36 --> 1
+    37 --> 39
+    37 --> 40
+    38 --> 37
+    42 --> 11

--- a/libs/@blockprotocol/type-system/rust/docs/dependency-diagram.mmd
+++ b/libs/@blockprotocol/type-system/rust/docs/dependency-diagram.mmd
@@ -14,63 +14,66 @@ graph TD
     2[<a href="../hash_codec/index.html">hash-codec</a>]
     3[<a href="../hash_codegen/index.html">hash-codegen</a>]
     4[<a href="../hash_graph_api/index.html">hash-graph-api</a>]
-    5[<a href="../hash_graph_authorization/index.html">hash-graph-authorization</a>]
-    6[<a href="../hash_graph_embeddings/index.html">hash-graph-embeddings</a>]
-    7[<a href="../hash_graph_postgres_store/index.html">hash-graph-postgres-store</a>]
-    8[<a href="../hash_graph_store/index.html">hash-graph-store</a>]
-    9[<a href="../hash_graph_temporal_versioning/index.html">hash-graph-temporal-versioning</a>]
-    10[<a href="../hash_graph_type_fetcher/index.html">hash-graph-type-fetcher</a>]
-    11[<a href="../hash_graph_types/index.html">hash-graph-types</a>]
-    12[<a href="../hash_graph_validation/index.html">hash-graph-validation</a>]
-    13[<a href="../harpc_server/index.html">harpc-server</a>]
-    14[<a href="../harpc_types/index.html">harpc-types</a>]
-    15[<a href="../harpc_wire_protocol/index.html">harpc-wire-protocol</a>]
-    16[<a href="../hashql_ast/index.html">hashql-ast</a>]
-    17[<a href="../hashql_compiletest/index.html">hashql-compiletest</a>]
-    18[<a href="../hashql_eval/index.html">hashql-eval</a>]
-    19[<a href="../hashql_hir/index.html">hashql-hir</a>]
-    20[<a href="../hashql_mir/index.html">hashql-mir</a>]
-    21[<a href="../hashql_syntax_jexpr/index.html">hashql-syntax-jexpr</a>]
-    22[<a href="../hash_temporal_client/index.html">hash-temporal-client</a>]
-    23[<a href="../error_stack/index.html">error-stack</a>]
-    24[<a href="../hash_graph_benches/index.html">hash-graph-benches</a>]
-    25[<a href="../hash_graph_integration/index.html">hash-graph-integration</a>]
-    26[<a href="../hash_graph_test_data/index.html">hash-graph-test-data</a>]
+    5[<a href="../hash_graph_authentication/index.html">hash-graph-authentication</a>]
+    6[<a href="../hash_graph_authorization/index.html">hash-graph-authorization</a>]
+    7[<a href="../hash_graph_embeddings/index.html">hash-graph-embeddings</a>]
+    8[<a href="../hash_graph_postgres_store/index.html">hash-graph-postgres-store</a>]
+    9[<a href="../hash_graph_store/index.html">hash-graph-store</a>]
+    10[<a href="../hash_graph_temporal_versioning/index.html">hash-graph-temporal-versioning</a>]
+    11[<a href="../hash_graph_type_fetcher/index.html">hash-graph-type-fetcher</a>]
+    12[<a href="../hash_graph_types/index.html">hash-graph-types</a>]
+    13[<a href="../hash_graph_validation/index.html">hash-graph-validation</a>]
+    14[<a href="../harpc_server/index.html">harpc-server</a>]
+    15[<a href="../harpc_types/index.html">harpc-types</a>]
+    16[<a href="../harpc_wire_protocol/index.html">harpc-wire-protocol</a>]
+    17[<a href="../hashql_ast/index.html">hashql-ast</a>]
+    18[<a href="../hashql_compiletest/index.html">hashql-compiletest</a>]
+    19[<a href="../hashql_eval/index.html">hashql-eval</a>]
+    20[<a href="../hashql_hir/index.html">hashql-hir</a>]
+    21[<a href="../hashql_mir/index.html">hashql-mir</a>]
+    22[<a href="../hashql_syntax_jexpr/index.html">hashql-syntax-jexpr</a>]
+    23[<a href="../hash_temporal_client/index.html">hash-temporal-client</a>]
+    24[<a href="../error_stack/index.html">error-stack</a>]
+    25[<a href="../hash_graph_benches/index.html">hash-graph-benches</a>]
+    26[<a href="../hash_graph_integration/index.html">hash-graph-integration</a>]
+    27[<a href="../hash_graph_test_data/index.html">hash-graph-test-data</a>]
     0 --> 4
-    1 --> 9
-    1 -.-> 26
+    1 --> 10
+    1 -.-> 27
     2 -.-> 3
-    2 --> 15
-    4 --> 10
-    4 --> 13
-    4 --> 18
-    4 --> 21
+    2 --> 16
+    4 --> 5
+    4 --> 11
+    4 --> 14
+    4 --> 19
+    4 --> 22
     5 --> 1
-    6 --> 11
-    7 --> 6
-    7 -.-> 7
+    6 --> 1
     7 --> 12
-    8 --> 5
-    8 --> 11
-    8 --> 22
-    9 --> 2
-    10 --> 8
-    11 -.-> 26
-    12 -.-> 26
-    13 -.-> 1
-    13 --> 14
-    15 -.-> 14
-    15 --> 14
-    15 --> 23
-    16 -.-> 17
-    17 --> 18
-    17 --> 21
-    18 --> 7
-    18 --> 20
-    19 -.-> 17
-    20 --> 19
-    21 --> 16
-    22 --> 1
-    24 -.-> 4
-    25 -.-> 7
-    26 --> 8
+    8 --> 7
+    8 -.-> 8
+    8 --> 13
+    9 --> 6
+    9 --> 12
+    9 --> 23
+    10 --> 2
+    11 --> 9
+    12 -.-> 27
+    13 -.-> 27
+    14 -.-> 1
+    14 --> 15
+    16 -.-> 15
+    16 --> 15
+    16 --> 24
+    17 -.-> 18
+    18 --> 19
+    18 --> 22
+    19 --> 8
+    19 --> 21
+    20 -.-> 18
+    21 --> 20
+    22 --> 17
+    23 --> 1
+    25 -.-> 4
+    26 -.-> 8
+    27 --> 9

--- a/libs/@local/codec/docs/dependency-diagram.mmd
+++ b/libs/@local/codec/docs/dependency-diagram.mmd
@@ -14,75 +14,78 @@ graph TD
     class 2 root
     3[<a href="../hash_codegen/index.html">hash-codegen</a>]
     4[<a href="../hash_graph_api/index.html">hash-graph-api</a>]
-    5[<a href="../hash_graph_authorization/index.html">hash-graph-authorization</a>]
-    6[<a href="../hash_graph_embeddings/index.html">hash-graph-embeddings</a>]
-    7[<a href="../hash_graph_postgres_store/index.html">hash-graph-postgres-store</a>]
-    8[<a href="../hash_graph_store/index.html">hash-graph-store</a>]
-    9[<a href="../hash_graph_temporal_versioning/index.html">hash-graph-temporal-versioning</a>]
-    10[<a href="../hash_graph_type_fetcher/index.html">hash-graph-type-fetcher</a>]
-    11[<a href="../hash_graph_types/index.html">hash-graph-types</a>]
-    12[<a href="../hash_graph_validation/index.html">hash-graph-validation</a>]
-    13[<a href="../harpc_client/index.html">harpc-client</a>]
-    14[<a href="../harpc_net/index.html">harpc-net</a>]
-    15[<a href="../harpc_server/index.html">harpc-server</a>]
-    16[<a href="../harpc_system/index.html">harpc-system</a>]
-    17[<a href="../harpc_tower/index.html">harpc-tower</a>]
-    18[<a href="../harpc_types/index.html">harpc-types</a>]
-    19[<a href="../harpc_wire_protocol/index.html">harpc-wire-protocol</a>]
-    20[<a href="../hashql_ast/index.html">hashql-ast</a>]
-    21[<a href="../hashql_compiletest/index.html">hashql-compiletest</a>]
-    22[<a href="../hashql_core/index.html">hashql-core</a>]
-    23[<a href="../hashql_eval/index.html">hashql-eval</a>]
-    24[<a href="../hashql_hir/index.html">hashql-hir</a>]
-    25[<a href="../hashql_mir/index.html">hashql-mir</a>]
-    26[<a href="../hashql_syntax_jexpr/index.html">hashql-syntax-jexpr</a>]
-    27[<a href="../hash_temporal_client/index.html">hash-temporal-client</a>]
-    28[<a href="../error_stack/index.html">error-stack</a>]
-    29[<a href="../hash_graph_benches/index.html">hash-graph-benches</a>]
-    30[<a href="../hash_graph_integration/index.html">hash-graph-integration</a>]
-    31[<a href="../hash_graph_test_data/index.html">hash-graph-test-data</a>]
+    5[<a href="../hash_graph_authentication/index.html">hash-graph-authentication</a>]
+    6[<a href="../hash_graph_authorization/index.html">hash-graph-authorization</a>]
+    7[<a href="../hash_graph_embeddings/index.html">hash-graph-embeddings</a>]
+    8[<a href="../hash_graph_postgres_store/index.html">hash-graph-postgres-store</a>]
+    9[<a href="../hash_graph_store/index.html">hash-graph-store</a>]
+    10[<a href="../hash_graph_temporal_versioning/index.html">hash-graph-temporal-versioning</a>]
+    11[<a href="../hash_graph_type_fetcher/index.html">hash-graph-type-fetcher</a>]
+    12[<a href="../hash_graph_types/index.html">hash-graph-types</a>]
+    13[<a href="../hash_graph_validation/index.html">hash-graph-validation</a>]
+    14[<a href="../harpc_client/index.html">harpc-client</a>]
+    15[<a href="../harpc_net/index.html">harpc-net</a>]
+    16[<a href="../harpc_server/index.html">harpc-server</a>]
+    17[<a href="../harpc_system/index.html">harpc-system</a>]
+    18[<a href="../harpc_tower/index.html">harpc-tower</a>]
+    19[<a href="../harpc_types/index.html">harpc-types</a>]
+    20[<a href="../harpc_wire_protocol/index.html">harpc-wire-protocol</a>]
+    21[<a href="../hashql_ast/index.html">hashql-ast</a>]
+    22[<a href="../hashql_compiletest/index.html">hashql-compiletest</a>]
+    23[<a href="../hashql_core/index.html">hashql-core</a>]
+    24[<a href="../hashql_eval/index.html">hashql-eval</a>]
+    25[<a href="../hashql_hir/index.html">hashql-hir</a>]
+    26[<a href="../hashql_mir/index.html">hashql-mir</a>]
+    27[<a href="../hashql_syntax_jexpr/index.html">hashql-syntax-jexpr</a>]
+    28[<a href="../hash_temporal_client/index.html">hash-temporal-client</a>]
+    29[<a href="../error_stack/index.html">error-stack</a>]
+    30[<a href="../hash_graph_benches/index.html">hash-graph-benches</a>]
+    31[<a href="../hash_graph_integration/index.html">hash-graph-integration</a>]
+    32[<a href="../hash_graph_test_data/index.html">hash-graph-test-data</a>]
     0 --> 4
-    1 --> 9
-    1 -.-> 31
+    1 --> 10
+    1 -.-> 32
     2 -.-> 3
-    2 --> 19
-    4 --> 10
-    4 --> 15
-    4 --> 23
-    4 --> 26
+    2 --> 20
+    4 --> 5
+    4 --> 11
+    4 --> 16
+    4 --> 24
+    4 --> 27
     5 --> 1
-    6 --> 11
-    7 --> 6
-    7 -.-> 7
+    6 --> 1
     7 --> 12
-    8 --> 5
-    8 --> 11
-    8 --> 27
-    9 --> 2
-    10 --> 8
-    11 -.-> 31
-    12 -.-> 31
-    13 --> 16
-    14 --> 2
-    15 -.-> 1
-    15 -.-> 13
-    16 --> 17
-    17 -.-> 14
-    17 --> 14
-    19 -.-> 18
-    19 --> 18
-    19 --> 28
-    20 -.-> 21
-    21 --> 23
-    21 --> 26
-    22 --> 2
-    23 --> 7
-    23 --> 25
-    24 -.-> 21
-    25 --> 24
-    26 --> 20
-    26 --> 22
-    27 --> 1
-    29 -.-> 4
-    30 -.-> 7
-    31 --> 8
+    8 --> 7
+    8 -.-> 8
+    8 --> 13
+    9 --> 6
+    9 --> 12
+    9 --> 28
+    10 --> 2
+    11 --> 9
+    12 -.-> 32
+    13 -.-> 32
+    14 --> 17
+    15 --> 2
+    16 -.-> 1
+    16 -.-> 14
+    17 --> 18
+    18 -.-> 15
+    18 --> 15
+    20 -.-> 19
+    20 --> 19
+    20 --> 29
+    21 -.-> 22
+    22 --> 24
+    22 --> 27
+    23 --> 2
+    24 --> 8
+    24 --> 26
+    25 -.-> 22
+    26 --> 25
+    27 --> 21
+    27 --> 23
+    28 --> 1
+    30 -.-> 4
+    31 -.-> 8
+    32 --> 9

--- a/libs/@local/codegen/docs/dependency-diagram.mmd
+++ b/libs/@local/codegen/docs/dependency-diagram.mmd
@@ -14,68 +14,71 @@ graph TD
     3[hash-codegen]
     class 3 root
     4[<a href="../hash_graph_api/index.html">hash-graph-api</a>]
-    5[<a href="../hash_graph_authorization/index.html">hash-graph-authorization</a>]
-    6[<a href="../hash_graph_embeddings/index.html">hash-graph-embeddings</a>]
-    7[<a href="../hash_graph_postgres_store/index.html">hash-graph-postgres-store</a>]
-    8[<a href="../hash_graph_store/index.html">hash-graph-store</a>]
-    9[<a href="../hash_graph_temporal_versioning/index.html">hash-graph-temporal-versioning</a>]
-    10[<a href="../hash_graph_type_fetcher/index.html">hash-graph-type-fetcher</a>]
-    11[<a href="../hash_graph_types/index.html">hash-graph-types</a>]
-    12[<a href="../hash_graph_validation/index.html">hash-graph-validation</a>]
-    13[<a href="../harpc_client/index.html">harpc-client</a>]
-    14[<a href="../harpc_net/index.html">harpc-net</a>]
-    15[<a href="../harpc_server/index.html">harpc-server</a>]
-    16[<a href="../harpc_system/index.html">harpc-system</a>]
-    17[<a href="../harpc_tower/index.html">harpc-tower</a>]
-    18[<a href="../hashql_ast/index.html">hashql-ast</a>]
-    19[<a href="../hashql_compiletest/index.html">hashql-compiletest</a>]
-    20[<a href="../hashql_core/index.html">hashql-core</a>]
-    21[<a href="../hashql_eval/index.html">hashql-eval</a>]
-    22[<a href="../hashql_hir/index.html">hashql-hir</a>]
-    23[<a href="../hashql_mir/index.html">hashql-mir</a>]
-    24[<a href="../hashql_syntax_jexpr/index.html">hashql-syntax-jexpr</a>]
-    25[<a href="../hash_temporal_client/index.html">hash-temporal-client</a>]
-    26[<a href="../hash_graph_benches/index.html">hash-graph-benches</a>]
-    27[<a href="../hash_graph_integration/index.html">hash-graph-integration</a>]
-    28[<a href="../hash_graph_test_data/index.html">hash-graph-test-data</a>]
+    5[<a href="../hash_graph_authentication/index.html">hash-graph-authentication</a>]
+    6[<a href="../hash_graph_authorization/index.html">hash-graph-authorization</a>]
+    7[<a href="../hash_graph_embeddings/index.html">hash-graph-embeddings</a>]
+    8[<a href="../hash_graph_postgres_store/index.html">hash-graph-postgres-store</a>]
+    9[<a href="../hash_graph_store/index.html">hash-graph-store</a>]
+    10[<a href="../hash_graph_temporal_versioning/index.html">hash-graph-temporal-versioning</a>]
+    11[<a href="../hash_graph_type_fetcher/index.html">hash-graph-type-fetcher</a>]
+    12[<a href="../hash_graph_types/index.html">hash-graph-types</a>]
+    13[<a href="../hash_graph_validation/index.html">hash-graph-validation</a>]
+    14[<a href="../harpc_client/index.html">harpc-client</a>]
+    15[<a href="../harpc_net/index.html">harpc-net</a>]
+    16[<a href="../harpc_server/index.html">harpc-server</a>]
+    17[<a href="../harpc_system/index.html">harpc-system</a>]
+    18[<a href="../harpc_tower/index.html">harpc-tower</a>]
+    19[<a href="../hashql_ast/index.html">hashql-ast</a>]
+    20[<a href="../hashql_compiletest/index.html">hashql-compiletest</a>]
+    21[<a href="../hashql_core/index.html">hashql-core</a>]
+    22[<a href="../hashql_eval/index.html">hashql-eval</a>]
+    23[<a href="../hashql_hir/index.html">hashql-hir</a>]
+    24[<a href="../hashql_mir/index.html">hashql-mir</a>]
+    25[<a href="../hashql_syntax_jexpr/index.html">hashql-syntax-jexpr</a>]
+    26[<a href="../hash_temporal_client/index.html">hash-temporal-client</a>]
+    27[<a href="../hash_graph_benches/index.html">hash-graph-benches</a>]
+    28[<a href="../hash_graph_integration/index.html">hash-graph-integration</a>]
+    29[<a href="../hash_graph_test_data/index.html">hash-graph-test-data</a>]
     0 --> 4
-    1 --> 9
-    1 -.-> 28
+    1 --> 10
+    1 -.-> 29
     2 -.-> 3
-    4 --> 10
-    4 --> 15
-    4 --> 21
-    4 --> 24
+    4 --> 5
+    4 --> 11
+    4 --> 16
+    4 --> 22
+    4 --> 25
     5 --> 1
-    6 --> 11
-    7 --> 6
-    7 -.-> 7
+    6 --> 1
     7 --> 12
-    8 --> 5
-    8 --> 11
-    8 --> 25
-    9 --> 2
-    10 --> 8
-    11 -.-> 28
-    12 -.-> 28
-    13 --> 16
-    14 --> 2
-    15 -.-> 1
-    15 -.-> 13
-    16 --> 17
-    17 -.-> 14
-    17 --> 14
-    18 -.-> 19
-    19 --> 21
-    19 --> 24
-    20 --> 2
-    21 --> 7
-    21 --> 23
-    22 -.-> 19
-    23 --> 22
-    24 --> 18
-    24 --> 20
-    25 --> 1
-    26 -.-> 4
-    27 -.-> 7
-    28 --> 8
+    8 --> 7
+    8 -.-> 8
+    8 --> 13
+    9 --> 6
+    9 --> 12
+    9 --> 26
+    10 --> 2
+    11 --> 9
+    12 -.-> 29
+    13 -.-> 29
+    14 --> 17
+    15 --> 2
+    16 -.-> 1
+    16 -.-> 14
+    17 --> 18
+    18 -.-> 15
+    18 --> 15
+    19 -.-> 20
+    20 --> 22
+    20 --> 25
+    21 --> 2
+    22 --> 8
+    22 --> 24
+    23 -.-> 20
+    24 --> 23
+    25 --> 19
+    25 --> 21
+    26 --> 1
+    27 -.-> 4
+    28 -.-> 8
+    29 --> 9

--- a/libs/@local/graph/api/Cargo.toml
+++ b/libs/@local/graph/api/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/bin/openapi-spec-generator.rs"
 # Public workspace dependencies
 harpc-client              = { workspace = true, public = true }
 harpc-server              = { workspace = true, public = true }
+hash-graph-authentication = { workspace = true, public = true }
 hash-graph-authorization  = { workspace = true, public = true }
 hash-graph-embeddings     = { workspace = true, public = true }
 hash-graph-postgres-store = { workspace = true, public = true, features = ["utoipa"] }
@@ -81,6 +82,11 @@ tracing-opentelemetry              = { workspace = true }
 utoipa                             = { workspace = true }
 utoipa-scalar                      = { workspace = true }
 uuid                               = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tower = { workspace = true, features = ["util"] }
+uuid  = { workspace = true, features = ["v4"] }
 
 [features]
 clap = ["dep:clap"]

--- a/libs/@local/graph/api/docs/dependency-diagram.mmd
+++ b/libs/@local/graph/api/docs/dependency-diagram.mmd
@@ -14,103 +14,107 @@ graph TD
     3[<a href="../hash_codegen/index.html">hash-codegen</a>]
     4[hash-graph-api]
     class 4 root
-    5[<a href="../hash_graph_authorization/index.html">hash-graph-authorization</a>]
-    6[<a href="../hash_graph_embeddings/index.html">hash-graph-embeddings</a>]
-    7[<a href="../hash_graph_migrations/index.html">hash-graph-migrations</a>]
-    8[<a href="../hash_graph_migrations_macros/index.html">hash-graph-migrations-macros</a>]
-    9[<a href="../hash_graph_postgres_store/index.html">hash-graph-postgres-store</a>]
-    10[<a href="../hash_graph_store/index.html">hash-graph-store</a>]
-    11[<a href="../hash_graph_temporal_versioning/index.html">hash-graph-temporal-versioning</a>]
-    12[<a href="../hash_graph_type_defs/index.html">hash-graph-type-defs</a>]
-    13[<a href="../hash_graph_type_fetcher/index.html">hash-graph-type-fetcher</a>]
-    14[<a href="../hash_graph_types/index.html">hash-graph-types</a>]
-    15[<a href="../hash_graph_validation/index.html">hash-graph-validation</a>]
-    16[<a href="../harpc_client/index.html">harpc-client</a>]
-    17[<a href="../harpc_codec/index.html">harpc-codec</a>]
-    18[<a href="../harpc_net/index.html">harpc-net</a>]
-    19[<a href="../harpc_server/index.html">harpc-server</a>]
-    20[<a href="../harpc_system/index.html">harpc-system</a>]
-    21[<a href="../harpc_tower/index.html">harpc-tower</a>]
-    22[<a href="../harpc_types/index.html">harpc-types</a>]
-    23[<a href="../harpc_wire_protocol/index.html">harpc-wire-protocol</a>]
-    24[<a href="../hashql_ast/index.html">hashql-ast</a>]
-    25[<a href="../hashql_compiletest/index.html">hashql-compiletest</a>]
-    26[<a href="../hashql_core/index.html">hashql-core</a>]
-    27[<a href="../hashql_diagnostics/index.html">hashql-diagnostics</a>]
-    28[<a href="../hashql_eval/index.html">hashql-eval</a>]
-    29[<a href="../hashql_hir/index.html">hashql-hir</a>]
-    30[<a href="../hashql_macros/index.html">hashql-macros</a>]
-    31[<a href="../hashql_mir/index.html">hashql-mir</a>]
-    32[<a href="../hashql_syntax_jexpr/index.html">hashql-syntax-jexpr</a>]
-    33[<a href="../hash_status/index.html">hash-status</a>]
-    34[<a href="../hash_telemetry/index.html">hash-telemetry</a>]
-    35[<a href="../hash_temporal_client/index.html">hash-temporal-client</a>]
-    36[<a href="../darwin_kperf/index.html">darwin-kperf</a>]
-    37[<a href="../darwin_kperf_criterion/index.html">darwin-kperf-criterion</a>]
-    38[<a href="../darwin_kperf_events/index.html">darwin-kperf-events</a>]
-    39[<a href="../darwin_kperf_sys/index.html">darwin-kperf-sys</a>]
-    40[<a href="../error_stack/index.html">error-stack</a>]
-    41[<a href="../hash_graph_benches/index.html">hash-graph-benches</a>]
-    42[<a href="../hash_graph_test_data/index.html">hash-graph-test-data</a>]
+    5[<a href="../hash_graph_authentication/index.html">hash-graph-authentication</a>]
+    6[<a href="../hash_graph_authorization/index.html">hash-graph-authorization</a>]
+    7[<a href="../hash_graph_embeddings/index.html">hash-graph-embeddings</a>]
+    8[<a href="../hash_graph_migrations/index.html">hash-graph-migrations</a>]
+    9[<a href="../hash_graph_migrations_macros/index.html">hash-graph-migrations-macros</a>]
+    10[<a href="../hash_graph_postgres_store/index.html">hash-graph-postgres-store</a>]
+    11[<a href="../hash_graph_store/index.html">hash-graph-store</a>]
+    12[<a href="../hash_graph_temporal_versioning/index.html">hash-graph-temporal-versioning</a>]
+    13[<a href="../hash_graph_type_defs/index.html">hash-graph-type-defs</a>]
+    14[<a href="../hash_graph_type_fetcher/index.html">hash-graph-type-fetcher</a>]
+    15[<a href="../hash_graph_types/index.html">hash-graph-types</a>]
+    16[<a href="../hash_graph_validation/index.html">hash-graph-validation</a>]
+    17[<a href="../harpc_client/index.html">harpc-client</a>]
+    18[<a href="../harpc_codec/index.html">harpc-codec</a>]
+    19[<a href="../harpc_net/index.html">harpc-net</a>]
+    20[<a href="../harpc_server/index.html">harpc-server</a>]
+    21[<a href="../harpc_system/index.html">harpc-system</a>]
+    22[<a href="../harpc_tower/index.html">harpc-tower</a>]
+    23[<a href="../harpc_types/index.html">harpc-types</a>]
+    24[<a href="../harpc_wire_protocol/index.html">harpc-wire-protocol</a>]
+    25[<a href="../hashql_ast/index.html">hashql-ast</a>]
+    26[<a href="../hashql_compiletest/index.html">hashql-compiletest</a>]
+    27[<a href="../hashql_core/index.html">hashql-core</a>]
+    28[<a href="../hashql_diagnostics/index.html">hashql-diagnostics</a>]
+    29[<a href="../hashql_eval/index.html">hashql-eval</a>]
+    30[<a href="../hashql_hir/index.html">hashql-hir</a>]
+    31[<a href="../hashql_macros/index.html">hashql-macros</a>]
+    32[<a href="../hashql_mir/index.html">hashql-mir</a>]
+    33[<a href="../hashql_syntax_jexpr/index.html">hashql-syntax-jexpr</a>]
+    34[<a href="../hash_status/index.html">hash-status</a>]
+    35[<a href="../hash_telemetry/index.html">hash-telemetry</a>]
+    36[<a href="../hash_temporal_client/index.html">hash-temporal-client</a>]
+    37[<a href="../darwin_kperf/index.html">darwin-kperf</a>]
+    38[<a href="../darwin_kperf_criterion/index.html">darwin-kperf-criterion</a>]
+    39[<a href="../darwin_kperf_events/index.html">darwin-kperf-events</a>]
+    40[<a href="../darwin_kperf_sys/index.html">darwin-kperf-sys</a>]
+    41[<a href="../error_stack/index.html">error-stack</a>]
+    42[<a href="../hash_graph_benches/index.html">hash-graph-benches</a>]
+    43[<a href="../hash_graph_test_data/index.html">hash-graph-test-data</a>]
     0 --> 4
-    1 --> 11
-    1 -.-> 42
+    1 --> 12
+    1 -.-> 43
     2 -.-> 3
-    2 --> 23
-    4 --> 12
+    2 --> 24
+    4 --> 5
     4 --> 13
-    4 --> 19
-    4 --> 28
-    4 --> 32
+    4 --> 14
+    4 --> 20
+    4 --> 29
+    4 --> 33
     5 --> 1
-    6 --> 14
-    6 -.-> 37
-    7 --> 8
-    7 --> 34
-    9 --> 6
-    9 --> 7
-    9 -.-> 9
-    9 --> 15
-    9 --> 33
-    10 --> 5
-    10 --> 14
-    10 --> 35
-    11 --> 2
-    12 --> 33
-    13 --> 10
-    14 -.-> 42
-    15 -.-> 42
-    16 --> 20
-    17 --> 22
-    17 --> 40
-    18 --> 2
-    18 -.-> 17
-    18 --> 17
-    19 -.-> 1
-    19 -.-> 16
-    20 --> 21
-    21 -.-> 18
-    21 --> 18
-    23 -.-> 22
-    23 --> 22
-    23 --> 40
-    24 -.-> 25
-    25 --> 28
-    25 --> 32
-    26 --> 2
-    26 --> 27
-    26 --> 30
-    26 -.-> 37
-    28 --> 9
-    28 --> 31
-    29 -.-> 25
-    31 --> 29
-    32 --> 24
-    32 --> 26
-    34 --> 40
-    35 --> 1
-    36 --> 38
-    36 --> 39
-    37 --> 36
-    41 -.-> 4
-    42 --> 10
+    5 --> 34
+    6 --> 1
+    7 --> 15
+    7 -.-> 38
+    8 --> 9
+    8 --> 35
+    10 --> 7
+    10 --> 8
+    10 -.-> 10
+    10 --> 16
+    10 --> 34
+    11 --> 6
+    11 --> 15
+    11 --> 36
+    12 --> 2
+    13 --> 34
+    14 --> 11
+    15 -.-> 43
+    16 -.-> 43
+    17 --> 21
+    18 --> 23
+    18 --> 41
+    19 --> 2
+    19 -.-> 18
+    19 --> 18
+    20 -.-> 1
+    20 -.-> 17
+    21 --> 22
+    22 -.-> 19
+    22 --> 19
+    24 -.-> 23
+    24 --> 23
+    24 --> 41
+    25 -.-> 26
+    26 --> 29
+    26 --> 33
+    27 --> 2
+    27 --> 28
+    27 --> 31
+    27 -.-> 38
+    29 --> 10
+    29 --> 32
+    30 -.-> 26
+    32 --> 30
+    33 --> 25
+    33 --> 27
+    35 --> 41
+    36 --> 1
+    37 --> 39
+    37 --> 40
+    38 --> 37
+    42 -.-> 4
+    43 --> 11

--- a/libs/@local/graph/api/package.json
+++ b/libs/@local/graph/api/package.json
@@ -24,6 +24,7 @@
     "@rust/harpc-tower": "workspace:*",
     "@rust/harpc-types": "workspace:*",
     "@rust/hash-codec": "workspace:*",
+    "@rust/hash-graph-authentication": "workspace:*",
     "@rust/hash-graph-authorization": "workspace:*",
     "@rust/hash-graph-embeddings": "workspace:*",
     "@rust/hash-graph-postgres-store": "workspace:*",

--- a/libs/@local/graph/api/src/rest/admin.rs
+++ b/libs/@local/graph/api/src/rest/admin.rs
@@ -42,7 +42,6 @@ use axum::{
     body::Body,
     extract::FromRequestParts,
     http::request::Parts,
-    response::IntoResponse as _,
     routing::{delete, post},
 };
 use error_stack::Report;
@@ -64,7 +63,7 @@ use type_system::principal::actor::{ActorEntityUuid, UserId};
 use uuid::Uuid;
 
 use super::{
-    AuthenticatedUserHeader, http_tracing_layer,
+    AuthenticatedActorId, auth, http_tracing_layer,
     jwt::{JwtValidator, OptionalJwtAuthentication},
     probe,
     status::{BoxedResponse, status_to_response},
@@ -124,6 +123,7 @@ pub fn routes(
                 vec![],
             ))
         })
+        .layer(axum::middleware::from_fn(auth::actor_id_header_middleware))
         .layer(http_tracing_layer::HttpTracingLayer)
         .layer(Extension(Arc::new(store_pool)))
         .layer(Extension(Arc::new(external_services)))
@@ -155,10 +155,8 @@ impl<S: Sync> FromRequestParts<S> for AdminActorId {
 
         let Some(claims) = jwt.0 else {
             // No JWT configured — fall back to header
-            let AuthenticatedUserHeader(actor_id) =
-                AuthenticatedUserHeader::from_request_parts(parts, state)
-                    .await
-                    .map_err(|rejection| BoxedResponse::from(rejection.into_response()))?;
+            let AuthenticatedActorId(actor_id) =
+                AuthenticatedActorId::from_request_parts(parts, state).await?;
             return Ok(Self(actor_id.into()));
         };
 

--- a/libs/@local/graph/api/src/rest/auth.rs
+++ b/libs/@local/graph/api/src/rest/auth.rs
@@ -39,14 +39,15 @@ struct ResolvedAuthentication(AuthenticationOutcome);
 
 /// Converts an authentication failure into the response returned to the client.
 ///
-/// Only logs at debug level: [`resolve_request_actor`] already logs failures with their full
-/// report at the level matching the fault domain.
+/// The response carries the client-safe message. Identifiers stay in the server-side logs. Only
+/// logs at debug level: [`resolve_request_actor`] already logs failures with their full report at
+/// the level matching the fault domain.
 fn rejection(error: &AuthenticationError) -> BoxedResponse {
     let status_code = error.status_code();
     tracing::debug!(%error, "request rejected");
     status_to_response(Status::<()>::new(
         status_code,
-        Some(error.to_string()),
+        Some(error.client_message().to_owned()),
         vec![],
     ))
 }

--- a/libs/@local/graph/api/src/rest/auth.rs
+++ b/libs/@local/graph/api/src/rest/auth.rs
@@ -1,0 +1,329 @@
+//! Axum bindings for Graph authentication.
+//!
+//! Bridges [`hash_graph_authentication`] into the REST layer: [`authentication_middleware`]
+//! resolves the request's credentials once and rejects the request when they are missing or
+//! invalid, so every route behind it requires authentication by default. The resolved
+//! [`AuthenticationOutcome`] is stored as a private request extension; the
+//! [`AuthenticatedActorId`] extractor hands the acting actor to handlers that need it.
+//!
+//! The only routes behind the middleware reachable without credentials are the bootstrap routes.
+//! The OpenAPI and probe routes are served outside the middleware.
+//!
+//! Routers whose callers are authenticated by other means and carry the acting actor only in the
+//! `X-Authenticated-User-Actor-Id` header use [`actor_id_header_middleware`] instead. The
+//! extractor rejects requests on routes without either middleware.
+
+use alloc::sync::Arc;
+
+use axum::{
+    extract::{FromRequestParts, Request},
+    http::request::Parts,
+    middleware::Next,
+    response::{IntoResponse as _, Response},
+};
+pub use hash_graph_authentication::provider::StaticAuthenticationProvider;
+use hash_graph_authentication::{
+    provider::AuthenticationProvider,
+    request::{
+        AuthenticationError, AuthenticationOutcome, actor_id_from_header, resolve_request_actor,
+    },
+};
+use hash_status::{Status, StatusCode};
+use type_system::principal::actor::ActorEntityUuid;
+
+use crate::rest::status::{BoxedResponse, status_to_response};
+
+/// The resolved authentication of a request, stored as a request extension.
+#[derive(Clone)]
+struct ResolvedAuthentication(AuthenticationOutcome);
+
+/// Converts an authentication failure into the response returned to the client.
+///
+/// Only logs at debug level: [`resolve_request_actor`] already logs failures with their full
+/// report at the level matching the fault domain.
+fn rejection(error: &AuthenticationError) -> BoxedResponse {
+    let status_code = error.status_code();
+    tracing::debug!(%error, "request rejected");
+    status_to_response(Status::<()>::new(
+        status_code,
+        Some(error.to_string()),
+        vec![],
+    ))
+}
+
+/// Returns whether the path is a bootstrap route reachable without credentials.
+///
+/// Bootstrap routes run before any actor exists, so they cannot demand actor credentials.
+// TODO(BE-714): remove once internal services authenticate with a service credential
+fn is_bootstrap_route(path: &str) -> bool {
+    if path == "/policies/seed" {
+        return true;
+    }
+
+    path.strip_prefix("/actors/machine/identifier/system/")
+        .is_some_and(|identifier| !identifier.is_empty() && !identifier.contains('/'))
+}
+
+/// Records the authenticated actor on the request span and stores the outcome as a request
+/// extension.
+fn store_outcome(request: &mut Request, outcome: AuthenticationOutcome) {
+    if let AuthenticationOutcome::Authenticated(actor_id) = &outcome {
+        tracing::Span::current().record("actor_entity_uuid", tracing::field::display(actor_id));
+    }
+    request
+        .extensions_mut()
+        .insert(ResolvedAuthentication(outcome));
+}
+
+/// Rejects requests without valid credentials and stores the resolved
+/// [`AuthenticationOutcome`] as a request extension.
+///
+/// Bootstrap routes pass through regardless of credential validity; every other route never
+/// reaches its handler unauthenticated.
+pub async fn authentication_middleware<P>(
+    provider: Arc<P>,
+    mut request: Request,
+    next: Next,
+) -> Response
+where
+    P: AuthenticationProvider,
+{
+    let outcome = resolve_request_actor(&*provider, request.headers()).await;
+
+    if let AuthenticationOutcome::Failed(error) = &outcome
+        && !is_bootstrap_route(request.uri().path())
+    {
+        return rejection(error).into_response();
+    }
+
+    store_outcome(&mut request, outcome);
+    next.run(request).await
+}
+
+/// Resolves the unverified `X-Authenticated-User-Actor-Id` header and stores the outcome as a
+/// request extension.
+///
+/// Never rejects a request: handlers opt into the actor through the [`AuthenticatedActorId`]
+/// extractor.
+pub async fn actor_id_header_middleware(mut request: Request, next: Next) -> Response {
+    let outcome = match actor_id_from_header(request.headers()) {
+        Ok(actor_id) => AuthenticationOutcome::Authenticated(actor_id),
+        Err(error) => AuthenticationOutcome::Failed(error),
+    };
+
+    store_outcome(&mut request, outcome);
+    next.run(request).await
+}
+
+/// Axum extractor providing the acting principal resolved by [`authentication_middleware`] or
+/// [`actor_id_header_middleware`].
+///
+/// Rejects the request on routes without either middleware.
+pub struct AuthenticatedActorId(pub ActorEntityUuid);
+
+impl<S: Sync> FromRequestParts<S> for AuthenticatedActorId {
+    type Rejection = BoxedResponse;
+
+    fn from_request_parts(
+        parts: &mut Parts,
+        _state: &S,
+    ) -> impl Future<Output = Result<Self, Self::Rejection>> + Send {
+        core::future::ready(match parts.extensions.get::<ResolvedAuthentication>() {
+            Some(ResolvedAuthentication(AuthenticationOutcome::Authenticated(actor_id))) => {
+                Ok(Self(*actor_id))
+            }
+            Some(ResolvedAuthentication(AuthenticationOutcome::Failed(error))) => {
+                Err(rejection(error))
+            }
+            None => {
+                tracing::error!(
+                    "`AuthenticatedActorId` extracted on a route without authentication middleware"
+                );
+                Err(status_to_response(Status::<()>::new(
+                    StatusCode::Internal,
+                    Some("internal server error".to_owned()),
+                    vec![],
+                )))
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::sync::Arc;
+
+    use axum::{Router, body::Body, middleware, routing::get};
+    use http::{Request, StatusCode};
+    use tower::ServiceExt as _;
+    use type_system::principal::actor::{ActorEntityUuid, ActorId, UserId};
+    use uuid::Uuid;
+
+    use super::{
+        AuthenticatedActorId, StaticAuthenticationProvider, actor_id_header_middleware,
+        authentication_middleware, is_bootstrap_route,
+    };
+
+    #[test]
+    fn bootstrap_routes_match() {
+        assert!(is_bootstrap_route("/policies/seed"));
+        assert!(is_bootstrap_route("/actors/machine/identifier/system/h"));
+    }
+
+    #[test]
+    fn other_routes_do_not_match() {
+        assert!(!is_bootstrap_route("/policies/query"));
+        assert!(!is_bootstrap_route("/policies/seed/extra"));
+        assert!(!is_bootstrap_route("/actors/machine/identifier/h"));
+        assert!(!is_bootstrap_route("/actors/machine/identifier/system/"));
+        assert!(!is_bootstrap_route(
+            "/actors/machine/identifier/system/h/extra"
+        ));
+        assert!(!is_bootstrap_route("/hashql"));
+    }
+
+    async fn protected(AuthenticatedActorId(actor_id): AuthenticatedActorId) -> String {
+        actor_id.to_string()
+    }
+
+    async fn bootstrap() -> &'static str {
+        "bootstrap"
+    }
+
+    fn router(provider: StaticAuthenticationProvider) -> Router {
+        let provider = Arc::new(provider);
+        Router::new()
+            .route("/protected", get(protected))
+            .route("/policies/seed", get(bootstrap))
+            .layer(middleware::from_fn(move |request, next| {
+                let provider = Arc::clone(&provider);
+                authentication_middleware(provider, request, next)
+            }))
+    }
+
+    fn request(uri: &str) -> Request<Body> {
+        Request::builder()
+            .uri(uri)
+            .body(Body::empty())
+            .expect("the request should build")
+    }
+
+    fn request_with_actor_header(uri: &str, value: &str) -> Request<Body> {
+        Request::builder()
+            .uri(uri)
+            .header("X-Authenticated-User-Actor-Id", value)
+            .body(Body::empty())
+            .expect("the request should build")
+    }
+
+    #[tokio::test]
+    async fn middleware_rejects_requests_without_credentials() {
+        let response = router(StaticAuthenticationProvider::NotRecognized)
+            .oneshot(request("/protected"))
+            .await
+            .expect("the router should respond");
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn middleware_passes_verified_actors_to_handlers() {
+        let actor_id = ActorEntityUuid::new(Uuid::new_v4());
+        let response = router(StaticAuthenticationProvider::Verified(ActorId::User(
+            UserId::new(actor_id),
+        )))
+        .oneshot(request("/protected"))
+        .await
+        .expect("the router should respond");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 1024)
+            .await
+            .expect("the response body should be readable");
+        assert_eq!(body, actor_id.to_string().as_bytes());
+    }
+
+    #[tokio::test]
+    async fn middleware_rejects_rejected_credentials_despite_actor_header() {
+        let response = router(StaticAuthenticationProvider::Rejected)
+            .oneshot(request_with_actor_header(
+                "/protected",
+                &Uuid::new_v4().to_string(),
+            ))
+            .await
+            .expect("the router should respond");
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn middleware_admits_bootstrap_routes_without_credentials() {
+        let response = router(StaticAuthenticationProvider::NotRecognized)
+            .oneshot(request("/policies/seed"))
+            .await
+            .expect("the router should respond");
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn middleware_rejects_malformed_actor_id_headers() {
+        let response = router(StaticAuthenticationProvider::NotRecognized)
+            .oneshot(request_with_actor_header("/protected", "not-a-uuid"))
+            .await
+            .expect("the router should respond");
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn extractor_rejects_routes_without_middleware() {
+        let router = Router::new().route("/protected", get(protected));
+
+        let response = router
+            .oneshot(request_with_actor_header(
+                "/protected",
+                &Uuid::new_v4().to_string(),
+            ))
+            .await
+            .expect("the router should respond");
+
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[tokio::test]
+    async fn header_middleware_resolves_actor_id_headers() {
+        let actor_id = Uuid::new_v4();
+        let router = Router::new()
+            .route("/protected", get(protected))
+            .layer(middleware::from_fn(actor_id_header_middleware));
+
+        let response = router
+            .oneshot(request_with_actor_header(
+                "/protected",
+                &actor_id.to_string(),
+            ))
+            .await
+            .expect("the router should respond");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 1024)
+            .await
+            .expect("the response body should be readable");
+        assert_eq!(body, actor_id.to_string().as_bytes());
+    }
+
+    #[tokio::test]
+    async fn header_middleware_rejects_missing_headers_at_extraction() {
+        let router = Router::new()
+            .route("/protected", get(protected))
+            .layer(middleware::from_fn(actor_id_header_middleware));
+
+        let response = router
+            .oneshot(request("/protected"))
+            .await
+            .expect("the router should respond");
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/libs/@local/graph/api/src/rest/data_type.rs
+++ b/libs/@local/graph/api/src/rest/data_type.rs
@@ -48,7 +48,7 @@ use utoipa::{OpenApi, ToSchema};
 
 use super::status::BoxedResponse;
 use crate::rest::{
-    ApiConfig, AuthenticatedUserHeader, OpenApiQuery, QueryLogger, RestApiStore,
+    ApiConfig, AuthenticatedActorId, OpenApiQuery, QueryLogger, RestApiStore,
     json::Json,
     resolve_limit,
     status::{report_to_response, status_to_response},
@@ -166,7 +166,7 @@ struct CreateDataTypeRequest {
     ),
 )]
 async fn create_data_type<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     domain_validator: Extension<DomainValidator>,
@@ -272,7 +272,7 @@ enum LoadExternalDataTypeRequest {
     ),
 )]
 async fn load_external_data_type<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     domain_validator: Extension<DomainValidator>,
@@ -359,7 +359,7 @@ where
     )
 )]
 async fn query_data_types<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     Extension(api_config): Extension<ApiConfig>,
@@ -429,7 +429,7 @@ struct QueryDataTypeSubgraphResponse {
     )
 )]
 async fn query_data_type_subgraph<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     Extension(api_config): Extension<ApiConfig>,
@@ -498,7 +498,7 @@ where
     )
 )]
 async fn find_data_type_conversion_targets<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     Json(request): Json<FindDataTypeConversionTargetsParams>,
@@ -543,7 +543,7 @@ struct UpdateDataTypeRequest {
     request_body = UpdateDataTypeRequest,
 )]
 async fn update_data_type<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     body: Json<UpdateDataTypeRequest>,
@@ -598,7 +598,7 @@ where
     request_body = [UpdateDataTypeRequest],
 )]
 async fn update_data_types<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     bodies: Json<Vec<UpdateDataTypeRequest>>,
@@ -655,7 +655,7 @@ where
     request_body = UpdateDataTypeEmbeddingParams,
 )]
 async fn update_data_type_embeddings<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     Json(body): Json<serde_json::Value>,
@@ -698,7 +698,7 @@ where
     request_body = ArchiveDataTypeParams,
 )]
 async fn archive_data_type<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     Json(body): Json<serde_json::Value>,
@@ -750,7 +750,7 @@ where
     request_body = UnarchiveDataTypeParams,
 )]
 async fn unarchive_data_type<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     Json(body): Json<serde_json::Value>,
@@ -799,7 +799,7 @@ where
     )
 )]
 async fn has_permission_for_data_types<S>(
-    AuthenticatedUserHeader(actor): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor): AuthenticatedActorId,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     store_pool: Extension<Arc<S>>,
     Json(params): Json<HasPermissionForDataTypesParams<'static>>,

--- a/libs/@local/graph/api/src/rest/entity/mod.rs
+++ b/libs/@local/graph/api/src/rest/entity/mod.rs
@@ -85,7 +85,7 @@ use self::query::{
     summarize_entities,
 };
 use crate::rest::{
-    ApiConfig, AuthenticatedUserHeader, OpenApiQuery, QueryLogger, SearchRequestError,
+    ApiConfig, AuthenticatedActorId, OpenApiQuery, QueryLogger, SearchRequestError,
     json::Json,
     resolve_limit, resolve_search_embedding,
     status::{BoxedResponse, report_to_response},
@@ -286,7 +286,7 @@ impl EntityResource {
     ),
 )]
 async fn create_entity<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     Json(body): Json<serde_json::Value>,
@@ -327,7 +327,7 @@ where
     ),
 )]
 async fn create_entities<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     Json(body): Json<serde_json::Value>,
@@ -368,7 +368,7 @@ where
     ),
 )]
 async fn validate_entity<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     mut query_logger: Option<Extension<QueryLogger>>,
@@ -416,7 +416,7 @@ where
     )
 )]
 async fn has_permission_for_entities<S>(
-    AuthenticatedUserHeader(actor): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor): AuthenticatedActorId,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     store_pool: Extension<Arc<S>>,
     Json(params): Json<HasPermissionForEntitiesParams<'static>>,
@@ -511,7 +511,7 @@ impl SearchEntitiesRequest {
     )
 )]
 async fn search_entities<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     embedding_client: Extension<Option<Arc<OpenAiEmbeddingClient>>>,
@@ -556,7 +556,7 @@ where
     request_body = PatchEntityParams,
 )]
 async fn patch_entity<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     Json(params): Json<PatchEntityParams>,
@@ -601,7 +601,7 @@ where
     request_body = UpdateEntityEmbeddingsParams,
 )]
 async fn update_entity_embeddings<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     Json(body): Json<serde_json::Value>,
@@ -655,7 +655,7 @@ impl ClusteringContext {
     request_body = ClusterEntitiesParams,
 )]
 async fn cluster_entities<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     Extension(store_pool): Extension<Arc<S>>,
     Extension(temporal_client): Extension<Option<Arc<TemporalClient>>>,
     Extension(context): Extension<Arc<ClusteringContext>>,
@@ -698,7 +698,7 @@ where
     request_body = DiffEntityParams,
 )]
 async fn diff_entity<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     mut query_logger: Option<Extension<QueryLogger>>,

--- a/libs/@local/graph/api/src/rest/entity/query/mod.rs
+++ b/libs/@local/graph/api/src/rest/entity/query/mod.rs
@@ -24,7 +24,7 @@ pub use self::request::{
     QueryEntitiesRequest, QueryEntitySubgraphError, QueryEntitySubgraphRequest,
 };
 use crate::rest::{
-    ApiConfig, AuthenticatedUserHeader, OpenApiQuery, QueryLogger,
+    ApiConfig, AuthenticatedActorId, OpenApiQuery, QueryLogger,
     json::Json,
     resolve_limit,
     status::{BoxedResponse, report_to_response},
@@ -51,7 +51,7 @@ use crate::rest::{
     )
 )]
 pub(super) async fn query_entities<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     Extension(api_config): Extension<ApiConfig>,
@@ -129,7 +129,7 @@ pub(super) struct QueryEntitySubgraphResponse<'r> {
     )
 )]
 pub(super) async fn query_entity_subgraph<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     Extension(api_config): Extension<ApiConfig>,
@@ -196,7 +196,7 @@ where
     )
 )]
 pub(super) async fn summarize_entities<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     mut query_logger: Option<Extension<QueryLogger>>,
@@ -250,7 +250,7 @@ where
     )
 )]
 pub(super) async fn query_entities_table<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     store_pool: Extension<Arc<S>>,
     Extension(api_config): Extension<ApiConfig>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,

--- a/libs/@local/graph/api/src/rest/entity_type.rs
+++ b/libs/@local/graph/api/src/rest/entity_type.rs
@@ -49,8 +49,7 @@ use utoipa::{OpenApi, ToSchema};
 
 use super::status::BoxedResponse;
 use crate::rest::{
-    ApiConfig, AuthenticatedUserHeader, OpenApiQuery, QueryLogger, RestApiStore,
-    SearchRequestError,
+    ApiConfig, AuthenticatedActorId, OpenApiQuery, QueryLogger, RestApiStore, SearchRequestError,
     json::Json,
     resolve_limit, resolve_search_embedding,
     status::{report_to_response, status_to_response},
@@ -155,7 +154,7 @@ impl EntityTypeResource {
     )
 )]
 async fn has_permission_for_entity_types<S>(
-    AuthenticatedUserHeader(actor): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor): AuthenticatedActorId,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     store_pool: Extension<Arc<S>>,
     Json(params): Json<HasPermissionForEntityTypesParams<'static>>,
@@ -200,7 +199,7 @@ struct CreateEntityTypeRequest {
 )]
 #[expect(clippy::too_many_lines)]
 async fn create_entity_type<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     domain_validator: Extension<DomainValidator>,
@@ -393,7 +392,7 @@ enum LoadExternalEntityTypeRequest {
     ),
 )]
 async fn load_external_entity_type<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     domain_validator: Extension<DomainValidator>,
@@ -498,7 +497,7 @@ where
     )
 )]
 async fn query_entity_types<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     Extension(api_config): Extension<ApiConfig>,
@@ -613,7 +612,7 @@ impl SearchEntityTypesRequest {
     )
 )]
 async fn search_entity_types<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     embedding_client: Extension<Option<Arc<OpenAiEmbeddingClient>>>,
@@ -661,7 +660,7 @@ where
     )
 )]
 async fn get_closed_multi_entity_types<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     mut query_logger: Option<Extension<QueryLogger>>,
@@ -740,7 +739,7 @@ struct QueryEntityTypeSubgraphResponse {
     )
 )]
 async fn query_entity_type_subgraph<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     Extension(api_config): Extension<ApiConfig>,
@@ -819,7 +818,7 @@ struct UpdateEntityTypeRequest {
     request_body = UpdateEntityTypeRequest,
 )]
 async fn update_entity_type<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     body: Json<UpdateEntityTypeRequest>,
@@ -872,7 +871,7 @@ where
     request_body = [UpdateEntityTypeRequest],
 )]
 async fn update_entity_types<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     bodies: Json<Vec<UpdateEntityTypeRequest>>,
@@ -927,7 +926,7 @@ where
     request_body = UpdateEntityTypeEmbeddingParams,
 )]
 async fn update_entity_type_embeddings<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     Json(body): Json<serde_json::Value>,
@@ -970,7 +969,7 @@ where
     request_body = ArchiveEntityTypeParams,
 )]
 async fn archive_entity_type<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     Json(body): Json<serde_json::Value>,
@@ -1022,7 +1021,7 @@ where
     request_body = UnarchiveEntityTypeParams,
 )]
 async fn unarchive_entity_type<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     Json(body): Json<serde_json::Value>,

--- a/libs/@local/graph/api/src/rest/http_tracing_layer.rs
+++ b/libs/@local/graph/api/src/rest/http_tracing_layer.rs
@@ -69,6 +69,7 @@ fn create_http_span<B>(request: &Request<B>) -> Span {
         { trace::NETWORK_PEER_PORT } = Empty,
         { trace::HTTP_RESPONSE_STATUS_CODE } = Empty,
         { trace::HTTP_RESPONSE_BODY_SIZE } = Empty,
+        // The authentication middleware records this field.
         { "actor_entity_uuid" } = Empty,
     );
 
@@ -101,12 +102,6 @@ fn create_http_span<B>(request: &Request<B>) -> Span {
         && let Ok(body_size) = content_length_str.parse::<i64>()
     {
         http_span.record(trace::HTTP_REQUEST_BODY_SIZE, body_size);
-    }
-
-    if let Some(actor_id_header) = headers.get("X-Authenticated-User-Actor-Id")
-        && let Ok(actor_id) = actor_id_header.to_str()
-    {
-        http_span.record("actor_entity_uuid", actor_id);
     }
 
     if let Some(ConnectInfo(addr)) = request.extensions().get::<ConnectInfo<SocketAddr>>() {

--- a/libs/@local/graph/api/src/rest/mod.rs
+++ b/libs/@local/graph/api/src/rest/mod.rs
@@ -13,6 +13,7 @@ pub mod property_type;
 pub mod status;
 
 pub mod admin;
+pub mod auth;
 pub mod http_tracing_layer;
 pub mod jwt;
 pub mod probe;
@@ -21,7 +22,7 @@ pub mod hashql;
 mod json;
 mod utoipa_typedef;
 use alloc::{borrow::Cow, sync::Arc};
-use core::{error::Error, str::FromStr as _};
+use core::error::Error;
 use std::{
     fs,
     io::{self, Write as _},
@@ -99,8 +100,8 @@ use utoipa::{
     },
 };
 use utoipa_scalar::Scalar;
-use uuid::Uuid;
 
+pub use self::auth::AuthenticatedActorId;
 use self::{
     entity::ClusteringContext,
     status::{BoxedResponse, report_to_response, status_to_response},
@@ -114,37 +115,6 @@ use self::{
         },
     },
 };
-
-pub struct AuthenticatedUserHeader(pub ActorEntityUuid);
-
-impl AuthenticatedUserHeader {
-    fn from_request_parts_impl(parts: &Parts) -> Result<Self, (StatusCode, Cow<'static, str>)> {
-        if let Some(header_value) = parts.headers.get("X-Authenticated-User-Actor-Id") {
-            let header_string = header_value
-                .to_str()
-                .map_err(|error| (StatusCode::BAD_REQUEST, Cow::Owned(error.to_string())))?;
-            let uuid = Uuid::from_str(header_string)
-                .map_err(|error| (StatusCode::BAD_REQUEST, Cow::Owned(error.to_string())))?;
-            Ok(Self(ActorEntityUuid::new(uuid)))
-        } else {
-            Err((
-                StatusCode::BAD_REQUEST,
-                Cow::Borrowed("`X-Authenticated-User-Actor-Id` header is missing"),
-            ))
-        }
-    }
-}
-
-impl<S: Sync> FromRequestParts<S> for AuthenticatedUserHeader {
-    type Rejection = (StatusCode, Cow<'static, str>);
-
-    fn from_request_parts(
-        parts: &mut Parts,
-        _state: &S,
-    ) -> impl Future<Output = Result<Self, Self::Rejection>> + Send {
-        core::future::ready(Self::from_request_parts_impl(parts))
-    }
-}
 
 pub struct InteractiveHeader(pub bool);
 
@@ -587,6 +557,9 @@ where
     S: StorePool + Send + Sync + 'static,
     for<'p> S::Store<'p>: RestApiStore + PrincipalStore + PolicyStore,
 {
+    // TODO(BE-332): replace with the Kratos session provider
+    let session_provider = Arc::new(auth::StaticAuthenticationProvider::NotRecognized);
+
     // All api resources are merged together into a super-router.
     let merged_routes = api_resources::<S>()
         .into_iter()
@@ -601,7 +574,15 @@ where
     // Make sure extensions are added at the end so they are made available to merged routers.
     // The `OpenAPI` endpoints are merged in afterwards as we don't want any layers or handlers to
     // apply to them. We use a `ServiceBuilder` to add the layers in the correct order.
+    //
+    // The authentication middleware is added first so it runs innermost: inside the HTTP tracing
+    // span, where its actor recording targets the request span. `route_layer` keeps the 404
+    // fallback outside the middleware, so unmatched paths return 404 instead of 401.
     let mut router = merged_routes
+        .route_layer(axum::middleware::from_fn(move |request, next| {
+            let provider = Arc::clone(&session_provider);
+            auth::authentication_middleware(provider, request, next)
+        }))
         .layer(
             ServiceBuilder::new()
                 .layer(NewSentryLayer::new_from_top())

--- a/libs/@local/graph/api/src/rest/mod.rs
+++ b/libs/@local/graph/api/src/rest/mod.rs
@@ -557,7 +557,7 @@ where
     S: StorePool + Send + Sync + 'static,
     for<'p> S::Store<'p>: RestApiStore + PrincipalStore + PolicyStore,
 {
-    // TODO(BE-332): replace with the Kratos session provider
+    // TODO(BE-760): replace with the Kratos session provider
     let session_provider = Arc::new(auth::StaticAuthenticationProvider::NotRecognized);
 
     // All api resources are merged together into a super-router.

--- a/libs/@local/graph/api/src/rest/permissions.rs
+++ b/libs/@local/graph/api/src/rest/permissions.rs
@@ -20,7 +20,7 @@ use http::StatusCode;
 use utoipa::OpenApi;
 
 use super::status::BoxedResponse;
-use crate::rest::{AuthenticatedUserHeader, json::Json, status::report_to_response};
+use crate::rest::{AuthenticatedActorId, json::Json, status::report_to_response};
 
 #[derive(OpenApi)]
 #[openapi(
@@ -86,7 +86,7 @@ impl PermissionResource {
     )
 )]
 async fn create_policy<S>(
-    AuthenticatedUserHeader(authenticated_actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(authenticated_actor_id): AuthenticatedActorId,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     Json(policy): Json<PolicyCreationParams>,
@@ -120,7 +120,7 @@ where
     )
 )]
 async fn get_policy_by_id<S>(
-    AuthenticatedUserHeader(authenticated_actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(authenticated_actor_id): AuthenticatedActorId,
     Path(policy_id): Path<PolicyId>,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
@@ -154,7 +154,7 @@ where
     )
 )]
 async fn query_policies<S>(
-    AuthenticatedUserHeader(authenticated_actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(authenticated_actor_id): AuthenticatedActorId,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     Json(filter): Json<PolicyFilter>,
@@ -188,7 +188,7 @@ where
     )
 )]
 async fn resolve_policies_for_actor<S>(
-    AuthenticatedUserHeader(authenticated_actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(authenticated_actor_id): AuthenticatedActorId,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     Json(params): Json<ResolvePoliciesParams<'static>>,
@@ -223,7 +223,7 @@ where
     )
 )]
 async fn update_policy_by_id<S>(
-    AuthenticatedUserHeader(authenticated_actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(authenticated_actor_id): AuthenticatedActorId,
     Path(policy_id): Path<PolicyId>,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
@@ -258,7 +258,7 @@ where
     )
 )]
 async fn archive_policy_by_id<S>(
-    AuthenticatedUserHeader(authenticated_actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(authenticated_actor_id): AuthenticatedActorId,
     Path(policy_id): Path<PolicyId>,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
@@ -292,7 +292,7 @@ where
     )
 )]
 async fn delete_policy_by_id<S>(
-    AuthenticatedUserHeader(authenticated_actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(authenticated_actor_id): AuthenticatedActorId,
     Path(policy_id): Path<PolicyId>,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,

--- a/libs/@local/graph/api/src/rest/principal.rs
+++ b/libs/@local/graph/api/src/rest/principal.rs
@@ -27,7 +27,7 @@ use type_system::principal::{
 use utoipa::OpenApi;
 
 use super::status::BoxedResponse;
-use crate::rest::{AuthenticatedUserHeader, json::Json, status::report_to_response};
+use crate::rest::{AuthenticatedActorId, json::Json, status::report_to_response};
 
 #[derive(OpenApi)]
 #[openapi(
@@ -213,7 +213,7 @@ where
     )
 )]
 async fn get_machine_by_identifier<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     Path(identifier): Path<String>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     store_pool: Extension<Arc<S>>,
@@ -247,7 +247,7 @@ where
     )
 )]
 async fn create_user_actor<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     store_pool: Extension<Arc<S>>,
     Json(params): Json<CreateUserActorParams>,
@@ -280,7 +280,7 @@ where
     )
 )]
 async fn create_ai_actor<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     store_pool: Extension<Arc<S>>,
     Json(params): Json<CreateAiActorParams>,
@@ -313,7 +313,7 @@ where
     )
 )]
 async fn get_ai_by_identifier<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     Path(identifier): Path<String>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     store_pool: Extension<Arc<S>>,
@@ -347,7 +347,7 @@ where
     )
 )]
 async fn create_org_web<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     store_pool: Extension<Arc<S>>,
     Json(params): Json<CreateOrgWebParams>,
@@ -383,7 +383,7 @@ where
     )
 )]
 async fn get_web_by_id<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     Path(web_id): Path<WebId>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     store_pool: Extension<Arc<S>>,
@@ -424,7 +424,7 @@ struct UpdateWebShortnameParams {
     )
 )]
 async fn update_web_shortname<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     Path(web_id): Path<WebId>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     store_pool: Extension<Arc<S>>,
@@ -458,7 +458,7 @@ where
     )
 )]
 async fn get_web_by_shortname<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     Path(shortname): Path<String>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     store_pool: Extension<Arc<S>>,
@@ -492,7 +492,7 @@ where
     )
 )]
 async fn get_web_roles<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     Path(web_id): Path<WebId>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     store_pool: Extension<Arc<S>>,
@@ -526,7 +526,7 @@ where
     )
 )]
 async fn get_team_by_name<S>(
-    AuthenticatedUserHeader(actor): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor): AuthenticatedActorId,
     Path(name): Path<String>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     store_pool: Extension<Arc<S>>,
@@ -560,7 +560,7 @@ where
     )
 )]
 async fn get_team_roles<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     Path(team_id): Path<TeamId>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     store_pool: Extension<Arc<S>>,
@@ -596,7 +596,7 @@ where
     )
 )]
 async fn get_actor_group_role_assignments<S>(
-    AuthenticatedUserHeader(_actor): AuthenticatedUserHeader,
+    AuthenticatedActorId(_actor): AuthenticatedActorId,
     Path((actor_group_id, role_name)): Path<(ActorGroupEntityUuid, RoleName)>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     store_pool: Extension<Arc<S>>,
@@ -634,7 +634,7 @@ where
     )
 )]
 async fn get_actor_group_role<S>(
-    AuthenticatedUserHeader(_actor): AuthenticatedUserHeader,
+    AuthenticatedActorId(_actor): AuthenticatedActorId,
     Path((actor_group_id, actor_id)): Path<(ActorGroupEntityUuid, ActorEntityUuid)>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     store_pool: Extension<Arc<S>>,
@@ -673,7 +673,7 @@ where
     )
 )]
 async fn assign_actor_group_role<S>(
-    AuthenticatedUserHeader(actor): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor): AuthenticatedActorId,
     Path((actor_group_id, role_name, actor_id)): Path<(
         ActorGroupEntityUuid,
         RoleName,
@@ -714,7 +714,7 @@ where
     )
 )]
 async fn unassign_actor_group_role<S>(
-    AuthenticatedUserHeader(actor): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor): AuthenticatedActorId,
     Path((actor_group_id, role_name, actor_id)): Path<(
         ActorGroupEntityUuid,
         RoleName,

--- a/libs/@local/graph/api/src/rest/property_type.rs
+++ b/libs/@local/graph/api/src/rest/property_type.rs
@@ -44,7 +44,7 @@ use utoipa::{OpenApi, ToSchema};
 
 use super::status::BoxedResponse;
 use crate::rest::{
-    ApiConfig, AuthenticatedUserHeader, OpenApiQuery, QueryLogger, RestApiStore,
+    ApiConfig, AuthenticatedActorId, OpenApiQuery, QueryLogger, RestApiStore,
     json::Json,
     resolve_limit,
     status::{report_to_response, status_to_response},
@@ -149,7 +149,7 @@ struct CreatePropertyTypeRequest {
     ),
 )]
 async fn create_property_type<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     domain_validator: Extension<DomainValidator>,
@@ -249,7 +249,7 @@ enum LoadExternalPropertyTypeRequest {
     ),
 )]
 async fn load_external_property_type<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     domain_validator: Extension<DomainValidator>,
@@ -330,7 +330,7 @@ where
     )
 )]
 async fn query_property_types<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     Extension(api_config): Extension<ApiConfig>,
@@ -404,7 +404,7 @@ struct QueryPropertyTypeSubgraphResponse {
     )
 )]
 async fn query_property_type_subgraph<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     Extension(api_config): Extension<ApiConfig>,
@@ -479,7 +479,7 @@ struct UpdatePropertyTypeRequest {
     request_body = UpdatePropertyTypeRequest,
 )]
 async fn update_property_type<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     body: Json<UpdatePropertyTypeRequest>,
@@ -532,7 +532,7 @@ where
     request_body = [UpdatePropertyTypeRequest],
 )]
 async fn update_property_types<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     bodies: Json<Vec<UpdatePropertyTypeRequest>>,
@@ -587,7 +587,7 @@ where
     request_body = UpdatePropertyTypeEmbeddingParams,
 )]
 async fn update_property_type_embeddings<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     Json(body): Json<serde_json::Value>,
@@ -630,7 +630,7 @@ where
     request_body = ArchivePropertyTypeParams,
 )]
 async fn archive_property_type<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     Json(body): Json<serde_json::Value>,
@@ -682,7 +682,7 @@ where
     request_body = UnarchivePropertyTypeParams,
 )]
 async fn unarchive_property_type<S>(
-    AuthenticatedUserHeader(actor_id): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     Json(body): Json<serde_json::Value>,
@@ -731,7 +731,7 @@ where
     )
 )]
 async fn has_permission_for_property_types<S>(
-    AuthenticatedUserHeader(actor): AuthenticatedUserHeader,
+    AuthenticatedActorId(actor): AuthenticatedActorId,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     store_pool: Extension<Arc<S>>,
     Json(params): Json<HasPermissionForPropertyTypesParams<'static>>,

--- a/libs/@local/graph/authentication/Cargo.toml
+++ b/libs/@local/graph/authentication/Cargo.toml
@@ -8,15 +8,24 @@ authors.workspace = true
 
 [dependencies]
 # Public workspace dependencies
+error-stack = { workspace = true, public = true }
+hash-status = { workspace = true, public = true }
+type-system = { workspace = true, public = true }
 
 # Public third-party dependencies
+http = { workspace = true, public = true, features = ["std"] }
 
 # Private workspace dependencies
 
 # Private third-party dependencies
+derive_more    = { workspace = true, features = ["display"] }
 simple-mermaid = { workspace = true }
+tracing        = { workspace = true }
+uuid           = { workspace = true }
 
 [dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+uuid  = { workspace = true, features = ["v4"] }
 
 [lints]
 workspace = true

--- a/libs/@local/graph/authentication/docs/dependency-diagram.mmd
+++ b/libs/@local/graph/authentication/docs/dependency-diagram.mmd
@@ -8,5 +8,42 @@ graph TD
     %% --> : Normal dependency
     %% -.-> : Dev dependency
     %% ---> : Build dependency
-    0[hash-graph-authentication]
-    class 0 root
+    0[<a href="../hash_graph/index.html">hash-graph</a>]
+    1[<a href="../type_system/index.html">type-system</a>]
+    2[<a href="../hash_codec/index.html">hash-codec</a>]
+    3[<a href="../hash_codegen/index.html">hash-codegen</a>]
+    4[<a href="../hash_graph_api/index.html">hash-graph-api</a>]
+    5[hash-graph-authentication]
+    class 5 root
+    6[<a href="../hash_graph_authorization/index.html">hash-graph-authorization</a>]
+    7[<a href="../hash_graph_store/index.html">hash-graph-store</a>]
+    8[<a href="../hash_graph_temporal_versioning/index.html">hash-graph-temporal-versioning</a>]
+    9[<a href="../hash_graph_types/index.html">hash-graph-types</a>]
+    10[<a href="../harpc_types/index.html">harpc-types</a>]
+    11[<a href="../harpc_wire_protocol/index.html">harpc-wire-protocol</a>]
+    12[<a href="../hash_status/index.html">hash-status</a>]
+    13[<a href="../hash_temporal_client/index.html">hash-temporal-client</a>]
+    14[<a href="../error_stack/index.html">error-stack</a>]
+    15[<a href="../hash_graph_benches/index.html">hash-graph-benches</a>]
+    16[<a href="../hash_graph_test_data/index.html">hash-graph-test-data</a>]
+    0 --> 4
+    1 --> 8
+    1 -.-> 16
+    2 -.-> 3
+    2 --> 11
+    4 --> 5
+    4 --> 7
+    5 --> 1
+    5 --> 12
+    6 --> 1
+    7 --> 6
+    7 --> 9
+    7 --> 13
+    8 --> 2
+    9 -.-> 16
+    11 -.-> 10
+    11 --> 10
+    11 --> 14
+    13 --> 1
+    15 -.-> 4
+    16 --> 7

--- a/libs/@local/graph/authentication/package.json
+++ b/libs/@local/graph/authentication/package.json
@@ -8,5 +8,10 @@
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",
     "test:unit": "mise run test:unit @rust/hash-graph-authentication"
+  },
+  "dependencies": {
+    "@blockprotocol/type-system-rs": "workspace:*",
+    "@rust/error-stack": "workspace:*",
+    "@rust/hash-status": "workspace:*"
   }
 }

--- a/libs/@local/graph/authentication/src/lib.rs
+++ b/libs/@local/graph/authentication/src/lib.rs
@@ -2,10 +2,7 @@
 //! ## Workspace dependencies
 #![doc = simple_mermaid::mermaid!("../docs/dependency-diagram.mmd")]
 
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}
+extern crate alloc;
+
+pub mod provider;
+pub mod request;

--- a/libs/@local/graph/authentication/src/provider.rs
+++ b/libs/@local/graph/authentication/src/provider.rs
@@ -1,0 +1,51 @@
+//! Provider-based request authentication.
+
+use error_stack::Report;
+use http::HeaderMap;
+use type_system::principal::actor::ActorId;
+
+use crate::request::AuthenticationError;
+
+/// The result of a provider inspecting a request's credentials.
+#[derive(Debug)]
+pub enum Authentication {
+    /// The request carries no credential this provider handles.
+    NotRecognized,
+    /// The credential verified to this actor.
+    Verified(ActorId),
+    /// A credential is present but does not verify.
+    ///
+    /// Callers must not fall back to other authentication paths.
+    Rejected(Report<AuthenticationError>),
+}
+
+/// Authenticates requests against a credential verifier.
+///
+/// A provider owns both the recognition of its credentials in the request headers and their
+/// verification.
+pub trait AuthenticationProvider: Send + Sync {
+    /// Resolves the credential of a request.
+    fn authenticate(&self, headers: &HeaderMap) -> impl Future<Output = Authentication> + Send;
+}
+
+/// Authentication provider serving a fixed result.
+pub enum StaticAuthenticationProvider {
+    /// Recognizes no credentials.
+    NotRecognized,
+    /// Verifies every request to this actor.
+    Verified(ActorId),
+    /// Rejects every request.
+    Rejected,
+}
+
+impl AuthenticationProvider for StaticAuthenticationProvider {
+    fn authenticate(&self, _headers: &HeaderMap) -> impl Future<Output = Authentication> + Send {
+        core::future::ready(match self {
+            Self::NotRecognized => Authentication::NotRecognized,
+            Self::Verified(actor_id) => Authentication::Verified(*actor_id),
+            Self::Rejected => {
+                Authentication::Rejected(Report::new(AuthenticationError::InvalidSession))
+            }
+        })
+    }
+}

--- a/libs/@local/graph/authentication/src/request.rs
+++ b/libs/@local/graph/authentication/src/request.rs
@@ -1,0 +1,255 @@
+//! Resolution of a request's credentials to the acting principal.
+
+use core::str::FromStr as _;
+
+use hash_status::StatusCode;
+use http::HeaderMap;
+use type_system::principal::actor::ActorEntityUuid;
+use uuid::Uuid;
+
+use crate::provider::{Authentication, AuthenticationProvider};
+
+/// Name of the header carrying an unverified actor ID.
+pub const ACTOR_ID_HEADER: &str = "X-Authenticated-User-Actor-Id";
+
+/// Errors that can occur while authenticating a request.
+#[derive(Debug, Clone, derive_more::Display)]
+pub enum AuthenticationError {
+    /// No credentials were provided with the request.
+    #[display("no credentials provided")]
+    MissingCredentials,
+    /// A credential is present but not decodable.
+    #[display("credential is malformed")]
+    MalformedCredential,
+    /// The actor-ID header is present but not a valid UUID.
+    #[display("`X-Authenticated-User-Actor-Id` header is not a valid UUID")]
+    InvalidActorIdHeader,
+    /// The credential provider could not be reached.
+    #[display("failed to verify the credential against the provider")]
+    ProviderUnreachable,
+    /// The credential provider rejected the verification request.
+    #[display("the credential provider rejected the verification request")]
+    ProviderRejection,
+    /// The credential provider returned a response that could not be interpreted.
+    #[display("the credential provider returned an invalid response")]
+    InvalidProviderResponse,
+    /// The session is invalid, expired, or revoked.
+    #[display("session is invalid or expired")]
+    InvalidSession,
+    /// The identity has no Graph actor provisioned.
+    #[display("identity `{identity_id}` has no Graph actor provisioned")]
+    NotProvisioned {
+        /// The provider-side identity ID lacking the actor provisioning.
+        identity_id: String,
+    },
+    /// The provisioned actor does not exist in the principal store.
+    #[display("actor `{actor_id}` does not exist")]
+    ActorNotFound {
+        /// The actor ID carried by the credential.
+        actor_id: ActorEntityUuid,
+    },
+    /// The provisioned actor exists but is not a user actor.
+    #[display("actor `{actor_id}` is not a user actor")]
+    NotAUser {
+        /// The actor ID carried by the credential.
+        actor_id: ActorEntityUuid,
+    },
+    /// The principal store could not be queried.
+    #[display("failed to validate actor against the principal store")]
+    StoreError,
+}
+
+impl core::error::Error for AuthenticationError {}
+
+impl AuthenticationError {
+    /// Returns the status code reported to the client for this error.
+    #[must_use]
+    pub const fn status_code(&self) -> StatusCode {
+        match self {
+            Self::InvalidActorIdHeader | Self::MalformedCredential => StatusCode::InvalidArgument,
+            Self::ProviderUnreachable | Self::ProviderRejection | Self::StoreError => {
+                StatusCode::Unavailable
+            }
+            Self::InvalidProviderResponse => StatusCode::Internal,
+            Self::MissingCredentials
+            | Self::InvalidSession
+            | Self::NotProvisioned { .. }
+            | Self::ActorNotFound { .. }
+            | Self::NotAUser { .. } => StatusCode::Unauthenticated,
+        }
+    }
+}
+
+/// The result of resolving a request's credentials.
+#[derive(Debug, Clone)]
+pub enum AuthenticationOutcome {
+    /// The request carries accepted credentials for this actor.
+    Authenticated(ActorEntityUuid),
+    /// The request carries no or invalid credentials.
+    Failed(AuthenticationError),
+}
+
+/// Resolves the acting principal from the request headers.
+///
+/// Credentials are considered in order: a provider credential first, the unverified
+/// `X-Authenticated-User-Actor-Id` header second. A request carrying a recognized provider
+/// credential never falls back to the actor-ID header: a rejected credential fails even if the
+/// header is present.
+pub async fn resolve_request_actor<P>(provider: &P, headers: &HeaderMap) -> AuthenticationOutcome
+where
+    P: AuthenticationProvider,
+{
+    // TODO(BE-755): cache verified credentials so repeated requests do not re-verify against the
+    //               provider and the principal store each time
+    match provider.authenticate(headers).await {
+        Authentication::Verified(actor_id) => {
+            AuthenticationOutcome::Authenticated(ActorEntityUuid::new(actor_id))
+        }
+        Authentication::Rejected(report) => {
+            let error = report.current_context().clone();
+            if matches!(
+                error.status_code(),
+                StatusCode::Unavailable | StatusCode::Internal
+            ) {
+                tracing::error!(error = ?report, "credential verification failed");
+            } else {
+                tracing::debug!(error = ?report, "credential rejected");
+            }
+            AuthenticationOutcome::Failed(error)
+        }
+        Authentication::NotRecognized => match actor_id_from_header(headers) {
+            Ok(actor_id) => AuthenticationOutcome::Authenticated(actor_id),
+            Err(error) => AuthenticationOutcome::Failed(error),
+        },
+    }
+}
+
+/// Parses the actor from the unverified actor-ID header.
+///
+/// # Errors
+///
+/// - [`MissingCredentials`] if the header is absent
+/// - [`InvalidActorIdHeader`] if the header is not a valid UUID
+///
+/// [`MissingCredentials`]: AuthenticationError::MissingCredentials
+/// [`InvalidActorIdHeader`]: AuthenticationError::InvalidActorIdHeader
+pub fn actor_id_from_header(headers: &HeaderMap) -> Result<ActorEntityUuid, AuthenticationError> {
+    let header_value = headers
+        .get(ACTOR_ID_HEADER)
+        .ok_or(AuthenticationError::MissingCredentials)?;
+
+    header_value
+        .to_str()
+        .ok()
+        .and_then(|header_string| Uuid::from_str(header_string).ok())
+        .map(ActorEntityUuid::new)
+        .ok_or(AuthenticationError::InvalidActorIdHeader)
+}
+
+#[cfg(test)]
+mod tests {
+    use http::HeaderMap;
+    use type_system::principal::actor::{ActorEntityUuid, ActorId, UserId};
+    use uuid::Uuid;
+
+    use super::{AuthenticationError, AuthenticationOutcome, resolve_request_actor};
+    use crate::provider::StaticAuthenticationProvider;
+
+    fn random_user() -> ActorId {
+        ActorId::User(UserId::new(ActorEntityUuid::new(Uuid::new_v4())))
+    }
+
+    fn actor_id_header(actor_id: ActorEntityUuid) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            super::ACTOR_ID_HEADER,
+            actor_id
+                .to_string()
+                .parse()
+                .expect("a UUID should be a valid header value"),
+        );
+        headers
+    }
+
+    #[tokio::test]
+    async fn verified_credential_authenticates_actor() {
+        let actor_id = random_user();
+        let provider = StaticAuthenticationProvider::Verified(actor_id);
+
+        let outcome = resolve_request_actor(&provider, &HeaderMap::new()).await;
+
+        assert!(
+            matches!(
+                outcome,
+                AuthenticationOutcome::Authenticated(resolved)
+                    if resolved == ActorEntityUuid::new(actor_id)
+            ),
+            "a verified credential should authenticate its actor"
+        );
+    }
+
+    #[tokio::test]
+    async fn rejected_credential_does_not_fall_back_to_actor_id_header() {
+        let provider = StaticAuthenticationProvider::Rejected;
+        let headers = actor_id_header(ActorEntityUuid::new(Uuid::new_v4()));
+
+        let outcome = resolve_request_actor(&provider, &headers).await;
+
+        assert!(
+            matches!(
+                outcome,
+                AuthenticationOutcome::Failed(AuthenticationError::InvalidSession)
+            ),
+            "a rejected credential should fail even when an actor-ID header is present"
+        );
+    }
+
+    #[tokio::test]
+    async fn actor_id_header_resolves_without_provider_credential() {
+        let actor_id = ActorEntityUuid::new(Uuid::new_v4());
+        let provider = StaticAuthenticationProvider::NotRecognized;
+        let headers = actor_id_header(actor_id);
+
+        let outcome = resolve_request_actor(&provider, &headers).await;
+
+        assert!(
+            matches!(outcome, AuthenticationOutcome::Authenticated(resolved) if resolved == actor_id),
+            "the actor-ID header should resolve when no provider credential is recognized"
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_credentials_fail_authentication() {
+        let provider = StaticAuthenticationProvider::NotRecognized;
+
+        let outcome = resolve_request_actor(&provider, &HeaderMap::new()).await;
+
+        assert!(
+            matches!(
+                outcome,
+                AuthenticationOutcome::Failed(AuthenticationError::MissingCredentials)
+            ),
+            "a request without credentials should fail authentication"
+        );
+    }
+
+    #[tokio::test]
+    async fn malformed_actor_id_header_fails_authentication() {
+        let provider = StaticAuthenticationProvider::NotRecognized;
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            super::ACTOR_ID_HEADER,
+            "not-a-uuid".parse().expect("the header value should parse"),
+        );
+
+        let outcome = resolve_request_actor(&provider, &headers).await;
+
+        assert!(
+            matches!(
+                outcome,
+                AuthenticationOutcome::Failed(AuthenticationError::InvalidActorIdHeader)
+            ),
+            "a malformed actor-ID header should fail authentication"
+        );
+    }
+}

--- a/libs/@local/graph/authentication/src/request.rs
+++ b/libs/@local/graph/authentication/src/request.rs
@@ -78,6 +78,31 @@ impl AuthenticationError {
             | Self::NotAUser { .. } => StatusCode::Unauthenticated,
         }
     }
+
+    /// Returns the message reported to the client for this error.
+    ///
+    /// Never carries identifiers. Those remain in the [`Display`] representation used for
+    /// server-side logs.
+    ///
+    /// [`Display`]: core::fmt::Display
+    #[must_use]
+    pub const fn client_message(&self) -> &'static str {
+        match self {
+            Self::MissingCredentials => "no credentials provided",
+            Self::MalformedCredential => "credential is malformed",
+            Self::InvalidActorIdHeader => {
+                "`X-Authenticated-User-Actor-Id` header is not a valid UUID"
+            }
+            Self::ProviderUnreachable => "failed to verify the credential against the provider",
+            Self::ProviderRejection => "the credential provider rejected the verification request",
+            Self::InvalidProviderResponse => "the credential provider returned an invalid response",
+            Self::InvalidSession => "session is invalid or expired",
+            Self::NotProvisioned { .. } => "identity has no Graph actor provisioned",
+            Self::ActorNotFound { .. } => "actor does not exist",
+            Self::NotAUser { .. } => "actor is not a user actor",
+            Self::StoreError => "failed to validate actor against the principal store",
+        }
+    }
 }
 
 /// The result of resolving a request's credentials.
@@ -112,6 +137,15 @@ where
                 StatusCode::Unavailable | StatusCode::Internal
             ) {
                 tracing::error!(error = ?report, "credential verification failed");
+            } else if matches!(
+                error,
+                AuthenticationError::NotProvisioned { .. }
+                    | AuthenticationError::ActorNotFound { .. }
+                    | AuthenticationError::NotAUser { .. }
+            ) {
+                // A verified credential pointing at a missing or non-user actor is broken
+                // provisioning. The client cannot resolve this on its own.
+                tracing::warn!(error = ?report, "credential rejected due to broken actor provisioning");
             } else {
                 tracing::debug!(error = ?report, "credential rejected");
             }

--- a/libs/@local/graph/authorization/docs/dependency-diagram.mmd
+++ b/libs/@local/graph/authorization/docs/dependency-diagram.mmd
@@ -13,64 +13,67 @@ graph TD
     2[<a href="../hash_codec/index.html">hash-codec</a>]
     3[<a href="../hash_codegen/index.html">hash-codegen</a>]
     4[<a href="../hash_graph_api/index.html">hash-graph-api</a>]
-    5[hash-graph-authorization]
-    class 5 root
-    6[<a href="../hash_graph_embeddings/index.html">hash-graph-embeddings</a>]
-    7[<a href="../hash_graph_postgres_store/index.html">hash-graph-postgres-store</a>]
-    8[<a href="../hash_graph_store/index.html">hash-graph-store</a>]
-    9[<a href="../hash_graph_temporal_versioning/index.html">hash-graph-temporal-versioning</a>]
-    10[<a href="../hash_graph_type_fetcher/index.html">hash-graph-type-fetcher</a>]
-    11[<a href="../hash_graph_types/index.html">hash-graph-types</a>]
-    12[<a href="../hash_graph_validation/index.html">hash-graph-validation</a>]
-    13[<a href="../harpc_server/index.html">harpc-server</a>]
-    14[<a href="../harpc_types/index.html">harpc-types</a>]
-    15[<a href="../harpc_wire_protocol/index.html">harpc-wire-protocol</a>]
-    16[<a href="../hashql_ast/index.html">hashql-ast</a>]
-    17[<a href="../hashql_compiletest/index.html">hashql-compiletest</a>]
-    18[<a href="../hashql_eval/index.html">hashql-eval</a>]
-    19[<a href="../hashql_hir/index.html">hashql-hir</a>]
-    20[<a href="../hashql_mir/index.html">hashql-mir</a>]
-    21[<a href="../hashql_syntax_jexpr/index.html">hashql-syntax-jexpr</a>]
-    22[<a href="../hash_temporal_client/index.html">hash-temporal-client</a>]
-    23[<a href="../error_stack/index.html">error-stack</a>]
-    24[<a href="../hash_graph_benches/index.html">hash-graph-benches</a>]
-    25[<a href="../hash_graph_integration/index.html">hash-graph-integration</a>]
-    26[<a href="../hash_graph_test_data/index.html">hash-graph-test-data</a>]
+    5[<a href="../hash_graph_authentication/index.html">hash-graph-authentication</a>]
+    6[hash-graph-authorization]
+    class 6 root
+    7[<a href="../hash_graph_embeddings/index.html">hash-graph-embeddings</a>]
+    8[<a href="../hash_graph_postgres_store/index.html">hash-graph-postgres-store</a>]
+    9[<a href="../hash_graph_store/index.html">hash-graph-store</a>]
+    10[<a href="../hash_graph_temporal_versioning/index.html">hash-graph-temporal-versioning</a>]
+    11[<a href="../hash_graph_type_fetcher/index.html">hash-graph-type-fetcher</a>]
+    12[<a href="../hash_graph_types/index.html">hash-graph-types</a>]
+    13[<a href="../hash_graph_validation/index.html">hash-graph-validation</a>]
+    14[<a href="../harpc_server/index.html">harpc-server</a>]
+    15[<a href="../harpc_types/index.html">harpc-types</a>]
+    16[<a href="../harpc_wire_protocol/index.html">harpc-wire-protocol</a>]
+    17[<a href="../hashql_ast/index.html">hashql-ast</a>]
+    18[<a href="../hashql_compiletest/index.html">hashql-compiletest</a>]
+    19[<a href="../hashql_eval/index.html">hashql-eval</a>]
+    20[<a href="../hashql_hir/index.html">hashql-hir</a>]
+    21[<a href="../hashql_mir/index.html">hashql-mir</a>]
+    22[<a href="../hashql_syntax_jexpr/index.html">hashql-syntax-jexpr</a>]
+    23[<a href="../hash_temporal_client/index.html">hash-temporal-client</a>]
+    24[<a href="../error_stack/index.html">error-stack</a>]
+    25[<a href="../hash_graph_benches/index.html">hash-graph-benches</a>]
+    26[<a href="../hash_graph_integration/index.html">hash-graph-integration</a>]
+    27[<a href="../hash_graph_test_data/index.html">hash-graph-test-data</a>]
     0 --> 4
-    1 --> 9
-    1 -.-> 26
+    1 --> 10
+    1 -.-> 27
     2 -.-> 3
-    2 --> 15
-    4 --> 10
-    4 --> 13
-    4 --> 18
-    4 --> 21
+    2 --> 16
+    4 --> 5
+    4 --> 11
+    4 --> 14
+    4 --> 19
+    4 --> 22
     5 --> 1
-    6 --> 11
-    7 --> 6
-    7 -.-> 7
+    6 --> 1
     7 --> 12
-    8 --> 5
-    8 --> 11
-    8 --> 22
-    9 --> 2
-    10 --> 8
-    11 -.-> 26
-    12 -.-> 26
-    13 -.-> 1
-    13 --> 14
-    15 -.-> 14
-    15 --> 14
-    15 --> 23
-    16 -.-> 17
-    17 --> 18
-    17 --> 21
-    18 --> 7
-    18 --> 20
-    19 -.-> 17
-    20 --> 19
-    21 --> 16
-    22 --> 1
-    24 -.-> 4
-    25 -.-> 7
-    26 --> 8
+    8 --> 7
+    8 -.-> 8
+    8 --> 13
+    9 --> 6
+    9 --> 12
+    9 --> 23
+    10 --> 2
+    11 --> 9
+    12 -.-> 27
+    13 -.-> 27
+    14 -.-> 1
+    14 --> 15
+    16 -.-> 15
+    16 --> 15
+    16 --> 24
+    17 -.-> 18
+    18 --> 19
+    18 --> 22
+    19 --> 8
+    19 --> 21
+    20 -.-> 18
+    21 --> 20
+    22 --> 17
+    23 --> 1
+    25 -.-> 4
+    26 -.-> 8
+    27 --> 9

--- a/libs/@local/graph/store/docs/dependency-diagram.mmd
+++ b/libs/@local/graph/store/docs/dependency-diagram.mmd
@@ -13,64 +13,67 @@ graph TD
     2[<a href="../hash_codec/index.html">hash-codec</a>]
     3[<a href="../hash_codegen/index.html">hash-codegen</a>]
     4[<a href="../hash_graph_api/index.html">hash-graph-api</a>]
-    5[<a href="../hash_graph_authorization/index.html">hash-graph-authorization</a>]
-    6[<a href="../hash_graph_embeddings/index.html">hash-graph-embeddings</a>]
-    7[<a href="../hash_graph_postgres_store/index.html">hash-graph-postgres-store</a>]
-    8[hash-graph-store]
-    class 8 root
-    9[<a href="../hash_graph_temporal_versioning/index.html">hash-graph-temporal-versioning</a>]
-    10[<a href="../hash_graph_type_fetcher/index.html">hash-graph-type-fetcher</a>]
-    11[<a href="../hash_graph_types/index.html">hash-graph-types</a>]
-    12[<a href="../hash_graph_validation/index.html">hash-graph-validation</a>]
-    13[<a href="../harpc_server/index.html">harpc-server</a>]
-    14[<a href="../harpc_types/index.html">harpc-types</a>]
-    15[<a href="../harpc_wire_protocol/index.html">harpc-wire-protocol</a>]
-    16[<a href="../hashql_ast/index.html">hashql-ast</a>]
-    17[<a href="../hashql_compiletest/index.html">hashql-compiletest</a>]
-    18[<a href="../hashql_eval/index.html">hashql-eval</a>]
-    19[<a href="../hashql_hir/index.html">hashql-hir</a>]
-    20[<a href="../hashql_mir/index.html">hashql-mir</a>]
-    21[<a href="../hashql_syntax_jexpr/index.html">hashql-syntax-jexpr</a>]
-    22[<a href="../hash_temporal_client/index.html">hash-temporal-client</a>]
-    23[<a href="../error_stack/index.html">error-stack</a>]
-    24[<a href="../hash_graph_benches/index.html">hash-graph-benches</a>]
-    25[<a href="../hash_graph_integration/index.html">hash-graph-integration</a>]
-    26[<a href="../hash_graph_test_data/index.html">hash-graph-test-data</a>]
+    5[<a href="../hash_graph_authentication/index.html">hash-graph-authentication</a>]
+    6[<a href="../hash_graph_authorization/index.html">hash-graph-authorization</a>]
+    7[<a href="../hash_graph_embeddings/index.html">hash-graph-embeddings</a>]
+    8[<a href="../hash_graph_postgres_store/index.html">hash-graph-postgres-store</a>]
+    9[hash-graph-store]
+    class 9 root
+    10[<a href="../hash_graph_temporal_versioning/index.html">hash-graph-temporal-versioning</a>]
+    11[<a href="../hash_graph_type_fetcher/index.html">hash-graph-type-fetcher</a>]
+    12[<a href="../hash_graph_types/index.html">hash-graph-types</a>]
+    13[<a href="../hash_graph_validation/index.html">hash-graph-validation</a>]
+    14[<a href="../harpc_server/index.html">harpc-server</a>]
+    15[<a href="../harpc_types/index.html">harpc-types</a>]
+    16[<a href="../harpc_wire_protocol/index.html">harpc-wire-protocol</a>]
+    17[<a href="../hashql_ast/index.html">hashql-ast</a>]
+    18[<a href="../hashql_compiletest/index.html">hashql-compiletest</a>]
+    19[<a href="../hashql_eval/index.html">hashql-eval</a>]
+    20[<a href="../hashql_hir/index.html">hashql-hir</a>]
+    21[<a href="../hashql_mir/index.html">hashql-mir</a>]
+    22[<a href="../hashql_syntax_jexpr/index.html">hashql-syntax-jexpr</a>]
+    23[<a href="../hash_temporal_client/index.html">hash-temporal-client</a>]
+    24[<a href="../error_stack/index.html">error-stack</a>]
+    25[<a href="../hash_graph_benches/index.html">hash-graph-benches</a>]
+    26[<a href="../hash_graph_integration/index.html">hash-graph-integration</a>]
+    27[<a href="../hash_graph_test_data/index.html">hash-graph-test-data</a>]
     0 --> 4
-    1 --> 9
-    1 -.-> 26
+    1 --> 10
+    1 -.-> 27
     2 -.-> 3
-    2 --> 15
-    4 --> 10
-    4 --> 13
-    4 --> 18
-    4 --> 21
+    2 --> 16
+    4 --> 5
+    4 --> 11
+    4 --> 14
+    4 --> 19
+    4 --> 22
     5 --> 1
-    6 --> 11
-    7 --> 6
-    7 -.-> 7
+    6 --> 1
     7 --> 12
-    8 --> 5
-    8 --> 11
-    8 --> 22
-    9 --> 2
-    10 --> 8
-    11 -.-> 26
-    12 -.-> 26
-    13 -.-> 1
-    13 --> 14
-    15 -.-> 14
-    15 --> 14
-    15 --> 23
-    16 -.-> 17
-    17 --> 18
-    17 --> 21
-    18 --> 7
-    18 --> 20
-    19 -.-> 17
-    20 --> 19
-    21 --> 16
-    22 --> 1
-    24 -.-> 4
-    25 -.-> 7
-    26 --> 8
+    8 --> 7
+    8 -.-> 8
+    8 --> 13
+    9 --> 6
+    9 --> 12
+    9 --> 23
+    10 --> 2
+    11 --> 9
+    12 -.-> 27
+    13 -.-> 27
+    14 -.-> 1
+    14 --> 15
+    16 -.-> 15
+    16 --> 15
+    16 --> 24
+    17 -.-> 18
+    18 --> 19
+    18 --> 22
+    19 --> 8
+    19 --> 21
+    20 -.-> 18
+    21 --> 20
+    22 --> 17
+    23 --> 1
+    25 -.-> 4
+    26 -.-> 8
+    27 --> 9

--- a/libs/@local/graph/temporal-versioning/docs/dependency-diagram.mmd
+++ b/libs/@local/graph/temporal-versioning/docs/dependency-diagram.mmd
@@ -13,64 +13,67 @@ graph TD
     2[<a href="../hash_codec/index.html">hash-codec</a>]
     3[<a href="../hash_codegen/index.html">hash-codegen</a>]
     4[<a href="../hash_graph_api/index.html">hash-graph-api</a>]
-    5[<a href="../hash_graph_authorization/index.html">hash-graph-authorization</a>]
-    6[<a href="../hash_graph_embeddings/index.html">hash-graph-embeddings</a>]
-    7[<a href="../hash_graph_postgres_store/index.html">hash-graph-postgres-store</a>]
-    8[<a href="../hash_graph_store/index.html">hash-graph-store</a>]
-    9[hash-graph-temporal-versioning]
-    class 9 root
-    10[<a href="../hash_graph_type_fetcher/index.html">hash-graph-type-fetcher</a>]
-    11[<a href="../hash_graph_types/index.html">hash-graph-types</a>]
-    12[<a href="../hash_graph_validation/index.html">hash-graph-validation</a>]
-    13[<a href="../harpc_server/index.html">harpc-server</a>]
-    14[<a href="../harpc_types/index.html">harpc-types</a>]
-    15[<a href="../harpc_wire_protocol/index.html">harpc-wire-protocol</a>]
-    16[<a href="../hashql_ast/index.html">hashql-ast</a>]
-    17[<a href="../hashql_compiletest/index.html">hashql-compiletest</a>]
-    18[<a href="../hashql_eval/index.html">hashql-eval</a>]
-    19[<a href="../hashql_hir/index.html">hashql-hir</a>]
-    20[<a href="../hashql_mir/index.html">hashql-mir</a>]
-    21[<a href="../hashql_syntax_jexpr/index.html">hashql-syntax-jexpr</a>]
-    22[<a href="../hash_temporal_client/index.html">hash-temporal-client</a>]
-    23[<a href="../error_stack/index.html">error-stack</a>]
-    24[<a href="../hash_graph_benches/index.html">hash-graph-benches</a>]
-    25[<a href="../hash_graph_integration/index.html">hash-graph-integration</a>]
-    26[<a href="../hash_graph_test_data/index.html">hash-graph-test-data</a>]
+    5[<a href="../hash_graph_authentication/index.html">hash-graph-authentication</a>]
+    6[<a href="../hash_graph_authorization/index.html">hash-graph-authorization</a>]
+    7[<a href="../hash_graph_embeddings/index.html">hash-graph-embeddings</a>]
+    8[<a href="../hash_graph_postgres_store/index.html">hash-graph-postgres-store</a>]
+    9[<a href="../hash_graph_store/index.html">hash-graph-store</a>]
+    10[hash-graph-temporal-versioning]
+    class 10 root
+    11[<a href="../hash_graph_type_fetcher/index.html">hash-graph-type-fetcher</a>]
+    12[<a href="../hash_graph_types/index.html">hash-graph-types</a>]
+    13[<a href="../hash_graph_validation/index.html">hash-graph-validation</a>]
+    14[<a href="../harpc_server/index.html">harpc-server</a>]
+    15[<a href="../harpc_types/index.html">harpc-types</a>]
+    16[<a href="../harpc_wire_protocol/index.html">harpc-wire-protocol</a>]
+    17[<a href="../hashql_ast/index.html">hashql-ast</a>]
+    18[<a href="../hashql_compiletest/index.html">hashql-compiletest</a>]
+    19[<a href="../hashql_eval/index.html">hashql-eval</a>]
+    20[<a href="../hashql_hir/index.html">hashql-hir</a>]
+    21[<a href="../hashql_mir/index.html">hashql-mir</a>]
+    22[<a href="../hashql_syntax_jexpr/index.html">hashql-syntax-jexpr</a>]
+    23[<a href="../hash_temporal_client/index.html">hash-temporal-client</a>]
+    24[<a href="../error_stack/index.html">error-stack</a>]
+    25[<a href="../hash_graph_benches/index.html">hash-graph-benches</a>]
+    26[<a href="../hash_graph_integration/index.html">hash-graph-integration</a>]
+    27[<a href="../hash_graph_test_data/index.html">hash-graph-test-data</a>]
     0 --> 4
-    1 --> 9
-    1 -.-> 26
+    1 --> 10
+    1 -.-> 27
     2 -.-> 3
-    2 --> 15
-    4 --> 10
-    4 --> 13
-    4 --> 18
-    4 --> 21
+    2 --> 16
+    4 --> 5
+    4 --> 11
+    4 --> 14
+    4 --> 19
+    4 --> 22
     5 --> 1
-    6 --> 11
-    7 --> 6
-    7 -.-> 7
+    6 --> 1
     7 --> 12
-    8 --> 5
-    8 --> 11
-    8 --> 22
-    9 --> 2
-    10 --> 8
-    11 -.-> 26
-    12 -.-> 26
-    13 -.-> 1
-    13 --> 14
-    15 -.-> 14
-    15 --> 14
-    15 --> 23
-    16 -.-> 17
-    17 --> 18
-    17 --> 21
-    18 --> 7
-    18 --> 20
-    19 -.-> 17
-    20 --> 19
-    21 --> 16
-    22 --> 1
-    24 -.-> 4
-    25 -.-> 7
-    26 --> 8
+    8 --> 7
+    8 -.-> 8
+    8 --> 13
+    9 --> 6
+    9 --> 12
+    9 --> 23
+    10 --> 2
+    11 --> 9
+    12 -.-> 27
+    13 -.-> 27
+    14 -.-> 1
+    14 --> 15
+    16 -.-> 15
+    16 --> 15
+    16 --> 24
+    17 -.-> 18
+    18 --> 19
+    18 --> 22
+    19 --> 8
+    19 --> 21
+    20 -.-> 18
+    21 --> 20
+    22 --> 17
+    23 --> 1
+    25 -.-> 4
+    26 -.-> 8
+    27 --> 9

--- a/libs/@local/graph/types/docs/dependency-diagram.mmd
+++ b/libs/@local/graph/types/docs/dependency-diagram.mmd
@@ -13,64 +13,67 @@ graph TD
     2[<a href="../hash_codec/index.html">hash-codec</a>]
     3[<a href="../hash_codegen/index.html">hash-codegen</a>]
     4[<a href="../hash_graph_api/index.html">hash-graph-api</a>]
-    5[<a href="../hash_graph_authorization/index.html">hash-graph-authorization</a>]
-    6[<a href="../hash_graph_embeddings/index.html">hash-graph-embeddings</a>]
-    7[<a href="../hash_graph_postgres_store/index.html">hash-graph-postgres-store</a>]
-    8[<a href="../hash_graph_store/index.html">hash-graph-store</a>]
-    9[<a href="../hash_graph_temporal_versioning/index.html">hash-graph-temporal-versioning</a>]
-    10[<a href="../hash_graph_type_fetcher/index.html">hash-graph-type-fetcher</a>]
-    11[hash-graph-types]
-    class 11 root
-    12[<a href="../hash_graph_validation/index.html">hash-graph-validation</a>]
-    13[<a href="../harpc_server/index.html">harpc-server</a>]
-    14[<a href="../harpc_types/index.html">harpc-types</a>]
-    15[<a href="../harpc_wire_protocol/index.html">harpc-wire-protocol</a>]
-    16[<a href="../hashql_ast/index.html">hashql-ast</a>]
-    17[<a href="../hashql_compiletest/index.html">hashql-compiletest</a>]
-    18[<a href="../hashql_eval/index.html">hashql-eval</a>]
-    19[<a href="../hashql_hir/index.html">hashql-hir</a>]
-    20[<a href="../hashql_mir/index.html">hashql-mir</a>]
-    21[<a href="../hashql_syntax_jexpr/index.html">hashql-syntax-jexpr</a>]
-    22[<a href="../hash_temporal_client/index.html">hash-temporal-client</a>]
-    23[<a href="../error_stack/index.html">error-stack</a>]
-    24[<a href="../hash_graph_benches/index.html">hash-graph-benches</a>]
-    25[<a href="../hash_graph_integration/index.html">hash-graph-integration</a>]
-    26[<a href="../hash_graph_test_data/index.html">hash-graph-test-data</a>]
+    5[<a href="../hash_graph_authentication/index.html">hash-graph-authentication</a>]
+    6[<a href="../hash_graph_authorization/index.html">hash-graph-authorization</a>]
+    7[<a href="../hash_graph_embeddings/index.html">hash-graph-embeddings</a>]
+    8[<a href="../hash_graph_postgres_store/index.html">hash-graph-postgres-store</a>]
+    9[<a href="../hash_graph_store/index.html">hash-graph-store</a>]
+    10[<a href="../hash_graph_temporal_versioning/index.html">hash-graph-temporal-versioning</a>]
+    11[<a href="../hash_graph_type_fetcher/index.html">hash-graph-type-fetcher</a>]
+    12[hash-graph-types]
+    class 12 root
+    13[<a href="../hash_graph_validation/index.html">hash-graph-validation</a>]
+    14[<a href="../harpc_server/index.html">harpc-server</a>]
+    15[<a href="../harpc_types/index.html">harpc-types</a>]
+    16[<a href="../harpc_wire_protocol/index.html">harpc-wire-protocol</a>]
+    17[<a href="../hashql_ast/index.html">hashql-ast</a>]
+    18[<a href="../hashql_compiletest/index.html">hashql-compiletest</a>]
+    19[<a href="../hashql_eval/index.html">hashql-eval</a>]
+    20[<a href="../hashql_hir/index.html">hashql-hir</a>]
+    21[<a href="../hashql_mir/index.html">hashql-mir</a>]
+    22[<a href="../hashql_syntax_jexpr/index.html">hashql-syntax-jexpr</a>]
+    23[<a href="../hash_temporal_client/index.html">hash-temporal-client</a>]
+    24[<a href="../error_stack/index.html">error-stack</a>]
+    25[<a href="../hash_graph_benches/index.html">hash-graph-benches</a>]
+    26[<a href="../hash_graph_integration/index.html">hash-graph-integration</a>]
+    27[<a href="../hash_graph_test_data/index.html">hash-graph-test-data</a>]
     0 --> 4
-    1 --> 9
-    1 -.-> 26
+    1 --> 10
+    1 -.-> 27
     2 -.-> 3
-    2 --> 15
-    4 --> 10
-    4 --> 13
-    4 --> 18
-    4 --> 21
+    2 --> 16
+    4 --> 5
+    4 --> 11
+    4 --> 14
+    4 --> 19
+    4 --> 22
     5 --> 1
-    6 --> 11
-    7 --> 6
-    7 -.-> 7
+    6 --> 1
     7 --> 12
-    8 --> 5
-    8 --> 11
-    8 --> 22
-    9 --> 2
-    10 --> 8
-    11 -.-> 26
-    12 -.-> 26
-    13 -.-> 1
-    13 --> 14
-    15 -.-> 14
-    15 --> 14
-    15 --> 23
-    16 -.-> 17
-    17 --> 18
-    17 --> 21
-    18 --> 7
-    18 --> 20
-    19 -.-> 17
-    20 --> 19
-    21 --> 16
-    22 --> 1
-    24 -.-> 4
-    25 -.-> 7
-    26 --> 8
+    8 --> 7
+    8 -.-> 8
+    8 --> 13
+    9 --> 6
+    9 --> 12
+    9 --> 23
+    10 --> 2
+    11 --> 9
+    12 -.-> 27
+    13 -.-> 27
+    14 -.-> 1
+    14 --> 15
+    16 -.-> 15
+    16 --> 15
+    16 --> 24
+    17 -.-> 18
+    18 --> 19
+    18 --> 22
+    19 --> 8
+    19 --> 21
+    20 -.-> 18
+    21 --> 20
+    22 --> 17
+    23 --> 1
+    25 -.-> 4
+    26 -.-> 8
+    27 --> 9

--- a/libs/@local/harpc/types/docs/dependency-diagram.mmd
+++ b/libs/@local/harpc/types/docs/dependency-diagram.mmd
@@ -12,77 +12,80 @@ graph TD
     1[<a href="../type_system/index.html">type-system</a>]
     2[<a href="../hash_codec/index.html">hash-codec</a>]
     3[<a href="../hash_graph_api/index.html">hash-graph-api</a>]
-    4[<a href="../hash_graph_authorization/index.html">hash-graph-authorization</a>]
-    5[<a href="../hash_graph_embeddings/index.html">hash-graph-embeddings</a>]
-    6[<a href="../hash_graph_postgres_store/index.html">hash-graph-postgres-store</a>]
-    7[<a href="../hash_graph_store/index.html">hash-graph-store</a>]
-    8[<a href="../hash_graph_temporal_versioning/index.html">hash-graph-temporal-versioning</a>]
-    9[<a href="../hash_graph_type_fetcher/index.html">hash-graph-type-fetcher</a>]
-    10[<a href="../hash_graph_types/index.html">hash-graph-types</a>]
-    11[<a href="../hash_graph_validation/index.html">hash-graph-validation</a>]
-    12[<a href="../harpc_client/index.html">harpc-client</a>]
-    13[<a href="../harpc_codec/index.html">harpc-codec</a>]
-    14[<a href="../harpc_net/index.html">harpc-net</a>]
-    15[<a href="../harpc_server/index.html">harpc-server</a>]
-    16[<a href="../harpc_system/index.html">harpc-system</a>]
-    17[<a href="../harpc_tower/index.html">harpc-tower</a>]
-    18[harpc-types]
-    class 18 root
-    19[<a href="../harpc_wire_protocol/index.html">harpc-wire-protocol</a>]
-    20[<a href="../hashql_ast/index.html">hashql-ast</a>]
-    21[<a href="../hashql_compiletest/index.html">hashql-compiletest</a>]
-    22[<a href="../hashql_core/index.html">hashql-core</a>]
-    23[<a href="../hashql_eval/index.html">hashql-eval</a>]
-    24[<a href="../hashql_hir/index.html">hashql-hir</a>]
-    25[<a href="../hashql_mir/index.html">hashql-mir</a>]
-    26[<a href="../hashql_syntax_jexpr/index.html">hashql-syntax-jexpr</a>]
-    27[<a href="../hash_temporal_client/index.html">hash-temporal-client</a>]
-    28[<a href="../hash_graph_benches/index.html">hash-graph-benches</a>]
-    29[<a href="../hash_graph_integration/index.html">hash-graph-integration</a>]
-    30[<a href="../hash_graph_test_data/index.html">hash-graph-test-data</a>]
+    4[<a href="../hash_graph_authentication/index.html">hash-graph-authentication</a>]
+    5[<a href="../hash_graph_authorization/index.html">hash-graph-authorization</a>]
+    6[<a href="../hash_graph_embeddings/index.html">hash-graph-embeddings</a>]
+    7[<a href="../hash_graph_postgres_store/index.html">hash-graph-postgres-store</a>]
+    8[<a href="../hash_graph_store/index.html">hash-graph-store</a>]
+    9[<a href="../hash_graph_temporal_versioning/index.html">hash-graph-temporal-versioning</a>]
+    10[<a href="../hash_graph_type_fetcher/index.html">hash-graph-type-fetcher</a>]
+    11[<a href="../hash_graph_types/index.html">hash-graph-types</a>]
+    12[<a href="../hash_graph_validation/index.html">hash-graph-validation</a>]
+    13[<a href="../harpc_client/index.html">harpc-client</a>]
+    14[<a href="../harpc_codec/index.html">harpc-codec</a>]
+    15[<a href="../harpc_net/index.html">harpc-net</a>]
+    16[<a href="../harpc_server/index.html">harpc-server</a>]
+    17[<a href="../harpc_system/index.html">harpc-system</a>]
+    18[<a href="../harpc_tower/index.html">harpc-tower</a>]
+    19[harpc-types]
+    class 19 root
+    20[<a href="../harpc_wire_protocol/index.html">harpc-wire-protocol</a>]
+    21[<a href="../hashql_ast/index.html">hashql-ast</a>]
+    22[<a href="../hashql_compiletest/index.html">hashql-compiletest</a>]
+    23[<a href="../hashql_core/index.html">hashql-core</a>]
+    24[<a href="../hashql_eval/index.html">hashql-eval</a>]
+    25[<a href="../hashql_hir/index.html">hashql-hir</a>]
+    26[<a href="../hashql_mir/index.html">hashql-mir</a>]
+    27[<a href="../hashql_syntax_jexpr/index.html">hashql-syntax-jexpr</a>]
+    28[<a href="../hash_temporal_client/index.html">hash-temporal-client</a>]
+    29[<a href="../hash_graph_benches/index.html">hash-graph-benches</a>]
+    30[<a href="../hash_graph_integration/index.html">hash-graph-integration</a>]
+    31[<a href="../hash_graph_test_data/index.html">hash-graph-test-data</a>]
     0 --> 3
-    1 --> 8
-    1 -.-> 30
-    2 --> 19
-    3 --> 9
-    3 --> 15
-    3 --> 23
-    3 --> 26
+    1 --> 9
+    1 -.-> 31
+    2 --> 20
+    3 --> 4
+    3 --> 10
+    3 --> 16
+    3 --> 24
+    3 --> 27
     4 --> 1
-    5 --> 10
-    6 --> 5
-    6 -.-> 6
+    5 --> 1
     6 --> 11
-    7 --> 4
-    7 --> 10
-    7 --> 27
-    8 --> 2
-    9 --> 7
-    10 -.-> 30
-    11 -.-> 30
-    12 --> 16
-    13 --> 18
-    14 --> 2
-    14 -.-> 13
-    14 --> 13
-    15 -.-> 1
-    15 -.-> 12
-    16 --> 17
-    17 -.-> 14
-    17 --> 14
-    19 -.-> 18
-    19 --> 18
-    20 -.-> 21
-    21 --> 23
-    21 --> 26
-    22 --> 2
-    23 --> 6
-    23 --> 25
-    24 -.-> 21
-    25 --> 24
-    26 --> 20
-    26 --> 22
-    27 --> 1
-    28 -.-> 3
-    29 -.-> 6
-    30 --> 7
+    7 --> 6
+    7 -.-> 7
+    7 --> 12
+    8 --> 5
+    8 --> 11
+    8 --> 28
+    9 --> 2
+    10 --> 8
+    11 -.-> 31
+    12 -.-> 31
+    13 --> 17
+    14 --> 19
+    15 --> 2
+    15 -.-> 14
+    15 --> 14
+    16 -.-> 1
+    16 -.-> 13
+    17 --> 18
+    18 -.-> 15
+    18 --> 15
+    20 -.-> 19
+    20 --> 19
+    21 -.-> 22
+    22 --> 24
+    22 --> 27
+    23 --> 2
+    24 --> 7
+    24 --> 26
+    25 -.-> 22
+    26 --> 25
+    27 --> 21
+    27 --> 23
+    28 --> 1
+    29 -.-> 3
+    30 -.-> 7
+    31 --> 8

--- a/libs/@local/harpc/wire-protocol/docs/dependency-diagram.mmd
+++ b/libs/@local/harpc/wire-protocol/docs/dependency-diagram.mmd
@@ -12,75 +12,78 @@ graph TD
     1[<a href="../type_system/index.html">type-system</a>]
     2[<a href="../hash_codec/index.html">hash-codec</a>]
     3[<a href="../hash_graph_api/index.html">hash-graph-api</a>]
-    4[<a href="../hash_graph_authorization/index.html">hash-graph-authorization</a>]
-    5[<a href="../hash_graph_embeddings/index.html">hash-graph-embeddings</a>]
-    6[<a href="../hash_graph_postgres_store/index.html">hash-graph-postgres-store</a>]
-    7[<a href="../hash_graph_store/index.html">hash-graph-store</a>]
-    8[<a href="../hash_graph_temporal_versioning/index.html">hash-graph-temporal-versioning</a>]
-    9[<a href="../hash_graph_type_fetcher/index.html">hash-graph-type-fetcher</a>]
-    10[<a href="../hash_graph_types/index.html">hash-graph-types</a>]
-    11[<a href="../hash_graph_validation/index.html">hash-graph-validation</a>]
-    12[<a href="../harpc_client/index.html">harpc-client</a>]
-    13[<a href="../harpc_net/index.html">harpc-net</a>]
-    14[<a href="../harpc_server/index.html">harpc-server</a>]
-    15[<a href="../harpc_system/index.html">harpc-system</a>]
-    16[<a href="../harpc_tower/index.html">harpc-tower</a>]
-    17[<a href="../harpc_types/index.html">harpc-types</a>]
-    18[harpc-wire-protocol]
-    class 18 root
-    19[<a href="../hashql_ast/index.html">hashql-ast</a>]
-    20[<a href="../hashql_compiletest/index.html">hashql-compiletest</a>]
-    21[<a href="../hashql_core/index.html">hashql-core</a>]
-    22[<a href="../hashql_eval/index.html">hashql-eval</a>]
-    23[<a href="../hashql_hir/index.html">hashql-hir</a>]
-    24[<a href="../hashql_mir/index.html">hashql-mir</a>]
-    25[<a href="../hashql_syntax_jexpr/index.html">hashql-syntax-jexpr</a>]
-    26[<a href="../hash_temporal_client/index.html">hash-temporal-client</a>]
-    27[<a href="../error_stack/index.html">error-stack</a>]
-    28[<a href="../hash_graph_benches/index.html">hash-graph-benches</a>]
-    29[<a href="../hash_graph_integration/index.html">hash-graph-integration</a>]
-    30[<a href="../hash_graph_test_data/index.html">hash-graph-test-data</a>]
+    4[<a href="../hash_graph_authentication/index.html">hash-graph-authentication</a>]
+    5[<a href="../hash_graph_authorization/index.html">hash-graph-authorization</a>]
+    6[<a href="../hash_graph_embeddings/index.html">hash-graph-embeddings</a>]
+    7[<a href="../hash_graph_postgres_store/index.html">hash-graph-postgres-store</a>]
+    8[<a href="../hash_graph_store/index.html">hash-graph-store</a>]
+    9[<a href="../hash_graph_temporal_versioning/index.html">hash-graph-temporal-versioning</a>]
+    10[<a href="../hash_graph_type_fetcher/index.html">hash-graph-type-fetcher</a>]
+    11[<a href="../hash_graph_types/index.html">hash-graph-types</a>]
+    12[<a href="../hash_graph_validation/index.html">hash-graph-validation</a>]
+    13[<a href="../harpc_client/index.html">harpc-client</a>]
+    14[<a href="../harpc_net/index.html">harpc-net</a>]
+    15[<a href="../harpc_server/index.html">harpc-server</a>]
+    16[<a href="../harpc_system/index.html">harpc-system</a>]
+    17[<a href="../harpc_tower/index.html">harpc-tower</a>]
+    18[<a href="../harpc_types/index.html">harpc-types</a>]
+    19[harpc-wire-protocol]
+    class 19 root
+    20[<a href="../hashql_ast/index.html">hashql-ast</a>]
+    21[<a href="../hashql_compiletest/index.html">hashql-compiletest</a>]
+    22[<a href="../hashql_core/index.html">hashql-core</a>]
+    23[<a href="../hashql_eval/index.html">hashql-eval</a>]
+    24[<a href="../hashql_hir/index.html">hashql-hir</a>]
+    25[<a href="../hashql_mir/index.html">hashql-mir</a>]
+    26[<a href="../hashql_syntax_jexpr/index.html">hashql-syntax-jexpr</a>]
+    27[<a href="../hash_temporal_client/index.html">hash-temporal-client</a>]
+    28[<a href="../error_stack/index.html">error-stack</a>]
+    29[<a href="../hash_graph_benches/index.html">hash-graph-benches</a>]
+    30[<a href="../hash_graph_integration/index.html">hash-graph-integration</a>]
+    31[<a href="../hash_graph_test_data/index.html">hash-graph-test-data</a>]
     0 --> 3
-    1 --> 8
-    1 -.-> 30
-    2 --> 18
-    3 --> 9
-    3 --> 14
-    3 --> 22
-    3 --> 25
+    1 --> 9
+    1 -.-> 31
+    2 --> 19
+    3 --> 4
+    3 --> 10
+    3 --> 15
+    3 --> 23
+    3 --> 26
     4 --> 1
-    5 --> 10
-    6 --> 5
-    6 -.-> 6
+    5 --> 1
     6 --> 11
-    7 --> 4
-    7 --> 10
-    7 --> 26
-    8 --> 2
-    9 --> 7
-    10 -.-> 30
-    11 -.-> 30
-    12 --> 15
-    13 --> 2
-    14 -.-> 1
-    14 -.-> 12
-    15 --> 16
-    16 -.-> 13
-    16 --> 13
-    18 -.-> 17
-    18 --> 17
-    18 --> 27
-    19 -.-> 20
-    20 --> 22
-    20 --> 25
-    21 --> 2
-    22 --> 6
-    22 --> 24
-    23 -.-> 20
-    24 --> 23
-    25 --> 19
-    25 --> 21
-    26 --> 1
-    28 -.-> 3
-    29 -.-> 6
-    30 --> 7
+    7 --> 6
+    7 -.-> 7
+    7 --> 12
+    8 --> 5
+    8 --> 11
+    8 --> 27
+    9 --> 2
+    10 --> 8
+    11 -.-> 31
+    12 -.-> 31
+    13 --> 16
+    14 --> 2
+    15 -.-> 1
+    15 -.-> 13
+    16 --> 17
+    17 -.-> 14
+    17 --> 14
+    19 -.-> 18
+    19 --> 18
+    19 --> 28
+    20 -.-> 21
+    21 --> 23
+    21 --> 26
+    22 --> 2
+    23 --> 7
+    23 --> 25
+    24 -.-> 21
+    25 --> 24
+    26 --> 20
+    26 --> 22
+    27 --> 1
+    29 -.-> 3
+    30 -.-> 7
+    31 --> 8

--- a/libs/@local/status/rust/docs/dependency-diagram.mmd
+++ b/libs/@local/status/rust/docs/dependency-diagram.mmd
@@ -10,32 +10,35 @@ graph TD
     %% ---> : Build dependency
     0[<a href="../hash_graph/index.html">hash-graph</a>]
     1[<a href="../hash_graph_api/index.html">hash-graph-api</a>]
-    2[<a href="../hash_graph_postgres_store/index.html">hash-graph-postgres-store</a>]
-    3[<a href="../hash_graph_type_defs/index.html">hash-graph-type-defs</a>]
-    4[<a href="../hashql_ast/index.html">hashql-ast</a>]
-    5[<a href="../hashql_compiletest/index.html">hashql-compiletest</a>]
-    6[<a href="../hashql_eval/index.html">hashql-eval</a>]
-    7[<a href="../hashql_hir/index.html">hashql-hir</a>]
-    8[<a href="../hashql_mir/index.html">hashql-mir</a>]
-    9[<a href="../hashql_syntax_jexpr/index.html">hashql-syntax-jexpr</a>]
-    10[hash-status]
-    class 10 root
-    11[<a href="../hash_graph_benches/index.html">hash-graph-benches</a>]
-    12[<a href="../hash_graph_integration/index.html">hash-graph-integration</a>]
+    2[<a href="../hash_graph_authentication/index.html">hash-graph-authentication</a>]
+    3[<a href="../hash_graph_postgres_store/index.html">hash-graph-postgres-store</a>]
+    4[<a href="../hash_graph_type_defs/index.html">hash-graph-type-defs</a>]
+    5[<a href="../hashql_ast/index.html">hashql-ast</a>]
+    6[<a href="../hashql_compiletest/index.html">hashql-compiletest</a>]
+    7[<a href="../hashql_eval/index.html">hashql-eval</a>]
+    8[<a href="../hashql_hir/index.html">hashql-hir</a>]
+    9[<a href="../hashql_mir/index.html">hashql-mir</a>]
+    10[<a href="../hashql_syntax_jexpr/index.html">hashql-syntax-jexpr</a>]
+    11[hash-status]
+    class 11 root
+    12[<a href="../hash_graph_benches/index.html">hash-graph-benches</a>]
+    13[<a href="../hash_graph_integration/index.html">hash-graph-integration</a>]
     0 --> 1
-    1 --> 3
-    1 --> 6
-    1 --> 9
-    2 -.-> 2
-    2 --> 10
-    3 --> 10
-    4 -.-> 5
-    5 --> 6
-    5 --> 9
-    6 --> 2
-    6 --> 8
-    7 -.-> 5
-    8 --> 7
-    9 --> 4
-    11 -.-> 1
-    12 -.-> 2
+    1 --> 2
+    1 --> 4
+    1 --> 7
+    1 --> 10
+    2 --> 11
+    3 -.-> 3
+    3 --> 11
+    4 --> 11
+    5 -.-> 6
+    6 --> 7
+    6 --> 10
+    7 --> 3
+    7 --> 9
+    8 -.-> 6
+    9 --> 8
+    10 --> 5
+    12 -.-> 1
+    13 -.-> 3

--- a/libs/@local/temporal-client/docs/dependency-diagram.mmd
+++ b/libs/@local/temporal-client/docs/dependency-diagram.mmd
@@ -13,64 +13,67 @@ graph TD
     2[<a href="../hash_codec/index.html">hash-codec</a>]
     3[<a href="../hash_codegen/index.html">hash-codegen</a>]
     4[<a href="../hash_graph_api/index.html">hash-graph-api</a>]
-    5[<a href="../hash_graph_authorization/index.html">hash-graph-authorization</a>]
-    6[<a href="../hash_graph_embeddings/index.html">hash-graph-embeddings</a>]
-    7[<a href="../hash_graph_postgres_store/index.html">hash-graph-postgres-store</a>]
-    8[<a href="../hash_graph_store/index.html">hash-graph-store</a>]
-    9[<a href="../hash_graph_temporal_versioning/index.html">hash-graph-temporal-versioning</a>]
-    10[<a href="../hash_graph_type_fetcher/index.html">hash-graph-type-fetcher</a>]
-    11[<a href="../hash_graph_types/index.html">hash-graph-types</a>]
-    12[<a href="../hash_graph_validation/index.html">hash-graph-validation</a>]
-    13[<a href="../harpc_server/index.html">harpc-server</a>]
-    14[<a href="../harpc_types/index.html">harpc-types</a>]
-    15[<a href="../harpc_wire_protocol/index.html">harpc-wire-protocol</a>]
-    16[<a href="../hashql_ast/index.html">hashql-ast</a>]
-    17[<a href="../hashql_compiletest/index.html">hashql-compiletest</a>]
-    18[<a href="../hashql_eval/index.html">hashql-eval</a>]
-    19[<a href="../hashql_hir/index.html">hashql-hir</a>]
-    20[<a href="../hashql_mir/index.html">hashql-mir</a>]
-    21[<a href="../hashql_syntax_jexpr/index.html">hashql-syntax-jexpr</a>]
-    22[hash-temporal-client]
-    class 22 root
-    23[<a href="../error_stack/index.html">error-stack</a>]
-    24[<a href="../hash_graph_benches/index.html">hash-graph-benches</a>]
-    25[<a href="../hash_graph_integration/index.html">hash-graph-integration</a>]
-    26[<a href="../hash_graph_test_data/index.html">hash-graph-test-data</a>]
+    5[<a href="../hash_graph_authentication/index.html">hash-graph-authentication</a>]
+    6[<a href="../hash_graph_authorization/index.html">hash-graph-authorization</a>]
+    7[<a href="../hash_graph_embeddings/index.html">hash-graph-embeddings</a>]
+    8[<a href="../hash_graph_postgres_store/index.html">hash-graph-postgres-store</a>]
+    9[<a href="../hash_graph_store/index.html">hash-graph-store</a>]
+    10[<a href="../hash_graph_temporal_versioning/index.html">hash-graph-temporal-versioning</a>]
+    11[<a href="../hash_graph_type_fetcher/index.html">hash-graph-type-fetcher</a>]
+    12[<a href="../hash_graph_types/index.html">hash-graph-types</a>]
+    13[<a href="../hash_graph_validation/index.html">hash-graph-validation</a>]
+    14[<a href="../harpc_server/index.html">harpc-server</a>]
+    15[<a href="../harpc_types/index.html">harpc-types</a>]
+    16[<a href="../harpc_wire_protocol/index.html">harpc-wire-protocol</a>]
+    17[<a href="../hashql_ast/index.html">hashql-ast</a>]
+    18[<a href="../hashql_compiletest/index.html">hashql-compiletest</a>]
+    19[<a href="../hashql_eval/index.html">hashql-eval</a>]
+    20[<a href="../hashql_hir/index.html">hashql-hir</a>]
+    21[<a href="../hashql_mir/index.html">hashql-mir</a>]
+    22[<a href="../hashql_syntax_jexpr/index.html">hashql-syntax-jexpr</a>]
+    23[hash-temporal-client]
+    class 23 root
+    24[<a href="../error_stack/index.html">error-stack</a>]
+    25[<a href="../hash_graph_benches/index.html">hash-graph-benches</a>]
+    26[<a href="../hash_graph_integration/index.html">hash-graph-integration</a>]
+    27[<a href="../hash_graph_test_data/index.html">hash-graph-test-data</a>]
     0 --> 4
-    1 --> 9
-    1 -.-> 26
+    1 --> 10
+    1 -.-> 27
     2 -.-> 3
-    2 --> 15
-    4 --> 10
-    4 --> 13
-    4 --> 18
-    4 --> 21
+    2 --> 16
+    4 --> 5
+    4 --> 11
+    4 --> 14
+    4 --> 19
+    4 --> 22
     5 --> 1
-    6 --> 11
-    7 --> 6
-    7 -.-> 7
+    6 --> 1
     7 --> 12
-    8 --> 5
-    8 --> 11
-    8 --> 22
-    9 --> 2
-    10 --> 8
-    11 -.-> 26
-    12 -.-> 26
-    13 -.-> 1
-    13 --> 14
-    15 -.-> 14
-    15 --> 14
-    15 --> 23
-    16 -.-> 17
-    17 --> 18
-    17 --> 21
-    18 --> 7
-    18 --> 20
-    19 -.-> 17
-    20 --> 19
-    21 --> 16
-    22 --> 1
-    24 -.-> 4
-    25 -.-> 7
-    26 --> 8
+    8 --> 7
+    8 -.-> 8
+    8 --> 13
+    9 --> 6
+    9 --> 12
+    9 --> 23
+    10 --> 2
+    11 --> 9
+    12 -.-> 27
+    13 -.-> 27
+    14 -.-> 1
+    14 --> 15
+    16 -.-> 15
+    16 --> 15
+    16 --> 24
+    17 -.-> 18
+    18 --> 19
+    18 --> 22
+    19 --> 8
+    19 --> 21
+    20 -.-> 18
+    21 --> 20
+    22 --> 17
+    23 --> 1
+    25 -.-> 4
+    26 -.-> 8
+    27 --> 9

--- a/tests/graph/http/tests/hashql.http
+++ b/tests/graph/http/tests/hashql.http
@@ -38,9 +38,22 @@ X-Authenticated-User-Actor-Id: {{system_machine_id}}
   client.global.set("user_id", response.body.userId);
 %}
 
+### HashQL without credentials is rejected
+POST http://127.0.0.1:4000/hashql
+Content-Type: application/json
+
+{}
+
+> {%
+  client.test("status", function() {
+    client.assert(response.status === 401, "Response status is not 401");
+  });
+%}
+
 ### HashQL: filter-false returns empty list
 POST http://127.0.0.1:4000/hashql
 Content-Type: application/json
+X-Authenticated-User-Actor-Id: {{system_machine_id}}
 
 {
   "query": ["let", "axes",
@@ -86,6 +99,7 @@ Content-Type: application/json
 ### HashQL: parse error returns 400 with diagnostics
 POST http://127.0.0.1:4000/hashql
 Content-Type: application/json
+X-Authenticated-User-Actor-Id: {{system_machine_id}}
 
 {
   "query": {"not": "a valid query"},
@@ -105,6 +119,7 @@ Content-Type: application/json
 ### HashQL: missing inputs field returns 400
 POST http://127.0.0.1:4000/hashql
 Content-Type: application/json
+X-Authenticated-User-Actor-Id: {{system_machine_id}}
 
 {
   "query": {"#literal": 1}
@@ -124,6 +139,7 @@ Content-Type: application/json
 ### HashQL: json-compat wraps result in envelope with advisories
 POST http://127.0.0.1:4000/hashql
 Content-Type: application/json
+X-Authenticated-User-Actor-Id: {{system_machine_id}}
 Json-Compat: true
 
 {
@@ -170,6 +186,7 @@ Json-Compat: true
 ### HashQL: interactive header returns HTML on error
 POST http://127.0.0.1:4000/hashql
 Content-Type: application/json
+X-Authenticated-User-Actor-Id: {{system_machine_id}}
 Interactive: true
 
 {

--- a/tests/graph/test-data/rust/docs/dependency-diagram.mmd
+++ b/tests/graph/test-data/rust/docs/dependency-diagram.mmd
@@ -13,64 +13,67 @@ graph TD
     2[<a href="../hash_codec/index.html">hash-codec</a>]
     3[<a href="../hash_codegen/index.html">hash-codegen</a>]
     4[<a href="../hash_graph_api/index.html">hash-graph-api</a>]
-    5[<a href="../hash_graph_authorization/index.html">hash-graph-authorization</a>]
-    6[<a href="../hash_graph_embeddings/index.html">hash-graph-embeddings</a>]
-    7[<a href="../hash_graph_postgres_store/index.html">hash-graph-postgres-store</a>]
-    8[<a href="../hash_graph_store/index.html">hash-graph-store</a>]
-    9[<a href="../hash_graph_temporal_versioning/index.html">hash-graph-temporal-versioning</a>]
-    10[<a href="../hash_graph_type_fetcher/index.html">hash-graph-type-fetcher</a>]
-    11[<a href="../hash_graph_types/index.html">hash-graph-types</a>]
-    12[<a href="../hash_graph_validation/index.html">hash-graph-validation</a>]
-    13[<a href="../harpc_server/index.html">harpc-server</a>]
-    14[<a href="../harpc_types/index.html">harpc-types</a>]
-    15[<a href="../harpc_wire_protocol/index.html">harpc-wire-protocol</a>]
-    16[<a href="../hashql_ast/index.html">hashql-ast</a>]
-    17[<a href="../hashql_compiletest/index.html">hashql-compiletest</a>]
-    18[<a href="../hashql_eval/index.html">hashql-eval</a>]
-    19[<a href="../hashql_hir/index.html">hashql-hir</a>]
-    20[<a href="../hashql_mir/index.html">hashql-mir</a>]
-    21[<a href="../hashql_syntax_jexpr/index.html">hashql-syntax-jexpr</a>]
-    22[<a href="../hash_temporal_client/index.html">hash-temporal-client</a>]
-    23[<a href="../error_stack/index.html">error-stack</a>]
-    24[<a href="../hash_graph_benches/index.html">hash-graph-benches</a>]
-    25[<a href="../hash_graph_integration/index.html">hash-graph-integration</a>]
-    26[hash-graph-test-data]
-    class 26 root
+    5[<a href="../hash_graph_authentication/index.html">hash-graph-authentication</a>]
+    6[<a href="../hash_graph_authorization/index.html">hash-graph-authorization</a>]
+    7[<a href="../hash_graph_embeddings/index.html">hash-graph-embeddings</a>]
+    8[<a href="../hash_graph_postgres_store/index.html">hash-graph-postgres-store</a>]
+    9[<a href="../hash_graph_store/index.html">hash-graph-store</a>]
+    10[<a href="../hash_graph_temporal_versioning/index.html">hash-graph-temporal-versioning</a>]
+    11[<a href="../hash_graph_type_fetcher/index.html">hash-graph-type-fetcher</a>]
+    12[<a href="../hash_graph_types/index.html">hash-graph-types</a>]
+    13[<a href="../hash_graph_validation/index.html">hash-graph-validation</a>]
+    14[<a href="../harpc_server/index.html">harpc-server</a>]
+    15[<a href="../harpc_types/index.html">harpc-types</a>]
+    16[<a href="../harpc_wire_protocol/index.html">harpc-wire-protocol</a>]
+    17[<a href="../hashql_ast/index.html">hashql-ast</a>]
+    18[<a href="../hashql_compiletest/index.html">hashql-compiletest</a>]
+    19[<a href="../hashql_eval/index.html">hashql-eval</a>]
+    20[<a href="../hashql_hir/index.html">hashql-hir</a>]
+    21[<a href="../hashql_mir/index.html">hashql-mir</a>]
+    22[<a href="../hashql_syntax_jexpr/index.html">hashql-syntax-jexpr</a>]
+    23[<a href="../hash_temporal_client/index.html">hash-temporal-client</a>]
+    24[<a href="../error_stack/index.html">error-stack</a>]
+    25[<a href="../hash_graph_benches/index.html">hash-graph-benches</a>]
+    26[<a href="../hash_graph_integration/index.html">hash-graph-integration</a>]
+    27[hash-graph-test-data]
+    class 27 root
     0 --> 4
-    1 --> 9
-    1 -.-> 26
+    1 --> 10
+    1 -.-> 27
     2 -.-> 3
-    2 --> 15
-    4 --> 10
-    4 --> 13
-    4 --> 18
-    4 --> 21
+    2 --> 16
+    4 --> 5
+    4 --> 11
+    4 --> 14
+    4 --> 19
+    4 --> 22
     5 --> 1
-    6 --> 11
-    7 --> 6
-    7 -.-> 7
+    6 --> 1
     7 --> 12
-    8 --> 5
-    8 --> 11
-    8 --> 22
-    9 --> 2
-    10 --> 8
-    11 -.-> 26
-    12 -.-> 26
-    13 -.-> 1
-    13 --> 14
-    15 -.-> 14
-    15 --> 14
-    15 --> 23
-    16 -.-> 17
-    17 --> 18
-    17 --> 21
-    18 --> 7
-    18 --> 20
-    19 -.-> 17
-    20 --> 19
-    21 --> 16
-    22 --> 1
-    24 -.-> 4
-    25 -.-> 7
-    26 --> 8
+    8 --> 7
+    8 -.-> 8
+    8 --> 13
+    9 --> 6
+    9 --> 12
+    9 --> 23
+    10 --> 2
+    11 --> 9
+    12 -.-> 27
+    13 -.-> 27
+    14 -.-> 1
+    14 --> 15
+    16 -.-> 15
+    16 --> 15
+    16 --> 24
+    17 -.-> 18
+    18 --> 19
+    18 --> 22
+    19 --> 8
+    19 --> 21
+    20 -.-> 18
+    21 --> 20
+    22 --> 17
+    23 --> 1
+    25 -.-> 4
+    26 -.-> 8
+    27 --> 9

--- a/yarn.lock
+++ b/yarn.lock
@@ -14416,6 +14416,7 @@ __metadata:
     "@rust/harpc-tower": "workspace:*"
     "@rust/harpc-types": "workspace:*"
     "@rust/hash-codec": "workspace:*"
+    "@rust/hash-graph-authentication": "workspace:*"
     "@rust/hash-graph-authorization": "workspace:*"
     "@rust/hash-graph-embeddings": "workspace:*"
     "@rust/hash-graph-postgres-store": "workspace:*"
@@ -14437,9 +14438,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rust/hash-graph-authentication@workspace:libs/@local/graph/authentication":
+"@rust/hash-graph-authentication@workspace:*, @rust/hash-graph-authentication@workspace:libs/@local/graph/authentication":
   version: 0.0.0-use.local
   resolution: "@rust/hash-graph-authentication@workspace:libs/@local/graph/authentication"
+  dependencies:
+    "@blockprotocol/type-system-rs": "workspace:*"
+    "@rust/error-stack": "workspace:*"
+    "@rust/hash-status": "workspace:*"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Makes authentication at the Graph REST API fail-closed and pluggable. Every route now rejects requests without credentials by default instead of each handler opting in, and credential verification is abstracted behind an `AuthenticationProvider` trait in the `hash-graph-authentication` crate so further providers (Kratos sessions, OAuth tokens) plug into the same pipeline in follow-up PRs.

## 🔗 Related links

- [BE-332: Move authentication to the Graph](https://linear.app/hash/issue/BE-332/move-authentication-to-the-graph) _(internal)_
- #9209 set up the `hash-graph-authentication` crate this PR builds on

## 🚫 Blocked by

Nothing.

## 🔍 What does this change?

- `hash-graph-authentication` gains `provider::AuthenticationProvider` — a provider owns both the recognition of its credentials in the request headers and their verification, returning `Authentication::{NotRecognized, Verified(ActorId), Rejected}` — plus `request::resolve_request_actor`, which resolves a request to the acting principal: provider credential first, the `X-Authenticated-User-Actor-Id` header second, and a recognized-but-rejected credential never falls back to the header
- `StaticAuthenticationProvider` serves as the wired provider (`NotRecognized`, so all traffic authenticates via the actor-ID header exactly as before) and as the test double
- the REST API applies an authentication middleware to all routes: missing or invalid credentials are rejected before any handler runs, so an endpoint can no longer be unauthenticated by omission; the resolved actor is stored as a private request extension and consumed through the `AuthenticatedActorId` extractor (renamed from `AuthenticatedUserHeader`)
- `POST /hashql` previously enforced no authentication and now requires it; the HTTP test suite pins this with a 401 test
- two bootstrap routes (`/policies/seed`, `/actors/machine/identifier/system/{identifier}`) stay reachable without credentials — they run before any actor exists
- the admin server resolves the actor through its own header middleware, which also records `actor_entity_uuid` on the request span for admin requests
- authentication rejections log at debug level; the HTTP span carries the status for observability

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] affected the execution graph, and the `turbo.json`'s have been updated to reflect this
  - the new `@rust/hash-graph-api` → `@rust/hash-graph-authentication` edge is carried by the generated `package.json` dependencies (`sync:turborepo`); no `turbo.json` changes are needed

## ⚠️ Known issues

- The `X-Authenticated-User-Actor-Id` header remains the transitional authentication path for internal services; its hardening is tracked in BE-714 _(internal)_. Until then the Graph must not be exposed beyond the internal network, which matches the current deployment.
- The two bootstrap routes accept requests without credentials for the Node API's startup sequence; they move behind service credentials with BE-714 _(internal)_.
- Verified credentials are not cached yet; caching is tracked in BE-755 _(internal)_ and becomes relevant once a remote-verifying provider lands.
- The generated TypeScript client cannot call `POST /hashql` anymore (its spec declares no credential parameter). No caller exists today; the session provider follow-up supersedes this, so the client is left as is.
- Requests to unmatched paths keep returning 404 — the fallback is deliberately outside the authentication middleware (`route_layer`).

## 🐾 Next steps

- Kratos session provider (whoami-backed `AuthenticationProvider` implementation, prepared as a follow-up to keep this diff reviewable)
- service credentials for internal services (BE-714) _(internal)_
- Cloudflare Access JWT as a provider in the same pipeline, replacing the admin server's bespoke actor resolution

## 🛡 What tests cover this?

- `hash-graph-authentication` unit tests: credential precedence, no-fallback on rejected credentials, header parsing
- `hash-graph-api` middleware tests (`tower::oneshot` harness): fail-closed rejection, bootstrap allowlist, extractor behavior with and without middleware, admin header middleware
- the Graph HTTP test suite runs entirely against the authenticated surface; `hashql.http` adds an explicit 401 test for credential-less requests

## ❓ How to test this?

1. Start the stack and the Graph (`yarn start:graph` or `cargo run --bin hash-graph --all-features -- server`)
2. `curl -i http://127.0.0.1:4000/actors/machine/identifier/system/h` → 200 (bootstrap route)
3. `curl -i http://127.0.0.1:4000/actors/machine/identifier/h` → 401 (no credentials)
4. Repeat 3 with `-H "X-Authenticated-User-Actor-Id: <id from step 2>"` → 200
5. `cd tests/graph/http && sh test.sh` for the full suite
