### PR TITLE
FE-1414: Support Python packages in the architecture docs

### DIFF
--- a/apps/petrinaut-opt/src/optimization_api.py
+++ b/apps/petrinaut-opt/src/optimization_api.py
@@ -2,7 +2,7 @@
 """HTTP API for streaming Petrinaut optimization studies.
 
 @layerRoot optimizer
-@role FastAPI service running detached Optuna studies through the Petrinaut Python bindings, with replayable event streams and admission control.
+@role FastAPI service running detached Optuna studies through the Python bindings, with replayable event streams and admission control
 """
 
 from __future__ import annotations

--- a/apps/petrinaut-opt/src/optimization_api.py
+++ b/apps/petrinaut-opt/src/optimization_api.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
-"""HTTP API for streaming Petrinaut optimization studies."""
+"""HTTP API for streaming Petrinaut optimization studies.
+
+@layerRoot optimizer
+@role FastAPI service running detached Optuna studies through the Petrinaut Python bindings, with replayable event streams and admission control.
+"""
 
 from __future__ import annotations
 

--- a/libs/@local/petrinaut-arch-docs/architecture.config.ts
+++ b/libs/@local/petrinaut-arch-docs/architecture.config.ts
@@ -54,6 +54,20 @@ export const config: ArchitectureConfig = {
         "JSON-lines CLI serving one compiled model per process: run requests and optimization studies over stdio or a Unix socket. No HTTP, no React.",
       language: "typescript",
     },
+    {
+      name: "@local/petrinaut-python",
+      path: "libs/@local/petrinaut-python",
+      description:
+        "Python bindings for the CLI's JSON-lines protocol: sessions, run requests, optimization studies. POSIX-only; pydantic validates protocol responses.",
+      language: "python",
+    },
+    {
+      name: "@apps/petrinaut-opt",
+      path: "apps/petrinaut-opt",
+      description:
+        "Python optimizer service: detached Optuna studies over the CLI, replayable SSE event streams, admission control.",
+      language: "python",
+    },
   ],
 
   /**
@@ -99,6 +113,8 @@ export const config: ArchitectureConfig = {
     "__fixtures__",
     "__snapshots__",
     "docs",
+    "__pycache__",
+    ".venv",
   ],
 
   /**

--- a/libs/@local/petrinaut-arch-docs/content/index.mdx
+++ b/libs/@local/petrinaut-arch-docs/content/index.mdx
@@ -75,7 +75,8 @@ way, which is enforced rather than merely intended.
 Python optimizer service drive; its [usage manual](doc:cli/usage-manual) covers
 the transports, the protocol, and optimization studies.
 
-Two further packages are not yet covered by the generated model:
-`@apps/petrinaut-website` and `apps/petrinaut-opt` (the Python Optuna service).
-Adding them is a matter of declaring layers in their source; see
-[Declaring layers](doc:maintaining/declaring-layers).
+`apps/petrinaut-opt` (the Python Optuna service) and `@local/petrinaut-python`
+(its CLI bindings) are covered as layers too, though Python files contribute
+no import edges yet. One package is not covered at all:
+`@apps/petrinaut-website`. Adding a package is a matter of declaring layers in
+its source; see [Declaring layers](doc:maintaining/declaring-layers).

--- a/libs/@local/petrinaut-arch-docs/content/maintaining.mdx
+++ b/libs/@local/petrinaut-arch-docs/content/maintaining.mdx
@@ -7,8 +7,9 @@ sidebar_order: 2
 These pages are about the documentation system itself, not about using Petrinaut.
 
 Everything under [Architecture](architecture) is generated from annotations in
-`@hashintel/petrinaut-core`, `@hashintel/petrinaut`, and
-`@hashintel/petrinaut-cli`, joined against the real import graph. Editing a
+the covered packages (`@hashintel/petrinaut-core`, `@hashintel/petrinaut`,
+`@hashintel/petrinaut-cli`, `@local/petrinaut-python`, and
+`@apps/petrinaut-opt`), joined against the real import graph. Editing a
 generated page does nothing: the next build replaces it.
 
 Two things follow from that, and they are what these pages cover.

--- a/libs/@local/petrinaut-arch-docs/content/optimizer/subprocess-boundary.mdx
+++ b/libs/@local/petrinaut-arch-docs/content/optimizer/subprocess-boundary.mdx
@@ -1,0 +1,46 @@
+---
+title: The subprocess boundary
+description: Why the optimizer↔CLI relationship is a process contract, not an import — and what each side owns.
+sidebar_order: 10
+attachTo: optimizer
+---
+
+The optimizer never imports Petrinaut. The [optimizer](layer:optimizer) and
+the [CLI](layer:cli) meet at a **process boundary**: one `petrinaut serve`
+child per optimization run, spoken to over JSON lines on stdio. No generated
+diagram shows this edge, and none ever will — the import graph records static
+module references, and claiming runtime facts it cannot check is exactly what
+the model refuses to do. This page is the missing arrow.
+
+## The contract
+
+- **One run, one child.** The service spawns the CLI with the manifest as the
+  first stdin line and waits for the readiness line on stderr; any other first
+  stderr line fails the start. From then on it sends one request per line and
+  reads one response per line, in order. The full protocol is specified in the
+  CLI's [usage manual](doc:cli/usage-manual).
+- **Ownership split.** The manifest is opaque to Python: scenario
+  compilation, fixed-value injection, simulation, seeding, and metric
+  evaluation are the CLI's. Study orchestration, admission, event streaming,
+  and cancellation are the service's. Optuna sees only flat parameter
+  descriptors and scalar objectives.
+- **Isolation.** The child gets a scrubbed environment, its own process
+  group, and (in the image) Node permission flags restricting filesystem
+  reads. Cancellation and failure paths signal the whole group rather than
+  waiting for a busy CLI to notice stdin closing.
+- **Bounded everything.** Bootstrap and per-response deadlines, 8 MiB line
+  caps on both sides, and a study wall-clock ceiling. The per-response
+  deadline scales with the study's seeds-per-trial, since one evaluate may
+  legally run up to that many simulations.
+
+## Where the boundary lives in code
+
+The Python side of the contract is the [python-bindings](layer:python-bindings) package —
+the optimizer consumes `OptimizationSession` rather than owning a transport.
+The CLI side is the [runtime](layer:cli.runtime), which interprets the same
+frames. Change either side of the frame vocabulary and both packages' tests
+break; that is the seam working as intended.
+
+Nothing else crosses: the optimizer's HTTP surface, Optuna, and telemetry
+never reach the CLI, and the CLI never learns it is being driven by a
+service rather than a script.

--- a/libs/@local/petrinaut-arch-docs/package.json
+++ b/libs/@local/petrinaut-arch-docs/package.json
@@ -25,9 +25,11 @@
     "zod": "4.4.3"
   },
   "devDependencies": {
+    "@apps/petrinaut-opt": "workspace:*",
     "@hashintel/petrinaut": "workspace:*",
     "@hashintel/petrinaut-cli": "workspace:*",
     "@hashintel/petrinaut-core": "workspace:*",
+    "@local/petrinaut-python": "workspace:*",
     "@local/tsconfig": "workspace:*",
     "@types/js-yaml": "^4",
     "@types/node": "22.18.13",

--- a/libs/@local/petrinaut-arch-docs/src/emit/d2.ts
+++ b/libs/@local/petrinaut-arch-docs/src/emit/d2.ts
@@ -36,6 +36,8 @@ const styleClasses = [
   `  ui: {style.fill: "#e2f4e8"; style.stroke: "#3d8055"}`,
   `  petrinaut: {style.fill: "#fdeedc"; style.stroke: "#b5762f"}`,
   `  cli: {style.fill: "#fbe3e8"; style.stroke: "#ad3a5b"}`,
+  `  python-bindings: {style.fill: "#fff4d6"; style.stroke: "#a3801f"}`,
+  `  optimizer: {style.fill: "#e0f2f1"; style.stroke: "#2b7a72"}`,
   `  other: {style.fill: "#f2f2f2"; style.stroke: "#777777"}`,
   `  boundary: {style.stroke-dash: 4}`,
   `  focus: {style.stroke-width: 3; style.bold: true}`,
@@ -43,7 +45,15 @@ const styleClasses = [
   `}`,
 ].join("\n");
 
-const knownRoots = ["core", "react", "ui", "petrinaut", "cli"];
+const knownRoots = [
+  "core",
+  "react",
+  "ui",
+  "petrinaut",
+  "cli",
+  "python-bindings",
+  "optimizer",
+];
 
 const classFor = (id: string): string => {
   const root = rootSegment(id);

--- a/libs/@local/petrinaut-arch-docs/src/extract.ts
+++ b/libs/@local/petrinaut-arch-docs/src/extract.ts
@@ -17,7 +17,7 @@ import { error, type Diagnostic } from "./diagnostics";
 import { parseFrontmatter } from "./frontmatter";
 import { layerSchema, parentLayerId } from "./model";
 import { toPosix } from "./paths";
-import { sourceExtensions, sourceRootOf } from "./scope";
+import { sourceExtensionsFor, sourceRootOf } from "./scope";
 import { scanTags } from "./tags";
 
 import type { Layer, ArchitecturePackage } from "./model";
@@ -52,8 +52,6 @@ export interface ExtractOptions {
   /** Regex matched against repo-relative paths to skip files. */
   ignoredFilePattern: RegExp;
 }
-
-const sourceExtensionSet = new Set<string>(sourceExtensions);
 
 const extensionOf = (name: string): string => {
   const dot = name.lastIndexOf(".");
@@ -149,22 +147,10 @@ export const extract = async (
   const declaredBy = new Map<string, string>();
 
   const packageEntries = new Map<string, WalkEntry[]>();
+  const isSourceEntry = (pkg: ArchitecturePackage, entry: WalkEntry): boolean =>
+    sourceExtensionsFor(pkg).includes(extensionOf(entry.name));
 
   for (const pkg of packages) {
-    // A package whose language has no extractor would otherwise contribute no
-    // files, no layers and no diagnostics — appearing in the model as covered
-    // while being entirely undescribed. That is the silent mis-bucketing this
-    // system exists to remove, so it is an error rather than a skip.
-    if (pkg.language !== "typescript") {
-      diagnostics.push(
-        error(
-          `${pkg.path}/package.json`,
-          `package \`${pkg.name}\` is configured as \`${pkg.language}\`, which has no extractor — it would be listed in the model with no layers. Remove it from architecture.config.ts until one exists.`,
-        ),
-      );
-      continue;
-    }
-
     const entries = await walkFiles(
       join(repoRoot, sourceRootOf(pkg)),
       repoRoot,
@@ -181,7 +167,7 @@ export const extract = async (
   for (const pkg of packages) {
     for (const entry of packageEntries.get(pkg.name) ?? []) {
       const isMarkdown = entry.name.toLowerCase().endsWith(".md");
-      const isSource = sourceExtensionSet.has(extensionOf(entry.name));
+      const isSource = isSourceEntry(pkg, entry);
 
       if (!isMarkdown && !isSource) {
         continue;
@@ -250,7 +236,10 @@ export const extract = async (
         continue;
       }
 
-      const { tags, diagnostics: tagDiagnostics } = scanTags(contents);
+      const { tags, diagnostics: tagDiagnostics } = scanTags(
+        contents,
+        pkg.language,
+      );
 
       for (const diagnostic of tagDiagnostics) {
         diagnostics.push(
@@ -290,7 +279,7 @@ export const extract = async (
   for (const pkg of packages) {
     for (const entry of packageEntries.get(pkg.name) ?? []) {
       const isMarkdown = entry.name.toLowerCase().endsWith(".md");
-      const isSource = sourceExtensionSet.has(extensionOf(entry.name));
+      const isSource = isSourceEntry(pkg, entry);
 
       if (!isMarkdown && !isSource) {
         continue;

--- a/libs/@local/petrinaut-arch-docs/src/scope.ts
+++ b/libs/@local/petrinaut-arch-docs/src/scope.ts
@@ -14,13 +14,29 @@ import { posix } from "node:path";
 import type { ArchitecturePackage } from "./model";
 
 /**
- * Extensions treated as architecture source.
+ * Extensions treated as architecture source in TypeScript packages.
  *
  * `.js` variants are absent on purpose: these packages are TypeScript, and a
  * committed `.js` file under `src` would be build output that no layer should
- * claim.
+ * claim. The graph builder reads this list directly — it only ever receives
+ * TypeScript packages.
  */
 export const sourceExtensions = [".ts", ".tsx", ".mts", ".cts"] as const;
+
+// Keyed by language so adding a member to the config's language enum fails to
+// compile here instead of silently scanning the new package as TypeScript.
+const sourceExtensionsByLanguage: Record<
+  ArchitecturePackage["language"],
+  readonly string[]
+> = {
+  typescript: sourceExtensions,
+  python: [".py"],
+};
+
+/** The source extensions for one package, by its declared language. */
+export const sourceExtensionsFor = (
+  pkg: ArchitecturePackage,
+): readonly string[] => sourceExtensionsByLanguage[pkg.language];
 
 /** Repo-relative, posix source root for a package. */
 export const sourceRootOf = (pkg: ArchitecturePackage): string =>

--- a/libs/@local/petrinaut-arch-docs/src/tags.test.ts
+++ b/libs/@local/petrinaut-arch-docs/src/tags.test.ts
@@ -108,3 +108,119 @@ line three
     expect(tags.layerRoot?.line).toBe(6);
   });
 });
+
+describe("scanTags for Python", () => {
+  it("reads a layer declaration from a module docstring", () => {
+    const { tags, diagnostics } = scanTags(
+      `"""HTTP API for optimization studies.
+
+@layerRoot optimizer
+@role Runs detached Optuna studies against the CLI.
+"""
+
+import asyncio
+`,
+      "python",
+    );
+
+    expect(diagnostics).toEqual([]);
+    expect(tags.layerRoot?.value).toBe("optimizer");
+    expect(tags.layerRoot?.line).toBe(3);
+    expect(tags.role?.value).toBe(
+      "Runs detached Optuna studies against the CLI.",
+    );
+  });
+
+  it("reads tags from single-quoted docstrings too", () => {
+    const { tags } = scanTags(
+      `'''
+@layerRoot bindings
+@role Sessions owning one CLI process each.
+'''
+`,
+      "python",
+    );
+
+    expect(tags.layerRoot?.value).toBe("bindings");
+  });
+
+  it("reads tags from a prefixed (raw) docstring", () => {
+    const { tags } = scanTags(
+      `r"""Escapes like \\d survive in raw docstrings.
+
+@layerRoot bindings
+@role Sessions owning one CLI process each.
+"""
+`,
+      "python",
+    );
+
+    expect(tags.layerRoot?.value).toBe("bindings");
+  });
+
+  it("ignores triple-quoted strings that are not the module docstring", () => {
+    const { tags } = scanTags(
+      `import textwrap
+
+QUERY = """
+@layerRoot not-a-layer
+"""
+
+
+def helper():
+    """@layerRoot also-not-a-layer"""
+`,
+      "python",
+    );
+
+    expect(tags.layerRoot).toBeNull();
+  });
+
+  it("reads the module docstring after leading comments and blank lines", () => {
+    const { tags } = scanTags(
+      `#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+@layerRoot optimizer
+@role One line.
+"""
+`,
+      "python",
+    );
+
+    expect(tags.layerRoot?.value).toBe("optimizer");
+  });
+
+  it("does not read JSDoc-style comments as Python docstrings", () => {
+    const { tags } = scanTags(
+      `# @layerRoot commented-out
+value = "/** @layerRoot not-a-docstring */"
+`,
+      "python",
+    );
+
+    expect(tags.layerRoot).toBeNull();
+  });
+
+  it("keeps duplicate detection and miscasing hints for Python", () => {
+    const { diagnostics } = scanTags(
+      `"""
+@layerroot optimizer
+@role One role.
+@role Another role.
+"""
+`,
+      "python",
+    );
+
+    expect(diagnostics).toEqual([
+      expect.objectContaining({
+        message: "unknown tag @layerroot; did you mean @layerRoot?",
+      }),
+      expect.objectContaining({
+        message: expect.stringContaining("duplicate @role"),
+      }),
+    ]);
+  });
+});

--- a/libs/@local/petrinaut-arch-docs/src/tags.ts
+++ b/libs/@local/petrinaut-arch-docs/src/tags.ts
@@ -71,11 +71,11 @@ const blockCommentPattern = /\/\*\*[\s\S]*?\*\//gu;
 /**
  * The module docstring only: the first statement after blank and `#` lines.
  * A triple-quoted string anywhere else is a value, not an annotation host.
- * String prefixes (`r"""`, `b'''`, ...) still open a docstring, so a raw
- * docstring cannot silently drop a package's `@layerRoot`.
+ * The `r` and `u` prefixes open a docstring too, so a raw docstring carries a
+ * package's `@layerRoot` like a plain one.
  */
 const pythonModuleDocstringPattern =
-  /^(?:[ \t]*(?:#[^\r\n]*)?\r?\n)*[ \t]*[rRbBuUfF]{0,2}("""[\s\S]*?"""|'''[\s\S]*?''')/u;
+  /^(?:[ \t]*(?:#[^\r\n]*)?\r?\n)*[ \t]*[rRuU]{0,2}("""[\s\S]*?"""|'''[\s\S]*?''')/u;
 
 /**
  * Byte offsets of the start of each line, so an offset can be turned into a

--- a/libs/@local/petrinaut-arch-docs/src/tags.ts
+++ b/libs/@local/petrinaut-arch-docs/src/tags.ts
@@ -11,14 +11,17 @@
  * claim the generator cannot check, and this version does not make claims it
  * cannot keep.
  *
- * Tags are recognised only at the start of a line inside a block comment, so a
- * tag named in running prose is not picked up.
+ * Tags are recognised only at the start of a line inside a doc comment — a
+ * `/** ... *​/` block in TypeScript, a triple-quoted docstring in Python — so a
+ * tag named in running prose is not picked up. Python `#` comments are
+ * deliberately not scanned: a layer declaration belongs in the module
+ * docstring, where the module already describes itself.
  *
- * Block comments are matched by pattern rather than by lexing the file, so a
- * string or template literal containing a whole comment block would be read as
- * one. Using the TypeScript scanner would remove that case, at the cost of
- * parsing every file. Worth revisiting if a package starts embedding annotated
- * code samples in string literals.
+ * Comments are matched by pattern rather than by lexing the file, so a string
+ * or template literal containing a whole comment block would be read as one.
+ * Using a real parser would remove that case, at the cost of parsing every
+ * file. Worth revisiting if a package starts embedding annotated code samples
+ * in string literals.
  */
 
 /** A tag occurrence, with the line it was found on for error reporting. */
@@ -60,7 +63,19 @@ type SingularTag = (typeof singularTags)[number];
 
 const knownTagNames = new Set<string>(singularTags);
 
+/** The language a file's doc comments are written for. */
+export type CommentLanguage = "typescript" | "python";
+
 const blockCommentPattern = /\/\*\*[\s\S]*?\*\//gu;
+
+/**
+ * The module docstring only: the first statement after blank and `#` lines.
+ * A triple-quoted string anywhere else is a value, not an annotation host.
+ * String prefixes (`r"""`, `b'''`, ...) still open a docstring, so a raw
+ * docstring cannot silently drop a package's `@layerRoot`.
+ */
+const pythonModuleDocstringPattern =
+  /^(?:[ \t]*(?:#[^\r\n]*)?\r?\n)*[ \t]*[rRbBuUfF]{0,2}("""[\s\S]*?"""|'''[\s\S]*?''')/u;
 
 /**
  * Byte offsets of the start of each line, so an offset can be turned into a
@@ -91,21 +106,25 @@ const lineNumberAt = (lineStarts: number[], offset: number): number => {
 };
 
 /**
- * Strips the comment delimiters and the leading `*` gutter, returning body
- * lines paired with their line number in the original file.
+ * Strips the comment delimiters and (for JSDoc) the leading `*` gutter,
+ * returning body lines paired with their line number in the original file.
+ * Python docstrings carry no gutter, so their lines only lose the quotes.
  */
 const commentBodyLines = (
   comment: string,
   startLine: number,
-): { text: string; line: number }[] =>
-  comment
-    .replace(/^\/\*\*/u, "")
-    .replace(/\*\/$/u, "")
-    .split("\n")
-    .map((rawLine, offset) => ({
-      text: rawLine.replace(/^\s*\*\s?/u, ""),
-      line: startLine + offset,
-    }));
+  language: CommentLanguage,
+): { text: string; line: number }[] => {
+  const body =
+    language === "python"
+      ? comment.replace(/^(?:"""|''')/u, "").replace(/(?:"""|''')$/u, "")
+      : comment.replace(/^\/\*\*/u, "").replace(/\*\/$/u, "");
+
+  return body.split("\n").map((rawLine, offset) => ({
+    text: language === "python" ? rawLine : rawLine.replace(/^\s*\*\s?/u, ""),
+    line: startLine + offset,
+  }));
+};
 
 interface RawTag {
   name: string;
@@ -152,8 +171,11 @@ const collectRawTags = (lines: { text: string; line: number }[]): RawTag[] => {
   return tags;
 };
 
-/** Reads every architecture tag out of a source file's block comments. */
-export const scanTags = (sourceText: string): TagScanResult => {
+/** Reads every architecture tag out of a source file's doc comments. */
+export const scanTags = (
+  sourceText: string,
+  language: CommentLanguage = "typescript",
+): TagScanResult => {
   const tags = emptyTags();
   const diagnostics: TagDiagnostic[] = [];
 
@@ -174,9 +196,26 @@ export const scanTags = (sourceText: string): TagScanResult => {
 
   const lineStarts = lineStartOffsets(sourceText);
 
-  for (const match of sourceText.matchAll(blockCommentPattern)) {
+  const comments: { text: string; index: number }[] = [];
+  if (language === "python") {
+    const match = pythonModuleDocstringPattern.exec(sourceText);
+    if (match?.[1] !== undefined) {
+      comments.push({
+        text: match[1],
+        index: match.index + match[0].length - match[1].length,
+      });
+    }
+  } else {
+    for (const match of sourceText.matchAll(blockCommentPattern)) {
+      comments.push({ text: match[0], index: match.index });
+    }
+  }
+
+  for (const match of comments) {
     const startLine = lineNumberAt(lineStarts, match.index);
-    const rawTags = collectRawTags(commentBodyLines(match[0], startLine));
+    const rawTags = collectRawTags(
+      commentBodyLines(match.text, startLine, language),
+    );
 
     for (const rawTag of rawTags) {
       const { name, line } = rawTag;

--- a/libs/@local/petrinaut-python/src/petrinaut/__init__.py
+++ b/libs/@local/petrinaut-python/src/petrinaut/__init__.py
@@ -7,6 +7,9 @@ A session is a client for one `petrinaut serve` child process that the session
 itself owns: it spawns the child for one model (or one optimization manifest),
 serializes requests to it, and shuts it down. "Session" rather than "client"
 because the object carries that lifecycle, not just the wire format.
+
+@layerRoot python-bindings
+@role Python sessions owning one CLI process each, translating protocol frames into methods and exceptions.
 """
 
 from .errors import (

--- a/libs/@local/petrinaut-python/src/petrinaut/__init__.py
+++ b/libs/@local/petrinaut-python/src/petrinaut/__init__.py
@@ -9,7 +9,7 @@ serializes requests to it, and shuts it down. "Session" rather than "client"
 because the object carries that lifecycle, not just the wire format.
 
 @layerRoot python-bindings
-@role Python sessions owning one CLI process each, translating protocol frames into methods and exceptions.
+@role Python sessions owning one CLI process each, translating protocol frames into methods and exceptions
 """
 
 from .errors import (

--- a/yarn.lock
+++ b/yarn.lock
@@ -9642,9 +9642,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@local/petrinaut-arch-docs@workspace:libs/@local/petrinaut-arch-docs"
   dependencies:
+    "@apps/petrinaut-opt": "workspace:*"
     "@hashintel/petrinaut": "workspace:*"
     "@hashintel/petrinaut-cli": "workspace:*"
     "@hashintel/petrinaut-core": "workspace:*"
+    "@local/petrinaut-python": "workspace:*"
     "@local/tsconfig": "workspace:*"
     "@types/js-yaml": "npm:^4"
     "@types/node": "npm:22.18.13"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The architecture docs generator accepted only TypeScript packages, so `apps/petrinaut-opt` and the new `@local/petrinaut-python` bindings could not be documented. This PR adds Python support: layer pages, roles, and diagrams for Python packages, with `@layerRoot`/`@role` read from module docstrings. Import edges for Python arrive in FE-1415 (#9265), further up this stack.

FE-1470 (#9278) has merged, so this PR is the bottom of the docs stack, with FE-1443 (#9263) above it. Merge the docs stack as a unit: until FE-1415 (#9265) lands, both Python packages appear as layers carrying no import edges.

## 🔗 Related links

- [FE-1414](https://linear.app/hash/issue/FE-1414/arch-docs-support-python-packages-layers-and-docstring-annotations) _(internal)_: this PR
- [FE-1415](https://linear.app/hash/issue/FE-1415/arch-docs-generate-import-edges-for-python-packages) _(internal)_: Python import edges, #9265 in this stack

## 🔍 What does this change?

**Generator (`@local/petrinaut-arch-docs`)**

- Source extensions resolve per package language, `.py` for Python, and the TypeScript-only check in the extractor is gone. An undescribed package is still an error: the extractor reports `no layer resolves for this file` for each unclaimed file, naming the folder that needs a declaration. The graph builder still receives only TypeScript packages, exactly as before.
- The tag scanner reads `@layerRoot`/`@role` from the module docstring only, in both quote styles; a triple-quoted string elsewhere in the file is a value. The tag grammar, duplicate detection, and miscasing hints are shared across languages.
- `__pycache__` and `.venv` join the ignored directories. The overview page now states that the Python packages contribute no import edges yet.

**Registrations**

- `@apps/petrinaut-opt` declares the root layer `optimizer` in `optimization_api.py`'s docstring.
- `@local/petrinaut-python` declares the root layer `python-bindings` in the package docstring.
- Both roots get diagram colours.

**Authored content**

- `content/optimizer/subprocess-boundary.mdx`, attached to `optimizer`, documents the optimizer-to-CLI process contract: the spawn handshake, the ownership split, isolation, and the bounded limits. It links the `cli`, `python-bindings`, and `cli.runtime` layers and the CLI usage manual.

**Review fixes**

- The module docstring pattern accepts string prefixes (`r"""`), with a test, so a raw docstring cannot silently drop a package's `@layerRoot`.
- The per-language extensions live in a `Record` keyed by the config's language enum, so adding an enum member fails to compile until it names its extensions. The single-use `pythonSourceExtensions` export was inlined.
- The docstring prefix class is `[rRuU]`. Python treats only plain string literals as docstrings, so a tag inside a `b"""` or `f"""` literal is not a declaration.
- The two new `@role` lines drop their trailing periods, which no other declaration in the repo carries.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] modifies workspaces but **not** a publishable library

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are docs (architecture). In-app user docs unaffected.

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- `tags.test.ts` grows from 9 to 16 cases: module docstrings, single-quoted and prefixed docstrings, non-matches for `#` comments and JSDoc text inside strings, and duplicate and miscasing diagnostics in Python.
- `lint:arch-docs` validates the real registrations end to end, including full file coverage of both Python packages and `attachTo` resolution.
- Both Python packages' suites still pass with the docstring declarations in place.

## ❓ How to test this?

1. `yarn workspace @local/petrinaut-arch-docs lint:arch-docs`
2. `turbo run dev --filter @apps/petrinaut-docs` and open Architecture → optimizer / python-bindings; the boundary guide sits under the optimizer page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


