### PR TITLE
FE-1408: Run a trial as multiple seeded simulations aggregated by mean

### DIFF
--- a/libs/@hashintel/petrinaut-cli/OPTIMIZATION_INTEGRATION.md
+++ b/libs/@hashintel/petrinaut-cli/OPTIMIZATION_INTEGRATION.md
@@ -2,9 +2,11 @@
 
 Petrinaut CLI owns the Petrinaut side of optimization: it validates the
 manifest, applies fixed and suggested scenario parameters, materializes the
-initial state, runs the model, and returns one scalar objective. An optimizer
-such as Optuna only needs to consume the flat parameter description and submit
-one suggestion per trial.
+initial state, runs the model, and returns one scalar objective. A trial runs
+one seeded simulation by default, or `execution.seedsPerTrial` of them with
+the per-seed objectives aggregated by mean. An optimizer such as Optuna only
+needs to consume the flat parameter description and submit one suggestion per
+trial.
 
 An optimization manifest is a versioned JSON document containing a complete
 model snapshot with **one scenario** and **one metric**. Its
@@ -63,7 +65,12 @@ only the non-fixed parameters:
   "id": 1,
   "result": {
     "direction": "maximize",
-    "study": { "trials": 100, "sampler": "tpe", "seed": 42 },
+    "study": {
+      "trials": 100,
+      "sampler": "tpe",
+      "seed": 42,
+      "seedsPerTrial": 1
+    },
     "parameters": [
       {
         "identifier": "production_rate",
@@ -129,6 +136,35 @@ and returns the objective value:
 
 Use one CLI process with a single Optuna worker, or start an independent CLI
 process for each parallel worker.
+
+### Seeded runs per trial
+
+Set `execution.seedsPerTrial` (1–100, default 1) to evaluate every trial as a
+small Monte Carlo batch. The seeds derive from `execution.seed`: run 0 keeps
+it, and run `i` uses `|seed + (i + 1) × 2654435761| mod 2^31`. Every trial
+reuses the same sequence, so Optuna compares parameter configurations under
+common random numbers.
+
+With more than one seed, the response's `objective` is the mean of the
+per-seed objectives and a `replicates` array reports each seed's value:
+
+```json
+{
+  "id": 2,
+  "result": {
+    "objective": 1234.5,
+    "replicates": [
+      { "seed": 42, "objective": 1230.0 },
+      { "seed": 1013904268, "objective": 1239.0 }
+    ]
+  }
+}
+```
+
+The seeded runs execute sequentially within the evaluate request, so a
+trial's wall-clock time grows linearly with `seedsPerTrial`: budget your
+protocol timeout accordingly. Parallelising them is deferred to the shared
+experiment-backend interface.
 
 ## Python wrapper with Optuna
 

--- a/libs/@hashintel/petrinaut-cli/README.md
+++ b/libs/@hashintel/petrinaut-cli/README.md
@@ -159,8 +159,12 @@ Methods:
 - `optimization.describe`: returns the Optuna direction, study configuration,
   and flat descriptors for only the parameters Optuna should suggest.
 - `optimization.evaluate`: evaluates one complete set of suggested parameter
-  values and returns `{ "objective": number }`. These two methods require an
-  optimization manifest source.
+  values and returns `{ "objective": number }`. When the manifest sets
+  `execution.seedsPerTrial` above 1, the trial runs that many seeded
+  simulations sequentially. `objective` is their mean, and a `replicates`
+  array reports the per-seed values (see
+  [OPTIMIZATION_INTEGRATION.md](./OPTIMIZATION_INTEGRATION.md)). These two
+  methods require an optimization manifest source.
 
 ## Run Request
 

--- a/libs/@hashintel/petrinaut-cli/src/commands/built-cli.test.ts
+++ b/libs/@hashintel/petrinaut-cli/src/commands/built-cli.test.ts
@@ -1,0 +1,78 @@
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { text } from "node:stream/consumers";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { deriveTrialSeeds } from "../runtime/optimization";
+import { createOptimizationManifest } from "./optimization-manifest.fixtures";
+
+const distCliPath = fileURLToPath(
+  new URL("../../dist/cli.js", import.meta.url),
+);
+
+/**
+ * Exercises the shipped bundle end to end. `turbo run test:unit` builds the
+ * bundle first; the suite only skips when vitest runs without it.
+ */
+describe.skipIf(!existsSync(distCliPath))("built CLI", () => {
+  it(
+    "evaluates a trial as sequential seeded runs",
+    { timeout: 120_000 },
+    async () => {
+      const manifest = await createOptimizationManifest({ seedsPerTrial: 2 });
+      const child = spawn(
+        process.execPath,
+        [distCliPath, "serve", "--optimization-stdin", "--stdio"],
+        { stdio: ["pipe", "pipe", "pipe"] },
+      );
+      child.stdin.end(
+        [
+          JSON.stringify(manifest),
+          JSON.stringify({ id: 1, method: "optimization.describe" }),
+          JSON.stringify({
+            id: 2,
+            method: "optimization.evaluate",
+            params: { parameterValues: { infected_ratio: 0.1 } },
+          }),
+          "",
+        ].join("\n"),
+      );
+      const [stdout, stderr, exitCode] = await Promise.all([
+        text(child.stdout),
+        text(child.stderr),
+        new Promise<number | null>((resolve) => {
+          child.on("close", resolve);
+        }),
+      ]);
+
+      expect(stderr).toContain(
+        "Petrinaut stdio ready for optimization manifest <stdin>",
+      );
+      expect(exitCode).toBe(0);
+
+      const responses = stdout
+        .trim()
+        .split("\n")
+        .filter(Boolean)
+        .map((line) => JSON.parse(line) as unknown);
+      const seeds = deriveTrialSeeds(42, 2);
+      expect(responses).toEqual([
+        {
+          id: 1,
+          result: expect.objectContaining({
+            study: { trials: 20, sampler: "tpe", seed: 42, seedsPerTrial: 2 },
+          }),
+        },
+        {
+          id: 2,
+          result: {
+            objective: 0.1,
+            replicates: seeds.map((seed) => ({ seed, objective: 0.1 })),
+          },
+        },
+      ]);
+    },
+  );
+});

--- a/libs/@hashintel/petrinaut-cli/src/commands/optimization-manifest.fixtures.ts
+++ b/libs/@hashintel/petrinaut-cli/src/commands/optimization-manifest.fixtures.ts
@@ -1,0 +1,57 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+const modelPath = fileURLToPath(
+  new URL("../../examples/sir-model.json", import.meta.url),
+);
+
+/**
+ * The SIR manifest the optimization suites bootstrap the CLI with: one fixed
+ * parameter, one optimized parameter, one metric. `execution` overrides the
+ * defaults, so a caller can ask for several seeds per trial.
+ */
+export async function createOptimizationManifest(execution?: {
+  seedsPerTrial?: number;
+}) {
+  const legacyModel = JSON.parse(await readFile(modelPath, "utf8")) as {
+    title: string;
+    scenarios: { id: string }[];
+    metrics: { id: string }[];
+    [key: string]: unknown;
+  };
+  const { title, ...definition } = legacyModel;
+  return {
+    kind: "petrinaut-optimization",
+    version: 1,
+    name: "Minimize infected fraction",
+    model: {
+      title,
+      definition: {
+        ...definition,
+        scenarios: [legacyModel.scenarios[0]],
+        metrics: [legacyModel.metrics[0]],
+      },
+    },
+    scenario: {
+      id: "scenario__seasonal_flu",
+      parameterBindings: {
+        population: { kind: "fixed", value: 200 },
+        infected_ratio: {
+          kind: "optimize",
+          domain: {
+            kind: "continuous",
+            minimum: 0.01,
+            maximum: 0.5,
+            scale: "log",
+          },
+        },
+      },
+    },
+    objective: {
+      metricId: "metric__infected_fraction",
+      direction: "minimize",
+    },
+    execution: { seed: 42, dt: 1, maxTime: Number.MIN_VALUE, ...execution },
+    study: { trials: 20, sampler: "tpe" },
+  };
+}

--- a/libs/@hashintel/petrinaut-cli/src/commands/transports.test.ts
+++ b/libs/@hashintel/petrinaut-cli/src/commands/transports.test.ts
@@ -8,7 +8,9 @@ import { fileURLToPath } from "node:url";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { deriveTrialSeeds } from "../runtime/optimization";
 import { MAX_REQUEST_LINE_BYTES } from "../runtime/protocol";
+import { createOptimizationManifest } from "./optimization-manifest.fixtures";
 import { serve } from "./serve";
 import { MAX_STDIN_SOURCE_LINE_BYTES, serveStdio } from "./stdio";
 
@@ -151,47 +153,7 @@ describe("CLI transports", () => {
       stderr += chunk;
     });
 
-    const legacyModel = JSON.parse(await readFile(modelPath, "utf8")) as {
-      title: string;
-      scenarios: { id: string }[];
-      metrics: { id: string }[];
-      [key: string]: unknown;
-    };
-    const { title, ...definition } = legacyModel;
-    const manifest = {
-      kind: "petrinaut-optimization",
-      version: 1,
-      name: "Minimize infected fraction",
-      model: {
-        title,
-        definition: {
-          ...definition,
-          scenarios: [legacyModel.scenarios[0]],
-          metrics: [legacyModel.metrics[0]],
-        },
-      },
-      scenario: {
-        id: "scenario__seasonal_flu",
-        parameterBindings: {
-          population: { kind: "fixed", value: 200 },
-          infected_ratio: {
-            kind: "optimize",
-            domain: {
-              kind: "continuous",
-              minimum: 0.01,
-              maximum: 0.5,
-              scale: "log",
-            },
-          },
-        },
-      },
-      objective: {
-        metricId: "metric__infected_fraction",
-        direction: "minimize",
-      },
-      execution: { seed: 42, dt: 1, maxTime: Number.MIN_VALUE },
-      study: { trials: 20, sampler: "tpe" },
-    };
+    const manifest = await createOptimizationManifest();
 
     const serving = serveStdio({
       optimizationStdin: true,
@@ -221,7 +183,7 @@ describe("CLI transports", () => {
         id: 1,
         result: {
           direction: "minimize",
-          study: { trials: 20, sampler: "tpe", seed: 42 },
+          study: { trials: 20, sampler: "tpe", seed: 42, seedsPerTrial: 1 },
           parameters: [
             {
               identifier: "infected_ratio",
@@ -235,6 +197,56 @@ describe("CLI transports", () => {
         },
       },
       { id: 2, result: { objective: 0.1 } },
+    ]);
+  });
+
+  it("runs every trial seed and reports the per-seed objectives", async () => {
+    const input = new PassThrough();
+    const output = new PassThrough();
+    let stdout = "";
+    output.setEncoding("utf8");
+    output.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+
+    const manifest = await createOptimizationManifest({ seedsPerTrial: 3 });
+
+    const serving = serveStdio({
+      optimizationStdin: true,
+      input,
+      output,
+      errorOutput: new PassThrough(),
+    });
+    input.end(
+      [
+        JSON.stringify(manifest),
+        JSON.stringify({ id: 1, method: "optimization.describe" }),
+        JSON.stringify({
+          id: 2,
+          method: "optimization.evaluate",
+          params: { parameterValues: { infected_ratio: 0.1 } },
+        }),
+        "",
+      ].join("\n"),
+    );
+    await serving;
+
+    const seeds = deriveTrialSeeds(42, 3);
+    expect(seeds[0]).toBe(42);
+    expect(parseResponses(stdout)).toEqual([
+      {
+        id: 1,
+        result: expect.objectContaining({
+          study: { trials: 20, sampler: "tpe", seed: 42, seedsPerTrial: 3 },
+        }),
+      },
+      {
+        id: 2,
+        result: {
+          objective: expect.closeTo(0.1, 12) as number,
+          replicates: seeds.map((seed) => ({ seed, objective: 0.1 })),
+        },
+      },
     ]);
   });
 

--- a/libs/@hashintel/petrinaut-cli/src/runtime/optimization.test.ts
+++ b/libs/@hashintel/petrinaut-cli/src/runtime/optimization.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   createOptimizationProtocol,
+  deriveTrialSeeds,
   loadOptimizationManifest,
   parseOptimizationManifest,
 } from "./optimization";
@@ -67,6 +68,36 @@ async function createManifest() {
   });
 }
 
+/** The base manifest with `execution.seedsPerTrial` set. */
+async function createSeededManifest(seedsPerTrial: number) {
+  const base = await createManifest();
+  return parseOptimizationManifest({
+    ...base,
+    execution: { ...base.execution, seedsPerTrial },
+  });
+}
+
+/** A model whose objective metric is picked per run seed. */
+function createSeededModel(objectiveForSeed: (seed: number) => number) {
+  const run = vi.fn((config: { seed?: number }) => {
+    const seed = config.seed ?? -1;
+    return {
+      seed,
+      status: "complete" as const,
+      completionReason: "maxTime" as const,
+      frameCount: 1,
+      finalTime: 10,
+      finalPlaceTokenCounts: {},
+      metrics: { "Infected Fraction": objectiveForSeed(seed) },
+    };
+  });
+  const model: PetrinautCompiledModel = {
+    metadata: { parameters: [], places: [], metrics: [] },
+    run,
+  };
+  return { model, run };
+}
+
 describe("createOptimizationProtocol", () => {
   it("executes the checked-in supply-chain optimization manifest", async () => {
     const manifest = await loadOptimizationManifest(
@@ -89,7 +120,7 @@ describe("createOptimizationProtocol", () => {
 
     expect(protocol.describe()).toEqual({
       direction: "maximize",
-      study: { trials: 1_000, sampler: "tpe", seed: 1234 },
+      study: { trials: 1_000, sampler: "tpe", seed: 1234, seedsPerTrial: 1 },
       parameters: [
         {
           identifier: "production_rate",
@@ -205,7 +236,7 @@ describe("createOptimizationProtocol", () => {
 
     expect(protocol.describe()).toEqual({
       direction: "minimize",
-      study: { trials: 20, sampler: "tpe", seed: 42 },
+      study: { trials: 20, sampler: "tpe", seed: 42, seedsPerTrial: 1 },
       parameters: [
         {
           identifier: "infected_ratio",
@@ -368,5 +399,102 @@ describe("createOptimizationProtocol", () => {
     ).rejects.toThrow(
       'Optimization parameter "infected_ratio" must be between 0.01 and 0.5',
     );
+  });
+
+  it("runs every trial seed and aggregates the objectives by mean", async () => {
+    const manifest = await createSeededManifest(3);
+    const seeds = deriveTrialSeeds(42, 3);
+    // Objectives 1, 2 and 3 in seed order, so the mean and the per-seed
+    // echoes are both observable.
+    const { model, run } = createSeededModel((seed) => seeds.indexOf(seed) + 1);
+    const protocol = createOptimizationProtocol({ manifest, model });
+
+    expect(protocol.describe().study).toEqual({
+      trials: 20,
+      sampler: "tpe",
+      seed: 42,
+      seedsPerTrial: 3,
+    });
+    await expect(
+      protocol.evaluate({ parameterValues: { infected_ratio: 0.1 } }),
+    ).resolves.toEqual({
+      objective: 2,
+      replicates: seeds.map((seed, index) => ({ seed, objective: index + 1 })),
+    });
+    expect(run.mock.calls.map(([config]) => config.seed)).toEqual(seeds);
+
+    // The same seeds are reused on every trial: common random numbers.
+    await expect(
+      protocol.evaluate({ parameterValues: { infected_ratio: 0.2 } }),
+    ).resolves.toEqual({
+      objective: 2,
+      replicates: seeds.map((seed, index) => ({ seed, objective: index + 1 })),
+    });
+    expect(run.mock.calls.map(([config]) => config.seed)).toEqual([
+      ...seeds,
+      ...seeds,
+    ]);
+  });
+
+  it("rejects a trial whose replicate omits a finite objective", async () => {
+    const manifest = await createSeededManifest(3);
+    const { model, run } = createSeededModel((seed) =>
+      seed === 42 ? 0.25 : Number.NaN,
+    );
+    const protocol = createOptimizationProtocol({ manifest, model });
+
+    await expect(
+      protocol.evaluate({ parameterValues: { infected_ratio: 0.1 } }),
+    ).rejects.toThrow(
+      'Petrinaut result omitted a finite objective metric "Infected Fraction"',
+    );
+    // Fail fast: the invalid second replicate spares the third simulation.
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps the mean finite when extreme finite objectives would overflow a sum", async () => {
+    const manifest = await createSeededManifest(2);
+    const { model } = createSeededModel(() => Number.MAX_VALUE);
+    const protocol = createOptimizationProtocol({ manifest, model });
+
+    await expect(
+      protocol.evaluate({ parameterValues: { infected_ratio: 0.1 } }),
+    ).resolves.toMatchObject({ objective: Number.MAX_VALUE });
+
+    // Opposite extremes overflow the mean update; the aggregate guard turns
+    // that into an error instead of a null objective on the wire.
+    const signFlipping = createSeededModel((seed) =>
+      seed === 42 ? Number.MAX_VALUE : -Number.MAX_VALUE,
+    );
+    const signFlippingProtocol = createOptimizationProtocol({
+      manifest,
+      model: signFlipping.model,
+    });
+    await expect(
+      signFlippingProtocol.evaluate({
+        parameterValues: { infected_ratio: 0.1 },
+      }),
+    ).rejects.toThrow(
+      'The mean of the objective metric "Infected Fraction" is not finite',
+    );
+  });
+});
+
+describe("deriveTrialSeeds", () => {
+  it("keeps the base seed first and derives a stable, in-range sequence", () => {
+    expect(deriveTrialSeeds(42, 1)).toEqual([42]);
+    // Pins the documented derivation |seed + (i + 1) x 2654435761| mod 2^31,
+    // which the other tests' expected seed sequences depend on.
+    expect(deriveTrialSeeds(42, 2)).toEqual([42, 1_013_904_268]);
+
+    const seeds = deriveTrialSeeds(42, 100);
+    expect(seeds[0]).toBe(42);
+    expect(seeds).toEqual(deriveTrialSeeds(42, 100));
+    expect(new Set(seeds).size).toBe(seeds.length);
+    for (const seed of seeds) {
+      expect(Number.isInteger(seed)).toBe(true);
+      expect(seed).toBeGreaterThanOrEqual(0);
+      expect(seed).toBeLessThanOrEqual(2_147_483_647);
+    }
   });
 });

--- a/libs/@hashintel/petrinaut-cli/src/runtime/optimization.ts
+++ b/libs/@hashintel/petrinaut-cli/src/runtime/optimization.ts
@@ -2,6 +2,7 @@ import { readFile } from "node:fs/promises";
 
 import {
   compileScenario,
+  deriveRunSeed,
   petrinautOptimizationEvaluateParamsSchema,
   petrinautOptimizationManifestSchema,
 } from "@hashintel/petrinaut-core";
@@ -137,11 +138,27 @@ export type OptimizationProtocol = {
   evaluate(params: unknown): Promise<PetrinautOptimizationEvaluateResult>;
 };
 
+/**
+ * Derives one trial's run seeds. Run 0 keeps the base seed, so a single-seed
+ * trial matches the old fixed-seed behaviour; later runs use the Monte Carlo
+ * derivation. Every trial gets the same sequence: common random numbers.
+ */
+export function deriveTrialSeeds(
+  baseSeed: number,
+  seedsPerTrial: number,
+): number[] {
+  return Array.from({ length: seedsPerTrial }, (_, index) =>
+    index === 0 ? baseSeed : deriveRunSeed(baseSeed, index),
+  );
+}
+
 export function createOptimizationProtocol(args: {
   manifest: PetrinautOptimizationManifest;
   model: PetrinautCompiledModel;
 }): OptimizationProtocol {
   const { manifest, model } = args;
+  const seedsPerTrial = manifest.execution.seedsPerTrial ?? 1;
+  const trialSeeds = deriveTrialSeeds(manifest.execution.seed, seedsPerTrial);
   const scenario = manifest.model.definition.scenarios?.[0];
   const metric = manifest.model.definition.metrics?.[0];
   if (!scenario || !metric) {
@@ -165,14 +182,16 @@ export function createOptimizationProtocol(args: {
     describe() {
       return {
         direction: manifest.objective.direction,
-        study: { ...manifest.study, seed: manifest.execution.seed },
+        study: {
+          ...manifest.study,
+          seed: manifest.execution.seed,
+          seedsPerTrial,
+        },
         parameters: optimizedParameters.map(({ parameter, domain }) =>
           describeParameter(parameter, domain),
         ),
       };
     },
-    // Async so implementations may defer simulation work (e.g. to worker
-    // threads) without another protocol change.
     async evaluate(params) {
       const parsed =
         petrinautOptimizationEvaluateParamsSchema.safeParse(params);
@@ -225,21 +244,40 @@ export function createOptimizationProtocol(args: {
         );
       }
 
-      const result = model.run({
-        initialMarking: compiledScenario.result.initialState,
-        parameterValues: compiledScenario.result.parameterValues,
-        metrics: [manifest.objective.metricId],
-        seed: manifest.execution.seed,
-        dt: manifest.execution.dt,
-        maxTime: manifest.execution.maxTime,
+      // Sequential seeded runs: each replicate is validated as it lands, so a
+      // bad objective fails the trial before the remaining seeds run.
+      // Parallelising is deferred to the shared experiment-backend interface.
+      const replicates = trialSeeds.map((seed) => {
+        const result = model.run({
+          initialMarking: compiledScenario.result.initialState,
+          parameterValues: compiledScenario.result.parameterValues,
+          metrics: [manifest.objective.metricId],
+          seed,
+          dt: manifest.execution.dt,
+          maxTime: manifest.execution.maxTime,
+        });
+        const value = result.metrics[metric.name];
+        if (value === undefined || !Number.isFinite(value)) {
+          throw new Error(
+            `Petrinaut result omitted a finite objective metric "${metric.name}" for seed ${seed}`,
+          );
+        }
+        return { seed, objective: value };
       });
-      const objective = result.metrics[metric.name];
-      if (objective === undefined || !Number.isFinite(objective)) {
+      // Online mean: summing the objectives first could overflow to Infinity
+      // even when each one is finite.
+      const objective = replicates.reduce(
+        (mean, replicate, index) =>
+          mean + (replicate.objective - mean) / (index + 1),
+        0,
+      );
+      // A non-finite mean would serialize as null on the wire; fail loudly.
+      if (!Number.isFinite(objective)) {
         throw new Error(
-          `Petrinaut result omitted a finite objective metric "${metric.name}"`,
+          `The mean of the objective metric "${metric.name}" is not finite`,
         );
       }
-      return { objective };
+      return seedsPerTrial > 1 ? { objective, replicates } : { objective };
     },
   };
 }

--- a/libs/@hashintel/petrinaut-cli/turbo.json
+++ b/libs/@hashintel/petrinaut-cli/turbo.json
@@ -5,6 +5,10 @@
       "dependsOn": ["^build"],
       "outputs": ["dist/**"],
       "cache": false
+    },
+    "test:unit": {
+      "dependsOn": ["build", "codegen", "^build"],
+      "env": ["TEST_COVERAGE"]
     }
   }
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The CLI scores an optimization trial on one simulation, so a stochastic net is judged on a single sample. This PR runs each trial as `execution.seedsPerTrial` seeded simulations and returns their mean.

- Runs execute **sequentially**. Parallel execution comes later through the shared experiment-backend interface (FE-1341), tracked as FE-1429, so the CLI and the editor share one worker implementation.
- The response keeps the `{ objective }` shape, so the Python optimizer service needs no changes.
- Out of scope: aggregation-method selection (FE-1277) and Optuna-side per-seed handling (FE-1281).

Stack #9226: FE-1410 (contract) → FE-1411 (async protocol) → **this PR** → FE-1413 (arch-docs manual) → FE-1270 (Python bindings) → FE-1412 (Python timeout).

## 🔗 Related links

- [FE-1408](https://linear.app/hash/issue/FE-1408/petrinaut-cli-run-a-trials-seeded-simulations-in-parallel-aggregated) *(internal)*: this PR
- [FE-1273](https://linear.app/hash/issue/FE-1273/stochastic-optimisation-run-m-seeded-simulations-per-optuna-step-and) *(internal)*: parent, M seeded runs per Optuna step
- [FE-1341](https://linear.app/hash/issue/FE-1341) *(internal)*: the shared experiment-backend interface
- [FE-1429](https://linear.app/hash/issue/FE-1429/run-trial-replicates-through-the-shared-experiment-backend) *(internal)*: follow-up, run these replicates through that backend
- [FE-1277](https://linear.app/hash/issue/FE-1277/aggregation-method-selection-for-stochastic-optimisation-results) *(internal)*: follow-up, user-selectable aggregation

## 🔍 What does this change?

`@hashintel/petrinaut-cli` only:

- **`optimization.evaluate`** runs the trial's seeds one after another and returns:
  - `objective`: the mean of the per-seed objectives;
  - `replicates: [{ seed, objective }]`, present when `seedsPerTrial > 1`.
- **`optimization.describe`** reports `study.seedsPerTrial`.
- **Seeds** derive once per study and are identical for every trial (common random numbers):
  - replicate 0 uses `execution.seed`, so one seed per trial behaves bit-identically to today and one editor run still reproduces a replicate;
  - replicate *i* uses the Monte Carlo `deriveRunSeed(seed, i)` exported by FE-1410.
- **Wall-clock time** of a trial grows linearly with `seedsPerTrial`.
- **New smoke test** spawns the bundled `dist/cli.js` and checks a full describe/evaluate exchange, including a two-seed trial.

## 🧪 Example

The manifest's `execution` block asks for three seeds per trial:

```jsonc
// optimization.json (excerpt)
"execution": { "seed": 42, "dt": 1, "maxTime": 100, "seedsPerTrial": 3 }
```

Serve it and send one trial over stdio:

```bash
node libs/@hashintel/petrinaut-cli/dist/cli.js serve --optimization optimization.json --stdio
```

```json
{ "id": 1, "method": "optimization.evaluate", "params": { "parameterValues": { "infected_ratio": 0.1 } } }
```

The trial runs seeds 42, 1013904268 and 1520856381 in that order and answers with their mean:

```json
{
  "id": 1,
  "result": {
    "objective": 0.31,
    "replicates": [
      { "seed": 42, "objective": 0.28 },
      { "seed": 1013904268, "objective": 0.33 },
      { "seed": 1520856381, "objective": 0.32 }
    ]
  }
}
```

Every trial reuses those three seeds, so repeating the request returns identical values. With `seedsPerTrial: 1` (or the field omitted) the response is `{ "objective": ... }` alone, unchanged from today.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] modifies a workspace but **not** a publishable library (`@hashintel/petrinaut-cli` is private; the `@hashintel/petrinaut-core` changeset landed with FE-1410)

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] require changes to docs which **are made** as part of this PR
  - `OPTIMIZATION_INTEGRATION.md` and the CLI README document the field, the seed derivation, and the response shape. The in-app user guide is untouched: the UI never sets `seedsPerTrial`, so in-app behaviour is unchanged until FE-1273's UI half lands.

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] affected the execution graph, and the `turbo.json`'s have been updated to reflect this
  - `petrinaut-cli`'s `test:unit` now depends on its own `build`, so the smoke test always runs against a fresh bundle in CI.

## 🐾 Next steps

- FE-1412 (top of stack): the Python client scales its per-response timeout by `seedsPerTrial`.
- FE-1429: run the seeded replicates through the shared experiment backend once FE-1341 lands.
- FE-1277 / FE-1281: aggregation selection and Optuna-side per-seed handling.

## 🛡 What tests cover this?

- `optimization.test.ts`: mean aggregation, per-seed `replicates`, identical seed list across trials, fail-fast on a non-finite replicate, extreme-value aggregation, `deriveTrialSeeds` range and stability.
- `transports.test.ts`: multi-seed evaluate over stdio, `seedsPerTrial` in describe.
- `built-cli.test.ts`: spawns the real bundled CLI for the full exchange with two seeds.

## ❓ How to test this?

1. `turbo run test:unit --filter @hashintel/petrinaut-cli`
2. Manual: add `"seedsPerTrial": 4` to `execution` in `libs/@hashintel/petrinaut-cli/examples/supply-chain-profit-optimization.json`, run `yarn workspace @hashintel/petrinaut-cli build`, then `node libs/@hashintel/petrinaut-cli/dist/cli.js serve --optimization <manifest> --stdio` and send an `optimization.evaluate` request.
3. The response carries the mean `objective` plus four `replicates`; repeating the request returns identical values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
