### PR TITLE
FE-1270: Extract Python bindings for the Petrinaut CLI into @local/petrinaut-python

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -140,7 +140,7 @@ jobs:
               push:       ["ecr", "ghcr"],
               dockerfile: "apps/petrinaut-opt/docker/Dockerfile",
               context:    ".",
-              paths:      ["apps/petrinaut-opt", "libs/@hashintel/petrinaut-cli", "libs/@hashintel/petrinaut-core"],
+              paths:      ["apps/petrinaut-opt", "libs/@hashintel/petrinaut-cli", "libs/@hashintel/petrinaut-core", "libs/@local/petrinaut-python"],
               ecs: [{ service: "petrinaut-opt", cluster: "h-stage-euc1-app", service_name: "h-stage-euc1-app-petrinaut-opt" }]
             },
             {

--- a/apps/petrinaut-opt/README.md
+++ b/apps/petrinaut-opt/README.md
@@ -105,7 +105,7 @@ bindings](../../libs/@local/petrinaut-python/README.md), created with the
 manifest as opaque JSON. This service starts the session, describes the study,
 evaluates one trial at a time, and closes the session.
 
-`describe_optimization()` returns the direction, the study settings, and the
+`describe()` returns the direction, the study settings, and the
 flat parameters that are not fixed, each one a descriptor such as:
 
 ```json

--- a/apps/petrinaut-opt/README.md
+++ b/apps/petrinaut-opt/README.md
@@ -1,9 +1,10 @@
 # Petrinaut optimization
 
 This service uses Optuna to optimize the flat, non-fixed parameters of one
-Petrinaut scenario. It keeps Yannis's Server-Sent Events API and study
-lifecycle, while delegating all Petrinaut-specific interpretation to
-`petrinaut-cli`.
+Petrinaut scenario. It owns the Server-Sent Events API and the study lifecycle,
+and delegates every Petrinaut-specific concern to the
+[`petrinaut` Python bindings](../../libs/@local/petrinaut-python/README.md).
+Which process the bindings run, and how, is theirs to decide.
 
 The Python service treats the optimization manifest as opaque JSON. It does not
 read Petrinaut models, scenario bindings, metrics, or the Petrinaut type system.
@@ -12,7 +13,7 @@ read Petrinaut models, scenario bindings, metrics, or the Petrinaut type system.
 
 Run creation accepts the complete optimization manifest as its JSON request
 body. The manifest is produced by the Petrinaut UI/Node API and is forwarded
-unchanged to the CLI.
+unchanged to the bindings.
 
 - `POST /optimize/runs` starts a detached run and returns its id. Attach or
   reattach to its replayable event stream with
@@ -37,7 +38,7 @@ data: {}
 ```
 
 `params` contains the flat values proposed by Optuna. Fixed parameter values
-remain the CLI's responsibility and are not echoed by Python. `init_state` is
+are applied behind the bindings and are not echoed by Python. `init_state` is
 retained as an empty object for response compatibility. Failed evaluations are
 reported with Optuna's existing state and a null metric. Study failures retain
 the existing error data frame and terminate the stream without a subsequent
@@ -56,7 +57,7 @@ SSE clients ignore comment frames, while load balancers and proxies see traffic
 before their idle timeout.
 
 The streaming endpoints are not resumable: disconnecting stops that study and
-releases its CLI. Detached-run event streams are resumable: every frame has an
+closes its session. Detached-run event streams are resumable: every frame has an
 event id, buffered frames can be replayed using `Last-Event-ID` (or `cursor`),
 and disconnecting an attachment does not stop the run.
 
@@ -79,8 +80,8 @@ This service emits normal Python log records with bounded structured fields
 such as `event`, `request_id`, and `run_id`. When OTLP is configured,
 `src/telemetry.py` exports those records and the service's traces and metrics.
 
-The CLI stderr pipe is drained so the child cannot block, but its content is
-not copied into service logs. Lifecycle logs never intentionally include
+The bindings drain their child's diagnostics so it cannot block, and none of
+that output is copied into service logs. Lifecycle logs never intentionally include
 optimization manifests, user-authored code, or raw request bodies.
 
 The process admits at most four active optimizations. Additional requests
@@ -97,88 +98,45 @@ log, so malformed resume requests cannot suppress later terminal events.
 
 Optimization request bodies are limited to 8 MiB, including chunked bodies.
 
-## CLI protocol
+## Optimization backend
 
-For each request, Python starts one long-lived CLI process:
+Each run gets one session from the [`petrinaut` Python
+bindings](../../libs/@local/petrinaut-python/README.md), created with the
+manifest as opaque JSON. This service starts the session, describes the study,
+evaluates one trial at a time, and closes the session.
 
-```text
-petrinaut serve --optimization-stdin --stdio
-```
-
-It writes the manifest as the first JSON line. After the CLI reports readiness,
-Python asks it to describe the generic Optuna search space:
-
-```json
-{
-  "id": 1,
-  "method": "optimization.describe"
-}
-```
-
-The result supplies the direction, study settings, and only the non-fixed flat
-parameters:
+`describe_optimization()` returns the direction, the study settings, and the
+flat parameters that are not fixed, each one a descriptor such as:
 
 ```json
 {
-  "direction": "maximize",
-  "study": { "trials": 100, "sampler": "tpe", "seed": 42 },
-  "parameters": [
-    {
-      "identifier": "rate",
-      "type": "float",
-      "default": 1,
-      "minimum": 0.1,
-      "maximum": 10,
-      "scale": "log"
-    },
-    {
-      "identifier": "workers",
-      "type": "int",
-      "default": 4,
-      "minimum": 1,
-      "maximum": 16,
-      "step": 1,
-      "scale": "linear"
-    },
-    {
-      "identifier": "enabled",
-      "type": "boolean",
-      "default": true
-    }
-  ]
+  "identifier": "rate",
+  "type": "float",
+  "minimum": 0.1,
+  "maximum": 10,
+  "scale": "log"
 }
 ```
 
-Python maps those descriptors directly to `suggest_float`, `suggest_int`, and
-`suggest_categorical`, and seeds the sampler with the CLI-provided execution
-seed. For every trial it sends only the suggestions back:
+`float`, `int`, and `boolean` map onto `suggest_float`, `suggest_int`, and
+`suggest_categorical`, and the study seed seeds the sampler. The bindings'
+[usage manual](../../libs/@local/petrinaut-python/README.md) documents the full
+response.
 
-```json
-{
-  "id": 2,
-  "method": "optimization.evaluate",
-  "params": {
-    "parameterValues": {
-      "rate": 1.25,
-      "workers": 6,
-      "enabled": true
-    }
-  }
-}
-```
+`objective(parameter_values)` evaluates one trial and returns one finite number.
+Fixed-value injection, scenario compilation, initial-state materialization,
+simulation, and metric evaluation all happen behind that call, and fixed values
+are never echoed back through this service. When the manifest sets
+`execution.seedsPerTrial` above 1, one trial runs that many seeded simulations
+and the objective is their mean.
 
-The CLI owns fixed-value injection, scenario compilation, initial-state
-materialization, simulation, and metric evaluation. It returns one finite
-number as `{ "objective": 42.5 }`.
+`close()` ends the session. The bindings bound every wait and clean up after
+themselves: a startup deadline, a per-response deadline, a line-size limit, and
+termination of the process they started on timeout, failure, or client
+disconnect. Their README documents the current values.
 
 For an end-to-end local request, export an optimization manifest from the
-Petrinaut editor. The supply-chain `Profit` study used by the end-to-end tests
-lives in `libs/@hashintel/petrinaut-cli/test-fixtures/`.
-
-CLI startup is limited to 25 seconds and each protocol response to 240 seconds.
-Protocol lines are limited to 8 MiB. Python continuously drains CLI stderr once
-startup completes and terminates the CLI's isolated process group on timeout,
-failure, or client disconnect.
+Petrinaut editor.
 
 ## Observability
 
@@ -223,9 +181,9 @@ uv run pytest
 uv run uvicorn src.optimization_api:app --reload
 ```
 
-When running outside the Docker image, build Petrinaut CLI first and make a
-`petrinaut` executable available on `PATH`. The production image installs that
-command at `/usr/local/bin/petrinaut`.
+Outside the Docker image, the bindings need their executable on `PATH`; their
+[README](../../libs/@local/petrinaut-python/README.md) covers how to provide it.
+The production image installs it at `/usr/local/bin/petrinaut`.
 
 Generate the checked-in OpenAPI document with:
 

--- a/apps/petrinaut-opt/docker/Dockerfile
+++ b/apps/petrinaut-opt/docker/Dockerfile
@@ -8,7 +8,7 @@ ARG PYTHON_VERSION=3.13
 ARG UV_VERSION=0.11.18
 
 
-FROM node:${NODE_VERSION}-bookworm-slim AS cli-tools
+FROM node:${NODE_VERSION}-bookworm-slim AS bindings-tools
 
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
@@ -26,17 +26,17 @@ RUN apt-get update && \
     mise install --locked npm:turbo
 
 
-FROM cli-tools AS cli-pruner
+FROM bindings-tools AS bindings-pruner
 
 WORKDIR /repo
 
 COPY . .
 
 RUN mise trust && \
-    turbo prune @hashintel/petrinaut-cli --docker
+    turbo prune @local/petrinaut-python --docker
 
 
-FROM cli-tools AS cli-builder
+FROM bindings-tools AS bindings-builder
 
 WORKDIR /repo
 
@@ -44,32 +44,31 @@ RUN corepack enable
 
 # Install from dependency manifests first so source changes do not invalidate
 # the dependency layer.
-COPY --from=cli-pruner /repo/out/json/ ./
-COPY --from=cli-pruner /repo/out/yarn.lock ./yarn.lock
-COPY --from=cli-pruner /repo/out/full/.yarn ./.yarn
-COPY --from=cli-pruner /repo/out/full/turbo.json ./turbo.json
+COPY --from=bindings-pruner /repo/out/json/ ./
+COPY --from=bindings-pruner /repo/out/yarn.lock ./yarn.lock
+COPY --from=bindings-pruner /repo/out/full/.yarn ./.yarn
+COPY --from=bindings-pruner /repo/out/full/turbo.json ./turbo.json
 
 RUN --mount=type=cache,target=/root/.yarn/berry/cache \
     yarn install --immutable
 
-COPY --from=cli-pruner /repo/out/full/ ./
+COPY --from=bindings-pruner /repo/out/full/ ./
 
-RUN yarn workspace @hashintel/petrinaut-core build && \
-    yarn workspace @hashintel/petrinaut-cli build && \
-    yarn workspaces focus @hashintel/petrinaut-cli --production && \
-    find \
-      libs/@hashintel/petrinaut-core/dist \
-      libs/@hashintel/petrinaut-cli/dist \
-      -type f \( -name "*.d.ts" -o -name "*.map" \) -delete
+# The bindings declare their executable as a dependency, so building and
+# focusing on them pulls in whatever provides it. This service does not name
+# that package anywhere.
+RUN turbo run build --filter '@local/petrinaut-python...' && \
+    yarn workspaces focus @local/petrinaut-python --production && \
+    find libs -mindepth 3 -maxdepth 3 -type d \
+      \( -name src -o -name tests -o -name test-fixtures \) \
+      -exec rm -rf {} + && \
+    find libs -type f \( -name "*.d.ts" -o -name "*.map" \) -delete
 
 
-FROM scratch AS cli-runtime
+FROM scratch AS bindings-runtime
 
-COPY --from=cli-builder /repo/node_modules /node_modules
-COPY --from=cli-builder /repo/libs/@hashintel/petrinaut-core/package.json /libs/@hashintel/petrinaut-core/package.json
-COPY --from=cli-builder /repo/libs/@hashintel/petrinaut-core/dist /libs/@hashintel/petrinaut-core/dist
-COPY --from=cli-builder /repo/libs/@hashintel/petrinaut-cli/package.json /libs/@hashintel/petrinaut-cli/package.json
-COPY --from=cli-builder /repo/libs/@hashintel/petrinaut-cli/dist /libs/@hashintel/petrinaut-cli/dist
+COPY --from=bindings-builder /repo/node_modules /node_modules
+COPY --from=bindings-builder /repo/libs /libs
 
 
 FROM node:${NODE_VERSION}-bookworm-slim AS node-runtime
@@ -84,15 +83,18 @@ ENV PATH="/opt/venv/bin:${PATH}" \
     UV_LINK_MODE=copy \
     UV_PROJECT_ENVIRONMENT=/opt/venv
 
-WORKDIR /app
+WORKDIR /repo/apps/petrinaut-opt
 
 COPY --from=uv /uv /usr/local/bin/uv
 
-# Install locked Python dependencies independently from the application source
-# for better layer caching. The project itself is imported directly from /app.
+# Installs dependencies before the service's own source, so editing `src/`
+# reuses this layer. Editing the bindings does rebuild it, since they are part
+# of the environment. `--no-editable` builds them into the virtualenv, so the
+# runner needs the virtualenv alone and no source tree at a matching path.
 COPY apps/petrinaut-opt/pyproject.toml apps/petrinaut-opt/uv.lock ./
+COPY libs/@local/petrinaut-python /repo/libs/@local/petrinaut-python
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --no-dev --no-install-project
+    uv sync --frozen --no-dev --no-install-project --no-editable
 
 
 FROM python:${PYTHON_VERSION}-slim-bookworm AS runner
@@ -100,24 +102,25 @@ FROM python:${PYTHON_VERSION}-slim-bookworm AS runner
 ENV PATH="/opt/venv/bin:${PATH}" \
     PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
-    NODE_OPTIONS="--permission --allow-fs-read=/opt/petrinaut-cli --allow-fs-read=/usr/local/bin/petrinaut --disable-proto=throw --max-old-space-size=768 --no-addons --no-global-search-paths" \
-    PETRINAUT_CLI_NODE_OPTIONS="--permission --allow-fs-read=/opt/petrinaut-cli --allow-fs-read=/usr/local/bin/petrinaut --disable-proto=throw --max-old-space-size=768 --no-addons --no-global-search-paths"
+    PETRINAUT_CHILD_NODE_OPTIONS="--permission --allow-fs-read=/opt/petrinaut-runtime --allow-fs-read=/usr/local/bin/petrinaut --disable-proto=throw --max-old-space-size=768 --no-addons --no-global-search-paths"
 
 WORKDIR /app
 
-# Node is the only runtime from the Node image needed by the compiled CLI.
+# Node is what the bindings' executable runs on today.
 COPY --from=node-runtime /usr/local/bin/node /usr/local/bin/node
 COPY --from=python-deps /opt/venv /opt/venv
 
 COPY apps/petrinaut-opt/src ./src
 
-# Import the prepared CLI filesystem as one runtime artifact. It contains only
-# the focused production dependency graph and the two built workspace packages.
-COPY --from=cli-runtime / /opt/petrinaut-cli
+# The bindings' runtime: their focused production dependency graph and the
+# built workspace packages it resolves.
+COPY --from=bindings-runtime / /opt/petrinaut-runtime
 
-RUN chmod +x /opt/petrinaut-cli/libs/@hashintel/petrinaut-cli/dist/cli.js && \
-    ln -s /opt/petrinaut-cli/libs /libs && \
-    ln -s /opt/petrinaut-cli/libs/@hashintel/petrinaut-cli/dist/cli.js /usr/local/bin/petrinaut && \
+# `petrinaut` is the command the bindings spawn by default, and they give the
+# child a fixed PATH of /usr/local/bin:/usr/bin:/bin, so it is linked there.
+RUN chmod +x /opt/petrinaut-runtime/node_modules/.bin/petrinaut && \
+    ln -s /opt/petrinaut-runtime/libs /libs && \
+    ln -s /opt/petrinaut-runtime/node_modules/.bin/petrinaut /usr/local/bin/petrinaut && \
     groupadd --system petrinaut && \
     useradd --system --gid petrinaut --create-home petrinaut
 

--- a/apps/petrinaut-opt/openapi/openapi.json
+++ b/apps/petrinaut-opt/openapi/openapi.json
@@ -218,7 +218,7 @@
             }
           },
           "500": {
-            "description": "The CLI or optimization study could not initialize"
+            "description": "The session or optimization study could not initialize"
           }
         },
         "summary": "Post Optimize Runs"

--- a/apps/petrinaut-opt/package.json
+++ b/apps/petrinaut-opt/package.json
@@ -10,5 +10,8 @@
     "start": "uv run uvicorn src.optimization_api:app",
     "start:dev": "uv run uvicorn src.optimization_api:app --reload",
     "test:unit": "uv run pytest && yarn codegen && git diff --exit-code -- openapi/openapi.json"
+  },
+  "dependencies": {
+    "@local/petrinaut-python": "workspace:*"
   }
 }

--- a/apps/petrinaut-opt/pyproject.toml
+++ b/apps/petrinaut-opt/pyproject.toml
@@ -11,9 +11,13 @@ dependencies = [
     "opentelemetry-instrumentation-fastapi>=0.65b0",
     "opentelemetry-sdk>=1.44.0",
     "optuna>=3.6",
+    "petrinaut-python",
     "python-dotenv>=1.0.0",
     "uvicorn[standard]>=0.39.0",
 ]
+
+[tool.uv.sources]
+petrinaut-python = { path = "../../libs/@local/petrinaut-python", editable = true }
 
 [dependency-groups]
 dev = [

--- a/apps/petrinaut-opt/src/optimization_api.py
+++ b/apps/petrinaut-opt/src/optimization_api.py
@@ -19,11 +19,11 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from opentelemetry import trace
 from opentelemetry.propagate import extract
 from opentelemetry.trace import SpanKind, Status, StatusCode
+from petrinaut import OptimizationSession
 from starlette.background import BackgroundTask
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from src.optimization_runs import OptimizationRunRegistry, attachment_event_stream
-from src.petrinaut_client import PetrinautModel
 from src.petrinaut_optimizer import PetrinautOptimizer
 from src.telemetry import flush_telemetry, setup_telemetry
 from src.utils import Phase, RunStatus, StatusStore, set_status
@@ -49,7 +49,7 @@ _CREATE_RUN_RESPONSES = {
             },
         },
     },
-    500: {"description": "The CLI or optimization study could not initialize"},
+    500: {"description": "The session or optimization study could not initialize"},
 }
 _RUN_EVENTS_RESPONSES = {
     200: {
@@ -174,21 +174,18 @@ app.add_middleware(RequestBodyLimitMiddleware)
 setup_telemetry(app)
 
 
-def create_model(optimization_manifest: dict[str, Any]) -> PetrinautModel:
-    """Create the CLI adapter; retained as a narrow seam for API tests."""
-    return PetrinautModel(optimization_manifest)
-
-
 def initialize_optimizer(
     optimization_manifest: dict[str, Any],
 ) -> PetrinautOptimizer:
     """Start Petrinaut and build an Optuna study from its description."""
-    model = create_model(optimization_manifest)
+    model = OptimizationSession(optimization_manifest)
     try:
         model.start()
         return PetrinautOptimizer(model)
     except Exception:
-        model.close()
+        # A failure path, so signal rather than wait out the graceful EOF while
+        # still holding the admission slot.
+        model.close(graceful=False)
         raise
 
 
@@ -201,7 +198,7 @@ async def _acquire_optimization_slot(
     async with app.state.optimization_admission_lock:
         # One account drives at most one optimization at a time. Pending
         # creations are tracked separately because the run only appears in
-        # the registry once its CLI has initialized.
+        # the registry once its session has initialized.
         if account_id is not None and (
             account_id in app.state.optimization_pending_accounts
             or app.state.optimization_runs.has_live_run_for_account(account_id)
@@ -274,7 +271,7 @@ async def _initialize_admitted_optimizer(
         return await asyncio.shield(initializer)
     except asyncio.CancelledError:
         # Backstop for a second cancellation racing the recovery below: once
-        # the initializer finishes, close whatever CLI it started even if no
+        # the initializer finishes, close whatever session it started even if no
         # coroutine is left awaiting it. close() is idempotent, so the
         # awaited recovery close and this callback can coexist.
         def _close_abandoned_optimizer(task: asyncio.Task[PetrinautOptimizer]) -> None:
@@ -284,7 +281,7 @@ async def _initialize_admitted_optimizer(
                 target=task.result().pn_model.close,
                 kwargs={"graceful": False},
                 daemon=True,
-                name="petrinaut-abandoned-cli-close",
+                name="petrinaut-abandoned-session-close",
             ).start()
 
         initializer.add_done_callback(_close_abandoned_optimizer)
@@ -311,7 +308,7 @@ def _create_admitted_run_cleanup(
     stream, and again as the response's background task: when a client aborts
     before the response body is ever pulled, the never-started generators skip
     their ``finally`` blocks entirely, which would otherwise leak both the
-    admission slot and a live CLI process.
+    admission slot and a live session.
     """
     cleaned_up = False
 
@@ -321,7 +318,7 @@ def _create_admitted_run_cleanup(
             return
         cleaned_up = True
         try:
-            # No-op when the stream already closed the CLI; prompt when the
+            # No-op when the stream already closed the session; prompt when the
             # stream generators never ran at all.
             with suppress(Exception):
                 await asyncio.to_thread(optimizer.pn_model.close, graceful=False)
@@ -342,9 +339,9 @@ def _initialization_error(
         app,
         run_id,
         phase=Phase.error,
-        detail="Petrinaut CLI and Optimization Model could NOT be initialized",
+        detail="Petrinaut session and Optimization Model could NOT be initialized",
     )
-    # The error string can embed the CLI's first stderr line, which may quote a
+    # The error string can embed the backend's first diagnostic line, which may quote a
     # user identifier or expression error, so log a stable classification only.
     # The full message still goes back to the requester in the 500 detail.
     log.error(
@@ -395,7 +392,7 @@ async def _admit_and_initialize_run(
             request.app,
             run_id,
             phase=Phase.running,
-            detail="Petrinaut CLI and Optimization Model initialized",
+            detail="Petrinaut session and Optimization Model initialized",
         )
     except Exception as error:
         if optimizer is not None:

--- a/apps/petrinaut-opt/src/optimization_runs.py
+++ b/apps/petrinaut-opt/src/optimization_runs.py
@@ -1,19 +1,19 @@
 #!/usr/bin/env python3
 """Detached, reconnectable optimization runs.
 
-A detached run owns one admitted optimizer/CLI pair and drives its study from
+A detached run owns one admitted optimizer and session pair, and drives its study from
 a background task, appending every SSE frame body to an in-memory event log
 instead of an HTTP response. Consumers attach — and re-attach — over
 ``GET /optimize/runs/{run_id}/events`` with a cursor; disconnecting a consumer
 does not affect the run. The admission slot's lifetime equals the run's
-lifetime: the idempotent cleanup (prompt CLI close plus slot release) runs
+lifetime: the idempotent cleanup (prompt session close plus slot release) runs
 when the run reaches a terminal state or is cancelled/reaped, never when a
 consumer detaches.
 
 The event log holds one frame per completed trial plus a handful of control
 frames; it is bounded because the optimizer itself rejects study descriptions
 above ``MAX_STUDY_TRIALS`` (1000) trials — mirroring the optimization
-manifest contract — rather than trusting the CLI's reported trial count.
+manifest contract — rather than trusting the reported trial count.
 """
 
 from __future__ import annotations
@@ -301,7 +301,7 @@ class OptimizationRunRegistry:
         state = RunState.failed
         cancellation: asyncio.CancelledError | None = None
         # The pump records its outcome right before returning — ahead of its
-        # cancellable CLI-shutdown finally — so a cancellation landing in
+        # cancellable session-shutdown finally — so a cancellation landing in
         # that teardown window cannot relabel an already-decided study.
         recorded_outcomes: list[str] = []
         try:
@@ -318,7 +318,7 @@ class OptimizationRunRegistry:
             )
         except asyncio.CancelledError as error:
             # Service shutdown cancels the pump task; the pump's own finally
-            # already closed the CLI on its way out. Keep a decided outcome:
+            # already closed the session on its way out. Keep a decided outcome:
             # its terminal frame is already in the log, and appending a
             # cancelled frame after it would corrupt the replay.
             state = (

--- a/apps/petrinaut-opt/src/petrinaut_optimizer.py
+++ b/apps/petrinaut-opt/src/petrinaut_optimizer.py
@@ -181,9 +181,7 @@ class PetrinautOptimizer:
         description: Mapping[str, Any] | None = None,
         **sampler_options: Any,
     ) -> None:
-        raw_description = (
-            pn_model.describe_optimization() if description is None else description
-        )
+        raw_description = pn_model.describe() if description is None else description
         direction, sampler_name, n_trials, seed, parameters = _parse_description(
             raw_description
         )

--- a/apps/petrinaut-opt/src/petrinaut_optimizer.py
+++ b/apps/petrinaut-opt/src/petrinaut_optimizer.py
@@ -16,8 +16,8 @@ from typing import Any, Literal, TypeAlias, cast
 import optuna
 from opentelemetry import context as otel_context, trace
 from opentelemetry.trace import Span, Status, StatusCode
+from petrinaut import OptimizationSession, PetrinautRunError
 
-from src.petrinaut_client import PetrinautModel, PetrinautRunError
 from src.utils import Phase, set_status
 
 
@@ -32,7 +32,7 @@ SAMPLERS = {
 DEFAULT_STUDY_NAME = "opt_study"
 # The service-side mirror of the optimization manifest's trial cap; it also
 # bounds every run's in-memory event log to one frame per trial plus a
-# handful of control frames, even against a CLI reporting a huge study.
+# handful of control frames, even against a study reporting a huge trial count.
 MAX_STUDY_TRIALS = 1000
 MAX_STUDY_SECONDS_ENVIRONMENT_VARIABLE = "HASH_PETRINAUT_OPT_MAX_STUDY_SECONDS"
 DEFAULT_MAX_STUDY_SECONDS = 900.0
@@ -172,11 +172,11 @@ def _parse_description(
 
 
 class PetrinautOptimizer:
-    """Optimize the flat parameter descriptors supplied by Petrinaut CLI."""
+    """Optimize the flat parameter descriptors the bindings report."""
 
     def __init__(
         self,
-        pn_model: PetrinautModel,
+        pn_model: OptimizationSession,
         *,
         description: Mapping[str, Any] | None = None,
         **sampler_options: Any,
@@ -207,7 +207,7 @@ class PetrinautOptimizer:
         self.lock = threading.Lock()
 
     def suggest(self, trial: optuna.Trial) -> dict[str, Scalar]:
-        """Ask Optuna for each non-fixed scenario parameter described by the CLI."""
+        """Ask Optuna for each non-fixed scenario parameter the study describes."""
         values: dict[str, Scalar] = {}
         for parameter in self.parameters:
             identifier = cast(str, parameter["identifier"])
@@ -450,7 +450,7 @@ class PetrinautOptimizer:
                 await asyncio.to_thread(worker.join, _WORKER_SHUTDOWN_TIMEOUT_SECONDS)
                 if worker.is_alive():
                     log.error(
-                        "Petrinaut optimizer worker did not stop after CLI shutdown",
+                        "Petrinaut optimizer worker did not stop after session shutdown",
                         extra={"event": "worker_join_timeout", **log_context},
                     )
             finally:

--- a/apps/petrinaut-opt/tests/test_optimization_api.py
+++ b/apps/petrinaut-opt/tests/test_optimization_api.py
@@ -16,7 +16,7 @@ from src.optimization_runs import CANCELLED_FRAME, RunState
 
 
 class RecordingModel:
-    """Track how the CLI adapter is shut down."""
+    """Track how the session is shut down."""
 
     def __init__(self) -> None:
         self.close_calls: list[bool] = []
@@ -98,7 +98,7 @@ def test_initialization_failure_log_omits_the_raw_error_message(
     monkeypatch,
     caplog,
 ) -> None:
-    """The CLI error string can embed user content, so it must not be logged."""
+    """The backend error string can embed user content, so it must not be logged."""
     secret = "Petrinaut failed to load the optimization manifest: user_secret_xyz"
 
     def initialize(_manifest: dict[str, Any], **_kwargs: Any) -> FakeOptimizer:
@@ -199,7 +199,7 @@ def test_admitted_run_cleanup_releases_the_slot_exactly_once() -> None:
     assert optimizer.pn_model.close_calls == [False]  # type: ignore[attr-defined]
 
 
-def test_cancellation_during_initialization_closes_cli_and_releases_slot(
+def test_cancellation_during_initialization_closes_session_and_releases_slot(
     optimization_manifest: dict,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -244,11 +244,11 @@ def test_cancellation_during_initialization_closes_cli_and_releases_slot(
     assert test_app.state.active_optimizations == 0
 
 
-def test_second_cancellation_still_closes_an_abandoned_cli(
+def test_second_cancellation_still_closes_an_abandoned_session(
     optimization_manifest: dict,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A cancel racing the init-cancel recovery must not orphan the CLI."""
+    """A cancel racing the init-cancel recovery must not orphan the session."""
     test_app = _admitted_test_app(active_optimizations=1)
     optimizer = _optimizer_with_recording_model()
     started = threading.Event()
@@ -275,7 +275,7 @@ def test_second_cancellation_still_closes_an_abandoned_cli(
         finish.set()
         with pytest.raises(asyncio.CancelledError):
             await task
-        # The abandoned CLI is closed by the initializer's done-callback,
+        # The abandoned session is closed by the initializer's done-callback,
         # which hands off to a daemon thread.
         for _ in range(100):
             if optimizer.pn_model.close_calls:  # type: ignore[attr-defined]
@@ -438,7 +438,7 @@ def test_create_detached_run_returns_201_and_holds_the_slot_until_terminal(
             lambda: optimization_api.app.state.active_optimizations == 0
         )
         _wait_until(lambda: run.state is RunState.completed)
-        # The pump closed the CLI gracefully; the idempotent run cleanup adds
+        # The pump closed the session gracefully; the idempotent run cleanup adds
         # its prompt close, which the real adapter treats as a no-op.
         assert optimizer.pn_model.close_calls == [True, False]
 
@@ -622,7 +622,7 @@ def test_delete_cancels_a_detached_run_and_is_idempotent(
         assert run is not None
         assert run.state is RunState.cancelled
         assert run.events[-1] == (2, CANCELLED_FRAME)
-        # The pump closed the CLI promptly and the cleanup added its
+        # The pump closed the session promptly and the cleanup added its
         # idempotent prompt close; neither waited for a graceful EOF.
         assert optimizer.pn_model.close_calls == [False, False]
         assert optimization_api.app.state.active_optimizations == 0
@@ -789,7 +789,7 @@ def test_create_detached_run_reports_initialization_failure_with_the_run_id(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def initialize(_manifest: dict[str, Any], **_kwargs: Any) -> Any:
-        raise RuntimeError("manifest rejected by CLI")
+        raise RuntimeError("manifest rejected by the backend")
 
     monkeypatch.setattr(optimization_api, "initialize_optimizer", initialize)
 
@@ -802,11 +802,11 @@ def test_create_detached_run_reports_initialization_failure_with_the_run_id(
         run_status = client.get(f"/status/{run_id}")
 
     assert response.status_code == 500
-    assert "manifest rejected by CLI" in response.json()["detail"]
+    assert "manifest rejected by the backend" in response.json()["detail"]
     assert statuses.json() == [
         {
             "phase": "error",
-            "detail": "Petrinaut CLI and Optimization Model could NOT be initialized",
+            "detail": "Petrinaut session and Optimization Model could NOT be initialized",
             "updated_at": statuses.json()[0]["updated_at"],
             "run_id": run_id,
         }

--- a/apps/petrinaut-opt/tests/test_optimization_runs.py
+++ b/apps/petrinaut-opt/tests/test_optimization_runs.py
@@ -486,7 +486,7 @@ class SlowCloseStudyModel:
         self.close_release = threading.Event()
         self.close_calls: list[bool] = []
 
-    def describe_optimization(self) -> dict[str, Any]:
+    def describe(self) -> dict[str, Any]:
         return self.description
 
     def objective(self, _parameter_values: dict[str, Any]) -> float:

--- a/apps/petrinaut-opt/tests/test_optimization_runs.py
+++ b/apps/petrinaut-opt/tests/test_optimization_runs.py
@@ -99,7 +99,7 @@ class CompletedThenBlockedPumpOptimizer:
     """Pump double stuck in its (cancellable) teardown after deciding.
 
     Mirrors the real engine's shape: the done frame is appended and the
-    outcome recorded before the CLI-shutdown ``finally`` — a cancellable
+    outcome recorded before the session-shutdown ``finally`` — a cancellable
     window in which ``registry.shutdown()`` may land its cancellation.
     """
 
@@ -478,7 +478,7 @@ def test_shutdown_during_pump_teardown_keeps_the_decided_outcome() -> None:
 
 
 class SlowCloseStudyModel:
-    """Real-optimizer model whose CLI close blocks until released."""
+    """Real-optimizer model whose session close blocks until released."""
 
     def __init__(self, description: dict[str, Any]) -> None:
         self.description = description
@@ -498,7 +498,7 @@ class SlowCloseStudyModel:
         self.close_calls.append(graceful)
 
 
-def test_cancel_during_the_real_pumps_cli_close_keeps_completed(
+def test_cancel_during_the_real_pumps_session_close_keeps_completed(
     optimization_description: dict,
 ) -> None:
     """The real engine records its outcome before the cancellable close."""
@@ -514,7 +514,7 @@ def test_cancel_during_the_real_pumps_cli_close_keeps_completed(
         )
         try:
             # The study finishes, the done frame lands, then the pump blocks
-            # in its CLI-shutdown finally; cancel it right there.
+            # in its session-shutdown finally; cancel it right there.
             await asyncio.to_thread(model.close_started.wait, 2)
             assert run.task is not None
             run.task.cancel()

--- a/apps/petrinaut-opt/tests/test_petrinaut_optimizer.py
+++ b/apps/petrinaut-opt/tests/test_petrinaut_optimizer.py
@@ -10,9 +10,9 @@ from typing import Any
 import optuna
 import pytest
 from fastapi import FastAPI
+from petrinaut import PetrinautClientError, PetrinautRunError
 
 from src import petrinaut_optimizer
-from src.petrinaut_client import PetrinautClientError, PetrinautRunError
 from src.petrinaut_optimizer import PetrinautOptimizer
 from src.utils import Phase, StatusStore
 
@@ -61,7 +61,7 @@ class StubbornModel(FakeModel):
     def objective(self, parameter_values: dict[str, Any]) -> float:
         self.entered.set()
         self.release.wait()
-        raise PetrinautClientError("CLI closed")
+        raise PetrinautClientError("session closed")
 
 
 def test_maps_float_integer_step_and_boolean_descriptors_to_optuna(
@@ -136,7 +136,7 @@ def test_objective_propagates_transport_errors(
         optimizer.objective(trial)
 
 
-def test_uses_the_cli_supplied_seed_for_deterministic_sampling(
+def test_uses_the_session_supplied_seed_for_deterministic_sampling(
     optimization_description: dict,
 ) -> None:
     first = PetrinautOptimizer(  # type: ignore[arg-type]
@@ -155,7 +155,7 @@ def test_uses_the_cli_supplied_seed_for_deterministic_sampling(
         {"direction": "up"},
         {"study": {"trials": 0, "sampler": "random", "seed": 42}},
         # The service-side trial cap bounds every run's event log even when
-        # the CLI's reported study is huge.
+        # the reported study is huge.
         {
             "study": {
                 "trials": petrinaut_optimizer.MAX_STUDY_TRIALS + 1,
@@ -190,7 +190,7 @@ def test_uses_the_cli_supplied_seed_for_deterministic_sampling(
         },
     ],
 )
-def test_rejects_invalid_cli_descriptions(
+def test_rejects_invalid_session_descriptions(
     optimization_description: dict,
     change: dict[str, Any],
 ) -> None:

--- a/apps/petrinaut-opt/tests/test_petrinaut_optimizer.py
+++ b/apps/petrinaut-opt/tests/test_petrinaut_optimizer.py
@@ -26,7 +26,7 @@ class FakeModel:
         self.closed = False
         self.close_calls: list[bool] = []
 
-    def describe_optimization(self) -> dict[str, Any]:
+    def describe(self) -> dict[str, Any]:
         return self.description
 
     def objective(self, parameter_values: dict[str, Any]) -> float:

--- a/apps/petrinaut-opt/turbo.json
+++ b/apps/petrinaut-opt/turbo.json
@@ -2,7 +2,13 @@
   "extends": ["//"],
   "tasks": {
     "codegen": {
-      "inputs": ["pyproject.toml", "scripts/generate_openapi.py", "src/**"],
+      "inputs": [
+        "pyproject.toml",
+        "uv.lock",
+        "scripts/generate_openapi.py",
+        "src/**/*.py",
+        "../../libs/@local/petrinaut-python/src/**/*.py"
+      ],
       "outputs": ["openapi/openapi.json"],
       "passThroughEnv": ["UV_CACHE_DIR"]
     }

--- a/apps/petrinaut-opt/uv.lock
+++ b/apps/petrinaut-opt/uv.lock
@@ -968,6 +968,7 @@ dependencies = [
     { name = "opentelemetry-instrumentation-fastapi" },
     { name = "opentelemetry-sdk" },
     { name = "optuna" },
+    { name = "petrinaut-python" },
     { name = "python-dotenv" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -986,6 +987,7 @@ requires-dist = [
     { name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.65b0" },
     { name = "opentelemetry-sdk", specifier = ">=1.44.0" },
     { name = "optuna", specifier = ">=3.6" },
+    { name = "petrinaut-python", editable = "../../libs/@local/petrinaut-python" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.39.0" },
 ]
@@ -995,6 +997,16 @@ dev = [
     { name = "httpx", specifier = ">=0.28" },
     { name = "pytest", specifier = ">=8.3" },
 ]
+
+[[package]]
+name = "petrinaut-python"
+version = "0.1.0"
+source = { editable = "../../libs/@local/petrinaut-python" }
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8.3" }]
 
 [[package]]
 name = "pluggy"

--- a/libs/@hashintel/petrinaut-cli/README.md
+++ b/libs/@hashintel/petrinaut-cli/README.md
@@ -10,6 +10,10 @@ studies — lives in the architecture docs'
 [usage manual](../../@local/petrinaut-arch-docs/content/cli/usage-manual.mdx)
 (browse it rendered with `turbo run dev --filter @apps/petrinaut-docs`).
 
+The [`@local/petrinaut-python`](../../@local/petrinaut-python/README.md)
+bindings drive this CLI from Python: sessions, run requests, and optimization
+studies.
+
 Build the CLI, then serve a model saved from the editor:
 
 ```bash

--- a/libs/@local/petrinaut-python/LICENSE-APACHE.md
+++ b/libs/@local/petrinaut-python/LICENSE-APACHE.md
@@ -1,0 +1,189 @@
+# Apache License
+
+_Version 2.0, January 2004_
+_&lt;<http://www.apache.org/licenses/>&gt;_
+
+### Terms and Conditions for use, reproduction, and distribution
+
+#### 1. Definitions
+
+“License” shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+“Licensor” shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+“Legal Entity” shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, “control” means **(i)** the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or **(ii)** ownership of fifty percent (50%) or more of the
+outstanding shares, or **(iii)** beneficial ownership of such entity.
+
+“You” (or “Your”) shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+“Source” form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+“Object” form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object code,
+generated documentation, and conversions to other media types.
+
+“Work” shall mean the work of authorship, whether in Source or Object form, made
+available under the License, as indicated by a copyright notice that is included
+in or attached to the work (an example is provided in the Appendix below).
+
+“Derivative Works” shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+“Contribution” shall mean any work of authorship, including the original version
+of the Work and any modifications or additions to that Work or Derivative Works
+thereof, that is intentionally submitted to Licensor for inclusion in the Work
+by the copyright owner or by an individual or Legal Entity authorized to submit
+on behalf of the copyright owner. For the purposes of this definition,
+“submitted” means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, the Licensor for
+the purpose of discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing by the copyright
+owner as “Not a Contribution.”
+
+“Contributor” shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+#### 2. Grant of Copyright License
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the Work and such
+Derivative Works in Source or Object form.
+
+#### 3. Grant of Patent License
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable (except as stated in this section) patent license to make, have
+made, use, offer to sell, sell, import, and otherwise transfer the Work, where
+such license applies only to those patent claims licensable by such Contributor
+that are necessarily infringed by their Contribution(s) alone or by combination
+of their Contribution(s) with the Work to which such Contribution(s) was
+submitted. If You institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work or a
+Contribution incorporated within the Work constitutes direct or contributory
+patent infringement, then any patent licenses granted to You under this License
+for that Work shall terminate as of the date such litigation is filed.
+
+#### 4. Redistribution
+
+You may reproduce and distribute copies of the Work or Derivative Works thereof
+in any medium, with or without modifications, and in Source or Object form,
+provided that You meet the following conditions:
+
+- **(a)** You must give any other recipients of the Work or Derivative Works a copy of
+  this License; and
+- **(b)** You must cause any modified files to carry prominent notices stating that You
+  changed the files; and
+- **(c)** You must retain, in the Source form of any Derivative Works that You distribute,
+  all copyright, patent, trademark, and attribution notices from the Source form
+  of the Work, excluding those notices that do not pertain to any part of the
+  Derivative Works; and
+- **(d)** If the Work includes a “NOTICE” text file as part of its distribution, then any
+  Derivative Works that You distribute must include a readable copy of the
+  attribution notices contained within such NOTICE file, excluding those notices
+  that do not pertain to any part of the Derivative Works, in at least one of the
+  following places: within a NOTICE text file distributed as part of the
+  Derivative Works; within the Source form or documentation, if provided along
+  with the Derivative Works; or, within a display generated by the Derivative
+  Works, if and wherever such third-party notices normally appear. The contents of
+  the NOTICE file are for informational purposes only and do not modify the
+  License. You may add Your own attribution notices within Derivative Works that
+  You distribute, alongside or as an addendum to the NOTICE text from the Work,
+  provided that such additional attribution notices cannot be construed as
+  modifying the License.
+
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a whole,
+provided Your use, reproduction, and distribution of the Work otherwise complies
+with the conditions stated in this License.
+
+#### 5. Submission of Contributions
+
+Unless You explicitly state otherwise, any Contribution intentionally submitted
+for inclusion in the Work by You to the Licensor shall be under the terms and
+conditions of this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify the terms of
+any separate license agreement you may have executed with Licensor regarding
+such Contributions.
+
+#### 6. Trademarks
+
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+#### 7. Disclaimer of Warranty
+
+Unless required by applicable law or agreed to in writing, Licensor provides the
+Work (and each Contributor provides its Contributions) on an “AS IS” BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+including, without limitation, any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
+solely responsible for determining the appropriateness of using or
+redistributing the Work and assume any risks associated with Your exercise of
+permissions under this License.
+
+#### 8. Limitation of Liability
+
+In no event and under no legal theory, whether in tort (including negligence),
+contract, or otherwise, unless required by applicable law (such as deliberate
+and grossly negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special, incidental,
+or consequential damages of any character arising as a result of this License or
+out of the use or inability to use the Work (including but not limited to
+damages for loss of goodwill, work stoppage, computer failure or malfunction, or
+any and all other commercial damages or losses), even if such Contributor has
+been advised of the possibility of such damages.
+
+#### 9. Accepting Warranty or Additional Liability
+
+While redistributing the Work or Derivative Works thereof, You may choose to
+offer, and charge a fee for, acceptance of support, warranty, indemnity, or
+other liability obligations and/or rights consistent with this License. However,
+in accepting such obligations, You may act only on Your own behalf and on Your
+sole responsibility, not on behalf of any other Contributor, and only if You
+agree to indemnify, defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.
+
+_END OF TERMS AND CONDITIONS_
+
+### APPENDIX: Apply the Apache License to a specific file
+
+To apply the Apache License to an individual file, attach the following notice.
+The text should be enclosed in the appropriate comment syntax for the file
+format.
+
+    Copyright © 2025–, HASH
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.

--- a/libs/@local/petrinaut-python/LICENSE-MIT.md
+++ b/libs/@local/petrinaut-python/LICENSE-MIT.md
@@ -1,0 +1,21 @@
+# MIT License
+
+Copyright © 2025–, HASH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/libs/@local/petrinaut-python/LICENSE.md
+++ b/libs/@local/petrinaut-python/LICENSE.md
@@ -1,0 +1,3 @@
+# License
+
+Licensed under either of the [Apache License, Version 2.0](LICENSE-APACHE.md) or [MIT license](LICENSE-MIT.md) at your option.

--- a/libs/@local/petrinaut-python/README.md
+++ b/libs/@local/petrinaut-python/README.md
@@ -60,7 +60,7 @@ from petrinaut import OptimizationSession
 
 # `OptimizationSession(manifest_path=...)` reads the manifest from disk instead.
 with OptimizationSession(manifest) as session:
-    description = session.describe_optimization()
+    description = session.describe()
     value = session.objective({"production_rate": 112.5, "enabled": True})
     full = session.evaluate({"production_rate": 112.5, "enabled": True})
     # full["replicates"] carries per-seed objectives when the manifest

--- a/libs/@local/petrinaut-python/README.md
+++ b/libs/@local/petrinaut-python/README.md
@@ -1,0 +1,91 @@
+# `@local/petrinaut-python`
+
+Python bindings for the [Petrinaut CLI](../../@hashintel/petrinaut-cli): run
+simulations and drive optimization studies against a compiled Petrinaut model
+from Python, over the CLI's JSON-lines stdio protocol.
+
+The package is internal to this monorepo and is consumed as a uv path
+dependency (`apps/petrinaut-opt` is the reference consumer). It has no
+third-party runtime dependencies and is **POSIX-only**: it relies on process
+groups and descriptor polling.
+
+Each session owns one long-lived `petrinaut serve` child process for one
+model. The child runs with a scrubbed environment, its own process group, and
+size- and time-bounded reads; protocol errors close the session, while
+per-request error frames raise `PetrinautRunError` and leave it usable.
+
+## Running a model
+
+```python
+from petrinaut import PetrinautSession
+
+with PetrinautSession.from_model_file("./sir-model.json") as session:
+    metadata = session.metadata()
+    result = session.run(
+        {
+            "parameters": {"infection_rate": 1.5, "recovery_rate": 0.8},
+            "initialState": {"Susceptible": 990, "Infected": 10, "Recovered": 0},
+            "metrics": ["Infected Fraction"],
+            "maxSteps": 100,
+            "dt": 0.1,
+            "seed": 4242,
+        }
+    )
+    print(result["metrics"]["Infected Fraction"])
+```
+
+`PetrinautSession.from_model(model_dict)` sends a model object over stdin
+instead of a file path, useful for read-only containers. The generic
+`session.request(method, params)` escape hatch reaches any protocol method.
+
+By default the child command is `petrinaut` on the child's fixed `PATH`
+(`/usr/local/bin:/usr/bin:/bin`), which is how the deployed image provides it.
+In a checkout, build the CLI (`turbo --filter @hashintel/petrinaut-cli build`)
+and either link its `bin` onto that `PATH` or point at the built bundle
+explicitly:
+
+```python
+import shutil
+
+session = PetrinautSession.from_model_file(
+    "./sir-model.json",
+    command=(shutil.which("node"), "libs/@hashintel/petrinaut-cli/dist/cli.js"),
+)
+```
+
+## Running an optimization study
+
+```python
+from petrinaut import OptimizationSession
+
+# `OptimizationSession(manifest_path=...)` reads the manifest from disk instead.
+with OptimizationSession(manifest) as session:
+    description = session.describe_optimization()
+    value = session.objective({"production_rate": 112.5, "enabled": True})
+    full = session.evaluate({"production_rate": 112.5, "enabled": True})
+    # full["replicates"] carries per-seed objectives when the manifest
+    # sets execution.seedsPerTrial above 1.
+```
+
+The manifest is opaque to Python: the CLI owns scenario compilation,
+fixed-value injection, simulation, and metric evaluation. The manifest
+contract, protocol, and seeded-runs semantics are documented in the
+[CLI usage manual](../petrinaut-arch-docs/content/cli/usage-manual.mdx).
+
+## Timeouts and limits
+
+- Bootstrap (spawn to readiness) and each protocol response have deadlines,
+  `BOOTSTRAP_TIMEOUT_SECONDS` and `PROTOCOL_READ_TIMEOUT_SECONDS`. Both are
+  constructor options.
+- Bootstrap and protocol lines are capped at `MAX_BOOTSTRAP_LINE_BYTES` and
+  `MAX_PROTOCOL_LINE_BYTES`.
+- A session serves one request at a time and is not synchronized: issue requests
+  from one thread. `close()` may be called from another.
+- `close(graceful=False)` signals the child's process group immediately;
+  the graceful default first waits for an EOF-driven exit.
+
+## Tests
+
+`turbo run test:unit --filter @local/petrinaut-python` builds the CLI bundle
+first, so the end-to-end tests run; a plain `uv run pytest` skips them when the
+bundle is missing.

--- a/libs/@local/petrinaut-python/package.json
+++ b/libs/@local/petrinaut-python/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@local/petrinaut-python",
+  "version": "0.0.0-private",
+  "private": true,
+  "description": "Python bindings for the Petrinaut CLI",
+  "license": "(MIT OR Apache-2.0)",
+  "scripts": {
+    "install:deps": "uv sync",
+    "test:unit": "uv run pytest"
+  },
+  "dependencies": {
+    "@hashintel/petrinaut-cli": "workspace:*"
+  }
+}

--- a/libs/@local/petrinaut-python/pyproject.toml
+++ b/libs/@local/petrinaut-python/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name            = "petrinaut-python"
+version         = "0.1.0"
+description     = "Python bindings for the Petrinaut CLI: run simulations and optimization studies from Python"
+readme          = "README.md"
+requires-python = ">=3.10"
+dependencies    = []
+
+[dependency-groups]
+dev = ["pytest>=8.3"]
+
+[build-system]
+requires      = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/petrinaut"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/libs/@local/petrinaut-python/src/petrinaut/__init__.py
+++ b/libs/@local/petrinaut-python/src/petrinaut/__init__.py
@@ -1,0 +1,21 @@
+"""Python bindings for the Petrinaut CLI.
+
+Run simulations and drive optimization studies against a compiled Petrinaut
+model from Python, over the CLI's JSON-lines stdio protocol.
+"""
+
+from .errors import (
+    PetrinautClientError,
+    PetrinautProtocolError,
+    PetrinautRunError,
+)
+from .optimization import OptimizationSession
+from .session import PetrinautSession
+
+__all__ = [
+    "OptimizationSession",
+    "PetrinautClientError",
+    "PetrinautProtocolError",
+    "PetrinautRunError",
+    "PetrinautSession",
+]

--- a/libs/@local/petrinaut-python/src/petrinaut/__init__.py
+++ b/libs/@local/petrinaut-python/src/petrinaut/__init__.py
@@ -2,6 +2,11 @@
 
 Run simulations and drive optimization studies against a compiled Petrinaut
 model from Python, over the CLI's JSON-lines stdio protocol.
+
+A session is a client for one `petrinaut serve` child process that the session
+itself owns: it spawns the child for one model (or one optimization manifest),
+serializes requests to it, and shuts it down. "Session" rather than "client"
+because the object carries that lifecycle, not just the wire format.
 """
 
 from .errors import (

--- a/libs/@local/petrinaut-python/src/petrinaut/errors.py
+++ b/libs/@local/petrinaut-python/src/petrinaut/errors.py
@@ -1,0 +1,19 @@
+"""Exception types raised by the Petrinaut CLI bindings."""
+
+from __future__ import annotations
+
+
+class PetrinautClientError(RuntimeError):
+    """The Petrinaut process or its transport is no longer usable."""
+
+
+class PetrinautProtocolError(PetrinautClientError):
+    """The Petrinaut process returned an invalid protocol response."""
+
+
+class PetrinautRunError(RuntimeError):
+    """One request failed while the session remains usable.
+
+    Raised when the CLI answers a request with an error frame, and by
+    ``OptimizationSession.objective`` when the objective value is not finite.
+    """

--- a/libs/@local/petrinaut-python/src/petrinaut/optimization.py
+++ b/libs/@local/petrinaut-python/src/petrinaut/optimization.py
@@ -46,9 +46,13 @@ class OptimizationSession(PetrinautSession):
             **options,
         )
 
-    def describe_optimization(self) -> dict[str, Any]:
+    def describe(self) -> dict[str, Any]:
         """Return the CLI-owned Optuna study and parameter description."""
         return self._request_object("optimization.describe")
+
+    # The previous name; prefer `describe()`, which maps 1:1 to the protocol's
+    # `optimization.describe` and reads without repeating the class name.
+    describe_optimization = describe
 
     def evaluate(self, parameter_values: Mapping[str, Any]) -> dict[str, Any]:
         """Evaluate one trial and return the whole result frame.

--- a/libs/@local/petrinaut-python/src/petrinaut/optimization.py
+++ b/libs/@local/petrinaut-python/src/petrinaut/optimization.py
@@ -1,0 +1,76 @@
+"""Session variant for manifest-driven optimization studies."""
+
+from __future__ import annotations
+
+import math
+import os
+from collections.abc import Mapping
+from typing import Any
+
+from .errors import PetrinautRunError
+from .session import PetrinautSession, _encode_bootstrap_line
+
+
+class OptimizationSession(PetrinautSession):
+    """Own one CLI process initialized with an opaque optimization manifest.
+
+    The manifest is serialized to the CLI's first stdin line (or read by the
+    CLI itself when ``manifest_path`` is given). The CLI owns every
+    Petrinaut-specific concern: fixed-value injection, scenario compilation,
+    simulation, and metric evaluation.
+    """
+
+    def __init__(
+        self,
+        optimization_manifest: Mapping[str, Any] | None = None,
+        *,
+        manifest_path: str | os.PathLike[str] | None = None,
+        **options: Any,
+    ) -> None:
+        if (optimization_manifest is None) == (manifest_path is None):
+            raise ValueError(
+                "provide exactly one of optimization_manifest or manifest_path"
+            )
+        if manifest_path is not None:
+            serve_arguments = ("--optimization", os.fspath(manifest_path), "--stdio")
+            bootstrap_line = None
+        else:
+            serve_arguments = ("--optimization-stdin", "--stdio")
+            bootstrap_line = _encode_bootstrap_line(
+                optimization_manifest, "optimization manifest"
+            )
+        super().__init__(
+            serve_arguments=serve_arguments,
+            bootstrap_line=bootstrap_line,
+            source_label="optimization manifest",
+            **options,
+        )
+
+    def describe_optimization(self) -> dict[str, Any]:
+        """Return the CLI-owned Optuna study and parameter description."""
+        return self._request_object("optimization.describe")
+
+    def evaluate(self, parameter_values: Mapping[str, Any]) -> dict[str, Any]:
+        """Evaluate one trial and return the whole result frame.
+
+        Carries per-seed ``replicates`` when the manifest asks for more than one
+        seed per trial.
+        """
+        return self._request_object(
+            "optimization.evaluate",
+            {"parameterValues": dict(parameter_values)},
+        )
+
+    def objective(self, parameter_values: Mapping[str, Any]) -> float:
+        """Evaluate one trial and return its finite scalar objective."""
+        result = self.evaluate(parameter_values)
+        objective = result.get("objective")
+        if (
+            isinstance(objective, bool)
+            or not isinstance(objective, (int, float))
+            or not math.isfinite(objective)
+        ):
+            raise PetrinautRunError(
+                "Petrinaut optimization objective is not a finite number"
+            )
+        return float(objective)

--- a/libs/@local/petrinaut-python/src/petrinaut/session.py
+++ b/libs/@local/petrinaut-python/src/petrinaut/session.py
@@ -52,13 +52,19 @@ def _child_environment() -> dict[str, str]:
 
 
 def _encode_bootstrap_line(payload: Mapping[str, Any], label: str) -> str:
-    """Serialize a stdin-provided model or manifest, enforcing the line cap."""
+    """Serialize a stdin-provided model or manifest, enforcing the line cap.
+
+    Raises ``TypeError`` for a payload that will not serialize to JSON and
+    ``ValueError`` for one over the line cap: both are caller input, found
+    before any process exists, so they are not ``PetrinautClientError``,
+    which means a session's process or transport is gone.
+    """
     try:
         line = json.dumps(dict(payload), ensure_ascii=False, separators=(",", ":"))
     except (TypeError, ValueError) as error:
-        raise PetrinautClientError(f"the {label} is not valid JSON: {error}") from error
+        raise TypeError(f"the {label} is not JSON-serializable: {error}") from error
     if len(line.encode("utf-8")) > MAX_BOOTSTRAP_LINE_BYTES:
-        raise PetrinautClientError(
+        raise ValueError(
             f"the {label} exceeds the {MAX_BOOTSTRAP_LINE_BYTES // _MIB} MiB limit"
         )
     return line
@@ -207,7 +213,9 @@ class PetrinautSession:
         Raises :class:`PetrinautRunError` when the CLI answers with an error
         frame (the session stays usable), and :class:`PetrinautClientError` /
         :class:`PetrinautProtocolError` when the transport or protocol breaks
-        (the session is closed).
+        (the session is closed). ``params`` that will not serialize to JSON
+        raise :class:`TypeError` before anything is written, leaving the
+        session usable.
         """
         return self._exchange(method, params)
 
@@ -316,19 +324,22 @@ class PetrinautSession:
             )
 
         request_id = self._next_id
-        self._next_id += 1
         request: dict[str, Any] = {"id": request_id, "method": method}
         if params is not None:
             request["params"] = dict(params)
 
         # Encoded before anything is sent: a params value that cannot be
-        # serialized is the caller's bug, and must not close a healthy session.
+        # serialized is the caller's bug, so it is a TypeError — not a
+        # PetrinautClientError, which would claim a healthy session is gone.
+        # The id is consumed only once encoding succeeds, so a request that
+        # was never written leaves no gap in the id sequence.
         try:
             payload = (json.dumps(request, separators=(",", ":")) + "\n").encode()
         except (TypeError, ValueError) as error:
-            raise PetrinautClientError(
+            raise TypeError(
                 f"{method} params are not JSON-serializable: {error}"
             ) from error
+        self._next_id += 1
 
         try:
             process.stdin.write(payload)

--- a/libs/@local/petrinaut-python/src/petrinaut/session.py
+++ b/libs/@local/petrinaut-python/src/petrinaut/session.py
@@ -1,10 +1,17 @@
-#!/usr/bin/env python3
-"""Small stdio client for the Petrinaut optimization CLI protocol."""
+"""One Petrinaut CLI process, spoken to over JSON lines on stdio.
+
+A session owns one long-lived ``petrinaut serve`` child process for one model
+(or one optimization manifest, see :mod:`petrinaut.optimization`). The child
+is spawned with a scrubbed environment and its own process group, requests are
+written one JSON object per line, and every read is size- and time-bounded.
+
+POSIX only: the session signals process groups with ``os.killpg`` and polls
+descriptors with ``select.select``.
+"""
 
 from __future__ import annotations
 
 import json
-import math
 import os
 import select
 import signal
@@ -14,17 +21,23 @@ import time
 from collections.abc import Callable, Mapping, Sequence
 from typing import Any
 
+from .errors import (
+    PetrinautClientError,
+    PetrinautProtocolError,
+    PetrinautRunError,
+)
 
-MAX_MANIFEST_BYTES = 8 * 1024 * 1024
-MAX_PROTOCOL_LINE_BYTES = 8 * 1024 * 1024
+_MIB = 1024 * 1024
+MAX_BOOTSTRAP_LINE_BYTES = 8 * _MIB
+MAX_PROTOCOL_LINE_BYTES = 8 * _MIB
 BOOTSTRAP_TIMEOUT_SECONDS = 25
 PROTOCOL_READ_TIMEOUT_SECONDS = 240
 PROCESS_SHUTDOWN_TIMEOUT_SECONDS = 5
-_STDERR_DRAIN_CHUNK_BYTES = 64 * 1024
+_READ_CHUNK_BYTES = 64 * 1024
 
 
 def _child_environment() -> dict[str, str]:
-    """Avoid exposing the API process's credentials to model expressions."""
+    """Avoid exposing the calling process's credentials to model expressions."""
     environment = {
         "PATH": "/usr/local/bin:/usr/bin:/bin",
         "LANG": "C.UTF-8",
@@ -32,31 +45,46 @@ def _child_environment() -> dict[str, str]:
         "NO_COLOR": "1",
         "TZ": "UTC",
     }
-    node_options = os.environ.get("PETRINAUT_CLI_NODE_OPTIONS", "").strip()
+    node_options = os.environ.get("PETRINAUT_CHILD_NODE_OPTIONS", "").strip()
     if node_options:
         environment["NODE_OPTIONS"] = node_options
     return environment
 
 
-class PetrinautClientError(RuntimeError):
-    """The Petrinaut process or its transport is no longer usable."""
+def _encode_bootstrap_line(payload: Mapping[str, Any], label: str) -> str:
+    """Serialize a stdin-provided model or manifest, enforcing the line cap."""
+    try:
+        line = json.dumps(dict(payload), ensure_ascii=False, separators=(",", ":"))
+    except (TypeError, ValueError) as error:
+        raise PetrinautClientError(f"the {label} is not valid JSON: {error}") from error
+    if len(line.encode("utf-8")) > MAX_BOOTSTRAP_LINE_BYTES:
+        raise PetrinautClientError(
+            f"the {label} exceeds the {MAX_BOOTSTRAP_LINE_BYTES // _MIB} MiB limit"
+        )
+    return line
 
 
-class PetrinautProtocolError(PetrinautClientError):
-    """The Petrinaut process returned an invalid protocol response."""
+class PetrinautSession:
+    """Own one CLI process serving one compiled Petrinaut model.
 
+    Construct through a classmethod naming the model source::
 
-class PetrinautRunError(RuntimeError):
-    """One optimization evaluation failed while the CLI remains usable."""
+        with PetrinautSession.from_model_file("./sir-model.json") as session:
+            metadata = session.metadata()
+            result = session.run({"maxSteps": 100, "seed": 42})
 
-
-class PetrinautModel:
-    """Own one CLI process initialized with an opaque optimization manifest."""
+    ``command`` defaults to the ``petrinaut`` executable on the child's fixed
+    ``PATH``; pass an absolute command (for example
+    ``(shutil.which("node"), cli_path)``) when the CLI lives elsewhere.
+    ``popen_factory`` lets tests substitute the spawned process.
+    """
 
     def __init__(
         self,
-        optimization_manifest: Mapping[str, Any],
         *,
+        serve_arguments: Sequence[str],
+        bootstrap_line: str | None = None,
+        source_label: str = "model",
         command: Sequence[str] = ("petrinaut",),
         popen_factory: Callable[..., Any] = subprocess.Popen,
         bootstrap_timeout_seconds: float = BOOTSTRAP_TIMEOUT_SECONDS,
@@ -67,8 +95,10 @@ class PetrinautModel:
         if bootstrap_timeout_seconds <= 0 or request_timeout_seconds <= 0:
             raise ValueError("Petrinaut timeouts must be positive")
 
-        self.optimization_manifest = dict(optimization_manifest)
         self.command = tuple(command)
+        self._serve_arguments = tuple(serve_arguments)
+        self._bootstrap_line = bootstrap_line
+        self._source_label = source_label
         self._popen_factory = popen_factory
         self._bootstrap_timeout_seconds = bootstrap_timeout_seconds
         self._request_timeout_seconds = request_timeout_seconds
@@ -79,7 +109,33 @@ class PetrinautModel:
         self._stderr_buffer = bytearray()
         self._stderr_thread: threading.Thread | None = None
 
-    def __enter__(self) -> PetrinautModel:
+    # Static rather than classmethods: a subclass serving a manifest has its
+    # own constructor, and routing through `cls` would reach it with no
+    # source. A classmethod would also read as a subclass constructor on
+    # `OptimizationSession.from_model_file(...)` while returning a base
+    # session; a staticmethod makes no such promise.
+    @staticmethod
+    def from_model_file(
+        path: str | os.PathLike[str], **options: Any
+    ) -> "PetrinautSession":
+        """Serve a model JSON file (``petrinaut serve --model <path> --stdio``)."""
+        return PetrinautSession(
+            serve_arguments=("--model", os.fspath(path), "--stdio"),
+            **options,
+        )
+
+    @staticmethod
+    def from_model(
+        model: Mapping[str, Any], **options: Any
+    ) -> "PetrinautSession":
+        """Serve a model object sent as the first stdin line (``--model-stdin``)."""
+        return PetrinautSession(
+            serve_arguments=("--model-stdin", "--stdio"),
+            bootstrap_line=_encode_bootstrap_line(model, "model"),
+            **options,
+        )
+
+    def __enter__(self) -> "PetrinautSession":
         self.start()
         return self
 
@@ -87,33 +143,13 @@ class PetrinautModel:
         self.close()
 
     def start(self) -> None:
-        """Launch the CLI and provide its optimization manifest over stdin."""
-        try:
-            manifest = json.dumps(
-                self.optimization_manifest,
-                ensure_ascii=False,
-                separators=(",", ":"),
-            )
-        except (TypeError, ValueError) as error:
-            raise PetrinautClientError(
-                f"the optimization manifest is not valid JSON: {error}"
-            ) from error
-        if len(manifest.encode("utf-8")) > MAX_MANIFEST_BYTES:
-            raise PetrinautClientError(
-                "the optimization manifest exceeds the 8 MiB limit"
-            )
-
+        """Launch the CLI and wait for its readiness line on stderr."""
         with self._state_lock:
             if self._process is not None:
                 return
             try:
                 process = self._popen_factory(
-                    [
-                        *self.command,
-                        "serve",
-                        "--optimization-stdin",
-                        "--stdio",
-                    ],
+                    [*self.command, "serve", *self._serve_arguments],
                     stdin=subprocess.PIPE,
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
@@ -134,13 +170,14 @@ class PetrinautModel:
             raise PetrinautClientError("the Petrinaut CLI pipes are unavailable")
 
         try:
-            process.stdin.write((manifest + "\n").encode())
-            process.stdin.flush()
+            if self._bootstrap_line is not None:
+                process.stdin.write((self._bootstrap_line + "\n").encode())
+                process.stdin.flush()
             status = self._readline(
                 process.stderr,
                 self._stderr_buffer,
                 timeout_seconds=self._bootstrap_timeout_seconds,
-                description="Petrinaut optimization bootstrap",
+                description="Petrinaut bootstrap",
             ).strip()
         except (BrokenPipeError, OSError, ValueError, PetrinautClientError) as error:
             self.close(graceful=False)
@@ -152,7 +189,7 @@ class PetrinautModel:
             details = status.strip() or f"process exited with code {process.poll()}"
             self.close(graceful=False)
             raise PetrinautClientError(
-                f"Petrinaut failed to load the optimization manifest: {details}"
+                f"Petrinaut failed to load the {self._source_label}: {details}"
             )
 
         self._stderr_buffer.clear()
@@ -163,6 +200,37 @@ class PetrinautModel:
             name="petrinaut-stderr-drain",
         )
         self._stderr_thread.start()
+
+    def request(self, method: str, params: Mapping[str, Any] | None = None) -> Any:
+        """Send one protocol request and return its ``result``.
+
+        Raises :class:`PetrinautRunError` when the CLI answers with an error
+        frame (the session stays usable), and :class:`PetrinautClientError` /
+        :class:`PetrinautProtocolError` when the transport or protocol breaks
+        (the session is closed).
+        """
+        return self._exchange(method, params)
+
+    def healthz(self) -> dict[str, Any]:
+        """Liveness check; returns ``{"ok": True}``."""
+        return self._request_object("healthz")
+
+    def metadata(self) -> dict[str, Any]:
+        """The compiled model's parameters, places, and metrics."""
+        return self._request_object("metadata")
+
+    def run(self, params: Mapping[str, Any]) -> dict[str, Any]:
+        """Run one simulation; ``params`` is the CLI's run config."""
+        return self._request_object("run", params)
+
+    def _request_object(
+        self, method: str, params: Mapping[str, Any] | None = None
+    ) -> dict[str, Any]:
+        result = self._exchange(method, params)
+        if not isinstance(result, dict):
+            self.close(graceful=False)
+            raise PetrinautProtocolError(f"{method} returned a non-object result")
+        return result
 
     @staticmethod
     def _fallback_readline(stream: Any, maximum_bytes: int) -> bytes:
@@ -181,13 +249,11 @@ class PetrinautModel:
         description: str,
     ) -> str:
         """Read one size- and time-bounded UTF-8 protocol line."""
-        try:
-            descriptor = stream.fileno()
-        except (AttributeError, OSError, ValueError):
-            line = self._fallback_readline(stream, MAX_PROTOCOL_LINE_BYTES)
+
+        def decode(line: bytes) -> str:
             if len(line) > MAX_PROTOCOL_LINE_BYTES:
                 raise PetrinautProtocolError(
-                    f"{description} exceeded the 8 MiB line limit"
+                    f"{description} exceeded the {MAX_PROTOCOL_LINE_BYTES // _MIB} MiB line limit"
                 )
             try:
                 return line.decode("utf-8")
@@ -196,16 +262,23 @@ class PetrinautModel:
                     f"{description} was not valid UTF-8"
                 ) from error
 
+        try:
+            descriptor = stream.fileno()
+        except (AttributeError, OSError, ValueError):
+            return decode(self._fallback_readline(stream, MAX_PROTOCOL_LINE_BYTES))
+
         deadline = time.monotonic() + timeout_seconds
         while True:
             newline = buffer.find(b"\n")
             if newline >= 0:
                 line = bytes(buffer[: newline + 1])
                 del buffer[: newline + 1]
-                break
+                return decode(line)
+            # Checked before the next read, so an unterminated line cannot grow
+            # the buffer without bound.
             if len(buffer) > MAX_PROTOCOL_LINE_BYTES:
                 raise PetrinautProtocolError(
-                    f"{description} exceeded the 8 MiB line limit"
+                    f"{description} exceeded the {MAX_PROTOCOL_LINE_BYTES // _MIB} MiB line limit"
                 )
 
             remaining = deadline - time.monotonic()
@@ -214,28 +287,20 @@ class PetrinautModel:
             ready, _, _ = select.select([descriptor], [], [], remaining)
             if not ready:
                 raise PetrinautClientError(f"{description} timed out")
-            chunk = os.read(descriptor, _STDERR_DRAIN_CHUNK_BYTES)
+            chunk = os.read(descriptor, _READ_CHUNK_BYTES)
             if not chunk:
+                # EOF with no newline: whatever arrived is the last line.
                 line = bytes(buffer)
                 buffer.clear()
-                break
+                return decode(line)
             buffer.extend(chunk)
-
-        if len(line) > MAX_PROTOCOL_LINE_BYTES:
-            raise PetrinautProtocolError(f"{description} exceeded the 8 MiB line limit")
-        try:
-            return line.decode("utf-8")
-        except UnicodeDecodeError as error:
-            raise PetrinautProtocolError(
-                f"{description} was not valid UTF-8"
-            ) from error
 
     @staticmethod
     def _drain_stderr(stream: Any) -> None:
         """Prevent CLI diagnostics from filling and blocking its stderr pipe."""
         while True:
             try:
-                chunk = stream.read(_STDERR_DRAIN_CHUNK_BYTES)
+                chunk = stream.read(_READ_CHUNK_BYTES)
             except (OSError, ValueError):
                 return
             if not chunk:
@@ -256,10 +321,17 @@ class PetrinautModel:
         if params is not None:
             request["params"] = dict(params)
 
+        # Encoded before anything is sent: a params value that cannot be
+        # serialized is the caller's bug, and must not close a healthy session.
         try:
-            process.stdin.write(
-                (json.dumps(request, separators=(",", ":")) + "\n").encode()
-            )
+            payload = (json.dumps(request, separators=(",", ":")) + "\n").encode()
+        except (TypeError, ValueError) as error:
+            raise PetrinautClientError(
+                f"{method} params are not JSON-serializable: {error}"
+            ) from error
+
+        try:
+            process.stdin.write(payload)
             process.stdin.flush()
             line = self._readline(
                 process.stdout,
@@ -267,18 +339,14 @@ class PetrinautModel:
                 timeout_seconds=self._request_timeout_seconds,
                 description="Petrinaut protocol response",
             )
-        except PetrinautProtocolError:
+        except (PetrinautProtocolError, PetrinautClientError):
+            # Already says which limit or deadline was hit; keep that message.
             self.close(graceful=False)
             raise
-        except (
-            BrokenPipeError,
-            OSError,
-            ValueError,
-            PetrinautClientError,
-        ) as error:
+        except (BrokenPipeError, OSError, ValueError) as error:
             self.close(graceful=False)
             raise PetrinautClientError(
-                "failed to communicate with the Petrinaut CLI"
+                f"failed to communicate with the Petrinaut CLI: {type(error).__name__}"
             ) from error
 
         if not line:
@@ -319,38 +387,6 @@ class PetrinautModel:
             )
         return response["result"]
 
-    def describe_optimization(self) -> dict[str, Any]:
-        """Return the CLI-owned Optuna study and parameter description."""
-        result = self._exchange("optimization.describe")
-        if not isinstance(result, dict):
-            self.close(graceful=False)
-            raise PetrinautProtocolError(
-                "optimization.describe returned a non-object result"
-            )
-        return result
-
-    def objective(self, parameter_values: Mapping[str, Any]) -> float:
-        """Evaluate one flat set of Optuna-proposed scenario parameter values."""
-        result = self._exchange(
-            "optimization.evaluate",
-            {"parameterValues": dict(parameter_values)},
-        )
-        if not isinstance(result, dict):
-            self.close(graceful=False)
-            raise PetrinautProtocolError(
-                "optimization.evaluate returned a non-object result"
-            )
-        objective = result.get("objective")
-        if (
-            isinstance(objective, bool)
-            or not isinstance(objective, (int, float))
-            or not math.isfinite(objective)
-        ):
-            raise PetrinautRunError(
-                "Petrinaut optimization objective is not a finite number"
-            )
-        return float(objective)
-
     @staticmethod
     def _signal_process(process: Any, signal_number: signal.Signals) -> None:
         """Signal the isolated process group, falling back for test doubles."""
@@ -372,11 +408,10 @@ class PetrinautModel:
         """Terminate the owned CLI process; safe to call repeatedly.
 
         A busy CLI only observes stdin EOF between protocol requests, so the
-        graceful EOF wait is reserved for shutdowns after a study finished and
-        the CLI is idle. Cancellation, timeouts, and failure paths must pass
-        ``graceful=False`` so the process group is signalled immediately and
-        optimizer capacity is released promptly instead of after the full
-        shutdown timeout.
+        graceful EOF wait is reserved for shutdowns while the CLI is idle.
+        Cancellation, timeouts, and failure paths must pass ``graceful=False``
+        so the process group is signalled immediately instead of after the
+        full shutdown timeout.
         """
         with self._state_lock:
             process = self._process

--- a/libs/@local/petrinaut-python/tests/conftest.py
+++ b/libs/@local/petrinaut-python/tests/conftest.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import io
+import json
+from typing import Any
+
+import pytest
+
+
+class FakeProcess:
+    """An in-memory stand-in for the spawned CLI process."""
+
+    def __init__(self, responses: list[dict[str, Any]]) -> None:
+        self.stdin = io.BytesIO()
+        self.stdout = io.BytesIO(
+            "".join(json.dumps(response) + "\n" for response in responses).encode()
+        )
+        self.stderr = io.BytesIO(b"Petrinaut stdio ready for model <stdin>\n")
+        self.returncode: int | None = None
+
+    def poll(self) -> int | None:
+        return self.returncode
+
+    def wait(self, timeout: float | None = None) -> int:
+        self.returncode = 0
+        return 0
+
+    def terminate(self) -> None:
+        self.returncode = -15
+
+    def kill(self) -> None:
+        self.returncode = -9
+
+
+def spawn(process: FakeProcess) -> dict[str, Any]:
+    """Record the command and keyword arguments a session spawns with."""
+    invocation: dict[str, Any] = {}
+
+    def popen_factory(command: list[str], **kwargs: Any) -> FakeProcess:
+        invocation["command"] = command
+        invocation["kwargs"] = kwargs
+        return process
+
+    invocation["popen_factory"] = popen_factory
+    return invocation
+
+
+@pytest.fixture
+def optimization_manifest() -> dict:
+    """The bindings treat this document as opaque JSON; the CLI owns its schema."""
+    return {
+        "kind": "petrinaut-optimization",
+        "version": 1,
+        "model": {
+            "title": "Example",
+            "definition": {
+                "scenarios": [{"id": "baseline"}],
+                "metrics": [{"id": "profit", "code": "return 1;"}],
+            },
+        },
+        "scenario": {
+            "id": "baseline",
+            "parameterBindings": {
+                "rate": {
+                    "kind": "optimize",
+                    "minimum": 0.1,
+                    "maximum": 2.0,
+                    "scale": "log",
+                },
+                "capacity": {"kind": "fixed", "value": 100},
+            },
+        },
+        "objective": {"metricId": "profit", "direction": "maximize"},
+    }
+
+
+@pytest.fixture
+def optimization_description() -> dict:
+    return {
+        "direction": "maximize",
+        "study": {"trials": 3, "sampler": "random", "seed": 42},
+        "parameters": [
+            {
+                "identifier": "rate",
+                "type": "float",
+                "default": 0.5,
+                "minimum": 0.1,
+                "maximum": 2.0,
+                "scale": "log",
+            },
+            {
+                "identifier": "count",
+                "type": "int",
+                "default": 4,
+                "minimum": 2,
+                "maximum": 8,
+                "step": 2,
+                "scale": "linear",
+            },
+            {
+                "identifier": "enabled",
+                "type": "boolean",
+                "default": True,
+            },
+        ],
+    }

--- a/libs/@local/petrinaut-python/tests/test_e2e_cli.py
+++ b/libs/@local/petrinaut-python/tests/test_e2e_cli.py
@@ -67,7 +67,7 @@ def test_evaluates_an_optimization_manifest_end_to_end() -> None:
         manifest_path=SUPPLY_CHAIN_OPTIMIZATION,
         command=(str(NODE), str(CLI_BUNDLE)),
     ) as session:
-        description = session.describe_optimization()
+        description = session.describe()
         assert description["direction"] == "maximize"
 
         parameters = {

--- a/libs/@local/petrinaut-python/tests/test_e2e_cli.py
+++ b/libs/@local/petrinaut-python/tests/test_e2e_cli.py
@@ -1,0 +1,92 @@
+"""End-to-end tests against the real built CLI bundle.
+
+These spawn `node dist/cli.js`, so they need the CLI built and `node` on the
+path. `turbo run test:unit --filter @local/petrinaut-python` builds the bundle
+through the workspace dependency; plain `uv run pytest` skips these tests when
+the bundle or `node` is missing.
+"""
+
+from __future__ import annotations
+
+import math
+import shutil
+from pathlib import Path
+
+import pytest
+
+from petrinaut import OptimizationSession, PetrinautSession
+
+REPO_LIBS = Path(__file__).resolve().parents[3]
+CLI_BUNDLE = REPO_LIBS / "@hashintel/petrinaut-cli/dist/cli.js"
+CLI_FIXTURES = REPO_LIBS / "@hashintel/petrinaut-cli/test-fixtures"
+SIR_MODEL = CLI_FIXTURES / "sir-model.json"
+SUPPLY_CHAIN_OPTIMIZATION = CLI_FIXTURES / "supply-chain-profit-optimization.json"
+NODE = shutil.which("node")
+
+pytestmark = pytest.mark.skipif(
+    not CLI_BUNDLE.exists() or NODE is None,
+    reason="requires the built Petrinaut CLI bundle and node",
+)
+
+
+def test_runs_the_sir_model_end_to_end() -> None:
+    request = {
+        "parameters": {"infection_rate": 1.5, "recovery_rate": 0.8},
+        "initialState": {
+            "Susceptible": 990,
+            "Infected": 10,
+            "Recovered": 0,
+        },
+        "metrics": ["Infected Fraction"],
+        "maxSteps": 50,
+        "dt": 0.1,
+        "seed": 4242,
+    }
+    with PetrinautSession.from_model_file(
+        SIR_MODEL,
+        command=(str(NODE), str(CLI_BUNDLE)),
+    ) as session:
+        assert session.healthz() == {"ok": True}
+
+        metadata = session.metadata()
+        metric_names = {metric["name"] for metric in metadata["metrics"]}
+        assert "Infected Fraction" in metric_names
+
+        result = session.run(request)
+        assert result["status"] == "complete"
+        assert result["seed"] == 4242
+        assert 0 <= result["metrics"]["Infected Fraction"] <= 1
+
+        # The same seed reproduces the same trajectory.
+        repeat = session.run(request)
+        assert repeat["metrics"] == result["metrics"]
+
+
+def test_evaluates_an_optimization_manifest_end_to_end() -> None:
+    with OptimizationSession(
+        manifest_path=SUPPLY_CHAIN_OPTIMIZATION,
+        command=(str(NODE), str(CLI_BUNDLE)),
+    ) as session:
+        description = session.describe_optimization()
+        assert description["direction"] == "maximize"
+
+        parameters = {
+            parameter["identifier"]: parameter
+            for parameter in description["parameters"]
+        }
+        assert parameters["production_rate"]["type"] == "float"
+        assert parameters["production_rate"]["minimum"] == 20
+        assert parameters["production_rate"]["maximum"] == 250
+        assert parameters["reorder_threshold"]["type"] == "int"
+
+        result = session.evaluate(
+            {
+                "production_rate": 100,
+                "reorder_threshold": 120,
+                "batch_size": 180,
+                "selling_price": 34,
+                "expedite_fraction": 0.25,
+                "marketing_spend": 40,
+            }
+        )
+        assert math.isfinite(result["objective"])

--- a/libs/@local/petrinaut-python/tests/test_optimization_session.py
+++ b/libs/@local/petrinaut-python/tests/test_optimization_session.py
@@ -11,40 +11,14 @@ from typing import Any
 
 import pytest
 
-from src import petrinaut_client
-from src.petrinaut_client import (
+from conftest import FakeProcess, spawn
+from petrinaut import (
+    OptimizationSession,
     PetrinautClientError,
-    PetrinautModel,
     PetrinautProtocolError,
     PetrinautRunError,
 )
-
-
-class FakeProcess:
-    def __init__(self, responses: list[dict[str, Any]]) -> None:
-        self.stdin = io.BytesIO()
-        self.stdout = io.BytesIO(
-            "".join(json.dumps(response) + "\n" for response in responses).encode()
-        )
-        self.stderr = io.BytesIO(b"Petrinaut stdio ready for optimization\n")
-        self.returncode: int | None = None
-        self.terminated = False
-        self.killed = False
-
-    def poll(self) -> int | None:
-        return self.returncode
-
-    def wait(self, timeout: float | None = None) -> int:
-        self.returncode = 0
-        return 0
-
-    def terminate(self) -> None:
-        self.terminated = True
-        self.returncode = -15
-
-    def kill(self) -> None:
-        self.killed = True
-        self.returncode = -9
+from petrinaut import session as petrinaut_session
 
 
 def test_bootstraps_an_opaque_manifest_and_uses_optimization_methods(
@@ -53,24 +27,19 @@ def test_bootstraps_an_opaque_manifest_and_uses_optimization_methods(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "must-not-leak")
-    monkeypatch.setenv("PETRINAUT_CLI_NODE_OPTIONS", "--max-old-space-size=768")
+    monkeypatch.setenv("PETRINAUT_CHILD_NODE_OPTIONS", "--max-old-space-size=768")
     process = FakeProcess(
         [
             {"id": 1, "result": optimization_description},
             {"id": 2, "result": {"objective": 12.5}},
         ]
     )
-    invocation: dict[str, Any] = {}
+    invocation = spawn(process)
 
-    def popen_factory(command: list[str], **kwargs: Any) -> FakeProcess:
-        invocation["command"] = command
-        invocation["kwargs"] = kwargs
-        return process
-
-    model = PetrinautModel(
+    model = OptimizationSession(
         optimization_manifest,
         command=("node", "/cli.js"),
-        popen_factory=popen_factory,
+        popen_factory=invocation["popen_factory"],
     )
     model.start()
 
@@ -109,22 +78,67 @@ def test_bootstraps_an_opaque_manifest_and_uses_optimization_methods(
     assert process.returncode == 0
 
 
-def test_bootstrap_and_protocol_reads_use_bounded_defaults(
+def test_optimization_session_from_a_manifest_file(
+    optimization_description: dict,
+) -> None:
+    process = FakeProcess([{"id": 1, "result": optimization_description}])
+    invocation = spawn(process)
+    session = OptimizationSession(
+        manifest_path="./optimize.json",
+        popen_factory=invocation["popen_factory"],
+    )
+    session.start()
+
+    assert session.describe_optimization() == optimization_description
+    assert invocation["command"] == [
+        "petrinaut",
+        "serve",
+        "--optimization",
+        "./optimize.json",
+        "--stdio",
+    ]
+    lines = process.stdin.getvalue().splitlines()
+    assert json.loads(lines[0]) == {"id": 1, "method": "optimization.describe"}
+    session.close()
+
+
+def test_optimization_session_requires_exactly_one_source(
     optimization_manifest: dict,
 ) -> None:
-    model = PetrinautModel(optimization_manifest)
+    with pytest.raises(ValueError, match="exactly one"):
+        OptimizationSession(optimization_manifest, manifest_path="./optimize.json")
+    with pytest.raises(ValueError, match="exactly one"):
+        OptimizationSession()
 
-    assert model._bootstrap_timeout_seconds == 25
-    assert model._request_timeout_seconds == 240
+
+def test_evaluate_returns_the_full_result_including_replicates(
+    optimization_manifest: dict,
+) -> None:
+    full_result = {
+        "objective": 12.5,
+        "replicates": [
+            {"seed": 42, "objective": 12.0},
+            {"seed": 7, "objective": 13.0},
+        ],
+    }
+    process = FakeProcess([{"id": 1, "result": full_result}])
+    invocation = spawn(process)
+    session = OptimizationSession(
+        optimization_manifest, popen_factory=invocation["popen_factory"]
+    )
+    session.start()
+
+    assert session.evaluate({"rate": 1.25}) == full_result
+    session.close()
 
 
 def test_bootstrap_timeout_terminates_a_stuck_process(
     optimization_manifest: dict,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(petrinaut_client, "PROCESS_SHUTDOWN_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(petrinaut_session, "PROCESS_SHUTDOWN_TIMEOUT_SECONDS", 0.05)
     script = "import sys, time; sys.stdin.readline(); time.sleep(60)"
-    model = PetrinautModel(
+    model = OptimizationSession(
         optimization_manifest,
         command=(sys.executable, "-c", script),
         bootstrap_timeout_seconds=0.05,
@@ -141,7 +155,7 @@ def test_protocol_timeout_terminates_a_stuck_process(
     optimization_manifest: dict,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(petrinaut_client, "PROCESS_SHUTDOWN_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(petrinaut_session, "PROCESS_SHUTDOWN_TIMEOUT_SECONDS", 0.05)
     script = """
 import sys
 import time
@@ -151,7 +165,7 @@ sys.stderr.flush()
 sys.stdin.readline()
 time.sleep(60)
 """
-    model = PetrinautModel(
+    model = OptimizationSession(
         optimization_manifest,
         command=(sys.executable, "-c", script),
         request_timeout_seconds=0.05,
@@ -159,7 +173,9 @@ time.sleep(60)
     model.start()
 
     started_at = time.monotonic()
-    with pytest.raises(PetrinautClientError, match="failed to communicate"):
+    # The deadline names itself rather than collapsing into a generic
+    # transport failure, so an operator can tell a stall from a broken pipe.
+    with pytest.raises(PetrinautClientError, match="protocol response timed out"):
         model.describe_optimization()
 
     assert time.monotonic() - started_at < 2
@@ -171,12 +187,12 @@ def test_rejects_an_oversized_protocol_line(
 ) -> None:
     process = FakeProcess([])
     process.stdout = io.BytesIO(b'{"id":1,"result":{}}\n')
-    model = PetrinautModel(
+    model = OptimizationSession(
         optimization_manifest,
         popen_factory=lambda *_args, **_kwargs: process,
     )
     model.start()
-    monkeypatch.setattr(petrinaut_client, "MAX_PROTOCOL_LINE_BYTES", 8)
+    monkeypatch.setattr(petrinaut_session, "MAX_PROTOCOL_LINE_BYTES", 8)
 
     with pytest.raises(PetrinautProtocolError, match="line limit"):
         model.describe_optimization()
@@ -199,7 +215,7 @@ def test_drains_stderr_after_the_ready_line(
     process.stderr = TrackingStream(
         b"Petrinaut stdio ready for optimization\ndiagnostic\n"
     )
-    model = PetrinautModel(
+    model = OptimizationSession(
         optimization_manifest,
         popen_factory=lambda *_args, **_kwargs: process,
     )
@@ -223,11 +239,11 @@ def test_close_signals_the_isolated_process_group(
     process.wait = wait  # type: ignore[method-assign]
     signals: list[tuple[int, signal.Signals]] = []
     monkeypatch.setattr(
-        petrinaut_client.os,
+        petrinaut_session.os,
         "killpg",
         lambda pid, sent_signal: signals.append((pid, sent_signal)),
     )
-    model = PetrinautModel(
+    model = OptimizationSession(
         optimization_manifest,
         popen_factory=lambda *_args, **_kwargs: process,
     )
@@ -256,13 +272,13 @@ def test_prompt_close_signals_the_group_before_any_shutdown_wait(
 
     process.wait = wait  # type: ignore[method-assign]
     monkeypatch.setattr(
-        petrinaut_client.os,
+        petrinaut_session.os,
         "killpg",
         lambda _pid, sent_signal: events.append(
             f"killpg:{signal.Signals(sent_signal).name}"
         ),
     )
-    model = PetrinautModel(
+    model = OptimizationSession(
         optimization_manifest,
         popen_factory=lambda *_args, **_kwargs: process,
     )
@@ -286,7 +302,7 @@ sys.stderr.flush()
 while True:
     time.sleep(0.1)
 """
-    model = PetrinautModel(
+    model = OptimizationSession(
         optimization_manifest,
         command=(sys.executable, "-c", script),
     )
@@ -307,7 +323,7 @@ def test_cli_error_during_evaluation_is_recoverable(
             {"id": 2, "result": {"objective": 7}},
         ]
     )
-    model = PetrinautModel(
+    model = OptimizationSession(
         optimization_manifest,
         popen_factory=lambda *_args, **_kwargs: process,
     )
@@ -326,7 +342,7 @@ def test_rejects_a_non_finite_numeric_objective(
     objective: Any,
 ) -> None:
     process = FakeProcess([{"id": 1, "result": {"objective": objective}}])
-    model = PetrinautModel(
+    model = OptimizationSession(
         optimization_manifest,
         popen_factory=lambda *_args, **_kwargs: process,
     )
@@ -342,7 +358,7 @@ def test_rejects_a_mismatched_protocol_response(
     optimization_manifest: dict,
 ) -> None:
     process = FakeProcess([{"id": 99, "result": {"objective": 12.5}}])
-    model = PetrinautModel(
+    model = OptimizationSession(
         optimization_manifest,
         popen_factory=lambda *_args, **_kwargs: process,
     )

--- a/libs/@local/petrinaut-python/tests/test_optimization_session.py
+++ b/libs/@local/petrinaut-python/tests/test_optimization_session.py
@@ -43,7 +43,9 @@ def test_bootstraps_an_opaque_manifest_and_uses_optimization_methods(
     )
     model.start()
 
-    assert model.describe_optimization() == optimization_description
+    assert model.describe() == optimization_description
+    # The previous name stays as an alias.
+    assert OptimizationSession.describe_optimization is OptimizationSession.describe
     assert model.objective({"rate": 1.25, "count": 6, "enabled": False}) == 12.5
     lines = [json.loads(line) for line in process.stdin.getvalue().splitlines()]
 
@@ -89,7 +91,7 @@ def test_optimization_session_from_a_manifest_file(
     )
     session.start()
 
-    assert session.describe_optimization() == optimization_description
+    assert session.describe() == optimization_description
     assert invocation["command"] == [
         "petrinaut",
         "serve",
@@ -176,7 +178,7 @@ time.sleep(60)
     # The deadline names itself rather than collapsing into a generic
     # transport failure, so an operator can tell a stall from a broken pipe.
     with pytest.raises(PetrinautClientError, match="protocol response timed out"):
-        model.describe_optimization()
+        model.describe()
 
     assert time.monotonic() - started_at < 2
 
@@ -195,7 +197,7 @@ def test_rejects_an_oversized_protocol_line(
     monkeypatch.setattr(petrinaut_session, "MAX_PROTOCOL_LINE_BYTES", 8)
 
     with pytest.raises(PetrinautProtocolError, match="line limit"):
-        model.describe_optimization()
+        model.describe()
 
     assert process.returncode == 0
     model.close()

--- a/libs/@local/petrinaut-python/tests/test_session.py
+++ b/libs/@local/petrinaut-python/tests/test_session.py
@@ -122,3 +122,31 @@ def test_request_reaches_any_protocol_method() -> None:
         "params": {"key": "value"},
     }
     session.close()
+
+
+def test_unserializable_params_raise_type_error_and_leave_the_session_usable() -> None:
+    process = FakeProcess([{"id": 1, "result": {"ok": True}}])
+    invocation = spawn(process)
+    session = PetrinautSession.from_model_file(
+        "./model.json",
+        command=("node", "/cli.js"),
+        popen_factory=invocation["popen_factory"],
+    )
+    session.start()
+
+    with pytest.raises(TypeError, match="not JSON-serializable"):
+        session.request("run", {"bad": object()})
+
+    # The caller's bug must not have closed the healthy session.
+    assert session.healthz() == {"ok": True}
+    session.close()
+
+
+def test_unserializable_model_raises_type_error_before_spawning() -> None:
+    with pytest.raises(TypeError, match="not JSON-serializable"):
+        PetrinautSession.from_model({"bad": object()})
+
+
+def test_oversized_model_raises_value_error_before_spawning() -> None:
+    with pytest.raises(ValueError, match="MiB limit"):
+        PetrinautSession.from_model({"blob": "x" * (9 * 1024 * 1024)})

--- a/libs/@local/petrinaut-python/tests/test_session.py
+++ b/libs/@local/petrinaut-python/tests/test_session.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from conftest import FakeProcess, spawn
+from petrinaut import (
+    PetrinautProtocolError,
+    PetrinautRunError,
+    PetrinautSession,
+)
+
+
+def test_model_file_session_serves_run_metadata_and_healthz() -> None:
+    process = FakeProcess(
+        [
+            {"id": 1, "result": {"ok": True}},
+            {"id": 2, "result": {"parameters": [], "places": [], "metrics": []}},
+            {"id": 3, "result": {"seed": 42, "metrics": {"Metric": 1.5}}},
+        ]
+    )
+    invocation = spawn(process)
+    session = PetrinautSession.from_model_file(
+        "./model.json",
+        command=("node", "/cli.js"),
+        popen_factory=invocation["popen_factory"],
+    )
+    session.start()
+
+    assert session.healthz() == {"ok": True}
+    assert session.metadata() == {"parameters": [], "places": [], "metrics": []}
+    assert session.run({"maxSteps": 10, "seed": 42})["metrics"] == {"Metric": 1.5}
+
+    assert invocation["command"] == [
+        "node",
+        "/cli.js",
+        "serve",
+        "--model",
+        "./model.json",
+        "--stdio",
+    ]
+    lines = [json.loads(line) for line in process.stdin.getvalue().splitlines()]
+    # A file source writes no bootstrap line: the first stdin line is a request.
+    assert lines[0] == {"id": 1, "method": "healthz"}
+    assert lines[2] == {
+        "id": 3,
+        "method": "run",
+        "params": {"maxSteps": 10, "seed": 42},
+    }
+    session.close()
+
+
+def test_model_stdin_session_writes_the_model_as_the_bootstrap_line() -> None:
+    process = FakeProcess([{"id": 1, "result": {"ok": True}}])
+    invocation = spawn(process)
+    session = PetrinautSession.from_model(
+        {"title": "Example", "places": []},
+        command=("node", "/cli.js"),
+        popen_factory=invocation["popen_factory"],
+    )
+    session.start()
+    assert session.healthz() == {"ok": True}
+
+    assert invocation["command"] == [
+        "node",
+        "/cli.js",
+        "serve",
+        "--model-stdin",
+        "--stdio",
+    ]
+    lines = [json.loads(line) for line in process.stdin.getvalue().splitlines()]
+    assert lines[0] == {"title": "Example", "places": []}
+    assert lines[1] == {"id": 1, "method": "healthz"}
+    session.close()
+
+
+def test_an_error_frame_raises_but_keeps_the_session_usable() -> None:
+    process = FakeProcess(
+        [
+            {"id": 1, "error": {"message": 'Unknown parameter "x"'}},
+            {"id": 2, "result": {"ok": True}},
+        ]
+    )
+    invocation = spawn(process)
+    session = PetrinautSession.from_model_file(
+        "./model.json", popen_factory=invocation["popen_factory"]
+    )
+    session.start()
+
+    with pytest.raises(PetrinautRunError, match='Unknown parameter "x"'):
+        session.run({"maxSteps": 1, "parameters": {"x": 1}})
+    assert session.healthz() == {"ok": True}
+    session.close()
+
+
+def test_a_non_object_result_is_a_protocol_error() -> None:
+    process = FakeProcess([{"id": 1, "result": 42}])
+    invocation = spawn(process)
+    session = PetrinautSession.from_model_file(
+        "./model.json", popen_factory=invocation["popen_factory"]
+    )
+    session.start()
+
+    with pytest.raises(PetrinautProtocolError, match="non-object result"):
+        session.healthz()
+
+
+def test_request_reaches_any_protocol_method() -> None:
+    process = FakeProcess([{"id": 1, "result": [1, 2, 3]}])
+    invocation = spawn(process)
+    session = PetrinautSession.from_model_file(
+        "./model.json", popen_factory=invocation["popen_factory"]
+    )
+    session.start()
+
+    assert session.request("custom.method", {"key": "value"}) == [1, 2, 3]
+    lines = [json.loads(line) for line in process.stdin.getvalue().splitlines()]
+    assert lines[0] == {
+        "id": 1,
+        "method": "custom.method",
+        "params": {"key": "value"},
+    }
+    session.close()

--- a/libs/@local/petrinaut-python/uv.lock
+++ b/libs/@local/petrinaut-python/uv.lock
@@ -1,0 +1,156 @@
+version = 1
+revision = 3
+requires-python = ">=3.10"
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
+name = "petrinaut-python"
+version = "0.1.0"
+source = { editable = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8.3" }]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]

--- a/yarn.lock
+++ b/yarn.lock
@@ -860,6 +860,8 @@ __metadata:
 "@apps/petrinaut-opt@workspace:*, @apps/petrinaut-opt@workspace:apps/petrinaut-opt":
   version: 0.0.0-use.local
   resolution: "@apps/petrinaut-opt@workspace:apps/petrinaut-opt"
+  dependencies:
+    "@local/petrinaut-python": "workspace:*"
   languageName: unknown
   linkType: soft
 
@@ -9470,6 +9472,14 @@ __metadata:
     rimraf: "npm:6.1.3"
     typescript: "npm:5.9.3"
     vitest: "npm:4.1.10"
+  languageName: unknown
+  linkType: soft
+
+"@local/petrinaut-python@workspace:*, @local/petrinaut-python@workspace:libs/@local/petrinaut-python":
+  version: 0.0.0-use.local
+  resolution: "@local/petrinaut-python@workspace:libs/@local/petrinaut-python"
+  dependencies:
+    "@hashintel/petrinaut-cli": "workspace:*"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

`apps/petrinaut-opt` carried its own Petrinaut CLI client, private to that service and covering two of the CLI's five protocol methods. This PR extracts the client into a package any Python code can use, and removes the service's knowledge of the CLI.

Bottom of stack #9269; FE-1467 (#9261) sits above.

Most of the diff is a move: `petrinaut_client.py` → `session.py`.

## 🔗 Related links

- [FE-1270](https://linear.app/hash/issue/FE-1270/create-python-bindings-to-petrinaut-core) *(internal)*: this PR

## 🔍 What does this change?

**New package `libs/@local/petrinaut-python`** (import name `petrinaut`), internal to the monorepo:

- `PetrinautSession` runs one model per CLI process and exposes `healthz()`, `metadata()`, `run()`, and `request()`.
- `OptimizationSession` drives a study over a manifest it treats as opaque JSON: `describe()`, `evaluate()`, `objective()`.
- Process handling is unchanged from the old client: scrubbed child environment, bounded reads with deadlines, process-group shutdown. Errors split into `PetrinautRunError` (recoverable) and `PetrinautClientError`/`PetrinautProtocolError` (session closes).

**`apps/petrinaut-opt` depends on the bindings and nothing else.** It no longer names the CLI in code, tests, docs, configuration, or the image:

- The bindings declare `@hashintel/petrinaut-cli` as a runtime dependency, so the Docker image provisions the bindings' closure (`turbo prune @local/petrinaut-python`) and links the closure's `petrinaut` executable into `/usr/local/bin`. The image ships built output only.
- `uv sync --no-editable` builds the bindings into the virtualenv, so the runner copies the virtualenv alone.
- The Node-options passthrough is renamed `PETRINAUT_CHILD_NODE_OPTIONS`; the image's own `NODE_OPTIONS` never reached the child and is removed.
- FE-1414 (#9230) adds the architecture check that enforces this: `optimizer → python-bindings` with no edge to `cli`.

**Review fixes.** `from_model_file` and `from_model` are staticmethods rather than classmethods: they always build a base `PetrinautSession`, and a classmethod read as a subclass constructor on `OptimizationSession` while returning the base class. `PetrinautRunError`'s docstring now also names the non-finite-objective case, and a doubled sentence in the README's development instructions is fixed.

Two follow-up commits address the remaining review threads:

- `describe_optimization()` is renamed to `describe()`: the old name repeated the class name, its siblings `evaluate()`/`objective()` carry no prefix, and `describe()` maps 1:1 to the protocol's `optimization.describe`. The previous name remains as an alias.
- Caller-input bugs no longer raise `PetrinautClientError`, whose contract says the session's process or transport is gone: `params` or a bootstrap payload that will not serialize to JSON raise `TypeError`, and a payload over the 8 MiB line cap raises `ValueError` — all before anything is written, leaving the session untouched (the request id is only consumed after a successful encode). Raised by Cursor and in review.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] modifies a workspace but **not** a publishable library. `@local/petrinaut-python` is private.

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] require changes to docs which **are made** as part of this PR: the package README and both consumers' READMEs. In-app user-guide behaviour is unchanged.

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] affected the execution graph, and the `turbo.json`'s have been updated to reflect this: the bindings' `test:unit` depends on the CLI's `build`, and `petrinaut-opt`'s codegen inputs include the bindings' `*.py` sources.

## 🛡 What tests cover this?

- Bindings: every test from the deleted `test_petrinaut_client.py`, plus end-to-end tests that spawn the built CLI for a run and an optimization study.
- `apps/petrinaut-opt`: 75 tests pass against the package.
- `Build petrinaut-opt (arm64)` in CI builds the rewired image.

## ❓ How to test this?

1. `turbo run test:unit --filter @local/petrinaut-python --filter @apps/petrinaut-opt`
2. `uv run python -c "from petrinaut import OptimizationSession, PetrinautSession"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


