### PR TITLE
FE-1457: Point source links at the branch being built

### DIFF
--- a/apps/petrinaut-docs/vercel-build.sh
+++ b/apps/petrinaut-docs/vercel-build.sh
@@ -18,5 +18,9 @@ rm -f .env
 # Run through Turborepo rather than `yarn workspace ... build`: the package
 # script alone skips `sync:bundle`, and would build whatever content happened to
 # be on disk.
-echo "Building Petrinaut architecture docs"
+#
+# Source links follow the commit being built rather than `main`: the generator
+# reads `VERCEL_GIT_COMMIT_SHA` and `VERCEL_GIT_COMMIT_REF`, declared in
+# `libs/@local/petrinaut-arch-docs/turbo.json`, and logs the prefix it used.
+echo "Building Petrinaut architecture docs from ${VERCEL_GIT_COMMIT_SHA:-a local checkout}"
 turbo build --filter='@apps/petrinaut-docs' --env-mode=loose

--- a/libs/@local/petrinaut-arch-docs/README.md
+++ b/libs/@local/petrinaut-arch-docs/README.md
@@ -145,6 +145,29 @@ required. In particular the bundle asks for **no Markdown or Rehype
 plugins** — a host renders it with its Markdown pipeline exactly as configured,
 which is what keeps "render the bundle" a small job rather than a negotiation.
 
+### Source links
+
+Generated pages link back to the source they describe: each layer's "Declared
+in" link, its source root, its further-reading list, and any relative link in a
+declaring README's prose. Those URLs carry a git ref, resolved once per build
+from the first of these variables that holds a value:
+
+| Variable                         | Set by                        |
+| -------------------------------- | ----------------------------- |
+| `PETRINAUT_ARCH_DOCS_SOURCE_REF` | You, overriding the rest      |
+| `VERCEL_GIT_COMMIT_SHA`          | Vercel                        |
+| `GITHUB_SHA`                     | GitHub Actions                |
+| `VERCEL_GIT_COMMIT_REF`          | Vercel (branch name)          |
+| `GITHUB_HEAD_REF`                | GitHub Actions (pull request) |
+| `GITHUB_REF_NAME`                | GitHub Actions (push)         |
+
+A commit SHA beats a branch name, because the link still resolves once the
+branch has moved on or been deleted. With none of them set the ref is `main`,
+which is what a local build gets; set `PETRINAUT_ARCH_DOCS_SOURCE_REF` to aim a
+local build at another ref. A preview deployment of `apps/petrinaut-docs`
+reads Vercel's variables, so its links point at the commit it was built from
+instead of at a file `main` may not have yet.
+
 ### Embedding the bundle elsewhere
 
 A host reads `manifest.json`, maps each page's `slug` onto its own URL space, and

--- a/libs/@local/petrinaut-arch-docs/architecture.config.ts
+++ b/libs/@local/petrinaut-arch-docs/architecture.config.ts
@@ -8,6 +8,8 @@
  * exercise. Resist the temptation to add a path→layer mapping here.
  */
 
+import { resolveSourceUrlPrefix } from "./src/source-url";
+
 import type { ArchitecturePackageInput } from "./src/model";
 
 export interface LayerRule {
@@ -27,7 +29,7 @@ export interface ArchitectureConfig {
   outputDirectory: string;
   /** Where hand-written MDX is read from, repo-relative. */
   contentDirectory: string;
-  /** Base URL for source links in generated pages. */
+  /** Base URL for source links in generated pages, including the git ref. */
   sourceUrlPrefix: string;
 }
 
@@ -132,5 +134,10 @@ export const config: ArchitectureConfig = {
    */
   outputDirectory: "libs/@local/petrinaut-arch-docs/bundle",
   contentDirectory: "libs/@local/petrinaut-arch-docs/content",
-  sourceUrlPrefix: "https://github.com/hashintel/hash/blob/main/",
+  /**
+   * Resolved from the build environment rather than pinned to `main`, so a
+   * preview deployment links to the commit it was built from. See
+   * `src/source-url.ts` for the variables and their precedence.
+   */
+  sourceUrlPrefix: resolveSourceUrlPrefix(process.env),
 };

--- a/libs/@local/petrinaut-arch-docs/src/cli.ts
+++ b/libs/@local/petrinaut-arch-docs/src/cli.ts
@@ -156,7 +156,12 @@ const main = async (): Promise<number> => {
     return 1;
   }
 
-  process.stdout.write(`Wrote ${config.outputDirectory}\n`);
+  // The prefix is logged because it varies by build: a preview deployment
+  // points its source links at the previewed commit, and a wrong ref is
+  // otherwise only visible by clicking a link on the published page.
+  process.stdout.write(
+    `Wrote ${config.outputDirectory}, source links to ${config.sourceUrlPrefix}\n`,
+  );
   return 0;
 };
 

--- a/libs/@local/petrinaut-arch-docs/src/source-url.test.ts
+++ b/libs/@local/petrinaut-arch-docs/src/source-url.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveSourceRef, resolveSourceUrlPrefix } from "./source-url";
+
+describe("resolveSourceRef", () => {
+  it("falls back to `main` when the environment names no ref", () => {
+    expect(resolveSourceRef({})).toBe("main");
+  });
+
+  it("ignores a variable that is set but empty", () => {
+    expect(resolveSourceRef({ GITHUB_SHA: "  " })).toBe("main");
+  });
+
+  it("prefers a commit SHA over a branch name", () => {
+    expect(
+      resolveSourceRef({
+        GITHUB_HEAD_REF: "cf/fe-1457-x",
+        GITHUB_SHA: "0123456789abcdef0123456789abcdef01234567",
+      }),
+    ).toBe("0123456789abcdef0123456789abcdef01234567");
+
+    expect(
+      resolveSourceRef({
+        VERCEL_GIT_COMMIT_REF: "cf/fe-1457-x",
+        VERCEL_GIT_COMMIT_SHA: "89abcdef",
+      }),
+    ).toBe("89abcdef");
+  });
+
+  it("prefers the explicit override over anything the CI provides", () => {
+    expect(
+      resolveSourceRef({
+        GITHUB_SHA: "0123456789abcdef",
+        PETRINAUT_ARCH_DOCS_SOURCE_REF: "my-local-branch",
+        VERCEL_GIT_COMMIT_SHA: "89abcdef",
+      }),
+    ).toBe("my-local-branch");
+  });
+
+  it("takes a branch name when no SHA is present", () => {
+    expect(resolveSourceRef({ GITHUB_REF_NAME: "main" })).toBe("main");
+    expect(resolveSourceRef({ GITHUB_HEAD_REF: "cf/fe-1457-x" })).toBe(
+      "cf/fe-1457-x",
+    );
+  });
+});
+
+describe("resolveSourceUrlPrefix", () => {
+  it("points at `main` by default", () => {
+    expect(resolveSourceUrlPrefix({})).toBe(
+      "https://github.com/hashintel/hash/blob/main/",
+    );
+  });
+
+  it("keeps the slashes in a branch name, which are path separators", () => {
+    expect(resolveSourceUrlPrefix({ GITHUB_HEAD_REF: "cf/fe-1457-x" })).toBe(
+      "https://github.com/hashintel/hash/blob/cf/fe-1457-x/",
+    );
+  });
+
+  it("encodes a character that would otherwise change the URL", () => {
+    expect(resolveSourceUrlPrefix({ GITHUB_HEAD_REF: "cf/a#b" })).toBe(
+      "https://github.com/hashintel/hash/blob/cf/a%23b/",
+    );
+  });
+});

--- a/libs/@local/petrinaut-arch-docs/src/source-url.ts
+++ b/libs/@local/petrinaut-arch-docs/src/source-url.ts
@@ -1,0 +1,56 @@
+/**
+ * Which git ref the generated source links point at.
+ *
+ * `main` 404s for a file the branch adds and shows the pre-change version of
+ * one it edits, so the ref comes from the build environment instead.
+ */
+
+/** Repository the source links resolve against. */
+const REPO_URL = "https://github.com/hashintel/hash";
+
+/** Ref used when the environment names none, such as a local build. */
+const DEFAULT_SOURCE_REF = "main";
+
+/**
+ * Environment variables carrying a ref, highest precedence first. A commit SHA
+ * beats a branch name because the link still resolves once the branch has moved
+ * on or been deleted.
+ */
+const REF_VARIABLES = [
+  "PETRINAUT_ARCH_DOCS_SOURCE_REF",
+  "VERCEL_GIT_COMMIT_SHA",
+  "GITHUB_SHA",
+  "VERCEL_GIT_COMMIT_REF",
+  "GITHUB_HEAD_REF",
+  "GITHUB_REF_NAME",
+] as const;
+
+export const resolveSourceRef = (
+  env: Record<string, string | undefined>,
+): string => {
+  for (const variable of REF_VARIABLES) {
+    const value = env[variable]?.trim();
+
+    if (value !== undefined && value !== "") {
+      return value;
+    }
+  }
+
+  return DEFAULT_SOURCE_REF;
+};
+
+/**
+ * Slashes are left literal: they separate path segments in a blob URL, so a
+ * `cf/fe-1457-x` branch only resolves with them intact. Everything else is
+ * encoded, since `#` or `%` in a ref would otherwise break the URL.
+ */
+const encodeRef = (ref: string): string =>
+  ref
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+
+/** Base URL for source links, ending in the slash paths are appended to. */
+export const resolveSourceUrlPrefix = (
+  env: Record<string, string | undefined>,
+): string => `${REPO_URL}/blob/${encodeRef(resolveSourceRef(env))}/`;

--- a/libs/@local/petrinaut-arch-docs/turbo.json
+++ b/libs/@local/petrinaut-arch-docs/turbo.json
@@ -12,7 +12,18 @@
       "cache": false,
       // Declared so consumers can depend on this task rather than on the
       // directory existing, and so `turbo run` prunes it on a clean.
-      "outputs": ["bundle/**"]
+      "outputs": ["bundle/**"],
+      // The ref the source links point at. Declared because the default strict
+      // env mode hides anything unlisted, which would leave a preview build
+      // emitting `main` links.
+      "env": [
+        "PETRINAUT_ARCH_DOCS_SOURCE_REF",
+        "VERCEL_GIT_COMMIT_SHA",
+        "GITHUB_SHA",
+        "VERCEL_GIT_COMMIT_REF",
+        "GITHUB_HEAD_REF",
+        "GITHUB_REF_NAME"
+      ]
     },
     "lint:arch-docs": {
       "cache": false


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Implements [FE-1457](https://linear.app/hash/issue/FE-1457/arch-docs-point-source-links-at-the-branch-being-built): every generated page links to the file that declared a layer, and the target was hardcoded to `main`. On a preview build those links showed the pre-change file, or 404'd for a file the branch adds.

The ref now comes from the build environment:

```text
no environment   → https://github.com/hashintel/hash/blob/main/libs/…
GITHUB_HEAD_REF  → https://github.com/hashintel/hash/blob/cf/fe-1457-…/libs/…
GITHUB_SHA       → https://github.com/hashintel/hash/blob/deadbeef…/libs/…
```

Top of stack #9226, on FE-1456.

## 🔗 Related links

- [FE-1457](https://linear.app/hash/issue/FE-1457/arch-docs-point-source-links-at-the-branch-being-built) *(internal)*: this PR
- [FE-1418](https://linear.app/hash/issue/FE-1418) *(internal)*: the Vercel deployment whose previews this fixes

## 🔍 What does this change?

- **`src/source-url.ts`** (new): resolves the ref from the first variable that holds a value, in order `PETRINAUT_ARCH_DOCS_SOURCE_REF`, `VERCEL_GIT_COMMIT_SHA`, `GITHUB_SHA`, `VERCEL_GIT_COMMIT_REF`, `GITHUB_HEAD_REF`, `GITHUB_REF_NAME`, defaulting to `main`. A SHA beats a branch name so the link survives the branch moving or being deleted. Slashes stay literal (they separate path segments in a blob URL) while `#` and `%` are encoded.
- **`architecture.config.ts`**: `sourceUrlPrefix` calls the resolver. No literal `main` remains.
- **`turbo.json`**: the six variables are declared in `doc:architecture`'s `env`, since Turborepo's strict env mode would otherwise hide them from the task.
- **`vercel-build.sh`** and the generator's "Wrote" line: both name the resolved ref, so a preview build's log shows which commit its links point at.

No workflow changes: nothing under `.github/workflows/` builds the bundle, and GitHub Actions exports the variables the resolver reads.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] modifies a workspace but **not** a publishable library

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] require changes to docs which **are made** as part of this PR
  - The package README documents the variables, the precedence, and the default.

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] affected the execution graph, and the `turbo.json`'s have been updated to reflect this
  - `doc:architecture` declares the ref variables. The task and its consumers are uncached, so a ref change cannot serve stale links.

## 🛡 What tests cover this?

- `source-url.test.ts`: the default, blank values skipped, SHA over branch for both providers, the local override over both, a branch name containing a slash, and `#` encoding.

## ❓ How to test this?

1. `yarn workspace @local/petrinaut-arch-docs doc:architecture` and grep a `declaredInUrl` in `bundle/pages/architecture/cli.mdx`: it points at `blob/main/`.
2. Repeat with `GITHUB_HEAD_REF=<a branch>`: the same link points at that branch. Adding `GITHUB_SHA=<sha>` switches it to the SHA.

## 🐾 Next steps

Four hand-written `blob/main/...` links remain in authored MDX. Those name specific files as references rather than being generated source links; giving them the same treatment needs a link helper in the authoring syntax.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
