### PR TITLE
FE-523: Sanitize user-controlled keys in the simulation path

### DIFF
--- a/.changeset/sanitize-user-controlled-keys.md
+++ b/.changeset/sanitize-user-controlled-keys.md
@@ -3,4 +3,4 @@
 "@hashintel/petrinaut": patch
 ---
 
-Reject net identifiers that collide with `Object.prototype` member names (`__proto__`, `constructor`, ...) at file import and at the simulation boundary, build all records keyed by user-authored strings without a prototype, bind compiled-program parameters as frozen prototype-free copies, and run place visualizer code under the same sandbox hardening as scenario code.
+Reject net identifiers that collide with `Object.prototype` member names (`__proto__`, `constructor`, ...) at file import and before simulation, and store user-authored keys in prototype-free records. Place visualizer code now runs under the same sandbox hardening as scenario code.

--- a/.changeset/sanitize-user-controlled-keys.md
+++ b/.changeset/sanitize-user-controlled-keys.md
@@ -1,0 +1,6 @@
+---
+"@hashintel/petrinaut-core": patch
+"@hashintel/petrinaut": patch
+---
+
+Reject net identifiers that collide with `Object.prototype` member names (`__proto__`, `constructor`, ...) at file import and at the simulation boundary, build all records keyed by user-authored strings without a prototype, bind compiled-program parameters as frozen prototype-free copies, and run place visualizer code under the same sandbox hardening as scenario code.

--- a/libs/@hashintel/petrinaut-core/src/actual-mode/marking.ts
+++ b/libs/@hashintel/petrinaut-core/src/actual-mode/marking.ts
@@ -1,3 +1,5 @@
+import { createUserKeyedRecord } from "../validation/record-keys";
+
 import type {
   ActualModeMarking,
   ActualModeTokenColour,
@@ -33,13 +35,15 @@ const cloneMarkingValue = (
     ? markingValue.map((token) => cloneTokenColour(token))
     : markingValue;
 
-const cloneMarking = (marking: ActualModeMarking): ActualModeMarking =>
-  Object.fromEntries(
-    Object.entries(marking).map(([placeId, value]) => [
-      placeId,
-      cloneMarkingValue(value),
-    ]),
-  );
+// Keyed by place ids from recorded firings: no prototype, so the writes in
+// `applyActualModeTransitionFiring` stay ordinary own properties.
+const cloneMarking = (marking: ActualModeMarking): ActualModeMarking => {
+  const next: ActualModeMarking = createUserKeyedRecord();
+  for (const [placeId, value] of Object.entries(marking)) {
+    next[placeId] = cloneMarkingValue(value);
+  }
+  return next;
+};
 
 const emptyTokens = (count: number): ActualModeTokenColour[] =>
   Array.from(

--- a/libs/@hashintel/petrinaut-core/src/file-format/parse-sdcpn-file.test.ts
+++ b/libs/@hashintel/petrinaut-core/src/file-format/parse-sdcpn-file.test.ts
@@ -488,4 +488,50 @@ describe("parseSDCPNFile", () => {
       expect(result.error.length).toBeGreaterThan(0);
     });
   });
+
+  describe("reserved property names", () => {
+    it("rejects ids colliding with Object.prototype members", () => {
+      const result = parseSDCPNFile({
+        version: 1,
+        meta: { generator: "Petrinaut" },
+        ...minimalSDCPN,
+        places: [{ ...minimalPlace, id: "__proto__" }],
+        transitions: [],
+      });
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toContain('place id "__proto__"');
+    });
+
+    it("rejects colour element names colliding with Object.prototype members", () => {
+      const result = parseSDCPNFile({
+        version: 1,
+        meta: { generator: "Petrinaut" },
+        ...minimalSDCPN,
+        types: [
+          {
+            id: "c1",
+            name: "Colour 1",
+            elements: [{ elementId: "e1", name: "constructor", type: "real" }],
+          },
+        ],
+      });
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toContain('colour element name "constructor"');
+    });
+
+    it("rejects reserved names in the legacy format too", () => {
+      const result = parseSDCPNFile({
+        ...minimalSDCPN,
+        transitions: [{ ...minimalTransition, id: "constructor" }],
+      });
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.error).toContain('transition id "constructor"');
+    });
+  });
 });

--- a/libs/@hashintel/petrinaut-core/src/file-format/parse-sdcpn-file.ts
+++ b/libs/@hashintel/petrinaut-core/src/file-format/parse-sdcpn-file.ts
@@ -4,6 +4,10 @@
  */
 
 import {
+  describeDangerousSdcpnKeys,
+  findDangerousSdcpnKeys,
+} from "../validation/record-keys";
+import {
   legacySdcpnFileSchema,
   SDCPN_FILE_FORMAT_VERSION,
   sdcpnFileSchema,
@@ -120,16 +124,36 @@ const fillMissingVisualInfo = (sdcpn: {
  * pre-2025-11-28 formats. Pure — no DOM, no I/O. Callers (e.g. the `/ui`
  * file-picker wrapper) are responsible for sourcing the data.
  */
+/**
+ * File-import trust boundary for identity strings. The file schemas accept
+ * any string as an id or element name, but downstream these strings key
+ * records and appear in compiled code, so names colliding with
+ * `Object.prototype` members are rejected here. `buildSimulation` repeats
+ * the check for nets that do not arrive through a file.
+ */
+const checkRecordKeys = (sdcpn: SDCPN): ImportResult | null => {
+  const dangerous = findDangerousSdcpnKeys(sdcpn);
+  return dangerous.length === 0
+    ? null
+    : {
+        ok: false,
+        error: `Invalid SDCPN file: ${describeDangerousSdcpnKeys(dangerous)}`,
+      };
+};
+
 export const parseSDCPNFile = (data: unknown): ImportResult => {
   // Try the versioned format first
   const versioned = sdcpnFileSchema.safeParse(data);
   if (versioned.success) {
     const { version: _version, meta: _meta, ...sdcpnData } = versioned.data;
-    return {
-      ok: true,
-      sdcpn: fillMissingVisualInfo(sdcpnData),
-      hadMissingPositions: hasMissingPositions(sdcpnData),
-    };
+    const sdcpn = fillMissingVisualInfo(sdcpnData);
+    return (
+      checkRecordKeys(sdcpn) ?? {
+        ok: true,
+        sdcpn,
+        hadMissingPositions: hasMissingPositions(sdcpnData),
+      }
+    );
   }
 
   // If the data has a `version` field but failed the versioned schema, reject it
@@ -157,11 +181,14 @@ export const parseSDCPNFile = (data: unknown): ImportResult => {
   // Fall back to legacy format (current schema without version/meta)
   const legacy = legacySdcpnFileSchema.safeParse(data);
   if (legacy.success) {
-    return {
-      ok: true,
-      sdcpn: fillMissingVisualInfo(legacy.data),
-      hadMissingPositions: hasMissingPositions(legacy.data),
-    };
+    const sdcpn = fillMissingVisualInfo(legacy.data);
+    return (
+      checkRecordKeys(sdcpn) ?? {
+        ok: true,
+        sdcpn,
+        hadMissingPositions: hasMissingPositions(legacy.data),
+      }
+    );
   }
 
   return {

--- a/libs/@hashintel/petrinaut-core/src/file-format/parse-sdcpn-file.ts
+++ b/libs/@hashintel/petrinaut-core/src/file-format/parse-sdcpn-file.ts
@@ -120,11 +120,6 @@ const fillMissingVisualInfo = (sdcpn: {
   }) as SDCPNWithTitle;
 
 /**
- * Parses raw JSON data into an SDCPN, handling versioned, legacy, and old
- * pre-2025-11-28 formats. Pure — no DOM, no I/O. Callers (e.g. the `/ui`
- * file-picker wrapper) are responsible for sourcing the data.
- */
-/**
  * File-import trust boundary for identity strings. The file schemas accept
  * any string as an id or element name, but downstream these strings key
  * records and appear in compiled code, so names colliding with
@@ -141,19 +136,32 @@ const checkRecordKeys = (sdcpn: SDCPN): ImportResult | null => {
       };
 };
 
+/** Successful parse of either format: fill visual info, then apply the
+ * record-key boundary check. */
+const toImportResult = (
+  sdcpnData: Parameters<typeof fillMissingVisualInfo>[0],
+): ImportResult => {
+  const sdcpn = fillMissingVisualInfo(sdcpnData);
+  return (
+    checkRecordKeys(sdcpn) ?? {
+      ok: true,
+      sdcpn,
+      hadMissingPositions: hasMissingPositions(sdcpnData),
+    }
+  );
+};
+
+/**
+ * Parses raw JSON data into an SDCPN, handling versioned, legacy, and old
+ * pre-2025-11-28 formats. Pure — no DOM, no I/O. Callers (e.g. the `/ui`
+ * file-picker wrapper) are responsible for sourcing the data.
+ */
 export const parseSDCPNFile = (data: unknown): ImportResult => {
   // Try the versioned format first
   const versioned = sdcpnFileSchema.safeParse(data);
   if (versioned.success) {
     const { version: _version, meta: _meta, ...sdcpnData } = versioned.data;
-    const sdcpn = fillMissingVisualInfo(sdcpnData);
-    return (
-      checkRecordKeys(sdcpn) ?? {
-        ok: true,
-        sdcpn,
-        hadMissingPositions: hasMissingPositions(sdcpnData),
-      }
-    );
+    return toImportResult(sdcpnData);
   }
 
   // If the data has a `version` field but failed the versioned schema, reject it
@@ -181,14 +189,7 @@ export const parseSDCPNFile = (data: unknown): ImportResult => {
   // Fall back to legacy format (current schema without version/meta)
   const legacy = legacySdcpnFileSchema.safeParse(data);
   if (legacy.success) {
-    const sdcpn = fillMissingVisualInfo(legacy.data);
-    return (
-      checkRecordKeys(sdcpn) ?? {
-        ok: true,
-        sdcpn,
-        hadMissingPositions: hasMissingPositions(legacy.data),
-      }
-    );
+    return toImportResult(legacy.data);
   }
 
   return {

--- a/libs/@hashintel/petrinaut-core/src/hir/compile.ts
+++ b/libs/@hashintel/petrinaut-core/src/hir/compile.ts
@@ -21,6 +21,7 @@ import {
   sanitizeSDCPNForExtensions,
   type PetrinautExtensionSettings,
 } from "../extensions";
+import { createUserKeyedRecord } from "../validation/record-keys";
 import { fingerprintHirCompilationInput } from "./artifact-fingerprint";
 import {
   emitBufferDynamicsJs,
@@ -105,13 +106,18 @@ export function compileHirArtifacts(
   extensions: PetrinautExtensionSettings = DEFAULT_PETRINAUT_EXTENSIONS,
 ): HirCompileResult {
   const sanitized = sanitizeSDCPNForExtensions(sdcpn, extensions);
+  // The four sub-records are keyed by item ids from the net definition, so
+  // they have no prototype: an id like "__proto__" becomes an ordinary own
+  // property instead of replacing the record's prototype and losing the
+  // artifact. Readers still guard with `getOwn` because a `structuredClone`
+  // or JSON round-trip revives these as plain objects.
   const artifacts: HirArtifacts = {
     version: 4,
     fingerprint: fingerprintHirCompilationInput(sanitized, extensions),
-    dynamics: {},
-    lambdas: {},
-    kernels: {},
-    metrics: {},
+    dynamics: createUserKeyedRecord(),
+    lambdas: createUserKeyedRecord(),
+    kernels: createUserKeyedRecord(),
+    metrics: createUserKeyedRecord(),
   };
   const failures: HirCompileFailure[] = [];
 

--- a/libs/@hashintel/petrinaut-core/src/hir/instantiate.test.ts
+++ b/libs/@hashintel/petrinaut-core/src/hir/instantiate.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { StringPool } from "../simulation/engine/string-pool";
+import { instantiateHirBufferLambda } from "./instantiate";
+
+/**
+ * The emitter reads parameters as `__params["<name>"]` (see
+ * `emit-buffer-js.ts`), so these sources mirror that shape directly.
+ */
+const lambdaSourceReading = (name: string): string =>
+  `(f64, u64, u8, placeBases, indices) => __params[${JSON.stringify(name)}]`;
+
+const callLambda = (
+  fn: ReturnType<typeof instantiateHirBufferLambda>,
+): number | boolean =>
+  fn(
+    new Float64Array(0),
+    new BigUint64Array(0),
+    new Uint8Array(0),
+    new Int32Array(0),
+    new Int32Array(0),
+  );
+
+describe("instantiate parameter binding", () => {
+  it("reads a parameter named after an Object.prototype member", () => {
+    const fn = instantiateHirBufferLambda(
+      lambdaSourceReading("constructor"),
+      { constructor: 42 },
+      new StringPool(),
+    );
+    expect(callLambda(fn)).toBe(42);
+  });
+
+  it("reads missing parameters as undefined instead of inherited members", () => {
+    const fn = instantiateHirBufferLambda(
+      lambdaSourceReading("toString"),
+      {},
+      new StringPool(),
+    );
+    expect(callLambda(fn)).toBeUndefined();
+  });
+
+  it("does not expose the caller's record to compiled code", () => {
+    const parameterValues = { rate: 1 };
+    const fn = instantiateHirBufferLambda(
+      "(f64, u64, u8, placeBases, indices) => { __params.rate = 99; return __params.rate; }",
+      parameterValues,
+      new StringPool(),
+    );
+    // The binding is frozen: strict-mode assignment throws, and the caller's
+    // record stays untouched either way.
+    expect(() => callLambda(fn)).toThrow(TypeError);
+    expect(parameterValues.rate).toBe(1);
+  });
+});

--- a/libs/@hashintel/petrinaut-core/src/hir/instantiate.test.ts
+++ b/libs/@hashintel/petrinaut-core/src/hir/instantiate.test.ts
@@ -5,10 +5,13 @@ import { instantiateHirBufferLambda } from "./instantiate";
 
 /**
  * The emitter reads parameters as `__params["<name>"]` (see
- * `emit-buffer-js.ts`), so these sources mirror that shape directly.
+ * `emit-buffer-js.ts`), so these sources mirror that shape directly. Fixed
+ * literals: no source is constructed from variables.
  */
-const lambdaSourceReading = (name: string): string =>
-  `(f64, u64, u8, placeBases, indices) => __params[${JSON.stringify(name)}]`;
+const CONSTRUCTOR_READING_SOURCE =
+  '(f64, u64, u8, placeBases, indices) => __params["constructor"]';
+const TOSTRING_READING_SOURCE =
+  '(f64, u64, u8, placeBases, indices) => __params["toString"]';
 
 const callLambda = (
   fn: ReturnType<typeof instantiateHirBufferLambda>,
@@ -24,7 +27,7 @@ const callLambda = (
 describe("instantiate parameter binding", () => {
   it("reads a parameter named after an Object.prototype member", () => {
     const fn = instantiateHirBufferLambda(
-      lambdaSourceReading("constructor"),
+      CONSTRUCTOR_READING_SOURCE,
       { constructor: 42 },
       new StringPool(),
     );
@@ -33,7 +36,7 @@ describe("instantiate parameter binding", () => {
 
   it("reads missing parameters as undefined instead of inherited members", () => {
     const fn = instantiateHirBufferLambda(
-      lambdaSourceReading("toString"),
+      TOSTRING_READING_SOURCE,
       {},
       new StringPool(),
     );

--- a/libs/@hashintel/petrinaut-core/src/hir/instantiate.ts
+++ b/libs/@hashintel/petrinaut-core/src/hir/instantiate.ts
@@ -154,6 +154,24 @@ export const hirDistributionRuntime = {
   }),
 };
 
+/**
+ * Rebinds parameter values onto a frozen, prototype-free copy before they
+ * become `__params` in a compiled program. Emitted parameter reads are
+ * `__params["<name>"]`; without this, a name colliding with an
+ * `Object.prototype` member ("constructor", "valueOf", ...) whose own value
+ * was lost upstream would read the inherited member instead of `undefined`.
+ * Parameter names come from imported files, so they are untrusted.
+ */
+function bindParameterValues(
+  parameterValues: HirParameterValues,
+): HirParameterValues {
+  const bound: HirParameterValues = Object.create(null) as HirParameterValues;
+  for (const [key, value] of Object.entries(parameterValues)) {
+    bound[key] = value;
+  }
+  return Object.freeze(bound);
+}
+
 function instantiate(
   source: string,
   parameterValues: HirParameterValues,
@@ -165,7 +183,7 @@ function instantiate(
     "__params",
     "__pool",
     `"use strict"; return (${source});`,
-  )(hirDistributionRuntime, parameterValues, stringPool);
+  )(hirDistributionRuntime, bindParameterValues(parameterValues), stringPool);
 }
 
 export function instantiateHirBufferDynamics(

--- a/libs/@hashintel/petrinaut-core/src/hir/instantiate.ts
+++ b/libs/@hashintel/petrinaut-core/src/hir/instantiate.ts
@@ -7,6 +7,8 @@
  * are emitted by `emit-buffer-js.ts` (the simulator's only program shape —
  * packed-struct buffer access with compile-time-constant offsets/strides).
  */
+import { cloneUserKeyedRecord } from "../validation/record-keys";
+
 import type { RuntimeDistribution } from "../simulation/authoring/user-code/distribution";
 
 export type HirParameterValues = Record<string, number | boolean>;
@@ -157,19 +159,15 @@ export const hirDistributionRuntime = {
 /**
  * Rebinds parameter values onto a frozen, prototype-free copy before they
  * become `__params` in a compiled program. Emitted parameter reads are
- * `__params["<name>"]`; without this, a name colliding with an
- * `Object.prototype` member ("constructor", "valueOf", ...) whose own value
- * was lost upstream would read the inherited member instead of `undefined`.
- * Parameter names come from imported files, so they are untrusted.
+ * `__params["<name>"]`; a name colliding with an `Object.prototype` member
+ * ("constructor", "valueOf", ...) must read its own value or `undefined`,
+ * never the inherited member. Parameter names come from imported files, so
+ * they are untrusted.
  */
 function bindParameterValues(
   parameterValues: HirParameterValues,
 ): HirParameterValues {
-  const bound: HirParameterValues = Object.create(null) as HirParameterValues;
-  for (const [key, value] of Object.entries(parameterValues)) {
-    bound[key] = value;
-  }
-  return Object.freeze(bound);
+  return Object.freeze(cloneUserKeyedRecord(parameterValues));
 }
 
 function instantiate(

--- a/libs/@hashintel/petrinaut-core/src/index.ts
+++ b/libs/@hashintel/petrinaut-core/src/index.ts
@@ -434,6 +434,7 @@ export {
 } from "./validation/display-name";
 export { entityNameSchema, validateEntityName } from "./validation/entity-name";
 export {
+  cloneUserKeyedRecord,
   createUserKeyedRecord,
   DANGEROUS_RECORD_KEYS,
   describeDangerousSdcpnKeys,

--- a/libs/@hashintel/petrinaut-core/src/index.ts
+++ b/libs/@hashintel/petrinaut-core/src/index.ts
@@ -433,7 +433,17 @@ export {
   validateDisplayName,
 } from "./validation/display-name";
 export { entityNameSchema, validateEntityName } from "./validation/entity-name";
+export {
+  createUserKeyedRecord,
+  DANGEROUS_RECORD_KEYS,
+  describeDangerousSdcpnKeys,
+  findDangerousSdcpnKeys,
+  getOwn,
+  isDangerousRecordKey,
+  type DangerousSdcpnKey,
+} from "./validation/record-keys";
 export { validateVariableName } from "./validation/variable-name";
+export { runSandboxed, SHADOWED_GLOBALS } from "./simulation/authoring/sandbox";
 
 // --- File, clipboard, and editor protocol helpers ---
 export {

--- a/libs/@hashintel/petrinaut-core/src/layout/calculate-graph-layout.ts
+++ b/libs/@hashintel/petrinaut-core/src/layout/calculate-graph-layout.ts
@@ -1,6 +1,7 @@
 import ELK from "elkjs";
 
 import { getArcEndpoint, getArcEndpointNodeId } from "../arc-endpoints";
+import { createUserKeyedRecord } from "../validation/record-keys";
 
 import type { SDCPN } from "../types/sdcpn";
 import type { ElkNode } from "elkjs";
@@ -130,7 +131,9 @@ export const calculateGraphLayout = async (
    * ELK returns top-left positions, but the SDCPN store uses center
    * coordinates, so we offset by half the node dimensions.
    */
-  const positionsByNodeId: Record<string, NodePosition> = {};
+  // Keyed by place/transition/component-instance ids: no prototype.
+  const positionsByNodeId: Record<string, NodePosition> =
+    createUserKeyedRecord();
   for (const child of updatedElements.children ?? []) {
     if (child.x !== undefined && child.y !== undefined) {
       const nodeDimensions = placeIds.has(child.id)

--- a/libs/@hashintel/petrinaut-core/src/optimization.test.ts
+++ b/libs/@hashintel/petrinaut-core/src/optimization.test.ts
@@ -149,7 +149,10 @@ describe("petrinautOptimizationManifestSchema", () => {
     expect(unknown.success).toBe(false);
   });
 
-  it("treats inherited object properties as missing bindings", () => {
+  // A binding named "constructor" previously exercised the binding check's
+  // own-property semantics; the model boundary now rejects the identifier
+  // before the binding check runs.
+  it("rejects reserved-name scenario parameters at the model boundary", () => {
     const parsed = petrinautOptimizationManifestSchema.safeParse({
       ...validManifest,
       model: {
@@ -176,8 +179,10 @@ describe("petrinautOptimizationManifestSchema", () => {
     if (!parsed.success) {
       expect(parsed.error.issues).toContainEqual(
         expect.objectContaining({
-          path: ["scenario", "parameterBindings", "constructor"],
-          message: "Every scenario parameter requires a binding",
+          path: ["model"],
+          message: expect.stringContaining(
+            'scenario parameter identifier "constructor"',
+          ) as string,
         }),
       );
     }

--- a/libs/@hashintel/petrinaut-core/src/parameter-values.test.ts
+++ b/libs/@hashintel/petrinaut-core/src/parameter-values.test.ts
@@ -1,6 +1,30 @@
 import { describe, expect, it } from "vitest";
 
-import { mergeParameterValues } from "./parameter-values";
+import {
+  deriveDefaultParameterValues,
+  mergeParameterValues,
+} from "./parameter-values";
+
+describe("deriveDefaultParameterValues", () => {
+  it("stores names colliding with Object.prototype members as own properties", () => {
+    const values = deriveDefaultParameterValues([
+      {
+        id: "param1",
+        name: "Constructor",
+        variableName: "constructor",
+        type: "real",
+        defaultValue: "3",
+      },
+    ]);
+    expect(Object.hasOwn(values, "constructor")).toBe(true);
+    expect(values.constructor).toBe(3);
+  });
+
+  it("returns a record without a prototype", () => {
+    expect(Object.getPrototypeOf(deriveDefaultParameterValues([]))).toBe(null);
+    expect(deriveDefaultParameterValues([])["toString"]).toBeUndefined();
+  });
+});
 
 describe("mergeParameterValues", () => {
   it("preserves boolean parameter overrides as booleans", () => {
@@ -19,5 +43,27 @@ describe("mergeParameterValues", () => {
     expect(() =>
       mergeParameterValues({ rate: "invalid" }, { rate: 1 }),
     ).toThrow('Parameter "rate" must be a finite number');
+  });
+
+  it("merges store keys colliding with Object.prototype members as own properties", () => {
+    const merged = mergeParameterValues({ constructor: "5" }, {}, [
+      {
+        id: "param1",
+        name: "Constructor",
+        variableName: "constructor",
+        type: "real",
+        defaultValue: "1",
+      },
+    ]);
+    expect(Object.hasOwn(merged, "constructor")).toBe(true);
+    expect(merged.constructor).toBe(5);
+    expect(Object.getPrototypeOf(merged)).toBe(null);
+  });
+
+  it("does not read defaults through the prototype chain", () => {
+    // "toString" has no declared type and no default: the inferred type
+    // must fall back to "real", not derive from Object.prototype.toString.
+    const merged = mergeParameterValues({ toString: "2" }, {});
+    expect(merged["toString"]).toBe(2);
   });
 });

--- a/libs/@hashintel/petrinaut-core/src/parameter-values.ts
+++ b/libs/@hashintel/petrinaut-core/src/parameter-values.ts
@@ -1,4 +1,8 @@
-import { createUserKeyedRecord, getOwn } from "./validation/record-keys";
+import {
+  cloneUserKeyedRecord,
+  createUserKeyedRecord,
+  getOwn,
+} from "./validation/record-keys";
 
 import type { Parameter } from "./types/sdcpn";
 
@@ -86,12 +90,9 @@ export function mergeParameterValues(
   defaultValues: DefaultParameterValues,
   parameters: readonly Parameter[] = [],
 ): DefaultParameterValues {
-  // Prototype-free: keys are parameter variable names from the net
-  // definition plus arbitrary keys from stored run inputs.
-  const merged = Object.assign(
-    createUserKeyedRecord<number | boolean>(),
-    defaultValues,
-  );
+  // Keys are parameter variable names from the net definition plus arbitrary
+  // keys from stored run inputs.
+  const merged = cloneUserKeyedRecord(defaultValues);
   const parameterTypes = new Map(
     parameters.map((parameter) => [parameter.variableName, parameter.type]),
   );

--- a/libs/@hashintel/petrinaut-core/src/parameter-values.ts
+++ b/libs/@hashintel/petrinaut-core/src/parameter-values.ts
@@ -1,3 +1,5 @@
+import { createUserKeyedRecord, getOwn } from "./validation/record-keys";
+
 import type { Parameter } from "./types/sdcpn";
 
 /**
@@ -57,7 +59,9 @@ export function parseParameterValue(
 export function deriveDefaultParameterValues(
   parameters: Parameter[],
 ): DefaultParameterValues {
-  const parameterValues: DefaultParameterValues = {};
+  // Variable names come from the net definition, so the record has no
+  // prototype: a name like "constructor" stays an ordinary own property.
+  const parameterValues = createUserKeyedRecord<number | boolean>();
 
   for (const param of parameters) {
     parameterValues[param.variableName] = parseParameterValue(
@@ -82,7 +86,12 @@ export function mergeParameterValues(
   defaultValues: DefaultParameterValues,
   parameters: readonly Parameter[] = [],
 ): DefaultParameterValues {
-  const merged: DefaultParameterValues = { ...defaultValues };
+  // Prototype-free: keys are parameter variable names from the net
+  // definition plus arbitrary keys from stored run inputs.
+  const merged = Object.assign(
+    createUserKeyedRecord<number | boolean>(),
+    defaultValues,
+  );
   const parameterTypes = new Map(
     parameters.map((parameter) => [parameter.variableName, parameter.type]),
   );
@@ -90,7 +99,7 @@ export function mergeParameterValues(
   // Override with SimulationStore values where they exist
   for (const [key, value] of Object.entries(simulationStoreValues)) {
     if (value !== "") {
-      const defaultValue = defaultValues[key];
+      const defaultValue = getOwn(defaultValues, key);
       const type =
         parameterTypes.get(key) ??
         (typeof defaultValue === "boolean" ? "boolean" : "real");

--- a/libs/@hashintel/petrinaut-core/src/schemas/entity-schemas.ts
+++ b/libs/@hashintel/petrinaut-core/src/schemas/entity-schemas.ts
@@ -9,6 +9,7 @@ import { getParameterValueError } from "../parameter-values";
 import { COLOR_ELEMENT_TYPES } from "../simulation/engine/type-policies";
 import { displayNameSchema } from "../validation/display-name";
 import { entityNameSchema } from "../validation/entity-name";
+import { isDangerousRecordKey } from "../validation/record-keys";
 import { variableNameSchema } from "../validation/variable-name";
 
 import type {
@@ -160,6 +161,11 @@ export const colorElementSchema = z
         z.refine((val) => /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(val), {
           message:
             "Element name must be a valid JavaScript identifier (start with a letter, `_`, or `$`; only letters, digits, `_`, `$` allowed).",
+        }),
+        // Element names key token records throughout the engine and UI.
+        z.refine((val) => !isDangerousRecordKey(val), {
+          message:
+            "Element name must not be a reserved JavaScript property name (e.g., `constructor`, `toString`, `__proto__`).",
         }),
       )
       .meta({

--- a/libs/@hashintel/petrinaut-core/src/schemas/scenario-schema.ts
+++ b/libs/@hashintel/petrinaut-core/src/schemas/scenario-schema.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { displayNameSchema } from "../validation/display-name";
+import { isDangerousRecordKey } from "../validation/record-keys";
 import { idSchema } from "./entity-schemas";
 
 import type { Scenario } from "../types/sdcpn";
@@ -25,6 +26,12 @@ export const scenarioParameterSchema = z
       .string()
       .min(1, "Identifier cannot be empty")
       .regex(SNAKE_CASE_RE, "Identifier must be snake_case")
+      // Identifiers key scenario-parameter records; "constructor" is the one
+      // all-lowercase `Object.prototype` member the snake_case rule admits.
+      .refine((val) => !isDangerousRecordKey(val), {
+        message:
+          "Identifier must not be a reserved JavaScript property name (e.g., constructor).",
+      })
       .meta({
         description:
           "Scenario-scoped identifier for a user-tunable variable. Reference it as scenario.identifier in parameterOverrides and initialState expressions. Must be snake_case.",

--- a/libs/@hashintel/petrinaut-core/src/simulation/authoring/scenario/compile-scenario.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/authoring/scenario/compile-scenario.ts
@@ -1,4 +1,5 @@
 import { parseParameterValue } from "../../../parameter-values";
+import { createUserKeyedRecord, getOwn } from "../../../validation/record-keys";
 import { coerceTokenRecord } from "../../engine/token-values";
 import { TYPE_POLICIES } from "../../engine/type-policies";
 import { runSandboxed, SHADOWED_GLOBALS } from "../sandbox";
@@ -122,7 +123,8 @@ function compileTokenRecord(
     elements,
     "Scenario initial state token",
   );
-  const token: MarkingTokenRecord = {};
+  // Element names come from the net definition: no prototype.
+  const token = createUserKeyedRecord<InitialTokenAttributeValue>();
   for (const element of elements) {
     token[element.name] = TYPE_POLICIES[element.type].encodeAtRest(
       coerced[element.name]!,
@@ -136,7 +138,7 @@ function tokenRecordsFromRows(
   elements: Color["elements"],
 ): MarkingTokenRecord[] {
   return rows.map((row) => {
-    const token: Record<string, unknown> = {};
+    const token = createUserKeyedRecord<unknown>();
     for (let i = 0; i < elements.length; i++) {
       token[elements[i]!.name] = row[i];
     }
@@ -190,14 +192,17 @@ export function compileScenario(
 
   // ── Step 1: Build the `scenario` object from scenario parameter defaults ──
 
-  const scenarioObj: NetParameterValues = {};
+  // Scenario parameter identifiers come from the net definition: no prototype.
+  const scenarioObj: NetParameterValues = createUserKeyedRecord();
   for (const sp of scenario.scenarioParameters) {
     if (sp.identifier.trim() === "") {
       continue;
     }
 
     const value =
-      options.scenarioParameterValues?.[sp.identifier] ?? sp.default;
+      (options.scenarioParameterValues
+        ? getOwn(options.scenarioParameterValues, sp.identifier)
+        : undefined) ?? sp.default;
     if (!Number.isFinite(value)) {
       errors.push({
         source: "scenarioParameter",
@@ -217,7 +222,7 @@ export function compileScenario(
   // Start with net-level defaults, then apply each override expression.
   // Expressions have access to the base `parameters` and `scenario`.
 
-  const parametersObj: NetParameterValues = {};
+  const parametersObj: NetParameterValues = createUserKeyedRecord();
   for (const param of netParameters) {
     try {
       parametersObj[param.variableName] = parseParameterValue(
@@ -290,7 +295,9 @@ export function compileScenario(
 
   // ── Step 3: Evaluate initial state ──
 
-  const initialState: InitialMarking = {};
+  // Keyed by place id; in code mode the key set additionally derives from
+  // whatever object the user-authored code block returns: no prototype.
+  const initialState: InitialMarking = createUserKeyedRecord();
   const placeById = new Map(places.map((p) => [p.id, p]));
   const placeByName = new Map(places.map((p) => [p.name, p]));
   const typeById = new Map(types.map((t) => [t.id, t]));
@@ -443,7 +450,7 @@ export function compileScenario(
   }
 
   // Convert parameters to string values (simulation worker input format)
-  const parameterValues: Record<string, string> = {};
+  const parameterValues = createUserKeyedRecord<string>();
   for (const [key, value] of Object.entries(parametersObj)) {
     parameterValues[key] = String(value);
   }

--- a/libs/@hashintel/petrinaut-core/src/simulation/compiled-model.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/compiled-model.ts
@@ -6,6 +6,7 @@ import {
 } from "../extensions";
 import { compileHirArtifacts } from "../hir";
 import { resolveNetParameterValues } from "../parameter-values";
+import { getOwn } from "../validation/record-keys";
 import { buildSimulation } from "./engine/build-simulation";
 import { computeNextFrame } from "./engine/compute-next-frame";
 import { readTokenRecord } from "./engine/token-layout";
@@ -136,7 +137,7 @@ function validateMetricIdentities(sdcpn: SDCPN): void {
 
 function validateCompiledMetrics(sdcpn: SDCPN, artifacts: HirArtifacts): void {
   for (const metric of sdcpn.metrics ?? []) {
-    if (!artifacts.metrics[metric.id]) {
+    if (!getOwn(artifacts.metrics, metric.id)) {
       throw new Error(
         `Metric "${metric.name}" has not been compiled. Check the model's metric diagnostics.`,
       );
@@ -284,7 +285,7 @@ function resolveMetrics(args: {
 
   return metricNamesOrIds.map((metricNameOrId) => {
     const metric = findMetric(sdcpn, metricNameOrId);
-    const artifact = artifacts.metrics[metric.id];
+    const artifact = getOwn(artifacts.metrics, metric.id);
     if (!artifact) {
       throw new Error(
         `Metric "${metric.name}" has not been compiled. Check the model's metric diagnostics.`,

--- a/libs/@hashintel/petrinaut-core/src/simulation/engine/build-simulation.test.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/engine/build-simulation.test.ts
@@ -944,4 +944,70 @@ describe("buildSimulation", () => {
       "Initial marking for colored place p1 must be an array of token records",
     );
   });
+
+  it("rejects nets whose ids collide with Object.prototype members", () => {
+    const input: SimulationInput = {
+      sdcpn: {
+        types: [],
+        differentialEquations: [],
+        parameters: [],
+        places: [],
+        transitions: [
+          {
+            id: "constructor",
+            name: "Transition 1",
+            inputArcs: [],
+            outputArcs: [],
+            lambdaType: "predicate",
+            lambdaCode: "",
+            transitionKernelCode: "",
+            x: 0,
+            y: 0,
+          },
+        ],
+      },
+      initialMarking: {},
+      parameterValues: {},
+      seed: 42,
+      dt: 0.1,
+      maxTime: null,
+    };
+
+    expect(() => buildSimulation(input)).toThrow(
+      'reserved JavaScript property names as identifiers: transition id "constructor"',
+    );
+  });
+
+  it("keeps initial marking reads off the prototype chain", () => {
+    const input: SimulationInput = {
+      sdcpn: {
+        types: [],
+        differentialEquations: [],
+        parameters: [],
+        places: [
+          {
+            id: "p1",
+            name: "Place 1",
+            colorId: null,
+            dynamicsEnabled: false,
+            differentialEquationId: null,
+            x: 0,
+            y: 0,
+          },
+        ],
+        transitions: [],
+      },
+      // An own `__proto__` key, as JSON.parse would produce it. The place id
+      // "p1" has no entry, and nothing may leak in from the prototype chain.
+      initialMarking: JSON.parse('{"__proto__": 3}') as Record<string, number>,
+      parameterValues: {},
+      seed: 42,
+      dt: 0.1,
+      maxTime: null,
+    };
+
+    expect(() => buildSimulation(input)).toThrow(
+      "Place with ID __proto__ in initialMarking does not exist in SDCPN",
+    );
+  });
 });

--- a/libs/@hashintel/petrinaut-core/src/simulation/engine/build-simulation.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/engine/build-simulation.ts
@@ -698,12 +698,10 @@ export function buildSimulation(input: SimulationInput): SimulationInstance {
       const placeParameterValues =
         flattened.placeParameterValues.get(place.id) ?? parameterValues;
 
-      const artifact: HirDynamicsArtifact | undefined = input.hirArtifacts
-        ? getOwn(
-            input.hirArtifacts.dynamics,
-            sourceItemId(differentialEquation.id),
-          )
-        : undefined;
+      const artifact: HirDynamicsArtifact | undefined = getOwn(
+        input.hirArtifacts?.dynamics,
+        sourceItemId(differentialEquation.id),
+      );
       if (!artifact) {
         throw missingArtifactError(
           "dynamics",
@@ -747,12 +745,14 @@ export function buildSimulation(input: SimulationInput): SimulationInstance {
         parameterValues:
           flattened.transitionParameterValues.get(transition.id) ??
           parameterValues,
-        lambdaArtifact: input.hirArtifacts
-          ? getOwn(input.hirArtifacts.lambdas, sourceItemId(transition.id))
-          : undefined,
-        kernelArtifact: input.hirArtifacts
-          ? getOwn(input.hirArtifacts.kernels, sourceItemId(transition.id))
-          : undefined,
+        lambdaArtifact: getOwn(
+          input.hirArtifacts?.lambdas,
+          sourceItemId(transition.id),
+        ),
+        kernelArtifact: getOwn(
+          input.hirArtifacts?.kernels,
+          sourceItemId(transition.id),
+        ),
         stringPool,
       }),
     );

--- a/libs/@hashintel/petrinaut-core/src/simulation/engine/build-simulation.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/engine/build-simulation.ts
@@ -18,6 +18,12 @@ import {
   mergeParameterValues,
 } from "../../parameter-values";
 import {
+  createUserKeyedRecord,
+  describeDangerousSdcpnKeys,
+  findDangerousSdcpnKeys,
+  getOwn,
+} from "../../validation/record-keys";
+import {
   createEngineFrame,
   createEngineFrameLayout,
   type EngineFrameSnapshot,
@@ -90,9 +96,7 @@ function getInitialMarkingValue(
   initialMarking: SimulationInput["initialMarking"],
   placeId: string,
 ): SimulationInput["initialMarking"][string] | undefined {
-  return Object.prototype.hasOwnProperty.call(initialMarking, placeId)
-    ? initialMarking[placeId]
-    : undefined;
+  return getOwn(initialMarking, placeId);
 }
 
 /**
@@ -592,6 +596,16 @@ export function buildSimulation(input: SimulationInput): SimulationInstance {
   } = input;
   const extensions = input.extensions ?? DEFAULT_PETRINAUT_EXTENSIONS;
   const sanitizedSdcpn = sanitizeSDCPNForExtensions(input.sdcpn, extensions);
+
+  // Simulation trust boundary: ids, parameter variable names and colour
+  // element names key records and reach compiled code from here on. The
+  // file-import boundary applies the same check; this one also covers nets
+  // supplied programmatically by embedding applications.
+  const dangerousKeys = findDangerousSdcpnKeys(sanitizedSdcpn);
+  if (dangerousKeys.length > 0) {
+    throw new Error(describeDangerousSdcpnKeys(dangerousKeys));
+  }
+
   validateHirArtifacts(input.hirArtifacts, sanitizedSdcpn, extensions);
 
   const defaultParameterValues = deriveDefaultParameterValues(
@@ -684,8 +698,12 @@ export function buildSimulation(input: SimulationInput): SimulationInstance {
       const placeParameterValues =
         flattened.placeParameterValues.get(place.id) ?? parameterValues;
 
-      const artifact: HirDynamicsArtifact | undefined =
-        input.hirArtifacts?.dynamics[sourceItemId(differentialEquation.id)];
+      const artifact: HirDynamicsArtifact | undefined = input.hirArtifacts
+        ? getOwn(
+            input.hirArtifacts.dynamics,
+            sourceItemId(differentialEquation.id),
+          )
+        : undefined;
       if (!artifact) {
         throw missingArtifactError(
           "dynamics",
@@ -729,10 +747,12 @@ export function buildSimulation(input: SimulationInput): SimulationInstance {
         parameterValues:
           flattened.transitionParameterValues.get(transition.id) ??
           parameterValues,
-        lambdaArtifact:
-          input.hirArtifacts?.lambdas[sourceItemId(transition.id)],
-        kernelArtifact:
-          input.hirArtifacts?.kernels[sourceItemId(transition.id)],
+        lambdaArtifact: input.hirArtifacts
+          ? getOwn(input.hirArtifacts.lambdas, sourceItemId(transition.id))
+          : undefined,
+        kernelArtifact: input.hirArtifacts
+          ? getOwn(input.hirArtifacts.kernels, sourceItemId(transition.id))
+          : undefined,
         stringPool,
       }),
     );
@@ -741,7 +761,8 @@ export function buildSimulation(input: SimulationInput): SimulationInstance {
   // Calculate buffer size and build place states
   let bufferByteSize = 0;
   const frameLayout = createEngineFrameLayout(sdcpn);
-  const placeStates: EngineFrameSnapshot["places"] = {};
+  // Keyed by place/transition id: no prototype (see `createUserKeyedRecord`).
+  const placeStates: EngineFrameSnapshot["places"] = createUserKeyedRecord();
 
   for (const [placeIndex, placeId] of frameLayout.placeIds.entries()) {
     const marking = packedInitialMarking.get(placeId);
@@ -770,7 +791,8 @@ export function buildSimulation(input: SimulationInput): SimulationInstance {
   }
 
   // Initialize transition states
-  const transitionStates: EngineFrameSnapshot["transitions"] = {};
+  const transitionStates: EngineFrameSnapshot["transitions"] =
+    createUserKeyedRecord();
   for (const transition of sdcpn.transitions) {
     transitionStates[transition.id] = {
       timeSinceLastFiringMs: 0,

--- a/libs/@hashintel/petrinaut-core/src/simulation/engine/flatten-component-instances.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/engine/flatten-component-instances.ts
@@ -1,4 +1,5 @@
 import { getArcEndpoint } from "../../arc-endpoints";
+import { createUserKeyedRecord, getOwn } from "../../validation/record-keys";
 
 import type {
   ArcEndpoint,
@@ -80,11 +81,12 @@ const deriveInstanceParameterValues = (
   parameters: readonly Parameter[],
   parameterValuesById: Record<ID, string>,
 ): ParameterValues => {
-  const values: ParameterValues = {};
+  // Keyed by parameter variable names from the net definition: no prototype.
+  const values: ParameterValues = createUserKeyedRecord();
   for (const parameter of parameters) {
     values[parameter.variableName] = coerceParameterValue(
       parameter,
-      parameterValuesById[parameter.id],
+      getOwn(parameterValuesById, parameter.id),
     );
   }
   return values;
@@ -484,7 +486,8 @@ export const flattenComponentInstancesForSimulation = ({
 
   const rootPlaceIds = new Set(sdcpn.places.map((place) => place.id));
   const flatPlaceIds = new Set(target.places.map((place) => place.id));
-  const flatInitialMarking: InitialMarking = {};
+  // Keyed by place ids from stored run inputs: no prototype.
+  const flatInitialMarking: InitialMarking = createUserKeyedRecord();
   for (const [placeId, value] of Object.entries(initialMarking)) {
     if (flatPlaceIds.has(placeId) || !rootPlaceIds.has(placeId)) {
       flatInitialMarking[placeId] = value;

--- a/libs/@hashintel/petrinaut-core/src/simulation/engine/token-layout.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/engine/token-layout.ts
@@ -1,3 +1,4 @@
+import { createUserKeyedRecord, getOwn } from "../../validation/record-keys";
 import {
   coerceTokenAttributeValue,
   decodeTokenAttributeValue,
@@ -195,7 +196,8 @@ export function readTokenRecord(
 ): TokenRecord {
   assertTokenAligned(tokenByteOffset);
   const { f64, u8, u64 } = views;
-  const token: TokenRecord = {};
+  // Element names come from the net definition: no prototype.
+  const token = createUserKeyedRecord<TokenRecord[string]>();
   for (const field of layout.fields) {
     if (field.kind === "u64") {
       if (!stringPool) {
@@ -284,7 +286,7 @@ export function encodeTokenValuesToBytes(
       field,
       views,
       0,
-      encodedValuesByName[field.element.name] ??
+      getOwn(encodedValuesByName, field.element.name) ??
         (field.kind === "u64x2" ? NIL_UUID : 0),
     );
   }
@@ -317,7 +319,7 @@ export function encodeTokenToBytes(
       }
       const coerced = coerceTokenAttributeValue(
         field.element,
-        record[field.element.name],
+        getOwn(record, field.element.name),
         `${context}.${field.element.name}`,
       );
       writeTokenValue(
@@ -330,7 +332,7 @@ export function encodeTokenToBytes(
     }
     const encodedValue = encodeTokenAttributeValue(
       field.element,
-      record[field.element.name],
+      getOwn(record, field.element.name),
       `${context}.${field.element.name}`,
     );
     writeTokenValue(field, views, 0, encodedValue);

--- a/libs/@hashintel/petrinaut-core/src/simulation/engine/token-values.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/engine/token-values.ts
@@ -1,3 +1,4 @@
+import { createUserKeyedRecord, getOwn } from "../../validation/record-keys";
 import { TYPE_POLICIES } from "./type-policies";
 import { formatUuid } from "./uuid";
 
@@ -70,11 +71,14 @@ export function coerceTokenRecord(
   elements: readonly ColorElement[],
   context: string,
 ): TokenRecord {
-  const token: TokenRecord = {};
+  // Element names come from the net definition and `source` from stored
+  // documents or scenario code, so keys are untrusted: build without a
+  // prototype and read own properties only.
+  const token = createUserKeyedRecord<TokenRecord[string]>();
   for (const element of elements) {
     token[element.name] = coerceTokenAttributeValue(
       element,
-      source[element.name],
+      getOwn(source, element.name),
       `${context}.${element.name}`,
     );
   }
@@ -140,7 +144,7 @@ export function decodeTokenRecord(
   elements: readonly ColorElement[],
   encodedValues: ArrayLike<number>,
 ): TokenRecord {
-  const token: TokenRecord = {};
+  const token = createUserKeyedRecord<TokenRecord[string]>();
   for (let index = 0; index < elements.length; index++) {
     const element = elements[index]!;
     token[element.name] = decodeTokenAttributeValue(

--- a/libs/@hashintel/petrinaut-core/src/simulation/frames/hir-metric.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/frames/hir-metric.ts
@@ -4,6 +4,7 @@ import {
   type HirMetricArtifact,
   type HirParameterValues,
 } from "../../hir/instantiate";
+import { createUserKeyedRecord } from "../../validation/record-keys";
 
 import type { Place } from "../../types/sdcpn";
 import type { SimulationFrameReader } from "../api";
@@ -52,7 +53,12 @@ export function createHirMetricEvaluator(args: {
   // Monte-Carlo runs can override parameters per run, so its contents are
   // refreshed from each frame's own resolved values before evaluation; frame
   // sources that carry none keep the evaluator's construction-time defaults.
-  const boundParameters: HirParameterValues = { ...parameterValues };
+  // No prototype: keys are parameter variable names from the net definition,
+  // and `Object.assign` below must create own properties for any of them.
+  const boundParameters: HirParameterValues = Object.assign(
+    createUserKeyedRecord<number | boolean>(),
+    parameterValues,
+  );
   let lastParameterValues: HirParameterValues | null = null;
   const bindParameters = (frameParameters: HirParameterValues): void => {
     if (frameParameters === lastParameterValues) {

--- a/libs/@hashintel/petrinaut-core/src/simulation/frames/hir-metric.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/frames/hir-metric.ts
@@ -4,7 +4,7 @@ import {
   type HirMetricArtifact,
   type HirParameterValues,
 } from "../../hir/instantiate";
-import { createUserKeyedRecord } from "../../validation/record-keys";
+import { cloneUserKeyedRecord } from "../../validation/record-keys";
 
 import type { Place } from "../../types/sdcpn";
 import type { SimulationFrameReader } from "../api";
@@ -53,12 +53,8 @@ export function createHirMetricEvaluator(args: {
   // Monte-Carlo runs can override parameters per run, so its contents are
   // refreshed from each frame's own resolved values before evaluation; frame
   // sources that carry none keep the evaluator's construction-time defaults.
-  // No prototype: keys are parameter variable names from the net definition,
-  // and `Object.assign` below must create own properties for any of them.
-  const boundParameters: HirParameterValues = Object.assign(
-    createUserKeyedRecord<number | boolean>(),
-    parameterValues,
-  );
+  const boundParameters: HirParameterValues =
+    cloneUserKeyedRecord(parameterValues);
   let lastParameterValues: HirParameterValues | null = null;
   const bindParameters = (frameParameters: HirParameterValues): void => {
     if (frameParameters === lastParameterValues) {

--- a/libs/@hashintel/petrinaut-core/src/simulation/frames/internal-frame.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/frames/internal-frame.ts
@@ -1,4 +1,8 @@
 import {
+  createUserKeyedRecord,
+  isDangerousRecordKey,
+} from "../../validation/record-keys";
+import {
   computeTokenSlotLayout,
   createTokenRegionViews,
   type TokenRegionViews,
@@ -128,8 +132,10 @@ export function createEngineFrameLayout(
 
   for (let index = 0; index < sdcpn.places.length; index++) {
     const place = sdcpn.places[index]!;
-    if (place.id === "__proto__") {
-      throw new Error("Cannot add place with id '__proto__'");
+    if (isDangerousRecordKey(place.id)) {
+      throw new Error(
+        `Cannot add place with id "${place.id}": reserved JavaScript property name`,
+      );
     }
     if (placeIndexById.has(place.id)) {
       throw new Error(`Duplicate place id in SDCPN: ${place.id}`);
@@ -144,8 +150,10 @@ export function createEngineFrameLayout(
   const transitionIndexById = new Map<ID, number>();
   for (let index = 0; index < sdcpn.transitions.length; index++) {
     const transition = sdcpn.transitions[index]!;
-    if (transition.id === "__proto__") {
-      throw new Error("Cannot add transition with id '__proto__'");
+    if (isDangerousRecordKey(transition.id)) {
+      throw new Error(
+        `Cannot add transition with id "${transition.id}": reserved JavaScript property name`,
+      );
     }
     if (transitionIndexById.has(transition.id)) {
       throw new Error(`Duplicate transition id in SDCPN: ${transition.id}`);
@@ -477,12 +485,14 @@ export function readEngineFrame(
     getTransitionState,
     getTransitionEntries,
     toSnapshot() {
-      const places: EngineFrameSnapshot["places"] = {};
+      // Keyed by place/transition id: no prototype.
+      const places: EngineFrameSnapshot["places"] = createUserKeyedRecord();
       for (const [placeId, placeState] of getPlaceEntries()) {
         places[placeId] = placeState;
       }
 
-      const transitions: EngineFrameSnapshot["transitions"] = {};
+      const transitions: EngineFrameSnapshot["transitions"] =
+        createUserKeyedRecord();
       for (const [transitionId, transitionState] of getTransitionEntries()) {
         transitions[transitionId] = transitionState;
       }

--- a/libs/@hashintel/petrinaut-core/src/simulation/monte-carlo/runtime/experiment.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/monte-carlo/runtime/experiment.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_PETRINAUT_EXTENSIONS } from "../../../extensions";
 import { resolveNetParameterValues } from "../../../parameter-values";
+import { createUserKeyedRecord } from "../../../validation/record-keys";
 import { createWorkerTransport } from "../../runtime/transport";
 import {
   createMonteCarloUserDefinedMetricConfigsFromSpecs,
@@ -167,7 +168,11 @@ function appendMetricFrames(
   state: MonteCarloExperimentMetrics,
   nextFrames: readonly MonteCarloUserDefinedMetricFrame[],
 ): MonteCarloExperimentMetrics {
-  const latestByMetricId = { ...state.latestByMetricId };
+  // Keyed by metric ids from the net definition: no prototype.
+  const latestByMetricId = Object.assign(
+    createUserKeyedRecord<MonteCarloUserDefinedMetricFrame>(),
+    state.latestByMetricId,
+  );
 
   for (const frame of nextFrames) {
     latestByMetricId[frame.metricId] = frame;

--- a/libs/@hashintel/petrinaut-core/src/validation/README.md
+++ b/libs/@hashintel/petrinaut-core/src/validation/README.md
@@ -1,6 +1,6 @@
 ---
 layer: core.validation
-role: Structural integrity validators for SDCPN entities, enforcing naming conventions
+role: Structural validators and record-key guards for user-authored SDCPN identifiers
 ---
 
 # validation/
@@ -13,9 +13,9 @@ Currently used by the property-panel UI components to validate on blur.
 
 `record-keys.ts` guards records keyed by user-authored strings: the
 `DANGEROUS_RECORD_KEYS` list (`Object.prototype` member names), prototype-free
-record construction (`createUserKeyedRecord`), own-property reads (`getOwn`),
-and `findDangerousSdcpnKeys`, the walk that the file-import and simulation
-boundaries use to reject hostile identifiers (FE-523).
+record construction (`createUserKeyedRecord`, `cloneUserKeyedRecord`),
+own-property reads (`getOwn`), and `findDangerousSdcpnKeys`, the walk that the
+file-import and simulation boundaries use to reject hostile identifiers.
 
 **@todo FE-521:** These validators should also be enforced in `MutationProvider`
 (as a safety net) and surfaced in the Diagnostics tab (so that files

--- a/libs/@hashintel/petrinaut-core/src/validation/README.md
+++ b/libs/@hashintel/petrinaut-core/src/validation/README.md
@@ -11,6 +11,12 @@ variable names) using Zod schemas with pure-function wrappers.
 
 Currently used by the property-panel UI components to validate on blur.
 
+`record-keys.ts` guards records keyed by user-authored strings: the
+`DANGEROUS_RECORD_KEYS` list (`Object.prototype` member names), prototype-free
+record construction (`createUserKeyedRecord`), own-property reads (`getOwn`),
+and `findDangerousSdcpnKeys`, the walk that the file-import and simulation
+boundaries use to reject hostile identifiers (FE-523).
+
 **@todo FE-521:** These validators should also be enforced in `MutationProvider`
 (as a safety net) and surfaced in the Diagnostics tab (so that files
 loaded with pre-existing invalid names show warnings).

--- a/libs/@hashintel/petrinaut-core/src/validation/record-keys.test.ts
+++ b/libs/@hashintel/petrinaut-core/src/validation/record-keys.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createUserKeyedRecord,
+  describeDangerousSdcpnKeys,
+  findDangerousSdcpnKeys,
+  getOwn,
+  isDangerousRecordKey,
+} from "./record-keys";
+
+import type { SDCPN } from "../types/sdcpn";
+
+const emptySdcpn = (): SDCPN => ({
+  places: [],
+  transitions: [],
+  types: [],
+  differentialEquations: [],
+  parameters: [],
+});
+
+describe("isDangerousRecordKey", () => {
+  it("rejects every Object.prototype member name and `prototype`", () => {
+    for (const key of [
+      "__proto__",
+      "constructor",
+      "prototype",
+      "toString",
+      "valueOf",
+      "hasOwnProperty",
+    ]) {
+      expect(isDangerousRecordKey(key)).toBe(true);
+    }
+  });
+
+  it("accepts ordinary identifiers", () => {
+    for (const key of ["p1", "crash_threshold", "Constructor", "proto"]) {
+      expect(isDangerousRecordKey(key)).toBe(false);
+    }
+  });
+});
+
+describe("createUserKeyedRecord", () => {
+  it("stores `__proto__` as an ordinary own property", () => {
+    const record = createUserKeyedRecord<number>();
+    record.__proto__ = 5;
+    expect(Object.hasOwn(record, "__proto__")).toBe(true);
+    expect(record.__proto__).toBe(5);
+    expect(Object.getPrototypeOf(record)).toBe(null);
+  });
+
+  it("returns undefined for missing Object.prototype member names", () => {
+    const record = createUserKeyedRecord<number>();
+    expect(record["constructor"]).toBeUndefined();
+    expect(record["toString"]).toBeUndefined();
+  });
+});
+
+describe("getOwn", () => {
+  it("does not fall through to Object.prototype on plain objects", () => {
+    const record: Record<string, number> = { p1: 1 };
+    expect(getOwn(record, "p1")).toBe(1);
+    expect(getOwn(record, "constructor")).toBeUndefined();
+    expect(getOwn(record, "toString")).toBeUndefined();
+  });
+
+  it("reads own `__proto__` data properties revived by JSON.parse", () => {
+    const record = JSON.parse('{"__proto__": 7}') as Record<string, number>;
+    expect(getOwn(record, "__proto__")).toBe(7);
+  });
+});
+
+describe("findDangerousSdcpnKeys", () => {
+  it("returns nothing for a net with ordinary identifiers", () => {
+    const sdcpn = emptySdcpn();
+    sdcpn.places.push({
+      id: "p1",
+      name: "Place 1",
+      colorId: null,
+      dynamicsEnabled: false,
+      differentialEquationId: null,
+      x: 0,
+      y: 0,
+    });
+    expect(findDangerousSdcpnKeys(sdcpn)).toEqual([]);
+  });
+
+  it("collects dangerous ids across every entity kind", () => {
+    const sdcpn: SDCPN = {
+      places: [
+        {
+          id: "__proto__",
+          name: "Place 1",
+          colorId: null,
+          dynamicsEnabled: false,
+          differentialEquationId: null,
+          x: 0,
+          y: 0,
+        },
+      ],
+      transitions: [
+        {
+          id: "constructor",
+          name: "Transition 1",
+          inputArcs: [],
+          outputArcs: [],
+          lambdaType: "predicate",
+          lambdaCode: "",
+          transitionKernelCode: "",
+          x: 0,
+          y: 0,
+        },
+      ],
+      types: [
+        {
+          id: "toString",
+          name: "Colour 1",
+          iconSlug: "circle",
+          displayColor: "#808080",
+          elements: [{ elementId: "e1", name: "valueOf", type: "real" }],
+        },
+      ],
+      differentialEquations: [
+        { id: "hasOwnProperty", name: "DE 1", colorId: null, code: "" },
+      ],
+      parameters: [
+        {
+          id: "prototype",
+          name: "Parameter 1",
+          variableName: "constructor",
+          type: "real",
+          defaultValue: "1",
+        },
+      ],
+      metrics: [{ id: "__defineGetter__", name: "Metric 1", code: "" }],
+      scenarios: [
+        {
+          id: "isPrototypeOf",
+          name: "Scenario 1",
+          scenarioParameters: [
+            { identifier: "constructor", type: "real", default: 1 },
+          ],
+          parameterOverrides: {},
+          initialState: { type: "per_place", content: {} },
+        },
+      ],
+    };
+
+    const found = findDangerousSdcpnKeys(sdcpn);
+    expect(found).toContainEqual({ location: "place id", key: "__proto__" });
+    expect(found).toContainEqual({
+      location: "transition id",
+      key: "constructor",
+    });
+    expect(found).toContainEqual({ location: "colour id", key: "toString" });
+    expect(found).toContainEqual({
+      location: "colour element name",
+      key: "valueOf",
+    });
+    expect(found).toContainEqual({
+      location: "differential equation id",
+      key: "hasOwnProperty",
+    });
+    expect(found).toContainEqual({
+      location: "parameter id",
+      key: "prototype",
+    });
+    expect(found).toContainEqual({
+      location: "parameter variable name",
+      key: "constructor",
+    });
+    expect(found).toContainEqual({
+      location: "metric id",
+      key: "__defineGetter__",
+    });
+    expect(found).toContainEqual({
+      location: "scenario id",
+      key: "isPrototypeOf",
+    });
+    expect(found).toContainEqual({
+      location: "scenario parameter identifier",
+      key: "constructor",
+    });
+  });
+
+  it("walks subnets", () => {
+    const sdcpn = emptySdcpn();
+    sdcpn.subnets = [
+      {
+        id: "s1",
+        name: "Subnet 1",
+        places: [
+          {
+            id: "constructor",
+            name: "Place 1",
+            colorId: null,
+            dynamicsEnabled: false,
+            differentialEquationId: null,
+            x: 0,
+            y: 0,
+          },
+        ],
+        transitions: [],
+        types: [],
+        differentialEquations: [],
+        parameters: [],
+      },
+    ];
+
+    expect(findDangerousSdcpnKeys(sdcpn)).toEqual([
+      { location: 'subnet "s1" place id', key: "constructor" },
+    ]);
+  });
+
+  it("describes findings in one sentence", () => {
+    expect(
+      describeDangerousSdcpnKeys([{ location: "place id", key: "__proto__" }]),
+    ).toBe(
+      'The net uses reserved JavaScript property names as identifiers: place id "__proto__". Rename them before running.',
+    );
+  });
+});

--- a/libs/@hashintel/petrinaut-core/src/validation/record-keys.ts
+++ b/libs/@hashintel/petrinaut-core/src/validation/record-keys.ts
@@ -57,12 +57,24 @@ export const createUserKeyedRecord = <T>(): Record<string, T> =>
 /**
  * Own-property read of a user-keyed record. Use for records that may have a
  * normal prototype (revived from `JSON.parse` or `structuredClone`), where a
- * missing key would otherwise return an `Object.prototype` member.
+ * missing key would otherwise return an `Object.prototype` member. A missing
+ * record reads as a missing key.
  */
 export const getOwn = <T>(
-  record: Readonly<Record<string, T>>,
+  record: Readonly<Record<string, T>> | undefined,
   key: string,
-): T | undefined => (Object.hasOwn(record, key) ? record[key] : undefined);
+): T | undefined =>
+  record !== undefined && Object.hasOwn(record, key) ? record[key] : undefined;
+
+/**
+ * Copies a record's own enumerable entries into a prototype-free record.
+ * Use when a record of user-authored keys arrives from outside: spreading
+ * onto `{}` keeps `Object.prototype`, and assigning into it goes through
+ * the `__proto__` setter.
+ */
+export const cloneUserKeyedRecord = <T>(
+  source: Readonly<Record<string, T>>,
+): Record<string, T> => Object.assign(createUserKeyedRecord<T>(), source);
 
 export type DangerousSdcpnKey = {
   /** Human-readable location, e.g. `transition id` or `parameter variable name`. */
@@ -117,8 +129,7 @@ const collectNetKeys = (
  * Collects every identity string of an SDCPN (ids, parameter variable names,
  * colour element names) that would collide with `Object.prototype` when used
  * as a record key. Empty result means the definition is safe to key records
- * by. Called at the file-import boundary (`parseSDCPNFile`) and at the
- * simulation boundary (`buildSimulation`).
+ * by.
  */
 export const findDangerousSdcpnKeys = (sdcpn: SDCPN): DangerousSdcpnKey[] => {
   const found: DangerousSdcpnKey[] = [];

--- a/libs/@hashintel/petrinaut-core/src/validation/record-keys.ts
+++ b/libs/@hashintel/petrinaut-core/src/validation/record-keys.ts
@@ -1,0 +1,151 @@
+import type { SDCPN } from "../types/sdcpn";
+
+/**
+ * Guards for records keyed by user-authored strings.
+ *
+ * Net definitions arrive from imported files, so every id, parameter variable
+ * name and colour element name is untrusted. Used as plain-object keys they
+ * collide with `Object.prototype`: writing `record["__proto__"] = value`
+ * replaces the record's prototype instead of adding a property, and reading a
+ * missing key such as `record["constructor"]` returns an inherited function
+ * instead of `undefined`.
+ *
+ * Three defences, used together:
+ *
+ * 1. `createUserKeyedRecord` builds records with no prototype, so any key is
+ *    an ordinary own property.
+ * 2. `getOwn` reads only own properties, for records whose provenance is not
+ *    controlled here (`structuredClone` and `JSON.parse` both revive plain
+ *    objects, so a null prototype does not survive a worker hop).
+ * 3. `findDangerousSdcpnKeys` rejects the keys outright at the file-import
+ *    and simulation boundaries.
+ */
+
+/**
+ * `Object.prototype` member names, plus `prototype`.
+ *
+ * A fixed list rather than `Object.getOwnPropertyNames(Object.prototype)`:
+ * what a file format accepts must not depend on the running environment.
+ */
+export const DANGEROUS_RECORD_KEYS: ReadonlySet<string> = new Set([
+  "__proto__",
+  "constructor",
+  "prototype",
+  "toString",
+  "toLocaleString",
+  "valueOf",
+  "hasOwnProperty",
+  "isPrototypeOf",
+  "propertyIsEnumerable",
+  "__defineGetter__",
+  "__defineSetter__",
+  "__lookupGetter__",
+  "__lookupSetter__",
+]);
+
+export const isDangerousRecordKey = (key: string): boolean =>
+  DANGEROUS_RECORD_KEYS.has(key);
+
+/**
+ * A `Record` with no prototype. Safe to write user-authored keys into:
+ * `__proto__` is an ordinary property and reads of missing keys return
+ * `undefined`.
+ */
+export const createUserKeyedRecord = <T>(): Record<string, T> =>
+  Object.create(null) as Record<string, T>;
+
+/**
+ * Own-property read of a user-keyed record. Use for records that may have a
+ * normal prototype (revived from `JSON.parse` or `structuredClone`), where a
+ * missing key would otherwise return an `Object.prototype` member.
+ */
+export const getOwn = <T>(
+  record: Readonly<Record<string, T>>,
+  key: string,
+): T | undefined => (Object.hasOwn(record, key) ? record[key] : undefined);
+
+export type DangerousSdcpnKey = {
+  /** Human-readable location, e.g. `transition id` or `parameter variable name`. */
+  location: string;
+  key: string;
+};
+
+const check = (
+  found: DangerousSdcpnKey[],
+  location: string,
+  key: string,
+): void => {
+  if (isDangerousRecordKey(key)) {
+    found.push({ location, key });
+  }
+};
+
+const collectNetKeys = (
+  found: DangerousSdcpnKey[],
+  net: Pick<
+    SDCPN,
+    "places" | "transitions" | "types" | "differentialEquations" | "parameters"
+  > &
+    Partial<Pick<SDCPN, "componentInstances">>,
+  scope: string,
+): void => {
+  for (const place of net.places) {
+    check(found, `${scope}place id`, place.id);
+  }
+  for (const transition of net.transitions) {
+    check(found, `${scope}transition id`, transition.id);
+  }
+  for (const type of net.types) {
+    check(found, `${scope}colour id`, type.id);
+    for (const element of type.elements) {
+      check(found, `${scope}colour element name`, element.name);
+    }
+  }
+  for (const equation of net.differentialEquations) {
+    check(found, `${scope}differential equation id`, equation.id);
+  }
+  for (const parameter of net.parameters) {
+    check(found, `${scope}parameter id`, parameter.id);
+    check(found, `${scope}parameter variable name`, parameter.variableName);
+  }
+  for (const instance of net.componentInstances ?? []) {
+    check(found, `${scope}component instance id`, instance.id);
+  }
+};
+
+/**
+ * Collects every identity string of an SDCPN (ids, parameter variable names,
+ * colour element names) that would collide with `Object.prototype` when used
+ * as a record key. Empty result means the definition is safe to key records
+ * by. Called at the file-import boundary (`parseSDCPNFile`) and at the
+ * simulation boundary (`buildSimulation`).
+ */
+export const findDangerousSdcpnKeys = (sdcpn: SDCPN): DangerousSdcpnKey[] => {
+  const found: DangerousSdcpnKey[] = [];
+
+  collectNetKeys(found, sdcpn, "");
+
+  for (const metric of sdcpn.metrics ?? []) {
+    check(found, "metric id", metric.id);
+  }
+  for (const scenario of sdcpn.scenarios ?? []) {
+    check(found, "scenario id", scenario.id);
+    for (const parameter of scenario.scenarioParameters) {
+      check(found, "scenario parameter identifier", parameter.identifier);
+    }
+  }
+  for (const subnet of sdcpn.subnets ?? []) {
+    check(found, "subnet id", subnet.id);
+    collectNetKeys(found, subnet, `subnet "${subnet.id}" `);
+  }
+
+  return found;
+};
+
+/** Formats `findDangerousSdcpnKeys` results into one error sentence. */
+export const describeDangerousSdcpnKeys = (
+  found: readonly DangerousSdcpnKey[],
+): string =>
+  `The net uses reserved JavaScript property names as identifiers: ${found
+    .map((entry) => `${entry.location} "${entry.key}"`)
+    .join(", ")}. Rename them before running.`;

--- a/libs/@hashintel/petrinaut-core/src/validation/variable-name.ts
+++ b/libs/@hashintel/petrinaut-core/src/validation/variable-name.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { isDangerousRecordKey } from "./record-keys";
+
 /**
  * Lower snake_case identifier: lowercase letters and digits separated by
  * single underscores. Must start with a letter.
@@ -19,6 +21,14 @@ export const variableNameSchema = z
     z.refine((val) => LOWER_SNAKE_CASE_REGEX.test(val), {
       message:
         "Variable name must be in lower_snake_case (e.g., crash_threshold or dt). Only lowercase letters, digits, and single underscores are allowed.",
+    }),
+    // The snake_case rule already blocks most `Object.prototype` member
+    // names; "constructor" is the one all-lowercase exception. Variable
+    // names key parameter-value records and become `__params["<name>"]`
+    // reads in compiled code.
+    z.refine((val) => !isDangerousRecordKey(val), {
+      message:
+        "Variable name must not be a reserved JavaScript property name (e.g., constructor).",
     }),
   )
   .describe("Lower snake_case variable name for parameters");

--- a/libs/@hashintel/petrinaut/docs/petri-net-extensions.md
+++ b/libs/@hashintel/petrinaut/docs/petri-net-extensions.md
@@ -41,7 +41,7 @@ Parameters are named values available in all user-authored code: dynamics, firin
 
 1. Open the **Parameters** tab in the left sidebar.
 2. Click **+** to add a new parameter.
-3. Set a **name** (display label), **variable name** (used in code), and **default value** (can be overridden in the simulation settings).
+3. Set a **name** (display label), **variable name** (used in code), and **default value** (can be overridden in the simulation settings). Variable names must be lower_snake_case (e.g. `infection_rate`) and must not be a reserved JavaScript property name such as `constructor`.
 
 <img width="1697" height="847" alt="parameters-SIR" src="https://github.com/user-attachments/assets/1b1df756-1fac-4201-8262-187473f2aeb6" />
 

--- a/libs/@hashintel/petrinaut/src/react/experiments/provider.tsx
+++ b/libs/@hashintel/petrinaut/src/react/experiments/provider.tsx
@@ -9,6 +9,7 @@ import { v4 as generateUuid } from "uuid";
 import {
   createMonteCarloExperiment,
   compileScenario,
+  getOwn,
   type InitialMarking,
   type MonteCarloExperiment,
   type MonteCarloExperimentState,
@@ -396,7 +397,7 @@ export const ExperimentsProvider: React.FC<ExperimentsProviderProps> = ({
           if (spec.kind !== "expression") {
             return spec;
           }
-          const artifact = artifacts.metrics[spec.id];
+          const artifact = getOwn(artifacts.metrics, spec.id);
           if (!artifact) {
             const diagnostics = failures
               .filter(

--- a/libs/@hashintel/petrinaut/src/react/simulation/provider/migrate-initial-marking.ts
+++ b/libs/@hashintel/petrinaut/src/react/simulation/provider/migrate-initial-marking.ts
@@ -1,5 +1,7 @@
 import {
   coerceToStoredTokenAttributeValue,
+  createUserKeyedRecord,
+  getOwn,
   type Color,
   type InitialMarking,
   type InitialTokenAttributeValue,
@@ -91,13 +93,15 @@ const migrateTokenRecord = (
   previousById: ReadonlyMap<string, ColorElement>,
   nextElements: readonly ColorElement[],
 ): TokenRecord => {
-  const migrated: TokenRecord = {};
+  // Element names come from the net definition and `record` from stored
+  // session state: no prototype, own-property reads only.
+  const migrated: TokenRecord = createUserKeyedRecord();
   for (const element of nextElements) {
     const previous = previousById.get(element.elementId);
     if (!previous) {
       // Added element: carry over an existing value if one is already
       // present under the new name, otherwise leave it absent.
-      const existing = record[element.name];
+      const existing = getOwn(record, element.name);
       if (existing !== undefined) {
         migrated[element.name] = existing;
       }
@@ -105,7 +109,7 @@ const migrateTokenRecord = (
     }
     // Prefer the pre-rename key; fall back to the new name so hand-edited
     // or already-normalized records don't lose their value on migration.
-    const value = record[previous.name] ?? record[element.name];
+    const value = getOwn(record, previous.name) ?? getOwn(record, element.name);
     if (previous.type !== element.type) {
       migrated[element.name] = coerceStoredValue(element, value);
     } else if (value !== undefined) {

--- a/libs/@hashintel/petrinaut/src/ui/lib/compile-visualizer.test.ts
+++ b/libs/@hashintel/petrinaut/src/ui/lib/compile-visualizer.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import { compileVisualizer } from "./compile-visualizer";
+
+const emptyProps = { tokens: [], parameters: {} };
+
+describe("compileVisualizer", () => {
+  it("compiles and renders a plain visualizer", () => {
+    const component = compileVisualizer(`
+      export default Visualization(({ tokens }) => {
+        return <div>{tokens.length}</div>;
+      });
+    `);
+    const element = component(emptyProps);
+    expect(element.type).toBe("div");
+  });
+
+  it("shadows browser globals for the component body", () => {
+    const component = compileVisualizer(`
+      export default Visualization(() => {
+        return <div>{String(typeof window)}-{String(typeof fetch)}-{String(typeof globalThis)}</div>;
+      });
+    `);
+    const element = component(emptyProps) as unknown as {
+      props: { children: string[] };
+    };
+    expect(element.props.children.join("")).toBe(
+      "undefined-undefined-undefined",
+    );
+  });
+
+  it("shadows browser globals for module-level code", () => {
+    expect(() =>
+      compileVisualizer(`
+        const stolen = fetch("https://example.com");
+        export default Visualization(() => <div />);
+      `),
+    ).toThrow(/fetch is not a function|Failed to compile/);
+  });
+
+  it("blocks the constructor-chain escape during render", () => {
+    const component = compileVisualizer(`
+      export default Visualization(() => {
+        const FunctionCtor = ({}).constructor.constructor;
+        return <div>{String(typeof FunctionCtor)}</div>;
+      });
+    `);
+    // `.constructor` is masked to undefined during the sandboxed call, so
+    // the second step of the walk throws.
+    expect(() => component(emptyProps)).toThrow(TypeError);
+  });
+
+  it("blocks the constructor-chain escape at module level", () => {
+    expect(() =>
+      compileVisualizer(`
+        const FunctionCtor = ({}).constructor.constructor;
+        const leak = FunctionCtor("return globalThis")();
+        export default Visualization(() => <div />);
+      `),
+    ).toThrow(/Failed to compile/);
+  });
+
+  it("runs the module body in strict mode", () => {
+    // Assigning to an undeclared identifier creates a global in sloppy mode
+    // and throws a ReferenceError in strict mode.
+    expect(() =>
+      compileVisualizer(`
+        undeclaredLeak = 1;
+        export default Visualization(() => <div />);
+      `),
+    ).toThrow(/Failed to compile/);
+  });
+});

--- a/libs/@hashintel/petrinaut/src/ui/lib/compile-visualizer.ts
+++ b/libs/@hashintel/petrinaut/src/ui/lib/compile-visualizer.ts
@@ -1,6 +1,8 @@
 import * as Babel from "@babel/standalone";
 import { createElement, type ReactElement } from "react";
 
+import { runSandboxed, SHADOWED_GLOBALS } from "@hashintel/petrinaut-core";
+
 type VisualizerProps = {
   tokens: Record<string, number | boolean | bigint | string>[];
   parameters: Record<string, number | boolean>;
@@ -59,9 +61,14 @@ export function compileVisualizer(code: string): VisualizerComponent {
       }
     `;
 
-    // Create an executable module-like environment
+    // Create an executable module-like environment with the same hardening
+    // as the scenario compiler: strict mode, browser/environment globals
+    // shadowed to `undefined` for the module body AND (through closure
+    // scope) the component body at render time.
     // The transformed JSX will use React.createElement (classic runtime)
     const executableCode = `
+      "use strict";
+      var ${SHADOWED_GLOBALS};
       ${mockConstructor}
       let __default_export__;
       ${transformedCode.replace(/export\s+default\s+/, "__default_export__ = ")}
@@ -70,10 +77,17 @@ export function compileVisualizer(code: string): VisualizerComponent {
 
     // Use Function constructor to create and execute the module
     // We need to provide React in scope for React.createElement calls
-    // eslint-disable-next-line no-new-func, @typescript-eslint/no-implied-eval, @typescript-eslint/no-unsafe-call
-    const compiledComponent = new Function("React", executableCode)(
-      // Provide a minimal React object with createElement
-      { createElement },
+    // eslint-disable-next-line no-new-func, @typescript-eslint/no-implied-eval
+    const moduleFn = new Function("React", executableCode) as (
+      react: unknown,
+    ) => unknown;
+    // Module-level code runs here; `runSandboxed` masks the
+    // `.constructor`-chain escape route for the duration of the call.
+    const compiledComponent = runSandboxed(() =>
+      moduleFn(
+        // Provide a minimal React object with createElement
+        { createElement },
+      ),
     ) as VisualizerComponent;
 
     if (typeof compiledComponent !== "function") {
@@ -82,7 +96,11 @@ export function compileVisualizer(code: string): VisualizerComponent {
       );
     }
 
-    return compiledComponent;
+    // The component body executes at render, outside the compile call, so
+    // apply the same masking around each render. Like the scenario sandbox,
+    // this is hardening rather than isolation (see `runSandboxed`).
+    return (props: VisualizerProps) =>
+      runSandboxed(() => compiledComponent(props));
   } catch (error) {
     // Provide a detailed error message for debugging
     const errorMessage =

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/create-optimization-drawer.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/create-optimization-drawer.tsx
@@ -18,6 +18,7 @@ import {
   PETRINAUT_OPTIMIZATION_MAX_STEPS_PER_TRIAL,
   PETRINAUT_OPTIMIZATION_MAX_TOTAL_STEPS,
   PETRINAUT_OPTIMIZATION_MAX_TRIALS,
+  createUserKeyedRecord,
   metricSchema,
   petrinautOptimizationInputSchema,
 } from "@hashintel/petrinaut-core";
@@ -401,10 +402,12 @@ export function buildPetrinautOptimizationInput({
   dt: number;
   maxTime: number;
 }): PetrinautOptimizationInput {
+  // Keyed by scenario parameter identifiers from the net definition: no
+  // prototype.
   const parameterBindings: Record<
     string,
     PetrinautOptimizationParameterBinding
-  > = {};
+  > = createUserKeyedRecord();
   for (const parameter of scenario.scenarioParameters) {
     const draft = drafts[parameter.identifier]!;
     if (draft.mode === "fixed") {

--- a/libs/@hashintel/petrinaut/src/ui/views/shared/place-state-visualization.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/shared/place-state-visualization.tsx
@@ -3,7 +3,9 @@ import { use, useMemo } from "react";
 import { css } from "@hashintel/ds-helpers/css";
 import {
   coerceTokenAttributeValue,
+  createUserKeyedRecord,
   defaultTokenAttributeValue,
+  getOwn,
 } from "@hashintel/petrinaut-core";
 
 import { ExecutionFrameSourceContext } from "../../../react/execution-frame/context";
@@ -84,12 +86,12 @@ export const PlaceStateVisualization: React.FC<
       // data predating a schema edit) falls back to the element's default
       // instead of crashing the panel.
       for (const token of marking) {
-        const coerced: TokenRecord = {};
+        const coerced: TokenRecord = createUserKeyedRecord();
         for (const element of placeType.elements) {
           try {
             coerced[element.name] = coerceTokenAttributeValue(
               element,
-              token[element.name],
+              getOwn(token, element.name),
               `Initial marking for place ${place.name}`,
             );
           } catch {

--- a/libs/@local/petrinaut-arch-docs/content/simulation/untrusted-names.mdx
+++ b/libs/@local/petrinaut-arch-docs/content/simulation/untrusted-names.mdx
@@ -14,7 +14,7 @@ colour element names. They arrive from imported `.petrinaut` files, whose
 schema accepts any string as an id. The engine, the HIR compiler and the UI
 all key records by these strings, so a name chosen to collide with
 `Object.prototype` corrupts whichever record it touches. CodeQL reports this
-class as `js/remote-property-injection` (FE-523).
+class as `js/remote-property-injection`.
 
 ## What a hostile name does to a plain object
 
@@ -148,7 +148,7 @@ so they keep a live record, created with no prototype at construction
 
 Names that survive the editor validators can still collide: `constructor` is
 the one `Object.prototype` member that is valid lower_snake_case. The
-validators now reject it, and every record on the path stores it as an own
+validators reject it, and every record on the path stores it as an own
 property, so nets that already contain one keep working.
 
 Code trust is the other half of this story:

--- a/libs/@local/petrinaut-arch-docs/content/simulation/untrusted-names.mdx
+++ b/libs/@local/petrinaut-arch-docs/content/simulation/untrusted-names.mdx
@@ -1,0 +1,157 @@
+---
+title: Untrusted names
+description: Why ids and names from a net definition never become plain-object keys unchecked, and where hostile ones are rejected.
+sidebar_order: 10
+attachTo: core.simulation.engine
+---
+
+import { Lanes } from "@diagrams/lanes";
+import { Sequence } from "@diagrams/sequence";
+
+Every identity string in a net is user-authored: place, transition, colour,
+differential-equation, metric and scenario ids, parameter variable names, and
+colour element names. They arrive from imported `.petrinaut` files, whose
+schema accepts any string as an id. The engine, the HIR compiler and the UI
+all key records by these strings, so a name chosen to collide with
+`Object.prototype` corrupts whichever record it touches. CodeQL reports this
+class as `js/remote-property-injection` (FE-523).
+
+## What a hostile name does to a plain object
+
+| Key                                       | `record[key] = value`                                                                                                     | `record[key]` when the key is missing                                                 |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `__proto__`, object value                 | Replaces the record's prototype. The entry never exists, and its fields appear inherited on every later missing-key read. | `Object.prototype` (an object, so truthy)                                             |
+| `__proto__`, primitive value              | Silently ignored. The entry never exists.                                                                                 | as above                                                                              |
+| `constructor`, `toString`, `valueOf`, ... | Works (creates an own property)                                                                                           | The inherited function. Truthy, so `?? fallback` and `if (!entry)` guards never fire. |
+
+Two concrete failures this caused before the guards existed:
+
+- `artifacts.lambdas["__proto__"] = { source }` in the HIR compiler replaced
+  the record's prototype instead of storing the artifact. The fingerprint
+  check still passed (it hashes the net, the artifact map is not hashed), so the
+  simulation started with a transition whose lambda silently did not exist.
+- A token field named `toString` defeated the
+  `encodedValuesByName[name] ?? 0` default in the packed-token encoder:
+  the read returned `Object.prototype.toString`, and `Number(fn)` produced
+  `NaN` token bytes.
+
+## Three defences
+
+<Lanes
+  title="Reject, contain, guard"
+  legend={[
+    { label: "core", accent: "core" },
+    { label: "ui / react", accent: "ui" },
+  ]}
+  lanes={[
+    {
+      title: "Reject at boundaries",
+      accent: "core",
+      boxes: [
+        {
+          label: "`parseSDCPNFile`",
+          note: "Imports fail with the offending id named (`file-format`)",
+        },
+        {
+          label: "`buildSimulation`",
+          note: "Same check for nets supplied programmatically by embedders",
+        },
+        {
+          label: "Editor validators",
+          note: "`variableNameSchema`, colour element and scenario identifier schemas",
+          accent: "ui",
+        },
+      ],
+    },
+    {
+      title: "Contain in prototype-free records",
+      accent: "core",
+      boxes: [
+        {
+          label: "`createUserKeyedRecord`",
+          note: "`Object.create(null)`: `__proto__` is an ordinary key",
+        },
+        {
+          label: "Applied at every build site",
+          note: "Artifact records, frame snapshots, token records, parameter values, scenario accumulators",
+        },
+      ],
+    },
+    {
+      title: "Guard reads",
+      accent: "core",
+      boxes: [
+        {
+          label: "`getOwn`",
+          note: "Own-property reads only; a missing key is `undefined`",
+        },
+        {
+          label: "Applied after every hop",
+          note: "Artifact lookups and marking reads on records revived from `postMessage` or JSON",
+        },
+      ],
+    },
+  ]}
+/>
+
+The shared vocabulary lives in [`core.validation`](layer:core.validation)
+(`record-keys.ts`): the `DANGEROUS_RECORD_KEYS` list, the two container
+helpers, and `findDangerousSdcpnKeys`, which walks a net and returns every
+identity string on the list.
+
+## Why one layer is not enough
+
+Rejection alone misses keys that never pass through a schema: scenario
+code-mode returns an object whose keys the user's code chose, and those keys
+seed the compiled initial marking. Containment alone does not survive
+serialization: `structuredClone` and `JSON.parse` both revive plain objects,
+so a record built with no prototype regains one after a worker hop, and its
+missing-key reads fall through again. Guarded reads alone leave the write
+side broken: a `__proto__` write on a plain object still replaces the
+prototype instead of storing the entry.
+
+<Sequence
+  title="One hostile transition id, three entry paths"
+  actors={["Untrusted input", "Engine"]}
+  rows={[
+    { phase: "Imported file" },
+    {
+      direction: "right",
+      label: "`.petrinaut` with transition id `constructor`",
+      note: "`parseSDCPNFile` returns an error naming the id",
+    },
+    { phase: "Programmatic net (embedding application)" },
+    {
+      direction: "right",
+      label: "`buildSimulation(input)`",
+      note: "Throws before compiling: reserved property name",
+    },
+    { phase: "Scenario code-mode return value" },
+    {
+      direction: "right",
+      label: "`{ __proto__: [...] }` from user code",
+      note: "Never validated; contained by the prototype-free accumulator",
+    },
+  ]}
+/>
+
+## Parameters that reach compiled code
+
+Compiled buffer programs read parameters as `__params["<name>"]` (the emitter
+quotes every key with `JSON.stringify`). At instantiation the engine binds
+`__params` to a frozen copy of the run's parameter values with no prototype,
+so a missing name reads as `undefined` rather than an `Object.prototype`
+member, and compiled code cannot mutate the caller's record. Metric
+evaluators are the one exception to the copy: they rebind values per frame,
+so they keep a live record, created with no prototype at construction
+(`hir-metric.ts`).
+
+Names that survive the editor validators can still collide: `constructor` is
+the one `Object.prototype` member that is valid lower_snake_case. The
+validators now reject it, and every record on the path stores it as an own
+property, so nets that already contain one keep working.
+
+Code trust is the other half of this story:
+[Compiling user code](doc:simulation/user-code) covers how authored
+TypeScript is compiled through the HIR and what the authoring sandbox does
+for scenario expressions and place visualizers.

--- a/libs/@local/petrinaut-arch-docs/content/simulation/user-code.mdx
+++ b/libs/@local/petrinaut-arch-docs/content/simulation/user-code.mdx
@@ -84,9 +84,20 @@ lookup, the sandbox additionally blocks the constructor-chain escape
 call, by swapping the `.constructor` descriptors on the built-in prototypes and
 restoring them afterwards.
 
+Place visualizers get the same treatment (`compile-visualizer.ts` in the UI
+package): the Babel-compiled module body runs in strict mode with the same
+globals shadowed, and both the module evaluation and each render are wrapped
+in the constructor masking. The shadowing is declared in the module scope, so
+it also covers the component body at render time.
+
 **Treat this as robustness hardening, not isolation.** User code executes with
 `new Function` in the same realm as the host. It protects against typos and
 accidental API use, not against an attacker.
+
+Identity strings (ids, parameter variable names, element names) are the other
+untrusted input: [Untrusted names](doc:simulation/untrusted-names) covers how
+they are rejected at the import and simulation boundaries and why records
+keyed by them have no prototype.
 
 ## Distributions are sampled once
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Closes the `js/remote-property-injection` class from FE-523: identity strings from imported `.petrinaut` files can no longer corrupt the records they key, and user-authored code paths lose their unguarded `new Function` gaps.

### The problem

Every identity string in a net comes from imported `.petrinaut` files, whose schema accepts any string: place, transition, colour, metric and scenario ids, parameter variable names, colour element names. Used as a plain-object key:

- Writing `record["__proto__"] = value` replaces the record's prototype instead of storing the entry.
- Reading a missing `constructor` key returns an inherited function, which defeats `?? fallback` and truthiness guards.

Two failures this caused: the HIR compiler dropped a `__proto__`-keyed lambda artifact while the fingerprint check still passed, and a token field named `toString` turned the packed-token encoder's `?? 0` default into `NaN` bytes.

### The fix: three layers

A single `Object.create(null)` at the flagged lines is not enough: a null prototype does not survive `structuredClone` or JSON revival across worker hops, and scenario code-mode keys never pass a schema. The shared vocabulary lives in `validation/record-keys.ts`:

1. **Reject** reserved identifiers at `parseSDCPNFile` and `buildSimulation`. The editor validators now also reject `constructor`, the one all-lowercase `Object.prototype` member they admitted.
2. **Contain** with `createUserKeyedRecord` (no prototype) at every site that builds a record from these strings.
3. **Guard** reads with `getOwn` (own properties only) wherever records cross serialization.

```mermaid
flowchart LR
    F[".petrinaut file"] --> P["parseSDCPNFile<br/>rejects reserved names"]
    E["Embedder net"] --> B["buildSimulation<br/>rejects reserved names"]
    P --> B
    B --> C["createUserKeyedRecord<br/>records without a prototype"]
    C --> H["worker hop<br/>structuredClone / JSON"]
    H --> G["getOwn<br/>own-property reads only"]
```

### Also in this PR

- Place **visualizer** code ran through `new Function` with no hardening at all, reachable by opening an imported file. It now gets the same sandbox treatment as scenario code, at compile and at each render.
- The HIR pipeline itself was already sound; its `__params` binding is now a frozen prototype-free copy, so a hostile parameter name cannot read `Object.prototype` from compiled code.

## 🔗 Related links

- [FE-523](https://linear.app/hash/issue/FE-523/fix-proto-pollution-in-build-simulation-and-use-default-parameter)
- CodeQL alerts [18495](https://github.com/hashintel/hash/security/code-scanning/18495)–[18498](https://github.com/hashintel/hash/security/code-scanning/18498) (dismissed in May; this makes the dismissals sound)
- [FE-521](https://linear.app/hash/issue/FE-521) _(internal)_: enforcing the name validators in `MutationProvider`

## 🚫 Blocked by

Nothing.

## 🔍 What does this change?

- New `validation/record-keys.ts`: `DANGEROUS_RECORD_KEYS`, `createUserKeyedRecord`, `getOwn`, and `findDangerousSdcpnKeys` (walks a net's identity strings), exported from the package index.
- Boundary rejection in `parseSDCPNFile` (versioned and legacy formats) and `buildSimulation`; the two ad-hoc `id === "__proto__"` throws in `createEngineFrameLayout` generalise to the shared list.
- Prototype-free records at every user-keyed build site: HIR artifact records, frame snapshots, token records, parameter values, scenario accumulators, layout positions, experiment state, and four UI sites.
- Own-property reads for HIR artifact lookups, initial marking values and token-encoder defaults.
- `variableNameSchema`, colour element names and scenario parameter identifiers reject reserved property names.
- `instantiate.ts` binds `__params` as a frozen prototype-free copy; metric evaluators keep their live rebinding on a prototype-free record.
- `compile-visualizer.ts` runs in strict mode with `SHADOWED_GLOBALS` and wraps module evaluation and each render in `runSandboxed`.
- Docs: new _Untrusted names_ architecture page under `core.simulation.engine`; the user-code and validation pages updated; parameter naming rules stated in the user guide.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] modifies an **npm**-publishable library and **I have added a changeset file(s)**

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] require changes to docs which **are made** as part of this PR

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

- The sandboxes are robustness hardening, not isolation; the durable fix for hostile code is the HIR ([#9332](https://github.com/hashintel/hash/pull/9332) covers scenarios).
- Files that already contain a reserved-name identifier now fail to import, with the identifier named in the error.
- CodeQL may not recognise `Object.create(null)` as a sanitizer; if alerts 18495–18498 resurface, dismiss them pointing at `record-keys.ts`.

## 🐾 Next steps

- FE-521 remains open for enforcing the name validators in `MutationProvider` and surfacing pre-existing invalid names in the Diagnostics tab.

## 🛡 What tests cover this?

- `validation/record-keys.test.ts` (new): the key list, prototype-free construction, own-property reads (including own `__proto__` keys revived by `JSON.parse`), the net walk.
- `hir/instantiate.test.ts` (new): a parameter named `constructor` reads its own value; missing names read `undefined`; compiled code cannot mutate the caller's record.
- Hostile-name cases added to `parameter-values`, `parse-sdcpn-file` and `build-simulation` tests; `compile-visualizer.test.ts` (new) covers shadowed globals, constructor-chain blocking and strict mode.

## ❓ How to test this?

1. Checkout the branch and run the demo site (`yarn dev` in `libs/@hashintel/petrinaut`).
2. Import a `.petrinaut` file with a transition id of `constructor`: the import fails naming the id.
3. Try `constructor` as a parameter variable name: the properties panel rejects it.
4. Give a place visualizer `export default Visualization(() => <div>{String(typeof fetch)}</div>)` and view the place: it renders `undefined`.

## 📹 Demo

Error paths and internal containment; covered by the tests above.
