### PR TITLE
BE-770: Use the Kratos user-ID lookup on the admin delete-user path

### DIFF
--- a/libs/@local/graph/api/src/identity_provider.rs
+++ b/libs/@local/graph/api/src/identity_provider.rs
@@ -21,6 +21,18 @@ pub(crate) enum EmailLookupError {
 struct AdminIdentity {
     id: String,
     metadata_public: Option<MetadataPublic>,
+    #[serde(default)]
+    traits: IdentityTraits,
+}
+
+/// The identity traits the Graph reads.
+///
+/// An identity created outside the registration flow may carry no traits at all, so the addresses
+/// default to none rather than failing the read.
+#[derive(Default, Deserialize)]
+struct IdentityTraits {
+    #[serde(default)]
+    emails: Vec<String>,
 }
 
 /// A Kratos identity resolved to its provisioned Graph actor.
@@ -183,6 +195,48 @@ impl IdentityProvider for KratosIdentityProvider {
         }
 
         Ok(())
+    }
+
+    #[tracing::instrument(level = "debug", skip(self), fields(kratos_url = %self.admin_url))]
+    async fn get_identity_emails(
+        &self,
+        identity_id: &str,
+    ) -> Result<Vec<String>, Report<IdentityProviderError>> {
+        let mut url = self.admin_url.clone();
+        url.path_segments_mut()
+            .expect("admin URL is not a cannot-be-a-base URL")
+            .extend(["admin", "identities", identity_id]);
+
+        let response = self
+            .client
+            .get(url)
+            .send()
+            .await
+            .change_context(IdentityProviderError::LookupFailed)?;
+
+        // An identity deleted between resolution and this read holds no addresses.
+        let status = response.status();
+        if status == reqwest::StatusCode::NOT_FOUND {
+            tracing::info!(%identity_id, "Kratos identity no longer exists");
+            return Ok(Vec::new());
+        }
+
+        // `error_for_status` only covers 4xx/5xx — with redirects disabled, a 3xx has to be
+        // rejected here as well.
+        if !status.is_success() {
+            return Err(Report::new(IdentityProviderError::LookupFailed)
+                .attach(format!("Kratos responded with status {status}")));
+        }
+
+        // A `reqwest::Error` renders the URL it failed on, which carries the identity ID. The
+        // span already records the base URL.
+        let identity: AdminIdentity = response
+            .json()
+            .await
+            .map_err(reqwest::Error::without_url)
+            .change_context(IdentityProviderError::LookupFailed)?;
+
+        Ok(identity.traits.emails)
     }
 }
 

--- a/libs/@local/graph/api/src/identity_provider.rs
+++ b/libs/@local/graph/api/src/identity_provider.rs
@@ -1,9 +1,7 @@
-use alloc::sync::Arc;
-
 use error_stack::{Report, ResultExt as _};
 use hash_graph_authentication::kratos::MetadataPublic;
 use hash_graph_store::identity_provider::{IdentityProvider, IdentityProviderError};
-use reqwest::{Client, Url};
+use reqwest::{Client, Url, redirect};
 use serde::Deserialize;
 use type_system::principal::actor::UserId;
 
@@ -34,14 +32,27 @@ pub(crate) struct ResolvedUser {
 
 /// Ory Kratos implementation of [`IdentityProvider`].
 pub(crate) struct KratosIdentityProvider {
-    client: Arc<Client>,
+    client: Client,
     admin_url: Url,
 }
 
 impl KratosIdentityProvider {
+    /// Creates a new identity provider for the given Kratos admin URL.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the HTTP client cannot be built.
     #[must_use]
-    pub(crate) const fn new(client: Arc<Client>, admin_url: Url) -> Self {
-        Self { client, admin_url }
+    pub(crate) fn new(admin_url: Url) -> Self {
+        Self {
+            // The admin endpoints never redirect. Following a redirect would forward the request
+            // — and the identity data it returns — to the redirect target.
+            client: Client::builder()
+                .redirect(redirect::Policy::none())
+                .build()
+                .expect("the HTTP client should build with default TLS configuration"),
+            admin_url,
+        }
     }
 
     /// Resolves the user actor owning the given email address.
@@ -87,10 +98,15 @@ impl KratosIdentityProvider {
             .send()
             .await
             .map_err(reqwest::Error::without_url)
-            .change_context(EmailLookupError::LookupFailed)?
-            .error_for_status()
-            .map_err(reqwest::Error::without_url)
             .change_context(EmailLookupError::LookupFailed)?;
+
+        // `error_for_status` only covers 4xx/5xx — with redirects disabled, a 3xx has to be
+        // rejected here as well.
+        let status = response.status();
+        if !status.is_success() {
+            return Err(Report::new(EmailLookupError::LookupFailed)
+                .attach(format!("Kratos responded with status {status}")));
+        }
 
         let mut identities: Vec<AdminIdentity> = response
             .json()
@@ -153,14 +169,18 @@ impl IdentityProvider for KratosIdentityProvider {
             .change_context(IdentityProviderError::DeletionFailed)?;
 
         // 404 means the identity was already deleted — treat as success for idempotency
-        if response.status() == reqwest::StatusCode::NOT_FOUND {
+        let status = response.status();
+        if status == reqwest::StatusCode::NOT_FOUND {
             tracing::info!(%identity_id, "Kratos identity already deleted");
             return Ok(());
         }
 
-        response
-            .error_for_status()
-            .change_context(IdentityProviderError::DeletionFailed)?;
+        // `error_for_status` only covers 4xx/5xx — with redirects disabled, a 3xx has to be
+        // rejected here as well.
+        if !status.is_success() {
+            return Err(Report::new(IdentityProviderError::DeletionFailed)
+                .attach(format!("Kratos responded with status {status}")));
+        }
 
         Ok(())
     }
@@ -168,7 +188,6 @@ impl IdentityProvider for KratosIdentityProvider {
 
 #[cfg(test)]
 mod tests {
-    use alloc::sync::Arc;
     use core::net::SocketAddr;
     use std::collections::HashMap;
 
@@ -223,10 +242,7 @@ mod tests {
     }
 
     async fn provider_for(identities: JsonValue) -> KratosIdentityProvider {
-        KratosIdentityProvider::new(
-            Arc::new(reqwest::Client::new()),
-            spawn_fake_kratos(identities).await,
-        )
+        KratosIdentityProvider::new(spawn_fake_kratos(identities).await)
     }
 
     /// Builds the wire format of a Kratos admin identity.

--- a/libs/@local/graph/api/src/identity_provider.rs
+++ b/libs/@local/graph/api/src/identity_provider.rs
@@ -1,8 +1,13 @@
+use core::time::Duration;
+
 use error_stack::{Report, ResultExt as _};
-use hash_graph_authentication::kratos::MetadataPublic;
-use hash_graph_store::identity_provider::{IdentityProvider, IdentityProviderError};
-use reqwest::{Client, Url, redirect};
-use serde::Deserialize;
+use hash_graph_authentication::kratos::{
+    IdentityDeletion as AdminIdentityDeletion, KratosAdminClient, KratosAdminError,
+};
+use hash_graph_store::identity_provider::{
+    IdentityDeletion, IdentityProvider, IdentityProviderError,
+};
+use reqwest::Url;
 use type_system::principal::actor::UserId;
 
 /// Errors returned by [`KratosIdentityProvider::find_user_by_email`].
@@ -10,29 +15,25 @@ use type_system::principal::actor::UserId;
 pub(crate) enum EmailLookupError {
     #[display("failed to look up the identity by email")]
     LookupFailed,
+    #[display("the email to look up is empty")]
+    EmptyEmail,
     #[display("identity `{identity_id}` has no Graph actor provisioned")]
     NotProvisioned { identity_id: String },
-    #[display("{count} identities hold the email as a credentials identifier")]
+    #[display(
+        "{count} identities hold the email as a credentials identifier; delete by user ID instead"
+    )]
     AmbiguousEmail { count: usize },
 }
 
-/// Deserialized subset of a Kratos admin identity.
-#[derive(Deserialize)]
-struct AdminIdentity {
-    id: String,
-    metadata_public: Option<MetadataPublic>,
-    #[serde(default)]
-    traits: IdentityTraits,
-}
-
-/// The identity traits the Graph reads.
-///
-/// An identity created outside the registration flow may carry no traits at all, so the addresses
-/// default to none rather than failing the read.
-#[derive(Default, Deserialize)]
-struct IdentityTraits {
-    #[serde(default)]
-    emails: Vec<String>,
+/// Restates an admin API failure as a failure of the email lookup.
+fn lookup_error(report: Report<KratosAdminError>) -> Report<EmailLookupError> {
+    let context = match report.current_context() {
+        KratosAdminError::EmptyIdentifier => EmailLookupError::EmptyEmail,
+        KratosAdminError::Unreachable
+        | KratosAdminError::Rejected
+        | KratosAdminError::InvalidResponse => EmailLookupError::LookupFailed,
+    };
+    report.change_context(context)
 }
 
 /// A Kratos identity resolved to its provisioned Graph actor.
@@ -44,8 +45,7 @@ pub(crate) struct ResolvedUser {
 
 /// Ory Kratos implementation of [`IdentityProvider`].
 pub(crate) struct KratosIdentityProvider {
-    client: Client,
-    admin_url: Url,
+    admin_client: KratosAdminClient,
 }
 
 impl KratosIdentityProvider {
@@ -53,17 +53,11 @@ impl KratosIdentityProvider {
     ///
     /// # Panics
     ///
-    /// Panics if the HTTP client cannot be built.
+    /// Panics if the HTTP client cannot be built, or if the admin URL cannot carry a path.
     #[must_use]
-    pub(crate) fn new(admin_url: Url) -> Self {
+    pub(crate) fn new(admin_url: Url, http_timeout: Duration) -> Self {
         Self {
-            // The admin endpoints never redirect. Following a redirect would forward the request
-            // — and the identity data it returns — to the redirect target.
-            client: Client::builder()
-                .redirect(redirect::Policy::none())
-                .build()
-                .expect("the HTTP client should build with default TLS configuration"),
-            admin_url,
+            admin_client: KratosAdminClient::new(admin_url, http_timeout),
         }
     }
 
@@ -82,57 +76,34 @@ impl KratosIdentityProvider {
     ///
     /// # Errors
     ///
+    /// - [`EmptyEmail`] if `email` is empty, which Kratos would read as no filter at all
     /// - [`LookupFailed`] if the Kratos request fails or the response cannot be read
     /// - [`NotProvisioned`] if the identity carries no Graph actor
     /// - [`AmbiguousEmail`] if several identities hold the email
     ///
+    /// [`EmptyEmail`]: EmailLookupError::EmptyEmail
     /// [`LookupFailed`]: EmailLookupError::LookupFailed
     /// [`NotProvisioned`]: EmailLookupError::NotProvisioned
     /// [`AmbiguousEmail`]: EmailLookupError::AmbiguousEmail
-    #[tracing::instrument(level = "debug", skip_all, fields(kratos_url = %self.admin_url))]
+    #[tracing::instrument(
+        level = "debug",
+        skip_all,
+        fields(kratos_url = %self.admin_client.identities_url())
+    )]
     pub(crate) async fn find_user_by_email(
         &self,
         email: &str,
     ) -> Result<Option<ResolvedUser>, Report<EmailLookupError>> {
-        let mut url = self.admin_url.clone();
-        url.path_segments_mut()
-            .expect("admin URL is not a cannot-be-a-base URL")
-            .extend(["admin", "identities"]);
-        url.query_pairs_mut()
-            .append_pair("credentials_identifier", email);
-
-        // A `reqwest::Error` renders the URL it failed on, and the query string carries the
-        // looked-up address. Dropping the URL keeps the address out of the report; the span
-        // already carries the base URL.
-        let response = self
-            .client
-            .get(url)
-            .send()
+        let mut identities = self
+            .admin_client
+            .list_by_credential(email)
             .await
-            .map_err(reqwest::Error::without_url)
-            .change_context(EmailLookupError::LookupFailed)?;
-
-        // `error_for_status` only covers 4xx/5xx — with redirects disabled, a 3xx has to be
-        // rejected here as well.
-        let status = response.status();
-        if !status.is_success() {
-            return Err(Report::new(EmailLookupError::LookupFailed)
-                .attach(format!("Kratos responded with status {status}")));
-        }
-
-        let mut identities: Vec<AdminIdentity> = response
-            .json()
-            .await
-            .map_err(reqwest::Error::without_url)
-            .change_context(EmailLookupError::LookupFailed)?;
+            .map_err(lookup_error)?;
 
         let Some(identity) = identities.pop() else {
             return Ok(None);
         };
         if !identities.is_empty() {
-            // Several identities hold the same address while one account claims an email it does
-            // not own. Deleting either account on an ambiguous address is unsafe, so the operator
-            // has to fall back to deletion by user ID.
             return Err(Report::new(EmailLookupError::AmbiguousEmail {
                 count: identities.len() + 1,
             })
@@ -163,119 +134,129 @@ impl KratosIdentityProvider {
 }
 
 impl IdentityProvider for KratosIdentityProvider {
-    #[tracing::instrument(level = "debug", skip(self), fields(kratos_url = %self.admin_url))]
+    #[tracing::instrument(
+        level = "debug",
+        skip(self),
+        fields(kratos_url = %self.admin_client.identities_url())
+    )]
     async fn delete_identity(
         &self,
         identity_id: &str,
-    ) -> Result<(), Report<IdentityProviderError>> {
-        let mut url = self.admin_url.clone();
-        url.path_segments_mut()
-            .expect("admin URL is not a cannot-be-a-base URL")
-            .extend(["admin", "identities", identity_id]);
-
-        let response = self
-            .client
-            .delete(url)
-            .send()
+    ) -> Result<IdentityDeletion, Report<IdentityProviderError>> {
+        self.admin_client
+            .delete_by_id(identity_id)
             .await
-            .change_context(IdentityProviderError::DeletionFailed)?;
-
-        // 404 means the identity was already deleted — treat as success for idempotency
-        let status = response.status();
-        if status == reqwest::StatusCode::NOT_FOUND {
-            tracing::info!(%identity_id, "Kratos identity already deleted");
-            return Ok(());
-        }
-
-        // `error_for_status` only covers 4xx/5xx — with redirects disabled, a 3xx has to be
-        // rejected here as well.
-        if !status.is_success() {
-            return Err(Report::new(IdentityProviderError::DeletionFailed)
-                .attach(format!("Kratos responded with status {status}")));
-        }
-
-        Ok(())
+            .map(|deletion| match deletion {
+                AdminIdentityDeletion::Deleted => IdentityDeletion::Deleted,
+                AdminIdentityDeletion::AlreadyAbsent => IdentityDeletion::AlreadyAbsent,
+            })
+            .change_context(IdentityProviderError::DeletionFailed)
     }
 
-    #[tracing::instrument(level = "debug", skip(self), fields(kratos_url = %self.admin_url))]
+    #[tracing::instrument(
+        level = "debug",
+        skip(self),
+        fields(kratos_url = %self.admin_client.identities_url())
+    )]
     async fn get_identity_emails(
         &self,
         identity_id: &str,
-    ) -> Result<Vec<String>, Report<IdentityProviderError>> {
-        let mut url = self.admin_url.clone();
-        url.path_segments_mut()
-            .expect("admin URL is not a cannot-be-a-base URL")
-            .extend(["admin", "identities", identity_id]);
-
-        let response = self
-            .client
-            .get(url)
-            .send()
+    ) -> Result<Option<Vec<String>>, Report<IdentityProviderError>> {
+        let Some(identity) = self
+            .admin_client
+            .get_by_id(identity_id)
             .await
-            .change_context(IdentityProviderError::LookupFailed)?;
+            .change_context(IdentityProviderError::LookupFailed)?
+        else {
+            tracing::warn!(
+                %identity_id,
+                "Kratos holds no such identity, so its addresses stay unknown"
+            );
+            return Ok(None);
+        };
 
-        // An identity deleted between resolution and this read holds no addresses.
-        let status = response.status();
-        if status == reqwest::StatusCode::NOT_FOUND {
-            tracing::info!(%identity_id, "Kratos identity no longer exists");
-            return Ok(Vec::new());
-        }
-
-        // `error_for_status` only covers 4xx/5xx — with redirects disabled, a 3xx has to be
-        // rejected here as well.
-        if !status.is_success() {
-            return Err(Report::new(IdentityProviderError::LookupFailed)
-                .attach(format!("Kratos responded with status {status}")));
-        }
-
-        // A `reqwest::Error` renders the URL it failed on, which carries the identity ID. The
-        // span already records the base URL.
-        let identity: AdminIdentity = response
-            .json()
-            .await
-            .map_err(reqwest::Error::without_url)
-            .change_context(IdentityProviderError::LookupFailed)?;
-
-        Ok(identity.traits.emails)
+        Ok(Some(identity.traits.emails))
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use core::net::SocketAddr;
+    use core::{net::SocketAddr, time::Duration};
     use std::collections::HashMap;
 
-    use axum::{Json, Router, extract::Query, response::IntoResponse as _, routing::get};
+    use axum::{
+        Json, Router,
+        extract::{Path, Query},
+        http::StatusCode,
+        response::IntoResponse as _,
+        routing::get,
+    };
     use reqwest::Url;
     use serde_json::{Value as JsonValue, json};
     use uuid::Uuid;
 
-    use super::{EmailLookupError, KratosIdentityProvider};
+    use super::{EmailLookupError, IdentityDeletion, KratosIdentityProvider};
 
     const EMAIL: &str = "user@example.com";
+    const HTTP_TIMEOUT: Duration = Duration::from_secs(5);
 
-    /// Binds a fake Kratos admin API on an ephemeral port and returns its base URL.
+    /// Picks a served identity by its ID.
+    fn identity_with_id(identities: &JsonValue, identity_id: &str) -> Option<JsonValue> {
+        identities
+            .as_array()
+            .expect("the served identities should be an array")
+            .iter()
+            .find(|identity| identity["id"] == identity_id)
+            .cloned()
+    }
+
+    /// Builds a fake Kratos admin API serving the given identities.
     ///
-    /// The fake only serves the identities when the request carries the expected email as
+    /// The list endpoint only serves the identities when the request carries the expected email as
     /// credentials identifier, so any test that reaches an identity also verifies the lookup
-    /// query.
-    async fn spawn_fake_kratos(identities: JsonValue) -> Url {
-        let router = Router::new().route(
-            "/admin/identities",
-            get(
-                move |Query(params): Query<HashMap<String, String>>| async move {
-                    let matches_email = params
-                        .get("credentials_identifier")
-                        .is_some_and(|identifier| identifier.eq_ignore_ascii_case(EMAIL));
-                    if matches_email {
-                        Json(identities).into_response()
+    /// query. The by-ID endpoints match on an identity's `id` and answer 404 for anything else.
+    fn kratos_router(identities: JsonValue) -> Router {
+        let listed = identities.clone();
+        let fetched = identities.clone();
+        Router::new()
+            .route(
+                "/admin/identities",
+                get(
+                    move |Query(params): Query<HashMap<String, String>>| async move {
+                        let matches_email = params
+                            .get("credentials_identifier")
+                            .is_some_and(|identifier| identifier.eq_ignore_ascii_case(EMAIL));
+                        if matches_email {
+                            Json(listed).into_response()
+                        } else {
+                            // Real Kratos answers an ABSENT identifier with every identity it
+                            // holds — the fake inverts that, so the empty-email guard is pinned
+                            // by its own error variant, never by this fake's leniency.
+                            Json(json!([])).into_response()
+                        }
+                    },
+                ),
+            )
+            .route(
+                "/admin/identities/{identity_id}",
+                get(move |Path(identity_id): Path<String>| async move {
+                    identity_with_id(&fetched, &identity_id).map_or_else(
+                        || StatusCode::NOT_FOUND.into_response(),
+                        |identity| Json(identity).into_response(),
+                    )
+                })
+                .delete(move |Path(identity_id): Path<String>| async move {
+                    if identity_with_id(&identities, &identity_id).is_some() {
+                        StatusCode::NO_CONTENT
                     } else {
-                        Json(json!([])).into_response()
+                        StatusCode::NOT_FOUND
                     }
-                },
-            ),
-        );
+                }),
+            )
+    }
 
+    /// Binds the given router on an ephemeral port and returns its base URL.
+    async fn spawn(router: Router) -> Url {
         let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
             .await
             .expect("the test server should bind to an ephemeral port");
@@ -296,7 +277,22 @@ mod tests {
     }
 
     async fn provider_for(identities: JsonValue) -> KratosIdentityProvider {
-        KratosIdentityProvider::new(spawn_fake_kratos(identities).await)
+        KratosIdentityProvider::new(spawn(kratos_router(identities)).await, HTTP_TIMEOUT)
+    }
+
+    /// A provider whose admin URL carries a path prefix ending in a slash, which an operator may
+    /// configure.
+    async fn provider_for_url_with_path_prefix(identities: JsonValue) -> KratosIdentityProvider {
+        let base = spawn(Router::new().nest("/kratos", kratos_router(identities))).await;
+        let with_prefix = base
+            .join("kratos/")
+            .expect("the test server address should take a path prefix");
+        assert_eq!(
+            with_prefix.path(),
+            "/kratos/",
+            "the fixture should hand the provider a trailing slash to strip"
+        );
+        KratosIdentityProvider::new(with_prefix, HTTP_TIMEOUT)
     }
 
     /// Builds the wire format of a Kratos admin identity.
@@ -306,6 +302,33 @@ mod tests {
             identity["metadata_public"] = json!({ "graph_actor_id": actor_id });
         }
         identity
+    }
+
+    /// Adds the traits the registration flow writes to an identity.
+    fn with_emails(mut identity: JsonValue, emails: &[&str]) -> JsonValue {
+        identity["traits"] = json!({ "emails": emails });
+        identity
+    }
+
+    #[tokio::test]
+    async fn trailing_slash_in_the_admin_url_still_resolves() {
+        let actor_id = Uuid::new_v4();
+        let provider = provider_for_url_with_path_prefix(json!([identity_json(
+            Uuid::new_v4(),
+            Some(actor_id)
+        )]))
+        .await;
+
+        let resolved = provider
+            .find_user_by_email(EMAIL)
+            .await
+            .expect("a trailing slash should not double the path separator")
+            .expect("the email should belong to an identity");
+        assert_eq!(
+            Uuid::from(resolved.user_id),
+            actor_id,
+            "the resolved user should be the provisioned actor"
+        );
     }
 
     #[tokio::test]
@@ -328,6 +351,122 @@ mod tests {
             resolved.kratos_identity_id,
             identity_id.to_string(),
             "the resolved identity should be the one holding the email"
+        );
+    }
+
+    /// Kratos reads an empty `credentials_identifier` as no filter and answers with every
+    /// identity, so the lookup would resolve an arbitrary user.
+    #[tokio::test]
+    async fn empty_email_is_rejected_before_the_lookup() {
+        let provider =
+            provider_for(json!([identity_json(Uuid::new_v4(), Some(Uuid::new_v4()))])).await;
+
+        let outcome = provider.find_user_by_email("").await;
+        assert!(
+            matches!(
+                outcome
+                    .expect_err("an empty email should be rejected")
+                    .current_context(),
+                EmailLookupError::EmptyEmail
+            ),
+            "an empty email should name its rejection rather than reach Kratos"
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_identity_leaves_the_addresses_unknown() {
+        use hash_graph_store::identity_provider::IdentityProvider as _;
+
+        let provider = provider_for(json!([])).await;
+
+        let emails = provider
+            .get_identity_emails("no-such-identity")
+            .await
+            .expect("a missing identity should not fail the read");
+        assert!(
+            emails.is_none(),
+            "a missing identity should leave the addresses unknown rather than empty"
+        );
+    }
+
+    #[tokio::test]
+    async fn identity_yields_its_registered_addresses() {
+        use hash_graph_store::identity_provider::IdentityProvider as _;
+
+        let identity_id = Uuid::new_v4();
+        let provider = provider_for(json!([with_emails(
+            identity_json(identity_id, Some(Uuid::new_v4())),
+            &["first@example.com", "second@example.com"]
+        )]))
+        .await;
+
+        let emails = provider
+            .get_identity_emails(&identity_id.to_string())
+            .await
+            .expect("an existing identity should not fail the read")
+            .expect("an existing identity should leave its addresses known");
+        assert_eq!(
+            emails,
+            ["first@example.com", "second@example.com"],
+            "the read should yield the addresses the identity holds"
+        );
+    }
+
+    /// An identity created outside the registration flow carries no traits, which is distinct from
+    /// an identity Kratos no longer holds.
+    #[tokio::test]
+    async fn identity_without_traits_yields_no_addresses() {
+        use hash_graph_store::identity_provider::IdentityProvider as _;
+
+        let identity_id = Uuid::new_v4();
+        let provider =
+            provider_for(json!([identity_json(identity_id, Some(Uuid::new_v4()))])).await;
+
+        let emails = provider
+            .get_identity_emails(&identity_id.to_string())
+            .await
+            .expect("an identity without traits should not fail the read");
+        assert_eq!(
+            emails,
+            Some(Vec::new()),
+            "an identity without traits should hold no addresses rather than leave them unknown"
+        );
+    }
+
+    #[tokio::test]
+    async fn deletion_removes_the_identity() {
+        use hash_graph_store::identity_provider::IdentityProvider as _;
+
+        let identity_id = Uuid::new_v4();
+        let provider =
+            provider_for(json!([identity_json(identity_id, Some(Uuid::new_v4()))])).await;
+
+        let deletion = provider
+            .delete_identity(&identity_id.to_string())
+            .await
+            .expect("an existing identity should be deletable");
+        assert_eq!(
+            deletion,
+            IdentityDeletion::Deleted,
+            "deleting an existing identity should report it as deleted"
+        );
+    }
+
+    /// Deletion runs after the identity may already have been deleted by an earlier partial run.
+    #[tokio::test]
+    async fn missing_identity_counts_as_deleted() {
+        use hash_graph_store::identity_provider::IdentityProvider as _;
+
+        let provider = provider_for(json!([])).await;
+
+        let deletion = provider
+            .delete_identity("no-such-identity")
+            .await
+            .expect("an identity that is already gone should not fail the deletion");
+        assert_eq!(
+            deletion,
+            IdentityDeletion::AlreadyAbsent,
+            "an identity that is already gone should report as already absent"
         );
     }
 
@@ -382,6 +521,132 @@ mod tests {
             ),
             "the lookup should report the email as ambiguous, got {:?}",
             report.current_context()
+        );
+    }
+
+    /// Deletion must reach accounts that never completed verification, so — unlike
+    /// authentication — the lookup accepts an unverified address.
+    #[tokio::test]
+    async fn unverified_address_still_resolves_for_deletion() {
+        let actor_id = Uuid::new_v4();
+        let mut identity = identity_json(Uuid::new_v4(), Some(actor_id));
+        identity["verifiable_addresses"] = json!([{ "value": EMAIL, "verified": false }]);
+        let provider = provider_for(json!([identity])).await;
+
+        let resolved = provider
+            .find_user_by_email(EMAIL)
+            .await
+            .expect("an unverified address should not fail the lookup")
+            .expect("an unverified address should still resolve for deletion");
+        assert_eq!(
+            Uuid::from(resolved.user_id),
+            actor_id,
+            "the resolved user should be the provisioned actor"
+        );
+    }
+
+    /// Each status covers a rung of the ladder that must fail the lookup rather than read as an
+    /// unknown user.
+    #[tokio::test]
+    async fn failure_statuses_fail_the_lookup() {
+        for status in [
+            StatusCode::UNAUTHORIZED,
+            StatusCode::INTERNAL_SERVER_ERROR,
+            StatusCode::FOUND,
+        ] {
+            let router =
+                Router::new().route("/admin/identities", get(move || async move { status }));
+            let provider = KratosIdentityProvider::new(spawn(router).await, HTTP_TIMEOUT);
+
+            let report = provider
+                .find_user_by_email(EMAIL)
+                .await
+                .expect_err("a failure status should fail the lookup rather than read as unknown");
+            assert!(
+                matches!(report.current_context(), EmailLookupError::LookupFailed),
+                "a {status} should fail the lookup, got {:?}",
+                report.current_context()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn undeserializable_list_response_fails_the_lookup() {
+        let router = Router::new().route(
+            "/admin/identities",
+            get(|| async { (StatusCode::OK, r#"{"identity-like": "body"}"#) }),
+        );
+        let provider = KratosIdentityProvider::new(spawn(router).await, HTTP_TIMEOUT);
+
+        let report = provider
+            .find_user_by_email(EMAIL)
+            .await
+            .expect_err("an undeserializable listing should fail the lookup");
+        assert!(
+            matches!(report.current_context(), EmailLookupError::LookupFailed),
+            "an undeserializable listing should fail the lookup, got {:?}",
+            report.current_context()
+        );
+        assert!(
+            !format!("{report:?}").contains("identity-like"),
+            "the report should not carry the identity response body"
+        );
+    }
+
+    /// The identity schema requires the addresses, so a `traits` object without them is a broken
+    /// provider contract rather than an identity without addresses.
+    #[tokio::test]
+    async fn traits_without_addresses_fail_the_read() {
+        use hash_graph_store::identity_provider::IdentityProvider as _;
+
+        let identity_id = Uuid::new_v4();
+        let mut identity = identity_json(identity_id, None);
+        identity["traits"] = json!({});
+        let provider = provider_for(json!([identity])).await;
+
+        let report = provider
+            .get_identity_emails(&identity_id.to_string())
+            .await
+            .expect_err(
+                "a traits object without addresses should fail the read rather than read as an \
+                 identity without addresses",
+            );
+        assert!(
+            matches!(
+                report.current_context(),
+                super::IdentityProviderError::LookupFailed
+            ),
+            "the broken contract should fail the read as a lookup failure"
+        );
+    }
+
+    #[tokio::test]
+    async fn undeserializable_identity_response_fails_the_read() {
+        use hash_graph_store::identity_provider::IdentityProvider as _;
+
+        let router = Router::new().route(
+            "/admin/identities/{identity_id}",
+            get(|| async { (StatusCode::OK, r#"{"identity-like": "body"}"#) }),
+        );
+        let provider = KratosIdentityProvider::new(spawn(router).await, HTTP_TIMEOUT);
+
+        let report = provider
+            .get_identity_emails("some-identity")
+            .await
+            .expect_err(
+                "an undeserializable identity should fail the read rather than leave the \
+                 addresses unknown",
+            );
+        assert!(
+            matches!(
+                report.current_context(),
+                super::IdentityProviderError::LookupFailed
+            ),
+            "the undeserializable identity should fail the read as a lookup failure"
+        );
+        assert!(
+            !format!("{report:?}").contains("identity-like"),
+            "the report should not carry the identity response body"
         );
     }
 }

--- a/libs/@local/graph/api/src/identity_provider.rs
+++ b/libs/@local/graph/api/src/identity_provider.rs
@@ -1,8 +1,36 @@
 use alloc::sync::Arc;
 
 use error_stack::{Report, ResultExt as _};
+use hash_graph_authentication::kratos::MetadataPublic;
 use hash_graph_store::identity_provider::{IdentityProvider, IdentityProviderError};
 use reqwest::{Client, Url};
+use serde::Deserialize;
+use type_system::principal::actor::UserId;
+
+/// Errors returned by [`KratosIdentityProvider::find_user_by_email`].
+#[derive(Debug, derive_more::Display, derive_more::Error)]
+pub(crate) enum EmailLookupError {
+    #[display("failed to look up the identity by email")]
+    LookupFailed,
+    #[display("identity `{identity_id}` has no Graph actor provisioned")]
+    NotProvisioned { identity_id: String },
+    #[display("{count} identities hold the email as a credentials identifier")]
+    AmbiguousEmail { count: usize },
+}
+
+/// Deserialized subset of a Kratos admin identity.
+#[derive(Deserialize)]
+struct AdminIdentity {
+    id: String,
+    metadata_public: Option<MetadataPublic>,
+}
+
+/// A Kratos identity resolved to its provisioned Graph actor.
+#[derive(Debug)]
+pub(crate) struct ResolvedUser {
+    pub user_id: UserId,
+    pub kratos_identity_id: String,
+}
 
 /// Ory Kratos implementation of [`IdentityProvider`].
 pub(crate) struct KratosIdentityProvider {
@@ -14,6 +42,95 @@ impl KratosIdentityProvider {
     #[must_use]
     pub(crate) const fn new(client: Arc<Client>, admin_url: Url) -> Self {
         Self { client, admin_url }
+    }
+
+    /// Resolves the user actor owning the given email address.
+    ///
+    /// The identity is looked up by credentials identifier and the actor is read from the
+    /// `graph_actor_id` field in its `metadata_public`. Unlike authentication, the lookup does not
+    /// require the address to be verified: deletion must reach accounts that never completed
+    /// verification.
+    ///
+    /// The resolved identity ID travels with the actor so that deletion does not have to read it
+    /// back from the graph — the graph entity may already be gone from an earlier partial
+    /// deletion.
+    ///
+    /// Returns `None` when no identity holds the email.
+    ///
+    /// # Errors
+    ///
+    /// - [`LookupFailed`] if the Kratos request fails or the response cannot be read
+    /// - [`NotProvisioned`] if the identity carries no Graph actor
+    /// - [`AmbiguousEmail`] if several identities hold the email
+    ///
+    /// [`LookupFailed`]: EmailLookupError::LookupFailed
+    /// [`NotProvisioned`]: EmailLookupError::NotProvisioned
+    /// [`AmbiguousEmail`]: EmailLookupError::AmbiguousEmail
+    #[tracing::instrument(level = "debug", skip_all, fields(kratos_url = %self.admin_url))]
+    pub(crate) async fn find_user_by_email(
+        &self,
+        email: &str,
+    ) -> Result<Option<ResolvedUser>, Report<EmailLookupError>> {
+        let mut url = self.admin_url.clone();
+        url.path_segments_mut()
+            .expect("admin URL is not a cannot-be-a-base URL")
+            .extend(["admin", "identities"]);
+        url.query_pairs_mut()
+            .append_pair("credentials_identifier", email);
+
+        // A `reqwest::Error` renders the URL it failed on, and the query string carries the
+        // looked-up address. Dropping the URL keeps the address out of the report; the span
+        // already carries the base URL.
+        let response = self
+            .client
+            .get(url)
+            .send()
+            .await
+            .map_err(reqwest::Error::without_url)
+            .change_context(EmailLookupError::LookupFailed)?
+            .error_for_status()
+            .map_err(reqwest::Error::without_url)
+            .change_context(EmailLookupError::LookupFailed)?;
+
+        let mut identities: Vec<AdminIdentity> = response
+            .json()
+            .await
+            .map_err(reqwest::Error::without_url)
+            .change_context(EmailLookupError::LookupFailed)?;
+
+        let Some(identity) = identities.pop() else {
+            return Ok(None);
+        };
+        if !identities.is_empty() {
+            // Several identities hold the same address while one account claims an email it does
+            // not own. Deleting either account on an ambiguous address is unsafe, so the operator
+            // has to fall back to deletion by user ID.
+            return Err(Report::new(EmailLookupError::AmbiguousEmail {
+                count: identities.len() + 1,
+            })
+            .attach(format!(
+                "identity ids: {}",
+                identities
+                    .iter()
+                    .chain(core::iter::once(&identity))
+                    .map(|identity| identity.id.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )));
+        }
+
+        match identity
+            .metadata_public
+            .and_then(|metadata| metadata.graph_actor_id)
+        {
+            Some(user_id) => Ok(Some(ResolvedUser {
+                user_id,
+                kratos_identity_id: identity.id,
+            })),
+            None => Err(Report::new(EmailLookupError::NotProvisioned {
+                identity_id: identity.id,
+            })),
+        }
     }
 }
 
@@ -46,5 +163,155 @@ impl IdentityProvider for KratosIdentityProvider {
             .change_context(IdentityProviderError::DeletionFailed)?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::sync::Arc;
+    use core::net::SocketAddr;
+    use std::collections::HashMap;
+
+    use axum::{Json, Router, extract::Query, response::IntoResponse as _, routing::get};
+    use reqwest::Url;
+    use serde_json::{Value as JsonValue, json};
+    use uuid::Uuid;
+
+    use super::{EmailLookupError, KratosIdentityProvider};
+
+    const EMAIL: &str = "user@example.com";
+
+    /// Binds a fake Kratos admin API on an ephemeral port and returns its base URL.
+    ///
+    /// The fake only serves the identities when the request carries the expected email as
+    /// credentials identifier, so any test that reaches an identity also verifies the lookup
+    /// query.
+    async fn spawn_fake_kratos(identities: JsonValue) -> Url {
+        let router = Router::new().route(
+            "/admin/identities",
+            get(
+                move |Query(params): Query<HashMap<String, String>>| async move {
+                    let matches_email = params
+                        .get("credentials_identifier")
+                        .is_some_and(|identifier| identifier.eq_ignore_ascii_case(EMAIL));
+                    if matches_email {
+                        Json(identities).into_response()
+                    } else {
+                        Json(json!([])).into_response()
+                    }
+                },
+            ),
+        );
+
+        let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("the test server should bind to an ephemeral port");
+        let address = listener
+            .local_addr()
+            .expect("the test listener should report its local address");
+        tokio::spawn(async move {
+            axum::serve(
+                listener,
+                router.into_make_service_with_connect_info::<SocketAddr>(),
+            )
+            .await
+            .expect("the test server should serve requests");
+        });
+
+        Url::parse(&format!("http://{address}"))
+            .expect("the test server address should parse as a URL")
+    }
+
+    async fn provider_for(identities: JsonValue) -> KratosIdentityProvider {
+        KratosIdentityProvider::new(
+            Arc::new(reqwest::Client::new()),
+            spawn_fake_kratos(identities).await,
+        )
+    }
+
+    /// Builds the wire format of a Kratos admin identity.
+    fn identity_json(identity_id: Uuid, actor_id: Option<Uuid>) -> JsonValue {
+        let mut identity = json!({ "id": identity_id });
+        if let Some(actor_id) = actor_id {
+            identity["metadata_public"] = json!({ "graph_actor_id": actor_id });
+        }
+        identity
+    }
+
+    #[tokio::test]
+    async fn provisioned_identity_resolves() {
+        let identity_id = Uuid::new_v4();
+        let actor_id = Uuid::new_v4();
+        let provider = provider_for(json!([identity_json(identity_id, Some(actor_id))])).await;
+
+        let resolved = provider
+            .find_user_by_email(EMAIL)
+            .await
+            .expect("a provisioned identity should resolve")
+            .expect("the email should belong to an identity");
+        assert_eq!(
+            Uuid::from(resolved.user_id),
+            actor_id,
+            "the resolved user should be the provisioned actor"
+        );
+        assert_eq!(
+            resolved.kratos_identity_id,
+            identity_id.to_string(),
+            "the resolved identity should be the one holding the email"
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_email_resolves_to_none() {
+        let provider = provider_for(json!([])).await;
+
+        let resolved = provider
+            .find_user_by_email(EMAIL)
+            .await
+            .expect("an unknown email should not fail the lookup");
+        assert!(
+            resolved.is_none(),
+            "an unknown email should resolve to none"
+        );
+    }
+
+    #[tokio::test]
+    async fn unprovisioned_identity_fails() {
+        let provider = provider_for(json!([identity_json(Uuid::new_v4(), None)])).await;
+
+        let report = provider
+            .find_user_by_email(EMAIL)
+            .await
+            .expect_err("an identity without a Graph actor should fail the lookup");
+        assert!(
+            matches!(
+                report.current_context(),
+                EmailLookupError::NotProvisioned { .. }
+            ),
+            "the lookup should report the identity as not provisioned, got {:?}",
+            report.current_context()
+        );
+    }
+
+    #[tokio::test]
+    async fn multiple_identities_fail() {
+        let provider = provider_for(json!([
+            identity_json(Uuid::new_v4(), Some(Uuid::new_v4())),
+            identity_json(Uuid::new_v4(), Some(Uuid::new_v4())),
+        ]))
+        .await;
+
+        let report = provider
+            .find_user_by_email(EMAIL)
+            .await
+            .expect_err("an email held by several identities should fail the lookup");
+        assert!(
+            matches!(
+                report.current_context(),
+                EmailLookupError::AmbiguousEmail { count: 2 }
+            ),
+            "the lookup should report the email as ambiguous, got {:?}",
+            report.current_context()
+        );
     }
 }

--- a/libs/@local/graph/api/src/rest/admin.rs
+++ b/libs/@local/graph/api/src/rest/admin.rs
@@ -48,7 +48,7 @@ use hash_graph_postgres_store::store::PostgresStorePool;
 use hash_graph_store::{
     entity::{DeleteEntitiesParams, DeletionSummary, EntityStore as _},
     pool::StorePool as _,
-    user_deletion,
+    user_deletion::{self, UserDeletionError},
 };
 use hash_status::{Status, StatusCode};
 use serde::Deserialize as _;
@@ -66,9 +66,14 @@ use super::{
     status::{BoxedResponse, status_to_response},
 };
 use crate::{
-    email_subscription::MailchimpSubscriptionProvider, identity_provider::KratosIdentityProvider,
-    oauth_provider::HydraOAuthProvider, rest::status::report_to_response,
+    email_subscription::MailchimpSubscriptionProvider,
+    identity_provider::{EmailLookupError, KratosIdentityProvider},
+    oauth_provider::HydraOAuthProvider,
+    rest::status::report_to_response,
 };
+
+/// HTTP timeout for the Kratos admin client.
+const KRATOS_HTTP_TIMEOUT: core::time::Duration = core::time::Duration::from_secs(10);
 
 /// Configuration for external identity services passed to admin routes.
 #[derive(Debug, Clone)]
@@ -107,6 +112,7 @@ where
 
     let kratos = Arc::new(KratosIdentityProvider::new(
         external_services.kratos_admin_url.clone(),
+        KRATOS_HTTP_TIMEOUT,
     ));
 
     probe::router()
@@ -315,11 +321,18 @@ async fn delete_user(
     let (user_id, kratos_identity_id) = match request {
         DeleteUserRequest::ById { user_id } => (UserId::new(user_id), None),
         DeleteUserRequest::ByEmail { email } => {
-            tracing::info!(%email, "resolving user by email");
             let resolved = kratos
                 .find_user_by_email(&email)
                 .await
-                .map_err(report_to_response)?
+                .map_err(|report| {
+                    let code = match report.current_context() {
+                        EmailLookupError::EmptyEmail => StatusCode::InvalidArgument,
+                        EmailLookupError::NotProvisioned { .. }
+                        | EmailLookupError::AmbiguousEmail { .. } => StatusCode::FailedPrecondition,
+                        EmailLookupError::LookupFailed => StatusCode::Unavailable,
+                    };
+                    report_to_response(report.attach(code))
+                })?
                 .ok_or_else(|| {
                     report_to_response(
                         Report::new(AdminError::UserNotFound).attach(StatusCode::NotFound),
@@ -360,7 +373,22 @@ async fn delete_user(
         kratos_identity_id,
     )
     .await
-    .map_err(report_to_response)?;
+    .map_err(|report| {
+        // Only the fatal variants can reach this path; the non-fatal ones are collected into
+        // the outcome.
+        let code = match report.current_context() {
+            UserDeletionError::UserLookup => StatusCode::Unavailable,
+            UserDeletionError::MissingKratosIdentityId => StatusCode::FailedPrecondition,
+            UserDeletionError::EntityDeletion
+            | UserDeletionError::KratosDeletion
+            | UserDeletionError::UnknownIdentity
+            | UserDeletionError::HydraLoginRevocation
+            | UserDeletionError::HydraConsentRevocation
+            | UserDeletionError::EmailSubscription
+            | UserDeletionError::UnknownEmailAddresses => StatusCode::Internal,
+        };
+        report_to_response(report.attach(code))
+    })?;
 
     let message = if outcome.errors.is_ok() {
         "User deleted successfully"

--- a/libs/@local/graph/api/src/rest/admin.rs
+++ b/libs/@local/graph/api/src/rest/admin.rs
@@ -105,6 +105,10 @@ where
         .route("/property-types", delete(delete_property_types))
         .route("/entity-types", delete(delete_entity_types));
 
+    let kratos = Arc::new(KratosIdentityProvider::new(
+        external_services.kratos_admin_url.clone(),
+    ));
+
     probe::router()
         .merge(
             protected.route_layer(axum::middleware::from_fn(move |request, next| {
@@ -123,6 +127,7 @@ where
         .layer(http_tracing_layer::HttpTracingLayer)
         .layer(Extension(store_pool))
         .layer(Extension(Arc::new(external_services)))
+        .layer(Extension(kratos))
         .layer(Extension(Arc::new(reqwest::Client::new())))
 }
 
@@ -301,15 +306,11 @@ async fn delete_user(
     AuthenticatedActorId(actor_id): AuthenticatedActorId,
     pool: Extension<Arc<PostgresStorePool>>,
     external_services: Extension<Arc<ExternalServicesConfig>>,
+    kratos: Extension<Arc<KratosIdentityProvider>>,
     http_client: Extension<Arc<reqwest::Client>>,
     Json(request): Json<DeleteUserRequest>,
 ) -> Result<BoxedResponse, BoxedResponse> {
     let mut store = pool.acquire(None).await.map_err(report_to_response)?;
-
-    let kratos = KratosIdentityProvider::new(
-        Arc::clone(&http_client),
-        external_services.kratos_admin_url.clone(),
-    );
 
     let (user_id, kratos_identity_id) = match request {
         DeleteUserRequest::ById { user_id } => (UserId::new(user_id), None),
@@ -351,7 +352,7 @@ async fn delete_user(
 
     let outcome = user_deletion::delete_user(
         &mut store,
-        &kratos,
+        kratos.as_ref(),
         &hydra,
         mailchimp.as_ref(),
         actor_id.into(),

--- a/libs/@local/graph/api/src/rest/admin.rs
+++ b/libs/@local/graph/api/src/rest/admin.rs
@@ -46,7 +46,6 @@ use hash_graph_authentication::provider::AuthenticationProvider;
 use hash_graph_postgres_store::snapshot::SnapshotStore;
 use hash_graph_postgres_store::store::PostgresStorePool;
 use hash_graph_store::{
-    account::AccountStore as _,
     entity::{DeleteEntitiesParams, DeletionSummary, EntityStore as _},
     pool::StorePool as _,
     user_deletion,
@@ -307,27 +306,28 @@ async fn delete_user(
 ) -> Result<BoxedResponse, BoxedResponse> {
     let mut store = pool.acquire(None).await.map_err(report_to_response)?;
 
-    let user_id = match request {
-        DeleteUserRequest::ById { user_id } => UserId::new(user_id),
+    let kratos = KratosIdentityProvider::new(
+        Arc::clone(&http_client),
+        external_services.kratos_admin_url.clone(),
+    );
+
+    let (user_id, kratos_identity_id) = match request {
+        DeleteUserRequest::ById { user_id } => (UserId::new(user_id), None),
         DeleteUserRequest::ByEmail { email } => {
             tracing::info!(%email, "resolving user by email");
-            store
-                .get_user_id_by_email(&email)
+            let resolved = kratos
+                .find_user_by_email(&email)
                 .await
                 .map_err(report_to_response)?
                 .ok_or_else(|| {
                     report_to_response(
                         Report::new(AdminError::UserNotFound).attach(StatusCode::NotFound),
                     )
-                })?
+                })?;
+            (resolved.user_id, Some(resolved.kratos_identity_id))
         }
     };
     tracing::info!(%user_id, "user deletion requested");
-
-    let kratos = KratosIdentityProvider::new(
-        Arc::clone(&http_client),
-        external_services.kratos_admin_url.clone(),
-    );
 
     let hydra = HydraOAuthProvider::new(
         Arc::clone(&http_client),
@@ -356,6 +356,7 @@ async fn delete_user(
         mailchimp.as_ref(),
         actor_id.into(),
         user_id,
+        kratos_identity_id,
     )
     .await
     .map_err(report_to_response)?;

--- a/libs/@local/graph/authentication/src/kratos/admin.rs
+++ b/libs/@local/graph/authentication/src/kratos/admin.rs
@@ -1,0 +1,448 @@
+//! Transport for the Kratos admin identity API.
+//!
+//! Carries the URL construction, the redirect policy and the response handling every admin
+//! identity call shares. Which identity a lookup accepts is policy and stays with the caller.
+
+use core::time::Duration;
+
+use error_stack::{Report, ResultExt as _};
+use reqwest::{Client, Response, StatusCode, Url, redirect};
+use serde::Deserialize;
+
+use super::{MetadataPublic, ProviderFailure, read_provider_body};
+
+/// Errors returned by the Kratos admin API calls.
+#[derive(Debug, derive_more::Display, derive_more::Error)]
+pub enum KratosAdminError {
+    /// The identifier to look up is empty.
+    ///
+    /// Kratos reads an empty `credentials_identifier` as no filter at all and answers with every
+    /// identity it holds, so a lookup would resolve an arbitrary one.
+    #[display("the identifier to look up is empty")]
+    EmptyIdentifier,
+    /// The admin API could not be reached, redirected, or answered with a server error.
+    #[display("failed to reach the Kratos admin API")]
+    Unreachable,
+    /// The admin API rejected the request.
+    #[display("the Kratos admin API rejected the request")]
+    Rejected,
+    /// The admin API answered with a body that could not be deserialized.
+    #[display("the Kratos admin API returned an invalid response")]
+    InvalidResponse,
+}
+
+/// The subset of a Kratos admin identity the Graph reads.
+///
+/// Deliberately not `Debug`: a rendered identity carries its addresses.
+#[derive(Deserialize)]
+pub struct AdminIdentity {
+    /// The identity's own ID.
+    pub id: String,
+    /// The metadata the Graph provisions, carrying the actor.
+    pub metadata_public: Option<MetadataPublic>,
+    /// The addresses the identity may sign in with, and whether each is verified.
+    #[serde(default)]
+    pub verifiable_addresses: Vec<VerifiableAddress>,
+}
+
+/// The subset of a Kratos admin identity the by-ID read yields.
+///
+/// The traits live here rather than on [`AdminIdentity`], so a malformed traits object fails
+/// this read alone and can never fail an identity listing.
+///
+/// Deliberately not `Debug`: a rendered identity carries its addresses.
+#[derive(Deserialize)]
+pub struct IdentityRecord {
+    /// The identity's own ID.
+    pub id: String,
+    /// The traits the registration flow writes.
+    ///
+    /// The identity schema does not require the traits object itself, so a missing `traits`
+    /// yields no addresses rather than failing the read.
+    #[serde(default)]
+    pub traits: IdentityTraits,
+}
+
+/// The observable outcome of an identity deletion.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IdentityDeletion {
+    /// The API held the identity and deleted it.
+    Deleted,
+    /// The API held no such identity.
+    AlreadyAbsent,
+}
+
+/// An address of an identity, and whether the owner proved they hold it.
+#[derive(Deserialize)]
+pub struct VerifiableAddress {
+    /// The address itself.
+    pub value: String,
+    /// Whether the owner completed verification for it.
+    pub verified: bool,
+}
+
+/// The identity traits the Graph reads.
+///
+/// The identity schema requires the addresses, so a `traits` object without them fails the read
+/// rather than reading as an identity without addresses.
+#[derive(Default, Deserialize)]
+pub struct IdentityTraits {
+    /// The addresses the registration flow recorded.
+    pub emails: Vec<String>,
+}
+
+/// Client for the Kratos admin identity API.
+pub struct KratosAdminClient {
+    http_client: Client,
+    identities_url: Url,
+}
+
+impl KratosAdminClient {
+    /// Creates a client against the given admin API base URL.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the HTTP client cannot be built, or if the admin URL cannot carry a path.
+    #[must_use]
+    pub fn new(admin_url: Url, http_timeout: Duration) -> Self {
+        // A base URL whose path ends in a slash keeps a trailing empty segment, which extending
+        // would turn into a doubled separator: `/kratos/` + `admin` gives `/kratos//admin`.
+        let mut identities_url = admin_url;
+        identities_url
+            .path_segments_mut()
+            .expect("the Kratos admin URL should be a valid base URL")
+            .pop_if_empty()
+            .extend(["admin", "identities"]);
+
+        // The admin endpoints never redirect. Following one would send the request — the
+        // identifier in the query string and any credential — to the redirect target.
+        Self {
+            http_client: Client::builder()
+                .redirect(redirect::Policy::none())
+                .timeout(http_timeout)
+                .build()
+                .expect("the HTTP client should build with default TLS configuration"),
+            identities_url,
+        }
+    }
+
+    /// The identities endpoint the client addresses.
+    #[must_use]
+    pub const fn identities_url(&self) -> &Url {
+        &self.identities_url
+    }
+
+    /// Returns every identity holding `identifier` as a credentials identifier.
+    ///
+    /// # Errors
+    ///
+    /// - [`EmptyIdentifier`] if `identifier` is empty
+    /// - [`Unreachable`], [`Rejected`] or [`InvalidResponse`] from the request
+    ///
+    /// [`EmptyIdentifier`]: KratosAdminError::EmptyIdentifier
+    /// [`Unreachable`]: KratosAdminError::Unreachable
+    /// [`Rejected`]: KratosAdminError::Rejected
+    /// [`InvalidResponse`]: KratosAdminError::InvalidResponse
+    pub async fn list_by_credential(
+        &self,
+        identifier: &str,
+    ) -> Result<Vec<AdminIdentity>, Report<KratosAdminError>> {
+        if identifier.is_empty() {
+            return Err(Report::new(KratosAdminError::EmptyIdentifier));
+        }
+
+        let mut url = self.identities_url.clone();
+        url.query_pairs_mut()
+            .append_pair("credentials_identifier", identifier);
+
+        // The looked-up address travels in the query string, and a `reqwest::Error` renders the
+        // URL it failed on. Dropping the URL keeps the address out of the report.
+        let response = self
+            .http_client
+            .get(url)
+            .send()
+            .await
+            .map_err(reqwest::Error::without_url)
+            .change_context(KratosAdminError::Unreachable)?;
+
+        let body = Self::read_body(response).await?;
+        // An identity listing carries addresses and traits, so it stays out of the report.
+        serde_json::from_str(&body).change_context(KratosAdminError::InvalidResponse)
+    }
+
+    /// Returns the identity with the given ID, or [`None`] where the API holds no such identity.
+    ///
+    /// # Errors
+    ///
+    /// [`Unreachable`], [`Rejected`] or [`InvalidResponse`] from the request.
+    ///
+    /// [`Unreachable`]: KratosAdminError::Unreachable
+    /// [`Rejected`]: KratosAdminError::Rejected
+    /// [`InvalidResponse`]: KratosAdminError::InvalidResponse
+    pub async fn get_by_id(
+        &self,
+        identity_id: &str,
+    ) -> Result<Option<IdentityRecord>, Report<KratosAdminError>> {
+        let response = self
+            .http_client
+            .get(self.identity_url(identity_id))
+            .send()
+            .await
+            .map_err(reqwest::Error::without_url)
+            .change_context(KratosAdminError::Unreachable)?;
+
+        if response.status() == StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+
+        let body = Self::read_body(response).await?;
+        // An identity body carries addresses and traits, so it stays out of the report.
+        serde_json::from_str(&body)
+            .map(Some)
+            .change_context(KratosAdminError::InvalidResponse)
+    }
+
+    /// Deletes the identity with the given ID, reporting whether the API held it.
+    ///
+    /// # Errors
+    ///
+    /// [`Unreachable`] or [`Rejected`] from the request.
+    ///
+    /// [`Unreachable`]: KratosAdminError::Unreachable
+    /// [`Rejected`]: KratosAdminError::Rejected
+    pub async fn delete_by_id(
+        &self,
+        identity_id: &str,
+    ) -> Result<IdentityDeletion, Report<KratosAdminError>> {
+        let response = self
+            .http_client
+            .delete(self.identity_url(identity_id))
+            .send()
+            .await
+            .map_err(reqwest::Error::without_url)
+            .change_context(KratosAdminError::Unreachable)?;
+
+        if response.status() == StatusCode::NOT_FOUND {
+            return Ok(IdentityDeletion::AlreadyAbsent);
+        }
+
+        Self::read_body(response)
+            .await
+            .map(|_body| IdentityDeletion::Deleted)
+    }
+
+    /// The URL of one identity.
+    fn identity_url(&self, identity_id: &str) -> Url {
+        let mut url = self.identities_url.clone();
+        url.path_segments_mut()
+            .expect("the identities URL should be a valid base URL")
+            .push(identity_id);
+        url
+    }
+
+    /// Reads a successful response body, restating a failure in the admin vocabulary.
+    async fn read_body(response: Response) -> Result<String, Report<KratosAdminError>> {
+        read_provider_body(response).await.map_err(|report| {
+            let context = match report.current_context() {
+                ProviderFailure::Rejected => KratosAdminError::Rejected,
+                ProviderFailure::Unavailable => KratosAdminError::Unreachable,
+            };
+            report.change_context(context)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::time::Duration;
+
+    use axum::{
+        Router,
+        http::{StatusCode, header::LOCATION},
+        response::IntoResponse as _,
+        routing::get,
+    };
+    use rstest::rstest;
+
+    use super::{IdentityDeletion, KratosAdminClient, KratosAdminError};
+    use crate::kratos::tests::spawn_fake_kratos;
+
+    /// A client against a fake whose by-ID endpoints answer with the given status.
+    async fn client_answering(status: StatusCode) -> KratosAdminClient {
+        let router = Router::new().route(
+            "/admin/identities/{identity_id}",
+            get(move || async move { (status, "{}") })
+                .delete(move || async move { (status, "{}") }),
+        );
+        KratosAdminClient::new(spawn_fake_kratos(router).await, Duration::from_secs(5))
+    }
+
+    /// Each case covers a rung of the status ladder that must not read as an absent identity.
+    #[rstest]
+    #[case::unauthorized(StatusCode::UNAUTHORIZED, KratosAdminError::Rejected)]
+    #[case::forbidden(StatusCode::FORBIDDEN, KratosAdminError::Rejected)]
+    #[case::server_error(StatusCode::INTERNAL_SERVER_ERROR, KratosAdminError::Unreachable)]
+    #[case::bad_gateway(StatusCode::BAD_GATEWAY, KratosAdminError::Unreachable)]
+    #[case::redirect(StatusCode::FOUND, KratosAdminError::Unreachable)]
+    #[tokio::test]
+    async fn failure_statuses_fail_the_identity_read(
+        #[case] status: StatusCode,
+        #[case] expected: KratosAdminError,
+    ) {
+        let client = client_answering(status).await;
+
+        // `expect_err` would ask `AdminIdentity` for a `Debug` it deliberately does not have:
+        // a debug-rendered identity carries its addresses.
+        let Err(report) = client.get_by_id("some-identity").await else {
+            panic!("a failure status should fail the read rather than read as absent");
+        };
+        assert!(
+            core::mem::discriminant(report.current_context()) == core::mem::discriminant(&expected),
+            "a {status} should fail the read as {expected}, got {}",
+            report.current_context()
+        );
+    }
+
+    /// Each case covers a rung of the status ladder that must not count as a deletion.
+    #[rstest]
+    #[case::forbidden(StatusCode::FORBIDDEN, KratosAdminError::Rejected)]
+    #[case::server_error(StatusCode::INTERNAL_SERVER_ERROR, KratosAdminError::Unreachable)]
+    #[case::redirect(StatusCode::FOUND, KratosAdminError::Unreachable)]
+    #[tokio::test]
+    async fn failure_statuses_fail_the_deletion(
+        #[case] status: StatusCode,
+        #[case] expected: KratosAdminError,
+    ) {
+        let client = client_answering(status).await;
+
+        let report = client
+            .delete_by_id("some-identity")
+            .await
+            .expect_err("a failure status should fail the deletion rather than count as one");
+        assert!(
+            core::mem::discriminant(report.current_context()) == core::mem::discriminant(&expected),
+            "a {status} should fail the deletion as {expected}, got {}",
+            report.current_context()
+        );
+    }
+
+    #[tokio::test]
+    async fn successful_deletion_reports_the_identity_as_deleted() {
+        let client = client_answering(StatusCode::NO_CONTENT).await;
+
+        let deletion = client
+            .delete_by_id("some-identity")
+            .await
+            .expect("a successful deletion should not fail");
+        assert_eq!(
+            deletion,
+            IdentityDeletion::Deleted,
+            "a 204 should report the identity as deleted"
+        );
+    }
+
+    #[tokio::test]
+    async fn absent_identity_reports_the_deletion_as_already_absent() {
+        let client = client_answering(StatusCode::NOT_FOUND).await;
+
+        let deletion = client
+            .delete_by_id("some-identity")
+            .await
+            .expect("an absent identity should not fail the deletion");
+        assert_eq!(
+            deletion,
+            IdentityDeletion::AlreadyAbsent,
+            "a 404 should report the identity as already absent"
+        );
+    }
+
+    #[tokio::test]
+    async fn redirect_target_reaches_the_report() {
+        let router = Router::new().route(
+            "/admin/identities/{identity_id}",
+            get(|| async {
+                (
+                    StatusCode::FOUND,
+                    [(LOCATION, "http://elsewhere.example/admin/identities")],
+                )
+            }),
+        );
+        let client =
+            KratosAdminClient::new(spawn_fake_kratos(router).await, Duration::from_secs(5));
+
+        let Err(report) = client.get_by_id("some-identity").await else {
+            panic!("a redirect should fail the read");
+        };
+        assert!(
+            format!("{report:?}").contains("elsewhere.example"),
+            "the redirect target should reach the report for diagnosis"
+        );
+    }
+
+    /// A canonicalizing redirect echoes the request's query string, which carries the looked-up
+    /// address.
+    #[tokio::test]
+    async fn redirect_target_query_stays_out_of_the_report() {
+        let router = Router::new().route(
+            "/admin/identities",
+            get(|| async {
+                (
+                    StatusCode::FOUND,
+                    [(
+                        LOCATION,
+                        "http://elsewhere.example/admin/identities?credentials_identifier=secret@example.com",
+                    )],
+                )
+            }),
+        );
+        let client =
+            KratosAdminClient::new(spawn_fake_kratos(router).await, Duration::from_secs(5));
+
+        // `expect_err` would ask `AdminIdentity` for a `Debug` it deliberately does not have.
+        let Err(report) = client.list_by_credential("secret@example.com").await else {
+            panic!("a redirect should fail the lookup");
+        };
+        let rendered = format!("{report:?}");
+        assert!(
+            rendered.contains("elsewhere.example"),
+            "the redirect target should reach the report for diagnosis"
+        );
+        assert!(
+            !rendered.contains("secret@example.com"),
+            "the echoed query string should stay out of the report"
+        );
+    }
+
+    /// A followed redirect would send the request to the target, so the policy must surface the
+    /// redirect instead — even when the target would answer with a valid identity.
+    #[tokio::test]
+    async fn redirect_to_a_serving_route_still_fails_the_read() {
+        let router = Router::new()
+            .route(
+                "/admin/identities/{identity_id}",
+                get(|headers: axum::http::HeaderMap| async move {
+                    let host = headers
+                        .get(axum::http::header::HOST)
+                        .and_then(|host| host.to_str().ok())
+                        .expect("the test request should carry a host header")
+                        .to_owned();
+                    (
+                        StatusCode::FOUND,
+                        [(LOCATION, format!("http://{host}/served"))],
+                    )
+                        .into_response()
+                }),
+            )
+            .route(
+                "/served",
+                get(|| async { (StatusCode::OK, r#"{"id": "followed"}"#).into_response() }),
+            );
+        let client =
+            KratosAdminClient::new(spawn_fake_kratos(router).await, Duration::from_secs(5));
+
+        assert!(
+            client.get_by_id("some-identity").await.is_err(),
+            "the redirect should fail the read rather than be followed to the serving route"
+        );
+    }
+}

--- a/libs/@local/graph/authentication/src/kratos/admin.rs
+++ b/libs/@local/graph/authentication/src/kratos/admin.rs
@@ -291,11 +291,14 @@ mod tests {
     ) {
         let client = client_answering(status).await;
 
-        // `expect_err` would ask `AdminIdentity` for a `Debug` it deliberately does not have:
-        // a debug-rendered identity carries its addresses.
-        let Err(report) = client.get_by_id("some-identity").await else {
-            panic!("a failure status should fail the read rather than read as absent");
-        };
+        // The record is dropped before `expect_err`, which would otherwise ask `IdentityRecord`
+        // for a `Debug` it deliberately does not have. A `let`-`else` here crashes the
+        // toolchain's llvm-cov when it instruments the rstest-generated cases.
+        let report = client
+            .get_by_id("some-identity")
+            .await
+            .map(|_identity| ())
+            .expect_err("a failure status should fail the read rather than read as absent");
         assert!(
             core::mem::discriminant(report.current_context()) == core::mem::discriminant(&expected),
             "a {status} should fail the read as {expected}, got {}",

--- a/libs/@local/graph/authentication/src/kratos/identity.rs
+++ b/libs/@local/graph/authentication/src/kratos/identity.rs
@@ -2,12 +2,11 @@
 
 use core::time::Duration;
 
-use error_stack::{Report, ResultExt as _};
-use reqwest::{Client, Url, redirect};
-use serde::Deserialize;
+use error_stack::Report;
+use reqwest::Url;
 use type_system::principal::actor::{ActorEntityUuid, UserId};
 
-use super::{MetadataPublic, read_response_body};
+use super::{KratosAdminClient, KratosAdminError};
 use crate::{
     actor::{ResolveActor, resolve_user_actor},
     cloudflare::ResolveEmailActor,
@@ -23,29 +22,13 @@ pub struct KratosAdminConfig {
     pub http_timeout: Duration,
 }
 
-/// Deserialized subset of a Kratos admin identity.
-#[derive(Deserialize)]
-struct AdminIdentity {
-    id: String,
-    metadata_public: Option<MetadataPublic>,
-    #[serde(default)]
-    verifiable_addresses: Vec<VerifiableAddress>,
-}
-
-#[derive(Deserialize)]
-struct VerifiableAddress {
-    value: String,
-    verified: bool,
-}
-
 /// Resolves verified email addresses to Graph actors via the Kratos admin API.
 ///
 /// Identities are looked up by credentials identifier. Only an identity whose matching address
 /// is verified resolves. The actor is read from the `graph_actor_id` field in the identity's
 /// `metadata_public` and checked to be an existing user actor in the principal store.
 pub struct KratosEmailActorResolver<R> {
-    http_client: Client,
-    identities_url: Url,
+    admin_client: KratosAdminClient,
     actor_resolver: R,
 }
 
@@ -58,52 +41,35 @@ impl<R> KratosEmailActorResolver<R> {
     /// the identities path.
     #[must_use]
     pub fn new(config: KratosAdminConfig, actor_resolver: R) -> Self {
-        let mut identities_url = config.kratos_admin_url;
-        identities_url
-            .path_segments_mut()
-            .expect("the Kratos admin URL should be a valid base URL")
-            .pop_if_empty()
-            .extend(["admin", "identities"]);
-
         Self {
-            // The identities endpoint never redirects. Following a redirect would forward the
-            // lookup to the redirect target.
-            http_client: Client::builder()
-                .timeout(config.http_timeout)
-                .redirect(redirect::Policy::none())
-                .build()
-                .expect("the HTTP client should build with default TLS configuration"),
-            identities_url,
+            admin_client: KratosAdminClient::new(config.kratos_admin_url, config.http_timeout),
             actor_resolver,
         }
     }
 }
 
+/// Restates an admin API failure as a failure to authenticate.
+fn authentication_error(report: Report<KratosAdminError>) -> Report<AuthenticationError> {
+    let context = match report.current_context() {
+        KratosAdminError::Rejected => AuthenticationError::ProviderRejection,
+        KratosAdminError::InvalidResponse => AuthenticationError::InvalidProviderResponse,
+        // An empty claim names no address to resolve, which is the token's fault rather than the
+        // provider's.
+        KratosAdminError::EmptyIdentifier => AuthenticationError::InvalidAccessToken,
+        KratosAdminError::Unreachable => AuthenticationError::ProviderUnreachable,
+    };
+    report.change_context(context)
+}
+
 /// Looks up the identity owning the given email as a verified address.
 async fn verified_identity(
-    http_client: &Client,
-    identities_url: &Url,
+    admin_client: &KratosAdminClient,
     email: &str,
 ) -> Result<ActorEntityUuid, Report<AuthenticationError>> {
-    let mut url = identities_url.clone();
-    url.query_pairs_mut()
-        .append_pair("credentials_identifier", email);
-
-    // The looked-up address travels in the query string, and a `reqwest::Error` renders the URL it
-    // failed on. Dropping the URL keeps the address out of the report, and therefore out of the
-    // logs and Sentry. The span already carries the base URL.
-    let response = http_client
-        .get(url)
-        .send()
+    let identities = admin_client
+        .list_by_credential(email)
         .await
-        .map_err(reqwest::Error::without_url)
-        .change_context(AuthenticationError::ProviderUnreachable)?;
-
-    let body = read_response_body(response).await?;
-    // An identity listing carries emails and traits, so it stays out of the report.
-    // Failure bodies are Kratos error responses without identity data.
-    let identities: Vec<AdminIdentity> =
-        serde_json::from_str(&body).change_context(AuthenticationError::InvalidProviderResponse)?;
+        .map_err(authentication_error)?;
 
     // A credentials-identifier lookup also returns identities whose matching address is still
     // unverified, so requiring `verified` here is what keeps an unverified address from
@@ -133,12 +99,16 @@ impl<R> ResolveEmailActor for KratosEmailActorResolver<R>
 where
     R: ResolveActor,
 {
-    #[tracing::instrument(level = "debug", skip_all, fields(identities_url = %self.identities_url))]
+    #[tracing::instrument(
+        level = "debug",
+        skip_all,
+        fields(identities_url = %self.admin_client.identities_url())
+    )]
     async fn resolve_email_actor(
         &self,
         email: &str,
     ) -> Result<UserId, Report<AuthenticationError>> {
-        let actor_uuid = verified_identity(&self.http_client, &self.identities_url, email).await?;
+        let actor_uuid = verified_identity(&self.admin_client, email).await?;
         resolve_user_actor(&self.actor_resolver, actor_uuid).await
     }
 }
@@ -271,6 +241,21 @@ mod tests {
             .expect("the email should resolve");
     }
 
+    /// Authentication never reads the traits, so a malformed traits object on a listed identity
+    /// must not fail the login.
+    #[tokio::test]
+    async fn malformed_traits_do_not_fail_authentication() {
+        let actor_id = random_actor();
+        let mut identity = identity_json(Some(actor_id), json!([verified_address(EMAIL)]));
+        identity["traits"] = json!({ "not-the-schema": true });
+        let resolver = resolver_for(json!([identity]), known_user(actor_id)).await;
+
+        resolver
+            .resolve_email_actor(EMAIL)
+            .await
+            .expect("a malformed traits object should not fail authentication");
+    }
+
     #[tokio::test]
     async fn verified_identity_resolves_over_unverified_match() {
         let actor_id = random_actor();
@@ -349,6 +334,33 @@ mod tests {
         assert!(
             expected(report.current_context()),
             "the email should fail resolution, got {:?}",
+            report.current_context()
+        );
+    }
+
+    /// Kratos reads an empty `credentials_identifier` as no filter and answers with every
+    /// identity, so an empty claim must not reach the lookup.
+    #[tokio::test]
+    async fn empty_email_is_rejected_before_the_lookup() {
+        let resolver = resolver_for(
+            json!([identity_json(
+                Some(case_actor()),
+                json!([verified_address("")])
+            )]),
+            known_user(case_actor()),
+        )
+        .await;
+
+        let report = resolver
+            .resolve_email_actor("")
+            .await
+            .expect_err("an empty email should be rejected");
+        assert!(
+            matches!(
+                report.current_context(),
+                AuthenticationError::InvalidAccessToken
+            ),
+            "an empty email should fail as an invalid token, got {:?}",
             report.current_context()
         );
     }

--- a/libs/@local/graph/authentication/src/kratos/identity.rs
+++ b/libs/@local/graph/authentication/src/kratos/identity.rs
@@ -74,14 +74,21 @@ async fn verified_identity(
     // A credentials-identifier lookup also returns identities whose matching address is still
     // unverified, so requiring `verified` here is what keeps an unverified address from
     // authenticating as its owner.
-    let Some(identity) = identities.into_iter().find(|identity| {
+    let mut matching = identities.into_iter().filter(|identity| {
         identity
             .verifiable_addresses
             .iter()
             .any(|address| address.verified && address.value.eq_ignore_ascii_case(email))
-    }) else {
+    });
+    let Some(identity) = matching.next() else {
         return Err(Report::new(AuthenticationError::IdentityWithoutActor));
     };
+    // The address is the identity's credentials identifier, which the provider keeps unique —
+    // several identities holding it as verified violate that invariant, and picking one would
+    // authenticate an arbitrary account.
+    if matching.next().is_some() {
+        return Err(Report::new(AuthenticationError::InvalidProviderResponse));
+    }
 
     let Some(actor_uuid) = identity
         .metadata_public
@@ -239,6 +246,38 @@ mod tests {
             .resolve_email_actor(lookup)
             .await
             .expect("the email should resolve");
+    }
+
+    /// The address is the provider's unique credentials identifier, so two identities holding it
+    /// as verified violate that invariant — authenticating as either would bind the caller to an
+    /// arbitrary account.
+    #[tokio::test]
+    async fn ambiguous_verified_address_fails_authentication() {
+        let first_actor = random_actor();
+        let second_actor = random_actor();
+        let mut actors = known_user(first_actor);
+        actors.extend(known_user(second_actor));
+        let resolver = resolver_for(
+            json!([
+                identity_json(Some(first_actor), json!([verified_address(EMAIL)])),
+                identity_json(Some(second_actor), json!([verified_address(EMAIL)])),
+            ]),
+            actors,
+        )
+        .await;
+
+        let report = resolver
+            .resolve_email_actor(EMAIL)
+            .await
+            .expect_err("an ambiguous verified address should fail rather than pick an account");
+        assert!(
+            matches!(
+                report.current_context(),
+                AuthenticationError::InvalidProviderResponse
+            ),
+            "the ambiguity should fail as an invalid provider state, got {:?}",
+            report.current_context()
+        );
     }
 
     /// Authentication never reads the traits, so a malformed traits object on a listed identity

--- a/libs/@local/graph/authentication/src/kratos/mod.rs
+++ b/libs/@local/graph/authentication/src/kratos/mod.rs
@@ -1,11 +1,13 @@
 //! Ory Kratos implementations of [`AuthenticationProvider`].
 //!
 //! [`KratosSessionProvider`] verifies end-user sessions against the public API and reads the Graph
-//! actor from the identity's `metadata_public`. This module carries the response handling and the
-//! metadata the Graph exchanges with an identity.
+//! actor from the identity's `metadata_public`. [`KratosAdminClient`] carries the transport for
+//! the admin identity API. This module carries the response handling and the metadata the Graph
+//! exchanges with an identity.
 //!
 //! [`AuthenticationProvider`]: crate::provider::AuthenticationProvider
 
+mod admin;
 mod identity;
 mod session;
 
@@ -15,6 +17,10 @@ use serde::Deserialize;
 use type_system::principal::actor::UserId;
 
 pub use self::{
+    admin::{
+        AdminIdentity, IdentityDeletion, IdentityRecord, IdentityTraits, KratosAdminClient,
+        KratosAdminError, VerifiableAddress,
+    },
     identity::{KratosAdminConfig, KratosEmailActorResolver},
     session::{
         KratosSessionConfig, KratosSessionProvider, SESSION_COOKIE_NAME, SESSION_TOKEN_HEADER,
@@ -42,11 +48,74 @@ fn provider_response(status: reqwest::StatusCode, body: Result<String, reqwest::
     format!("provider response ({status}): {snippet}")
 }
 
-/// Reads the body of a successful Kratos response, mapping failure statuses to errors.
+/// How a Kratos response failed before its body could be used.
 ///
-/// Client errors report a provider rejection, any other unsuccessful status reports provider
-/// unavailability. Callers that treat individual client errors as a credential failure check for
-/// those before calling this.
+/// Both Kratos error vocabularies map from this classification, so a status class fails the same
+/// way on every path.
+#[derive(Debug, derive_more::Display, derive_more::Error)]
+enum ProviderFailure {
+    /// Kratos rejected the request with a client error.
+    #[display("the provider rejected the request")]
+    Rejected,
+    /// Kratos redirected or answered with a server error.
+    ///
+    /// A body that cannot be read counts as unavailable as well: the transport failed mid-body.
+    #[display("the provider is unavailable")]
+    Unavailable,
+}
+
+/// Reads the body of a successful Kratos response, classifying failure statuses.
+///
+/// Failure bodies are attached to the report, truncated by [`provider_response`]. Callers that
+/// treat individual client errors as a credential failure check for those before calling this.
+///
+/// # Errors
+///
+/// - [`Rejected`] if Kratos reported a client error
+/// - [`Unavailable`] for any other unsuccessful status, or if the body cannot be read
+///
+/// [`Rejected`]: ProviderFailure::Rejected
+/// [`Unavailable`]: ProviderFailure::Unavailable
+async fn read_provider_body(response: Response) -> Result<String, Report<ProviderFailure>> {
+    let status = response.status();
+    if status.is_client_error() {
+        return Err(Report::new(ProviderFailure::Rejected)
+            .attach(provider_response(status, response.text().await)));
+    }
+    if !status.is_success() {
+        // A redirect reaches here because the redirect policy is disabled. Its body is usually
+        // empty, so the target is what identifies the answering endpoint. The target is echoed
+        // by the server, and a canonicalizing redirect carries the request's query string —
+        // which holds the looked-up address — so only the origin and path survive.
+        let redirect_target = response
+            .headers()
+            .get(reqwest::header::LOCATION)
+            .and_then(|target| target.to_str().ok())
+            .and_then(|target| reqwest::Url::parse(target).ok())
+            .map(|mut target| {
+                target.set_query(None);
+                target.set_fragment(None);
+                format!("redirect target: {target}")
+            });
+
+        let mut report = Report::new(ProviderFailure::Unavailable)
+            .attach(provider_response(status, response.text().await));
+        if let Some(redirect_target) = redirect_target {
+            report = report.attach(redirect_target);
+        }
+        return Err(report);
+    }
+
+    // A `reqwest::Error` renders the URL it failed on, and a lookup URL can carry the address it
+    // was looking up. The instrumented span already records the base URL.
+    response
+        .text()
+        .await
+        .map_err(reqwest::Error::without_url)
+        .change_context(ProviderFailure::Unavailable)
+}
+
+/// Reads a Kratos response body, restating a failure as an [`AuthenticationError`].
 ///
 /// # Errors
 ///
@@ -56,23 +125,13 @@ fn provider_response(status: reqwest::StatusCode, body: Result<String, reqwest::
 /// [`ProviderRejection`]: AuthenticationError::ProviderRejection
 /// [`ProviderUnreachable`]: AuthenticationError::ProviderUnreachable
 async fn read_response_body(response: Response) -> Result<String, Report<AuthenticationError>> {
-    let status = response.status();
-    if status.is_client_error() {
-        return Err(Report::new(AuthenticationError::ProviderRejection)
-            .attach(provider_response(status, response.text().await)));
-    }
-    if !status.is_success() {
-        return Err(Report::new(AuthenticationError::ProviderUnreachable)
-            .attach(provider_response(status, response.text().await)));
-    }
-
-    // A `reqwest::Error` renders the URL it failed on, and a lookup URL can carry the address it
-    // was looking up. The instrumented span already records the base URL.
-    response
-        .text()
-        .await
-        .map_err(reqwest::Error::without_url)
-        .change_context(AuthenticationError::ProviderUnreachable)
+    read_provider_body(response).await.map_err(|report| {
+        let context = match report.current_context() {
+            ProviderFailure::Rejected => AuthenticationError::ProviderRejection,
+            ProviderFailure::Unavailable => AuthenticationError::ProviderUnreachable,
+        };
+        report.change_context(context)
+    })
 }
 
 #[cfg(test)]

--- a/libs/@local/graph/authentication/src/kratos/mod.rs
+++ b/libs/@local/graph/authentication/src/kratos/mod.rs
@@ -26,8 +26,8 @@ use crate::request::AuthenticationError;
 ///
 /// The Graph provisions this field, and it provisions it for users only.
 #[derive(Deserialize)]
-struct MetadataPublic {
-    graph_actor_id: Option<UserId>,
+pub struct MetadataPublic {
+    pub graph_actor_id: Option<UserId>,
 }
 
 /// Formats a provider response for report attachments, truncating long bodies.

--- a/libs/@local/graph/authentication/tests/kratos.rs
+++ b/libs/@local/graph/authentication/tests/kratos.rs
@@ -21,7 +21,7 @@ use core::{error::Error, time::Duration};
 use hash_graph_authentication::{
     actor::ResolveActor,
     cloudflare::ResolveEmailActor as _,
-    kratos::{KratosAdminConfig, KratosEmailActorResolver},
+    kratos::{IdentityDeletion, KratosAdminClient, KratosAdminConfig, KratosEmailActorResolver},
     request::AuthenticationError,
 };
 use hash_graph_authorization::policies::store::error::DetermineActorError;
@@ -221,5 +221,64 @@ async fn address_resolves_regardless_of_case() -> Result<(), Box<dyn Error>> {
     delete_identity(&client, &identity_id).await?;
 
     resolved.expect("an address differing in case should resolve");
+    Ok(())
+}
+
+fn admin_client() -> KratosAdminClient {
+    KratosAdminClient::new(kratos_admin_url(), Duration::from_secs(10))
+}
+
+#[tokio::test]
+async fn identity_read_by_id_yields_the_registered_addresses() -> Result<(), Box<dyn Error>> {
+    let client = Client::new();
+    let email = unique_email();
+    let identity_id = create_identity(&client, &email, false, None).await?;
+
+    let read = admin_client().get_by_id(&identity_id).await;
+
+    delete_identity(&client, &identity_id).await?;
+
+    let identity = read
+        .expect("an existing identity should be readable")
+        .expect("the created identity should be found");
+    assert_eq!(
+        identity.traits.emails,
+        [email],
+        "the read should yield the address the identity was created with"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn identity_read_by_unknown_id_yields_none() {
+    let read = admin_client()
+        .get_by_id(&Uuid::new_v4().to_string())
+        .await
+        .expect("an unknown identity should not fail the read");
+    assert!(
+        read.is_none(),
+        "an unknown identity should read as absent rather than fail"
+    );
+}
+
+#[tokio::test]
+async fn deletion_by_id_reports_the_absent_identity() -> Result<(), Box<dyn Error>> {
+    let client = Client::new();
+    let email = unique_email();
+    let identity_id = create_identity(&client, &email, false, None).await?;
+
+    let first = admin_client().delete_by_id(&identity_id).await?;
+    let second = admin_client().delete_by_id(&identity_id).await?;
+
+    assert_eq!(
+        first,
+        IdentityDeletion::Deleted,
+        "the first deletion should report the identity as deleted"
+    );
+    assert_eq!(
+        second,
+        IdentityDeletion::AlreadyAbsent,
+        "the second deletion should report the identity as already absent"
+    );
     Ok(())
 }

--- a/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
@@ -3644,48 +3644,6 @@ impl<C: AsClient, S: TransactionState> AccountStore for PostgresStore<C, S> {
             }))
     }
 
-    async fn get_user_id_by_email(
-        &self,
-        email: &str,
-    ) -> Result<Option<UserId>, Report<GetActorError>> {
-        let rows = self
-            .as_client()
-            .query(
-                "
-                SELECT DISTINCT user_actor.id
-                FROM user_actor
-                JOIN entity_temporal_metadata ON user_actor.id = entity_temporal_metadata.entity_uuid
-                JOIN entity_editions ON entity_temporal_metadata.entity_edition_id = entity_editions.entity_edition_id
-                WHERE entity_temporal_metadata.decision_time @> now()
-                  AND entity_temporal_metadata.transaction_time @> now()
-                  AND EXISTS (
-                      SELECT 1
-                      FROM jsonb_array_elements_text(
-                          entity_editions.properties -> 'https://hash.ai/@h/types/property-type/email/'
-                      ) AS stored_email
-                      WHERE LOWER(stored_email) = LOWER($1)
-                  )",
-                &[&email],
-            )
-            .instrument(tracing::info_span!(
-                "SELECT",
-                otel.kind = "client",
-                db.system = "postgresql",
-                peer.service = "Postgres",
-            ))
-            .await
-            .change_context(GetActorError)?;
-
-        match rows.as_slice() {
-            [] => Ok(None),
-            [row] => Ok(Some(UserId::new(row.get::<_, Uuid>(0)))),
-            rows => Err(Report::new(GetActorError).attach(format!(
-                "expected at most one user for email {email:?}, found {}",
-                rows.len()
-            ))),
-        }
-    }
-
     async fn get_user_kratos_identity_id(
         &self,
         user_id: UserId,

--- a/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
@@ -3683,62 +3683,6 @@ impl<C: AsClient, S: TransactionState> AccountStore for PostgresStore<C, S> {
         }
     }
 
-    #[tracing::instrument(level = "info", skip(self))]
-    async fn get_user_emails(&self, user_id: UserId) -> Result<Vec<String>, Report<GetActorError>> {
-        let rows = self
-            .as_client()
-            .query(
-                "
-                SELECT entity_editions.properties \
-                  -> 'https://hash.ai/@h/types/property-type/email/'
-                FROM entity_temporal_metadata
-                JOIN entity_editions
-                  ON entity_temporal_metadata.entity_edition_id = \
-                     entity_editions.entity_edition_id
-                WHERE entity_temporal_metadata.entity_uuid = $1
-                  AND entity_temporal_metadata.decision_time @> now()
-                  AND entity_temporal_metadata.transaction_time @> now()
-                  AND entity_temporal_metadata.draft_id IS NULL",
-                &[&user_id],
-            )
-            .instrument(tracing::info_span!(
-                "SELECT",
-                otel.kind = "client",
-                db.system = "postgresql",
-                peer.service = "Postgres",
-            ))
-            .await
-            .change_context(GetActorError)?;
-
-        match rows.as_slice() {
-            [] => Ok(Vec::new()),
-            [row] => {
-                let Some(emails) = row.get::<_, Option<serde_json::Value>>(0) else {
-                    return Ok(Vec::new());
-                };
-                let serde_json::Value::Array(arr) = emails else {
-                    return Err(Report::new(GetActorError).attach(format!(
-                        "expected email property to be an array for {user_id}"
-                    )));
-                };
-                arr.iter()
-                    .map(|entry| {
-                        entry.as_str().map(String::from).ok_or_else(|| {
-                            Report::new(GetActorError).attach(format!(
-                                "expected email array entry to be a string for {user_id}, got \
-                                 {entry}"
-                            ))
-                        })
-                    })
-                    .collect()
-            }
-            rows => Err(Report::new(GetActorError).attach(format!(
-                "expected at most one user entity for {user_id}, found {}",
-                rows.len()
-            ))),
-        }
-    }
-
     async fn get_machine_by_id(
         &self,
         _actor_id: ActorEntityUuid,

--- a/libs/@local/graph/store/src/account/mod.rs
+++ b/libs/@local/graph/store/src/account/mod.rs
@@ -146,16 +146,6 @@ pub trait AccountStore {
         user_id: UserId,
     ) -> impl Future<Output = Result<Option<String>, Report<GetActorError>>> + Send;
 
-    /// Returns the email addresses for a user, read from their entity properties.
-    ///
-    /// # Errors
-    ///
-    /// - [`GetActorError`] if the lookup failed.
-    fn get_user_emails(
-        &self,
-        user_id: UserId,
-    ) -> impl Future<Output = Result<Vec<String>, Report<GetActorError>>> + Send;
-
     /// Returns a [`Machine`] actor by its [`MachineId`].
     ///
     /// # Errors

--- a/libs/@local/graph/store/src/account/mod.rs
+++ b/libs/@local/graph/store/src/account/mod.rs
@@ -136,18 +136,6 @@ pub trait AccountStore {
         id: UserId,
     ) -> impl Future<Output = Result<Option<User>, Report<GetActorError>>> + Send;
 
-    /// Returns the [`UserId`] for a user with the given email address.
-    ///
-    /// Looks up the email in entity properties, bypassing property masking.
-    ///
-    /// # Errors
-    ///
-    /// - [`GetActorError`] if the lookup failed.
-    fn get_user_id_by_email(
-        &self,
-        email: &str,
-    ) -> impl Future<Output = Result<Option<UserId>, Report<GetActorError>>> + Send;
-
     /// Returns the Kratos identity ID for a user, read from their entity properties.
     ///
     /// # Errors

--- a/libs/@local/graph/store/src/identity_provider.rs
+++ b/libs/@local/graph/store/src/identity_provider.rs
@@ -2,25 +2,50 @@ use error_stack::Report;
 
 #[derive(Debug, derive_more::Display, derive_more::Error)]
 pub enum IdentityProviderError {
+    /// The identity could not be deleted from the provider.
     #[display("failed to delete identity")]
     DeletionFailed,
+    /// The identity could not be read from the provider.
     #[display("failed to read the identity")]
     LookupFailed,
 }
 
+/// The observable outcome of an identity deletion.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IdentityDeletion {
+    /// The provider held the identity and deleted it.
+    Deleted,
+    /// The provider held no such identity.
+    AlreadyAbsent,
+}
+
 /// Abstraction over an external identity management system (e.g. Ory Kratos).
 pub trait IdentityProvider: Send + Sync {
+    /// Deletes the identity from the provider, reporting whether the provider held it.
+    ///
+    /// # Errors
+    ///
+    /// - [`DeletionFailed`] if the provider fails the deletion
+    ///
+    /// [`DeletionFailed`]: IdentityProviderError::DeletionFailed
     fn delete_identity(
         &self,
         identity_id: &str,
-    ) -> impl Future<Output = Result<(), Report<IdentityProviderError>>> + Send;
+    ) -> impl Future<Output = Result<IdentityDeletion, Report<IdentityProviderError>>> + Send;
 
-    /// Returns the email addresses the identity holds.
+    /// Returns the email addresses the identity holds, or [`None`] where the provider holds no
+    /// such identity.
     ///
-    /// The provider owns the addresses a user signs up and signs in with, so they are read from
-    /// there rather than from the copy the graph carries.
+    /// The provider owns the addresses a user signs up and signs in with. An absent identity is
+    /// distinct from one without addresses: the first leaves the addresses unknown.
+    ///
+    /// # Errors
+    ///
+    /// - [`LookupFailed`] if the identity cannot be read from the provider
+    ///
+    /// [`LookupFailed`]: IdentityProviderError::LookupFailed
     fn get_identity_emails(
         &self,
         identity_id: &str,
-    ) -> impl Future<Output = Result<Vec<String>, Report<IdentityProviderError>>> + Send;
+    ) -> impl Future<Output = Result<Option<Vec<String>>, Report<IdentityProviderError>>> + Send;
 }

--- a/libs/@local/graph/store/src/identity_provider.rs
+++ b/libs/@local/graph/store/src/identity_provider.rs
@@ -4,6 +4,8 @@ use error_stack::Report;
 pub enum IdentityProviderError {
     #[display("failed to delete identity")]
     DeletionFailed,
+    #[display("failed to read the identity")]
+    LookupFailed,
 }
 
 /// Abstraction over an external identity management system (e.g. Ory Kratos).
@@ -12,4 +14,13 @@ pub trait IdentityProvider: Send + Sync {
         &self,
         identity_id: &str,
     ) -> impl Future<Output = Result<(), Report<IdentityProviderError>>> + Send;
+
+    /// Returns the email addresses the identity holds.
+    ///
+    /// The provider owns the addresses a user signs up and signs in with, so they are read from
+    /// there rather than from the copy the graph carries.
+    fn get_identity_emails(
+        &self,
+        identity_id: &str,
+    ) -> impl Future<Output = Result<Vec<String>, Report<IdentityProviderError>>> + Send;
 }

--- a/libs/@local/graph/store/src/user_deletion.rs
+++ b/libs/@local/graph/store/src/user_deletion.rs
@@ -10,7 +10,7 @@ use crate::{
         DeleteEntitiesParams, DeletionScope, EntityQueryPath, EntityStore, LinkDeletionBehavior,
     },
     filter::{Filter, FilterExpression, Parameter},
-    identity_provider::IdentityProvider,
+    identity_provider::{IdentityDeletion, IdentityProvider},
     oauth_provider::OAuthProvider,
     subgraph::temporal_axes::QueryTemporalAxesUnresolved,
 };
@@ -20,9 +20,8 @@ use crate::{
 /// Fatal variants (`UserLookup`, `MissingKratosIdentityId`, `EntityDeletion`) prevent the
 /// operation from completing and cause an `Err` return from [`delete_user`].
 ///
-/// Non-fatal variants (`KratosDeletion`, `HydraLoginRevocation`, `HydraConsentRevocation`,
-/// `EmailSubscription`) are collected into [`UserDeletionOutcome::errors`] but do not prevent
-/// the entity deletion from succeeding.
+/// Every other variant is non-fatal: collected into [`UserDeletionOutcome::errors`] without
+/// preventing the entity deletion from succeeding.
 #[derive(Debug, derive_more::Display, derive_more::Error)]
 pub enum UserDeletionError {
     // Fatal
@@ -35,19 +34,30 @@ pub enum UserDeletionError {
     // Non-fatal (collected via ReportSink)
     #[display("failed to delete Kratos identity")]
     KratosDeletion,
+    #[display(
+        "the identity was absent for both the read and the delete, so the deletion is unconfirmed"
+    )]
+    UnknownIdentity,
     #[display("failed to revoke Hydra login sessions")]
     HydraLoginRevocation,
     #[display("failed to revoke Hydra consent sessions")]
     HydraConsentRevocation,
     #[display("failed to delete email subscription")]
     EmailSubscription,
+    #[display(
+        "the provider no longer holds the identity, so its addresses are unknown and \
+         subscriptions were left in place"
+    )]
+    UnknownEmailAddresses,
 }
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UserDeletionReport {
     pub kratos_identity_id: String,
-    pub emails: Vec<String>,
+    /// The addresses the identity held, or [`None`] where they could not be learned.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub emails: Option<Vec<String>>,
     pub entities_deleted: usize,
     pub drafts_deleted: usize,
     pub links_archived: u64,
@@ -76,15 +86,15 @@ pub struct UserDeletionOutcome {
 ///
 /// Orchestrates the following operations in order:
 /// 1. Look up the user's Kratos identity ID, then its email addresses through the identity provider
+///    (a missing identity leaves the addresses unknown rather than failing)
 /// 2. Purge all entities owned by the user's personal web
 /// 3. Delete the Kratos identity (removes PII such as email)
 /// 4. Revoke Hydra login and consent sessions
 /// 5. Delete email subscription entries
 ///
-/// A caller that already resolved the Kratos identity — deletion by email goes through the
-/// identity provider — passes it as `kratos_identity_id`, which skips the graph read in step 1.
-/// This keeps a partially deleted user deletable: the graph entity carrying the identity ID may
-/// already be purged while the identity still exists.
+/// `kratos_identity_id`, when given, replaces the graph read in step 1. This keeps a partially
+/// deleted user deletable: the graph entity carrying the identity ID may already be purged while
+/// the identity still exists.
 ///
 /// Steps 1–2 are fatal: failure causes an `Err` return and no entities are deleted.
 /// Steps 3–5 are non-fatal: failures are collected into [`UserDeletionOutcome::errors`]
@@ -94,10 +104,7 @@ pub struct UserDeletionOutcome {
 ///
 /// Returns [`UserDeletionError`] if steps 1 or 2 fail. Non-fatal errors from steps 3–5 are
 /// returned in [`UserDeletionOutcome::errors`].
-#[expect(
-    clippy::too_many_lines,
-    reason = "linear orchestration flow, splitting would reduce readability"
-)]
+#[expect(clippy::too_many_lines, reason = "linear orchestration flow")]
 #[tracing::instrument(
     level = "info",
     skip(store, identity_provider, oauth_provider, email_subscription_provider)
@@ -128,11 +135,17 @@ where
     };
     tracing::info!(%user_id, %kratos_identity_id, "resolved Kratos identity");
 
+    // The addresses are only obtainable while the identity exists, so an unreadable provider
+    // aborts here — before the irreversible purge — rather than after it.
     let emails = identity_provider
         .get_identity_emails(&kratos_identity_id)
         .await
         .change_context(UserDeletionError::UserLookup)?;
-    tracing::info!(%user_id, email_count = emails.len(), "resolved user emails");
+    if let Some(emails) = &emails {
+        tracing::info!(%user_id, email_count = emails.len(), "resolved user emails");
+    } else {
+        tracing::warn!(%user_id, "the user's addresses are unknown");
+    }
 
     // Step 2: Purge all entities owned by the user's personal web
     // User ID == Web ID for personal webs
@@ -172,17 +185,18 @@ where
     let mut sink = ReportSink::<UserDeletionError>::new();
 
     // Step 3: Delete Kratos identity (removes PII: email, name, recovery addresses)
-    let kratos_deleted = sink
-        .attempt(
+    let kratos_deleted = record_identity_deletion(
+        sink.attempt(
             identity_provider
                 .delete_identity(&kratos_identity_id)
                 .await
                 .change_context(UserDeletionError::KratosDeletion),
-        )
-        .is_some();
-    if kratos_deleted {
-        tracing::info!(%kratos_identity_id, "deleted Kratos identity");
-    }
+        ),
+        // `Some` means the step-1 read saw the identity, even when it held no addresses.
+        emails.is_some(),
+        &kratos_identity_id,
+        &mut sink,
+    );
 
     // Step 4: Revoke all Hydra sessions
     let login_revoked = sink
@@ -210,28 +224,8 @@ where
     }
 
     // Step 5: Delete email subscriptions
-    let subscriptions_deleted = if let Some(provider) = email_subscription_provider {
-        let mut all_ok = true;
-        for email in &emails {
-            if sink
-                .attempt(
-                    provider
-                        .delete_subscriber(email)
-                        .await
-                        .change_context(UserDeletionError::EmailSubscription),
-                )
-                .is_some()
-            {
-                tracing::info!(%email, "deleted email subscription");
-            } else {
-                all_ok = false;
-            }
-        }
-        Some(all_ok)
-    } else {
-        tracing::info!("no email subscription provider configured, skipping");
-        None
-    };
+    let subscriptions_deleted =
+        delete_email_subscriptions(email_subscription_provider, emails.as_deref(), &mut sink).await;
 
     let errors = sink.finish();
     if let Err(report) = &errors {
@@ -252,4 +246,318 @@ where
         },
         errors,
     })
+}
+
+/// Records the outcome of the identity deletion, reporting whether the identity is confirmed
+/// gone.
+///
+/// An identity that is absent although the address read saw it was deleted between the two
+/// calls, so it counts as gone. An identity absent for both calls confirms nothing — the ID may
+/// be stale, or the URL may answer 404 for every route — so the deletion is reported as
+/// unconfirmed rather than done.
+fn record_identity_deletion(
+    outcome: Option<IdentityDeletion>,
+    identity_seen: bool,
+    kratos_identity_id: &str,
+    sink: &mut ReportSink<UserDeletionError>,
+) -> bool {
+    match outcome {
+        Some(IdentityDeletion::Deleted) => {
+            tracing::info!(%kratos_identity_id, "deleted Kratos identity");
+            true
+        }
+        Some(IdentityDeletion::AlreadyAbsent) if identity_seen => {
+            tracing::info!(%kratos_identity_id, "Kratos identity already deleted");
+            true
+        }
+        Some(IdentityDeletion::AlreadyAbsent) => {
+            sink.capture(
+                Report::new(UserDeletionError::UnknownIdentity)
+                    .attach(format!("identity: {kratos_identity_id}")),
+            );
+            false
+        }
+        None => false,
+    }
+}
+
+/// Deletes the email subscriptions of the given addresses, reporting whether all of them are
+/// gone.
+///
+/// Returns [`None`] where no provider is configured, so the report omits the claim entirely.
+/// Unknown addresses report `false`: unsubscribing needs the addresses, and they are only
+/// obtainable while the identity exists, so claiming success here would leave a subscriber
+/// nothing can reach again.
+async fn delete_email_subscriptions<E>(
+    provider: Option<&E>,
+    emails: Option<&[String]>,
+    sink: &mut ReportSink<UserDeletionError>,
+) -> Option<bool>
+where
+    E: EmailSubscriptionProvider,
+{
+    match (provider, emails) {
+        (None, _) => {
+            tracing::info!("no email subscription provider configured, skipping");
+            None
+        }
+        (Some(_), None) => {
+            sink.capture(UserDeletionError::UnknownEmailAddresses);
+            Some(false)
+        }
+        (Some(provider), Some(emails)) => {
+            let mut all_ok = true;
+            for email in emails {
+                if sink
+                    .attempt(
+                        provider
+                            .delete_subscriber(email)
+                            .await
+                            .change_context(UserDeletionError::EmailSubscription),
+                    )
+                    .is_some()
+                {
+                    tracing::info!(%email, "deleted email subscription");
+                } else {
+                    all_ok = false;
+                }
+            }
+            Some(all_ok)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use error_stack::{Report, ReportSink};
+
+    use super::{UserDeletionError, delete_email_subscriptions, record_identity_deletion};
+    use crate::{
+        email_subscription::{EmailSubscriptionError, EmailSubscriptionProvider},
+        identity_provider::IdentityDeletion,
+    };
+
+    /// A provider that records the addresses it deleted and fails on one designated address.
+    struct RecordingProvider {
+        deleted: Mutex<Vec<String>>,
+        fail_on: Option<&'static str>,
+    }
+
+    impl RecordingProvider {
+        fn new(fail_on: Option<&'static str>) -> Self {
+            Self {
+                deleted: Mutex::new(Vec::new()),
+                fail_on,
+            }
+        }
+
+        fn deleted(&self) -> Vec<String> {
+            self.deleted
+                .lock()
+                .expect("the recording mutex should not be poisoned")
+                .clone()
+        }
+    }
+
+    impl EmailSubscriptionProvider for RecordingProvider {
+        fn delete_subscriber(
+            &self,
+            email: &str,
+        ) -> impl Future<Output = Result<(), Report<EmailSubscriptionError>>> + Send {
+            let outcome = if self.fail_on == Some(email) {
+                Err(Report::new(EmailSubscriptionError::DeletionFailed {
+                    email: email.to_owned(),
+                }))
+            } else {
+                self.deleted
+                    .lock()
+                    .expect("the recording mutex should not be poisoned")
+                    .push(email.to_owned());
+                Ok(())
+            };
+            core::future::ready(outcome)
+        }
+    }
+
+    #[test]
+    fn confirmed_deletion_reports_the_identity_as_deleted() {
+        let mut sink = ReportSink::new();
+
+        let deleted = record_identity_deletion(
+            Some(IdentityDeletion::Deleted),
+            false,
+            "some-identity",
+            &mut sink,
+        );
+
+        assert!(
+            deleted,
+            "a confirmed deletion should report the identity as deleted"
+        );
+        assert!(
+            sink.finish().is_ok(),
+            "a confirmed deletion should not be an error"
+        );
+    }
+
+    /// The address read saw the identity, so its absence for the delete means it was deleted
+    /// between the two calls.
+    #[test]
+    fn identity_deleted_between_the_calls_counts_as_deleted() {
+        let mut sink = ReportSink::new();
+
+        let deleted = record_identity_deletion(
+            Some(IdentityDeletion::AlreadyAbsent),
+            true,
+            "some-identity",
+            &mut sink,
+        );
+
+        assert!(
+            deleted,
+            "an identity gone since the address read should count as deleted"
+        );
+        assert!(
+            sink.finish().is_ok(),
+            "an identity gone since the address read should not be an error"
+        );
+    }
+
+    /// An identity absent for both the read and the delete confirms nothing — the ID may be
+    /// stale, or the URL may answer 404 for every route.
+    #[test]
+    fn identity_absent_for_every_call_reports_the_deletion_as_unconfirmed() {
+        let mut sink = ReportSink::new();
+
+        let deleted = record_identity_deletion(
+            Some(IdentityDeletion::AlreadyAbsent),
+            false,
+            "some-identity",
+            &mut sink,
+        );
+
+        assert!(
+            !deleted,
+            "an identity absent for every call should not report the deletion as done"
+        );
+        let report = sink
+            .finish()
+            .expect_err("the unconfirmed deletion should surface as an error");
+        assert!(
+            report
+                .current_contexts()
+                .any(|context| matches!(context, UserDeletionError::UnknownIdentity)),
+            "the unconfirmed deletion should surface as an unknown identity"
+        );
+    }
+
+    #[test]
+    fn failed_deletion_reports_the_identity_as_kept() {
+        let mut sink = ReportSink::new();
+
+        let deleted = record_identity_deletion(None, true, "some-identity", &mut sink);
+
+        assert!(
+            !deleted,
+            "a failed deletion should not report the identity as deleted"
+        );
+        // The call site's `sink.attempt` already captured the failure.
+        assert!(
+            sink.finish().is_ok(),
+            "the recording should not report the failure a second time"
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_addresses_report_the_cleanup_as_incomplete() {
+        let provider = RecordingProvider::new(None);
+        let mut sink = ReportSink::new();
+
+        let deleted = delete_email_subscriptions(Some(&provider), None, &mut sink).await;
+
+        assert_eq!(
+            deleted,
+            Some(false),
+            "unknown addresses should report the cleanup as incomplete rather than done"
+        );
+        let report = sink
+            .finish()
+            .expect_err("the unknown addresses should surface as an error");
+        assert!(
+            report
+                .current_contexts()
+                .any(|context| matches!(context, UserDeletionError::UnknownEmailAddresses)),
+            "the unknown addresses should surface as unknown addresses"
+        );
+        assert!(
+            provider.deleted().is_empty(),
+            "no deletion should be attempted without addresses"
+        );
+    }
+
+    #[tokio::test]
+    async fn identity_without_addresses_reports_the_cleanup_as_complete() {
+        let provider = RecordingProvider::new(None);
+        let mut sink = ReportSink::new();
+
+        let deleted = delete_email_subscriptions(Some(&provider), Some(&[]), &mut sink).await;
+
+        assert_eq!(
+            deleted,
+            Some(true),
+            "an identity without addresses should leave nothing to clean up"
+        );
+        assert!(sink.finish().is_ok(), "no addresses should mean no errors");
+    }
+
+    #[tokio::test]
+    async fn absent_provider_leaves_the_cleanup_unreported() {
+        let mut sink = ReportSink::new();
+
+        let deleted =
+            delete_email_subscriptions(Option::<&RecordingProvider>::None, None, &mut sink).await;
+
+        assert_eq!(
+            deleted, None,
+            "an absent provider should leave the claim out of the report entirely"
+        );
+        assert!(
+            sink.finish().is_ok(),
+            "an absent provider should not be an error"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_failed_unsubscribe_still_attempts_the_remaining_addresses() {
+        let provider = RecordingProvider::new(Some("first@example.com"));
+        let mut sink = ReportSink::new();
+        let emails = [
+            "first@example.com".to_owned(),
+            "second@example.com".to_owned(),
+        ];
+
+        let deleted = delete_email_subscriptions(Some(&provider), Some(&emails), &mut sink).await;
+
+        assert_eq!(
+            deleted,
+            Some(false),
+            "a failed unsubscribe should report the cleanup as incomplete"
+        );
+        let report = sink
+            .finish()
+            .expect_err("the failed address should surface as an error");
+        assert!(
+            report
+                .current_contexts()
+                .any(|context| matches!(context, UserDeletionError::EmailSubscription)),
+            "the failed address should surface as a subscription failure"
+        );
+        assert_eq!(
+            provider.deleted(),
+            ["second@example.com"],
+            "the remaining address should still be attempted"
+        );
+    }
 }

--- a/libs/@local/graph/store/src/user_deletion.rs
+++ b/libs/@local/graph/store/src/user_deletion.rs
@@ -75,7 +75,7 @@ pub struct UserDeletionOutcome {
 /// principal would break those references.
 ///
 /// Orchestrates the following operations in order:
-/// 1. Look up the user's Kratos identity ID and email addresses
+/// 1. Look up the user's Kratos identity ID, then its email addresses through the identity provider
 /// 2. Purge all entities owned by the user's personal web
 /// 3. Delete the Kratos identity (removes PII such as email)
 /// 4. Revoke Hydra login and consent sessions
@@ -128,8 +128,8 @@ where
     };
     tracing::info!(%user_id, %kratos_identity_id, "resolved Kratos identity");
 
-    let emails = store
-        .get_user_emails(user_id)
+    let emails = identity_provider
+        .get_identity_emails(&kratos_identity_id)
         .await
         .change_context(UserDeletionError::UserLookup)?;
     tracing::info!(%user_id, email_count = emails.len(), "resolved user emails");

--- a/libs/@local/graph/store/src/user_deletion.rs
+++ b/libs/@local/graph/store/src/user_deletion.rs
@@ -81,6 +81,11 @@ pub struct UserDeletionOutcome {
 /// 4. Revoke Hydra login and consent sessions
 /// 5. Delete email subscription entries
 ///
+/// A caller that already resolved the Kratos identity — deletion by email goes through the
+/// identity provider — passes it as `kratos_identity_id`, which skips the graph read in step 1.
+/// This keeps a partially deleted user deletable: the graph entity carrying the identity ID may
+/// already be purged while the identity still exists.
+///
 /// Steps 1–2 are fatal: failure causes an `Err` return and no entities are deleted.
 /// Steps 3–5 are non-fatal: failures are collected into [`UserDeletionOutcome::errors`]
 /// with full error-stack context, but entity deletion is not rolled back.
@@ -104,6 +109,7 @@ pub async fn delete_user<S, I, O, E>(
     email_subscription_provider: Option<&E>,
     actor: AuthenticatedActor,
     user_id: UserId,
+    kratos_identity_id: Option<String>,
 ) -> Result<UserDeletionOutcome, Report<UserDeletionError>>
 where
     S: AccountStore + EntityStore,
@@ -112,11 +118,14 @@ where
     E: EmailSubscriptionProvider,
 {
     // Step 1: Gather data before we delete anything
-    let kratos_identity_id = store
-        .get_user_kratos_identity_id(user_id)
-        .await
-        .change_context(UserDeletionError::UserLookup)?
-        .ok_or(UserDeletionError::MissingKratosIdentityId)?;
+    let kratos_identity_id = match kratos_identity_id {
+        Some(kratos_identity_id) => kratos_identity_id,
+        None => store
+            .get_user_kratos_identity_id(user_id)
+            .await
+            .change_context(UserDeletionError::UserLookup)?
+            .ok_or(UserDeletionError::MissingKratosIdentityId)?,
+    };
     tracing::info!(%user_id, %kratos_identity_id, "resolved Kratos identity");
 
     let emails = store

--- a/libs/@local/graph/type-fetcher/src/store.rs
+++ b/libs/@local/graph/type-fetcher/src/store.rs
@@ -1002,10 +1002,6 @@ where
         self.store.get_user_kratos_identity_id(user_id).await
     }
 
-    async fn get_user_emails(&self, user_id: UserId) -> Result<Vec<String>, Report<GetActorError>> {
-        self.store.get_user_emails(user_id).await
-    }
-
     async fn get_machine_by_id(
         &self,
         actor_id: ActorEntityUuid,

--- a/libs/@local/graph/type-fetcher/src/store.rs
+++ b/libs/@local/graph/type-fetcher/src/store.rs
@@ -995,13 +995,6 @@ where
         self.store.get_user_by_id(actor_id, id).await
     }
 
-    async fn get_user_id_by_email(
-        &self,
-        email: &str,
-    ) -> Result<Option<UserId>, Report<GetActorError>> {
-        self.store.get_user_id_by_email(email).await
-    }
-
     async fn get_user_kratos_identity_id(
         &self,
         user_id: UserId,

--- a/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/user.test.ts
+++ b/tests/hash-backend-integration/src/tests/graph/knowledge/system-types/user.test.ts
@@ -15,10 +15,12 @@ import {
   createUser,
   getUser,
   getUserOrgMemberships,
+  getUserPendingInvitations,
   isUserMemberOfOrg,
   joinOrg,
 } from "@apps/hash-api/src/graph/knowledge/system-types/user";
 import { systemAccountId } from "@apps/hash-api/src/graph/system-account";
+import { inviteUserToOrgResolver } from "@apps/hash-api/src/graphql/resolvers/knowledge/org/invite-user-to-org";
 import { userHasAccessToHash } from "@apps/hash-api/src/shared/user-has-access-to-hash";
 import {
   extractEntityUuidFromEntityId,
@@ -26,7 +28,10 @@ import {
 } from "@blockprotocol/type-system";
 import { Logger } from "@local/hash-backend-utils/logger";
 import { queryEntities } from "@local/hash-graph-sdk/entity";
-import { getActorGroupRole } from "@local/hash-graph-sdk/principal/actor-group";
+import {
+  addActorGroupAdministrator,
+  getActorGroupRole,
+} from "@local/hash-graph-sdk/principal/actor-group";
 import { getWebRoles } from "@local/hash-graph-sdk/principal/web";
 import {
   currentTimeInstantTemporalAxes,
@@ -43,11 +48,15 @@ import { deleteUser } from "../../../admin-server";
 import {
   createTestImpureGraphContext,
   createTestOrg,
+  createTestUser,
   generateRandomShortname,
 } from "../../../util";
 
+import type { EmailTransporter } from "@apps/hash-api/src/email/transporters";
 import type { User } from "@apps/hash-api/src/graph/knowledge/system-types/user";
+import type { LoggedInGraphQLContext } from "@apps/hash-api/src/graphql/context";
 import type { EntityId } from "@blockprotocol/type-system";
+import type { GraphQLResolveInfo } from "graphql";
 
 const logger = new Logger({
   environment: "test",
@@ -56,6 +65,23 @@ const logger = new Logger({
 });
 
 const graphContext = createTestImpureGraphContext();
+
+const resolverInfo = {} as unknown as GraphQLResolveInfo;
+
+const graphQLContextForUser = (user: User): LoggedInGraphQLContext => ({
+  dataSources: {
+    graphApi: graphContext.graphApi,
+    uploadProvider: graphContext.uploadProvider,
+  },
+  emailTransporter: {
+    sendMail: async () => {},
+  } as unknown as EmailTransporter,
+  logger,
+  authentication: { actorId: user.accountId },
+  user,
+  provenance: { ...graphContext.provenance, actorType: "user" },
+  temporal: graphContext.temporalClient,
+});
 
 const shortname = generateRandomShortname("userTest");
 const incompleteUserShortname = generateRandomShortname("incomplete");
@@ -364,6 +390,73 @@ describe("User model class", () => {
         await deleteUser({ userId: user.accountId });
       } else {
         await deleteKratosIdentity({ kratosIdentityId: identity.id });
+      }
+    }
+  });
+
+  it("does not treat unverified trait emails as invitation or access credentials", async () => {
+    const authentication = { actorId: systemAccountId };
+    const attackerEmail = `${generateRandomShortname("inviteAttacker")}@example.com`;
+    const victimEmail = `${generateRandomShortname("inviteVictim")}@example.com`;
+
+    const identity = await createKratosIdentity({
+      traits: {
+        emails: [attackerEmail],
+      },
+      verifyEmails: true,
+    });
+
+    let inviter: User | undefined;
+
+    try {
+      const attacker = await createUser(graphContext, authentication, {
+        emails: [attackerEmail],
+        kratosIdentityId: identity.id,
+      });
+
+      inviter = await createTestUser(graphContext, "invadmin", logger);
+      const testOrg = await createTestOrg(
+        graphContext,
+        authentication,
+        "invorg",
+      );
+
+      await addActorGroupAdministrator(graphContext.graphApi, authentication, {
+        actorId: inviter.accountId,
+        actorGroupId: testOrg.webId,
+      });
+
+      await inviteUserToOrgResolver(
+        {},
+        { orgWebId: testOrg.webId, userEmail: victimEmail },
+        graphQLContextForUser(inviter),
+        resolverInfo,
+      );
+
+      const attackerWithInjectedEmail = {
+        ...attacker,
+        emails: [attackerEmail, victimEmail],
+      };
+
+      await expect(
+        getUserPendingInvitations(graphContext, authentication, {
+          user: attackerWithInjectedEmail,
+        }),
+      ).resolves.toHaveLength(0);
+
+      await expect(
+        userHasAccessToHash(
+          graphContext,
+          authentication,
+          attackerWithInjectedEmail,
+        ),
+      ).resolves.toMatchObject({ allowed: false });
+    } finally {
+      await deleteKratosIdentity({ kratosIdentityId: identity.id });
+      if (inviter) {
+        await deleteKratosIdentity({
+          kratosIdentityId: inviter.kratosIdentityId,
+        });
       }
     }
   });


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Deleting a user by email resolved the address through a JSONB scan over all entity editions, extracting every `email` property as an array. One entity carrying a scalar `email` — an org invitation, for example — could fail the whole query with `cannot extract elements from a scalar`, because Postgres does not guarantee predicate evaluation order even though the query joined `user_actor`.

Kratos already owns the email-to-identity mapping, and the Graph provisions each identity with its actor (`graph_actor_id` in `metadata_public`). The delete-user endpoint now resolves the email there, so the shape of stored `email` properties no longer matters for deletion.

## 🔗 Related links

- [BE-770](https://linear.app/hash/issue/BE-770/use-the-kratos-user-id-lookup-on-the-admin-delete-user-path) _(internal)_

## 🚫 Blocked by

- [ ] #9235

## 🔍 What does this change?

- `KratosIdentityProvider` gains `find_user_by_email`: the identity is looked up by credentials identifier and the actor is read from its `metadata_public.graph_actor_id`. Unlike the authentication resolver, an **unverified** address resolves — deletion must reach accounts that never completed verification.
- An address held by several identities fails with an explicit error instead of picking one — that state means an account has claimed an address it may not own, so the operator falls back to deletion by user ID. An identity without a provisioned actor is reported as such rather than as a missing user.
- The resolved Kratos identity ID travels into `delete_user` instead of being read back from the graph. Deletion order stays graph-then-Kratos, so the partial state a non-fatal Kratos failure leaves behind — entities purged, identity still alive — remains findable and deletable by email.
- `get_user_id_by_email` and its JSONB scan are removed from `AccountStore`, the Postgres store, and the type-fetcher passthrough.
- `MetadataPublic` is exported from the authentication crate, so the metadata contract keeps a single Rust definition.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] require changes to docs which are **not** made in this PR
  - The [Graph Admin API] runbook's delete-user section: deleting by email now requires the identity to exist in Kratos and carry a provisioned actor, and an ambiguous address is rejected. Same page #9235 already flags for updating.

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

- A user whose Kratos identity is already gone while their graph entities remain is deletable by user ID only; the email lookup no longer sees them.

## 🐾 Next steps

- Update the [Graph Admin API] runbook once this lands.

## 🛡 What tests cover this?

- New unit tests for the Kratos lookup against a fake admin API: resolution of a provisioned identity, unknown email, unprovisioned identity, and an address held by several identities.
- A new integration test creates an org invitation — whose `email` property is a single string — through the real invite resolver and deletes a user by email against the admin server; this failed with `cannot extract elements from a scalar` before.
- The existing integration tests that delete users by email exercise the new path.

## ❓ How to test this?

The new integration test in `user.test.ts` automates the scenario: an org invitation exists, and deleting a user by email through the admin server succeeds.

[Graph Admin API]: https://www.notion.so/hashintel/Graph-Admin-API-31a3c81fe02480f792c9d7bedfdc49db

