### PR TITLE
FE-1412: Scale the Python client's timeout for seeded trials

### DIFF
--- a/apps/petrinaut-opt/README.md
+++ b/apps/petrinaut-opt/README.md
@@ -128,15 +128,15 @@ Fixed-value injection, scenario compilation, initial-state materialization,
 simulation, and metric evaluation all happen behind that call, and fixed values
 are never echoed back through this service. When the manifest sets
 `execution.seedsPerTrial` above 1, one trial runs that many seeded simulations
-and the objective is their mean.
+with the same derived seed sequence every time, and the objective is their mean.
+The per-seed values come back alongside it, and this service ignores them.
 
 `close()` ends the session. The bindings bound every wait and clean up after
-themselves: a startup deadline, a per-response deadline, a line-size limit, and
-termination of the process they started on timeout, failure, or client
-disconnect. Their README documents the current values.
-
-For an end-to-end local request, export an optimization manifest from the
-Petrinaut editor.
+themselves: a startup deadline, a per-response deadline that scales with the
+`seedsPerTrial` the study reports, since one evaluation may run that many
+simulations, a line-size limit, and termination of the process they started on
+timeout, failure, or client disconnect. Their README documents the current
+values.
 
 ## Observability
 

--- a/libs/@local/petrinaut-python/README.md
+++ b/libs/@local/petrinaut-python/README.md
@@ -84,7 +84,9 @@ contract, protocol, and seeded-runs semantics are documented in the
 
 - Bootstrap (spawn to readiness) and each protocol response have deadlines,
   `BOOTSTRAP_TIMEOUT_SECONDS` and `PROTOCOL_READ_TIMEOUT_SECONDS`. Both are
-  constructor options.
+  constructor options. For optimization sessions the per-response deadline is
+  multiplied by the `seedsPerTrial` the study reports, since one evaluate may
+  run that many simulations.
 - Bootstrap and protocol lines are capped at `MAX_BOOTSTRAP_LINE_BYTES` and
   `MAX_PROTOCOL_LINE_BYTES`.
 - A session serves one request at a time and is not synchronized: issue requests

--- a/libs/@local/petrinaut-python/src/petrinaut/optimization.py
+++ b/libs/@local/petrinaut-python/src/petrinaut/optimization.py
@@ -55,10 +55,23 @@ class OptimizationSession(PetrinautSession):
             source_label="optimization manifest",
             **options,
         )
+        self._timeout_configured = False
 
     def describe(self) -> OptimizationDescribeResult:
         """Return the CLI-owned Optuna study and parameter description."""
-        return self._validated("optimization.describe", OptimizationDescribeResult)
+        # The generated model bounds seedsPerTrial to the CLI's 1-100 range,
+        # so an out-of-range value already failed validation in `_validated`.
+        result = self._validated("optimization.describe", OptimizationDescribeResult)
+        seeds_per_trial = (
+            1 if result.study.seedsPerTrial is None else result.study.seedsPerTrial
+        )
+        # One evaluate may run this many seeded simulations, sequentially in
+        # the worst case, so the per-response deadline scales with it.
+        self._request_timeout_seconds = (
+            self._base_request_timeout_seconds * seeds_per_trial
+        )
+        self._timeout_configured = True
+        return result
 
     # The previous name; prefer `describe()`, which maps 1:1 to the protocol's
     # `optimization.describe` and reads without repeating the class name.
@@ -72,6 +85,10 @@ class OptimizationSession(PetrinautSession):
         Carries per-seed ``replicates`` when the manifest asks for more than one
         seed per trial.
         """
+        if not self._timeout_configured:
+            # A seeded trial needs the scaled deadline before its first
+            # evaluation, so an un-described session describes once here.
+            self.describe()
         return self._validated(
             "optimization.evaluate",
             OptimizationEvaluateResult,

--- a/libs/@local/petrinaut-python/src/petrinaut/session.py
+++ b/libs/@local/petrinaut-python/src/petrinaut/session.py
@@ -118,6 +118,7 @@ class PetrinautSession:
         self._source_label = source_label
         self._popen_factory = popen_factory
         self._bootstrap_timeout_seconds = bootstrap_timeout_seconds
+        self._base_request_timeout_seconds = request_timeout_seconds
         self._request_timeout_seconds = request_timeout_seconds
         self._process: subprocess.Popen[bytes] | None = None
         self._next_id = 1

--- a/libs/@local/petrinaut-python/tests/test_e2e_cli.py
+++ b/libs/@local/petrinaut-python/tests/test_e2e_cli.py
@@ -8,6 +8,7 @@ the bundle or `node` is missing.
 
 from __future__ import annotations
 
+import json
 import math
 import shutil
 from pathlib import Path
@@ -95,3 +96,56 @@ def test_evaluates_an_optimization_manifest_end_to_end() -> None:
             }
         )
         assert math.isfinite(result.objective)
+
+
+def test_runs_a_seeded_optimization_study_end_to_end() -> None:
+    """Evaluates one trial as two sequential seeded runs on the real CLI."""
+    legacy_model = json.loads(SIR_MODEL.read_text())
+    definition = {key: value for key, value in legacy_model.items() if key != "title"}
+    manifest = {
+        "kind": "petrinaut-optimization",
+        "version": 1,
+        "name": "Minimize infected fraction",
+        "model": {
+            "title": legacy_model["title"],
+            "definition": {
+                **definition,
+                "scenarios": [legacy_model["scenarios"][0]],
+                "metrics": [legacy_model["metrics"][0]],
+            },
+        },
+        "scenario": {
+            "id": "scenario__seasonal_flu",
+            "parameterBindings": {
+                "population": {"kind": "fixed", "value": 200},
+                "infected_ratio": {
+                    "kind": "optimize",
+                    "domain": {
+                        "kind": "continuous",
+                        "minimum": 0.01,
+                        "maximum": 0.5,
+                        "scale": "log",
+                    },
+                },
+            },
+        },
+        "objective": {
+            "metricId": "metric__infected_fraction",
+            "direction": "minimize",
+        },
+        "execution": {"seed": 42, "dt": 1, "maxTime": 5e-324, "seedsPerTrial": 2},
+        "study": {"trials": 20, "sampler": "tpe"},
+    }
+    with OptimizationSession(manifest, command=(str(NODE), str(CLI_BUNDLE))) as session:
+        description = session.describe()
+        assert description.study.seedsPerTrial == 2
+        assert session._request_timeout_seconds == 480
+
+        result = session.evaluate({"infected_ratio": 0.1})
+        assert result.objective == pytest.approx(0.1)
+        assert result.replicates is not None
+        assert [replicate.seed for replicate in result.replicates] == [
+            42,
+            1013904268,
+        ]
+        assert session.objective({"infected_ratio": 0.1}) == pytest.approx(0.1)

--- a/libs/@local/petrinaut-python/tests/test_optimization_session.py
+++ b/libs/@local/petrinaut-python/tests/test_optimization_session.py
@@ -121,6 +121,7 @@ def test_optimization_session_requires_exactly_one_source(
 
 def test_evaluate_returns_the_full_result_including_replicates(
     optimization_manifest: dict,
+    optimization_description: dict,
 ) -> None:
     full_result = {
         "objective": 12.5,
@@ -129,7 +130,13 @@ def test_evaluate_returns_the_full_result_including_replicates(
             {"seed": 7, "objective": 13.0},
         ],
     }
-    process = FakeProcess([{"id": 1, "result": full_result}])
+    # The first evaluate describes once to scale the response deadline.
+    process = FakeProcess(
+        [
+            {"id": 1, "result": optimization_description},
+            {"id": 2, "result": full_result},
+        ]
+    )
     invocation = spawn(process)
     session = OptimizationSession(
         optimization_manifest, popen_factory=invocation["popen_factory"]
@@ -326,11 +333,13 @@ while True:
 
 def test_cli_error_during_evaluation_is_recoverable(
     optimization_manifest: dict,
+    optimization_description: dict,
 ) -> None:
     process = FakeProcess(
         [
-            {"id": 1, "error": {"message": "scenario failed"}},
-            {"id": 2, "result": {"objective": 7}},
+            {"id": 1, "result": optimization_description},
+            {"id": 2, "error": {"message": "scenario failed"}},
+            {"id": 3, "result": {"objective": 7}},
         ]
     )
     model = OptimizationSession(
@@ -349,10 +358,16 @@ def test_cli_error_during_evaluation_is_recoverable(
 @pytest.mark.parametrize("objective", [True, None, "12.5"])
 def test_a_non_numeric_objective_is_a_protocol_error(
     optimization_manifest: dict,
+    optimization_description: dict,
     objective: Any,
 ) -> None:
     """A result outside the protocol schema closes the session."""
-    process = FakeProcess([{"id": 1, "result": {"objective": objective}}])
+    process = FakeProcess(
+        [
+            {"id": 1, "result": optimization_description},
+            {"id": 2, "result": {"objective": objective}},
+        ]
+    )
     model = OptimizationSession(
         optimization_manifest,
         popen_factory=lambda *_args, **_kwargs: process,
@@ -367,9 +382,15 @@ def test_a_non_numeric_objective_is_a_protocol_error(
 
 def test_rejects_a_non_finite_numeric_objective(
     optimization_manifest: dict,
+    optimization_description: dict,
 ) -> None:
     """JSON cannot carry Infinity, but Python's parser admits it; refuse it."""
-    process = FakeProcess([{"id": 1, "result": {"objective": float("inf")}}])
+    process = FakeProcess(
+        [
+            {"id": 1, "result": optimization_description},
+            {"id": 2, "result": {"objective": float("inf")}},
+        ]
+    )
     model = OptimizationSession(
         optimization_manifest,
         popen_factory=lambda *_args, **_kwargs: process,
@@ -397,3 +418,72 @@ def test_rejects_a_mismatched_protocol_response(
 
     assert process.returncode == 0
     model.close()
+
+
+def test_scales_the_request_timeout_by_the_described_seeds_per_trial(
+    optimization_manifest: dict,
+    optimization_description: dict,
+) -> None:
+    description = {
+        **optimization_description,
+        "study": {**optimization_description["study"], "seedsPerTrial": 5},
+    }
+    process = FakeProcess([{"id": 1, "result": description}])
+    model = OptimizationSession(
+        optimization_manifest,
+        command=("node", "/cli.js"),
+        popen_factory=lambda command, **kwargs: process,
+        request_timeout_seconds=240,
+    )
+    model.start()
+
+    assert model.describe() == OptimizationDescribeResult.model_validate(description)
+    assert model._request_timeout_seconds == 1200
+    model.close()
+
+
+def test_evaluate_without_describe_scales_the_timeout_first(
+    optimization_manifest: dict,
+    optimization_description: dict,
+) -> None:
+    description = {
+        **optimization_description,
+        "study": {**optimization_description["study"], "seedsPerTrial": 5},
+    }
+    process = FakeProcess(
+        [
+            {"id": 1, "result": description},
+            {"id": 2, "result": {"objective": 1.5}},
+        ]
+    )
+    model = OptimizationSession(
+        optimization_manifest,
+        command=("node", "/cli.js"),
+        popen_factory=lambda command, **kwargs: process,
+        request_timeout_seconds=240,
+    )
+    model.start()
+
+    assert model.evaluate({"rate": 1.0}).objective == 1.5
+    assert model._request_timeout_seconds == 1200
+    model.close()
+
+
+def test_rejects_an_invalid_described_seeds_per_trial(
+    optimization_manifest: dict,
+    optimization_description: dict,
+) -> None:
+    description = {
+        **optimization_description,
+        "study": {**optimization_description["study"], "seedsPerTrial": 0},
+    }
+    process = FakeProcess([{"id": 1, "result": description}])
+    model = OptimizationSession(
+        optimization_manifest,
+        command=("node", "/cli.js"),
+        popen_factory=lambda command, **kwargs: process,
+    )
+    model.start()
+
+    with pytest.raises(PetrinautProtocolError, match="seedsPerTrial"):
+        model.describe()


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

A trial's seeded runs execute sequentially in the CLI, so one `optimization.evaluate` may take `seedsPerTrial ×` the single-run time. The client's fixed 240 s response deadline must scale with it.

FE-1468 (#9262) has merged; this PR now sits at the bottom of stack #9280 on main, with FE-1470 (#9278) above.

## 🔗 Related links

- [FE-1412](https://linear.app/hash/issue/FE-1412/python-client-support-seeded-trials-in-the-optimizer-service-and-image) *(internal)*: this PR
- [FE-1408](https://linear.app/hash/issue/FE-1408/petrinaut-cli-run-a-trial-as-multiple-seeded-simulations-aggregated-by) *(internal)*: parent — seeded trials in the CLI

## 🔍 What does this change?

In `@local/petrinaut-python`:

- `describe()` reads the typed `study.seedsPerTrial`, rejects values outside 1–100 as a protocol error, and multiplies the per-response deadline by it.
- `evaluate()` describes first when the session has not been described, so the scaled deadline is in place before the first trial.
- A new end-to-end test drives a two-seed trial against the built CLI and asserts the derived seed sequence `[42, 1013904268]`, the per-seed `replicates`, and the mean objective.

The seeded runs are sequential, so the image needs no worker permissions or pool caps.

**Review fixes.** The hand-rolled `MAX_SEEDS_PER_TRIAL` constant and its range check are deleted: FE-1468's schema bounds `seedsPerTrial` to 1–100, so an out-of-range value already fails model validation in `_validated`, which closes the session and raises `PetrinautProtocolError` — the same observable behaviour with one owner for the bound.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] modifies workspaces but **not** a publishable library.

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] require changes to docs which **are made** as part of this PR: the bindings and optimizer READMEs document the scaled deadline.

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph.

## 🛡 What tests cover this?

- Bindings (28 tests): timeout scaling from the described `seedsPerTrial`, rejection of out-of-range values, and the two-seed e2e against the built CLI.
- `apps/petrinaut-opt`: 75 tests, unchanged.

## ❓ How to test this?

```bash
turbo run test:unit --filter @local/petrinaut-python --filter @apps/petrinaut-opt
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)



