### PR TITLE
FE-1418: Build @apps/petrinaut-docs on Vercel

### DIFF
--- a/apps/petrinaut-docs/README.md
+++ b/apps/petrinaut-docs/README.md
@@ -73,20 +73,18 @@ Vercel builds the site from [`vercel.json`](vercel.json), which runs
 root, so the project needs **Root Directory** set to `apps/petrinaut-docs` with
 **Include files outside of the Root Directory in the Build Step** enabled.
 
-The site is served from `architecture.petrinaut.org` behind a Cloudflare Access
-gate requiring SSO. That host is proposed rather than settled, so treat `site` in
-[`astro.config.mjs`](astro.config.mjs) as provisional: it sets the canonical URL
-and every sitemap entry. SRE-955 assigns the domain and configures the gate.
+The site is served from `architecture.petrinaut.org`. That host is proposed
+rather than settled, so treat `site` in [`astro.config.mjs`](astro.config.mjs) as
+provisional: it sets the canonical URL and every sitemap entry. SRE-955 assigns
+the domain and decides how access to the deployment is restricted.
 
-This host renders every page in the manifest. FE-1157 publishes a subset to
-`hash.dev/docs/petrinaut`, so the two run side by side and a page can appear on
-one and not the other. Nothing in the bundle records which pages belong to that
-subset: `ManifestPage` carries `kind`, which is `generated` or `authored`, a
-source distinction rather than an audience one. FE-1157 chooses the rule.
-
-The gate also covers `architecture.md` and `architecture.json`, which
-`sync:bundle` copies into `public/`, so an agent reading either over HTTP needs a
-session. Both describe the whole model rather than the subset.
+This host renders every page in the manifest, including the `architecture.md` and
+`architecture.json` that `sync:bundle` copies into `public/`, both of which
+describe the whole model. FE-1157 publishes a subset to `hash.dev/docs/petrinaut`,
+so the two run side by side and a page can appear on one and not the other.
+Nothing in the bundle records which pages belong to that subset: `ManifestPage`
+carries `kind`, which is `generated` or `authored`, a source distinction rather
+than an audience one. FE-1157 chooses the rule.
 
 The install script fetches Node, Turborepo and `d2`, and nothing else. The build
 graph is `astro build` <- `sync:bundle` <- `doc:architecture`, Node throughout,

--- a/apps/petrinaut-docs/README.md
+++ b/apps/petrinaut-docs/README.md
@@ -75,14 +75,3 @@ enables **Include files outside of the Root Directory in the Build Step**.
 The site is served from `docs.petrinaut.org` and is internal, so reaching it
 needs access. `site` in [`astro.config.mjs`](astro.config.mjs) has to match it:
 that is what sets the canonical URL and every sitemap entry.
-
-The tools the build needs are listed in
-[`vercel-install.sh`](vercel-install.sh), with a comment on why that list is
-shorter than the other Vercel apps' in this repo.
-
-`cleanUrls` and `trailingSlash` in `vercel.json` follow `build.format: "file"`
-and `trailingSlash: "never"` above: Vercel serves `/architecture` from
-`architecture.html` and redirects `/architecture/` rather than 404ing.
-
-`vercel-build.sh` deletes the repo-root `.env` before building, because mise
-reads it. Worth knowing if you run the Vercel CLI locally and keep secrets there.

--- a/apps/petrinaut-docs/README.md
+++ b/apps/petrinaut-docs/README.md
@@ -69,13 +69,12 @@ its own `cookie@2.x` without changing hoisting for the rest of the monorepo.
 Vercel builds the site from [`vercel.json`](vercel.json), which runs
 [`vercel-install.sh`](vercel-install.sh) then
 [`vercel-build.sh`](vercel-build.sh). Both `cd ../..` and build from the repo
-root, so the project needs **Root Directory** set to `apps/petrinaut-docs` with
-**Include files outside of the Root Directory in the Build Step** enabled.
+root, so the Vercel project sets **Root Directory** to `apps/petrinaut-docs` and
+enables **Include files outside of the Root Directory in the Build Step**.
 
-The site is served from `architecture.petrinaut.org`. That host is proposed
-rather than settled, so treat `site` in [`astro.config.mjs`](astro.config.mjs) as
-provisional: it sets the canonical URL and every sitemap entry. SRE-955 assigns
-the domain and decides how access to the deployment is restricted.
+The site is served from `docs.petrinaut.org` and is internal, so reaching it
+needs access. `site` in [`astro.config.mjs`](astro.config.mjs) has to match it:
+that is what sets the canonical URL and every sitemap entry.
 
 The tools the build needs are listed in
 [`vercel-install.sh`](vercel-install.sh), with a comment on why that list is

--- a/apps/petrinaut-docs/README.md
+++ b/apps/petrinaut-docs/README.md
@@ -77,12 +77,9 @@ rather than settled, so treat `site` in [`astro.config.mjs`](astro.config.mjs) a
 provisional: it sets the canonical URL and every sitemap entry. SRE-955 assigns
 the domain and decides how access to the deployment is restricted.
 
-The install script fetches Node, Turborepo and `d2`, and nothing else. The build
-graph is `astro build` <- `sync:bundle` <- `doc:architecture`, Node throughout,
-and `.yarnrc.yml` sets `enableScripts: false`, so nothing compiles during
-install. `d2` renders the diagrams, and the generator treats it as optional and
-omits every diagram when it is absent, so a build that succeeds is not on its own
-evidence that the toolchain is complete.
+The tools the build needs are listed in
+[`vercel-install.sh`](vercel-install.sh), with a comment on why that list is
+shorter than the other Vercel apps' in this repo.
 
 `cleanUrls` and `trailingSlash` in `vercel.json` follow `build.format: "file"`
 and `trailingSlash: "never"` above: Vercel serves `/architecture` from

--- a/apps/petrinaut-docs/README.md
+++ b/apps/petrinaut-docs/README.md
@@ -78,13 +78,26 @@ The site is served from `architecture.petrinaut.org`, behind a Cloudflare Access
 gate that requires SSO. That host is proposed rather than settled, so treat `site`
 in [`astro.config.mjs`](astro.config.mjs) as provisional: it sets the canonical
 URL and every sitemap entry, and has to match wherever the site ends up. SRE-955
-assigns the domain and configures the gate; FE-1157 may move these docs under
-`hash.dev/docs/petrinaut` instead.
+assigns the domain and configures the gate.
 
-The gate covers the machine-readable artefacts too. `sync:bundle` copies the
+### This host is not the only one
+
+This site renders every page in the manifest, all 48 of them. FE-1157 publishes a
+subset to `hash.dev/docs/petrinaut`, so the two hosts run side by side and a page
+can appear on one and not the other. That is the reason the app owns no content
+and builds its sidebar from `manifest.json`: a host that shows fewer pages is
+reading the same bundle, filtered.
+
+Nothing in the bundle records which pages belong in that subset. `ManifestPage`
+carries `kind`, which is `generated` or `authored`, and that is a source
+distinction rather than an audience one. FE-1157 has to decide how pages are
+selected, and until it does, the split lives in whatever consumes the manifest
+rather than in the manifest.
+
+The SSO gate covers the machine-readable artefacts too. `sync:bundle` copies the
 bundle's `architecture.md` and `architecture.json` into `public/`, so an agent
 reading either over HTTP needs a session, unlike one reading the bundle from a
-checkout.
+checkout. Both describe the whole model, not the public subset.
 
 The install script fetches Node, Turborepo and `d2`, and nothing else. The build
 graph is `astro build` <- `sync:bundle` <- `doc:architecture`, which is Node

--- a/apps/petrinaut-docs/README.md
+++ b/apps/petrinaut-docs/README.md
@@ -64,3 +64,30 @@ them. Astro's generated prerender entry resolves `cookie` from this app's build
 output, which would otherwise reach the root-hoisted `cookie@0.7.2` that
 `express` pins and fail on a missing `parseCookie` export. Nesting keeps Astro on
 its own `cookie@2.x` without changing hoisting for the rest of the monorepo.
+
+## Deployment
+
+Vercel builds the site from [`vercel.json`](vercel.json), which runs
+[`vercel-install.sh`](vercel-install.sh) and then
+[`vercel-build.sh`](vercel-build.sh). Both scripts `cd ../..` and work from the
+repo root, so the Vercel project needs **Root Directory** set to
+`apps/petrinaut-docs` with **Include files outside of the Root Directory in the
+Build Step** enabled. `site` in [`astro.config.mjs`](astro.config.mjs) sets the
+canonical URL to `https://petrinaut-docs.hash.dev`, so the project needs that
+domain assigned for sitemap and canonical links to match where it is served.
+
+The install script fetches Node, Turborepo and `d2`, and nothing else. The build
+graph is `astro build` <- `sync:bundle` <- `doc:architecture`, which is Node
+throughout, and `.yarnrc.yml` sets `enableScripts: false`, so no dependency
+compiles during install. `d2` renders the architecture diagrams; the generator
+treats it as optional and omits every diagram when it is absent, so a build that
+succeeds is not on its own evidence that the toolchain is complete.
+
+`cleanUrls` and `trailingSlash` in `vercel.json` mirror `build.format: "file"`
+and `trailingSlash: "never"` above. Astro emits `architecture.html` and
+`architecture/core.html`, and the bundle's relative links break under a trailing
+slash, so Vercel redirects `/architecture/` to `/architecture` and serves it from
+`architecture.html`.
+
+`vercel-build.sh` deletes the repo-root `.env` before building, because mise
+reads it. Worth knowing if you run the Vercel CLI locally and keep secrets there.

--- a/apps/petrinaut-docs/README.md
+++ b/apps/petrinaut-docs/README.md
@@ -68,49 +68,36 @@ its own `cookie@2.x` without changing hoisting for the rest of the monorepo.
 ## Deployment
 
 Vercel builds the site from [`vercel.json`](vercel.json), which runs
-[`vercel-install.sh`](vercel-install.sh) and then
-[`vercel-build.sh`](vercel-build.sh). Both scripts `cd ../..` and work from the
-repo root, so the Vercel project needs **Root Directory** set to
-`apps/petrinaut-docs` with **Include files outside of the Root Directory in the
-Build Step** enabled.
+[`vercel-install.sh`](vercel-install.sh) then
+[`vercel-build.sh`](vercel-build.sh). Both `cd ../..` and build from the repo
+root, so the project needs **Root Directory** set to `apps/petrinaut-docs` with
+**Include files outside of the Root Directory in the Build Step** enabled.
 
-The site is served from `architecture.petrinaut.org`, behind a Cloudflare Access
-gate that requires SSO. That host is proposed rather than settled, so treat `site`
-in [`astro.config.mjs`](astro.config.mjs) as provisional: it sets the canonical
-URL and every sitemap entry, and has to match wherever the site ends up. SRE-955
-assigns the domain and configures the gate.
+The site is served from `architecture.petrinaut.org` behind a Cloudflare Access
+gate requiring SSO. That host is proposed rather than settled, so treat `site` in
+[`astro.config.mjs`](astro.config.mjs) as provisional: it sets the canonical URL
+and every sitemap entry. SRE-955 assigns the domain and configures the gate.
 
-### This host is not the only one
+This host renders every page in the manifest. FE-1157 publishes a subset to
+`hash.dev/docs/petrinaut`, so the two run side by side and a page can appear on
+one and not the other. Nothing in the bundle records which pages belong to that
+subset: `ManifestPage` carries `kind`, which is `generated` or `authored`, a
+source distinction rather than an audience one. FE-1157 chooses the rule.
 
-This site renders every page in the manifest, all 48 of them. FE-1157 publishes a
-subset to `hash.dev/docs/petrinaut`, so the two hosts run side by side and a page
-can appear on one and not the other. That is the reason the app owns no content
-and builds its sidebar from `manifest.json`: a host that shows fewer pages is
-reading the same bundle, filtered.
-
-Nothing in the bundle records which pages belong in that subset. `ManifestPage`
-carries `kind`, which is `generated` or `authored`, and that is a source
-distinction rather than an audience one. FE-1157 has to decide how pages are
-selected, and until it does, the split lives in whatever consumes the manifest
-rather than in the manifest.
-
-The SSO gate covers the machine-readable artefacts too. `sync:bundle` copies the
-bundle's `architecture.md` and `architecture.json` into `public/`, so an agent
-reading either over HTTP needs a session, unlike one reading the bundle from a
-checkout. Both describe the whole model, not the public subset.
+The gate also covers `architecture.md` and `architecture.json`, which
+`sync:bundle` copies into `public/`, so an agent reading either over HTTP needs a
+session. Both describe the whole model rather than the subset.
 
 The install script fetches Node, Turborepo and `d2`, and nothing else. The build
-graph is `astro build` <- `sync:bundle` <- `doc:architecture`, which is Node
-throughout, and `.yarnrc.yml` sets `enableScripts: false`, so no dependency
-compiles during install. `d2` renders the architecture diagrams; the generator
-treats it as optional and omits every diagram when it is absent, so a build that
-succeeds is not on its own evidence that the toolchain is complete.
+graph is `astro build` <- `sync:bundle` <- `doc:architecture`, Node throughout,
+and `.yarnrc.yml` sets `enableScripts: false`, so nothing compiles during
+install. `d2` renders the diagrams, and the generator treats it as optional and
+omits every diagram when it is absent, so a build that succeeds is not on its own
+evidence that the toolchain is complete.
 
-`cleanUrls` and `trailingSlash` in `vercel.json` mirror `build.format: "file"`
-and `trailingSlash: "never"` above. Astro emits `architecture.html` and
-`architecture/core.html`, and the bundle's relative links break under a trailing
-slash, so Vercel redirects `/architecture/` to `/architecture` and serves it from
-`architecture.html`.
+`cleanUrls` and `trailingSlash` in `vercel.json` follow `build.format: "file"`
+and `trailingSlash: "never"` above: Vercel serves `/architecture` from
+`architecture.html` and redirects `/architecture/` rather than 404ing.
 
 `vercel-build.sh` deletes the repo-root `.env` before building, because mise
 reads it. Worth knowing if you run the Vercel CLI locally and keep secrets there.

--- a/apps/petrinaut-docs/README.md
+++ b/apps/petrinaut-docs/README.md
@@ -25,10 +25,9 @@ dependency. The bundle is build output and is not committed.
 each running it — they used to call it themselves, which raced when Turborepo ran
 them concurrently on the same directories.
 
-That separation is deliberate. The bundle has to render in a host that did not
-generate it — hash.dev is the other one — so this site is a test of the bundle's
-portability as much as a way to read it. Anything that only works here is a bug
-in the bundle.
+That separation is what makes this site a test of the bundle's portability as
+much as a way to read it: the bundle has to render in a host that did not
+generate it. Anything that only works here is a bug in the bundle.
 
 To change what the docs say, change the annotations in the Petrinaut source or
 the authored pages in `libs/@local/petrinaut-arch-docs/content/`. Anything run
@@ -77,14 +76,6 @@ The site is served from `architecture.petrinaut.org`. That host is proposed
 rather than settled, so treat `site` in [`astro.config.mjs`](astro.config.mjs) as
 provisional: it sets the canonical URL and every sitemap entry. SRE-955 assigns
 the domain and decides how access to the deployment is restricted.
-
-This host renders every page in the manifest, including the `architecture.md` and
-`architecture.json` that `sync:bundle` copies into `public/`, both of which
-describe the whole model. FE-1157 publishes a subset to `hash.dev/docs/petrinaut`,
-so the two run side by side and a page can appear on one and not the other.
-Nothing in the bundle records which pages belong to that subset: `ManifestPage`
-carries `kind`, which is `generated` or `authored`, a source distinction rather
-than an audience one. FE-1157 chooses the rule.
 
 The install script fetches Node, Turborepo and `d2`, and nothing else. The build
 graph is `astro build` <- `sync:bundle` <- `doc:architecture`, Node throughout,

--- a/apps/petrinaut-docs/README.md
+++ b/apps/petrinaut-docs/README.md
@@ -72,9 +72,19 @@ Vercel builds the site from [`vercel.json`](vercel.json), which runs
 [`vercel-build.sh`](vercel-build.sh). Both scripts `cd ../..` and work from the
 repo root, so the Vercel project needs **Root Directory** set to
 `apps/petrinaut-docs` with **Include files outside of the Root Directory in the
-Build Step** enabled. `site` in [`astro.config.mjs`](astro.config.mjs) sets the
-canonical URL to `https://petrinaut-docs.hash.dev`, so the project needs that
-domain assigned for sitemap and canonical links to match where it is served.
+Build Step** enabled.
+
+The site is served from `architecture.petrinaut.org`, behind a Cloudflare Access
+gate that requires SSO. That host is proposed rather than settled, so treat `site`
+in [`astro.config.mjs`](astro.config.mjs) as provisional: it sets the canonical
+URL and every sitemap entry, and has to match wherever the site ends up. SRE-955
+assigns the domain and configures the gate; FE-1157 may move these docs under
+`hash.dev/docs/petrinaut` instead.
+
+The gate covers the machine-readable artefacts too. `sync:bundle` copies the
+bundle's `architecture.md` and `architecture.json` into `public/`, so an agent
+reading either over HTTP needs a session, unlike one reading the bundle from a
+checkout.
 
 The install script fetches Node, Turborepo and `d2`, and nothing else. The build
 graph is `astro build` <- `sync:bundle` <- `doc:architecture`, which is Node

--- a/apps/petrinaut-docs/astro.config.mjs
+++ b/apps/petrinaut-docs/astro.config.mjs
@@ -10,9 +10,8 @@ import { defineConfig } from "astro/config";
  * Renders the architecture bundle produced by `@local/petrinaut-arch-docs`.
  *
  * This site owns no content. That is the point: the bundle has to render in a
- * host that did not generate it, and this site is the first of two such hosts
- * (hash.dev being the other). Anything that only works here is a bug in the
- * bundle's portability, which is why the sidebar below is built from
+ * host that did not generate it, so anything that only works here is a bug in
+ * the bundle's portability, which is why the sidebar below is built from
  * `manifest.json` rather than from Starlight-specific frontmatter.
  */
 
@@ -204,10 +203,6 @@ const hasAuthoredIndex = manifest.pages.some(
 export default defineConfig({
   // Sets the canonical URL and the sitemap's entries. Proposed rather than
   // settled, and assigned by SRE-955.
-  //
-  // This host serves every page in the manifest; FE-1157 publishes a subset to
-  // `hash.dev/docs/petrinaut`. The two coexist, and nothing in the manifest
-  // says which pages belong to the subset.
   site: "https://architecture.petrinaut.org",
 
   ...(hasAuthoredIndex ? {} : { redirects: { "/": "/architecture" } }),

--- a/apps/petrinaut-docs/astro.config.mjs
+++ b/apps/petrinaut-docs/astro.config.mjs
@@ -202,7 +202,10 @@ const hasAuthoredIndex = manifest.pages.some(
 );
 
 export default defineConfig({
-  site: "https://petrinaut-docs.hash.dev",
+  // Sets the canonical URL and the sitemap's entries. Proposed rather than
+  // settled: SRE-955 assigns the domain, and FE-1157 may move these docs to
+  // `hash.dev/docs/petrinaut` instead, at which point this changes again.
+  site: "https://architecture.petrinaut.org",
 
   ...(hasAuthoredIndex ? {} : { redirects: { "/": "/architecture" } }),
 

--- a/apps/petrinaut-docs/astro.config.mjs
+++ b/apps/petrinaut-docs/astro.config.mjs
@@ -203,8 +203,11 @@ const hasAuthoredIndex = manifest.pages.some(
 
 export default defineConfig({
   // Sets the canonical URL and the sitemap's entries. Proposed rather than
-  // settled: SRE-955 assigns the domain, and FE-1157 may move these docs to
-  // `hash.dev/docs/petrinaut` instead, at which point this changes again.
+  // settled, and assigned by SRE-955.
+  //
+  // This host serves every page in the manifest. FE-1157 publishes a subset to
+  // `hash.dev/docs/petrinaut`, so the two coexist and a page can appear on one
+  // and not the other. Nothing in the manifest says which pages those are.
   site: "https://architecture.petrinaut.org",
 
   ...(hasAuthoredIndex ? {} : { redirects: { "/": "/architecture" } }),

--- a/apps/petrinaut-docs/astro.config.mjs
+++ b/apps/petrinaut-docs/astro.config.mjs
@@ -201,9 +201,7 @@ const hasAuthoredIndex = manifest.pages.some(
 );
 
 export default defineConfig({
-  // Sets the canonical URL and the sitemap's entries. Proposed rather than
-  // settled, and assigned by SRE-955.
-  site: "https://architecture.petrinaut.org",
+  site: "https://docs.petrinaut.org",
 
   ...(hasAuthoredIndex ? {} : { redirects: { "/": "/architecture" } }),
 

--- a/apps/petrinaut-docs/astro.config.mjs
+++ b/apps/petrinaut-docs/astro.config.mjs
@@ -205,9 +205,9 @@ export default defineConfig({
   // Sets the canonical URL and the sitemap's entries. Proposed rather than
   // settled, and assigned by SRE-955.
   //
-  // This host serves every page in the manifest. FE-1157 publishes a subset to
-  // `hash.dev/docs/petrinaut`, so the two coexist and a page can appear on one
-  // and not the other. Nothing in the manifest says which pages those are.
+  // This host serves every page in the manifest; FE-1157 publishes a subset to
+  // `hash.dev/docs/petrinaut`. The two coexist, and nothing in the manifest
+  // says which pages belong to the subset.
   site: "https://architecture.petrinaut.org",
 
   ...(hasAuthoredIndex ? {} : { redirects: { "/": "/architecture" } }),

--- a/apps/petrinaut-docs/package.json
+++ b/apps/petrinaut-docs/package.json
@@ -28,6 +28,9 @@
     "@types/react-dom": "19.2.3",
     "typescript": "5.9.3"
   },
+  "engines": {
+    "node": "22.x"
+  },
   "installConfig": {
     "hoistingLimits": "dependencies"
   }

--- a/apps/petrinaut-docs/vercel-build.sh
+++ b/apps/petrinaut-docs/vercel-build.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+eval "$(mise activate bash --shims)"
+
+echo "Changing dir to root"
+cd ../..
+
+# TODO: Mise is picking up `.env` files. We need to overhaul our approach for
+#   environment variables. To avoid this in the meantime, we'll remove the
+#   `.env` file.
+# See: https://linear.app/hash/issue/H-3213/use-consistent-naming-schema-for-environment-variables
+# See: https://linear.app/hash/issue/H-4202/sort-out-which-environment-variables-are-defined-where
+# See: https://linear.app/hash/issue/H-3212/clean-up-env-files
+rm .env
+
+# Run through Turborepo rather than `yarn workspace ... build`: the package
+# script alone skips `sync:bundle`, and would build whatever content happened to
+# be on disk.
+echo "Building Petrinaut architecture docs"
+turbo build --filter='@apps/petrinaut-docs' --env-mode=loose

--- a/apps/petrinaut-docs/vercel-build.sh
+++ b/apps/petrinaut-docs/vercel-build.sh
@@ -13,7 +13,7 @@ cd ../..
 # See: https://linear.app/hash/issue/H-3213/use-consistent-naming-schema-for-environment-variables
 # See: https://linear.app/hash/issue/H-4202/sort-out-which-environment-variables-are-defined-where
 # See: https://linear.app/hash/issue/H-3212/clean-up-env-files
-rm .env
+rm -f .env
 
 # Run through Turborepo rather than `yarn workspace ... build`: the package
 # script alone skips `sync:bundle`, and would build whatever content happened to

--- a/apps/petrinaut-docs/vercel-install.sh
+++ b/apps/petrinaut-docs/vercel-install.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "Changing dir to root"
+cd ../..
+
+echo "updating certificates"
+yum update ca-certificates -y
+
+echo "installing mise"
+./.config/mise/install.sh
+eval "$(mise activate bash --shims)"
+
+# The build graph is `astro build` <- `sync:bundle` <- `doc:architecture`, which
+# is Node throughout, and `.yarnrc.yml` sets `enableScripts: false`, so no
+# dependency compiles during install. That leaves out the Rust toolchain, wasm
+# target, wasm-pack, binaryen, java, protoc and redocly that the other Vercel
+# apps in this repo install.
+#
+# `d2` renders the architecture diagrams. Without it `canRenderDiagrams` in the
+# generator returns false and the bundle omits every diagram, exiting 0, so
+# dropping `d2` here loses all 44 SVGs without failing the build.
+echo "Installing prerequisites"
+mise install --locked node npm:turbo ubi:terrastruct/d2
+
+echo "Installing yarn dependencies"
+LEFTHOOK=0 yarn install --immutable

--- a/apps/petrinaut-docs/vercel-install.sh
+++ b/apps/petrinaut-docs/vercel-install.sh
@@ -12,15 +12,14 @@ echo "installing mise"
 ./.config/mise/install.sh
 eval "$(mise activate bash --shims)"
 
-# The build graph is `astro build` <- `sync:bundle` <- `doc:architecture`, which
-# is Node throughout, and `.yarnrc.yml` sets `enableScripts: false`, so no
-# dependency compiles during install. That leaves out the Rust toolchain, wasm
-# target, wasm-pack, binaryen, java, protoc and redocly that the other Vercel
-# apps in this repo install.
+# The build graph is `astro build` <- `sync:bundle` <- `doc:architecture`, Node
+# throughout, and `.yarnrc.yml` sets `enableScripts: false`, so nothing compiles
+# during install. That leaves out the Rust toolchain, wasm target, wasm-pack,
+# binaryen, java, protoc and redocly that the other Vercel apps here install.
 #
-# `d2` renders the architecture diagrams. Without it `canRenderDiagrams` in the
-# generator returns false and the bundle omits every diagram, exiting 0, so
-# dropping `d2` here loses all 44 SVGs without failing the build.
+# `d2` renders the architecture diagrams. Without it `canRenderDiagrams` returns
+# false and the bundle omits every diagram, exiting 0, so dropping `d2` here
+# loses them all without failing the build.
 echo "Installing prerequisites"
 mise install --locked node npm:turbo ubi:terrastruct/d2
 

--- a/apps/petrinaut-docs/vercel.json
+++ b/apps/petrinaut-docs/vercel.json
@@ -5,7 +5,7 @@
   },
   "buildCommand": "./vercel-build.sh",
   "installCommand": "./vercel-install.sh",
-  "outputDirectory": "./.next",
+  "outputDirectory": "./dist",
   "cleanUrls": true,
   "trailingSlash": false
 }

--- a/apps/petrinaut-docs/vercel.json
+++ b/apps/petrinaut-docs/vercel.json
@@ -5,7 +5,7 @@
   },
   "buildCommand": "./vercel-build.sh",
   "installCommand": "./vercel-install.sh",
-  "outputDirectory": "./dist",
+  "outputDirectory": "./.next",
   "cleanUrls": true,
   "trailingSlash": false
 }

--- a/apps/petrinaut-docs/vercel.json
+++ b/apps/petrinaut-docs/vercel.json
@@ -1,0 +1,11 @@
+{
+  "github": {
+    "silent": true,
+    "autoJobCancelation": true
+  },
+  "buildCommand": "./vercel-build.sh",
+  "installCommand": "./vercel-install.sh",
+  "outputDirectory": "./dist",
+  "cleanUrls": true,
+  "trailingSlash": false
+}

--- a/apps/petrinaut-docs/vercel.json
+++ b/apps/petrinaut-docs/vercel.json
@@ -3,6 +3,7 @@
     "silent": true,
     "autoJobCancelation": true
   },
+  "framework": "astro",
   "buildCommand": "./vercel-build.sh",
   "installCommand": "./vercel-install.sh",
   "outputDirectory": "./dist",

--- a/apps/petrinaut-docs/vercel.json
+++ b/apps/petrinaut-docs/vercel.json
@@ -4,6 +4,7 @@
     "autoJobCancelation": true
   },
   "framework": "astro",
+  "ignoreCommand": "npx turbo-ignore @apps/petrinaut-docs",
   "buildCommand": "./vercel-build.sh",
   "installCommand": "./vercel-install.sh",
   "outputDirectory": "./dist",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Adds the Vercel build for `@apps/petrinaut-docs`. The app shipped in #9206 with no `vercel.json` and no build or install script, so a Vercel project pointed at it has nothing to run.

## 🔗 Related links

- FE-1418
- SRE-955, creating the Vercel project. The project now exists and deploys this branch.
- FE-1157, publishing a subset of the same bundle to `hash.dev/docs/petrinaut`. Runs alongside this host.
- #9206, which added the app.

## 🔍 What does this change?

`vercel.json` plus the two scripts, following `hash-frontend` and `petrinaut-website`. `vercel-install.sh` installs a shorter tool list than either, for the reason given in the script. `vercel-build.sh` builds through Turborepo, since the package script alone skips `sync:bundle`.

`cleanUrls` and `trailingSlash: false` match `build.format: "file"` and `trailingSlash: "never"` in `astro.config.mjs`, whose relative inter-page links break under a trailing slash.

`site` moves to `docs.petrinaut.org`, which sets the canonical URL and the sitemap entries.

Settings the repo cannot carry, tracked in SRE-955:

| Setting | Value |
| --- | --- |
| Root Directory | `apps/petrinaut-docs` |
| Include files outside of the Root Directory in the Build Step | enabled |
| Domain | `docs.petrinaut.org` |

Both scripts `cd ../..`, so the build fails without the second.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

- [x] require changes to docs which **are made** as part of this PR

`apps/petrinaut-docs/README.md` gains a Deployment section, covering this site only.

### 🕸️ Does this require a change to the Turbo Graph?

- [x] do not affect the execution graph

`vercel-build.sh` calls the existing `build` task.

## ⚠️ Known issues

- **`d2` is optional to the generator.** Without it the bundle builds with no diagrams and exits 0, so a green deployment does not show the install list worked. SRE-955 asks for a check on the first deploy.
- **Access control is not in the repo.** The site is internal; how that is enforced belongs to SRE-955, including the `*.vercel.app` URLs that a hostname rule does not cover.

## 🛡 What tests cover this?

None. CI does not run Vercel build configuration, and the two existing apps' scripts are not covered either. The `petrinaut-docs` Vercel project now builds this branch, which exercises both scripts end to end.

## ❓ How to test this?

```bash
turbo build --filter='@apps/petrinaut-docs' --env-mode=loose
```

Static output lands in `apps/petrinaut-docs/dist`.
