### PR TITLE
FE-1447: Emit layer facts and relations as structured data with card components

### DIFF
--- a/apps/petrinaut-docs/astro.config.mjs
+++ b/apps/petrinaut-docs/astro.config.mjs
@@ -214,8 +214,8 @@ export default defineConfig({
   build: { format: "file" },
 
   integrations: [
-    // Authored pages may import diagram components from the bundle; generated
-    // pages stay plain Markdown and never need this.
+    // Generated layer pages import the bundle's facts and relations cards, and
+    // authored pages may import its diagram components; both are React.
     react(),
     starlight({
       title: "Architecture Docs",

--- a/apps/petrinaut-docs/scripts/sync-bundle.mjs
+++ b/apps/petrinaut-docs/scripts/sync-bundle.mjs
@@ -45,11 +45,11 @@ await mkdir(contentRoot, { recursive: true });
 /**
  * Copies a bundle directory when the generator produced one.
  *
- * Only `pages/` is always present. `components/` exists when an authored page
- * ships a diagram component, and `diagrams/` when `d2` was available to render
- * them, so both are absent from a valid bundle in ordinary cases: a bundle with
- * no `content/` at all has neither. Copying unconditionally turned that into an
- * `ENOENT` that took down `build`, `dev` and `lint:tsc` together.
+ * `pages/` and `components/` are always present (the generator ships the layer
+ * card components in every bundle), but `diagrams/` only exists when `d2` was
+ * available to render them, so it is absent from a valid bundle in ordinary
+ * cases. Copying unconditionally turned that into an `ENOENT` that took down
+ * `build`, `dev` and `lint:tsc` together.
  *
  * @param {string} name Directory within the bundle.
  * @param {string} destination Directory within `src/content/`.
@@ -72,7 +72,7 @@ await cp(`${bundleRoot}pages`, `${contentRoot}docs`, { recursive: true });
 
 await copyIfPresent("diagrams", "diagrams");
 
-// Diagram components imported by authored pages. Copied as siblings of `docs/`
+// React components imported by the pages. Copied as siblings of `docs/`
 // because that is the layout the bundle's own relative imports assume.
 await copyIfPresent("components", "components");
 

--- a/libs/@local/petrinaut-arch-docs/README.md
+++ b/libs/@local/petrinaut-arch-docs/README.md
@@ -94,8 +94,8 @@ comment or docstring the scanner already reads:
 The declaring file's own layer is the edge source, the id before `via` is the
 target, and the text after `via` is required and becomes the edge label. The
 tag is repeatable. Declared edges render dashed with their protocol in every
-diagram that shows the pair, and sit in their own "Declared" table on the
-layer pages, apart from the edges aggregated from imports.
+diagram that shows the pair, and the relations card on a layer page marks them
+with a dashed protocol label, apart from the edges aggregated from imports.
 
 The build fails when the target is not a declared layer, and when the pair is
 already derived from imports; remove the declaration in the second case, since
@@ -117,26 +117,28 @@ Regenerate it whenever you need it; nothing depends on a stored copy.
 The bundle is framework-neutral by design — the Starlight site in
 `apps/petrinaut-docs` and hash.dev are both just consumers.
 
-| File                | What it is                                                       |
-| ------------------- | ---------------------------------------------------------------- |
-| `architecture.json` | The model: layers, edges, enforced rules                         |
-| `architecture.md`   | The whole architecture as one file — the cheapest read for an AI |
-| `manifest.json`     | Page tree for building navigation without crawling `pages/`      |
-| `pages/**.mdx`      | Generated layer pages, plus authored pages merged in             |
-| `components/*.tsx`  | React diagram components imported by authored pages              |
-| `diagrams/**.d2`    | Diagram sources (diffable)                                       |
-| `diagrams/**.svg`   | Rendered diagrams                                                |
+| File                | What it is                                                                                                    |
+| ------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `architecture.json` | The model: layers, edges, enforced rules                                                                      |
+| `architecture.md`   | The whole architecture as one file — the cheapest read for an AI                                              |
+| `manifest.json`     | Page tree for building navigation without crawling `pages/`                                                   |
+| `pages/**.mdx`      | Generated layer pages, plus authored pages merged in                                                          |
+| `components/*.tsx`  | React components: the layer card components every bundle ships, plus diagram components authored pages import |
+| `diagrams/**.d2`    | Diagram sources (diffable)                                                                                    |
+| `diagrams/**.svg`   | Rendered diagrams                                                                                             |
 
-**Generated** MDX is YAML frontmatter plus plain CommonMark — no JSX, no
-imports, no framework components — which is what lets it render in Astro, in
-hash.dev's Next.js MDX pipeline, and as plain text.
+**Generated** MDX is YAML frontmatter plus CommonMark, with one exception: each
+layer page imports the bundle's `LayerFacts` and `LayerRelations` cards and
+passes its facts and edges as structured props, so a host restyles the cards
+rather than re-parsing prose. The same facts stay plain text in
+`architecture.md`, the cheapest read for an agent.
 
-**Authored** pages may additionally import the diagram components below, which is
-where every requirement the bundle places on a host comes from:
+**Authored** pages may additionally import the bundle's diagram components.
+Together that is every requirement the bundle places on a host:
 
-| A host must provide          | For                                                |
-| ---------------------------- | -------------------------------------------------- |
-| A React-capable MDX pipeline | Any authored page that imports a diagram component |
+| A host must provide          | For                                                                           |
+| ---------------------------- | ----------------------------------------------------------------------------- |
+| A React-capable MDX pipeline | Generated layer pages, and any authored page that imports a diagram component |
 
 Nothing else — in particular nothing hydrates, so no client-side runtime is
 required. In particular the bundle asks for **no Markdown or Rehype

--- a/libs/@local/petrinaut-arch-docs/content/maintaining/declaring-layers.mdx
+++ b/libs/@local/petrinaut-arch-docs/content/maintaining/declaring-layers.mdx
@@ -149,8 +149,8 @@ already reads:
 The edge starts at the declaring file's own layer. The word before `via` is the
 target layer id; the text after `via` is required and becomes the edge label.
 The tag is repeatable, one target per tag. Declared edges are drawn dashed in
-the diagrams and listed under "Declared" in the dependency tables, separate
-from the edges aggregated from imports.
+the diagrams, and the relations card on a layer page shows them with a dashed
+protocol label, separate from the edges aggregated from imports.
 
 The check fails when the target is not a declared layer. It also fails when the
 pair is already derived from imports; the import edge is the record in that

--- a/libs/@local/petrinaut-arch-docs/src/build.ts
+++ b/libs/@local/petrinaut-arch-docs/src/build.ts
@@ -33,6 +33,7 @@ import {
   layerSlug,
   type GeneratedPage,
 } from "./emit/mdx";
+import { readShippedComponents } from "./emit/shipped-components";
 import { extract } from "./extract";
 import { buildGraph } from "./graph";
 import {
@@ -50,7 +51,7 @@ export interface BuiltBundle {
   authored: AuthoredPage[];
   /** Diagram name → D2 source. */
   diagramSources: Map<string, string>;
-  /** Importable diagram components shipped with the bundle. */
+  /** Bundle components: authored diagram components plus the shipped cards. */
   components: AuthoredComponent[];
   singleFile: string;
   diagnostics: Diagnostic[];
@@ -253,6 +254,24 @@ export const buildBundle = async (options: {
     ]);
   }
 
+  // Both component sets land in the bundle's `components/`, so an authored
+  // component whose file name matches a shipped one would overwrite a module
+  // every generated layer page imports.
+  const shippedComponents = await readShippedComponents();
+  const shippedPaths = new Set(
+    shippedComponents.map((component) => component.path),
+  );
+  for (const component of authoredResult.components) {
+    if (shippedPaths.has(component.path)) {
+      diagnostics.push(
+        error(
+          `${settings.contentDirectory}/${component.path}`,
+          `component \`${component.name}\` collides with a component the generator ships`,
+        ),
+      );
+    }
+  }
+
   const componentNames = new Set(
     authoredResult.components.map((component) => component.name),
   );
@@ -348,7 +367,7 @@ export const buildBundle = async (options: {
     authored,
     diagramSources,
     singleFile: buildSingleFileArchitecture(model),
-    components: authoredResult.components,
+    components: [...authoredResult.components, ...shippedComponents],
     diagnostics,
   };
 };

--- a/libs/@local/petrinaut-arch-docs/src/emit/components/layer-cards.css
+++ b/libs/@local/petrinaut-arch-docs/src/emit/components/layer-cards.css
@@ -1,0 +1,300 @@
+/*
+ * Styling for the layer facts and relations cards on generated layer pages.
+ *
+ * Self-contained plain CSS, same rules as the authored diagram components:
+ * colours derive from the host's text colour via color-mix, so the cards render
+ * in the Starlight site's light and dark themes and in any other host without
+ * that host defining anything.
+ *
+ * Inner selectors are written as `.arch-card .arch-*` because two classes
+ * outrank Starlight's `.sl-markdown-content :not(...) + :not(...)` spacing rule,
+ * which would otherwise insert 1rem of margin between every pair of siblings
+ * inside the cards.
+ */
+
+.arch-card {
+  --arch-line: color-mix(in srgb, currentColor 22%, transparent);
+  --arch-hairline: color-mix(in srgb, currentColor 12%, transparent);
+  --arch-muted: color-mix(in srgb, currentColor 62%, transparent);
+  --arch-surface: color-mix(in srgb, currentColor 4%, transparent);
+  --arch-badge: color-mix(in srgb, currentColor 10%, transparent);
+  --arch-accent: #3676b8;
+
+  margin: 1.25rem 0;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--arch-line);
+  border-radius: 0.5rem;
+  background: var(--arch-surface);
+  font-size: 0.8rem;
+  line-height: 1.45;
+}
+
+.arch-card code {
+  padding: 0.1em 0.35em;
+  font-size: 0.95em;
+}
+
+/* One label style everywhere, so columns read as one system. */
+.arch-card .arch-label {
+  display: block;
+  margin: 0;
+  padding: 0;
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--arch-muted);
+}
+
+/* Facts ------------------------------------------------------------------ */
+
+.arch-card .arch-facts-grid {
+  display: grid;
+  grid-template-columns: repeat(4, max-content);
+  justify-content: start;
+  column-gap: 2.5rem;
+  row-gap: 0.75rem;
+  margin: 0;
+  padding: 0;
+}
+
+.arch-card .arch-facts-cell {
+  display: grid;
+  row-gap: 0.3rem;
+  justify-items: start;
+  margin: 0;
+  padding: 0;
+}
+
+.arch-card .arch-facts-value {
+  display: block;
+  margin: 0;
+  padding: 0;
+  font-variant-numeric: tabular-nums;
+}
+
+/* The code chip's own left padding would un-align it from the label. */
+.arch-card .arch-facts-value > code {
+  margin-left: -0.35em;
+}
+
+.arch-card .arch-facts-source {
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+  margin: 0.75rem 0 0;
+  padding: 0.6rem 0 0;
+  border-top: 1px solid var(--arch-hairline);
+  overflow-wrap: anywhere;
+}
+
+.arch-card .arch-facts-source .arch-label {
+  flex: none;
+}
+
+@media (max-width: 640px) {
+  .arch-card .arch-facts-grid {
+    grid-template-columns: repeat(2, max-content);
+  }
+}
+
+/* Relations ---------------------------------------------------------------- */
+
+.arch-rel {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.6rem 0;
+}
+
+/* `margin: 0` beats Starlight's sibling-margin rule, which otherwise pushes
+   the second direction down and un-aligns the two column headings. */
+.arch-card .arch-rel-direction {
+  min-width: 0;
+  margin: 0;
+  padding: 0 1.25rem 0 0;
+}
+
+.arch-card .arch-rel-direction + .arch-rel-direction {
+  padding: 0 0 0 1.25rem;
+  border-left: 1px solid var(--arch-hairline);
+}
+
+.arch-card .arch-rel-direction .arch-label {
+  margin-bottom: 0.4rem;
+}
+
+.arch-card .arch-rel-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+/* One line per row: name, then the protocol of a declared edge, then badges
+   pinned right. The name keeps its width and the protocol truncates. */
+.arch-card .arch-rel-row {
+  display: grid;
+  grid-template-columns: minmax(0, auto) minmax(0, 1fr) auto;
+  align-items: baseline;
+  column-gap: 0.5rem;
+  margin: 0;
+  padding: 0.3rem 0;
+}
+
+.arch-card .arch-rel-row + .arch-rel-row {
+  border-top: 1px solid var(--arch-hairline);
+}
+
+/* One line per row: a long id truncates rather than reflowing the column.
+   The full id is on the element's title. */
+.arch-card .arch-rel-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Column 3 explicitly: a row without a protocol still pins its badges right. */
+.arch-card .arch-rel-badges {
+  display: inline-flex;
+  grid-column: 3;
+  align-items: baseline;
+  gap: 0.35rem;
+  justify-self: end;
+}
+
+.arch-card .arch-rel-count {
+  min-width: 1.4rem;
+  padding: 0 0.35rem;
+  border-radius: 0.6rem;
+  background: var(--arch-badge);
+  font-size: 0.7rem;
+  font-variant-numeric: tabular-nums;
+  text-align: center;
+  color: var(--arch-muted);
+}
+
+.arch-card .arch-rel-pkg {
+  padding: 0 0.3rem;
+  border: 1px solid color-mix(in srgb, var(--arch-accent) 55%, transparent);
+  border-radius: 0.25rem;
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  color: var(--arch-accent);
+}
+
+/* A declared edge is an annotation's claim, so its label is drawn dashed. */
+.arch-card .arch-rel-protocol {
+  grid-column: 2;
+  justify-self: start;
+  max-width: 100%;
+  padding: 0.05rem 0.4rem;
+  border: 1px dashed var(--arch-line);
+  border-radius: 0.25rem;
+  overflow: hidden;
+  font-size: 0.7rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--arch-muted);
+}
+
+.arch-card .arch-rel-via {
+  font-style: italic;
+  opacity: 0.75;
+}
+
+.arch-card .arch-rel-empty {
+  margin: 0;
+  padding: 0;
+  color: var(--arch-muted);
+}
+
+.arch-card .arch-rel-note {
+  grid-column: 1 / -1;
+  margin: 0.2rem 0 0;
+  padding: 0.5rem 0 0;
+  border-top: 1px solid var(--arch-hairline);
+  font-size: 0.7rem;
+  color: var(--arch-muted);
+}
+
+/* Links -------------------------------------------------------------------- */
+
+.arch-card .arch-links-note {
+  margin: 0.35rem 0 0;
+  padding: 0;
+  font-size: 0.7rem;
+  color: var(--arch-muted);
+}
+
+.arch-card .arch-links-grid {
+  margin: 0.5rem 0 0;
+  padding: 0;
+}
+
+.arch-card .arch-links-row {
+  display: grid;
+  grid-template-columns: minmax(0, max-content) minmax(0, 1fr);
+  align-items: baseline;
+  column-gap: 1rem;
+  margin: 0;
+  padding: 0.3rem 0;
+}
+
+.arch-card .arch-links-row + .arch-links-row {
+  border-top: 1px solid var(--arch-hairline);
+}
+
+.arch-card .arch-links-term {
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.arch-card .arch-links-description {
+  margin: 0;
+  padding: 0;
+  color: var(--arch-muted);
+}
+
+@media (max-width: 640px) {
+  .arch-card .arch-links-row {
+    grid-template-columns: minmax(0, 1fr);
+    row-gap: 0.15rem;
+  }
+}
+
+/* Source ------------------------------------------------------------------- */
+
+.arch-card .arch-source-line {
+  margin: 0.35rem 0 0;
+  padding: 0;
+  overflow-wrap: anywhere;
+}
+
+.arch-card .arch-source-note {
+  margin: 0.5rem 0 0;
+  padding: 0.5rem 0 0;
+  border-top: 1px solid var(--arch-hairline);
+  font-size: 0.7rem;
+  color: var(--arch-muted);
+}
+
+@media (max-width: 640px) {
+  .arch-rel {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .arch-card .arch-rel-direction {
+    padding: 0;
+  }
+
+  .arch-card .arch-rel-direction + .arch-rel-direction {
+    margin-top: 0.6rem;
+    padding: 0.6rem 0 0;
+    border-top: 1px solid var(--arch-hairline);
+    border-left: none;
+  }
+}

--- a/libs/@local/petrinaut-arch-docs/src/emit/components/layer-facts.tsx
+++ b/libs/@local/petrinaut-arch-docs/src/emit/components/layer-facts.tsx
@@ -1,0 +1,49 @@
+/**
+ * The facts card at the top of every generated layer page: package, layer id,
+ * size, and the annotation that declared the layer. The generator emits the
+ * values as props, so a host restyles the card rather than re-parsing prose.
+ */
+
+import "./layer-cards.css";
+import type { ReactNode } from "react";
+
+export interface LayerFactsProps {
+  package: string;
+  layerId: string;
+  files: number;
+  lines: number;
+  declaredIn: string;
+  declaredInUrl: string;
+}
+
+const Cell = ({ label, value }: { label: string; value: ReactNode }) => (
+  <div className="arch-facts-cell">
+    <span className="arch-label">{label}</span>
+    <span className="arch-facts-value">{value}</span>
+  </div>
+);
+
+export const LayerFacts = ({
+  // `package` is a reserved word, so it cannot be a plain binding.
+  package: packageName,
+  layerId,
+  files,
+  lines,
+  declaredIn,
+  declaredInUrl,
+}: LayerFactsProps) => (
+  <section className="arch-card arch-facts">
+    <div className="arch-facts-grid">
+      <Cell label="Package" value={<code>{packageName}</code>} />
+      <Cell label="Layer id" value={<code>{layerId}</code>} />
+      <Cell label="Files" value={files.toLocaleString("en-US")} />
+      <Cell label="Lines" value={lines.toLocaleString("en-US")} />
+    </div>
+    <div className="arch-facts-source">
+      <span className="arch-label">Declared in</span>
+      <a href={declaredInUrl}>
+        <code>{declaredIn}</code>
+      </a>
+    </div>
+  </section>
+);

--- a/libs/@local/petrinaut-arch-docs/src/emit/components/layer-links.tsx
+++ b/libs/@local/petrinaut-arch-docs/src/emit/components/layer-links.tsx
@@ -1,0 +1,41 @@
+/**
+ * A titled card of links on generated layer pages: sub-layers, attached
+ * guides, and further reading. Each entry is a link with an optional
+ * one-line description.
+ */
+
+import "./layer-cards.css";
+
+export interface LayerLinkEntry {
+  label: string;
+  href: string;
+  description?: string;
+  /** Render the label as code, for source paths. */
+  code?: boolean;
+}
+
+export interface LayerLinksProps {
+  title: string;
+  entries: LayerLinkEntry[];
+  /** One line under the title, for a caveat that applies to every entry. */
+  note?: string;
+}
+
+export const LayerLinks = ({ title, entries, note }: LayerLinksProps) => (
+  <section className="arch-card arch-links">
+    <span className="arch-label">{title}</span>
+    {note === undefined ? null : <p className="arch-links-note">{note}</p>}
+    <dl className="arch-links-grid">
+      {entries.map((entry) => (
+        <div className="arch-links-row" key={entry.href}>
+          <dt className="arch-links-term">
+            <a href={entry.href}>
+              {entry.code === true ? <code>{entry.label}</code> : entry.label}
+            </a>
+          </dt>
+          <dd className="arch-links-description">{entry.description ?? ""}</dd>
+        </div>
+      ))}
+    </dl>
+  </section>
+);

--- a/libs/@local/petrinaut-arch-docs/src/emit/components/layer-relations.tsx
+++ b/libs/@local/petrinaut-arch-docs/src/emit/components/layer-relations.tsx
@@ -1,0 +1,93 @@
+/**
+ * The relations card on generated layer pages: what the layer depends on and
+ * what depends on it, both directions in one card. Import edges carry a count
+ * badge; declared `@talksTo` edges carry their protocol in a dashed label.
+ */
+
+import "./layer-cards.css";
+
+export interface LayerRelation {
+  /** Layer id of the other endpoint. */
+  id: string;
+  name: string;
+  /** Relative URL of the other endpoint's page. */
+  href: string;
+  provenance: "imports" | "declared";
+  crossesPackage: boolean;
+  /** File-level import count, for `imports` provenance. */
+  imports?: number;
+  /** The annotation's protocol text, for `declared` provenance. */
+  protocol?: string;
+}
+
+export interface LayerRelationsProps {
+  dependsOn: LayerRelation[];
+  dependedOnBy: LayerRelation[];
+}
+
+const Direction = ({
+  title,
+  entries,
+}: {
+  title: string;
+  entries: LayerRelation[];
+}) => (
+  <div className="arch-rel-direction">
+    <div className="arch-label">{title}</div>
+    {entries.length === 0 ? (
+      <p className="arch-rel-empty">—</p>
+    ) : (
+      <ul className="arch-rel-list">
+        {entries.map((entry) => (
+          <li className="arch-rel-row" key={entry.id}>
+            <a className="arch-rel-name" href={entry.href} title={entry.id}>
+              {entry.name}
+            </a>
+            {entry.protocol === undefined ? null : (
+              <span
+                className="arch-rel-protocol"
+                title={`via ${entry.protocol}. Declared with @talksTo; only the endpoints are checked.`}
+              >
+                <span className="arch-rel-via">via</span> {entry.protocol}
+              </span>
+            )}
+            <span className="arch-rel-badges">
+              {entry.imports === undefined ? null : (
+                <span
+                  className="arch-rel-count"
+                  title={`${entry.imports} file-level import${entry.imports === 1 ? "" : "s"}`}
+                >
+                  {entry.imports}
+                </span>
+              )}
+              {entry.crossesPackage ? (
+                <span
+                  className="arch-rel-pkg"
+                  title="Crosses a package boundary"
+                >
+                  pkg
+                </span>
+              ) : null}
+            </span>
+          </li>
+        ))}
+      </ul>
+    )}
+  </div>
+);
+
+export const LayerRelations = ({
+  dependsOn,
+  dependedOnBy,
+}: LayerRelationsProps) => (
+  // Left to right matches the diagrams: consumers first, then dependencies.
+  <section className="arch-card arch-rel">
+    <Direction title="Depended on by" entries={dependedOnBy} />
+    <Direction title="Depends on" entries={dependsOn} />
+    <p className="arch-rel-note">
+      Counts are file-level imports, aggregated from TypeScript packages only.
+      Dashed labels are <code>@talksTo</code> declarations: the protocol text is
+      the annotation's claim, and only the endpoints are checked.
+    </p>
+  </section>
+);

--- a/libs/@local/petrinaut-arch-docs/src/emit/components/layer-source.tsx
+++ b/libs/@local/petrinaut-arch-docs/src/emit/components/layer-source.tsx
@@ -1,0 +1,28 @@
+/**
+ * The source card at the bottom of every generated layer page: how many files
+ * resolve to the layer and where they are rooted.
+ */
+
+import "./layer-cards.css";
+
+export interface LayerSourceProps {
+  files: number;
+  root: string;
+  rootUrl: string;
+}
+
+export const LayerSource = ({ files, root, rootUrl }: LayerSourceProps) => (
+  <section className="arch-card arch-source">
+    <span className="arch-label">Source</span>
+    <p className="arch-source-line">
+      {files.toLocaleString("en-US")} file{files === 1 ? "" : "s"} rooted at{" "}
+      <a href={rootUrl}>
+        <code>{root}</code>
+      </a>
+    </p>
+    <p className="arch-source-note">
+      Files under a sub-layer's folder belong to that sub-layer. The full list
+      is in <code>architecture.json</code>.
+    </p>
+  </section>
+);

--- a/libs/@local/petrinaut-arch-docs/src/emit/mdx.test.ts
+++ b/libs/@local/petrinaut-arch-docs/src/emit/mdx.test.ts
@@ -190,26 +190,92 @@ describe("resolveDiagramImages", () => {
   });
 });
 
-describe("buildPages with a declared edge", () => {
-  const testLayer = (id: string): Layer => ({
-    id,
-    name: id,
-    parent: null,
-    package: "@test/pkg",
-    role: `role of ${id}`,
-    declaredIn: `src/${id}/index.ts`,
-    prose: null,
-    references: [],
-    files: [`src/${id}/index.ts`],
-    fileCount: 1,
-    lineCount: 1,
+const testLayer = (id: string): Layer => ({
+  id,
+  name: id,
+  parent: null,
+  package: "@test/pkg",
+  role: `role of ${id}`,
+  declaredIn: `src/${id}/index.ts`,
+  prose: null,
+  references: [],
+  files: [`src/${id}/index.ts`],
+  fileCount: 1,
+  lineCount: 1,
+});
+
+const buildTestPages = (model: ArchitectureModel) =>
+  buildPages(model, {
+    sourceUrlPrefix: "https://example.com/",
+    overviewDiagram: null,
+    neighbourhoodDiagrams: new Map(),
+    subtreeDiagrams: new Map(),
   });
 
+describe("buildPages layer facts card", () => {
   const model: ArchitectureModel = {
     version: 1,
     packages: [],
-    layers: [testLayer("bindings"), testLayer("cli")],
+    layers: [testLayer("core"), testLayer("core.simulation")],
+    edges: [],
+    rules: [],
+  };
+
+  const pages = buildTestPages(model);
+  const nested = pages.find(
+    (page) => page.slug === layerSlug("core.simulation"),
+  );
+  const root = pages.find((page) => page.slug === layerSlug("core"));
+
+  it("imports the component relative to the page file's depth", () => {
+    expect(nested?.contents).toContain(
+      'import { LayerFacts } from "../../../components/layer-facts";',
+    );
+    expect(root?.contents).toContain(
+      'import { LayerFacts } from "../../components/layer-facts";',
+    );
+  });
+
+  it("passes the layer's facts as structured props", () => {
+    expect(nested?.contents).toContain('package={"@test/pkg"}');
+    expect(nested?.contents).toContain('layerId={"core.simulation"}');
+    expect(nested?.contents).toContain("files={1}");
+    expect(nested?.contents).toContain("lines={1}");
+    expect(nested?.contents).toContain(
+      'declaredIn={"src/core.simulation/index.ts"}',
+    );
+    expect(nested?.contents).toContain(
+      'declaredInUrl={"https://example.com/src/core.simulation/index.ts"}',
+    );
+    // The role reads as a plain lead paragraph before the card, not a prop.
+    expect(nested?.contents).not.toContain("role={");
+    expect(nested?.contents).toContain("\nrole of core.simulation\n");
+  });
+
+  it("emits no relations card or import on a page with no edges", () => {
+    expect(nested?.contents).not.toContain("LayerRelations");
+  });
+
+  it("emits no prose header alongside the card", () => {
+    expect(nested?.contents).not.toContain("**Package**");
+    expect(nested?.contents).not.toContain("Declared in [");
+  });
+});
+
+describe("buildPages layer relations card", () => {
+  const model: ArchitectureModel = {
+    version: 1,
+    packages: [],
+    layers: [testLayer("bindings"), testLayer("cli"), testLayer("store")],
     edges: [
+      {
+        from: "bindings",
+        to: "store",
+        provenance: "imports",
+        fileDependencies: 2,
+        examples: [],
+        crossesPackage: false,
+      },
       {
         from: "bindings",
         to: "cli",
@@ -221,26 +287,42 @@ describe("buildPages with a declared edge", () => {
     rules: [],
   };
 
-  const pages = buildPages(model, {
-    sourceUrlPrefix: "https://example.com/",
-    overviewDiagram: null,
-    neighbourhoodDiagrams: new Map(),
-    subtreeDiagrams: new Map(),
+  const pages = buildTestPages(model);
+  const bindings = pages.find((page) => page.slug === layerSlug("bindings"));
+  const cli = pages.find((page) => page.slug === layerSlug("cli"));
+  const store = pages.find((page) => page.slug === layerSlug("store"));
+
+  it("passes each direction as one JSON entry per edge", () => {
+    expect(bindings?.contents).toContain(
+      'import { LayerRelations } from "../../components/layer-relations";',
+    );
+    expect(bindings?.contents).toContain(
+      '{"id":"store","name":"store","href":"store","provenance":"imports","crossesPackage":false,"imports":2},',
+    );
+    expect(bindings?.contents).toContain("dependedOnBy={[]}");
   });
 
-  it("lists the edge in a Declared block with its protocol, both directions", () => {
-    const bindings = pages.find((page) => page.slug === layerSlug("bindings"));
-    expect(bindings?.contents).toContain("## Depends on");
-    expect(bindings?.contents).toContain("### Declared");
-    expect(bindings?.contents).toContain("| JSON lines over stdio |");
+  it("marks a declared edge with its protocol and no import count", () => {
+    expect(bindings?.contents).toContain(
+      '{"id":"cli","name":"cli","href":"cli","provenance":"declared","crossesPackage":true,"protocol":"JSON lines over stdio"},',
+    );
 
-    const cli = pages.find((page) => page.slug === layerSlug("cli"));
-    expect(cli?.contents).toContain("## Depended on by");
-    expect(cli?.contents).toContain("### Declared");
+    // The receiving side sees the same edge under dependedOnBy.
+    expect(cli?.contents).toContain('"id":"bindings"');
+    expect(cli?.contents).toContain('"provenance":"declared"');
+    expect(cli?.contents).toContain("dependsOn={[]}");
   });
 
-  it("keeps the declared edge out of the import table", () => {
-    const bindings = pages.find((page) => page.slug === layerSlug("bindings"));
-    expect(bindings?.contents).not.toContain("| Layer | Imports |");
+  it("replaces the heading-plus-table sections entirely", () => {
+    expect(bindings?.contents).not.toContain("## Depends on");
+    expect(store?.contents).not.toContain("## Depended on by");
+    expect(bindings?.contents).not.toContain("| Layer |");
+  });
+
+  it("orders imports by count before declared edges", () => {
+    const contents = bindings?.contents ?? "";
+    expect(contents.indexOf('"id":"store"')).toBeLessThan(
+      contents.indexOf('"id":"cli"'),
+    );
   });
 });

--- a/libs/@local/petrinaut-arch-docs/src/emit/mdx.ts
+++ b/libs/@local/petrinaut-arch-docs/src/emit/mdx.ts
@@ -1,11 +1,14 @@
 /**
  * MDX page generation.
  *
- * Output here is deliberately **framework-neutral**: YAML frontmatter plus plain
- * CommonMark. No JSX, no imports, no framework-specific components. That
- * constraint is what lets the same bundle render in the Starlight site, in
- * hash.dev's Next.js MDX pipeline, and as plain text for an AI agent — a single
- * `<LayerGraph/>` component here would break two of those three.
+ * Output is YAML frontmatter plus CommonMark, with one exception: generated
+ * layer pages import the `LayerFacts` and `LayerRelations` cards shipped in
+ * the bundle's `components/` directory and pass their facts as structured
+ * props, so a host restyles the cards instead of re-parsing prose. A host
+ * therefore needs a React-capable MDX pipeline for layer pages, the same
+ * requirement authored pages with diagram components already impose.
+ * `architecture.md` keeps every fact as plain text for consumers that render
+ * none of this.
  *
  * Diagrams are referenced as relative image paths, and every layer page links
  * back to the annotation that declared it so a reader can go straight from the
@@ -15,6 +18,12 @@
 import { posix } from "node:path";
 
 import { isDeclaredEdge, isImportEdge } from "../model";
+import {
+  LAYER_FACTS_MODULE,
+  LAYER_RELATIONS_MODULE,
+  LAYER_LINKS_MODULE,
+  LAYER_SOURCE_MODULE,
+} from "./shipped-components";
 
 import type { ArchitectureModel, Edge, Layer } from "../model";
 
@@ -266,93 +275,112 @@ export const resolveDiagramImages = (
   return { contents: resolved, unresolved };
 };
 
-const describeEdges = (
+/** One row of the relations card, mirroring `LayerRelation` in the component. */
+interface LayerRelationEntry {
+  id: string;
+  name: string;
+  href: string;
+  provenance: "imports" | "declared";
+  crossesPackage: boolean;
+  imports?: number;
+  protocol?: string;
+}
+
+/**
+ * Rows for the relations card, per direction. Import edges come first, sorted
+ * by import count, then declared edges: one kind is aggregated from real
+ * imports, the other is an annotation someone wrote, and the `provenance`
+ * field is how the card keeps a reader from mistaking one for the other.
+ */
+const relationEntries = (
   layer: Layer,
   edges: Edge[],
   layersById: Map<string, Layer>,
   slug: string,
-): string[] => {
-  const outgoing = edges.filter((edge) => edge.from === layer.id);
-  const incoming = edges.filter((edge) => edge.to === layer.id);
-
-  const layerLink = (otherId: string): string => {
+): { dependsOn: LayerRelationEntry[]; dependedOnBy: LayerRelationEntry[] } => {
+  const toEntry = (edge: Edge, otherId: string): LayerRelationEntry => {
     const other = layersById.get(otherId);
-    const label = other ? other.name : otherId;
-    return `[${escapeTableCell(label)}](${relativeTo(slug, layerSlug(otherId))})`;
+    const base = {
+      id: otherId,
+      name: other ? other.name : otherId,
+      href: relativeTo(slug, layerSlug(otherId)),
+      provenance: edge.provenance,
+      crossesPackage: edge.crossesPackage,
+    };
+    return isImportEdge(edge)
+      ? { ...base, imports: edge.fileDependencies }
+      : { ...base, protocol: edge.protocol };
   };
 
-  /**
-   * Import edges and declared edges never share a table: one kind is aggregated
-   * from real imports, the other is an annotation someone wrote, and a reader
-   * should not mistake the second kind for the first.
-   */
-  const section = (
-    heading: string,
-    intro: string,
+  const inDirection = (
     rows: Edge[],
     direction: "to" | "from",
-  ): string[] => {
-    const imports = rows.filter(isImportEdge);
-    const declared = rows.filter(isDeclaredEdge);
-
-    if (imports.length === 0 && declared.length === 0) {
-      return [];
-    }
-
-    const lines: string[] = [`## ${heading}`, ""];
-
-    if (imports.length > 0) {
-      lines.push(
-        intro,
-        "",
-        "| Layer | Imports | Package boundary |",
-        "| --- | --- | --- |",
-        ...imports
-          .slice()
-          .sort((left, right) => right.fileDependencies - left.fileDependencies)
-          .map((edge) => {
-            const otherId = direction === "to" ? edge.to : edge.from;
-            const crosses = edge.crossesPackage ? "crossed" : "—";
-            return `| ${layerLink(otherId)} | ${edge.fileDependencies} | ${crosses} |`;
-          }),
-        "",
-      );
-    }
-
-    if (declared.length > 0) {
-      lines.push(
-        "### Declared",
-        "",
-        "Declared with `@talksTo` in the source, for boundaries no import crosses. The protocol text is the annotation's claim; only the endpoints are checked.",
-        "",
-        "| Layer | Protocol |",
-        "| --- | --- |",
-        ...declared.map((edge) => {
-          const otherId = direction === "to" ? edge.to : edge.from;
-          return `| ${layerLink(otherId)} | ${escapeTableCell(edge.protocol)} |`;
-        }),
-        "",
-      );
-    }
-
-    return lines;
+  ): LayerRelationEntry[] => {
+    const otherOf = (edge: Edge): string =>
+      direction === "to" ? edge.to : edge.from;
+    return [
+      ...rows
+        .filter(isImportEdge)
+        .sort((left, right) => right.fileDependencies - left.fileDependencies)
+        .map((edge) => toEntry(edge, otherOf(edge))),
+      ...rows
+        .filter(isDeclaredEdge)
+        .map((edge) => toEntry(edge, otherOf(edge))),
+    ];
   };
 
-  return [
-    ...section(
-      "Depends on",
-      "Aggregated from real TypeScript imports.",
-      outgoing,
+  return {
+    dependsOn: inDirection(
+      edges.filter((edge) => edge.from === layer.id),
       "to",
     ),
-    ...section(
-      "Depended on by",
-      "Who reaches into this layer.",
-      incoming,
+    dependedOnBy: inDirection(
+      edges.filter((edge) => edge.to === layer.id),
       "from",
     ),
-  ];
+  };
 };
+
+/**
+ * A JSX attribute carrying an array of relation entries, one JSON object per
+ * line so a diff of the emitted page shows which edge changed.
+ */
+const relationsProp = (key: string, entries: LayerRelationEntry[]): string[] =>
+  entries.length === 0
+    ? [`  ${key}={[]}`]
+    : [
+        `  ${key}={[`,
+        ...entries.map((entry) => `    ${JSON.stringify(entry)},`),
+        "  ]}",
+      ];
+
+/**
+ * A links card instance. Entries are one per line, like relation entries, so a
+ * diff of the emitted page shows which link changed.
+ */
+const linksCard = (
+  title: string,
+  entries: {
+    label: string;
+    href: string;
+    description?: string;
+    code?: boolean;
+  }[],
+  note?: string,
+): string[] => [
+  "<LayerLinks",
+  `  title={${JSON.stringify(title)}}`,
+  ...(note === undefined ? [] : [`  note={${JSON.stringify(note)}}`]),
+  "  entries={[",
+  ...entries.map((entry) => `    ${JSON.stringify(entry)},`),
+  "  ]}",
+  "/>",
+  "",
+];
+
+/** Import of a shipped component, relative to the page file like any asset. */
+const componentImport = (slug: string, name: string, module: string): string =>
+  `import { ${name} } from "${assetPathFrom(slug, `components/${module}`)}";`;
 
 const buildLayerPage = (
   layer: Layer,
@@ -367,22 +395,43 @@ const buildLayerPage = (
   const slug = layerSlug(layer.id);
   const children = model.layers.filter((other) => other.parent === layer.id);
 
+  const relations = relationEntries(layer, model.edges, layersById, slug);
+  const hasRelations =
+    relations.dependsOn.length > 0 || relations.dependedOnBy.length > 0;
+
   const body: string[] = [];
 
-  body.push(`> ${layer.role}`, "");
+  body.push(componentImport(slug, "LayerFacts", LAYER_FACTS_MODULE));
+  if (hasRelations) {
+    body.push(componentImport(slug, "LayerRelations", LAYER_RELATIONS_MODULE));
+  }
+  if (layer.files.length > 0) {
+    body.push(componentImport(slug, "LayerSource", LAYER_SOURCE_MODULE));
+  }
+  if (
+    children.length > 0 ||
+    attachedGuides.length > 0 ||
+    layer.references.length > 0
+  ) {
+    body.push(componentImport(slug, "LayerLinks", LAYER_LINKS_MODULE));
+  }
+  body.push("");
 
-  body.push(
-    [
-      `**Package** \`${layer.package}\``,
-      `**Layer id** \`${layer.id}\``,
-      `**Files** ${layer.fileCount}`,
-      `**Lines** ${layer.lineCount.toLocaleString("en-US")}`,
-    ].join(" · "),
-    "",
-  );
+  // The role reads as the page's lead paragraph, outside the facts card.
+  body.push(layer.role, "");
 
+  // Values are emitted as `{JSON}` expressions rather than quoted attributes:
+  // JSX string attributes have no escape sequences, so a value containing a
+  // double quote would end the attribute early.
   body.push(
-    `Declared in [\`${layer.declaredIn}\`](${sourceLink(sourceUrlPrefix, layer.declaredIn)}).`,
+    "<LayerFacts",
+    `  package={${JSON.stringify(layer.package)}}`,
+    `  layerId={${JSON.stringify(layer.id)}}`,
+    `  files={${layer.fileCount}}`,
+    `  lines={${layer.lineCount}}`,
+    `  declaredIn={${JSON.stringify(layer.declaredIn)}}`,
+    `  declaredInUrl={${JSON.stringify(sourceLink(sourceUrlPrefix, layer.declaredIn))}}`,
+    "/>",
     "",
   );
 
@@ -392,6 +441,16 @@ const buildLayerPage = (
         slug,
         `diagrams/${neighbourhoodDiagram}.svg`,
       )})`,
+      "",
+    );
+  }
+
+  if (hasRelations) {
+    body.push(
+      "<LayerRelations",
+      ...relationsProp("dependsOn", relations.dependsOn),
+      ...relationsProp("dependedOnBy", relations.dependedOnBy),
+      "/>",
       "",
     );
   }
@@ -408,31 +467,32 @@ const buildLayerPage = (
 
   if (children.length > 0) {
     body.push(
-      "## Sub-layers",
-      "",
-      ...children.map(
-        (child) =>
-          `- [${child.name}](${relativeTo(slug, layerSlug(child.id))}) — ${child.role}`,
+      ...linksCard(
+        "Sub-layers",
+        children.map((child) => ({
+          label: child.name,
+          href: relativeTo(slug, layerSlug(child.id)),
+          description: child.role,
+        })),
       ),
-      "",
     );
   }
 
   if (attachedGuides.length > 0) {
     body.push(
-      "## Guides",
-      "",
-      "Hand-written explanations of this layer. Unlike the rest of this page, they are not generated and not checked against the code.",
-      "",
-      ...attachedGuides.map(
-        (guide) =>
-          `- [${guide.title}](${relativeTo(slug, guide.slug)})${guide.description === "" ? "" : ` — ${guide.description}`}`,
+      ...linksCard(
+        "Guides",
+        attachedGuides.map((guide) => ({
+          label: guide.title,
+          href: relativeTo(slug, guide.slug),
+          ...(guide.description === ""
+            ? {}
+            : { description: guide.description }),
+        })),
+        "Hand-written, not generated and not checked against the code.",
       ),
-      "",
     );
   }
-
-  body.push(...describeEdges(layer, model.edges, layersById, slug));
 
   if (layer.prose !== null) {
     body.push(
@@ -445,13 +505,14 @@ const buildLayerPage = (
 
   if (layer.references.length > 0) {
     body.push(
-      "## Further reading",
-      "",
-      ...layer.references.map(
-        (reference) =>
-          `- [\`${reference}\`](${sourceLink(sourceUrlPrefix, reference)})`,
+      ...linksCard(
+        "Further reading",
+        layer.references.map((reference) => ({
+          label: reference,
+          href: sourceLink(sourceUrlPrefix, reference),
+          code: true,
+        })),
       ),
-      "",
     );
   }
 
@@ -461,9 +522,11 @@ const buildLayerPage = (
     // read `files` from architecture.json instead.
     const folder = posix.dirname(layer.declaredIn);
     body.push(
-      "## Source",
-      "",
-      `${layer.fileCount} file${layer.fileCount === 1 ? "" : "s"} resolve to this layer, rooted at [\`${folder}\`](${sourceUrlPrefix}${folder}) — files under a sub-layer's folder belong to that sub-layer instead. The full list is in \`architecture.json\`.`,
+      "<LayerSource",
+      `  files={${layer.fileCount}}`,
+      `  root={${JSON.stringify(folder)}}`,
+      `  rootUrl={${JSON.stringify(sourceLink(sourceUrlPrefix, folder))}}`,
+      "/>",
       "",
     );
   }

--- a/libs/@local/petrinaut-arch-docs/src/emit/shipped-components.ts
+++ b/libs/@local/petrinaut-arch-docs/src/emit/shipped-components.ts
@@ -1,0 +1,46 @@
+/**
+ * Components the generator ships in every bundle's `components/` directory.
+ *
+ * Generated layer pages import these, so they are build output owned by the
+ * generator, unlike the authored diagram components a repo opts into under
+ * `content/components/`. The sources live in `./components/` as ordinary
+ * `.tsx`/`.css` files and are copied into the bundle verbatim.
+ */
+
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+import type { AuthoredComponent } from "../content";
+
+/** Module name generated pages import the facts card from. */
+export const LAYER_FACTS_MODULE = "layer-facts";
+
+/** Module name generated pages import the relations card from. */
+export const LAYER_RELATIONS_MODULE = "layer-relations";
+
+/** Module name generated pages import the source card from. */
+export const LAYER_SOURCE_MODULE = "layer-source";
+
+/** Module name generated pages import the links card from. */
+export const LAYER_LINKS_MODULE = "layer-links";
+
+const shippedComponentFiles = [
+  `${LAYER_FACTS_MODULE}.tsx`,
+  `${LAYER_RELATIONS_MODULE}.tsx`,
+  `${LAYER_SOURCE_MODULE}.tsx`,
+  `${LAYER_LINKS_MODULE}.tsx`,
+  // Styling the cards share, imported by the components above.
+  "layer-cards.css",
+];
+
+export const readShippedComponents = async (): Promise<AuthoredComponent[]> =>
+  Promise.all(
+    shippedComponentFiles.map(async (file) => ({
+      path: `components/${file}`,
+      name: file.replace(/\.[^.]+$/u, ""),
+      contents: await readFile(
+        fileURLToPath(new URL(`components/${file}`, import.meta.url)),
+        "utf8",
+      ),
+    })),
+  );

--- a/libs/@local/petrinaut-arch-docs/tsconfig.json
+++ b/libs/@local/petrinaut-arch-docs/tsconfig.json
@@ -15,5 +15,9 @@
     "skipLibCheck": true,
     "isolatedModules": true
   },
-  "include": ["src", "architecture.config.ts"]
+  "include": ["src", "architecture.config.ts"],
+  // Shipped bundle components are React sources copied into the bundle
+  // verbatim, compiled by the consuming site rather than by this package,
+  // which has neither a JSX config nor React types.
+  "exclude": ["src/emit/components"]
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Implements [FE-1447](https://linear.app/hash/issue/FE-1447/arch-docs-emit-layer-facts-and-relations-as-structured-data-with-card): generated layer pages baked their facts into MDX prose (the Package/Layer id/Files/Lines line, "Declared in", and the "Depends on" / "Depended on by" heading-plus-table blocks), so a host could not restyle them. The pages now render two components shipped in the bundle, receiving structured props.

Top of stack #9226, on FE-1443 (its "Declared" edge tables fold into the relations component).

## 🔗 Related links

- [FE-1447](https://linear.app/hash/issue/FE-1447/arch-docs-emit-layer-facts-and-relations-as-structured-data-with-card) *(internal)*: this PR
- [FE-1443](https://linear.app/hash/issue/FE-1443/arch-docs-declared-protocol-edges-for-import-invisible-boundaries) *(internal)*: the declared edges this renders as dashed protocol pills

## 🔍 What does this change?

`libs/@local/petrinaut-arch-docs`:

- **Three shipped components**, emitted into the bundle's `components/` beside authored ones:
  - `LayerFacts`: an aligned Package / Layer id / Files / Lines grid with a Declared-in footer link, as one compact bordered card. The role reads as the page's plain lead paragraph above it, outside the card.
  - `LayerRelations`: both directions side by side (single column under 640px) with the column headings top-aligned, layer names left and count/`pkg` badges pinned right, and a dashed protocol pill on its own line for declared edges.
  - `LayerSource`: the file count and source root as a matching card, replacing the old "Source" heading and sentence.
- **Styling**: plain CSS, colors derived from `currentColor` via `color-mix`, so both Starlight themes work without theme-specific rules.
- **Emission** (`mdx.ts`): pages import the components by page-relative path and pass props as JSON expressions (JSX string attributes cannot escape a `"` in a role). One relation entry per line keeps diffs reviewable. Pages without edges emit no relations block. `architecture.md` keeps plain text.
- The generator's tsconfig excludes the component sources: the Astro build compiles them, same as authored `content/components/`.

Contract note, documented in the README: hosts now need a React-capable MDX pipeline for generated layer pages, not only for authored pages.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] modifies a workspace but **not** a publishable library

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] require changes to docs which **are made** as part of this PR

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- `mdx.test.ts`: import-path depth per page, structured props, declared-edge entries in the relations props, and the removal of the old heading-plus-table sections.
- `lint:arch-docs` and `turbo run build --filter @apps/petrinaut-docs` prove the emitted MDX compiles and renders.

## ❓ How to test this?

1. `turbo run dev --filter @apps/petrinaut-docs`
2. Open any layer page (for example `architecture/bindings`): the facts card replaces the header prose, the relations card shows both directions, and the declared edge to `cli` renders as a dashed protocol pill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
