### PR TITLE
FE-1411: Make the Petrinaut CLI protocol handler async-safe

### DIFF
--- a/libs/@hashintel/petrinaut-cli/src/commands/serve.ts
+++ b/libs/@hashintel/petrinaut-cli/src/commands/serve.ts
@@ -43,9 +43,31 @@ export async function serve(options: ServeOptions): Promise<void> {
   };
 
   const activeSockets = new Set<Socket>();
-  const server = createServer((socket) => {
+  // Half-open keeps the write side available until the async protocol chain
+  // has flushed every response for requests received before the client's FIN.
+  const server = createServer({ allowHalfOpen: true }, (socket) => {
     activeSockets.add(socket);
     let buffer = "";
+    // Serializes the async protocol handler per connection so responses keep
+    // the one-line-per-request order the transport promises.
+    let pending: Promise<void> = Promise.resolve();
+    // A rejected task must not orphan the chain (and the socket.end it still
+    // owes): drop the connection and leave `pending` resolved.
+    const enqueue = (task: () => void | Promise<void>): void => {
+      pending = pending.then(task).catch(() => {
+        socket.destroy();
+      });
+    };
+    const enqueueLine = (line: string): void => {
+      enqueue(() =>
+        handleProtocolLine(
+          model,
+          line,
+          (value) => writeResponse(socket, value),
+          sdcpn,
+        ),
+      );
+    };
 
     socket.setEncoding("utf8");
     socket.on("data", (chunk) => {
@@ -57,42 +79,39 @@ export async function serve(options: ServeOptions): Promise<void> {
       buffer = bufferedLines.remainder;
 
       for (const line of bufferedLines.lines) {
-        handleProtocolLine(
-          model,
-          line,
-          (value) => writeResponse(socket, value),
-          sdcpn,
-        );
+        enqueueLine(line);
       }
 
       if (bufferedLines.requestTooLarge) {
         buffer = "";
         socket.pause();
-        socket.end(
-          `${JSON.stringify({
-            id: null,
-            error: { message: "Request line is too large" },
-          })}\n`,
-        );
+        enqueue(() => {
+          socket.end(
+            `${JSON.stringify({
+              id: null,
+              error: { message: "Request line is too large" },
+            })}\n`,
+          );
+        });
       }
     });
 
     socket.on("end", () => {
       if (buffer.trim() !== "") {
         if (Buffer.byteLength(buffer, "utf8") > MAX_REQUEST_LINE_BYTES) {
-          writeResponse(socket, {
-            id: null,
-            error: { message: "Request line is too large" },
+          enqueue(() => {
+            writeResponse(socket, {
+              id: null,
+              error: { message: "Request line is too large" },
+            });
           });
-          return;
+        } else {
+          enqueueLine(buffer);
         }
-        handleProtocolLine(
-          model,
-          buffer,
-          (value) => writeResponse(socket, value),
-          sdcpn,
-        );
       }
+      enqueue(() => {
+        socket.end();
+      });
     });
     socket.on("error", () => {
       // Per-connection errors are reported through the socket lifecycle.

--- a/libs/@hashintel/petrinaut-cli/src/commands/stdio.ts
+++ b/libs/@hashintel/petrinaut-cli/src/commands/stdio.ts
@@ -138,7 +138,7 @@ export async function serveStdio(options: ServeStdioOptions): Promise<void> {
       });
       continue;
     }
-    handleProtocolLine(
+    await handleProtocolLine(
       model,
       line,
       (value) => writeResponse(output, value),

--- a/libs/@hashintel/petrinaut-cli/src/runtime/optimization.test.ts
+++ b/libs/@hashintel/petrinaut-cli/src/runtime/optimization.test.ts
@@ -143,7 +143,7 @@ describe("createOptimizationProtocol", () => {
         },
       ],
     });
-    expect(
+    await expect(
       protocol.evaluate({
         parameterValues: {
           production_rate: 125,
@@ -154,7 +154,7 @@ describe("createOptimizationProtocol", () => {
           marketing_spend: 40,
         },
       }),
-    ).toEqual({ objective: 42 });
+    ).resolves.toEqual({ objective: 42 });
     expect(run).toHaveBeenCalledWith(
       expect.objectContaining({
         parameterValues: {
@@ -217,9 +217,9 @@ describe("createOptimizationProtocol", () => {
         },
       ],
     });
-    expect(
+    await expect(
       protocol.evaluate({ parameterValues: { infected_ratio: 0.1 } }),
-    ).toEqual({ objective: 0.25 });
+    ).resolves.toEqual({ objective: 0.25 });
     expect(run).toHaveBeenCalledWith({
       initialMarking: {
         place__susceptible: 180,
@@ -319,16 +319,18 @@ describe("createOptimizationProtocol", () => {
       },
       { identifier: "enabled", type: "boolean", default: false },
     ]);
-    expect(() =>
+    await expect(
       protocol.evaluate({ parameterValues: { count: 5, enabled: false } }),
-    ).toThrow('Optimization parameter "count" must align with step 2 from 2');
-    expect(() =>
+    ).rejects.toThrow(
+      'Optimization parameter "count" must align with step 2 from 2',
+    );
+    await expect(
       protocol.evaluate({ parameterValues: { count: 6, enabled: 1 } }),
-    ).toThrow('Optimization parameter "enabled" must be boolean');
+    ).rejects.toThrow('Optimization parameter "enabled" must be boolean');
 
-    expect(
+    await expect(
       protocol.evaluate({ parameterValues: { count: 6, enabled: false } }),
-    ).toEqual({ objective: 0.25 });
+    ).resolves.toEqual({ objective: 0.25 });
     expect(run).toHaveBeenCalledWith({
       initialMarking: {
         place__susceptible: 0,
@@ -353,17 +355,17 @@ describe("createOptimizationProtocol", () => {
     };
     const protocol = createOptimizationProtocol({ manifest, model });
 
-    expect(() => protocol.evaluate({ parameterValues: {} })).toThrow(
+    await expect(protocol.evaluate({ parameterValues: {} })).rejects.toThrow(
       'Missing optimized parameter "infected_ratio"',
     );
-    expect(() =>
+    await expect(
       protocol.evaluate({
         parameterValues: { infected_ratio: 0.1, population: 200 },
       }),
-    ).toThrow('Unexpected optimization parameter "population"');
-    expect(() =>
+    ).rejects.toThrow('Unexpected optimization parameter "population"');
+    await expect(
       protocol.evaluate({ parameterValues: { infected_ratio: 0.75 } }),
-    ).toThrow(
+    ).rejects.toThrow(
       'Optimization parameter "infected_ratio" must be between 0.01 and 0.5',
     );
   });

--- a/libs/@hashintel/petrinaut-cli/src/runtime/optimization.ts
+++ b/libs/@hashintel/petrinaut-cli/src/runtime/optimization.ts
@@ -134,7 +134,7 @@ function validateSuggestedValue(
 
 export type OptimizationProtocol = {
   describe(): PetrinautOptimizationDescribeResult;
-  evaluate(params: unknown): PetrinautOptimizationEvaluateResult;
+  evaluate(params: unknown): Promise<PetrinautOptimizationEvaluateResult>;
 };
 
 export function createOptimizationProtocol(args: {
@@ -171,7 +171,9 @@ export function createOptimizationProtocol(args: {
         ),
       };
     },
-    evaluate(params) {
+    // Async so implementations may defer simulation work (e.g. to worker
+    // threads) without another protocol change.
+    async evaluate(params) {
       const parsed =
         petrinautOptimizationEvaluateParamsSchema.safeParse(params);
       if (!parsed.success) {

--- a/libs/@hashintel/petrinaut-cli/src/runtime/protocol.test.ts
+++ b/libs/@hashintel/petrinaut-cli/src/runtime/protocol.test.ts
@@ -78,9 +78,12 @@ function createModel(modelMetadata = metadata) {
   };
 }
 
-function send(model: PetrinautCompiledModel, request: unknown): unknown {
+async function send(
+  model: PetrinautCompiledModel,
+  request: unknown,
+): Promise<unknown> {
   const responses: unknown[] = [];
-  handleProtocolLine(model, JSON.stringify(request), (response) => {
+  await handleProtocolLine(model, JSON.stringify(request), (response) => {
     responses.push(response);
   });
   expect(responses).toHaveLength(1);
@@ -88,24 +91,24 @@ function send(model: PetrinautCompiledModel, request: unknown): unknown {
 }
 
 describe("handleProtocolLine", () => {
-  it("handles healthz and metadata requests", () => {
+  it("handles healthz and metadata requests", async () => {
     const model = createModel();
 
-    expect(send(model, { id: 1, method: "healthz" })).toEqual({
+    expect(await send(model, { id: 1, method: "healthz" })).toEqual({
       id: 1,
       result: { ok: true },
     });
-    expect(send(model, { id: 2, method: "metadata" })).toEqual({
+    expect(await send(model, { id: 2, method: "metadata" })).toEqual({
       id: 2,
       result: metadata,
     });
   });
 
-  it("normalizes a representative run request", () => {
+  it("normalizes a representative run request", async () => {
     const model = createModel();
 
     expect(
-      send(model, {
+      await send(model, {
         id: "run-1",
         method: "run",
         params: {
@@ -144,11 +147,11 @@ describe("handleProtocolLine", () => {
     );
   });
 
-  it("returns metric values under the requested stable id", () => {
+  it("returns metric values under the requested stable id", async () => {
     const model = createModel();
 
     expect(
-      send(model, {
+      await send(model, {
         id: 4,
         method: "run",
         params: { metrics: ["metric-id"], maxSteps: 0 },
@@ -162,7 +165,7 @@ describe("handleProtocolLine", () => {
     );
   });
 
-  it("prioritizes exact ids and uses last-wins name aliases", () => {
+  it("prioritizes exact ids and uses last-wins name aliases", async () => {
     const model = createModel({
       ...metadata,
       parameters: [
@@ -200,7 +203,7 @@ describe("handleProtocolLine", () => {
     });
 
     expect(
-      send(model, {
+      await send(model, {
         id: 3,
         method: "run",
         params: {
@@ -237,15 +240,19 @@ describe("handleProtocolLine", () => {
     [{ seed: "42" }, "seed must be a finite number"],
     [{ dt: "0.1" }, "dt must be a finite number"],
     [{ maxSteps: 1.5 }, "maxSteps must be a non-negative integer"],
-  ])("rejects invalid run field %#", (params, message) => {
-    const response = send(createModel(), { id: 7, method: "run", params });
+  ])("rejects invalid run field %#", async (params, message) => {
+    const response = await send(createModel(), {
+      id: 7,
+      method: "run",
+      params,
+    });
 
     expect(response).toEqual({ id: 7, error: { message } });
   });
 
-  it("rejects markings incompatible with a place's color", () => {
+  it("rejects markings incompatible with a place's color", async () => {
     expect(
-      send(createModel(), {
+      await send(createModel(), {
         id: 8,
         method: "run",
         params: { initialState: { Colored: 1 }, maxSteps: 1 },
@@ -259,7 +266,7 @@ describe("handleProtocolLine", () => {
     });
 
     expect(
-      send(createModel(), {
+      await send(createModel(), {
         id: 9,
         method: "run",
         params: { initialState: { Plain: [{}] }, maxSteps: 1 },
@@ -273,9 +280,9 @@ describe("handleProtocolLine", () => {
     });
   });
 
-  it("rejects uncolored token counts that overflow engine storage", () => {
+  it("rejects uncolored token counts that overflow engine storage", async () => {
     expect(
-      send(createModel(), {
+      await send(createModel(), {
         id: 10,
         method: "run",
         params: { initialState: { Plain: 4_294_967_296 }, maxSteps: 1 },
@@ -289,10 +296,12 @@ describe("handleProtocolLine", () => {
     });
   });
 
-  it("preserves request ids on protocol errors", () => {
-    expect(send(createModel(), { id: "bad", method: "unknown" })).toEqual({
-      id: "bad",
-      error: { message: 'Unknown method "unknown"' },
-    });
+  it("preserves request ids on protocol errors", async () => {
+    expect(await send(createModel(), { id: "bad", method: "unknown" })).toEqual(
+      {
+        id: "bad",
+        error: { message: 'Unknown method "unknown"' },
+      },
+    );
   });
 });

--- a/libs/@hashintel/petrinaut-cli/src/runtime/protocol.ts
+++ b/libs/@hashintel/petrinaut-cli/src/runtime/protocol.ts
@@ -20,13 +20,13 @@ function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-export function handleProtocolLine(
+export async function handleProtocolLine(
   model: PetrinautCompiledModel,
   line: string,
   writeResponse: (value: unknown) => void,
   sdcpn?: SDCPN,
   optimization?: OptimizationProtocol,
-): void {
+): Promise<void> {
   if (line.trim() === "") {
     return;
   }
@@ -76,7 +76,7 @@ export function handleProtocolLine(
         }
         writeResponse({
           id,
-          result: optimization.evaluate(request.params ?? {}),
+          result: await optimization.evaluate(request.params ?? {}),
         });
         return;
       default:


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Preparation layer for running a trial's seeded simulations on worker threads (FE-1408 stack): `optimization.evaluate` becomes asynchronous, so the CLI's protocol dispatch and both transports must stop assuming a synchronous handler. This PR makes that safe with **no request or response shape changes** — every evaluate still resolves synchronously, so behaviour is identical.

Stack: FE-1410 (contract) → **this PR** → FE-1408 (worker pool).

## 🔗 Related links

- [FE-1411](https://linear.app/hash/issue/FE-1411/petrinaut-cli-make-the-protocol-handler-async-safe) _(internal)_ — this PR
- [FE-1408](https://linear.app/hash/issue/FE-1408/petrinaut-cli-run-a-trials-seeded-simulations-in-parallel-aggregated) _(internal)_ — parent: seeded trials in the CLI

## 🔍 What does this change?

`@hashintel/petrinaut-cli` only:

- `OptimizationProtocol.evaluate` returns a `Promise`; `handleProtocolLine` is async and awaits it. All errors still become one `{ id, error }` line.
- The stdio loop awaits each line, preserving strict request ordering.
- The Unix-socket transport serializes per-connection handling on a promise chain and opens the server with `allowHalfOpen: true`, ending the socket itself once queued responses have flushed. Previously, Node's auto-close on the client's FIN could race responses that a deferred handler had not yet written; the trailing-buffer request received just before FIN is the observable case.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] modifies a workspace but **not** a publishable library (`@hashintel/petrinaut-cli` is private)

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are not user-facing so no docs are required — no protocol or CLI surface changes.

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- `protocol.test.ts` — all dispatch tests run through the awaited handler.
- `transports.test.ts` — stdio and Unix-socket suites, including chunked and trailing-buffer socket requests whose responses must flush before close.
- `optimization.test.ts` — evaluate assertions moved to `resolves`/`rejects`.

## ❓ How to test this?

```bash
turbo run test:unit --filter @hashintel/petrinaut-cli
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
