### PR TITLE
FE-1410: Define the seeds-per-trial contract in the optimization manifest

### DIFF
--- a/.changeset/optimization-seeds-per-trial.md
+++ b/.changeset/optimization-seeds-per-trial.md
@@ -1,0 +1,5 @@
+---
+"@hashintel/petrinaut-core": patch
+---
+
+Add an optional `execution.seedsPerTrial` field to the optimization manifest (1–100, default 1), extend the describe/evaluate contract types with the seeds-per-trial count and per-seed `replicates`, count every trial seed against the total simulation-step budget, and export the Monte Carlo `deriveRunSeed` derivation.

--- a/libs/@hashintel/petrinaut-core/src/index.ts
+++ b/libs/@hashintel/petrinaut-core/src/index.ts
@@ -86,6 +86,7 @@ export type {
 export {
   PETRINAUT_OPTIMIZATION_CANCELLED_ERROR_CODE,
   PETRINAUT_OPTIMIZATION_MAX_SEED,
+  PETRINAUT_OPTIMIZATION_MAX_SEEDS_PER_TRIAL,
   PETRINAUT_OPTIMIZATION_MAX_STEPS_PER_TRIAL,
   PETRINAUT_OPTIMIZATION_MAX_TOTAL_STEPS,
   PETRINAUT_OPTIMIZATION_MAX_TRIALS,
@@ -206,6 +207,7 @@ export {
   createMonteCarloUserDefinedMetric,
   createSimulation,
   createWorkerTransport,
+  deriveRunSeed,
 } from "./simulation";
 export type {
   BackpressureConfig,

--- a/libs/@hashintel/petrinaut-core/src/optimization.test.ts
+++ b/libs/@hashintel/petrinaut-core/src/optimization.test.ts
@@ -363,6 +363,67 @@ describe("petrinautOptimizationManifestSchema", () => {
     expect(tooManySteps.success).toBe(false);
     expect(tooMuchTotalWork.success).toBe(false);
   });
+
+  it("bounds the seeds each trial may run", () => {
+    const withSeeds = petrinautOptimizationManifestSchema.safeParse({
+      ...validManifest,
+      execution: { ...validManifest.execution, seedsPerTrial: 10 },
+    });
+    const zeroSeeds = petrinautOptimizationManifestSchema.safeParse({
+      ...validManifest,
+      execution: { ...validManifest.execution, seedsPerTrial: 0 },
+    });
+    const fractionalSeeds = petrinautOptimizationManifestSchema.safeParse({
+      ...validManifest,
+      execution: { ...validManifest.execution, seedsPerTrial: 1.5 },
+    });
+    const tooManySeeds = petrinautOptimizationManifestSchema.safeParse({
+      ...validManifest,
+      execution: { ...validManifest.execution, seedsPerTrial: 101 },
+    });
+
+    expect(withSeeds.success).toBe(true);
+    expect(zeroSeeds.success).toBe(false);
+    expect(fractionalSeeds.success).toBe(false);
+    expect(tooManySeeds.success).toBe(false);
+  });
+
+  it("counts every trial seed against the total work budget", () => {
+    // 1,000 steps x 100 trials fits the 5,000,000-step budget with one seed
+    // per trial but exceeds it with one hundred.
+    const base = {
+      ...validManifest,
+      execution: { ...validManifest.execution, dt: 0.1, maxTime: 100 },
+      study: { ...validManifest.study, trials: 100 },
+    };
+    const singleSeed = petrinautOptimizationManifestSchema.safeParse(base);
+    const replicated = petrinautOptimizationManifestSchema.safeParse({
+      ...base,
+      execution: { ...base.execution, seedsPerTrial: 100 },
+    });
+
+    expect(singleSeed.success).toBe(true);
+    expect(replicated.success).toBe(false);
+    if (!replicated.success) {
+      expect(replicated.error.issues[0]?.path).toEqual([
+        "execution",
+        "seedsPerTrial",
+      ]);
+    }
+
+    // A workload that overflows even unseeded stays a trial-count issue.
+    const oversizedUnseeded = petrinautOptimizationManifestSchema.safeParse({
+      ...base,
+      execution: { ...base.execution, dt: 0.001, seedsPerTrial: 2 },
+    });
+    expect(oversizedUnseeded.success).toBe(false);
+    if (!oversizedUnseeded.success) {
+      expect(oversizedUnseeded.error.issues[0]?.path).toEqual([
+        "study",
+        "trials",
+      ]);
+    }
+  });
 });
 
 describe("petrinautOptimizationEventSchema", () => {

--- a/libs/@hashintel/petrinaut-core/src/optimization.ts
+++ b/libs/@hashintel/petrinaut-core/src/optimization.ts
@@ -9,6 +9,7 @@ export const PETRINAUT_OPTIMIZATION_MAX_SEED = 2_147_483_647;
 export const PETRINAUT_OPTIMIZATION_MAX_TRIALS = 1_000;
 export const PETRINAUT_OPTIMIZATION_MAX_STEPS_PER_TRIAL = 100_000;
 export const PETRINAUT_OPTIMIZATION_MAX_TOTAL_STEPS = 5_000_000;
+export const PETRINAUT_OPTIMIZATION_MAX_SEEDS_PER_TRIAL = 100;
 
 const optimizationScalarSchema = z.union([z.number(), z.boolean()]);
 
@@ -130,6 +131,16 @@ export const petrinautOptimizationExecutionSchema = z
     seed: z.number().int().min(0).max(PETRINAUT_OPTIMIZATION_MAX_SEED),
     dt: z.number().positive(),
     maxTime: z.number().positive(),
+    seedsPerTrial: z
+      .number()
+      .int()
+      .min(1)
+      .max(PETRINAUT_OPTIMIZATION_MAX_SEEDS_PER_TRIAL)
+      .optional()
+      .meta({
+        description:
+          "How many seeded simulations each trial runs. The same derived seed sequence is reused for every trial, and the per-seed objectives are aggregated into the trial objective. Defaults to 1.",
+      }),
   })
   .meta({ description: "Simulation settings shared by every trial." });
 
@@ -410,6 +421,7 @@ export const petrinautOptimizationManifestSchema = z
     const stepsPerTrial = Math.ceil(
       manifest.execution.maxTime / manifest.execution.dt,
     );
+    const seedsPerTrial = manifest.execution.seedsPerTrial ?? 1;
     if (
       !Number.isSafeInteger(stepsPerTrial) ||
       stepsPerTrial > PETRINAUT_OPTIMIZATION_MAX_STEPS_PER_TRIAL
@@ -417,15 +429,19 @@ export const petrinautOptimizationManifestSchema = z
       addIssue(
         context,
         ["execution"],
-        `An optimization may run at most ${PETRINAUT_OPTIMIZATION_MAX_STEPS_PER_TRIAL.toLocaleString()} simulation steps per trial`,
+        `An optimization may run at most ${PETRINAUT_OPTIMIZATION_MAX_STEPS_PER_TRIAL.toLocaleString()} simulation steps per seeded run`,
       );
     } else if (
-      stepsPerTrial * manifest.study.trials >
+      stepsPerTrial * seedsPerTrial * manifest.study.trials >
       PETRINAUT_OPTIMIZATION_MAX_TOTAL_STEPS
     ) {
+      // Blame the seed multiplier only when the study fits without it.
+      const fitsUnseeded =
+        stepsPerTrial * manifest.study.trials <=
+        PETRINAUT_OPTIMIZATION_MAX_TOTAL_STEPS;
       addIssue(
         context,
-        ["study", "trials"],
+        fitsUnseeded ? ["execution", "seedsPerTrial"] : ["study", "trials"],
         `An optimization may run at most ${PETRINAUT_OPTIMIZATION_MAX_TOTAL_STEPS.toLocaleString()} simulation steps across all trials`,
       );
     }
@@ -473,7 +489,11 @@ export type PetrinautOptimizationDescribeParameter =
 
 export type PetrinautOptimizationDescribeResult = {
   direction: "maximize" | "minimize";
-  study: PetrinautOptimizationStudy & { seed: number };
+  study: PetrinautOptimizationStudy & {
+    seed: number;
+    /** Reported once the CLI runs seeded replicates; absent means 1. */
+    seedsPerTrial?: number;
+  };
   parameters: PetrinautOptimizationDescribeParameter[];
 };
 
@@ -481,7 +501,16 @@ export type PetrinautOptimizationEvaluateParams = z.infer<
   typeof petrinautOptimizationEvaluateParamsSchema
 >;
 
-export type PetrinautOptimizationEvaluateResult = { objective: number };
+/**
+ * One trial evaluation. `objective` is the mean of the per-seed objectives
+ * (identical to the sole run's objective when the trial runs one seed).
+ * `replicates` reports the per-seed values whenever a trial runs more than
+ * one seed, so consumers can inspect the spread behind the aggregate.
+ */
+export type PetrinautOptimizationEvaluateResult = {
+  objective: number;
+  replicates?: { seed: number; objective: number }[];
+};
 
 const optimizationBestSchema = z
   .strictObject({

--- a/libs/@hashintel/petrinaut-core/src/simulation/index.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/index.ts
@@ -26,6 +26,7 @@ export {
   createMonteCarloSimulator,
   createMonteCarloUserDefinedMetricConfigsFromSpecs,
   createMonteCarloUserDefinedMetric,
+  deriveRunSeed,
 } from "./monte-carlo";
 export type {
   CreateMonteCarloExperimentConfig,

--- a/libs/@hashintel/petrinaut-core/src/simulation/monte-carlo/index.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/monte-carlo/index.ts
@@ -1,4 +1,5 @@
 export { createMonteCarloSimulator } from "./monte-carlo-simulator";
+export { deriveRunSeed } from "./run-state";
 export {
   addAllMonteCarloMetricValues,
   createMonteCarloMetricHistogramAccumulator,

--- a/libs/@hashintel/petrinaut-core/src/simulation/monte-carlo/run-state.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/monte-carlo/run-state.ts
@@ -23,9 +23,11 @@ import type {
  * explicit per-run seed.
  *
  * This keeps runs reproducible while avoiding identical RNG streams across the
- * default run set.
+ * default run set. The CLI's optimization protocol reuses this derivation for
+ * a trial's non-first replicate seeds (its first replicate keeps the base
+ * seed itself).
  */
-function deriveRunSeed(baseSeed: number, runIndex: number): number {
+export function deriveRunSeed(baseSeed: number, runIndex: number): number {
   return (
     Math.abs(Math.trunc(baseSeed + (runIndex + 1) * 2_654_435_761)) %
     2_147_483_648


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Contract layer for FE-1408 (run M seeded simulations per optimization trial). It adds the manifest field and the protocol types. Behaviour is unchanged: manifests without the field parse and run as before, and the CLI is untouched.

Stack: **this PR** → FE-1411 (async-safe protocol) → FE-1408 (sequential seeded trials) → arch-docs and Python bindings follow-ups.

## 🔗 Related links

- [FE-1410](https://linear.app/hash/issue/FE-1410/optimization-manifest-define-the-seeds-per-trial-contract-in-petrinaut) *(internal)*: this PR
- [FE-1408](https://linear.app/hash/issue/FE-1408/petrinaut-cli-run-a-trials-seeded-simulations-in-parallel-aggregated) *(internal)*: parent, seeded trials in the CLI
- [FE-1273](https://linear.app/hash/issue/FE-1273/stochastic-optimisation-run-m-seeded-simulations-per-optuna-step-and) *(internal)*: grandparent, M seeded runs per Optuna step

## 🔍 What does this change?

`@hashintel/petrinaut-core` only:

- **New manifest field**: `execution.seedsPerTrial`, optional integer 1–100, default 1.
- **Budget check counts seeds**: a study must satisfy `stepsPerTrial × seedsPerTrial × trials ≤ 5,000,000`. When it does not, the validation error points at the field to fix:
  - `study.trials` when the study is over budget even at one seed per trial;
  - `execution.seedsPerTrial` when the study fits at one seed per trial and the seed count pushed it over.
- **Protocol types**: `describe().study` gains optional `seedsPerTrial`; `evaluate()` gains optional `replicates: [{ seed, objective }]`. Both are optional so this PR merges before the CLI layer.
- **`deriveRunSeed` is exported** from the Monte Carlo module. The CLI layer reuses it, so optimization replicate seeds and Monte Carlo experiment seeds share one derivation.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] modifies an **npm**-publishable library and **I have added a changeset file(s)**

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are not user-facing so no docs are required. Behaviour is unchanged until the CLI layer lands; that PR carries the doc updates.

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- `optimization.test.ts`: field bounds (rejects 0, 1.5, 101), the seeds-aware budget including which field the error points at, and unchanged parsing of manifests without the field.

## ❓ How to test this?

```bash
turbo run test:unit --filter @hashintel/petrinaut-core
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
