### PR TITLE
FE-1455: Tighten the docs site chrome

### DIFF
--- a/apps/petrinaut-docs/README.md
+++ b/apps/petrinaut-docs/README.md
@@ -58,11 +58,38 @@ stylistic. The bundle's inter-page links are relative and assume a page's slug
 maps to a URL with no trailing slash; serving `/architecture/core/` instead would
 resolve those links one level too deep.
 
+## Chrome overrides
+
+[`src/styles/chrome.css`](src/styles/chrome.css), registered as Starlight's
+`customCss`, narrows both side panels to give the content column more width,
+tones down the header, and rounds the corners on markdown images so the embedded
+diagrams match the bordered cards beside them. The left nav takes its own
+`--pnd-sidebar-width` because Starlight sizes both panels from
+`--sl-sidebar-width`, and collapsing the nav has to zero one of them without
+flattening the other. The collapse toggle and resize handle come from
+`components.SiteTitle`, the only overridable component inside the fixed header,
+which is the one piece of chrome still on screen once the nav is gone. Both
+controls remember their state in `localStorage`, restored by a `head` script so
+a collapsed sidebar does not render open and then jump.
+
 `installConfig.hoistingLimits` nests this app's dependencies rather than hoisting
 them. Astro's generated prerender entry resolves `cookie` from this app's build
 output, which would otherwise reach the root-hoisted `cookie@0.7.2` that
 `express` pins and fail on a missing `parseCookie` export. Nesting keeps Astro on
 its own `cookie@2.x` without changing hoisting for the rest of the monorepo.
+
+## The code font
+
+Code renders in JetBrains Mono, requested through Astro's font support in
+[`astro.config.mjs`](astro.config.mjs) and emitted by `<Font>` in
+[`src/components/Head.astro`](src/components/Head.astro).
+
+A build downloads one variable file covering weights 400 to 700, subsets it to
+latin, and writes it beside the other assets, so a reader makes no request to a
+font host. The head carries a `preload` link and `font-display: swap`, and Astro
+generates a metric-matched fallback, which is what keeps text from shifting when
+the file arrives. The downloaded originals are cached under `.astro/`, which is
+ignored.
 
 ## Deployment
 

--- a/apps/petrinaut-docs/astro.config.mjs
+++ b/apps/petrinaut-docs/astro.config.mjs
@@ -4,7 +4,7 @@ import { fileURLToPath } from "node:url";
 
 import react from "@astrojs/react";
 import starlight from "@astrojs/starlight";
-import { defineConfig } from "astro/config";
+import { defineConfig, fontProviders } from "astro/config";
 
 /**
  * Renders the architecture bundle produced by `@local/petrinaut-arch-docs`.
@@ -213,12 +213,29 @@ export default defineConfig({
   trailingSlash: "never",
   build: { format: "file" },
 
+  /*
+   * One variable file covers every weight the code blocks use, downloaded and
+   * subset at build time so a reader makes no request to a font host. Italic is
+   * left out: no code style in the docs uses it.
+   */
+  fonts: [
+    {
+      provider: fontProviders.fontsource(),
+      name: "JetBrains Mono",
+      cssVariable: "--pnd-font-mono",
+      weights: ["400 700"],
+      styles: ["normal"],
+      subsets: ["latin"],
+      fallbacks: ["ui-monospace", "SFMono-Regular", "Menlo", "monospace"],
+    },
+  ],
+
   integrations: [
     // Generated layer pages import the bundle's facts and relations cards, and
     // authored pages may import its diagram components; both are React.
     react(),
     starlight({
-      title: "Architecture Docs",
+      title: "Docs",
       description:
         "How the Petrinaut packages fit together — generated from annotations in the source.",
       // The helmet carries the Petrinaut identity, so the title beside it names
@@ -229,6 +246,26 @@ export default defineConfig({
         replacesTitle: false,
       },
       favicon: "/favicon.ico",
+      // Narrows both side panels and rounds the images, and styles the collapse
+      // controls that `components.SiteTitle` renders. See `chrome.css`.
+      customCss: ["./src/styles/chrome.css"],
+      components: {
+        Head: "./src/components/Head.astro",
+        SiteTitle: "./src/components/SiteTitle.astro",
+      },
+      // Restores the collapsed state before first paint. In the component's own
+      // script the sidebar would render at full width and then jump.
+      head: [
+        {
+          tag: "script",
+          content: `try {
+  const stored = localStorage.getItem("pnd:sidebar");
+  const width = localStorage.getItem("pnd:sidebar-width");
+  if (stored === "collapsed") document.documentElement.dataset.pndSidebar = stored;
+  if (width) document.documentElement.style.setProperty("--pnd-sidebar-open-width", width);
+} catch {}`,
+        },
+      ],
       social: [
         {
           icon: "github",

--- a/apps/petrinaut-docs/src/components/Head.astro
+++ b/apps/petrinaut-docs/src/components/Head.astro
@@ -1,0 +1,14 @@
+---
+/**
+ * Starlight's head, plus the font faces and preload links for the code font.
+ *
+ * Astro's `<Font>` emits both, so the family has to be requested from a
+ * component in the head rather than from configuration alone.
+ */
+
+import Default from "@astrojs/starlight/components/Head.astro";
+import { Font } from "astro:assets";
+---
+
+<Default><slot /></Default>
+<Font cssVariable="--pnd-font-mono" preload />

--- a/apps/petrinaut-docs/src/components/SiteTitle.astro
+++ b/apps/petrinaut-docs/src/components/SiteTitle.astro
@@ -1,0 +1,155 @@
+---
+import Default from "@astrojs/starlight/components/SiteTitle.astro";
+
+/**
+ * Adds the desktop sidebar collapse toggle and resize handle beside the title.
+ *
+ * They hang off `SiteTitle` because it is the one overridable component inside
+ * Starlight's fixed header, which is the only chrome still on screen once the
+ * sidebar pane itself is collapsed away.
+ */
+---
+
+<button
+  class="pnd-sidebar-toggle"
+  type="button"
+  aria-controls="starlight__sidebar"
+  aria-expanded="true"
+  aria-label="Toggle sidebar"
+>
+  <svg
+    aria-hidden="true"
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linejoin="round"
+  >
+    <rect x="3" y="3" width="18" height="18" rx="2"></rect>
+    <path d="M9 3v18"></path>
+  </svg>
+</button>
+
+<Default><slot /></Default>
+
+<div
+  class="pnd-sidebar-resize"
+  role="separator"
+  aria-orientation="vertical"
+  aria-label="Resize sidebar"
+  tabindex="0"
+>
+</div>
+
+<script is:inline>
+  (() => {
+    const root = document.documentElement;
+    const toggle = /** @type {HTMLButtonElement | null} */ (
+      document.querySelector(".pnd-sidebar-toggle")
+    );
+    const handle = /** @type {HTMLElement | null} */ (
+      document.querySelector(".pnd-sidebar-resize")
+    );
+
+    if (!toggle || !handle) {
+      return;
+    }
+
+    /**
+     * @param {string} key
+     * @param {string} value
+     */
+    const remember = (key, value) => {
+      try {
+        localStorage.setItem(key, value);
+      } catch {
+        // Private browsing denies storage; the control still works this session.
+      }
+    };
+
+    toggle.setAttribute(
+      "aria-expanded",
+      String(root.dataset.pndSidebar !== "collapsed"),
+    );
+
+    toggle.addEventListener("click", () => {
+      const collapsed = root.dataset.pndSidebar !== "collapsed";
+
+      if (collapsed) {
+        root.dataset.pndSidebar = "collapsed";
+      } else {
+        delete root.dataset.pndSidebar;
+      }
+
+      toggle.setAttribute("aria-expanded", String(!collapsed));
+      remember("pnd:sidebar", collapsed ? "collapsed" : "expanded");
+    });
+
+    /** @param {number} edge Where the pane's trailing edge should land, in px. */
+    const resizeTo = (edge) => {
+      const width = `${Math.round(Math.min(Math.max(edge, 224), 480))}px`;
+
+      root.style.setProperty("--pnd-sidebar-open-width", width);
+      remember("pnd:sidebar-width", width);
+    };
+
+    handle.addEventListener("pointerdown", (event) => {
+      handle.setPointerCapture(event.pointerId);
+
+      /** @param {PointerEvent} move */
+      const onMove = (move) => resizeTo(move.clientX);
+
+      handle.addEventListener("pointermove", onMove);
+      handle.addEventListener(
+        "pointerup",
+        () => handle.removeEventListener("pointermove", onMove),
+        { once: true },
+      );
+    });
+
+    handle.addEventListener("keydown", (event) => {
+      const step =
+        event.key === "ArrowLeft" ? -16 : event.key === "ArrowRight" ? 16 : 0;
+
+      if (step !== 0) {
+        event.preventDefault();
+        resizeTo(handle.getBoundingClientRect().left + 3 + step);
+      }
+    });
+
+    // A gradient cannot ask whether the text fits, so the labels that do not
+    // fit are marked here and the fade keys off the mark. Deferred because this
+    // script is in the header, which the browser parses before the sidebar.
+    const markLabels = () => {
+      const pane = document.querySelector(".sidebar-content");
+
+      if (!pane) {
+        return;
+      }
+
+      const labels = pane.querySelectorAll("a > span, .group-label > span");
+
+      const markClipped = () => {
+        for (const label of labels) {
+          label.toggleAttribute(
+            "data-pnd-clipped",
+            label.scrollWidth > label.clientWidth + 1,
+          );
+        }
+      };
+
+      markClipped();
+      // Fires on the pane's own resize and when expanding a group changes it.
+      new ResizeObserver(markClipped).observe(pane);
+      pane.addEventListener("toggle", markClipped, { capture: true });
+    };
+
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", markLabels, { once: true });
+    } else {
+      markLabels();
+    }
+  })();
+</script>

--- a/apps/petrinaut-docs/src/styles/chrome.css
+++ b/apps/petrinaut-docs/src/styles/chrome.css
@@ -1,0 +1,197 @@
+/*
+ * Chrome overrides for the architecture docs site, registered as Starlight's
+ * `customCss`. Custom CSS is unlayered, so these rules win over Starlight's
+ * `@layer starlight.core` without needing extra specificity to fight it.
+ */
+
+:root {
+  /*
+   * Starlight derives both side panels from `--sl-sidebar-width`. The left nav
+   * takes its own width so collapsing it can zero that one without flattening
+   * the on-this-page column, which keeps this variable for the right panel.
+   */
+  --sl-sidebar-width: 15rem;
+  --sl-content-width: 56rem;
+
+  /* Set inline on `<html>` by the resize handle, then restored on load. */
+  --pnd-sidebar-open-width: 15.5rem;
+  --pnd-sidebar-width: var(--pnd-sidebar-open-width);
+}
+
+/* Collapsing hands the width the nav gives up to the content column. */
+:root[data-pnd-sidebar="collapsed"] {
+  --pnd-sidebar-width: 0rem;
+  --sl-content-width: 64rem;
+}
+
+/* 50rem is where Starlight turns the mobile drawer into a fixed rail. */
+@media (min-width: 50rem) {
+  :root[data-has-sidebar] {
+    --sl-content-inline-start: var(--pnd-sidebar-width);
+  }
+
+  .sidebar-pane {
+    width: var(--pnd-sidebar-width);
+  }
+
+  :root[data-pnd-sidebar="collapsed"] .sidebar-pane {
+    display: none;
+  }
+
+  /* Not zero: below 72rem nothing else insets the column from the edge. */
+  :root[data-pnd-sidebar="collapsed"] {
+    --sl-content-inline-start: 2rem;
+  }
+}
+
+/* Code font -------------------------------------------------------------- */
+
+/* Starlight composes its own system stack after this, so it stays the fallback. */
+:root {
+  --sl-font-mono: var(--pnd-font-mono);
+}
+
+/* Header ---------------------------------------------------------------- */
+
+.site-title {
+  gap: 0.6rem;
+  font-size: var(--sl-text-sm);
+  font-weight: 500;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.site-title img {
+  height: 1.5rem;
+}
+
+/* Sidebar controls ------------------------------------------------------ */
+
+/* Both controls belong to the desktop rail; the mobile drawer has its own. */
+.pnd-sidebar-toggle,
+.pnd-sidebar-resize {
+  display: none;
+}
+
+@media (min-width: 50rem) {
+  .pnd-sidebar-toggle {
+    display: flex;
+    flex: none;
+    align-items: center;
+    justify-content: center;
+    /* The wrapper has no gap, so the separation from the logo is set here.
+       The negative start pulls the button in from the header padding. */
+    margin-inline: -0.5rem 0.85rem;
+    width: var(--sl-menu-button-size);
+    height: var(--sl-menu-button-size);
+    padding: 0;
+    border: 0;
+    border-radius: 0.25rem;
+    background: none;
+    color: var(--sl-color-gray-3);
+    cursor: pointer;
+  }
+
+  .pnd-sidebar-toggle:hover {
+    background: var(--sl-color-gray-6);
+    color: var(--sl-color-white);
+  }
+
+  /*
+   * Rendered in the header but positioned against the viewport, so it sits on
+   * the pane's trailing edge and escapes the title wrapper's `overflow: clip`.
+   */
+  .pnd-sidebar-resize {
+    display: block;
+    position: fixed;
+    z-index: var(--sl-z-index-menu);
+    inset-block: var(--sl-nav-height) 0;
+    inset-inline-start: calc(var(--pnd-sidebar-width) - 3px);
+    width: 6px;
+    cursor: col-resize;
+    touch-action: none;
+  }
+
+  .pnd-sidebar-resize:hover,
+  .pnd-sidebar-resize:focus-visible {
+    background: var(--sl-color-accent);
+    outline: none;
+  }
+
+  :root[data-pnd-sidebar="collapsed"] .pnd-sidebar-resize {
+    display: none;
+  }
+}
+
+/* Sidebar labels -------------------------------------------------------- */
+
+/*
+ * One line per item. A label that outgrows the rail fades out at its trailing
+ * edge rather than wrapping to a second line, so the rail keeps one rhythm and
+ * a narrow sidebar stays readable. `min-width: 0` lets the flex label shrink
+ * far enough to clip at all.
+ */
+.sidebar-content a > span,
+.sidebar-content .group-label > span {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+/* Marked by the header script, so a label that fits keeps its last letters. */
+.sidebar-content [data-pnd-clipped] {
+  mask-image: linear-gradient(to right, #000 calc(100% - 1.25rem), transparent);
+}
+
+/*
+ * The label fills the row rather than shrink-wrapping its text. Left as a flex
+ * item sized to content, the fade landed on the last word of every group
+ * header instead of at the rail's edge.
+ */
+.sidebar-content .group-label {
+  flex: 1;
+  min-width: 0;
+}
+
+/* Sidebar groups -------------------------------------------------------- */
+
+/*
+ * A group grows and shrinks instead of snapping. `::details-content` is the box
+ * to animate, and `interpolate-size` is what makes the `auto` keyword a
+ * transition target; `allow-discrete` keeps the content painted for the whole
+ * collapse rather than dropping it on the first frame. Both features are recent,
+ * so the rule is guarded and older browsers keep the instant toggle.
+ */
+@supports selector(::details-content) and (interpolate-size: allow-keywords) {
+  @media (prefers-reduced-motion: no-preference) {
+    :root {
+      interpolate-size: allow-keywords;
+    }
+
+    .sidebar-content details::details-content {
+      block-size: 0;
+      overflow: hidden;
+      transition:
+        block-size 220ms ease,
+        content-visibility 220ms allow-discrete;
+    }
+
+    .sidebar-content details[open]::details-content {
+      block-size: auto;
+    }
+  }
+}
+
+/* Content --------------------------------------------------------------- */
+
+/*
+ * Rendered diagrams arrive as plain markdown images with a white background
+ * baked into the SVG, so they read as cards once their edge matches the layer
+ * cards beside them. Radius and border are `.arch-card`'s own values, which is
+ * why the border is a `color-mix` rather than a Starlight hairline token.
+ */
+.sl-markdown-content img {
+  border: 1px solid color-mix(in srgb, currentColor 22%, transparent);
+  border-radius: 0.5rem;
+}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Implements [FE-1455](https://linear.app/hash/issue/FE-1455/petrinaut-docs-site-tighter-chrome-and-more-room-for-content): the docs site ran on Starlight's defaults, which spent most of the width on the two side panels, and the header carried an oversized logo and title. Diagrams sat in square-cornered frames next to rounded cards.

Content column at 1440px: **720px → 869px**, and **1024px** with the sidebar collapsed.

Top of stack #9226, on FE-1457. `apps/petrinaut-docs` only; the bundle stays host-neutral.

## 🔗 Related links

- [FE-1455](https://linear.app/hash/issue/FE-1455/petrinaut-docs-site-tighter-chrome-and-more-room-for-content) *(internal)*: this PR
- [FE-1447](https://linear.app/hash/issue/FE-1447/arch-docs-emit-layer-facts-and-relations-as-structured-data-with-card) *(internal)*: the cards whose radius and border the images now match

## 🔍 What does this change?

- **Widths** (`src/styles/chrome.css`, registered as Starlight `customCss`): sidebar 18.75rem → 15rem, content 45rem → 56rem. Starlight sizes both panels from `--sl-sidebar-width`, so the left nav gets its own `--pnd-sidebar-width` in the two places Starlight consumes it; collapsing it no longer gives the table of contents a negative width.
- **Collapse and resize** (`src/components/SiteTitle.astro`): a toggle button and a drag handle. `SiteTitle` is the only overridable component in the fixed header, which is the chrome that stays on screen when the pane is gone. Collapsing sets `data-pnd-sidebar` on the root and widens content to 64rem; the handle resizes between 176px and 480px, with arrow-key support. Both persist in `localStorage`, restored by a `head` script that runs before the first stylesheet so a collapsed sidebar never renders open first.
- **Header**: logo 2rem → 1.5rem, title from 20px semibold to 14px medium, uppercase with `0.09em` letter-spacing.
- **Images**: `0.5rem` radius and a `color-mix` border, the same values `.arch-card` uses, so a diagram frame matches the cards in both themes. The SVG interior is untouched.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] modifies a workspace but **not** a publishable library

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] require changes to docs which **are made** as part of this PR
  - The app README describes the custom CSS and the `SiteTitle` override.

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

Presentation only, so no unit tests. `turbo run build --filter @apps/petrinaut-docs` passes (61 pages) and `lint:tsc` covers the component.

Checked in the browser on generated and authored pages, in dev and in the production preview: 1440px, 1024px and 375px, light and dark. The toggle persists across a reload with no flash, drag and arrow keys resize and clamp, both controls hide at 375px where the mobile drawer still works, and no page overflows horizontally.

## ❓ How to test this?

1. `turbo run dev --filter @apps/petrinaut-docs`
2. Toggle the sidebar from the header control, drag its right edge, then reload: the state comes back.

## 🐾 Next steps

Collapsed content width is 64rem rather than the 68rem a 1440px viewport allows, because at 68rem the column sat flush against the edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
