### PR TITLE
BE-764: Model the public actor as an anonymous caller instead of the nil UUID

### DIFF
--- a/apps/hash-ai-worker-ts/src/activities/graph.ts
+++ b/apps/hash-ai-worker-ts/src/activities/graph.ts
@@ -4,7 +4,6 @@ import {
   getEntityTypes,
   getPropertyTypes,
 } from "@blockprotocol/graph/stdlib";
-import { publicUserAccountId } from "@local/hash-backend-utils/public-user-account-id";
 import {
   queryDataTypes,
   type QueryDataTypesParams,
@@ -30,7 +29,6 @@ import {
   type SerializedQueryEntityTypeSubgraphResponse,
   serializeQueryEntityTypeSubgraphResponse,
 } from "@local/hash-graph-sdk/entity-type";
-import * as actor from "@local/hash-graph-sdk/principal/actor";
 import { getInstanceAdminsTeam } from "@local/hash-graph-sdk/principal/hash-instance-admins";
 import {
   queryPropertyTypes,
@@ -53,6 +51,7 @@ import type {
   DataTypeWithMetadata,
   EntityId,
   EntityTypeWithMetadata,
+  MachineId,
   PropertyTypeWithMetadata,
 } from "@blockprotocol/type-system";
 import type {
@@ -79,11 +78,22 @@ export type EntityQueryResponse = {
   cursor?: EntityQueryCursor | null;
 };
 
+const fetchSystemMachineActorId = async (
+  graphApiClient: GraphApi,
+): Promise<MachineId> =>
+  await graphApiClient
+    .getOrCreateSystemMachine("h")
+    .then(({ data: machineId }) => machineId as MachineId);
+
 export const createGraphActivities = ({
   graphApiClient,
 }: {
   graphApiClient: GraphApi;
 }) => ({
+  async getSystemMachineActorId(): Promise<MachineId> {
+    return await fetchSystemMachineActorId(graphApiClient);
+  },
+
   async getSystemMachineIds(params: {
     cursor?: EntityQueryCursor;
     limit?: number;
@@ -91,18 +101,11 @@ export const createGraphActivities = ({
     machineIds: EntityId[];
     cursor?: EntityQueryCursor | null;
   }> {
-    const systemMachine = await actor.getMachineByIdentifier(
-      graphApiClient,
-      { actorId: publicUserAccountId },
-      "h",
-    );
-    if (!systemMachine) {
-      throw new Error("System machine not found");
-    }
+    const systemMachineId = await fetchSystemMachineActorId(graphApiClient);
 
     const { entities, cursor } = await queryEntities(
       { graphApi: graphApiClient },
-      { actorId: systemMachine.id },
+      { actorId: systemMachineId },
       {
         filter: {
           all: [

--- a/apps/hash-ai-worker-ts/src/workflows.ts
+++ b/apps/hash-ai-worker-ts/src/workflows.ts
@@ -7,7 +7,6 @@ import {
 } from "@temporalio/workflow";
 
 import { splitEntityId } from "@blockprotocol/type-system";
-import { publicUserAccountId } from "@local/hash-backend-utils/public-user-account-id";
 import { deserializeQueryEntitiesResponse } from "@local/hash-graph-sdk/entity";
 import { systemEntityTypes } from "@local/hash-isomorphic-utils/ontology-type-ids";
 
@@ -436,7 +435,7 @@ export const updateAllDataTypeEmbeddings =
   async (): Promise<OpenAI.CreateEmbeddingResponse.Usage> =>
     await updateDataTypeEmbeddings({
       authentication: {
-        actorId: publicUserAccountId,
+        actorId: await graphActivities.getSystemMachineActorId(),
       },
       filter: {
         equal: [{ path: ["version"] }, { parameter: "latest" }],
@@ -447,7 +446,7 @@ export const updateAllPropertyTypeEmbeddings =
   async (): Promise<OpenAI.CreateEmbeddingResponse.Usage> =>
     await updatePropertyTypeEmbeddings({
       authentication: {
-        actorId: publicUserAccountId,
+        actorId: await graphActivities.getSystemMachineActorId(),
       },
       filter: {
         equal: [{ path: ["version"] }, { parameter: "latest" }],
@@ -458,7 +457,7 @@ export const updateAllEntityTypeEmbeddings =
   async (): Promise<OpenAI.CreateEmbeddingResponse.Usage> =>
     await updateEntityTypeEmbeddings({
       authentication: {
-        actorId: publicUserAccountId,
+        actorId: await graphActivities.getSystemMachineActorId(),
       },
       filter: {
         equal: [{ path: ["version"] }, { parameter: "latest" }],

--- a/apps/hash-api/src/graphql/resolvers/index.ts
+++ b/apps/hash-api/src/graphql/resolvers/index.ts
@@ -39,7 +39,6 @@ import {
   archiveEntityResolver,
   summarizeEntitiesResolver,
   createEntityResolver,
-  isEntityPublicResolver,
   queryEntitiesResolver,
   queryEntitiesTableResolver,
   searchEntitiesResolver,
@@ -162,7 +161,6 @@ export const resolvers: Omit<Resolvers, "Query" | "Mutation"> & {
     getEntityDiffs: loggedInAndSignedUpMiddleware(getEntityDiffsResolver),
     getFlowRuns: loggedInAndSignedUpMiddleware(getFlowRunsResolver),
     getFlowRunById: loggedInAndSignedUpMiddleware(getFlowRunByIdResolver),
-    isEntityPublic: loggedInAndSignedUpMiddleware(isEntityPublicResolver),
     getEntityAuthorizationRelationships: loggedInAndSignedUpMiddleware(() => {
       throw new Error(
         "`getEntityAuthorizationRelationships` is not implemented",

--- a/apps/hash-api/src/graphql/resolvers/knowledge/entity/entity.ts
+++ b/apps/hash-api/src/graphql/resolvers/knowledge/entity/entity.ts
@@ -2,7 +2,6 @@ import {
   extractEntityUuidFromEntityId,
   mustHaveAtLeastOne,
 } from "@blockprotocol/type-system";
-import { publicUserAccountId } from "@local/hash-backend-utils/public-user-account-id";
 import {
   HashEntity,
   queryEntities,
@@ -24,7 +23,6 @@ import { generateUuid } from "@local/hash-isomorphic-utils/generate-uuid";
 
 import {
   canUserReadEntity,
-  checkEntityPermission,
   createEntityWithLinks,
   getLatestEntityById,
   updateEntity,
@@ -49,7 +47,6 @@ import type {
   Query,
   QueryQueryEntitiesTableArgs,
   QuerySummarizeEntitiesArgs,
-  QueryIsEntityPublicArgs,
   QueryQueryEntitiesArgs,
   QuerySearchEntitiesArgs,
   QueryQueryEntitySubgraphArgs,
@@ -413,15 +410,3 @@ export const removeEntityViewerResolver: ResolverFn<
 
   return true;
 };
-
-export const isEntityPublicResolver: ResolverFn<
-  Promise<boolean>,
-  Record<string, never>,
-  LoggedInGraphQLContext,
-  QueryIsEntityPublicArgs
-> = async (_, { entityId }, graphQLContext) =>
-  checkEntityPermission(
-    graphQLContextToImpureGraphContext(graphQLContext),
-    { actorId: publicUserAccountId },
-    { entityId, permission: "viewEntity" },
-  );

--- a/apps/hash-api/src/graphql/resolvers/knowledge/hash-instance/hash-instance.ts
+++ b/apps/hash-api/src/graphql/resolvers/knowledge/hash-instance/hash-instance.ts
@@ -13,16 +13,16 @@ export const hashInstanceSettingsResolver: ResolverFn<
   GraphQLContext,
   Record<string, never>
 > = async (_, __, graphQLContext) => {
-  const { authentication } = graphQLContext;
+  const { authentication, user } = graphQLContext;
   const context = graphQLContextToImpureGraphContext(graphQLContext);
 
   const { entity } = await getHashInstance(context, authentication);
 
-  const isUserAdmin = await isUserHashInstanceAdmin(
-    graphQLContextToImpureGraphContext(graphQLContext),
-    graphQLContext.authentication,
-    { userAccountId: authentication.actorId },
-  );
+  const isUserAdmin = user
+    ? await isUserHashInstanceAdmin(context, authentication, {
+        userAccountId: authentication.actorId,
+      })
+    : false;
 
   return {
     entity: entity.toJSON(),

--- a/apps/hash-api/src/seed-data/seed-crm-data.ts
+++ b/apps/hash-api/src/seed-data/seed-crm-data.ts
@@ -45,6 +45,7 @@ import {
   type PropertyTypeWithMetadata,
   type PropertyValueWithMetadata,
   type PropertyWithMetadata,
+  type MachineId,
   type ProvidedEntityEditionProvenance,
   type VersionedUrl,
   versionedUrlFromComponents,
@@ -52,8 +53,6 @@ import {
 } from "@blockprotocol/type-system";
 import { createGraphClient } from "@local/hash-backend-utils/create-graph-client";
 import { getRequiredEnv } from "@local/hash-backend-utils/environment";
-import { getMachineIdByIdentifier } from "@local/hash-backend-utils/machine-actors";
-import { publicUserAccountId } from "@local/hash-backend-utils/public-user-account-id";
 import { getEntityTypeById } from "@local/hash-graph-sdk/entity-type";
 import { getPropertyTypeById } from "@local/hash-graph-sdk/property-type";
 import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
@@ -398,16 +397,9 @@ const seedCrmData = async () => {
 
   const context = { graphApi, provenance };
 
-  const hashBotActorId = await getMachineIdByIdentifier(
-    context,
-    { actorId: publicUserAccountId },
-    { identifier: "h" },
-  ).then((maybeMachineId) => {
-    if (!maybeMachineId) {
-      throw new Error("Failed to get hash bot");
-    }
-    return maybeMachineId;
-  });
+  const hashBotActorId = await graphApi
+    .getOrCreateSystemMachine("h")
+    .then(({ data: machineId }) => machineId as MachineId);
 
   const authentication = { actorId: hashBotActorId };
 

--- a/apps/hash-api/src/seed-data/seed-dashboard-demo.ts
+++ b/apps/hash-api/src/seed-data/seed-dashboard-demo.ts
@@ -21,8 +21,6 @@
 import { extractEntityUuidFromEntityId } from "@blockprotocol/type-system";
 import { createGraphClient } from "@local/hash-backend-utils/create-graph-client";
 import { getRequiredEnv } from "@local/hash-backend-utils/environment";
-import { getMachineIdByIdentifier } from "@local/hash-backend-utils/machine-actors";
-import { publicUserAccountId } from "@local/hash-backend-utils/public-user-account-id";
 import { createTemporalClient } from "@local/hash-backend-utils/temporal";
 import { queryEntities } from "@local/hash-graph-sdk/entity";
 import { outgoingHopEdges } from "@local/hash-isomorphic-utils/dashboard-types";
@@ -48,6 +46,7 @@ import { logger } from "../logger";
 import type { ImpureGraphContext } from "../graph/context-types";
 import type {
   BaseUrl,
+  MachineId,
   PropertyPatchOperation,
   PropertyValueWithMetadata,
   PropertyWithMetadata,
@@ -475,14 +474,9 @@ const seedDashboardDemo = async () => {
   const temporalClient = await createTemporalClient();
   const context = { graphApi, provenance, temporalClient };
 
-  const hashBotActorId = await getMachineIdByIdentifier(
-    context,
-    { actorId: publicUserAccountId },
-    { identifier: "h" },
-  );
-  if (!hashBotActorId) {
-    throw new Error("Failed to get hash bot machine actor");
-  }
+  const hashBotActorId = await graphApi
+    .getOrCreateSystemMachine("h")
+    .then(({ data: machineId }) => machineId as MachineId);
   const botAuthentication = { actorId: hashBotActorId };
 
   /*

--- a/apps/hash-api/src/seed-data/seed-flow-test-types.ts
+++ b/apps/hash-api/src/seed-data/seed-flow-test-types.ts
@@ -1,5 +1,6 @@
 import {
   type EntityTypeWithMetadata,
+  type MachineId,
   makeOntologyTypeVersion,
   type PropertyTypeWithMetadata,
   type ProvidedEntityEditionProvenance,
@@ -8,8 +9,6 @@ import {
 } from "@blockprotocol/type-system";
 import { createGraphClient } from "@local/hash-backend-utils/create-graph-client";
 import { getRequiredEnv } from "@local/hash-backend-utils/environment";
-import { getMachineIdByIdentifier } from "@local/hash-backend-utils/machine-actors";
-import { publicUserAccountId } from "@local/hash-backend-utils/public-user-account-id";
 import { getEntityTypeById } from "@local/hash-graph-sdk/entity-type";
 import { getPropertyTypeById } from "@local/hash-graph-sdk/property-type";
 import { currentTimeInstantTemporalAxes } from "@local/hash-isomorphic-utils/graph-queries";
@@ -154,16 +153,9 @@ const seedFlowTestTypes = async () => {
 
   const context = { graphApi, provenance };
 
-  const hashBotActorId = await getMachineIdByIdentifier(
-    context,
-    { actorId: publicUserAccountId },
-    { identifier: "h" },
-  ).then((maybeMachineId) => {
-    if (!maybeMachineId) {
-      throw new Error("Failed to get hash bot");
-    }
-    return maybeMachineId;
-  });
+  const hashBotActorId = await graphApi
+    .getOrCreateSystemMachine("h")
+    .then(({ data: machineId }) => machineId as MachineId);
 
   const authentication = { actorId: hashBotActorId };
 

--- a/apps/hash-frontend/src/graphql/queries/knowledge/entity.queries.ts
+++ b/apps/hash-frontend/src/graphql/queries/knowledge/entity.queries.ts
@@ -124,12 +124,6 @@ export const removeEntityViewerMutation = gql`
   }
 `;
 
-export const isEntityPublicQuery = gql`
-  query isEntityPublic($entityId: EntityId!) {
-    isEntityPublic(entityId: $entityId)
-  }
-`;
-
 export const getEntityAuthorizationRelationshipsQuery = gql`
   query getEntityAuthorizationRelationships($entityId: EntityId!) {
     getEntityAuthorizationRelationships(entityId: $entityId) {

--- a/libs/@blockprotocol/type-system/rust/src/principal/actor/mod.rs
+++ b/libs/@blockprotocol/type-system/rust/src/principal/actor/mod.rs
@@ -54,16 +54,6 @@ impl ActorEntityUuid {
     pub fn new(entity_uuid: impl Into<Uuid>) -> Self {
         Self(EntityUuid::new(entity_uuid))
     }
-
-    #[must_use]
-    pub fn public_actor() -> Self {
-        Self::new(Uuid::nil())
-    }
-
-    #[must_use]
-    pub fn is_public_actor(self) -> bool {
-        Uuid::from(self).is_nil()
-    }
 }
 
 impl From<ActorEntityUuid> for EntityUuid {

--- a/libs/@local/graph/api/src/rest/admin.rs
+++ b/libs/@local/graph/api/src/rest/admin.rs
@@ -56,9 +56,7 @@ use serde::Deserialize as _;
 use tokio::io;
 #[cfg(feature = "unsafe-dev-endpoints")]
 use tokio_util::{codec::FramedRead, io::StreamReader};
-#[cfg(feature = "unsafe-dev-endpoints")]
-use type_system::principal::actor::ActorEntityUuid;
-use type_system::principal::actor::UserId;
+use type_system::principal::actor::{ActorId, UserId};
 use uuid::Uuid;
 
 use super::{
@@ -86,9 +84,14 @@ pub struct ExternalServicesConfig {
 
 /// Creates the admin API router.
 ///
-/// All routes except `/health` require authentication through the given provider chain. The bulk
-/// destructive endpoints (`/snapshot`, `/accounts`, `/data-types`, `/property-types`,
-/// `/entity-types`) exist only in builds with the `unsafe-dev-endpoints` feature.
+/// `/entities/delete` and `/users/delete` authenticate through the given provider chain and
+/// require an actor.
+///
+/// The bulk destructive endpoints (`/snapshot`, `/accounts`, `/data-types`, `/property-types`,
+/// `/entity-types`) exist only in builds with the `unsafe-dev-endpoints` feature. They must work
+/// on a store with no principals, so they take no actor — the service secret is their only gate.
+///
+/// `/health` is open.
 pub fn routes<P>(
     store_pool: Arc<PostgresStorePool>,
     authentication_provider: Arc<P>,
@@ -96,33 +99,44 @@ pub fn routes<P>(
     external_services: ExternalServicesConfig,
 ) -> Router
 where
-    P: AuthenticationProvider + 'static,
+    P: AuthenticationProvider<ActorId> + 'static,
 {
     let protected = Router::new()
         .route("/entities/delete", post(delete_entities))
         .route("/users/delete", post(delete_user));
 
     #[cfg(feature = "unsafe-dev-endpoints")]
-    let protected = protected
-        .route("/snapshot", post(restore_snapshot))
-        .route("/accounts", delete(delete_accounts))
-        .route("/data-types", delete(delete_data_types))
-        .route("/property-types", delete(delete_property_types))
-        .route("/entity-types", delete(delete_entity_types));
+    let secret_gate_secret = Arc::clone(&service_secret);
 
     let kratos = Arc::new(KratosIdentityProvider::new(
         external_services.kratos_admin_url.clone(),
         KRATOS_HTTP_TIMEOUT,
     ));
 
-    probe::router()
-        .merge(
-            protected.route_layer(axum::middleware::from_fn(move |request, next| {
-                let provider = Arc::clone(&authentication_provider);
-                let service_secret = Arc::clone(&service_secret);
-                auth::authentication_middleware(provider, service_secret, request, next)
+    let router = probe::router().merge(protected.route_layer(axum::middleware::from_fn(
+        move |request, next| {
+            let provider = Arc::clone(&authentication_provider);
+            let service_secret = Arc::clone(&service_secret);
+            auth::authentication_middleware::<_, ActorId>(provider, service_secret, request, next)
+        },
+    )));
+
+    // Layering an empty router panics, so the group only exists with its routes.
+    #[cfg(feature = "unsafe-dev-endpoints")]
+    let router = router.merge(
+        Router::new()
+            .route("/snapshot", post(restore_snapshot))
+            .route("/accounts", delete(delete_accounts))
+            .route("/data-types", delete(delete_data_types))
+            .route("/property-types", delete(delete_property_types))
+            .route("/entity-types", delete(delete_entity_types))
+            .route_layer(axum::middleware::from_fn(move |request, next| {
+                let service_secret = Arc::clone(&secret_gate_secret);
+                auth::service_secret_middleware(service_secret, request, next)
             })),
-        )
+    );
+
+    router
         .fallback(|| async {
             status_to_response(Status::<()>::new(
                 StatusCode::NotFound,
@@ -148,11 +162,10 @@ enum AdminError {
 /// See [`SnapshotStore::restore_snapshot`] for details.
 #[cfg(feature = "unsafe-dev-endpoints")]
 async fn restore_snapshot(
-    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     store_pool: Extension<Arc<PostgresStorePool>>,
     snapshot: Body,
 ) -> Result<BoxedResponse, BoxedResponse> {
-    tracing::info!(%actor_id, "restoring snapshot");
+    tracing::info!("restoring snapshot");
     let store = store_pool.acquire(None).await.map_err(report_to_response)?;
 
     SnapshotStore::new(store)
@@ -181,14 +194,13 @@ async fn restore_snapshot(
 /// [`PostgresStore::delete_principals`]: hash_graph_postgres_store::store::PostgresStore::delete_principals
 #[cfg(feature = "unsafe-dev-endpoints")]
 async fn delete_accounts(
-    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     pool: Extension<Arc<PostgresStorePool>>,
 ) -> Result<BoxedResponse, BoxedResponse> {
-    tracing::info!(%actor_id, "deleting all accounts");
+    tracing::info!("deleting all accounts");
     pool.acquire(None)
         .await
         .map_err(report_to_response)?
-        .delete_principals(ActorEntityUuid::new(Uuid::nil()))
+        .delete_principals()
         .await
         .map_err(report_to_response)?;
 
@@ -206,10 +218,9 @@ async fn delete_accounts(
 /// [`PostgresStore::delete_data_types`]: hash_graph_postgres_store::store::PostgresStore::delete_data_types
 #[cfg(feature = "unsafe-dev-endpoints")]
 async fn delete_data_types(
-    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     pool: Extension<Arc<PostgresStorePool>>,
 ) -> Result<BoxedResponse, BoxedResponse> {
-    tracing::info!(%actor_id, "deleting all data types");
+    tracing::info!("deleting all data types");
     pool.acquire(None)
         .await
         .map_err(report_to_response)?
@@ -231,10 +242,9 @@ async fn delete_data_types(
 /// [`PostgresStore::delete_property_types`]: hash_graph_postgres_store::store::PostgresStore::delete_property_types
 #[cfg(feature = "unsafe-dev-endpoints")]
 async fn delete_property_types(
-    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     pool: Extension<Arc<PostgresStorePool>>,
 ) -> Result<BoxedResponse, BoxedResponse> {
-    tracing::info!(%actor_id, "deleting all property types");
+    tracing::info!("deleting all property types");
     pool.acquire(None)
         .await
         .map_err(report_to_response)?
@@ -256,10 +266,9 @@ async fn delete_property_types(
 /// [`PostgresStore::delete_entity_types`]: hash_graph_postgres_store::store::PostgresStore::delete_entity_types
 #[cfg(feature = "unsafe-dev-endpoints")]
 async fn delete_entity_types(
-    AuthenticatedActorId(actor_id): AuthenticatedActorId,
     pool: Extension<Arc<PostgresStorePool>>,
 ) -> Result<BoxedResponse, BoxedResponse> {
-    tracing::info!(%actor_id, "deleting all entity types");
+    tracing::info!("deleting all entity types");
     pool.acquire(None)
         .await
         .map_err(report_to_response)?
@@ -295,7 +304,7 @@ async fn delete_entities(
     pool.acquire(None)
         .await
         .map_err(report_to_response)?
-        .delete_entities(actor_id.into(), params)
+        .delete_entities(actor_id, params)
         .await
         .map(Json)
         .map_err(report_to_response)
@@ -368,7 +377,7 @@ async fn delete_user(
         kratos.as_ref(),
         &hydra,
         mailchimp.as_ref(),
-        actor_id.into(),
+        actor_id,
         user_id,
         kratos_identity_id,
     )

--- a/libs/@local/graph/api/src/rest/auth.rs
+++ b/libs/@local/graph/api/src/rest/auth.rs
@@ -1,30 +1,31 @@
 //! Axum bindings for Graph authentication.
 //!
 //! Bridges [`hash_graph_authentication`] into the REST layer: [`authentication_middleware`]
-//! resolves the request's credentials once — a Kratos session, a Cloudflare Access JWT, or a
-//! service delegation pair — and rejects the request when they are missing or invalid, so every
-//! route behind it requires authentication by default. The resolved [`AuthenticationOutcome`] is
-//! stored as a private request extension; the [`AuthenticatedActorId`] extractor hands the acting
-//! actor to handlers that need it.
+//! resolves the request's credentials once — a Kratos session, a Cloudflare Access JWT, or the
+//! service secret with its actor header — and rejects the request when they are invalid. A
+//! request without credentials resolves through the chain's [`Caller`] type: a chain over
+//! [`ActorId`] rejects it, a chain over `Option<ActorId>` verifies it as anonymous. The
+//! resolution is stored as a private request extension. The [`AuthenticatedActorId`] extractor
+//! hands the acting actor to handlers that need it, and taking it as an `Option` is how a handler
+//! serves anonymous callers.
 //!
-//! The only routes behind the middleware reachable without an actor are the bootstrap routes,
-//! which still require the service secret. The OpenAPI and probe routes are served outside the
-//! middleware.
+//! The bootstrap routes require the service secret regardless of the chain. The OpenAPI and probe
+//! routes are served outside the middleware.
 
 use alloc::sync::Arc;
 
 use axum::{
-    extract::{FromRequestParts, Request},
+    extract::{FromRequestParts, OptionalFromRequestParts, Request},
     http::request::Parts,
     middleware::Next,
     response::{IntoResponse as _, Response},
 };
 use hash_graph_authentication::{
     actor::StorePoolActorResolver,
-    delegation::{ServiceDelegationProvider, presents_service_secret},
+    delegation::{ServiceDelegationProvider, presents_service_secret, service_credential},
     kratos::{KratosEmailActorResolver, KratosSessionProvider},
-    provider::AuthenticationProvider,
-    request::{AuthenticationError, AuthenticationOutcome, resolve_request_actor},
+    provider::{AuthenticationProvider, Caller},
+    request::{AuthenticationError, resolve_request_actor},
 };
 pub use hash_graph_authentication::{
     cloudflare::CloudflareAccessProvider,
@@ -34,7 +35,7 @@ pub use hash_graph_authentication::{
 use hash_graph_authorization::policies::store::PrincipalStore;
 use hash_graph_store::pool::StorePool;
 use hash_status::{Status, StatusCode};
-use type_system::principal::actor::ActorEntityUuid;
+use type_system::principal::actor::ActorId;
 
 use crate::rest::status::{BoxedResponse, status_to_response};
 
@@ -47,11 +48,11 @@ pub struct CloudflareAccessConfig {
     pub kratos_admin: KratosAdminConfig,
 }
 
-/// The operator-facing half of a provider chain: Cloudflare Access JWT (when configured), then
-/// service delegation.
+/// The operator-facing provider chain: Cloudflare Access JWT (when configured), then service
+/// delegation.
 pub type OperatorChain<S> = (
     Option<CloudflareAccessProvider<KratosEmailActorResolver<StorePoolActorResolver<S>>>>,
-    ServiceDelegationProvider,
+    ServiceDelegationProvider<StorePoolActorResolver<S>>,
 );
 
 /// The provider chain of the REST router.
@@ -85,7 +86,10 @@ where
                 ),
             )
         }),
-        ServiceDelegationProvider::new(service_secret),
+        ServiceDelegationProvider::new(
+            service_secret,
+            StorePoolActorResolver::new(Arc::clone(store)),
+        ),
     )
 }
 
@@ -109,7 +113,7 @@ where
 
 /// The resolved authentication of a request, stored as a request extension.
 #[derive(Clone)]
-struct ResolvedAuthentication(AuthenticationOutcome);
+struct ResolvedAuthentication(Result<Option<ActorId>, AuthenticationError>);
 
 /// Converts an authentication failure into the response returned to the client.
 ///
@@ -126,6 +130,39 @@ fn rejection(error: &AuthenticationError) -> BoxedResponse {
     ))
 }
 
+/// Returns the rejection for a request that does not carry the service secret, [`None`] when it
+/// does.
+fn service_secret_rejection(
+    headers: &axum::http::HeaderMap,
+    service_secret: &str,
+) -> Option<BoxedResponse> {
+    if presents_service_secret(headers, service_secret) {
+        return None;
+    }
+
+    if service_credential(headers).is_some() {
+        tracing::warn!("request rejected due to a service credential mismatch");
+        return Some(rejection(&AuthenticationError::InvalidServiceSecret));
+    }
+    tracing::debug!("request rejected without a service credential");
+    Some(rejection(&AuthenticationError::MissingServiceSecret))
+}
+
+/// Rejects requests that do not carry the service secret.
+///
+/// No credential is resolved, so no actor reaches the handler.
+pub async fn service_secret_middleware(
+    service_secret: Arc<str>,
+    request: Request,
+    next: Next,
+) -> Response {
+    if let Some(rejection) = service_secret_rejection(request.headers(), &service_secret) {
+        return rejection.into_response();
+    }
+
+    next.run(request).await
+}
+
 /// Returns whether the path is a bootstrap route.
 fn is_bootstrap_route(path: &str) -> bool {
     if path == "/policies/seed" {
@@ -138,8 +175,8 @@ fn is_bootstrap_route(path: &str) -> bool {
 
 /// Records the authenticated actor on the request span and stores the outcome as a request
 /// extension.
-fn store_outcome(request: &mut Request, outcome: AuthenticationOutcome) {
-    if let AuthenticationOutcome::Authenticated(actor_id) = &outcome {
+fn store_outcome(request: &mut Request, outcome: Result<Option<ActorId>, AuthenticationError>) {
+    if let Ok(Some(actor_id)) = &outcome {
         tracing::Span::current().record("actor_entity_uuid", tracing::field::display(actor_id));
     }
     request
@@ -147,32 +184,41 @@ fn store_outcome(request: &mut Request, outcome: AuthenticationOutcome) {
         .insert(ResolvedAuthentication(outcome));
 }
 
-/// Rejects requests without valid credentials and stores the resolved
-/// [`AuthenticationOutcome`] as a request extension.
+/// Rejects requests with invalid credentials and stores the resolution as a request extension.
+///
+/// A request without credentials resolves through the chain's [`Caller`] type: a chain over
+/// [`ActorId`] rejects it, a chain over `Option<ActorId>` verifies it as anonymous, and whether an
+/// anonymous caller may proceed is the handler's to state, through which extractor it takes.
 ///
 /// Bootstrap routes are service operations: they require the service secret regardless of any
-/// actor credential, and pass without an actor. Every other route never reaches its handler
-/// unauthenticated.
-pub async fn authentication_middleware<P>(
+/// actor credential, and pass without an actor.
+///
+/// Routes that take no actor are gated by [`service_secret_middleware`] instead.
+pub async fn authentication_middleware<P, C>(
     provider: Arc<P>,
     service_secret: Arc<str>,
     mut request: Request,
     next: Next,
 ) -> Response
 where
-    P: AuthenticationProvider,
+    P: AuthenticationProvider<C>,
+    C: Caller,
 {
     let bootstrap = is_bootstrap_route(request.uri().path());
-    if bootstrap && !presents_service_secret(request.headers(), &service_secret) {
-        return rejection(&AuthenticationError::MissingServiceSecret).into_response();
+    if bootstrap
+        && let Some(rejection) = service_secret_rejection(request.headers(), &service_secret)
+    {
+        return rejection.into_response();
     }
 
-    let outcome = resolve_request_actor(&*provider, request.headers()).await;
+    let outcome = resolve_request_actor(&*provider, request.headers())
+        .await
+        .map(Caller::into_actor);
 
     match &outcome {
-        AuthenticationOutcome::Failed(AuthenticationError::MissingCredentials) if bootstrap => {}
-        AuthenticationOutcome::Failed(error) => return rejection(error).into_response(),
-        AuthenticationOutcome::Authenticated(_) => {}
+        Err(AuthenticationError::MissingDelegatedActor) if bootstrap => {}
+        Err(error) => return rejection(error).into_response(),
+        Ok(_) => {}
     }
 
     store_outcome(&mut request, outcome);
@@ -181,8 +227,12 @@ where
 
 /// Axum extractor providing the acting principal resolved by [`authentication_middleware`].
 ///
+/// Taking this extractor is how a handler states that it requires an actor: an anonymous caller
+/// is rejected here rather than reaching the handler. Handlers that serve callers without an
+/// actor take `Option<AuthenticatedActorId>` instead.
+///
 /// Rejects the request on routes without the middleware.
-pub struct AuthenticatedActorId(pub ActorEntityUuid);
+pub struct AuthenticatedActorId(pub ActorId);
 
 impl<S: Sync> FromRequestParts<S> for AuthenticatedActorId {
     type Rejection = BoxedResponse;
@@ -192,12 +242,40 @@ impl<S: Sync> FromRequestParts<S> for AuthenticatedActorId {
         _state: &S,
     ) -> impl Future<Output = Result<Self, Self::Rejection>> + Send {
         core::future::ready(match parts.extensions.get::<ResolvedAuthentication>() {
-            Some(ResolvedAuthentication(AuthenticationOutcome::Authenticated(actor_id))) => {
-                Ok(Self(*actor_id))
+            Some(ResolvedAuthentication(Ok(Some(actor_id)))) => Ok(Self(*actor_id)),
+            Some(ResolvedAuthentication(Ok(None))) => {
+                Err(rejection(&AuthenticationError::MissingCredentials))
             }
-            Some(ResolvedAuthentication(AuthenticationOutcome::Failed(error))) => {
-                Err(rejection(error))
+            Some(ResolvedAuthentication(Err(error))) => Err(rejection(error)),
+            None => {
+                tracing::error!(
+                    "`AuthenticatedActorId` extracted on a route without authentication middleware"
+                );
+                Err(status_to_response(Status::<()>::new(
+                    StatusCode::Internal,
+                    Some("internal server error".to_owned()),
+                    vec![],
+                )))
             }
+        })
+    }
+}
+
+/// `Option<AuthenticatedActorId>` yields [`None`] for an anonymous caller.
+///
+/// Writing the extractor as an [`Option`] is how a handler states that it serves callers without an
+/// actor. An invalid credential is still rejected — [`None`] means the chain resolved the request
+/// as anonymous, never that a credential failed.
+impl<S: Sync> OptionalFromRequestParts<S> for AuthenticatedActorId {
+    type Rejection = BoxedResponse;
+
+    fn from_request_parts(
+        parts: &mut Parts,
+        _state: &S,
+    ) -> impl Future<Output = Result<Option<Self>, Self::Rejection>> + Send {
+        core::future::ready(match parts.extensions.get::<ResolvedAuthentication>() {
+            Some(ResolvedAuthentication(Ok(caller))) => Ok(caller.map(Self)),
+            Some(ResolvedAuthentication(Err(error))) => Err(rejection(error)),
             None => {
                 tracing::error!(
                     "`AuthenticatedActorId` extracted on a route without authentication middleware"
@@ -215,12 +293,13 @@ impl<S: Sync> FromRequestParts<S> for AuthenticatedActorId {
 #[cfg(test)]
 mod tests {
     use alloc::sync::Arc;
+    use std::collections::HashMap;
 
     use axum::{Router, body::Body, middleware, routing::get};
     use hash_graph_authentication::{
-        delegation::ServiceDelegationProvider, provider::StaticAuthenticationProvider,
+        actor::tests::FixedActorResolver, delegation::ServiceDelegationProvider,
+        provider::StaticAuthenticationProvider,
     };
-    use hash_graph_authorization::policies::principal::actor::AuthenticatedActor;
     use http::{Request, StatusCode};
     use tower::ServiceExt as _;
     use type_system::principal::actor::{ActorEntityUuid, ActorId, UserId};
@@ -250,23 +329,34 @@ mod tests {
         actor_id.to_string()
     }
 
+    async fn anonymous_allowed(actor_id: Option<AuthenticatedActorId>) -> String {
+        actor_id.map_or_else(
+            || "anonymous".to_owned(),
+            |AuthenticatedActorId(actor_id)| actor_id.to_string(),
+        )
+    }
+
     async fn bootstrap() -> &'static str {
         "bootstrap"
     }
 
     const SERVICE_SECRET: &str = "hash-svc-test-secret";
 
+    fn routes() -> Router {
+        Router::new()
+            .route("/protected", get(protected))
+            .route("/anonymous-allowed", get(anonymous_allowed))
+            .route("/policies/seed", get(bootstrap))
+    }
+
     fn router(provider: StaticAuthenticationProvider) -> Router {
         let provider = Arc::new(provider);
         let service_secret: Arc<str> = Arc::from(SERVICE_SECRET);
-        Router::new()
-            .route("/protected", get(protected))
-            .route("/policies/seed", get(bootstrap))
-            .layer(middleware::from_fn(move |request, next| {
-                let provider = Arc::clone(&provider);
-                let service_secret = Arc::clone(&service_secret);
-                authentication_middleware(provider, service_secret, request, next)
-            }))
+        routes().layer(middleware::from_fn(move |request, next| {
+            let provider = Arc::clone(&provider);
+            let service_secret = Arc::clone(&service_secret);
+            authentication_middleware::<_, Option<ActorId>>(provider, service_secret, request, next)
+        }))
     }
 
     fn request(uri: &str) -> Request<Body> {
@@ -293,6 +383,47 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn anonymous_caller_does_not_reach_a_handler_requiring_an_actor() {
+        let response = router(StaticAuthenticationProvider::NotRecognized)
+            .oneshot(request("/protected"))
+            .await
+            .expect("the router should respond");
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn anonymous_caller_reaches_a_handler_allowing_no_actor() {
+        let response = router(StaticAuthenticationProvider::NotRecognized)
+            .oneshot(request("/anonymous-allowed"))
+            .await
+            .expect("the router should respond");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 1024)
+            .await
+            .expect("the response body should be readable");
+        assert_eq!(body, b"anonymous".as_slice());
+    }
+
+    #[tokio::test]
+    async fn verified_actor_reaches_an_anonymous_handler_as_itself() {
+        let actor_id = ActorEntityUuid::new(Uuid::new_v4());
+        let response = router(StaticAuthenticationProvider::Verified(ActorId::User(
+            UserId::new(actor_id),
+        )))
+        .oneshot(request("/anonymous-allowed"))
+        .await
+        .expect("the router should respond");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 1024)
+            .await
+            .expect("the response body should be readable");
+        assert_eq!(body, actor_id.to_string().as_bytes());
+    }
+
+    #[tokio::test]
     async fn middleware_rejects_requests_without_credentials() {
         let response = router(StaticAuthenticationProvider::NotRecognized)
             .oneshot(request("/protected"))
@@ -305,9 +436,9 @@ mod tests {
     #[tokio::test]
     async fn middleware_passes_verified_actors_to_handlers() {
         let actor_id = ActorEntityUuid::new(Uuid::new_v4());
-        let response = router(StaticAuthenticationProvider::Verified(
-            AuthenticatedActor::Id(ActorId::User(UserId::new(actor_id))),
-        ))
+        let response = router(StaticAuthenticationProvider::Verified(ActorId::User(
+            UserId::new(actor_id),
+        )))
         .oneshot(request("/protected"))
         .await
         .expect("the router should respond");
@@ -365,9 +496,9 @@ mod tests {
     #[tokio::test]
     async fn middleware_rejects_authenticated_bootstrap_requests_without_secret() {
         let actor_id = ActorEntityUuid::new(Uuid::new_v4());
-        let response = router(StaticAuthenticationProvider::Verified(
-            AuthenticatedActor::Id(ActorId::User(UserId::new(actor_id))),
-        ))
+        let response = router(StaticAuthenticationProvider::Verified(ActorId::User(
+            UserId::new(actor_id),
+        )))
         .oneshot(request("/policies/seed"))
         .await
         .expect("the router should respond");
@@ -378,9 +509,9 @@ mod tests {
     #[tokio::test]
     async fn middleware_admits_authenticated_bootstrap_requests_with_secret() {
         let actor_id = ActorEntityUuid::new(Uuid::new_v4());
-        let response = router(StaticAuthenticationProvider::Verified(
-            AuthenticatedActor::Id(ActorId::User(UserId::new(actor_id))),
-        ))
+        let response = router(StaticAuthenticationProvider::Verified(ActorId::User(
+            UserId::new(actor_id),
+        )))
         .oneshot(request_with_secret("/policies/seed", SERVICE_SECRET))
         .await
         .expect("the router should respond");
@@ -398,19 +529,22 @@ mod tests {
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
 
+    /// The REST chain shape around service delegation, serving anonymous callers.
+    fn delegation_router() -> Router {
+        let provider = Arc::new(ServiceDelegationProvider::new(
+            SERVICE_SECRET.to_owned(),
+            FixedActorResolver::new(HashMap::new()),
+        ));
+        let service_secret: Arc<str> = Arc::from(SERVICE_SECRET);
+        routes().layer(middleware::from_fn(move |request, next| {
+            let provider = Arc::clone(&provider);
+            let service_secret = Arc::clone(&service_secret);
+            authentication_middleware::<_, Option<ActorId>>(provider, service_secret, request, next)
+        }))
+    }
+
     #[tokio::test]
     async fn middleware_rejects_malformed_actor_headers_on_bootstrap_routes() {
-        let provider = Arc::new(ServiceDelegationProvider::new(SERVICE_SECRET.to_owned()));
-        let service_secret: Arc<str> = Arc::from(SERVICE_SECRET);
-        let router =
-            Router::new()
-                .route("/policies/seed", get(bootstrap))
-                .layer(middleware::from_fn(move |request, next| {
-                    let provider = Arc::clone(&provider);
-                    let service_secret = Arc::clone(&service_secret);
-                    authentication_middleware(provider, service_secret, request, next)
-                }));
-
         let request = Request::builder()
             .uri("/policies/seed")
             .header("Authorization", format!("HASH-Service {SERVICE_SECRET}"))
@@ -418,12 +552,177 @@ mod tests {
             .body(Body::empty())
             .expect("the request should build");
 
-        let response = router
+        let response = delegation_router()
             .oneshot(request)
             .await
             .expect("the router should respond");
 
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    /// A router requiring an actor.
+    fn actor_required_router(provider: StaticAuthenticationProvider) -> Router {
+        let provider = Arc::new(provider);
+        let service_secret: Arc<str> = Arc::from(SERVICE_SECRET);
+        routes().layer(middleware::from_fn(move |request, next| {
+            let provider = Arc::clone(&provider);
+            let service_secret = Arc::clone(&service_secret);
+            authentication_middleware::<_, ActorId>(provider, service_secret, request, next)
+        }))
+    }
+
+    #[tokio::test]
+    async fn rejected_credential_does_not_degrade_to_anonymous() {
+        let response = router(StaticAuthenticationProvider::Rejected)
+            .oneshot(request("/anonymous-allowed"))
+            .await
+            .expect("the router should respond");
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn actor_requiring_chain_rejects_uncredentialed_requests_before_handlers() {
+        let response = actor_required_router(StaticAuthenticationProvider::NotRecognized)
+            .oneshot(request("/anonymous-allowed"))
+            .await
+            .expect("the router should respond");
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn actor_requiring_chain_passes_verified_actors_to_handlers() {
+        let actor_id = ActorEntityUuid::new(Uuid::new_v4());
+        let response = actor_required_router(StaticAuthenticationProvider::Verified(
+            ActorId::User(UserId::new(actor_id)),
+        ))
+        .oneshot(request("/protected"))
+        .await
+        .expect("the router should respond");
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn bootstrap_route_passes_with_secret_only_on_the_delegation_chain() {
+        // Bootstrap admission hinges on the delegation provider resolving "secret without an
+        // actor header" to the missing-delegated-actor error the bootstrap arm admits.
+        let response = delegation_router()
+            .oneshot(request_with_secret("/policies/seed", SERVICE_SECRET))
+            .await
+            .expect("the router should respond");
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn bootstrap_route_reports_a_wrong_secret_as_invalid() {
+        let response = delegation_router()
+            .oneshot(request_with_secret("/policies/seed", "hash-svc-wrong"))
+            .await
+            .expect("the router should respond");
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        let body = axum::body::to_bytes(response.into_body(), 1024)
+            .await
+            .expect("the response body should be readable");
+        let body = String::from_utf8_lossy(&body);
+        assert!(
+            body.contains("invalid"),
+            "a wrong secret should be reported as invalid, not missing, got {body}"
+        );
+    }
+
+    /// A router gated by the service secret alone, as the bulk-destructive admin routes are.
+    fn secret_gated_router() -> Router {
+        let service_secret: Arc<str> = Arc::from(SERVICE_SECRET);
+        routes().layer(middleware::from_fn(move |request, next| {
+            let service_secret = Arc::clone(&service_secret);
+            super::service_secret_middleware(service_secret, request, next)
+        }))
+    }
+
+    #[tokio::test]
+    async fn secret_gate_rejects_requests_without_the_secret() {
+        let response = secret_gated_router()
+            .oneshot(request("/protected"))
+            .await
+            .expect("the router should respond");
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn secret_gate_reports_a_wrong_secret_as_invalid() {
+        let response = secret_gated_router()
+            .oneshot(request_with_secret("/protected", "hash-svc-wrong"))
+            .await
+            .expect("the router should respond");
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        let body = axum::body::to_bytes(response.into_body(), 1024)
+            .await
+            .expect("the response body should be readable");
+        let body = String::from_utf8_lossy(&body);
+        assert!(
+            body.contains("invalid"),
+            "a wrong secret should be reported as invalid, not missing, got {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn secret_gate_passes_requests_with_the_secret_without_an_actor() {
+        // The gate stores no authentication result, so the routes behind it take no actor
+        // extractor — mirrored by the `/policies/seed` test handler.
+        let response = secret_gated_router()
+            .oneshot(request_with_secret("/policies/seed", SERVICE_SECRET))
+            .await
+            .expect("the router should respond");
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn bare_actor_id_header_does_not_impersonate() {
+        // Without the service secret the delegation provider recognizes no credential, so the
+        // header's actor must never be honored — the request is served as anonymous.
+        let response = delegation_router()
+            .oneshot(request_with_actor_header(
+                "/anonymous-allowed",
+                &Uuid::new_v4().to_string(),
+            ))
+            .await
+            .expect("the router should respond");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 1024)
+            .await
+            .expect("the response body should be readable");
+        assert_eq!(body, b"anonymous".as_slice());
+    }
+
+    #[tokio::test]
+    async fn nil_actor_header_is_read_as_no_actor() {
+        // The resolver knows no actor, so resolving the nil UUID would fail — an anonymous
+        // response proves the delegation provider reads it as "acting for nobody".
+        let request = Request::builder()
+            .uri("/anonymous-allowed")
+            .header("Authorization", format!("HASH-Service {SERVICE_SECRET}"))
+            .header("X-Authenticated-User-Actor-Id", &Uuid::nil().to_string())
+            .body(Body::empty())
+            .expect("the request should build");
+
+        let response = delegation_router()
+            .oneshot(request)
+            .await
+            .expect("the router should respond");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 1024)
+            .await
+            .expect("the response body should be readable");
+        assert_eq!(body, b"anonymous".as_slice());
     }
 
     #[tokio::test]

--- a/libs/@local/graph/api/src/rest/data_type.rs
+++ b/libs/@local/graph/api/src/rest/data_type.rs
@@ -8,7 +8,6 @@ use axum::{
     routing::{post, put},
 };
 use error_stack::{Report, ResultExt as _};
-use hash_graph_authorization::policies::principal::actor::AuthenticatedActor;
 use hash_graph_postgres_store::{
     ontology::patch_id_and_parse,
     store::error::{OntologyVersionDoesNotExist, VersionedUrlAlreadyExists},
@@ -359,7 +358,7 @@ where
     )
 )]
 async fn query_data_types<S>(
-    AuthenticatedActorId(actor_id): AuthenticatedActorId,
+    actor_id: Option<AuthenticatedActorId>,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     Extension(api_config): Extension<ApiConfig>,
@@ -369,6 +368,7 @@ async fn query_data_types<S>(
 where
     S: StorePool + Send + Sync,
 {
+    let actor_id = actor_id.map(|AuthenticatedActorId(actor_id)| actor_id);
     if let Some(query_logger) = &mut query_logger {
         query_logger.capture(actor_id, OpenApiQuery::GetDataTypes(&request));
     }
@@ -429,7 +429,7 @@ struct QueryDataTypeSubgraphResponse {
     )
 )]
 async fn query_data_type_subgraph<S>(
-    AuthenticatedActorId(actor_id): AuthenticatedActorId,
+    actor_id: Option<AuthenticatedActorId>,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     Extension(api_config): Extension<ApiConfig>,
@@ -439,6 +439,7 @@ async fn query_data_type_subgraph<S>(
 where
     S: StorePool + Send + Sync,
 {
+    let actor_id = actor_id.map(|AuthenticatedActorId(actor_id)| actor_id);
     if let Some(query_logger) = &mut query_logger {
         query_logger.capture(actor_id, OpenApiQuery::GetDataTypeSubgraph(&request));
     }
@@ -498,7 +499,7 @@ where
     )
 )]
 async fn find_data_type_conversion_targets<S>(
-    AuthenticatedActorId(actor_id): AuthenticatedActorId,
+    actor_id: Option<AuthenticatedActorId>,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     Json(request): Json<FindDataTypeConversionTargetsParams>,
@@ -510,7 +511,10 @@ where
         .acquire(temporal_client.0)
         .await
         .map_err(report_to_response)?
-        .find_data_type_conversion_targets(actor_id, request)
+        .find_data_type_conversion_targets(
+            actor_id.map(|AuthenticatedActorId(actor_id)| actor_id),
+            request,
+        )
         .await
         .map_err(report_to_response)
         .map(Json)
@@ -812,7 +816,7 @@ where
         .acquire(temporal_client.0)
         .await
         .map_err(report_to_response)?
-        .has_permission_for_data_types(AuthenticatedActor::from(actor), params)
+        .has_permission_for_data_types(actor, params)
         .await
         .map(Json)
         .map_err(report_to_response)

--- a/libs/@local/graph/api/src/rest/entity/mod.rs
+++ b/libs/@local/graph/api/src/rest/entity/mod.rs
@@ -9,7 +9,6 @@ use std::collections::HashMap;
 use axum::{Extension, Router, routing::post};
 use error_stack::{Report, ResultExt as _};
 use futures::future::OptionFuture;
-use hash_graph_authorization::policies::principal::actor::AuthenticatedActor;
 use hash_graph_embeddings::OpenAiEmbeddingClient;
 use hash_graph_postgres_store::store::error::{EntityDoesNotExist, RaceConditionOnUpdate};
 use hash_graph_store::{
@@ -378,7 +377,7 @@ where
     S: StorePool + Send + Sync,
 {
     if let Some(query_logger) = &mut query_logger {
-        query_logger.capture(actor_id, OpenApiQuery::ValidateEntity(&body));
+        query_logger.capture(Some(actor_id), OpenApiQuery::ValidateEntity(&body));
     }
 
     let params = ValidateEntityParams::deserialize(&body)
@@ -429,7 +428,7 @@ where
         .acquire(temporal_client.0)
         .await
         .map_err(report_to_response)?
-        .has_permission_for_entities(AuthenticatedActor::from(actor), params)
+        .has_permission_for_entities(actor, params)
         .await
         .map(Json)
         .map_err(report_to_response)
@@ -708,7 +707,7 @@ where
     S: StorePool + Send + Sync,
 {
     if let Some(query_logger) = &mut query_logger {
-        query_logger.capture(actor_id, OpenApiQuery::DiffEntity(&params));
+        query_logger.capture(Some(actor_id), OpenApiQuery::DiffEntity(&params));
     }
 
     let store = store_pool

--- a/libs/@local/graph/api/src/rest/entity/query/mod.rs
+++ b/libs/@local/graph/api/src/rest/entity/query/mod.rs
@@ -51,7 +51,7 @@ use crate::rest::{
     )
 )]
 pub(super) async fn query_entities<S>(
-    AuthenticatedActorId(actor_id): AuthenticatedActorId,
+    actor_id: Option<AuthenticatedActorId>,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     Extension(api_config): Extension<ApiConfig>,
@@ -61,6 +61,7 @@ pub(super) async fn query_entities<S>(
 where
     S: StorePool + Send + Sync,
 {
+    let actor_id = actor_id.map(|AuthenticatedActorId(actor_id)| actor_id);
     if let Some(query_logger) = &mut query_logger {
         query_logger.capture(actor_id, OpenApiQuery::GetEntities(&request));
     }
@@ -129,7 +130,7 @@ pub(super) struct QueryEntitySubgraphResponse<'r> {
     )
 )]
 pub(super) async fn query_entity_subgraph<S>(
-    AuthenticatedActorId(actor_id): AuthenticatedActorId,
+    actor_id: Option<AuthenticatedActorId>,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     Extension(api_config): Extension<ApiConfig>,
@@ -139,6 +140,7 @@ pub(super) async fn query_entity_subgraph<S>(
 where
     S: StorePool + Send + Sync,
 {
+    let actor_id = actor_id.map(|AuthenticatedActorId(actor_id)| actor_id);
     if let Some(query_logger) = &mut query_logger {
         query_logger.capture(actor_id, OpenApiQuery::GetEntitySubgraph(&request));
     }
@@ -206,7 +208,7 @@ where
     S: StorePool + Send + Sync,
 {
     if let Some(query_logger) = &mut query_logger {
-        query_logger.capture(actor_id, OpenApiQuery::SummarizeEntities(&request));
+        query_logger.capture(Some(actor_id), OpenApiQuery::SummarizeEntities(&request));
     }
 
     let store = store_pool

--- a/libs/@local/graph/api/src/rest/entity_type.rs
+++ b/libs/@local/graph/api/src/rest/entity_type.rs
@@ -8,7 +8,6 @@ use axum::{
     routing::{post, put},
 };
 use error_stack::{Report, ResultExt as _};
-use hash_graph_authorization::policies::principal::actor::AuthenticatedActor;
 use hash_graph_embeddings::OpenAiEmbeddingClient;
 use hash_graph_postgres_store::{
     ontology::patch_id_and_parse,
@@ -167,7 +166,7 @@ where
         .acquire(temporal_client.0)
         .await
         .map_err(report_to_response)?
-        .has_permission_for_entity_types(AuthenticatedActor::from(actor), params)
+        .has_permission_for_entity_types(actor, params)
         .await
         .map(Json)
         .map_err(report_to_response)
@@ -497,7 +496,7 @@ where
     )
 )]
 async fn query_entity_types<S>(
-    AuthenticatedActorId(actor_id): AuthenticatedActorId,
+    actor_id: Option<AuthenticatedActorId>,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     Extension(api_config): Extension<ApiConfig>,
@@ -507,6 +506,7 @@ async fn query_entity_types<S>(
 where
     S: StorePool + Send + Sync,
 {
+    let actor_id = actor_id.map(|AuthenticatedActorId(actor_id)| actor_id);
     if let Some(query_logger) = &mut query_logger {
         query_logger.capture(actor_id, OpenApiQuery::GetEntityTypes(&request));
     }
@@ -660,7 +660,7 @@ where
     )
 )]
 async fn get_closed_multi_entity_types<S>(
-    AuthenticatedActorId(actor_id): AuthenticatedActorId,
+    actor_id: Option<AuthenticatedActorId>,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     mut query_logger: Option<Extension<QueryLogger>>,
@@ -669,6 +669,7 @@ async fn get_closed_multi_entity_types<S>(
 where
     S: StorePool + Send + Sync,
 {
+    let actor_id = actor_id.map(|AuthenticatedActorId(actor_id)| actor_id);
     if let Some(query_logger) = &mut query_logger {
         query_logger.capture(actor_id, OpenApiQuery::GetClosedMultiEntityTypes(&request));
     }
@@ -739,7 +740,7 @@ struct QueryEntityTypeSubgraphResponse {
     )
 )]
 async fn query_entity_type_subgraph<S>(
-    AuthenticatedActorId(actor_id): AuthenticatedActorId,
+    actor_id: Option<AuthenticatedActorId>,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     Extension(api_config): Extension<ApiConfig>,
@@ -749,6 +750,7 @@ async fn query_entity_type_subgraph<S>(
 where
     S: StorePool + Send + Sync,
 {
+    let actor_id = actor_id.map(|AuthenticatedActorId(actor_id)| actor_id);
     if let Some(query_logger) = &mut query_logger {
         query_logger.capture(actor_id, OpenApiQuery::GetEntityTypeSubgraph(&request));
     }

--- a/libs/@local/graph/api/src/rest/hashql/mod.rs
+++ b/libs/@local/graph/api/src/rest/hashql/mod.rs
@@ -38,7 +38,9 @@ use self::{
     error::{HashQlDiagnosticCategory, status_to_response},
     value::OwnedValue,
 };
-use crate::rest::{InteractiveHeader, JsonCompatHeader, json::Json, status::BoxedResponse};
+use crate::rest::{
+    AuthenticatedActorId, InteractiveHeader, JsonCompatHeader, json::Json, status::BoxedResponse,
+};
 
 /// Shared resources for HashQL query compilation and execution, created once at server startup.
 pub struct CompilerContext {
@@ -231,6 +233,7 @@ pub(crate) struct HashQlRequest {
     )
 )]
 pub(crate) async fn query_hashql(
+    AuthenticatedActorId(_actor_id): AuthenticatedActorId,
     Extension(compiler): Extension<Arc<CompilerContext>>,
     Extension(postgres): Extension<Arc<PostgresStorePool>>,
     Extension(temporal): Extension<Option<Arc<TemporalClient>>>,

--- a/libs/@local/graph/api/src/rest/mod.rs
+++ b/libs/@local/graph/api/src/rest/mod.rs
@@ -89,7 +89,7 @@ use type_system::{
             OntologyEditionProvenance, OntologyProvenance, ProvidedOntologyEditionProvenance,
         },
     },
-    principal::{actor::ActorEntityUuid, actor_group::WebId},
+    principal::{actor::ActorId, actor_group::WebId},
 };
 use utoipa::{
     Modify, OpenApi, ToSchema,
@@ -183,7 +183,7 @@ pub trait RestApiStore:
 {
     fn load_external_type(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         domain_validator: &DomainValidator,
         reference: OntologyTypeReference<'_>,
     ) -> impl Future<Output = Result<OntologyTypeMetadata, BoxedResponse>> + Send;
@@ -201,7 +201,7 @@ where
 {
     async fn load_external_type(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         domain_validator: &DomainValidator,
         reference: OntologyTypeReference<'_>,
     ) -> Result<OntologyTypeMetadata, BoxedResponse> {
@@ -280,13 +280,18 @@ impl QueryLogger {
     }
 
     #[expect(clippy::missing_panics_doc)]
-    pub fn capture(&mut self, actor: ActorEntityUuid, query: OpenApiQuery<'_>) {
+    pub fn capture(&mut self, actor: Option<ActorId>, query: OpenApiQuery<'_>) {
         let mut record = serde_json::to_value(query)
             .change_context(QueryLoggingError)
             .expect("query should be serializable");
-        record
-            .as_object_mut()
-            .map(|object| object.insert("actor".to_owned(), JsonValue::String(actor.to_string())));
+        record.as_object_mut().map(|object| {
+            object.insert(
+                "actor".to_owned(),
+                actor.map_or(JsonValue::Null, |actor| {
+                    JsonValue::String(actor.to_string())
+                }),
+            )
+        });
         self.value = Some(record);
         self.created_at = Instant::now();
     }
@@ -589,7 +594,12 @@ where
         .route_layer(axum::middleware::from_fn(move |request, next| {
             let provider = Arc::clone(&authentication_provider);
             let service_secret = Arc::clone(&service_secret);
-            auth::authentication_middleware(provider, service_secret, request, next)
+            auth::authentication_middleware::<_, Option<ActorId>>(
+                provider,
+                service_secret,
+                request,
+                next,
+            )
         }))
         .layer(
             ServiceBuilder::new()

--- a/libs/@local/graph/api/src/rest/permissions.rs
+++ b/libs/@local/graph/api/src/rest/permissions.rs
@@ -99,7 +99,7 @@ where
         .acquire(temporal_client.0)
         .await
         .map_err(report_to_response)?
-        .create_policy(authenticated_actor_id.into(), policy)
+        .create_policy(authenticated_actor_id, policy)
         .await
         .map_err(report_to_response)
         .map(Json)
@@ -133,7 +133,7 @@ where
         .acquire(temporal_client.0)
         .await
         .map_err(report_to_response)?
-        .get_policy_by_id(authenticated_actor_id.into(), policy_id)
+        .get_policy_by_id(authenticated_actor_id, policy_id)
         .await
         .map_err(report_to_response)
         .map(Json)
@@ -167,7 +167,7 @@ where
         .acquire(temporal_client.0)
         .await
         .map_err(report_to_response)?
-        .query_policies(authenticated_actor_id.into(), &filter)
+        .query_policies(authenticated_actor_id, &filter)
         .await
         .map_err(report_to_response)
         .map(Json)
@@ -237,7 +237,7 @@ where
         .acquire(temporal_client.0)
         .await
         .map_err(report_to_response)?
-        .update_policy_by_id(authenticated_actor_id.into(), policy_id, &operations)
+        .update_policy_by_id(authenticated_actor_id, policy_id, &operations)
         .await
         .map_err(report_to_response)
         .map(Json)
@@ -271,7 +271,7 @@ where
         .acquire(temporal_client.0)
         .await
         .map_err(report_to_response)?
-        .archive_policy_by_id(authenticated_actor_id.into(), policy_id)
+        .archive_policy_by_id(authenticated_actor_id, policy_id)
         .await
         .map_err(report_to_response)
         .map(|()| StatusCode::NO_CONTENT)
@@ -305,7 +305,7 @@ where
         .acquire(temporal_client.0)
         .await
         .map_err(report_to_response)?
-        .delete_policy_by_id(authenticated_actor_id.into(), policy_id)
+        .delete_policy_by_id(authenticated_actor_id, policy_id)
         .await
         .map_err(report_to_response)
         .map(|()| StatusCode::NO_CONTENT)

--- a/libs/@local/graph/api/src/rest/property_type.rs
+++ b/libs/@local/graph/api/src/rest/property_type.rs
@@ -8,7 +8,6 @@ use axum::{
     routing::{post, put},
 };
 use error_stack::{Report, ResultExt as _};
-use hash_graph_authorization::policies::principal::actor::AuthenticatedActor;
 use hash_graph_postgres_store::{
     ontology::patch_id_and_parse,
     store::error::{OntologyVersionDoesNotExist, VersionedUrlAlreadyExists},
@@ -330,7 +329,7 @@ where
     )
 )]
 async fn query_property_types<S>(
-    AuthenticatedActorId(actor_id): AuthenticatedActorId,
+    actor_id: Option<AuthenticatedActorId>,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     Extension(api_config): Extension<ApiConfig>,
@@ -340,6 +339,7 @@ async fn query_property_types<S>(
 where
     S: StorePool + Send + Sync,
 {
+    let actor_id = actor_id.map(|AuthenticatedActorId(actor_id)| actor_id);
     if let Some(query_logger) = &mut query_logger {
         query_logger.capture(actor_id, OpenApiQuery::GetPropertyTypes(&request));
     }
@@ -404,7 +404,7 @@ struct QueryPropertyTypeSubgraphResponse {
     )
 )]
 async fn query_property_type_subgraph<S>(
-    AuthenticatedActorId(actor_id): AuthenticatedActorId,
+    actor_id: Option<AuthenticatedActorId>,
     store_pool: Extension<Arc<S>>,
     temporal_client: Extension<Option<Arc<TemporalClient>>>,
     Extension(api_config): Extension<ApiConfig>,
@@ -414,6 +414,7 @@ async fn query_property_type_subgraph<S>(
 where
     S: StorePool + Send + Sync,
 {
+    let actor_id = actor_id.map(|AuthenticatedActorId(actor_id)| actor_id);
     if let Some(query_logger) = &mut query_logger {
         query_logger.capture(actor_id, OpenApiQuery::GetPropertyTypeSubgraph(&request));
     }
@@ -744,7 +745,7 @@ where
         .acquire(temporal_client.0)
         .await
         .map_err(report_to_response)?
-        .has_permission_for_property_types(AuthenticatedActor::from(actor), params)
+        .has_permission_for_property_types(actor, params)
         .await
         .map(Json)
         .map_err(report_to_response)

--- a/libs/@local/graph/api/src/rpc/account.rs
+++ b/libs/@local/graph/api/src/rpc/account.rs
@@ -196,9 +196,14 @@ where
         role_name: RoleName,
         account_id: ActorEntityUuid,
     ) -> Result<RoleAssignmentStatus, Report<AccountError>> {
-        self.store()
-            .await?
-            .assign_role(Self::actor(&scope)?, account_id, actor_group_id, role_name)
+        let mut store = self.store().await?;
+        // The session carries the actor as a bare UUID, so its type comes from the store.
+        let actor_id = store
+            .determine_actor(Self::actor(&scope)?)
+            .await
+            .change_context(AccountError)?;
+        store
+            .assign_role(actor_id, account_id, actor_group_id, role_name)
             .await
             .inspect_err(|error| {
                 tracing::error!(?error, "Could not assign role to account group");
@@ -213,9 +218,14 @@ where
         role_name: RoleName,
         account_id: ActorEntityUuid,
     ) -> Result<RoleUnassignmentStatus, Report<AccountError>> {
-        self.store()
-            .await?
-            .unassign_role(Self::actor(&scope)?, account_id, actor_group_id, role_name)
+        let mut store = self.store().await?;
+        // The session carries the actor as a bare UUID, so its type comes from the store.
+        let actor_id = store
+            .determine_actor(Self::actor(&scope)?)
+            .await
+            .change_context(AccountError)?;
+        store
+            .unassign_role(actor_id, account_id, actor_group_id, role_name)
             .await
             .inspect_err(|error| {
                 tracing::error!(?error, "Could not unassign role from account group");

--- a/libs/@local/graph/authentication/src/actor.rs
+++ b/libs/@local/graph/authentication/src/actor.rs
@@ -13,7 +13,7 @@ use crate::request::AuthenticationError;
 ///
 /// Indirection over [`PrincipalStore::determine_actor`].
 pub trait ResolveActor: Send + Sync {
-    /// Returns the [`ActorId`] for the given actor entity UUID, or `None` for the public actor.
+    /// Returns the [`ActorId`] for the given actor entity UUID.
     ///
     /// # Errors
     ///
@@ -25,7 +25,7 @@ pub trait ResolveActor: Send + Sync {
     fn resolve_actor(
         &self,
         actor_entity_uuid: ActorEntityUuid,
-    ) -> impl Future<Output = Result<Option<ActorId>, Report<DetermineActorError>>> + Send;
+    ) -> impl Future<Output = Result<ActorId, Report<DetermineActorError>>> + Send;
 }
 
 /// [`ResolveActor`] implementation backed by a [`StorePool`].
@@ -48,7 +48,7 @@ where
     async fn resolve_actor(
         &self,
         actor_entity_uuid: ActorEntityUuid,
-    ) -> Result<Option<ActorId>, Report<DetermineActorError>> {
+    ) -> Result<ActorId, Report<DetermineActorError>> {
         self.pool
             .acquire(None)
             .await
@@ -58,11 +58,40 @@ where
     }
 }
 
+/// Resolves the actor against the principal store.
+///
+/// # Errors
+///
+/// - [`ActorNotFound`] if the actor does not exist
+/// - [`StoreError`] if the underlying store returns an error
+///
+/// [`ActorNotFound`]: AuthenticationError::ActorNotFound
+/// [`StoreError`]: AuthenticationError::StoreError
+pub(crate) async fn resolve_actor<R>(
+    actor_resolver: &R,
+    actor_id: ActorEntityUuid,
+) -> Result<ActorId, Report<AuthenticationError>>
+where
+    R: ResolveActor,
+{
+    actor_resolver
+        .resolve_actor(actor_id)
+        .await
+        .map_err(|report| match report.current_context() {
+            DetermineActorError::ActorNotFound { .. } => {
+                report.change_context(AuthenticationError::ActorNotFound { actor_id })
+            }
+            DetermineActorError::StoreError => {
+                report.change_context(AuthenticationError::StoreError)
+            }
+        })
+}
+
 /// Resolves the actor against the principal store and requires it to be a user actor.
 ///
 /// # Errors
 ///
-/// - [`NotAUser`] if the actor is not a user, or is the public actor
+/// - [`NotAUser`] if the actor is not a user
 /// - [`ActorNotFound`] if the actor does not exist
 /// - [`StoreError`] if the underlying store returns an error
 ///
@@ -76,22 +105,16 @@ pub(crate) async fn resolve_user_actor<R>(
 where
     R: ResolveActor,
 {
-    match actor_resolver.resolve_actor(actor_id).await {
-        Ok(Some(ActorId::User(user_id))) => Ok(user_id),
-        Ok(Some(_) | None) => Err(Report::new(AuthenticationError::NotAUser { actor_id })),
-        Err(report) => match report.current_context() {
-            DetermineActorError::ActorNotFound { .. } => {
-                Err(report.change_context(AuthenticationError::ActorNotFound { actor_id }))
-            }
-            DetermineActorError::StoreError => {
-                Err(report.change_context(AuthenticationError::StoreError))
-            }
-        },
+    match resolve_actor(actor_resolver, actor_id).await? {
+        ActorId::User(user_id) => Ok(user_id),
+        ActorId::Machine(_) | ActorId::Ai(_) => {
+            Err(Report::new(AuthenticationError::NotAUser { actor_id }))
+        }
     }
 }
 
-#[cfg(test)]
-pub(crate) mod tests {
+#[cfg(any(test, feature = "test-utils"))]
+pub mod tests {
     use std::collections::HashMap;
 
     use error_stack::Report;
@@ -102,14 +125,13 @@ pub(crate) mod tests {
     use super::ResolveActor;
 
     /// Actor resolver serving a fixed set of actors.
-    ///
-    /// A `None` entry resolves to the public actor.
-    pub(crate) struct FixedActorResolver {
-        actors: HashMap<ActorEntityUuid, Option<ActorId>>,
+    pub struct FixedActorResolver {
+        actors: HashMap<ActorEntityUuid, ActorId>,
     }
 
     impl FixedActorResolver {
-        pub(crate) fn new(actors: HashMap<ActorEntityUuid, Option<ActorId>>) -> Self {
+        #[must_use]
+        pub const fn new(actors: HashMap<ActorEntityUuid, ActorId>) -> Self {
             Self { actors }
         }
     }
@@ -118,22 +140,21 @@ pub(crate) mod tests {
         fn resolve_actor(
             &self,
             actor_entity_uuid: ActorEntityUuid,
-        ) -> impl Future<Output = Result<Option<ActorId>, Report<DetermineActorError>>> + Send
-        {
+        ) -> impl Future<Output = Result<ActorId, Report<DetermineActorError>>> + Send {
             core::future::ready(self.actors.get(&actor_entity_uuid).copied().ok_or_else(|| {
                 Report::new(DetermineActorError::ActorNotFound { actor_entity_uuid })
             }))
         }
     }
 
-    pub(crate) fn random_actor() -> ActorEntityUuid {
+    #[must_use]
+    pub fn random_actor() -> ActorEntityUuid {
         ActorEntityUuid::new(Uuid::new_v4())
     }
 
     /// A resolver map holding the given actor as a user.
-    pub(crate) fn known_user(
-        actor_id: ActorEntityUuid,
-    ) -> HashMap<ActorEntityUuid, Option<ActorId>> {
-        HashMap::from([(actor_id, Some(ActorId::User(UserId::new(actor_id))))])
+    #[must_use]
+    pub fn known_user(actor_id: ActorEntityUuid) -> HashMap<ActorEntityUuid, ActorId> {
+        HashMap::from([(actor_id, ActorId::User(UserId::new(actor_id)))])
     }
 }

--- a/libs/@local/graph/authentication/src/cloudflare.rs
+++ b/libs/@local/graph/authentication/src/cloudflare.rs
@@ -3,13 +3,12 @@
 use core::ops::ControlFlow;
 
 use error_stack::Report;
-use hash_graph_authorization::policies::principal::actor::AuthenticatedActor;
 use http::HeaderMap;
 use type_system::principal::actor::{ActorId, UserId};
 
 use crate::{
     jwt::{JwtError, JwtValidator},
-    provider::AuthenticationProvider,
+    provider::{AuthenticationProvider, Caller},
     request::AuthenticationError,
 };
 
@@ -93,14 +92,15 @@ where
     }
 }
 
-impl<R> AuthenticationProvider for CloudflareAccessProvider<R>
+impl<C, R> AuthenticationProvider<C> for CloudflareAccessProvider<R>
 where
+    C: Caller,
     R: ResolveEmailActor,
 {
     async fn authenticate(
         &self,
         headers: &HeaderMap,
-    ) -> ControlFlow<Result<AuthenticatedActor, Report<AuthenticationError>>> {
+    ) -> ControlFlow<Result<C, Report<AuthenticationError>>> {
         let Some(token) = headers.get(ACCESS_JWT_HEADER) else {
             return ControlFlow::Continue(());
         };
@@ -112,7 +112,7 @@ where
         ControlFlow::Break(
             self.verify_token(token)
                 .await
-                .map(|user_id| AuthenticatedActor::Id(ActorId::User(user_id))),
+                .map(|user_id| C::from_actor(ActorId::User(user_id))),
         )
     }
 }
@@ -127,7 +127,6 @@ mod tests {
 
     use axum::{Json, Router, routing::get};
     use error_stack::Report;
-    use hash_graph_authorization::policies::principal::actor::AuthenticatedActor;
     use http::{HeaderMap, HeaderValue, StatusCode};
     use jsonwebtoken::{Algorithm, EncodingKey, Header};
     use reqwest::Url;
@@ -316,16 +315,15 @@ i3YB+IEvO6Qr8c5tSNv9NB0=
         let (actors, actor_id) = known_user(EMAIL);
         let provider = provider_for(actors).await;
 
-        let authentication = provider
+        let authentication: ControlFlow<Result<ActorId, _>> = provider
             .authenticate(&access_token_header(&mint_token(&valid_claims(EMAIL))))
             .await;
 
         assert!(
             matches!(
                 authentication,
-                ControlFlow::Break(Ok(AuthenticatedActor::Id(
-                    ActorId::User(user_id)
-                ))) if ActorEntityUuid::new(user_id) == actor_id
+                ControlFlow::Break(Ok(ActorId::User(user_id)))
+                    if ActorEntityUuid::new(user_id) == actor_id
             ),
             "a valid token should verify to the actor resolved from its email claim"
         );
@@ -335,11 +333,10 @@ i3YB+IEvO6Qr8c5tSNv9NB0=
     async fn request_without_access_token_carries_no_credential() {
         let provider = provider_for(HashMap::new()).await;
 
+        let decision: ControlFlow<Result<ActorId, _>> =
+            provider.authenticate(&HeaderMap::new()).await;
         assert!(
-            matches!(
-                provider.authenticate(&HeaderMap::new()).await,
-                ControlFlow::Continue(())
-            ),
+            matches!(decision, ControlFlow::Continue(())),
             "a request without an Access token should not be recognized"
         );
     }
@@ -355,7 +352,7 @@ i3YB+IEvO6Qr8c5tSNv9NB0=
                 .expect("the token should be a valid header value"),
         );
 
-        let report = expect_rejection(provider.authenticate(&headers).await);
+        let report = expect_rejection::<ActorId>(provider.authenticate(&headers).await);
         assert!(
             matches!(
                 report.current_context(),
@@ -388,7 +385,7 @@ i3YB+IEvO6Qr8c5tSNv9NB0=
         let mut claims = valid_claims(EMAIL);
         claims[claim] = value;
 
-        let report = expect_rejection(
+        let report = expect_rejection::<ActorId>(
             provider
                 .authenticate(&access_token_header(&mint_token(&claims)))
                 .await,
@@ -419,7 +416,8 @@ i3YB+IEvO6Qr8c5tSNv9NB0=
         )
         .expect("the token should encode");
 
-        let report = expect_rejection(provider.authenticate(&access_token_header(&token)).await);
+        let report =
+            expect_rejection::<ActorId>(provider.authenticate(&access_token_header(&token)).await);
         assert!(
             matches!(
                 report.current_context(),
@@ -444,7 +442,8 @@ i3YB+IEvO6Qr8c5tSNv9NB0=
             .expect("the token should contain a signature segment");
         let forged = format!("{target_message}.{victim_signature}");
 
-        let report = expect_rejection(provider.authenticate(&access_token_header(&forged)).await);
+        let report =
+            expect_rejection::<ActorId>(provider.authenticate(&access_token_header(&forged)).await);
         assert!(
             matches!(
                 report.current_context(),
@@ -474,7 +473,7 @@ i3YB+IEvO6Qr8c5tSNv9NB0=
             .expect("the claims should be a JSON object")
             .remove(claim);
 
-        let report = expect_rejection(
+        let report = expect_rejection::<ActorId>(
             provider
                 .authenticate(&access_token_header(&mint_token(&claims)))
                 .await,
@@ -504,11 +503,9 @@ i3YB+IEvO6Qr8c5tSNv9NB0=
                 .expect("the email should be a valid header value"),
         );
 
+        let decision: ControlFlow<Result<ActorId, _>> = provider.authenticate(&headers).await;
         assert!(
-            matches!(
-                provider.authenticate(&headers).await,
-                ControlFlow::Continue(())
-            ),
+            matches!(decision, ControlFlow::Continue(())),
             "the unsigned email header should not be recognized as a credential"
         );
     }
@@ -524,7 +521,7 @@ i3YB+IEvO6Qr8c5tSNv9NB0=
             .expect("the claims should be a JSON object")
             .remove("email");
 
-        let report = expect_rejection(
+        let report = expect_rejection::<ActorId>(
             provider
                 .authenticate(&access_token_header(&mint_token(&claims)))
                 .await,
@@ -542,7 +539,7 @@ i3YB+IEvO6Qr8c5tSNv9NB0=
     async fn token_with_unknown_email_fails_authentication() {
         let provider = provider_for(HashMap::new()).await;
 
-        let report = expect_rejection(
+        let report = expect_rejection::<ActorId>(
             provider
                 .authenticate(&access_token_header(&mint_token(&valid_claims(EMAIL))))
                 .await,
@@ -569,7 +566,8 @@ i3YB+IEvO6Qr8c5tSNv9NB0=
         header.kid = key_id.map(str::to_owned);
         let token = sign(&header, &valid_claims(EMAIL));
 
-        let report = expect_rejection(provider.authenticate(&access_token_header(&token)).await);
+        let report =
+            expect_rejection::<ActorId>(provider.authenticate(&access_token_header(&token)).await);
         assert!(
             matches!(
                 report.current_context(),
@@ -591,7 +589,7 @@ i3YB+IEvO6Qr8c5tSNv9NB0=
             },
         );
 
-        let report = expect_rejection(
+        let report = expect_rejection::<ActorId>(
             provider
                 .authenticate(&access_token_header(&mint_token(&valid_claims(EMAIL))))
                 .await,

--- a/libs/@local/graph/authentication/src/delegation.rs
+++ b/libs/@local/graph/authentication/src/delegation.rs
@@ -3,13 +3,15 @@
 use core::ops::ControlFlow;
 
 use error_stack::Report;
-use hash_graph_authorization::policies::principal::actor::AuthenticatedActor;
 use http::{HeaderMap, header};
 use subtle::ConstantTimeEq as _;
+use type_system::principal::actor::ActorId;
+use uuid::Uuid;
 
 use crate::{
-    provider::AuthenticationProvider,
-    request::{ACTOR_ID_HEADER, AuthenticationError, actor_id_from_header},
+    actor::{ResolveActor, resolve_actor},
+    provider::{AuthenticationProvider, Caller},
+    request::{AuthenticationError, actor_id_from_header},
 };
 
 /// The `Authorization` scheme carrying the service secret.
@@ -42,69 +44,115 @@ pub fn presents_service_secret(headers: &HeaderMap, secret: &str) -> bool {
 
 /// Authenticates internal services acting on behalf of an actor.
 ///
-/// Recognizes the pair of the service secret and the actor-ID header as one credential: the
-/// secret authenticates the calling service, and the named actor is taken as claimed without
-/// validation against the principal store. An actor-ID header without the secret is rejected,
-/// never ignored.
-pub struct ServiceDelegationProvider {
+/// Recognizes the service secret as its credential: the secret authenticates the calling service,
+/// and the actor-ID header names the actor the service acts for, resolved against the principal
+/// store to its typed [`ActorId`]. Within the flow the actor header is mandatory — a chain serving
+/// anonymous callers reads the nil UUID as acting for nobody, a chain requiring an actor rejects
+/// it.
+pub struct ServiceDelegationProvider<R> {
     secret: String,
+    actor_resolver: R,
 }
 
-impl ServiceDelegationProvider {
+impl<R> ServiceDelegationProvider<R> {
     #[must_use]
-    pub const fn new(secret: String) -> Self {
-        Self { secret }
+    pub const fn new(secret: String, actor_resolver: R) -> Self {
+        Self {
+            secret,
+            actor_resolver,
+        }
     }
 }
 
-impl AuthenticationProvider for ServiceDelegationProvider {
-    fn authenticate(
+impl<R> ServiceDelegationProvider<R>
+where
+    R: ResolveActor,
+{
+    /// Runs the delegation flow up to the actor the service acts for.
+    ///
+    /// `Ok(None)` means the actor header carried the nil UUID, its encoding for acting for
+    /// nobody. `Continue` means the request carries no service secret.
+    async fn delegated_actor(
         &self,
         headers: &HeaderMap,
-    ) -> impl Future<Output = ControlFlow<Result<AuthenticatedActor, Report<AuthenticationError>>>> + Send
-    {
-        let decision = if headers.get(ACTOR_ID_HEADER).is_none() {
-            // A secret without a named actor requests no delegation.
-            ControlFlow::Continue(())
-        } else if service_credential(headers).is_none() {
-            ControlFlow::Break(Err(Report::new(AuthenticationError::MissingServiceSecret)))
-        } else if !presents_service_secret(headers, &self.secret) {
-            ControlFlow::Break(Err(Report::new(AuthenticationError::InvalidServiceSecret)))
-        } else {
-            ControlFlow::Break(
-                actor_id_from_header(headers)
-                    .map(AuthenticatedActor::Uuid)
-                    .map_err(Report::new),
-            )
+    ) -> ControlFlow<Result<Option<ActorId>, Report<AuthenticationError>>> {
+        if service_credential(headers).is_none() {
+            return ControlFlow::Continue(());
+        }
+        if !presents_service_secret(headers, &self.secret) {
+            return ControlFlow::Break(Err(Report::new(AuthenticationError::InvalidServiceSecret)));
+        }
+
+        let actor_uuid = match actor_id_from_header(headers) {
+            Ok(actor_uuid) => actor_uuid,
+            Err(error) => return ControlFlow::Break(Err(Report::new(error))),
         };
 
-        core::future::ready(decision)
+        if Uuid::from(actor_uuid).is_nil() {
+            return ControlFlow::Break(Ok(None));
+        }
+
+        ControlFlow::Break(
+            resolve_actor(&self.actor_resolver, actor_uuid)
+                .await
+                .map(Some),
+        )
+    }
+}
+
+impl<C, R> AuthenticationProvider<C> for ServiceDelegationProvider<R>
+where
+    C: Caller,
+    R: ResolveActor,
+{
+    async fn authenticate(
+        &self,
+        headers: &HeaderMap,
+    ) -> ControlFlow<Result<C, Report<AuthenticationError>>> {
+        match self.delegated_actor(headers).await {
+            ControlFlow::Continue(()) => ControlFlow::Continue(()),
+            ControlFlow::Break(Ok(Some(actor_id))) => {
+                ControlFlow::Break(Ok(C::from_actor(actor_id)))
+            }
+            // The nil UUID names no actor, so the request resolves as an anonymous one does. A
+            // chain requiring an actor is missing the delegated actor, not the credential.
+            ControlFlow::Break(Ok(None)) => ControlFlow::Break(
+                C::anonymous()
+                    .map_err(|_error| Report::new(AuthenticationError::MissingDelegatedActor)),
+            ),
+            ControlFlow::Break(Err(report)) => ControlFlow::Break(Err(report)),
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use core::ops::ControlFlow;
+    use std::collections::HashMap;
 
-    use hash_graph_authorization::policies::principal::actor::AuthenticatedActor;
+    use error_stack::Report;
     use http::HeaderMap;
-    use type_system::principal::actor::ActorEntityUuid;
+    use type_system::principal::actor::{ActorEntityUuid, ActorId};
     use uuid::Uuid;
 
     use super::{SERVICE_AUTH_SCHEME, ServiceDelegationProvider};
     use crate::{
-        provider::{AuthenticationProvider as _, tests::expect_rejection},
+        actor::tests::{FixedActorResolver, known_user, random_actor},
+        provider::{AuthenticationProvider as _, Caller, tests::expect_rejection},
         request::{ACTOR_ID_HEADER, AuthenticationError},
     };
 
     const SERVICE_SECRET: &str = "hash-svc-test-secret";
 
-    fn provider() -> ServiceDelegationProvider {
-        ServiceDelegationProvider::new(SERVICE_SECRET.to_owned())
+    fn provider_for(
+        actors: HashMap<ActorEntityUuid, ActorId>,
+    ) -> ServiceDelegationProvider<FixedActorResolver> {
+        ServiceDelegationProvider::new(SERVICE_SECRET.to_owned(), FixedActorResolver::new(actors))
     }
 
-    fn random_actor() -> ActorEntityUuid {
-        ActorEntityUuid::new(Uuid::new_v4())
+    /// A provider whose store knows no actor.
+    fn provider() -> ServiceDelegationProvider<FixedActorResolver> {
+        provider_for(HashMap::new())
     }
 
     fn headers(secret: Option<&str>, actor_id: Option<ActorEntityUuid>) -> HeaderMap {
@@ -129,19 +177,29 @@ mod tests {
         headers
     }
 
+    /// Pins the caller type `C` the provider authenticates as.
+    async fn authenticate<C: Caller>(
+        provider: &ServiceDelegationProvider<FixedActorResolver>,
+        headers: &HeaderMap,
+    ) -> ControlFlow<Result<C, Report<AuthenticationError>>> {
+        provider.authenticate(headers).await
+    }
+
     #[tokio::test]
     async fn secret_and_actor_header_delegate_to_named_actor() {
         let actor_id = random_actor();
 
-        let decision = provider()
-            .authenticate(&headers(Some(SERVICE_SECRET), Some(actor_id)))
-            .await;
+        let decision = authenticate::<ActorId>(
+            &provider_for(known_user(actor_id)),
+            &headers(Some(SERVICE_SECRET), Some(actor_id)),
+        )
+        .await;
 
         assert!(
             matches!(
                 decision,
-                ControlFlow::Break(Ok(AuthenticatedActor::Uuid(resolved)))
-                    if resolved == actor_id
+                ControlFlow::Break(Ok(ActorId::User(user_id)))
+                    if ActorEntityUuid::new(user_id) == actor_id
             ),
             "the service secret with an actor-ID header should delegate to the named actor"
         );
@@ -158,12 +216,9 @@ mod tests {
                 .expect("the credential should be a valid header value"),
         );
 
-        let report = expect_rejection(provider().authenticate(&request_headers).await);
+        let decision = authenticate::<ActorId>(&provider(), &request_headers).await;
         assert!(
-            matches!(
-                report.current_context(),
-                AuthenticationError::MissingServiceSecret
-            ),
+            matches!(decision, ControlFlow::Continue(())),
             "a credential of another scheme should not be read as the service secret"
         );
     }
@@ -179,24 +234,44 @@ mod tests {
                 .expect("the credential should be a valid header value"),
         );
 
-        let decision = provider().authenticate(&request_headers).await;
+        let decision =
+            authenticate::<ActorId>(&provider_for(known_user(actor_id)), &request_headers).await;
         assert!(
             matches!(
                 decision,
-                ControlFlow::Break(Ok(AuthenticatedActor::Uuid(resolved)))
-                    if resolved == actor_id
+                ControlFlow::Break(Ok(ActorId::User(user_id)))
+                    if ActorEntityUuid::new(user_id) == actor_id
             ),
             "the authorization scheme should match case-insensitively"
         );
     }
 
     #[tokio::test]
-    async fn empty_secret_never_authenticates() {
-        let provider = ServiceDelegationProvider::new(String::new());
+    async fn delegation_to_an_unknown_actor_fails_authentication() {
+        let report = expect_rejection(
+            authenticate::<ActorId>(
+                &provider(),
+                &headers(Some(SERVICE_SECRET), Some(random_actor())),
+            )
+            .await,
+        );
+        assert!(
+            matches!(
+                report.current_context(),
+                AuthenticationError::ActorNotFound { .. }
+            ),
+            "a delegated actor that does not exist should be rejected, got {:?}",
+            report.current_context()
+        );
+    }
 
-        let decision = provider
-            .authenticate(&headers(Some(""), Some(random_actor())))
-            .await;
+    #[tokio::test]
+    async fn empty_secret_never_authenticates() {
+        let provider =
+            ServiceDelegationProvider::new(String::new(), FixedActorResolver::new(HashMap::new()));
+
+        let decision =
+            authenticate::<ActorId>(&provider, &headers(Some(""), Some(random_actor()))).await;
 
         assert!(
             matches!(decision, ControlFlow::Break(Err(_))),
@@ -207,9 +282,11 @@ mod tests {
     #[tokio::test]
     async fn wrong_secret_fails_authentication() {
         let report = expect_rejection(
-            provider()
-                .authenticate(&headers(Some("hash-svc-wrong"), Some(random_actor())))
-                .await,
+            authenticate::<ActorId>(
+                &provider(),
+                &headers(Some("hash-svc-wrong"), Some(random_actor())),
+            )
+            .await,
         );
         assert!(
             matches!(
@@ -221,41 +298,93 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn actor_header_without_secret_fails_authentication() {
-        let report = expect_rejection(
-            provider()
-                .authenticate(&headers(None, Some(random_actor())))
-                .await,
-        );
+    async fn actor_header_without_secret_carries_no_credential() {
+        let decision =
+            authenticate::<ActorId>(&provider(), &headers(None, Some(random_actor()))).await;
         assert!(
-            matches!(
-                report.current_context(),
-                AuthenticationError::MissingServiceSecret
-            ),
-            "an actor-ID header without the service secret should be rejected, never honored"
+            matches!(decision, ControlFlow::Continue(())),
+            "an actor-ID header without the service secret should not be recognized"
         );
     }
 
     #[tokio::test]
-    async fn secret_without_actor_header_carries_no_credential() {
+    async fn secret_without_actor_header_fails_authentication() {
+        let report = expect_rejection(
+            authenticate::<ActorId>(&provider(), &headers(Some(SERVICE_SECRET), None)).await,
+        );
         assert!(
             matches!(
-                provider()
-                    .authenticate(&headers(Some(SERVICE_SECRET), None))
-                    .await,
-                ControlFlow::Continue(())
+                report.current_context(),
+                AuthenticationError::MissingDelegatedActor
             ),
-            "the service secret without an actor-ID header should not be recognized"
+            "the service secret should require the actor-ID header"
+        );
+    }
+
+    #[tokio::test]
+    async fn delegation_to_an_unknown_actor_fails_where_anonymity_is_allowed() {
+        let report = expect_rejection(
+            authenticate::<Option<ActorId>>(
+                &provider(),
+                &headers(Some(SERVICE_SECRET), Some(random_actor())),
+            )
+            .await,
+        );
+        assert!(
+            matches!(
+                report.current_context(),
+                AuthenticationError::ActorNotFound { .. }
+            ),
+            "an unknown delegated actor should never degrade to the public actor, got {:?}",
+            report.current_context()
+        );
+    }
+
+    #[tokio::test]
+    async fn nil_actor_header_resolves_to_no_actor() {
+        // The resolver knows no actor, so resolving the nil UUID would fail — reaching `None`
+        // proves it is read as "acting for nobody" instead.
+        let decision = authenticate::<Option<ActorId>>(
+            &provider(),
+            &headers(
+                Some(SERVICE_SECRET),
+                Some(ActorEntityUuid::new(Uuid::nil())),
+            ),
+        )
+        .await;
+
+        assert!(
+            matches!(decision, ControlFlow::Break(Ok(None))),
+            "the nil actor header should resolve to no actor, got {decision:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn nil_actor_header_fails_where_an_actor_is_required() {
+        let report = expect_rejection(
+            authenticate::<ActorId>(
+                &provider(),
+                &headers(
+                    Some(SERVICE_SECRET),
+                    Some(ActorEntityUuid::new(Uuid::nil())),
+                ),
+            )
+            .await,
+        );
+        assert!(
+            matches!(
+                report.current_context(),
+                AuthenticationError::MissingDelegatedActor
+            ),
+            "the nil actor header should be rejected where an actor is required"
         );
     }
 
     #[tokio::test]
     async fn requests_without_credentials_carry_no_credential() {
+        let decision = authenticate::<ActorId>(&provider(), &HeaderMap::new()).await;
         assert!(
-            matches!(
-                provider().authenticate(&HeaderMap::new()).await,
-                ControlFlow::Continue(())
-            ),
+            matches!(decision, ControlFlow::Continue(())),
             "a request without either header should not be recognized"
         );
     }
@@ -268,7 +397,7 @@ mod tests {
             "not-a-uuid".parse().expect("the header value should parse"),
         );
 
-        let report = expect_rejection(provider().authenticate(&request_headers).await);
+        let report = expect_rejection(authenticate::<ActorId>(&provider(), &request_headers).await);
         assert!(
             matches!(
                 report.current_context(),

--- a/libs/@local/graph/authentication/src/kratos/identity.rs
+++ b/libs/@local/graph/authentication/src/kratos/identity.rs
@@ -163,7 +163,7 @@ mod tests {
 
     fn resolver_at(
         url: Url,
-        actors: HashMap<ActorEntityUuid, Option<ActorId>>,
+        actors: HashMap<ActorEntityUuid, ActorId>,
     ) -> KratosEmailActorResolver<FixedActorResolver> {
         KratosEmailActorResolver::new(
             KratosAdminConfig {
@@ -182,7 +182,7 @@ mod tests {
     /// query.
     async fn resolver_for(
         identities: JsonValue,
-        actors: HashMap<ActorEntityUuid, Option<ActorId>>,
+        actors: HashMap<ActorEntityUuid, ActorId>,
     ) -> KratosEmailActorResolver<FixedActorResolver> {
         let router = Router::new().route(
             "/admin/identities",
@@ -355,13 +355,13 @@ mod tests {
     )]
     #[case::machine_actor(
         json!([identity_json(Some(case_actor()), json!([verified_address(EMAIL)]))]),
-        HashMap::from([(case_actor(), Some(ActorId::Machine(MachineId::new(case_actor()))))]),
+        HashMap::from([(case_actor(), ActorId::Machine(MachineId::new(case_actor())))]),
         |error: &AuthenticationError| matches!(error, AuthenticationError::NotAUser { .. })
     )]
     #[tokio::test]
     async fn unresolvable_email_fails_resolution(
         #[case] identities: JsonValue,
-        #[case] actors: HashMap<ActorEntityUuid, Option<ActorId>>,
+        #[case] actors: HashMap<ActorEntityUuid, ActorId>,
         #[case] expected: fn(&AuthenticationError) -> bool,
     ) {
         let resolver = resolver_for(identities, actors).await;

--- a/libs/@local/graph/authentication/src/kratos/session.rs
+++ b/libs/@local/graph/authentication/src/kratos/session.rs
@@ -4,7 +4,6 @@ use core::{ops::ControlFlow, time::Duration};
 
 use cookie::Cookie;
 use error_stack::{Report, ResultExt as _};
-use hash_graph_authorization::policies::principal::actor::AuthenticatedActor;
 use http::{HeaderMap, header};
 use reqwest::{Client, Url, redirect};
 use serde::Deserialize;
@@ -13,7 +12,7 @@ use type_system::principal::actor::{ActorEntityUuid, ActorId};
 use super::{MetadataPublic, provider_response, read_response_body};
 use crate::{
     actor::{ResolveActor, resolve_user_actor},
-    provider::AuthenticationProvider,
+    provider::{AuthenticationProvider, Caller},
     request::AuthenticationError,
 };
 
@@ -197,15 +196,16 @@ where
     }
 }
 
-impl<R> AuthenticationProvider for KratosSessionProvider<R>
+impl<C, R> AuthenticationProvider<C> for KratosSessionProvider<R>
 where
+    C: Caller,
     R: ResolveActor,
 {
     #[tracing::instrument(level = "debug", skip_all, fields(whoami_url = %self.whoami_url))]
     async fn authenticate(
         &self,
         headers: &HeaderMap,
-    ) -> ControlFlow<Result<AuthenticatedActor, Report<AuthenticationError>>> {
+    ) -> ControlFlow<Result<C, Report<AuthenticationError>>> {
         let credential = match extract_session_credential(headers) {
             None => return ControlFlow::Continue(()),
             Some(Err(report)) => return ControlFlow::Break(Err(report)),
@@ -220,7 +220,7 @@ where
         ControlFlow::Break(
             resolution
                 .await
-                .map(|user_id| AuthenticatedActor::Id(ActorId::User(user_id))),
+                .map(|user_id| C::from_actor(ActorId::User(user_id))),
         )
     }
 }
@@ -231,7 +231,6 @@ mod tests {
     use std::collections::HashMap;
 
     use axum::{Json, Router, response::IntoResponse as _, routing::get};
-    use hash_graph_authorization::policies::principal::actor::AuthenticatedActor;
     use http::{HeaderMap, HeaderValue, StatusCode};
     use reqwest::Url;
     use rstest::rstest;
@@ -305,7 +304,7 @@ mod tests {
 
     fn provider_at(
         url: Url,
-        actors: HashMap<ActorEntityUuid, Option<ActorId>>,
+        actors: HashMap<ActorEntityUuid, ActorId>,
     ) -> KratosSessionProvider<FixedActorResolver> {
         KratosSessionProvider::new(
             KratosSessionConfig {
@@ -322,7 +321,7 @@ mod tests {
     /// session cookie, so any test that reaches verification also verifies credential forwarding.
     async fn provider_for(
         session: FakeSession,
-        actors: HashMap<ActorEntityUuid, Option<ActorId>>,
+        actors: HashMap<ActorEntityUuid, ActorId>,
     ) -> KratosSessionProvider<FixedActorResolver> {
         let whoami = session.into_whoami_json();
         let router = Router::new().route(
@@ -366,14 +365,14 @@ mod tests {
         let actor_id = random_actor();
         let provider = provider_for(FakeSession::active_for(actor_id), known_user(actor_id)).await;
 
-        let authentication = provider.authenticate(&session_token_header()).await;
+        let authentication: ControlFlow<Result<ActorId, _>> =
+            provider.authenticate(&session_token_header()).await;
 
         assert!(
             matches!(
                 authentication,
-                ControlFlow::Break(Ok(AuthenticatedActor::Id(
-                    ActorId::User(user_id)
-                ))) if ActorEntityUuid::new(user_id) == actor_id
+                ControlFlow::Break(Ok(ActorId::User(user_id)))
+                if ActorEntityUuid::new(user_id) == actor_id
             ),
             "a valid session should verify to the provisioned user actor"
         );
@@ -395,13 +394,10 @@ mod tests {
             .expect("the cookie should be a valid header value"),
         );
 
-        let authentication = provider.authenticate(&headers).await;
+        let authentication: ControlFlow<Result<ActorId, _>> = provider.authenticate(&headers).await;
 
         assert!(
-            matches!(
-                authentication,
-                ControlFlow::Break(Ok(AuthenticatedActor::Id(ActorId::User(_))))
-            ),
+            matches!(authentication, ControlFlow::Break(Ok(ActorId::User(_)))),
             "a session cookie next to non-ASCII cookies should verify"
         );
     }
@@ -417,7 +413,7 @@ mod tests {
                 .expect("the token should be a valid header value"),
         );
 
-        let report = expect_rejection(provider.authenticate(&headers).await);
+        let report = expect_rejection::<ActorId>(provider.authenticate(&headers).await);
         assert!(
             matches!(
                 report.current_context(),
@@ -451,12 +447,7 @@ mod tests {
     )]
     #[case::machine_actor(
         FakeSession::active_for(case_actor()),
-        HashMap::from([(case_actor(), Some(ActorId::Machine(MachineId::new(case_actor()))))]),
-        |error: &AuthenticationError| matches!(error, AuthenticationError::NotAUser { .. })
-    )]
-    #[case::public_actor(
-        FakeSession::active_for(case_actor()),
-        HashMap::from([(case_actor(), None)]),
+        HashMap::from([(case_actor(), ActorId::Machine(MachineId::new(case_actor())))]),
         |error: &AuthenticationError| matches!(error, AuthenticationError::NotAUser { .. })
     )]
     #[case::inactive_session(
@@ -472,12 +463,13 @@ mod tests {
     #[tokio::test]
     async fn invalid_session_fails_authentication(
         #[case] session: FakeSession,
-        #[case] actors: HashMap<ActorEntityUuid, Option<ActorId>>,
+        #[case] actors: HashMap<ActorEntityUuid, ActorId>,
         #[case] expected: fn(&AuthenticationError) -> bool,
     ) {
         let provider = provider_for(session, actors).await;
 
-        let report = expect_rejection(provider.authenticate(&session_token_header()).await);
+        let report =
+            expect_rejection::<ActorId>(provider.authenticate(&session_token_header()).await);
         assert!(
             expected(report.current_context()),
             "the session should fail authentication, got {:?}",
@@ -497,11 +489,9 @@ mod tests {
                 .expect("the cookie should be a valid header value"),
         );
 
+        let decision: ControlFlow<Result<ActorId, _>> = provider.authenticate(&headers).await;
         assert!(
-            matches!(
-                provider.authenticate(&headers).await,
-                ControlFlow::Continue(())
-            ),
+            matches!(decision, ControlFlow::Continue(())),
             "unrelated cookies should not be recognized as a session credential"
         );
     }
@@ -510,11 +500,10 @@ mod tests {
     async fn requests_without_credentials_carry_no_session_credential() {
         let provider = provider_for(FakeSession::unprovisioned(), HashMap::new()).await;
 
+        let decision: ControlFlow<Result<ActorId, _>> =
+            provider.authenticate(&HeaderMap::new()).await;
         assert!(
-            matches!(
-                provider.authenticate(&HeaderMap::new()).await,
-                ControlFlow::Continue(())
-            ),
+            matches!(decision, ControlFlow::Continue(())),
             "a request without session credentials should not be recognized"
         );
     }
@@ -536,7 +525,8 @@ mod tests {
     async fn forbidden_session_fails_authentication() {
         let provider = provider_with_static_response(StatusCode::FORBIDDEN, "{}").await;
 
-        let report = expect_rejection(provider.authenticate(&session_token_header()).await);
+        let report =
+            expect_rejection::<ActorId>(provider.authenticate(&session_token_header()).await);
         assert!(
             matches!(
                 report.current_context(),
@@ -550,7 +540,8 @@ mod tests {
     async fn redirecting_provider_fails_verification() {
         let provider = provider_with_static_response(StatusCode::FOUND, "").await;
 
-        let report = expect_rejection(provider.authenticate(&session_token_header()).await);
+        let report =
+            expect_rejection::<ActorId>(provider.authenticate(&session_token_header()).await);
         assert!(
             matches!(
                 report.current_context(),
@@ -568,7 +559,8 @@ mod tests {
     async fn rate_limited_provider_fails_verification() {
         let provider = provider_with_static_response(StatusCode::TOO_MANY_REQUESTS, "{}").await;
 
-        let report = expect_rejection(provider.authenticate(&session_token_header()).await);
+        let report =
+            expect_rejection::<ActorId>(provider.authenticate(&session_token_header()).await);
         assert!(
             matches!(
                 report.current_context(),
@@ -597,7 +589,8 @@ mod tests {
             FixedActorResolver::new(HashMap::new()),
         );
 
-        let report = expect_rejection(provider.authenticate(&session_token_header()).await);
+        let report =
+            expect_rejection::<ActorId>(provider.authenticate(&session_token_header()).await);
         assert!(
             matches!(
                 report.current_context(),
@@ -612,7 +605,8 @@ mod tests {
         let provider =
             provider_with_static_response(StatusCode::OK, r#"{"identity-like": "body"}"#).await;
 
-        let report = expect_rejection(provider.authenticate(&session_token_header()).await);
+        let report =
+            expect_rejection::<ActorId>(provider.authenticate(&session_token_header()).await);
         assert!(
             matches!(
                 report.current_context(),
@@ -649,12 +643,16 @@ mod tests {
     async fn chain_rejects_invalid_session_despite_delegation_pair() {
         let chain = (
             provider_with_static_response(StatusCode::UNAUTHORIZED, "{}").await,
-            ServiceDelegationProvider::new(CHAIN_SERVICE_SECRET.to_owned()),
+            ServiceDelegationProvider::new(
+                CHAIN_SERVICE_SECRET.to_owned(),
+                FixedActorResolver::new(HashMap::new()),
+            ),
         );
 
         let headers = with_delegation_pair(session_token_header(), random_actor());
 
-        let report = expect_rejection(chain.authenticate(&headers).await);
+        let report = expect_rejection::<ActorId>(chain.authenticate(&headers).await);
+
         assert!(
             matches!(
                 report.current_context(),
@@ -673,18 +671,20 @@ mod tests {
                 known_user(session_actor),
             )
             .await,
-            ServiceDelegationProvider::new(CHAIN_SERVICE_SECRET.to_owned()),
+            ServiceDelegationProvider::new(
+                CHAIN_SERVICE_SECRET.to_owned(),
+                FixedActorResolver::new(HashMap::new()),
+            ),
         );
 
         let headers = with_delegation_pair(session_token_header(), random_actor());
 
-        let decision = chain.authenticate(&headers).await;
+        let decision: ControlFlow<Result<ActorId, _>> = chain.authenticate(&headers).await;
         assert!(
             matches!(
                 decision,
-                ControlFlow::Break(Ok(AuthenticatedActor::Id(
-                    ActorId::User(user_id)
-                ))) if ActorEntityUuid::new(user_id) == session_actor
+                ControlFlow::Break(Ok(ActorId::User(user_id)))
+                    if ActorEntityUuid::new(user_id) == session_actor
             ),
             "a valid session should act as the session user, not the delegated actor"
         );

--- a/libs/@local/graph/authentication/src/provider.rs
+++ b/libs/@local/graph/authentication/src/provider.rs
@@ -3,35 +3,97 @@
 use core::ops::ControlFlow;
 
 use error_stack::Report;
-use hash_graph_authorization::policies::principal::actor::AuthenticatedActor;
 use http::HeaderMap;
+use type_system::principal::actor::ActorId;
 
 use crate::request::AuthenticationError;
+
+mod sealed {
+    use type_system::principal::actor::ActorId;
+
+    pub trait Sealed {}
+
+    impl Sealed for ActorId {}
+    impl Sealed for Option<ActorId> {}
+}
+
+/// The principal a provider chain resolves a request to.
+///
+/// Exactly two caller types exist: [`ActorId`] for chains that require an actor, and
+/// `Option<ActorId>` for chains that also serve anonymous callers. What a request without a
+/// recognized credential resolves to follows from [`anonymous`].
+///
+/// [`anonymous`]: Self::anonymous
+pub trait Caller: Send + Sized + sealed::Sealed {
+    /// Returns the caller for an actor a credential verified to.
+    fn from_actor(actor: ActorId) -> Self;
+
+    /// Returns the caller for a request that names no actor.
+    ///
+    /// # Errors
+    ///
+    /// - [`MissingCredentials`] if the caller type requires an actor
+    ///
+    /// [`MissingCredentials`]: AuthenticationError::MissingCredentials
+    fn anonymous() -> Result<Self, AuthenticationError>;
+
+    /// Returns the actor, or [`None`] for an anonymous caller.
+    fn into_actor(self) -> Option<ActorId>;
+}
+
+impl Caller for ActorId {
+    fn from_actor(actor: ActorId) -> Self {
+        actor
+    }
+
+    fn anonymous() -> Result<Self, AuthenticationError> {
+        Err(AuthenticationError::MissingCredentials)
+    }
+
+    fn into_actor(self) -> Option<ActorId> {
+        Some(self)
+    }
+}
+
+impl Caller for Option<ActorId> {
+    fn from_actor(actor: ActorId) -> Self {
+        Some(actor)
+    }
+
+    fn anonymous() -> Result<Self, AuthenticationError> {
+        Ok(None)
+    }
+
+    fn into_actor(self) -> Option<ActorId> {
+        self
+    }
+}
 
 /// Authenticates requests against a credential verifier.
 ///
 /// A provider owns both the recognition of its credentials in the request headers and their
 /// verification. `Continue(())` means the request carries no credential this provider handles
-/// and the chain moves on. Breaking with `Ok` carries the actor the credential verified to, with
+/// and the chain moves on. Breaking with `Ok` carries the caller the credential verified to, with
 /// `Err` the reason it did not — either way the chain stops, so a rejected credential never falls
 /// through to another provider.
-pub trait AuthenticationProvider: Send + Sync {
+pub trait AuthenticationProvider<C: Caller>: Send + Sync {
     /// Resolves the credential of a request.
     fn authenticate(
         &self,
         headers: &HeaderMap,
-    ) -> impl Future<Output = ControlFlow<Result<AuthenticatedActor, Report<AuthenticationError>>>> + Send;
+    ) -> impl Future<Output = ControlFlow<Result<C, Report<AuthenticationError>>>> + Send;
 }
 
 /// An absent provider recognizes no credential, so the chain moves on.
-impl<P> AuthenticationProvider for Option<P>
+impl<C, P> AuthenticationProvider<C> for Option<P>
 where
-    P: AuthenticationProvider,
+    C: Caller,
+    P: AuthenticationProvider<C>,
 {
     async fn authenticate(
         &self,
         headers: &HeaderMap,
-    ) -> ControlFlow<Result<AuthenticatedActor, Report<AuthenticationError>>> {
+    ) -> ControlFlow<Result<C, Report<AuthenticationError>>> {
         match self {
             Some(provider) => provider.authenticate(headers).await,
             None => ControlFlow::Continue(()),
@@ -40,15 +102,16 @@ where
 }
 
 /// Chains two providers: the second is consulted only when the first recognizes no credential.
-impl<A, B> AuthenticationProvider for (A, B)
+impl<C, A, B> AuthenticationProvider<C> for (A, B)
 where
-    A: AuthenticationProvider,
-    B: AuthenticationProvider,
+    C: Caller,
+    A: AuthenticationProvider<C>,
+    B: AuthenticationProvider<C>,
 {
     async fn authenticate(
         &self,
         headers: &HeaderMap,
-    ) -> ControlFlow<Result<AuthenticatedActor, Report<AuthenticationError>>> {
+    ) -> ControlFlow<Result<C, Report<AuthenticationError>>> {
         self.0.authenticate(headers).await?;
         self.1.authenticate(headers).await
     }
@@ -60,21 +123,23 @@ pub enum StaticAuthenticationProvider {
     /// Recognizes no credentials.
     NotRecognized,
     /// Verifies every request to this actor.
-    Verified(AuthenticatedActor),
+    Verified(ActorId),
     /// Rejects every request.
     Rejected,
 }
 
 #[cfg(any(test, feature = "test-utils"))]
-impl AuthenticationProvider for StaticAuthenticationProvider {
+impl<C> AuthenticationProvider<C> for StaticAuthenticationProvider
+where
+    C: Caller,
+{
     fn authenticate(
         &self,
         _headers: &HeaderMap,
-    ) -> impl Future<Output = ControlFlow<Result<AuthenticatedActor, Report<AuthenticationError>>>> + Send
-    {
+    ) -> impl Future<Output = ControlFlow<Result<C, Report<AuthenticationError>>>> + Send {
         core::future::ready(match self {
             Self::NotRecognized => ControlFlow::Continue(()),
-            Self::Verified(actor) => ControlFlow::Break(Ok(*actor)),
+            Self::Verified(actor) => ControlFlow::Break(Ok(C::from_actor(*actor))),
             Self::Rejected => {
                 ControlFlow::Break(Err(Report::new(AuthenticationError::InvalidSession)))
             }
@@ -87,18 +152,17 @@ pub(crate) mod tests {
     use core::ops::ControlFlow;
 
     use error_stack::Report;
-    use hash_graph_authorization::policies::principal::actor::AuthenticatedActor;
     use http::HeaderMap;
     use type_system::principal::actor::{ActorEntityUuid, ActorId, UserId};
     use uuid::Uuid;
 
-    use super::{AuthenticationProvider as _, StaticAuthenticationProvider};
+    use super::{AuthenticationProvider as _, Caller, StaticAuthenticationProvider};
     use crate::request::AuthenticationError;
 
     /// Returns the report of a rejected decision, panicking on any other outcome.
     #[track_caller]
-    pub(crate) fn expect_rejection(
-        authentication: ControlFlow<Result<AuthenticatedActor, Report<AuthenticationError>>>,
+    pub(crate) fn expect_rejection<C: core::fmt::Debug>(
+        authentication: ControlFlow<Result<C, Report<AuthenticationError>>>,
     ) -> Report<AuthenticationError> {
         match authentication {
             ControlFlow::Break(Err(report)) => report,
@@ -108,10 +172,27 @@ pub(crate) mod tests {
         }
     }
 
-    fn random_user() -> AuthenticatedActor {
-        AuthenticatedActor::Id(ActorId::User(UserId::new(ActorEntityUuid::new(
-            Uuid::new_v4(),
-        ))))
+    fn random_user() -> ActorId {
+        ActorId::User(UserId::new(ActorEntityUuid::new(Uuid::new_v4())))
+    }
+
+    #[test]
+    fn anonymous_caller_names_no_actor_where_one_is_optional() {
+        assert!(
+            matches!(<Option<ActorId>>::anonymous(), Ok(None)),
+            "an optional caller should resolve anonymity to no actor"
+        );
+    }
+
+    #[test]
+    fn anonymous_caller_fails_where_an_actor_is_required() {
+        assert!(
+            matches!(
+                <ActorId as Caller>::anonymous(),
+                Err(AuthenticationError::MissingCredentials)
+            ),
+            "a required caller should reject anonymity"
+        );
     }
 
     #[tokio::test]
@@ -122,11 +203,9 @@ pub(crate) mod tests {
             StaticAuthenticationProvider::Verified(actor),
         );
 
+        let decision: ControlFlow<Result<ActorId, _>> = chain.authenticate(&HeaderMap::new()).await;
         assert!(
-            matches!(
-                chain.authenticate(&HeaderMap::new()).await,
-                ControlFlow::Break(Ok(resolved)) if resolved == actor
-            ),
+            matches!(decision, ControlFlow::Break(Ok(resolved)) if resolved == actor),
             "the chain should fall through to the second provider"
         );
     }
@@ -139,11 +218,9 @@ pub(crate) mod tests {
             StaticAuthenticationProvider::Rejected,
         );
 
+        let decision: ControlFlow<Result<ActorId, _>> = chain.authenticate(&HeaderMap::new()).await;
         assert!(
-            matches!(
-                chain.authenticate(&HeaderMap::new()).await,
-                ControlFlow::Break(Ok(resolved)) if resolved == actor
-            ),
+            matches!(decision, ControlFlow::Break(Ok(resolved)) if resolved == actor),
             "the chain should stop at the first verified credential"
         );
     }
@@ -155,11 +232,9 @@ pub(crate) mod tests {
             StaticAuthenticationProvider::Verified(random_user()),
         );
 
+        let decision: ControlFlow<Result<ActorId, _>> = chain.authenticate(&HeaderMap::new()).await;
         assert!(
-            matches!(
-                chain.authenticate(&HeaderMap::new()).await,
-                ControlFlow::Break(Err(_))
-            ),
+            matches!(decision, ControlFlow::Break(Err(_))),
             "a rejection by the first provider should never fall through to the second"
         );
     }
@@ -171,11 +246,9 @@ pub(crate) mod tests {
             StaticAuthenticationProvider::NotRecognized,
         );
 
+        let decision: ControlFlow<Result<ActorId, _>> = chain.authenticate(&HeaderMap::new()).await;
         assert!(
-            matches!(
-                chain.authenticate(&HeaderMap::new()).await,
-                ControlFlow::Continue(())
-            ),
+            matches!(decision, ControlFlow::Continue(())),
             "the chain should recognize nothing when no provider does"
         );
     }

--- a/libs/@local/graph/authentication/src/request.rs
+++ b/libs/@local/graph/authentication/src/request.rs
@@ -7,7 +7,7 @@ use http::HeaderMap;
 use type_system::principal::actor::ActorEntityUuid;
 use uuid::Uuid;
 
-use crate::provider::AuthenticationProvider;
+use crate::provider::{AuthenticationProvider, Caller};
 
 /// Name of the header carrying an unverified actor ID.
 pub const ACTOR_ID_HEADER: &str = "X-Authenticated-User-Actor-Id";
@@ -30,6 +30,9 @@ pub enum AuthenticationError {
     /// The service secret does not match.
     #[display("service credential is invalid")]
     InvalidServiceSecret,
+    /// The service credential is verified but carries no delegated actor.
+    #[display("the service credential carries no delegated actor")]
+    MissingDelegatedActor,
     /// The credential provider could not be reached.
     #[display("failed to verify the credential against the provider")]
     ProviderUnreachable,
@@ -86,6 +89,7 @@ impl AuthenticationError {
             Self::MissingCredentials
             | Self::MissingServiceSecret
             | Self::InvalidServiceSecret
+            | Self::MissingDelegatedActor
             | Self::InvalidSession
             | Self::InvalidAccessToken
             | Self::IdentityWithoutActor
@@ -111,6 +115,7 @@ impl AuthenticationError {
             }
             Self::MissingServiceSecret => "the request requires the service credential",
             Self::InvalidServiceSecret => "service credential is invalid",
+            Self::MissingDelegatedActor => "the service credential carries no delegated actor",
             Self::ProviderUnreachable => "failed to verify the credential against the provider",
             Self::ProviderRejection => "the credential provider rejected the verification request",
             Self::InvalidProviderResponse => "the credential provider returned an invalid response",
@@ -125,30 +130,31 @@ impl AuthenticationError {
     }
 }
 
-/// The result of resolving a request's credentials.
-#[derive(Debug, Clone)]
-pub enum AuthenticationOutcome {
-    /// The request carries accepted credentials for this actor.
-    Authenticated(ActorEntityUuid),
-    /// The request carries no or invalid credentials.
-    Failed(AuthenticationError),
-}
-
 /// Resolves the acting principal from the request headers.
 ///
 /// The provider is the only credential path: a request whose credential is rejected fails, and a
-/// request without a recognized credential fails as [`MissingCredentials`]. Chain providers as
-/// pairs, nested for more than two, to accept several credential kinds.
+/// request without a recognized credential resolves through [`Caller::anonymous`]. Chain providers
+/// as pairs, nested for more than two, to accept several credential kinds.
+///
+/// # Errors
+///
+/// - the rejection reason of the provider that recognized the credential
+/// - [`MissingCredentials`] if no provider recognized a credential and the caller type requires an
+///   actor
 ///
 /// [`MissingCredentials`]: AuthenticationError::MissingCredentials
-pub async fn resolve_request_actor<P>(provider: &P, headers: &HeaderMap) -> AuthenticationOutcome
+pub async fn resolve_request_actor<P, C>(
+    provider: &P,
+    headers: &HeaderMap,
+) -> Result<C, AuthenticationError>
 where
-    P: AuthenticationProvider,
+    P: AuthenticationProvider<C>,
+    C: Caller,
 {
     // TODO(BE-755): cache verified credentials so repeated requests do not re-verify against the
     //               provider and the principal store each time
     match provider.authenticate(headers).await {
-        ControlFlow::Break(Ok(actor)) => AuthenticationOutcome::Authenticated(actor.into()),
+        ControlFlow::Break(Ok(caller)) => Ok(caller),
         ControlFlow::Break(Err(report)) => {
             let error = report.current_context().clone();
             if matches!(
@@ -171,16 +177,21 @@ where
                 AuthenticationError::MissingServiceSecret
                     | AuthenticationError::InvalidServiceSecret
             ) {
-                // Legitimate senders of this credential pair are internal services, so a
+                // Legitimate senders of this credential are internal services, so a
                 // mismatch points at deployment configuration.
                 tracing::warn!(error = ?report, "credential rejected due to a service credential mismatch");
             } else {
                 tracing::debug!(error = ?report, "credential rejected");
             }
-            AuthenticationOutcome::Failed(error)
+            Err(error)
         }
         ControlFlow::Continue(()) => {
-            AuthenticationOutcome::Failed(AuthenticationError::MissingCredentials)
+            if headers.contains_key(ACTOR_ID_HEADER) {
+                // An actor-ID header without its credential says the caller believed it was
+                // delegating, so resolving it as anonymous points at a configuration fault.
+                tracing::warn!("actor-ID header carried no recognized credential");
+            }
+            C::anonymous()
         }
     }
 }
@@ -189,15 +200,15 @@ where
 ///
 /// # Errors
 ///
-/// - [`MissingCredentials`] if the header is absent
+/// - [`MissingDelegatedActor`] if the header is absent
 /// - [`InvalidActorIdHeader`] if the header is not a valid UUID
 ///
-/// [`MissingCredentials`]: AuthenticationError::MissingCredentials
+/// [`MissingDelegatedActor`]: AuthenticationError::MissingDelegatedActor
 /// [`InvalidActorIdHeader`]: AuthenticationError::InvalidActorIdHeader
 pub fn actor_id_from_header(headers: &HeaderMap) -> Result<ActorEntityUuid, AuthenticationError> {
     let header_value = headers
         .get(ACTOR_ID_HEADER)
-        .ok_or(AuthenticationError::MissingCredentials)?;
+        .ok_or(AuthenticationError::MissingDelegatedActor)?;
 
     header_value
         .to_str()
@@ -211,18 +222,15 @@ pub fn actor_id_from_header(headers: &HeaderMap) -> Result<ActorEntityUuid, Auth
 mod tests {
     use core::mem;
 
-    use hash_graph_authorization::policies::principal::actor::AuthenticatedActor;
     use http::HeaderMap;
     use type_system::principal::actor::{ActorEntityUuid, ActorId, UserId};
     use uuid::Uuid;
 
-    use super::{AuthenticationError, AuthenticationOutcome, resolve_request_actor};
+    use super::{AuthenticationError, resolve_request_actor};
     use crate::provider::StaticAuthenticationProvider;
 
-    fn random_user() -> AuthenticatedActor {
-        AuthenticatedActor::Id(ActorId::User(UserId::new(ActorEntityUuid::new(
-            Uuid::new_v4(),
-        ))))
+    fn random_user() -> ActorId {
+        ActorId::User(UserId::new(ActorEntityUuid::new(Uuid::new_v4())))
     }
 
     fn actor_id_header(actor_id: ActorEntityUuid) -> HeaderMap {
@@ -242,14 +250,10 @@ mod tests {
         let actor_id = random_user();
         let provider = StaticAuthenticationProvider::Verified(actor_id);
 
-        let outcome = resolve_request_actor(&provider, &HeaderMap::new()).await;
+        let outcome: Result<ActorId, _> = resolve_request_actor(&provider, &HeaderMap::new()).await;
 
         assert!(
-            matches!(
-                outcome,
-                AuthenticationOutcome::Authenticated(resolved)
-                    if resolved == ActorEntityUuid::from(actor_id)
-            ),
+            matches!(outcome, Ok(resolved) if resolved == actor_id),
             "a verified credential should authenticate its actor"
         );
     }
@@ -259,13 +263,10 @@ mod tests {
         let provider = StaticAuthenticationProvider::Rejected;
         let headers = actor_id_header(ActorEntityUuid::new(Uuid::new_v4()));
 
-        let outcome = resolve_request_actor(&provider, &headers).await;
+        let outcome: Result<ActorId, _> = resolve_request_actor(&provider, &headers).await;
 
         assert!(
-            matches!(
-                outcome,
-                AuthenticationOutcome::Failed(AuthenticationError::InvalidSession)
-            ),
+            matches!(outcome, Err(AuthenticationError::InvalidSession)),
             "a rejected credential should fail even when an actor-ID header is present"
         );
     }
@@ -275,13 +276,10 @@ mod tests {
         let provider = StaticAuthenticationProvider::NotRecognized;
         let headers = actor_id_header(ActorEntityUuid::new(Uuid::new_v4()));
 
-        let outcome = resolve_request_actor(&provider, &headers).await;
+        let outcome: Result<ActorId, _> = resolve_request_actor(&provider, &headers).await;
 
         assert!(
-            matches!(
-                outcome,
-                AuthenticationOutcome::Failed(AuthenticationError::MissingCredentials)
-            ),
+            matches!(outcome, Err(AuthenticationError::MissingCredentials)),
             "the actor-ID header should not resolve without a provider recognizing it"
         );
     }
@@ -290,13 +288,10 @@ mod tests {
     async fn missing_credentials_fail_authentication() {
         let provider = StaticAuthenticationProvider::NotRecognized;
 
-        let outcome = resolve_request_actor(&provider, &HeaderMap::new()).await;
+        let outcome: Result<ActorId, _> = resolve_request_actor(&provider, &HeaderMap::new()).await;
 
         assert!(
-            matches!(
-                outcome,
-                AuthenticationOutcome::Failed(AuthenticationError::MissingCredentials)
-            ),
+            matches!(outcome, Err(AuthenticationError::MissingCredentials)),
             "a request without credentials should fail authentication"
         );
     }
@@ -316,6 +311,7 @@ mod tests {
             AuthenticationError::InvalidActorIdHeader,
             AuthenticationError::MissingServiceSecret,
             AuthenticationError::InvalidServiceSecret,
+            AuthenticationError::MissingDelegatedActor,
             AuthenticationError::ProviderUnreachable,
             AuthenticationError::ProviderRejection,
             AuthenticationError::InvalidProviderResponse,

--- a/libs/@local/graph/authentication/tests/kratos.rs
+++ b/libs/@local/graph/authentication/tests/kratos.rs
@@ -38,9 +38,9 @@ impl ResolveActor for EchoingActorResolver {
     fn resolve_actor(
         &self,
         actor_entity_uuid: ActorEntityUuid,
-    ) -> impl Future<Output = Result<Option<ActorId>, error_stack::Report<DetermineActorError>>> + Send
+    ) -> impl Future<Output = Result<ActorId, error_stack::Report<DetermineActorError>>> + Send
     {
-        core::future::ready(Ok(Some(ActorId::User(UserId::new(actor_entity_uuid)))))
+        core::future::ready(Ok(ActorId::User(UserId::new(actor_entity_uuid))))
     }
 }
 

--- a/libs/@local/graph/authorization/src/policies/components.rs
+++ b/libs/@local/graph/authorization/src/policies/components.rs
@@ -11,16 +11,12 @@ use type_system::{
         VersionedUrl, data_type::DataTypeUuid, entity_type::EntityTypeUuid,
         property_type::PropertyTypeUuid,
     },
-    principal::{
-        actor::{ActorEntityUuid, ActorId},
-        actor_group::WebId,
-    },
+    principal::{actor::ActorId, actor_group::WebId},
 };
 
 use super::{
     Context, ContextBuilder, Effect, PolicySet, ResolvedPolicy,
     action::ActionName,
-    principal::actor::AuthenticatedActor,
     resource::{
         DataTypeResource, DataTypeResourceConstraint, EntityResource, EntityResourceConstraint,
         EntityTypeResource, EntityTypeResourceConstraint, PolicyMetaResource, PropertyTypeResource,
@@ -318,7 +314,8 @@ impl PolicyComponents {
 
 pub struct PolicyComponentsBuilder<'a, S> {
     store: &'a S,
-    actor: AuthenticatedActor,
+    /// The actor to resolve policies for, or [`None`] for the public actor.
+    actor: Option<ActorId>,
     context: ContextBuilder,
     entity_type_ids: HashSet<Cow<'a, VersionedUrl>>,
     property_type_ids: HashSet<Cow<'a, VersionedUrl>>,
@@ -333,7 +330,7 @@ impl<'a, S> PolicyComponentsBuilder<'a, S> {
     pub fn new(store: &'a S) -> Self {
         Self {
             store,
-            actor: AuthenticatedActor::Uuid(ActorEntityUuid::public_actor()),
+            actor: None,
             context: ContextBuilder::default(),
             entity_type_ids: HashSet::new(),
             property_type_ids: HashSet::new(),
@@ -343,12 +340,12 @@ impl<'a, S> PolicyComponentsBuilder<'a, S> {
         }
     }
 
-    pub fn set_actor(&mut self, actor: impl Into<AuthenticatedActor>) {
-        self.actor = actor.into();
+    pub const fn set_actor(&mut self, actor: Option<ActorId>) {
+        self.actor = actor;
     }
 
     #[must_use]
-    pub fn with_actor(mut self, actor: impl Into<AuthenticatedActor>) -> Self {
+    pub const fn with_actor(mut self, actor: Option<ActorId>) -> Self {
         self.set_actor(actor);
         self
     }
@@ -584,16 +581,7 @@ where
     #[tracing::instrument(level = "info", skip(self))]
     fn into_future(mut self) -> Self::IntoFuture {
         async move {
-            let actor_id = match self.actor {
-                AuthenticatedActor::Id(actor_id) => Some(actor_id),
-                AuthenticatedActor::Uuid(actor_uuid) => self
-                    .store
-                    .determine_actor(actor_uuid)
-                    .await
-                    .change_context(ContextCreationError::DetermineActor {
-                        actor_id: actor_uuid,
-                    })?,
-            };
+            let actor_id = self.actor;
 
             if let Some(actor_id) = actor_id {
                 self.store
@@ -696,7 +684,7 @@ where
             } else {
                 self.store
                     .resolve_policies_for_actor(
-                        actor_id.into(),
+                        actor_id,
                         ResolvePoliciesParams {
                             actions: Cow::Borrowed(&actions),
                         },

--- a/libs/@local/graph/authorization/src/policies/principal/actor/mod.rs
+++ b/libs/@local/graph/authorization/src/policies/principal/actor/mod.rs
@@ -9,7 +9,7 @@ use std::{collections::HashSet, sync::LazyLock};
 use cedar_policy_core::ast;
 use error_stack::{Report, ResultExt as _};
 use smol_str::SmolStr;
-use type_system::principal::actor::{Actor, ActorEntityUuid, ActorId, AiId, MachineId, UserId};
+use type_system::principal::actor::{Actor, ActorId, AiId, MachineId, UserId};
 
 use crate::policies::{
     cedar::{
@@ -18,57 +18,9 @@ use crate::policies::{
     error::FromCedarRefernceError,
 };
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum AuthenticatedActor {
-    Id(ActorId),
-    Uuid(ActorEntityUuid),
-}
-
-impl From<AuthenticatedActor> for ActorEntityUuid {
-    fn from(authenticated_actor: AuthenticatedActor) -> Self {
-        match authenticated_actor {
-            AuthenticatedActor::Id(actor_id) => Self::new(actor_id),
-            AuthenticatedActor::Uuid(actor_uuid) => actor_uuid,
-        }
-    }
-}
-
-impl From<ActorId> for AuthenticatedActor {
-    fn from(actor_id: ActorId) -> Self {
-        Self::Id(actor_id)
-    }
-}
-
-impl From<Option<ActorId>> for AuthenticatedActor {
-    fn from(actor_id: Option<ActorId>) -> Self {
-        actor_id.map_or_else(|| Self::Uuid(ActorEntityUuid::public_actor()), Self::Id)
-    }
-}
-
-impl From<MachineId> for AuthenticatedActor {
-    fn from(machine_id: MachineId) -> Self {
-        Self::Id(machine_id.into())
-    }
-}
-
-impl From<UserId> for AuthenticatedActor {
-    fn from(user_id: UserId) -> Self {
-        Self::Id(user_id.into())
-    }
-}
-
-impl From<AiId> for AuthenticatedActor {
-    fn from(ai_id: AiId) -> Self {
-        Self::Id(ai_id.into())
-    }
-}
-
-impl From<ActorEntityUuid> for AuthenticatedActor {
-    fn from(actor_uuid: ActorEntityUuid) -> Self {
-        Self::Uuid(actor_uuid)
-    }
-}
-
+/// The principal a request acts as when it carries no actor.
+///
+/// Matches policies without principal constraints, and nothing else.
 pub struct PublicActor;
 
 impl ToCedarEntityId for PublicActor {

--- a/libs/@local/graph/authorization/src/policies/store/error.rs
+++ b/libs/@local/graph/authorization/src/policies/store/error.rs
@@ -195,10 +195,8 @@ impl Error for TeamRoleError {}
 #[derive(Debug, derive_more::Display)]
 #[display("Could change role assignment: {_variant}")]
 pub enum RoleAssignmentError {
-    #[display("Actor was not provided")]
-    ActorNotProvided,
     #[display("Actor with ID `{actor_id}` does not exist")]
-    ActorNotFound { actor_id: ActorId },
+    ActorNotFound { actor_id: ActorEntityUuid },
     #[display("{name} role for `{actor_group_id}` does not exist")]
     RoleNotFound {
         actor_group_id: ActorGroupId,
@@ -225,8 +223,6 @@ impl Error for RoleAssignmentError {}
 pub enum ContextCreationError {
     #[display("Actor with ID `{actor_id}` does not exist")]
     ActorNotFound { actor_id: ActorId },
-    #[display("Actor with ID `{actor_id}` is not a valid actor")]
-    DetermineActor { actor_id: ActorEntityUuid },
     #[display("Could not build principal context for actor with ID `{actor_id}`")]
     BuildPrincipalContext { actor_id: ActorId },
     #[display("Could not build entity type context for entity types with IDs `{}`",
@@ -249,7 +245,11 @@ pub enum ContextCreationError {
     BuildEntityContext {
         entity_edition_ids: HashSet<EntityEditionId>,
     },
-    #[display("Could not resolve policies for actor with ID `{}`", actor_id.map_or_else(ActorEntityUuid::public_actor, ActorEntityUuid::from))]
+    #[display("Could not resolve policies for {}",
+        actor_id.map_or_else(
+            || "the public actor".to_owned(),
+            |actor_id| format!("actor with ID `{actor_id}`"),
+        ))]
     ResolveActorPolicies { actor_id: Option<ActorId> },
     #[display("Could not create policy set")]
     CreatePolicySet,
@@ -358,8 +358,6 @@ impl Error for UpdatePolicyError {}
 #[derive(Debug, derive_more::Display)]
 #[display("Could not get policies for actor: {_variant}")]
 pub enum GetPoliciesError {
-    #[display("Actor with UUID `{actor_entity_uuid}` does not exist")]
-    ActorIdNotFound { actor_entity_uuid: ActorEntityUuid },
     #[display("Actor with ID `{actor_id}` does not exist")]
     ActorNotFound { actor_id: ActorId },
     #[display("Invalid principal constraint")]

--- a/libs/@local/graph/authorization/src/policies/store/mod.rs
+++ b/libs/@local/graph/authorization/src/policies/store/mod.rs
@@ -30,7 +30,7 @@ use self::error::{
 use super::{
     ContextBuilder, Effect, Policy, PolicyId, ResolvedPolicy,
     action::ActionName,
-    principal::{PrincipalConstraint, actor::AuthenticatedActor},
+    principal::PrincipalConstraint,
     resource::{
         DataTypeResource, EntityResource, EntityTypeResource, PropertyTypeResource,
         ResourceConstraint,
@@ -190,7 +190,7 @@ pub trait PolicyStore {
     /// [`StoreError`]: CreatePolicyError::StoreError
     async fn create_policy(
         &mut self,
-        authenticated_actor: AuthenticatedActor,
+        authenticated_actor: ActorId,
         policy: PolicyCreationParams,
     ) -> Result<PolicyId, Report<CreatePolicyError>>;
 
@@ -203,7 +203,7 @@ pub trait PolicyStore {
     /// [`StoreError`]: GetPoliciesError::StoreError
     async fn get_policy_by_id(
         &self,
-        authenticated_actor: AuthenticatedActor,
+        authenticated_actor: ActorId,
         id: PolicyId,
     ) -> Result<Option<Policy>, Report<GetPoliciesError>>;
 
@@ -226,7 +226,7 @@ pub trait PolicyStore {
     /// [`StoreError`]: GetPoliciesError::StoreError
     async fn query_policies(
         &self,
-        authenticated_actor: AuthenticatedActor,
+        authenticated_actor: ActorId,
         filter: &PolicyFilter,
     ) -> Result<Vec<Policy>, Report<GetPoliciesError>>;
 
@@ -252,7 +252,7 @@ pub trait PolicyStore {
     /// [`StoreError`]: GetPoliciesError::StoreError
     async fn resolve_policies_for_actor(
         &self,
-        authenticated_actor: AuthenticatedActor,
+        authenticated_actor: Option<ActorId>,
         params: ResolvePoliciesParams,
     ) -> Result<Vec<ResolvedPolicy>, Report<GetPoliciesError>>;
 
@@ -273,7 +273,7 @@ pub trait PolicyStore {
     /// [`StoreError`]: UpdatePolicyError::StoreError
     async fn update_policy_by_id(
         &mut self,
-        authenticated_actor: AuthenticatedActor,
+        authenticated_actor: ActorId,
         policy_id: PolicyId,
         operations: &[PolicyUpdateOperation],
     ) -> Result<Policy, Report<UpdatePolicyError>>;
@@ -289,7 +289,7 @@ pub trait PolicyStore {
     /// [`StoreError`]: RemovePolicyError::StoreError
     async fn archive_policy_by_id(
         &mut self,
-        authenticated_actor: AuthenticatedActor,
+        authenticated_actor: ActorId,
         policy_id: PolicyId,
     ) -> Result<(), Report<RemovePolicyError>>;
 
@@ -310,7 +310,7 @@ pub trait PolicyStore {
     /// [`StoreError`]: RemovePolicyError::StoreError
     async fn delete_policy_by_id(
         &mut self,
-        authenticated_actor: AuthenticatedActor,
+        authenticated_actor: ActorId,
         policy_id: PolicyId,
     ) -> Result<(), Report<RemovePolicyError>>;
 
@@ -427,7 +427,7 @@ pub trait PrincipalStore {
     /// [`StoreError`]: WebRoleError::StoreError
     async fn get_web_roles(
         &mut self,
-        actor: ActorEntityUuid,
+        actor: ActorId,
         web_id: WebId,
     ) -> Result<HashMap<WebRoleId, WebRole>, Report<WebRoleError>>;
 
@@ -442,7 +442,7 @@ pub trait PrincipalStore {
     /// [`StoreError`]: TeamRoleError::StoreError
     async fn get_team_roles(
         &mut self,
-        actor: ActorEntityUuid,
+        actor: ActorId,
         team_id: TeamId,
     ) -> Result<HashMap<TeamRoleId, TeamRole>, Report<TeamRoleError>>;
 
@@ -459,7 +459,7 @@ pub trait PrincipalStore {
     /// [`StoreError`]: RoleAssignmentError::StoreError
     async fn assign_role(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         actor_to_assign: ActorEntityUuid,
         actor_group_id: ActorGroupEntityUuid,
         name: RoleName,
@@ -512,15 +512,13 @@ pub trait PrincipalStore {
     /// [`StoreError`]: RoleAssignmentError::StoreError
     async fn unassign_role(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         actor_to_unassign: ActorEntityUuid,
         actor_group_id: ActorGroupEntityUuid,
         name: RoleName,
     ) -> Result<RoleUnassignmentStatus, Report<RoleAssignmentError>>;
 
     /// Determines the type of an actor by its ID.
-    ///
-    /// Returns `None` if the ID is the public actor.
     ///
     /// # Errors
     ///
@@ -532,7 +530,7 @@ pub trait PrincipalStore {
     async fn determine_actor(
         &self,
         actor_entity_uuid: ActorEntityUuid,
-    ) -> Result<Option<ActorId>, Report<DetermineActorError>>;
+    ) -> Result<ActorId, Report<DetermineActorError>>;
 
     /// Builds a context used to evaluate policies for an actor.
     ///
@@ -878,7 +876,9 @@ impl OldPolicyStore for MemoryPolicyStore {
         name: RoleName,
     ) -> Result<(), Report<RoleAssignmentError>> {
         let Some(actor) = self.actors.get_mut(&actor_id) else {
-            bail!(RoleAssignmentError::ActorNotFound { actor_id })
+            bail!(RoleAssignmentError::ActorNotFound {
+                actor_id: actor_id.into()
+            })
         };
         let role_id = self.role_ids.get(&(actor_group_id, name)).ok_or(
             RoleAssignmentError::RoleNotFound {
@@ -908,7 +908,9 @@ impl OldPolicyStore for MemoryPolicyStore {
         name: RoleName,
     ) -> Result<(), Report<RoleAssignmentError>> {
         let Some(actor) = self.actors.get_mut(&actor_id) else {
-            bail!(RoleAssignmentError::ActorNotFound { actor_id })
+            bail!(RoleAssignmentError::ActorNotFound {
+                actor_id: actor_id.into()
+            })
         };
         let role_id = self.role_ids.get(&(actor_group_id, name)).ok_or(
             RoleAssignmentError::RoleNotFound {

--- a/libs/@local/graph/postgres-store/src/permissions/mod.rs
+++ b/libs/@local/graph/postgres-store/src/permissions/mod.rs
@@ -13,7 +13,7 @@ use tokio_postgres::{GenericClient as _, error::SqlState};
 use tracing::Instrument as _;
 use type_system::principal::{
     PrincipalId, PrincipalType,
-    actor::{Actor, ActorEntityUuid, ActorId, AiId, MachineId, UserId},
+    actor::{Actor, ActorId, AiId, MachineId, UserId},
     actor_group::{ActorGroupEntityUuid, ActorGroupId, TeamId, WebId},
     role::{Role, RoleId, RoleName, TeamRole, TeamRoleId, WebRole, WebRoleId},
 };
@@ -191,7 +191,7 @@ where
     /// - [`GetActorError`] if a database error occurs
     pub async fn get_actor(
         &self,
-        authenticated_actor: ActorEntityUuid,
+        authenticated_actor: ActorId,
         id: ActorId,
     ) -> Result<Option<Actor>, Report<GetActorError>> {
         Ok(match id {

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/delete.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/delete.rs
@@ -25,7 +25,10 @@ use type_system::{
             provenance::EntityDeletionProvenance,
         },
     },
-    principal::{actor::ActorEntityUuid, actor_group::WebId},
+    principal::{
+        actor::{ActorEntityUuid, ActorId},
+        actor_group::WebId,
+    },
 };
 
 use crate::store::{
@@ -550,7 +553,7 @@ where
     /// All operations run in a single CTE within the caller's transaction.
     async fn archive_incoming_link_edges(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         target: &FullEntityDeletionTarget,
         transaction_time: Timestamp<TransactionTime>,
         decision_time: Timestamp<DecisionTime>,
@@ -652,7 +655,7 @@ where
     /// - [`LinkDeletionBehavior::Ignore`] — no-op.
     async fn handle_incoming_link_edges(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         scope: &DeletionScope,
         target: &FullEntityDeletionTarget,
         transaction_time: Timestamp<TransactionTime>,
@@ -761,12 +764,12 @@ where
     async fn update_entity_ids_provenance(
         &mut self,
         target: &FullEntityDeletionTarget,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         decision_time: Timestamp<DecisionTime>,
         transaction_time: Timestamp<TransactionTime>,
     ) -> Result<u64, Report<DeletionError>> {
         let provenance = EntityDeletionProvenance {
-            deleted_by_id: actor_id,
+            deleted_by_id: ActorEntityUuid::from(actor_id),
             deleted_at_transaction_time: transaction_time,
             deleted_at_decision_time: decision_time,
         };
@@ -898,7 +901,7 @@ where
     /// [`Store`]: DeletionError::Store
     pub(super) async fn execute_entity_deletion(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: DeleteEntitiesParams<'_>,
     ) -> Result<DeletionSummary, Report<DeletionError>> {
         let transaction_time = Timestamp::<TransactionTime>::now();

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
@@ -15,9 +15,8 @@ use futures::{StreamExt as _, TryStreamExt as _, stream};
 use hash_graph_authorization::policies::{
     Authorized, MergePolicies, PolicyComponents, Request, RequestContext, ResourceId,
     action::ActionName,
-    principal::actor::AuthenticatedActor,
     resource::{EntityResourceConstraint, ResourceConstraint},
-    store::{PolicyCreationParams, PrincipalStore as _},
+    store::PolicyCreationParams,
 };
 use hash_graph_embeddings::{Dimension, clustering::Clustering};
 use hash_graph_migrations::Transaction as _;
@@ -93,7 +92,10 @@ use type_system::{
         entity_type::{ClosedEntityType, ClosedMultiEntityType, EntityTypeUuid},
         id::{OntologyTypeUuid, VersionedUrl},
     },
-    principal::{actor::ActorEntityUuid, actor_group::WebId},
+    principal::{
+        actor::{ActorEntityUuid, ActorId},
+        actor_group::WebId,
+    },
 };
 use uuid::Uuid;
 
@@ -683,9 +685,7 @@ where
             closed_multi_entity_types: if params.include_entity_types.is_some() {
                 Some(
                     self.get_closed_multi_entity_types(
-                        policy_components
-                            .actor_id()
-                            .map_or_else(ActorEntityUuid::public_actor, ActorEntityUuid::from),
+                        policy_components.actor_id(),
                         entities
                             .iter()
                             .map(|entity| entity.metadata.entity_type_ids.clone()),
@@ -717,9 +717,7 @@ where
                         .collect::<Vec<_>>();
                     Some(
                         self.get_entity_type_resolve_definitions(
-                            policy_components
-                                .actor_id()
-                                .map_or_else(ActorEntityUuid::public_actor, ActorEntityUuid::from),
+                            policy_components.actor_id(),
                             &entity_type_uuids,
                             params.include_entity_types
                                 == Some(IncludeEntityTypeOption::ResolvedWithDataTypeChildren),
@@ -746,7 +744,7 @@ where
     #[tracing::instrument(level = "info", skip(self, params))]
     async fn query_entities_impl(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         mut params: QueryEntitiesParams<'_>,
     ) -> Result<QueryEntitiesResponse<'static>, Report<QueryError>> {
         let policy_components = PolicyComponents::builder(self)
@@ -786,7 +784,7 @@ where
 
             let update_permissions = self
                 .has_permission_for_entities_impl(
-                    policy_components.actor_id().into(),
+                    policy_components.actor_id(),
                     HasPermissionForEntitiesParams {
                         action: ActionName::UpdateEntity,
                         entity_ids: Cow::Borrowed(&entity_ids),
@@ -818,7 +816,7 @@ where
     #[expect(clippy::too_many_lines)]
     async fn query_entity_subgraph_impl(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         params: QueryEntitySubgraphParams<'_>,
     ) -> Result<QueryEntitySubgraphResponse<'static>, Report<QueryError>> {
         let actions = params.view_actions();
@@ -999,7 +997,7 @@ where
 
                     let update_permissions = self
                         .has_permission_for_entities_impl(
-                            actor.into(),
+                            actor,
                             HasPermissionForEntitiesParams {
                                 action: ActionName::UpdateEntity,
                                 entity_ids: Cow::Borrowed(&entity_ids),
@@ -1111,7 +1109,7 @@ where
     #[tracing::instrument(skip(self, params))]
     pub(crate) async fn has_permission_for_entities_impl(
         &self,
-        authenticated_actor: AuthenticatedActor,
+        authenticated_actor: Option<ActorId>,
         params: HasPermissionForEntitiesParams<'_>,
     ) -> Result<HashMap<EntityId, Vec<EntityEditionId>>, Report<CheckPermissionError>> {
         let temporal_axes = params.temporal_axes.resolve();
@@ -1201,7 +1199,7 @@ where
     #[expect(clippy::too_many_lines)]
     async fn create_entities(
         &mut self,
-        actor_uuid: ActorEntityUuid,
+        actor_id: ActorId,
         params: Vec<CreateEntityParams>,
     ) -> Result<Vec<Entity>, Report<InsertionError>> {
         let transaction_time = Timestamp::<TransactionTime>::now().remove_nanosecond();
@@ -1225,12 +1223,6 @@ where
             .begin_transaction()
             .await
             .change_context(InsertionError)?;
-
-        let actor_id = transaction
-            .determine_actor(actor_uuid)
-            .await
-            .change_context(InsertionError)?
-            .ok_or_else(|| Report::new(InsertionError).attach("Actor not found"))?;
 
         let mut policy_components_builder = PolicyComponents::builder(&transaction);
 
@@ -1261,7 +1253,7 @@ where
         // The policy components builder will make sure, that also parent entity types are added to
         // the set of entity type IDs. These are accessible via `tracked_entity_types` method.
         let policy_components = policy_components_builder
-            .with_actor(actor_id)
+            .with_actor(Some(actor_id))
             .with_entity_type_ids(entity_type_id_set)
             .with_actions(
                 [ActionName::Instantiate, ActionName::CreateEntity],
@@ -1407,7 +1399,7 @@ where
                 .map_or_else(|| transaction_time.cast(), Timestamp::remove_nanosecond);
 
             let stored_provenance = SqlEntityProvenance::from(EntityProvenance {
-                created_by_id: actor_uuid,
+                created_by_id: ActorEntityUuid::from(actor_id),
                 created_at_transaction_time: transaction_time,
                 created_at_decision_time: decision_time,
                 first_non_draft_created_at_transaction_time: entity_id
@@ -1420,7 +1412,7 @@ where
                     .then_some(decision_time),
                 deletion: None,
                 edition: EntityEditionProvenance {
-                    created_by_id: actor_uuid,
+                    created_by_id: ActorEntityUuid::from(actor_id),
                     archived_by_id: None,
                     provided: params.provenance,
                 },
@@ -1705,7 +1697,7 @@ where
                 .collect();
             temporal_client
                 .start_update_entity_embeddings_workflow(
-                    actor_uuid,
+                    ActorEntityUuid::from(actor_id),
                     &entity_ids,
                     self.settings.filter_protection.embedding_exclusions(),
                 )
@@ -1723,11 +1715,11 @@ where
     #[tracing::instrument(level = "info", skip(self, params))]
     async fn validate_entities(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: Vec<ValidateEntityParams<'_>>,
     ) -> Result<HashMap<usize, EntityValidationReport>, Report<QueryError>> {
         let policy_components = PolicyComponents::builder(self)
-            .with_actor(actor_id)
+            .with_actor(Some(actor_id))
             .with_actions(
                 [
                     ActionName::ViewEntity,
@@ -1819,7 +1811,7 @@ where
     #[tracing::instrument(level = "info", skip(self, params))]
     async fn query_entities(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         params: QueryEntitiesParams<'_>,
     ) -> Result<QueryEntitiesResponse<'static>, Report<QueryError>> {
         // An entity query consists of multiple statements: the entity read itself, the optional
@@ -1843,7 +1835,7 @@ where
     #[tracing::instrument(level = "info", skip(self, params))]
     async fn search_entities(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: SearchEntitiesParams,
     ) -> Result<SearchEntitiesResponse, Report<QueryError>> {
         // The search issues several statements — one candidate read per policy branch, the
@@ -1865,7 +1857,7 @@ where
     #[tracing::instrument(level = "info", skip(self, params))]
     async fn query_entity_subgraph(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         params: QueryEntitySubgraphParams<'_>,
     ) -> Result<QueryEntitySubgraphResponse<'static>, Report<QueryError>> {
         // A subgraph read consists of multiple statements: the roots query, one recursive CTE
@@ -1892,7 +1884,7 @@ where
     #[tracing::instrument(level = "info", skip_all)]
     async fn query_entities_table(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: QueryEntitiesTableParams,
     ) -> Result<QueryEntitiesTableResponse, Report<QueryError>> {
         // The summary defines the type universe the page query runs on. Reading
@@ -1914,11 +1906,11 @@ where
 
     async fn summarize_entities(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         mut params: SummarizeEntitiesParams<'_>,
     ) -> Result<SummarizeEntitiesResponse, Report<QueryError>> {
         let policy_components = PolicyComponents::builder(self)
-            .with_actor(actor_id)
+            .with_actor(Some(actor_id))
             .with_action(ActionName::ViewEntity, MergePolicies::Yes)
             .await
             .change_context(QueryError)?;
@@ -2022,7 +2014,7 @@ where
 
     async fn get_entity_by_id(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         entity_id: EntityId,
         transaction_time: Option<Timestamp<TransactionTime>>,
         decision_time: Option<Timestamp<DecisionTime>>,
@@ -2064,7 +2056,7 @@ where
     #[expect(clippy::too_many_lines)]
     async fn patch_entity(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         mut params: PatchEntityParams,
     ) -> Result<Entity, Report<UpdateError>> {
         let transaction_time = Timestamp::now().remove_nanosecond();
@@ -2113,7 +2105,7 @@ where
         .change_context(UpdateError)?;
 
         let policy_components = PolicyComponents::builder(&transaction)
-            .with_actor(actor_id)
+            .with_actor(Some(actor_id))
             .with_entity_edition_id(previous_entity.metadata.record_id.edition_id)
             .with_entity_type_ids(&params.entity_type_ids)
             .with_actions(
@@ -2384,7 +2376,7 @@ where
         let link_data = previous_entity.link_data;
 
         let edition_provenance = EntityEditionProvenance {
-            created_by_id: actor_id,
+            created_by_id: ActorEntityUuid::from(actor_id),
             archived_by_id: None,
             provided: params.provenance,
         };
@@ -2559,7 +2551,7 @@ where
                 .collect();
             temporal_client
                 .start_update_entity_embeddings_workflow(
-                    actor_id,
+                    ActorEntityUuid::from(actor_id),
                     &entity_ids,
                     self.settings.filter_protection.embedding_exclusions(),
                 )
@@ -2573,7 +2565,7 @@ where
     #[tracing::instrument(level = "info", skip(self))]
     async fn delete_entities(
         &mut self,
-        actor_id: AuthenticatedActor,
+        actor_id: ActorId,
         params: DeleteEntitiesParams<'_>,
     ) -> Result<DeletionSummary, Report<DeletionError>> {
         // TODO: Authorization — check delete permission via PolicyComponents
@@ -2583,7 +2575,7 @@ where
             .await
             .change_context(DeletionError::Store)?;
         let summary = transaction
-            .execute_entity_deletion(actor_id.into(), params)
+            .execute_entity_deletion(actor_id, params)
             .await?;
         transaction
             .commit()
@@ -2597,7 +2589,7 @@ where
     #[expect(clippy::too_many_lines)]
     async fn update_entity_embeddings(
         &mut self,
-        _: ActorEntityUuid,
+        _: ActorId,
         params: UpdateEntityEmbeddingsParams<'_>,
     ) -> Result<(), Report<UpdateError>> {
         let mut properties = Vec::with_capacity(params.embeddings.len());
@@ -2748,13 +2740,13 @@ where
 
     async fn has_permission_for_entities(
         &self,
-        authenticated_actor: AuthenticatedActor,
+        authenticated_actor: ActorId,
         params: HasPermissionForEntitiesParams<'_>,
     ) -> Result<HashMap<EntityId, Vec<EntityEditionId>>, Report<CheckPermissionError>> {
         // Delegates to the inherent method on `PostgresStore<C, S>`, so the permission check is
         // also reachable where the `EntityStore` impl — bounded on `BeginReadOnlyTransaction` —
         // is unavailable.
-        self.has_permission_for_entities_impl(authenticated_actor, params)
+        self.has_permission_for_entities_impl(Some(authenticated_actor), params)
             .await
     }
 
@@ -2762,7 +2754,7 @@ where
     #[tracing::instrument(skip(self, params))]
     async fn cluster_entities(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: ClusterEntitiesParams,
     ) -> Result<ClusterEntitiesResponse, Report<ClusterError>> {
         const MAX_ALLOWED_DIM: u16 = 512;
@@ -2797,7 +2789,7 @@ where
         // Filter to entities the actor is allowed to view.
         let permitted = self
             .has_permission_for_entities_impl(
-                AuthenticatedActor::from(actor_id),
+                Some(actor_id),
                 HasPermissionForEntitiesParams {
                     action: ActionName::ViewEntity,
                     entity_ids: Cow::Borrowed(&params.entity_ids),
@@ -3522,7 +3514,7 @@ where
     #[expect(clippy::too_many_lines)]
     async fn archive_entity(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         locked_row: LockedEntityEdition,
         transaction_time: Timestamp<TransactionTime>,
         decision_time: Timestamp<DecisionTime>,

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/search.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/search.rs
@@ -19,7 +19,7 @@ use tracing::Instrument as _;
 use type_system::{
     knowledge::{Entity, entity::id::EntityId},
     ontology::id::VersionedUrl,
-    principal::{actor::ActorEntityUuid, actor_group::WebId},
+    principal::{actor::ActorId, actor_group::WebId},
 };
 
 use crate::store::{
@@ -121,7 +121,7 @@ where
     )]
     pub(crate) async fn search_entities_impl(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: SearchEntitiesParams,
     ) -> Result<SearchEntitiesResponse, Report<QueryError>> {
         let SearchEntitiesParams {
@@ -138,7 +138,7 @@ where
         } = params;
 
         let policy_components = PolicyComponents::builder(self)
-            .with_actor(actor_id)
+            .with_actor(Some(actor_id))
             .with_action(ActionName::ViewEntity, MergePolicies::Yes)
             .await
             .change_context(QueryError)?;
@@ -343,7 +343,7 @@ where
     /// Hydrates the ranked entities, restoring the ranking the hydration read does not preserve.
     async fn hydrate_ranked(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         ranked: &[EntityId],
         include_drafts: bool,
         include_entity_types: bool,
@@ -352,7 +352,7 @@ where
         // otherwise overflows rustc's recursion depth.
         let response = Box::pin(
             self.query_entities_impl(
-                actor_id,
+                Some(actor_id),
                 QueryEntitiesParams {
                     filter: Filter::Any(
                         ranked

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/table.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/table.rs
@@ -53,7 +53,7 @@ use type_system::{
         property::metadata::PropertyObjectMetadata,
     },
     ontology::{VersionedUrl, entity_type::EntityTypeUuid},
-    principal::{actor::ActorEntityUuid, actor_group::WebId},
+    principal::{actor::ActorId, actor_group::WebId},
 };
 
 use crate::store::{
@@ -356,11 +356,11 @@ where
     #[tracing::instrument(level = "info", skip(self, params))]
     pub(crate) async fn query_entities_table_impl(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: QueryEntitiesTableParams,
     ) -> Result<QueryEntitiesTableResponse, Report<QueryError>> {
         let policy_components = PolicyComponents::builder(self)
-            .with_actor(actor_id)
+            .with_actor(Some(actor_id))
             .with_action(ActionName::ViewEntity, MergePolicies::Yes)
             .await
             .change_context(QueryError)?;
@@ -643,7 +643,7 @@ where
             };
             Some(
                 self.get_closed_multi_entity_types(
-                    actor_id,
+                    Some(actor_id),
                     rows.iter()
                         .map(|row| row.entity_type_ids.clone())
                         .chain(
@@ -690,7 +690,7 @@ where
                     .collect::<Vec<_>>();
                 Some(
                     self.get_entity_type_resolve_definitions(
-                        actor_id,
+                        Some(actor_id),
                         &entity_type_uuids,
                         params.include_entity_types
                             == Some(IncludeEntityTypeOption::ResolvedWithDataTypeChildren),

--- a/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
@@ -17,7 +17,7 @@ use hash_graph_authorization::policies::{
     Authorized, ContextBuilder, Effect, MergePolicies, Policy, PolicyComponents, PolicyId, Request,
     RequestContext, ResolvedPolicy, ResourceId,
     action::ActionName,
-    principal::{PrincipalConstraint, actor::AuthenticatedActor},
+    principal::PrincipalConstraint,
     resource::{
         DataTypeId, DataTypeResource, EntityResource, EntityTypeId, EntityTypeResource,
         PolicyMetaResource, PropertyTypeId, PropertyTypeResource, ResourceConstraint,
@@ -842,7 +842,7 @@ where
         parameter: CreateWebParameter,
     ) -> Result<CreateWebResponse, Report<WebCreationError>> {
         let policy_components = PolicyComponents::builder(self)
-            .with_actor(actor)
+            .with_actor(Some(actor))
             .with_action(ActionName::CreateWeb, MergePolicies::No)
             .await
             .change_context(WebCreationError::BuildPolicyComponents)?;
@@ -962,7 +962,7 @@ where
 
     async fn get_web_roles(
         &mut self,
-        _actor: ActorEntityUuid,
+        _actor: ActorId,
         web_id: WebId,
     ) -> Result<HashMap<WebRoleId, WebRole>, Report<WebRoleError>> {
         let roles = self
@@ -1001,7 +1001,7 @@ where
 
     async fn get_team_roles(
         &mut self,
-        _actor: ActorEntityUuid,
+        _actor: ActorId,
         team_id: TeamId,
     ) -> Result<HashMap<TeamRoleId, TeamRole>, Report<TeamRoleError>> {
         let roles = self
@@ -1040,13 +1040,13 @@ where
 
     async fn assign_role(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         actor_to_assign: ActorEntityUuid,
         actor_group_id: ActorGroupEntityUuid,
         name: RoleName,
     ) -> Result<RoleAssignmentStatus, Report<RoleAssignmentError>> {
         if self
-            .get_actor_group_role(actor_id, actor_group_id)
+            .get_actor_group_role(ActorEntityUuid::from(actor_id), actor_group_id)
             .await
             .change_context(RoleAssignmentError::StoreError)?
             != Some(RoleName::Administrator)
@@ -1069,19 +1069,30 @@ where
 
         // We don't know what kind of actor and group we're dealing with, so we need to determine
         // the actor and group IDs.
-        let actor_to_assign_id = transaction
-            .determine_actor(actor_to_assign)
-            .await
-            .change_context(RoleAssignmentError::StoreError)?
-            .ok_or(RoleAssignmentError::ActorNotProvided)
-            .attach_opaque(StatusCode::InvalidArgument)?;
+        let actor_to_assign_id =
+            transaction
+                .determine_actor(actor_to_assign)
+                .await
+                .map_err(|report| match report.current_context() {
+                    DetermineActorError::ActorNotFound { .. } => report
+                        .change_context(RoleAssignmentError::ActorNotFound {
+                            actor_id: actor_to_assign,
+                        })
+                        .attach(StatusCode::InvalidArgument),
+                    DetermineActorError::StoreError => {
+                        report.change_context(RoleAssignmentError::StoreError)
+                    }
+                })?;
         let actor_group_id = transaction
             .determine_actor_group(actor_group_id)
             .await
             .change_context(RoleAssignmentError::StoreError)?;
 
         if let Some(already_assigned_role) = transaction
-            .get_actor_group_role(actor_to_assign_id.into(), actor_group_id.into())
+            .get_actor_group_role(
+                ActorEntityUuid::from(actor_to_assign_id),
+                actor_group_id.into(),
+            )
             .await?
         {
             if already_assigned_role == name {
@@ -1171,13 +1182,13 @@ where
 
     async fn unassign_role(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         actor_to_unassign: ActorEntityUuid,
         actor_group_id: ActorGroupEntityUuid,
         name: RoleName,
     ) -> Result<RoleUnassignmentStatus, Report<RoleAssignmentError>> {
         if self
-            .get_actor_group_role(actor_id, actor_group_id)
+            .get_actor_group_role(ActorEntityUuid::from(actor_id), actor_group_id)
             .await
             .change_context(RoleAssignmentError::StoreError)?
             != Some(RoleName::Administrator)
@@ -1196,9 +1207,16 @@ where
         let actor_to_unassign_id = transaction
             .determine_actor(actor_to_unassign)
             .await
-            .change_context(RoleAssignmentError::StoreError)?
-            .ok_or(RoleAssignmentError::ActorNotProvided)
-            .attach_opaque(StatusCode::InvalidArgument)?;
+            .map_err(|report| match report.current_context() {
+                DetermineActorError::ActorNotFound { .. } => report
+                    .change_context(RoleAssignmentError::ActorNotFound {
+                        actor_id: actor_to_unassign,
+                    })
+                    .attach(StatusCode::InvalidArgument),
+                DetermineActorError::StoreError => {
+                    report.change_context(RoleAssignmentError::StoreError)
+                }
+            })?;
         let actor_group_id = transaction
             .determine_actor_group(actor_group_id)
             .await
@@ -1230,11 +1248,7 @@ where
     async fn determine_actor(
         &self,
         actor_entity_uuid: ActorEntityUuid,
-    ) -> Result<Option<ActorId>, Report<DetermineActorError>> {
-        if actor_entity_uuid.is_public_actor() {
-            return Ok(None);
-        }
-
+    ) -> Result<ActorId, Report<DetermineActorError>> {
         let row = self
             .as_client()
             .query_opt(
@@ -1251,7 +1265,7 @@ where
             .change_context(DetermineActorError::StoreError)?
             .ok_or(DetermineActorError::ActorNotFound { actor_entity_uuid })?;
 
-        Ok(Some(match row.get(0) {
+        Ok(match row.get(0) {
             PrincipalType::User => ActorId::User(UserId::new(actor_entity_uuid)),
             PrincipalType::Machine => ActorId::Machine(MachineId::new(actor_entity_uuid)),
             PrincipalType::Ai => ActorId::Ai(AiId::new(actor_entity_uuid)),
@@ -1261,7 +1275,7 @@ where
             | PrincipalType::TeamRole) => {
                 unreachable!("Unexpected actor type: {principal_type:?}")
             }
-        }))
+        })
     }
 
     #[tracing::instrument(level = "info", skip(self, context_builder))]
@@ -1278,7 +1292,7 @@ where
         //   - Prefetching contexts for related actors in batch operations
 
         let actor = self
-            .get_actor(actor_id.into(), actor_id)
+            .get_actor(actor_id, actor_id)
             .await
             .change_context(BuildPrincipalContextError::StoreError)?
             .ok_or(BuildPrincipalContextError::ActorNotFound { actor_id })?;
@@ -1445,7 +1459,7 @@ where
 {
     async fn create_policy(
         &mut self,
-        authenticated_actor: AuthenticatedActor,
+        authenticated_actor: ActorId,
         policy: PolicyCreationParams,
     ) -> Result<PolicyId, Report<CreatePolicyError>> {
         let transaction = self
@@ -1459,7 +1473,7 @@ where
         };
 
         let policy_components = PolicyComponents::builder(&transaction)
-            .with_actor(authenticated_actor)
+            .with_actor(Some(authenticated_actor))
             .with_action(ActionName::CreatePolicy, MergePolicies::No)
             .with_policy_meta_resource(&PolicyMetaResource {
                 id: policy_id,
@@ -1500,7 +1514,7 @@ where
 
     async fn get_policy_by_id(
         &self,
-        _authenticated_actor: AuthenticatedActor,
+        _authenticated_actor: ActorId,
         id: PolicyId,
     ) -> Result<Option<Policy>, Report<GetPoliciesError>> {
         self.as_client()
@@ -1554,13 +1568,13 @@ where
 
     async fn query_policies(
         &self,
-        authenticated_actor: AuthenticatedActor,
+        authenticated_actor: ActorId,
         filter: &PolicyFilter,
     ) -> Result<Vec<Policy>, Report<GetPoliciesError>> {
         let policies = self.read_policies_from_database(filter).await?;
 
         let mut policy_components_builder = PolicyComponents::builder(self)
-            .with_actor(authenticated_actor)
+            .with_actor(Some(authenticated_actor))
             .with_action(ActionName::ViewPolicy, MergePolicies::No);
         for policy in &policies {
             policy_components_builder.add_policy_meta_resource(&PolicyMetaResource::from(policy));
@@ -1600,18 +1614,10 @@ where
     #[tracing::instrument(level = "info", skip(self, params), fields(action_count = params.actions.len()))]
     async fn resolve_policies_for_actor(
         &self,
-        authenticated_actor: AuthenticatedActor,
+        authenticated_actor: Option<ActorId>,
         params: ResolvePoliciesParams<'_>,
     ) -> Result<Vec<ResolvedPolicy>, Report<GetPoliciesError>> {
-        let actor_id = match authenticated_actor {
-            AuthenticatedActor::Uuid(actor_entity_uuid) => self
-                .determine_actor(actor_entity_uuid)
-                .await
-                .change_context(GetPoliciesError::ActorIdNotFound { actor_entity_uuid })?,
-            AuthenticatedActor::Id(actor_id) => Some(actor_id),
-        };
-
-        let Some(actor_id) = actor_id else {
+        let Some(actor_id) = authenticated_actor else {
             // If no actor is provided, only policies without principal constraints are returned.
             return Ok(self
                 .read_policies_from_database(&PolicyFilter {
@@ -1755,7 +1761,7 @@ where
 
     async fn update_policy_by_id(
         &mut self,
-        authenticated_actor: AuthenticatedActor,
+        authenticated_actor: ActorId,
         policy_id: PolicyId,
         operations: &[PolicyUpdateOperation],
     ) -> Result<Policy, Report<UpdatePolicyError>> {
@@ -1771,7 +1777,7 @@ where
             .ok_or(UpdatePolicyError::PolicyNotFound { id: policy_id })?;
 
         let old_policy_components = PolicyComponents::builder(&transaction)
-            .with_actor(authenticated_actor)
+            .with_actor(Some(authenticated_actor))
             .with_action(ActionName::UpdatePolicy, MergePolicies::No)
             .with_policy_meta_resource(&PolicyMetaResource::from(&old_policy))
             .await
@@ -1803,7 +1809,7 @@ where
             .await?;
 
         let updated_policy_components = PolicyComponents::builder(&transaction)
-            .with_actor(authenticated_actor)
+            .with_actor(Some(authenticated_actor))
             .with_actions([ActionName::UpdatePolicy], MergePolicies::No)
             .with_policy_meta_resource(&PolicyMetaResource::from(&update_policy))
             .await
@@ -1840,7 +1846,7 @@ where
 
     async fn archive_policy_by_id(
         &mut self,
-        authenticated_actor: AuthenticatedActor,
+        authenticated_actor: ActorId,
         policy_id: PolicyId,
     ) -> Result<(), Report<RemovePolicyError>> {
         let policy = self
@@ -1853,7 +1859,7 @@ where
             })?;
 
         let policy_components = PolicyComponents::builder(self)
-            .with_actor(authenticated_actor)
+            .with_actor(Some(authenticated_actor))
             .with_action(ActionName::ArchivePolicy, MergePolicies::No)
             .with_policy_meta_resource(&PolicyMetaResource::from(&policy))
             .await
@@ -1886,7 +1892,7 @@ where
 
     async fn delete_policy_by_id(
         &mut self,
-        authenticated_actor: AuthenticatedActor,
+        authenticated_actor: ActorId,
         policy_id: PolicyId,
     ) -> Result<(), Report<RemovePolicyError>> {
         let policy = self
@@ -1899,7 +1905,7 @@ where
             })?;
 
         let policy_components = PolicyComponents::builder(self)
-            .with_actor(authenticated_actor)
+            .with_actor(Some(authenticated_actor))
             .with_action(ActionName::DeletePolicy, MergePolicies::No)
             .with_policy_meta_resource(&PolicyMetaResource::from(&policy))
             .await
@@ -3538,20 +3544,13 @@ where
 impl<C: AsClient, S: TransactionState> AccountStore for PostgresStore<C, S> {
     async fn create_user_actor(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: CreateUserActorParams,
     ) -> Result<CreateUserActorResponse, Report<AccountInsertionError>> {
         let mut transaction = self
             .begin_transaction()
             .await
             .change_context(AccountInsertionError)?;
-
-        let actor_id = transaction
-            .determine_actor(actor_id)
-            .await
-            .change_context(AccountInsertionError)?
-            .ok_or(AccountInsertionError)
-            .attach_opaque(StatusCode::Unauthenticated)?;
 
         let user_id = transaction
             .create_user(params.user_id)
@@ -3585,7 +3584,7 @@ impl<C: AsClient, S: TransactionState> AccountStore for PostgresStore<C, S> {
 
     async fn create_machine_actor(
         &mut self,
-        _actor_id: ActorEntityUuid,
+        _actor_id: ActorId,
         params: CreateMachineActorParams,
     ) -> Result<MachineId, Report<AccountInsertionError>> {
         self.create_machine(None, &params.identifier)
@@ -3595,7 +3594,7 @@ impl<C: AsClient, S: TransactionState> AccountStore for PostgresStore<C, S> {
 
     async fn get_user_by_id(
         &self,
-        _actor_id: ActorEntityUuid,
+        _actor_id: ActorId,
         id: UserId,
     ) -> Result<Option<User>, Report<GetActorError>> {
         Ok(self
@@ -3685,7 +3684,7 @@ impl<C: AsClient, S: TransactionState> AccountStore for PostgresStore<C, S> {
 
     async fn get_machine_by_id(
         &self,
-        _actor_id: ActorEntityUuid,
+        _actor_id: ActorId,
         id: MachineId,
     ) -> Result<Option<Machine>, Report<GetActorError>> {
         Ok(self
@@ -3738,7 +3737,7 @@ impl<C: AsClient, S: TransactionState> AccountStore for PostgresStore<C, S> {
 
     async fn get_machine_by_identifier(
         &self,
-        _actor_id: ActorEntityUuid,
+        _actor_id: ActorId,
         identifier: &str,
     ) -> Result<Option<Machine>, Report<GetActorError>> {
         Ok(self
@@ -3791,7 +3790,7 @@ impl<C: AsClient, S: TransactionState> AccountStore for PostgresStore<C, S> {
 
     async fn get_ai_by_id(
         &self,
-        _actor_id: ActorEntityUuid,
+        _actor_id: ActorId,
         id: AiId,
     ) -> Result<Option<Ai>, Report<GetActorError>> {
         Ok(self
@@ -3844,7 +3843,7 @@ impl<C: AsClient, S: TransactionState> AccountStore for PostgresStore<C, S> {
 
     async fn get_ai_by_identifier(
         &self,
-        _actor_id: ActorEntityUuid,
+        _actor_id: ActorId,
         identifier: &str,
     ) -> Result<Option<Ai>, Report<GetActorError>> {
         Ok(self
@@ -3897,7 +3896,7 @@ impl<C: AsClient, S: TransactionState> AccountStore for PostgresStore<C, S> {
 
     async fn create_ai_actor(
         &mut self,
-        _actor_id: ActorEntityUuid,
+        _actor_id: ActorId,
         params: CreateAiActorParams,
     ) -> Result<AiId, Report<AccountInsertionError>> {
         self.create_ai(None, &params.identifier)
@@ -3908,7 +3907,7 @@ impl<C: AsClient, S: TransactionState> AccountStore for PostgresStore<C, S> {
     #[tracing::instrument(level = "info", skip(self))]
     async fn create_org_web(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: CreateOrgWebParams,
     ) -> Result<CreateWebResponse, Report<WebInsertionError>> {
         let mut transaction = self
@@ -3916,20 +3915,16 @@ impl<C: AsClient, S: TransactionState> AccountStore for PostgresStore<C, S> {
             .await
             .change_context(WebInsertionError)?;
 
-        let actor_id = transaction
-            .determine_actor(actor_id)
-            .await
-            .change_context(WebInsertionError)?
-            .ok_or(WebInsertionError)
-            .attach_opaque(StatusCode::Unauthenticated)?;
-
         let administrator = if let Some(administrator) = params.administrator {
             transaction
                 .determine_actor(administrator)
                 .await
-                .change_context(WebInsertionError)?
-                .ok_or(WebInsertionError)
-                .attach_opaque(StatusCode::InvalidArgument)?
+                .map_err(|report| match report.current_context() {
+                    DetermineActorError::ActorNotFound { .. } => report
+                        .change_context(WebInsertionError)
+                        .attach(StatusCode::InvalidArgument),
+                    DetermineActorError::StoreError => report.change_context(WebInsertionError),
+                })?
         } else {
             actor_id
         };
@@ -3957,7 +3952,7 @@ impl<C: AsClient, S: TransactionState> AccountStore for PostgresStore<C, S> {
 
     async fn get_web_by_id(
         &self,
-        _actor_id: ActorEntityUuid,
+        _actor_id: ActorId,
         id: WebId,
     ) -> Result<Option<Web>, Report<WebRetrievalError>> {
         Ok(self
@@ -3994,7 +3989,7 @@ impl<C: AsClient, S: TransactionState> AccountStore for PostgresStore<C, S> {
 
     async fn update_web_shortname(
         &mut self,
-        _actor_id: ActorEntityUuid,
+        _actor_id: ActorId,
         id: WebId,
         shortname: &str,
     ) -> Result<(), Report<WebUpdateError>> {
@@ -4033,7 +4028,7 @@ impl<C: AsClient, S: TransactionState> AccountStore for PostgresStore<C, S> {
 
     async fn get_web_by_shortname(
         &self,
-        _actor_id: ActorEntityUuid,
+        _actor_id: ActorId,
         shortname: &str,
     ) -> Result<Option<Web>, Report<WebRetrievalError>> {
         Ok(self
@@ -4072,7 +4067,7 @@ impl<C: AsClient, S: TransactionState> AccountStore for PostgresStore<C, S> {
     #[tracing::instrument(level = "info", skip(self))]
     async fn create_team(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: CreateTeamParams,
     ) -> Result<TeamId, Report<AccountGroupInsertionError>> {
         let mut transaction = self
@@ -4096,15 +4091,7 @@ impl<C: AsClient, S: TransactionState> AccountStore for PostgresStore<C, S> {
             .change_context(AccountGroupInsertionError)?;
 
         transaction
-            .assign_role_by_id(
-                transaction
-                    .determine_actor(actor_id)
-                    .await
-                    .change_context(AccountGroupInsertionError)?
-                    .ok_or(AccountGroupInsertionError)
-                    .attach_opaque(StatusCode::InvalidArgument)?,
-                admin_role,
-            )
+            .assign_role_by_id(actor_id, admin_role)
             .await
             .change_context(AccountGroupInsertionError)?;
 
@@ -4118,7 +4105,7 @@ impl<C: AsClient, S: TransactionState> AccountStore for PostgresStore<C, S> {
 
     async fn get_team_by_id(
         &self,
-        _actor_id: ActorEntityUuid,
+        _actor_id: ActorId,
         id: TeamId,
     ) -> Result<Option<Team>, Report<TeamRetrievalError>> {
         Ok(self
@@ -4169,7 +4156,7 @@ impl<C: AsClient, S: TransactionState> AccountStore for PostgresStore<C, S> {
 
     async fn get_team_by_name(
         &self,
-        _actor_id: ActorEntityUuid,
+        _actor_id: ActorId,
         name: &str,
     ) -> Result<Option<Team>, Report<TeamRetrievalError>> {
         Ok(self
@@ -4233,10 +4220,7 @@ where
     ///
     /// Returns [`DeletionError`] if any of the database deletion operations fail.
     #[tracing::instrument(level = "info", skip(self))]
-    pub async fn delete_principals(
-        &self,
-        actor_id: ActorEntityUuid,
-    ) -> Result<(), Report<DeletionError>> {
+    pub async fn delete_principals(&self) -> Result<(), Report<DeletionError>> {
         self.as_client()
             .client()
             .simple_query("DELETE FROM policy;")

--- a/libs/@local/graph/postgres-store/src/store/postgres/ontology/data_type.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/ontology/data_type.rs
@@ -6,7 +6,7 @@ use error_stack::{Report, ResultExt as _};
 use futures::{StreamExt as _, TryStreamExt as _};
 use hash_graph_authorization::policies::{
     Authorized, MergePolicies, PolicyComponents, Request, RequestContext, ResourceId,
-    action::ActionName, principal::actor::AuthenticatedActor,
+    action::ActionName,
 };
 use hash_graph_migrations::Transaction as _;
 use hash_graph_store::{
@@ -49,7 +49,7 @@ use type_system::{
         json_schema::OntologyTypeResolver,
         provenance::{OntologyEditionProvenance, OntologyOwnership, OntologyProvenance},
     },
-    principal::actor::ActorEntityUuid,
+    principal::actor::{ActorEntityUuid, ActorId},
 };
 
 use crate::store::{
@@ -499,7 +499,7 @@ where
     #[expect(clippy::too_many_lines)]
     async fn create_data_types<P>(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: P,
     ) -> Result<Vec<DataTypeMetadata>, Report<InsertionError>>
     where
@@ -520,7 +520,7 @@ where
         for parameters in params {
             let provenance = OntologyProvenance {
                 edition: OntologyEditionProvenance {
-                    created_by_id: actor_id,
+                    created_by_id: ActorEntityUuid::from(actor_id),
                     archived_by_id: None,
                     user_defined: parameters.provenance,
                 },
@@ -569,7 +569,7 @@ where
         }
 
         let policy_components = policy_components_builder
-            .with_actor(actor_id)
+            .with_actor(Some(actor_id))
             .with_actions([ActionName::CreateDataType], MergePolicies::No)
             .await
             .change_context(InsertionError)?;
@@ -620,7 +620,7 @@ where
 
         transaction
             .query_data_types(
-                actor_id,
+                Some(actor_id),
                 QueryDataTypesParams {
                     filter: Filter::In(
                         FilterExpression::Path {
@@ -729,7 +729,7 @@ where
         {
             temporal_client
                 .start_update_data_type_embeddings_workflow(
-                    actor_id,
+                    ActorEntityUuid::from(actor_id),
                     &inserted_data_types
                         .iter()
                         .zip(&inserted_data_type_metadata)
@@ -748,7 +748,7 @@ where
 
     async fn query_data_types(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         mut params: QueryDataTypesParams<'_>,
     ) -> Result<QueryDataTypesResponse, Report<QueryError>> {
         let policy_components = PolicyComponents::builder(self)
@@ -772,7 +772,7 @@ where
     //       anyway.
     async fn count_data_types(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         mut params: CountDataTypesParams<'_>,
     ) -> Result<usize, Report<QueryError>> {
         let policy_components = PolicyComponents::builder(self)
@@ -802,7 +802,7 @@ where
     #[expect(clippy::too_many_lines)]
     async fn query_data_type_subgraph(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         params: QueryDataTypeSubgraphParams<'_>,
     ) -> Result<QueryDataTypeSubgraphResponse, Report<QueryError>> {
         let policy_components = PolicyComponents::builder(self)
@@ -928,7 +928,7 @@ where
     #[expect(clippy::too_many_lines)]
     async fn update_data_types<P>(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: P,
     ) -> Result<Vec<DataTypeMetadata>, Report<UpdateError>>
     where
@@ -946,7 +946,7 @@ where
         for parameters in params {
             let provenance = OntologyProvenance {
                 edition: OntologyEditionProvenance {
-                    created_by_id: actor_id,
+                    created_by_id: ActorEntityUuid::from(actor_id),
                     archived_by_id: None,
                     user_defined: parameters.provenance,
                 },
@@ -1001,7 +1001,7 @@ where
         }
 
         let policy_components = PolicyComponents::builder(&transaction)
-            .with_actor(actor_id)
+            .with_actor(Some(actor_id))
             .with_data_type_ids(&old_data_type_ids)
             .with_actions([ActionName::UpdateDataType], MergePolicies::No)
             .await
@@ -1054,7 +1054,7 @@ where
 
         transaction
             .query_data_types(
-                actor_id,
+                Some(actor_id),
                 QueryDataTypesParams {
                     filter: Filter::In(
                         FilterExpression::Path {
@@ -1165,7 +1165,7 @@ where
         {
             temporal_client
                 .start_update_data_type_embeddings_workflow(
-                    actor_id,
+                    ActorEntityUuid::from(actor_id),
                     &inserted_data_types
                         .iter()
                         .zip(&updated_data_type_metadata)
@@ -1185,11 +1185,11 @@ where
     #[tracing::instrument(level = "info", skip(self))]
     async fn archive_data_type(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: ArchiveDataTypeParams<'_>,
     ) -> Result<OntologyTemporalMetadata, Report<UpdateError>> {
         let policy_components = PolicyComponents::builder(self)
-            .with_actor(actor_id)
+            .with_actor(Some(actor_id))
             .with_data_type_id(&params.data_type_id)
             .with_actions([ActionName::ArchiveDataType], MergePolicies::No)
             .await
@@ -1220,18 +1220,18 @@ where
             }
         }
 
-        self.archive_ontology_type(&params.data_type_id, actor_id)
+        self.archive_ontology_type(&params.data_type_id, ActorEntityUuid::from(actor_id))
             .await
     }
 
     #[tracing::instrument(level = "info", skip(self))]
     async fn unarchive_data_type(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: UnarchiveDataTypeParams,
     ) -> Result<OntologyTemporalMetadata, Report<UpdateError>> {
         let policy_components = PolicyComponents::builder(self)
-            .with_actor(actor_id)
+            .with_actor(Some(actor_id))
             .with_data_type_id(&params.data_type_id)
             .with_actions([ActionName::ArchiveDataType], MergePolicies::No)
             .await
@@ -1265,7 +1265,7 @@ where
         self.unarchive_ontology_type(
             &params.data_type_id,
             &OntologyEditionProvenance {
-                created_by_id: actor_id,
+                created_by_id: ActorEntityUuid::from(actor_id),
                 archived_by_id: None,
                 user_defined: params.provenance,
             },
@@ -1276,7 +1276,7 @@ where
     #[tracing::instrument(level = "info", skip(self, params))]
     async fn update_data_type_embeddings(
         &mut self,
-        _: ActorEntityUuid,
+        _: ActorId,
         params: UpdateDataTypeEmbeddingParams<'_>,
     ) -> Result<(), Report<UpdateError>> {
         let ontology_id = OntologyTypeUuid::from(DataTypeUuid::from_url(&params.data_type_id));
@@ -1360,7 +1360,7 @@ where
     )]
     async fn find_data_type_conversion_targets(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         params: FindDataTypeConversionTargetsParams,
     ) -> Result<FindDataTypeConversionTargetsResponse, Report<QueryError>> {
         let policy_components = PolicyComponents::builder(self)
@@ -1611,7 +1611,7 @@ where
     #[tracing::instrument(skip(self, params))]
     async fn has_permission_for_data_types(
         &self,
-        authenticated_actor: AuthenticatedActor,
+        authenticated_actor: ActorId,
         params: HasPermissionForDataTypesParams<'_>,
     ) -> Result<HashSet<VersionedUrl>, Report<hash_graph_store::error::CheckPermissionError>> {
         let temporal_axes = QueryTemporalAxesUnresolved::live_only().resolve();
@@ -1629,7 +1629,7 @@ where
             .change_context(CheckPermissionError::CompileFilter)?;
 
         let policy_components = PolicyComponents::builder(self)
-            .with_actor(authenticated_actor)
+            .with_actor(Some(authenticated_actor))
             .with_action(params.action, MergePolicies::Yes)
             .await
             .change_context(CheckPermissionError::BuildPolicyContext)?;

--- a/libs/@local/graph/postgres-store/src/store/postgres/ontology/entity_type.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/ontology/entity_type.rs
@@ -6,7 +6,7 @@ use error_stack::{Report, ResultExt as _};
 use futures::{StreamExt as _, TryStreamExt as _};
 use hash_graph_authorization::policies::{
     Authorized, MergePolicies, PolicyComponents, Request, RequestContext, ResourceId,
-    action::ActionName, principal::actor::AuthenticatedActor,
+    action::ActionName,
 };
 use hash_graph_migrations::Transaction as _;
 use hash_graph_store::{
@@ -63,7 +63,10 @@ use type_system::{
         property_type::PropertyTypeUuid,
         provenance::{OntologyEditionProvenance, OntologyOwnership, OntologyProvenance},
     },
-    principal::{actor::ActorEntityUuid, actor_group::WebId},
+    principal::{
+        actor::{ActorEntityUuid, ActorId},
+        actor_group::WebId,
+    },
 };
 
 use crate::store::{
@@ -165,7 +168,7 @@ where
     #[tracing::instrument(level = "info", skip(self, entity_types))]
     pub(crate) async fn get_entity_type_resolve_definitions(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         entity_types: &[EntityTypeUuid],
         include_data_type_children: bool,
     ) -> Result<EntityTypeResolveDefinitions, Report<QueryError>> {
@@ -888,7 +891,7 @@ where
     #[expect(clippy::too_many_lines)]
     async fn create_entity_types<P>(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: P,
     ) -> Result<Vec<EntityTypeMetadata>, Report<InsertionError>>
     where
@@ -908,7 +911,7 @@ where
         for parameters in params {
             let provenance = OntologyProvenance {
                 edition: OntologyEditionProvenance {
-                    created_by_id: actor_id,
+                    created_by_id: ActorEntityUuid::from(actor_id),
                     archived_by_id: None,
                     user_defined: parameters.provenance,
                 },
@@ -949,7 +952,7 @@ where
         }
 
         let policy_components = policy_components_builder
-            .with_actor(actor_id)
+            .with_actor(Some(actor_id))
             .with_actions([ActionName::CreateEntityType], MergePolicies::No)
             .await
             .change_context(InsertionError)?;
@@ -1002,7 +1005,7 @@ where
 
         transaction
             .query_entity_types(
-                actor_id,
+                Some(actor_id),
                 QueryEntityTypesParams {
                     request: CommonQueryEntityTypesParams {
                         filter: Filter::In(
@@ -1087,7 +1090,7 @@ where
         {
             temporal_client
                 .start_update_entity_type_embeddings_workflow(
-                    actor_id,
+                    ActorEntityUuid::from(actor_id),
                     &inserted_entity_types
                         .iter()
                         .zip(&inserted_entity_type_metadata)
@@ -1106,7 +1109,7 @@ where
 
     async fn count_entity_types(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         mut params: CountEntityTypesParams<'_>,
     ) -> Result<usize, Report<QueryError>> {
         let policy_components = PolicyComponents::builder(self)
@@ -1155,7 +1158,7 @@ where
 
     async fn query_entity_types(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         mut params: QueryEntityTypesParams<'_>,
     ) -> Result<QueryEntityTypesResponse, Report<QueryError>> {
         let policy_components = PolicyComponents::builder(self)
@@ -1213,7 +1216,7 @@ where
     #[expect(clippy::too_many_lines)]
     async fn search_entity_types(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: SearchEntityTypesParams,
     ) -> Result<SearchEntityTypesResponse, Report<QueryError>> {
         let SearchEntityTypesParams {
@@ -1223,7 +1226,7 @@ where
         } = params;
 
         let policy_components = PolicyComponents::builder(self)
-            .with_actor(actor_id)
+            .with_actor(Some(actor_id))
             .with_action(ActionName::ViewEntityType, MergePolicies::Yes)
             .await
             .change_context(QueryError)?;
@@ -1311,7 +1314,7 @@ where
 
         let response = self
             .query_entity_types(
-                actor_id,
+                Some(actor_id),
                 QueryEntityTypesParams {
                     request: CommonQueryEntityTypesParams {
                         filter: Filter::for_entity_type_uuids(&ranked),
@@ -1356,7 +1359,7 @@ where
     )]
     async fn get_closed_multi_entity_types<I, J>(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         entity_type_ids: I,
         temporal_axes: QueryTemporalAxesUnresolved,
         include_resolved: Option<IncludeResolvedEntityTypeOption>,
@@ -1483,7 +1486,7 @@ where
     #[expect(clippy::too_many_lines)]
     async fn query_entity_type_subgraph(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         params: QueryEntityTypeSubgraphParams<'_>,
     ) -> Result<QueryEntityTypeSubgraphResponse, Report<QueryError>> {
         let actions = params.view_actions();
@@ -1618,7 +1621,7 @@ where
     #[expect(clippy::too_many_lines)]
     async fn update_entity_types<P>(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: P,
     ) -> Result<Vec<EntityTypeMetadata>, Report<UpdateError>>
     where
@@ -1635,7 +1638,7 @@ where
         for parameters in params {
             let provenance = OntologyProvenance {
                 edition: OntologyEditionProvenance {
-                    created_by_id: actor_id,
+                    created_by_id: ActorEntityUuid::from(actor_id),
                     archived_by_id: None,
                     user_defined: parameters.provenance,
                 },
@@ -1682,7 +1685,7 @@ where
         }
 
         let policy_components = PolicyComponents::builder(&transaction)
-            .with_actor(actor_id)
+            .with_actor(Some(actor_id))
             .with_entity_type_ids(&old_entity_type_ids)
             .with_actions([ActionName::UpdateEntityType], MergePolicies::No)
             .await
@@ -1736,7 +1739,7 @@ where
 
         transaction
             .query_entity_types(
-                actor_id,
+                Some(actor_id),
                 QueryEntityTypesParams {
                     request: CommonQueryEntityTypesParams {
                         filter: Filter::In(
@@ -1823,7 +1826,7 @@ where
         {
             temporal_client
                 .start_update_entity_type_embeddings_workflow(
-                    actor_id,
+                    ActorEntityUuid::from(actor_id),
                     &inserted_entity_types
                         .iter()
                         .zip(&updated_entity_type_metadata)
@@ -1843,11 +1846,11 @@ where
     #[tracing::instrument(level = "info", skip(self))]
     async fn archive_entity_type(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: ArchiveEntityTypeParams<'_>,
     ) -> Result<OntologyTemporalMetadata, Report<UpdateError>> {
         let policy_components = PolicyComponents::builder(self)
-            .with_actor(actor_id)
+            .with_actor(Some(actor_id))
             .with_entity_type_id(&params.entity_type_id)
             .with_actions([ActionName::ArchiveEntityType], MergePolicies::No)
             .await
@@ -1880,18 +1883,18 @@ where
             }
         }
 
-        self.archive_ontology_type(&params.entity_type_id, actor_id)
+        self.archive_ontology_type(&params.entity_type_id, ActorEntityUuid::from(actor_id))
             .await
     }
 
     #[tracing::instrument(level = "info", skip(self))]
     async fn unarchive_entity_type(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: UnarchiveEntityTypeParams<'_>,
     ) -> Result<OntologyTemporalMetadata, Report<UpdateError>> {
         let policy_components = PolicyComponents::builder(self)
-            .with_actor(actor_id)
+            .with_actor(Some(actor_id))
             .with_entity_type_id(&params.entity_type_id)
             .with_actions([ActionName::ArchiveEntityType], MergePolicies::No)
             .await
@@ -1927,7 +1930,7 @@ where
         self.unarchive_ontology_type(
             &params.entity_type_id,
             &OntologyEditionProvenance {
-                created_by_id: actor_id,
+                created_by_id: ActorEntityUuid::from(actor_id),
                 archived_by_id: None,
                 user_defined: params.provenance,
             },
@@ -1938,7 +1941,7 @@ where
     #[tracing::instrument(level = "info", skip(self, params))]
     async fn update_entity_type_embeddings(
         &mut self,
-        _: ActorEntityUuid,
+        _: ActorId,
         params: UpdateEntityTypeEmbeddingParams<'_>,
     ) -> Result<(), Report<UpdateError>> {
         let ontology_id = OntologyTypeUuid::from(DataTypeUuid::from_url(&params.entity_type_id));
@@ -2113,7 +2116,7 @@ where
     )]
     async fn has_permission_for_entity_types(
         &self,
-        authenticated_actor: AuthenticatedActor,
+        authenticated_actor: ActorId,
         params: HasPermissionForEntityTypesParams<'_>,
     ) -> Result<HashSet<VersionedUrl>, Report<CheckPermissionError>> {
         if params.action == ActionName::Instantiate {
@@ -2123,7 +2126,7 @@ where
             //   see https://linear.app/hash/issue/H-4956
 
             let policy_components = PolicyComponents::builder(self)
-                .with_actor(authenticated_actor)
+                .with_actor(Some(authenticated_actor))
                 .with_action(ActionName::Instantiate, MergePolicies::No)
                 .with_action(ActionName::ViewEntityType, MergePolicies::Yes)
                 .with_entity_type_ids(params.entity_type_ids.iter())
@@ -2211,7 +2214,7 @@ where
                 .change_context(CheckPermissionError::CompileFilter)?;
 
             let policy_components = PolicyComponents::builder(self)
-                .with_actor(authenticated_actor)
+                .with_actor(Some(authenticated_actor))
                 .with_action(params.action, MergePolicies::Yes)
                 .await
                 .change_context(CheckPermissionError::BuildPolicyContext)?;

--- a/libs/@local/graph/postgres-store/src/store/postgres/ontology/property_type.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/ontology/property_type.rs
@@ -5,7 +5,7 @@ use error_stack::{Report, ResultExt as _};
 use futures::{StreamExt as _, TryStreamExt as _};
 use hash_graph_authorization::policies::{
     Authorized, MergePolicies, PolicyComponents, Request, RequestContext, ResourceId,
-    action::ActionName, principal::actor::AuthenticatedActor,
+    action::ActionName,
 };
 use hash_graph_migrations::Transaction as _;
 use hash_graph_store::{
@@ -46,7 +46,7 @@ use type_system::{
         },
         provenance::{OntologyEditionProvenance, OntologyOwnership, OntologyProvenance},
     },
-    principal::actor::ActorEntityUuid,
+    principal::actor::{ActorEntityUuid, ActorId},
 };
 
 use crate::store::{
@@ -497,7 +497,7 @@ where
     #[expect(clippy::too_many_lines)]
     async fn create_property_types<P>(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: P,
     ) -> Result<Vec<PropertyTypeMetadata>, Report<InsertionError>>
     where
@@ -519,7 +519,7 @@ where
         for parameters in params {
             let provenance = OntologyProvenance {
                 edition: OntologyEditionProvenance {
-                    created_by_id: actor_id,
+                    created_by_id: ActorEntityUuid::from(actor_id),
                     archived_by_id: None,
                     user_defined: parameters.provenance,
                 },
@@ -567,7 +567,7 @@ where
         }
 
         let policy_components = policy_components_builder
-            .with_actor(actor_id)
+            .with_actor(Some(actor_id))
             .with_actions([ActionName::CreatePropertyType], MergePolicies::No)
             .await
             .change_context(InsertionError)?;
@@ -627,7 +627,10 @@ where
             && let Some(temporal_client) = &self.temporal_client
         {
             temporal_client
-                .start_update_property_type_embeddings_workflow(actor_id, &inserted_property_types)
+                .start_update_property_type_embeddings_workflow(
+                    ActorEntityUuid::from(actor_id),
+                    &inserted_property_types,
+                )
                 .await
                 .change_context(InsertionError)?;
         }
@@ -637,7 +640,7 @@ where
 
     async fn count_property_types(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         mut params: CountPropertyTypesParams<'_>,
     ) -> Result<usize, Report<QueryError>> {
         let policy_components = PolicyComponents::builder(self)
@@ -686,7 +689,7 @@ where
 
     async fn query_property_types(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         mut params: QueryPropertyTypesParams<'_>,
     ) -> Result<QueryPropertyTypesResponse, Report<QueryError>> {
         let policy_components = PolicyComponents::builder(self)
@@ -710,7 +713,7 @@ where
     #[expect(clippy::too_many_lines)]
     async fn query_property_type_subgraph(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         params: QueryPropertyTypeSubgraphParams<'_>,
     ) -> Result<QueryPropertyTypeSubgraphResponse, Report<QueryError>> {
         let actions = params.view_actions();
@@ -838,7 +841,7 @@ where
     #[expect(clippy::too_many_lines)]
     async fn update_property_types<P>(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: P,
     ) -> Result<Vec<PropertyTypeMetadata>, Report<UpdateError>>
     where
@@ -857,7 +860,7 @@ where
         for parameters in params {
             let provenance = OntologyProvenance {
                 edition: OntologyEditionProvenance {
-                    created_by_id: actor_id,
+                    created_by_id: ActorEntityUuid::from(actor_id),
                     archived_by_id: None,
                     user_defined: parameters.provenance,
                 },
@@ -912,7 +915,7 @@ where
         }
 
         let policy_components = PolicyComponents::builder(&transaction)
-            .with_actor(actor_id)
+            .with_actor(Some(actor_id))
             .with_property_type_ids(&old_property_type_ids)
             .with_actions([ActionName::UpdatePropertyType], MergePolicies::No)
             .await
@@ -970,7 +973,10 @@ where
             && let Some(temporal_client) = &self.temporal_client
         {
             temporal_client
-                .start_update_property_type_embeddings_workflow(actor_id, &inserted_property_types)
+                .start_update_property_type_embeddings_workflow(
+                    ActorEntityUuid::from(actor_id),
+                    &inserted_property_types,
+                )
                 .await
                 .change_context(UpdateError)?;
         }
@@ -981,11 +987,11 @@ where
     #[tracing::instrument(level = "info", skip(self))]
     async fn archive_property_type(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: ArchivePropertyTypeParams<'_>,
     ) -> Result<OntologyTemporalMetadata, Report<UpdateError>> {
         let policy_components = PolicyComponents::builder(self)
-            .with_actor(actor_id)
+            .with_actor(Some(actor_id))
             .with_property_type_id(&params.property_type_id)
             .with_actions([ActionName::ArchivePropertyType], MergePolicies::No)
             .await
@@ -1018,18 +1024,18 @@ where
             }
         }
 
-        self.archive_ontology_type(&params.property_type_id, actor_id)
+        self.archive_ontology_type(&params.property_type_id, ActorEntityUuid::from(actor_id))
             .await
     }
 
     #[tracing::instrument(level = "info", skip(self))]
     async fn unarchive_property_type(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: UnarchivePropertyTypeParams<'_>,
     ) -> Result<OntologyTemporalMetadata, Report<UpdateError>> {
         let policy_components = PolicyComponents::builder(self)
-            .with_actor(actor_id)
+            .with_actor(Some(actor_id))
             .with_property_type_id(&params.property_type_id)
             .with_actions([ActionName::ArchivePropertyType], MergePolicies::No)
             .await
@@ -1065,7 +1071,7 @@ where
         self.unarchive_ontology_type(
             &params.property_type_id,
             &OntologyEditionProvenance {
-                created_by_id: actor_id,
+                created_by_id: ActorEntityUuid::from(actor_id),
                 archived_by_id: None,
                 user_defined: params.provenance,
             },
@@ -1076,7 +1082,7 @@ where
     #[tracing::instrument(level = "info", skip(self, params))]
     async fn update_property_type_embeddings(
         &mut self,
-        _: ActorEntityUuid,
+        _: ActorId,
         params: UpdatePropertyTypeEmbeddingParams<'_>,
     ) -> Result<(), Report<UpdateError>> {
         let ontology_id = OntologyTypeUuid::from(DataTypeUuid::from_url(&params.property_type_id));
@@ -1156,7 +1162,7 @@ where
     #[tracing::instrument(skip(self, params))]
     async fn has_permission_for_property_types(
         &self,
-        authenticated_actor: AuthenticatedActor,
+        authenticated_actor: ActorId,
         params: HasPermissionForPropertyTypesParams<'_>,
     ) -> Result<HashSet<VersionedUrl>, Report<hash_graph_store::error::CheckPermissionError>> {
         let temporal_axes = QueryTemporalAxesUnresolved::live_only().resolve();
@@ -1174,7 +1180,7 @@ where
             .change_context(CheckPermissionError::CompileFilter)?;
 
         let policy_components = PolicyComponents::builder(self)
-            .with_actor(authenticated_actor)
+            .with_actor(Some(authenticated_actor))
             .with_action(params.action, MergePolicies::Yes)
             .await
             .change_context(CheckPermissionError::BuildPolicyContext)?;

--- a/libs/@local/graph/postgres-store/tests/deletion/created_by_columns.rs
+++ b/libs/@local/graph/postgres-store/tests/deletion/created_by_columns.rs
@@ -37,7 +37,7 @@ use crate::{
     person_type_id, provenance, seed,
 };
 
-fn created_by_filter(actor_id: ActorEntityUuid) -> Filter<'static, Entity> {
+fn created_by_filter(actor_id: ActorId) -> Filter<'static, Entity> {
     Filter::Equal(
         FilterExpression::Path {
             path: EntityQueryPath::CreatedById,
@@ -83,7 +83,7 @@ async fn created_by_round_trips_through_columns() {
     let response = api
         .store
         .query_entities(
-            api.account_id,
+            Some(api.account_id),
             QueryEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(created.metadata.record_id.entity_id),
                 temporal_axes: QueryTemporalAxesUnresolved::all(),
@@ -109,7 +109,7 @@ async fn created_by_round_trips_through_columns() {
     };
     let read = &entity.metadata.provenance;
     let original = &created.metadata.provenance;
-    assert_eq!(read.created_by_id, api.account_id);
+    assert_eq!(read.created_by_id, ActorEntityUuid::from(api.account_id));
     assert_eq!(
         read.created_at_transaction_time,
         original.created_at_transaction_time
@@ -118,7 +118,10 @@ async fn created_by_round_trips_through_columns() {
         read.created_at_decision_time,
         original.created_at_decision_time
     );
-    assert_eq!(read.edition.created_by_id, api.account_id);
+    assert_eq!(
+        read.edition.created_by_id,
+        ActorEntityUuid::from(api.account_id)
+    );
 }
 
 /// The entity creator and the edition creator are independent columns.
@@ -134,7 +137,7 @@ async fn creator_columns_discriminate_actors() {
     let mut api = seed(&mut database).await;
 
     let user_b = create_second_user(&mut api).await;
-    let actor_b: ActorEntityUuid = user_b.into();
+    let actor_b: ActorId = user_b.into();
 
     let decision_time = Timestamp::<DecisionTime>::from_str("2020-01-01T00:00:00Z")
         .expect("timestamp should parse");
@@ -192,7 +195,7 @@ async fn creator_columns_discriminate_actors() {
     let response = api
         .store
         .query_entities(
-            api.account_id,
+            Some(api.account_id),
             QueryEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(entity_id),
                 temporal_axes: QueryTemporalAxesUnresolved::all(),
@@ -220,8 +223,8 @@ async fn creator_columns_discriminate_actors() {
         .expect("expected at least one entity revision");
 
     let read = &entity.metadata.provenance;
-    assert_eq!(read.created_by_id, api.account_id);
-    assert_eq!(read.edition.created_by_id, actor_b);
+    assert_eq!(read.created_by_id, ActorEntityUuid::from(api.account_id));
+    assert_eq!(read.edition.created_by_id, ActorEntityUuid::from(actor_b));
     assert_eq!(read.created_at_decision_time, decision_time);
     assert_ne!(
         read.created_at_transaction_time.cast::<DecisionTime>(),
@@ -239,13 +242,22 @@ async fn creator_columns_discriminate_actors() {
         .created_by_ids
         .as_ref()
         .expect("summary should include created-by ids");
-    assert_eq!(created_by_ids.get(&api.account_id), Some(&2));
+    assert_eq!(
+        created_by_ids.get(&ActorEntityUuid::from(api.account_id)),
+        Some(&2)
+    );
     let edition_created_by_ids = summary_a
         .edition_created_by_ids
         .as_ref()
         .expect("summary should include edition created-by ids");
-    assert_eq!(edition_created_by_ids.get(&api.account_id), Some(&1));
-    assert_eq!(edition_created_by_ids.get(&actor_b), Some(&1));
+    assert_eq!(
+        edition_created_by_ids.get(&ActorEntityUuid::from(api.account_id)),
+        Some(&1)
+    );
+    assert_eq!(
+        edition_created_by_ids.get(&ActorEntityUuid::from(actor_b)),
+        Some(&1)
+    );
 }
 
 /// The summary aggregation counts entities by creator through the column read path.
@@ -263,7 +275,7 @@ async fn created_by_summaries_use_columns() {
             .created_by_ids
             .as_ref()
             .expect("summary should include created-by ids")
-            .get(&api.account_id),
+            .get(&ActorEntityUuid::from(api.account_id)),
         Some(&2)
     );
     assert_eq!(
@@ -271,7 +283,7 @@ async fn created_by_summaries_use_columns() {
             .edition_created_by_ids
             .as_ref()
             .expect("summary should include edition created-by ids")
-            .get(&api.account_id),
+            .get(&ActorEntityUuid::from(api.account_id)),
         Some(&2)
     );
 }

--- a/libs/@local/graph/postgres-store/tests/deletion/drafts.rs
+++ b/libs/@local/graph/postgres-store/tests/deletion/drafts.rs
@@ -43,7 +43,7 @@ async fn draft_only_entity_promoted_to_full_delete() {
     let summary = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(base_id),
                 include_drafts: true,
@@ -121,7 +121,7 @@ async fn draft_of_published_entity_preserves_published() {
     let summary = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(draft_entity_id),
                 include_drafts: true,
@@ -190,7 +190,7 @@ async fn include_drafts_false_skips_drafts() {
     let summary = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(base_id),
                 include_drafts: false,
@@ -291,7 +291,7 @@ async fn partial_draft_match_not_promoted() {
     let summary = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(draft_entity_id_1),
                 include_drafts: true,
@@ -373,7 +373,7 @@ async fn published_and_draft_matched_becomes_full_delete() {
     let summary = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(entity_id),
                 include_drafts: true,
@@ -449,7 +449,7 @@ async fn mixed_full_and_draft_targets() {
     let summary = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::Any(vec![
                     Filter::for_entity_by_entity_id(id_a),
@@ -537,7 +537,7 @@ async fn empty_target_guards() {
     let summary = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(draft_entity_id),
                 include_drafts: true,
@@ -623,7 +623,7 @@ async fn draft_link_entity_edge_survives() {
     let summary1 = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(draft_link_entity_id),
                 include_drafts: true,
@@ -656,7 +656,7 @@ async fn draft_link_entity_edge_survives() {
     let summary2 = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(link_entity_id),
                 include_drafts: false,
@@ -757,7 +757,7 @@ async fn summary_counts_draft_ids_not_entities() {
     let summary = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::Any(vec![
                     Filter::for_entity_by_entity_id(draft_entity_id_1),

--- a/libs/@local/graph/postgres-store/tests/deletion/erase.rs
+++ b/libs/@local/graph/postgres-store/tests/deletion/erase.rs
@@ -35,7 +35,7 @@ async fn removes_entity_ids_row() {
     let summary = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(entity_id),
                 include_drafts: false,
@@ -79,7 +79,7 @@ async fn satellite_tables_cleaned() {
     let summary = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(entity_id),
                 include_drafts: false,
@@ -168,7 +168,7 @@ async fn entity_with_history() {
     let summary = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(entity_id),
                 include_drafts: false,
@@ -215,7 +215,7 @@ async fn double_deletion_is_noop() {
     let summary1 = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(entity_id),
                 include_drafts: false,
@@ -239,7 +239,7 @@ async fn double_deletion_is_noop() {
     let summary2 = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(entity_id),
                 include_drafts: false,
@@ -280,7 +280,7 @@ async fn entity_reuse_after_erase() {
 
     api.store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(entity_id),
                 include_drafts: false,
@@ -363,7 +363,7 @@ async fn promoted_draft_only_entity() {
     let summary = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(base_entity_id),
                 include_drafts: true,
@@ -434,7 +434,7 @@ async fn erase_partial_draft_preserves_entity_ids() {
     let summary = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(draft_entity_id),
                 include_drafts: true,

--- a/libs/@local/graph/postgres-store/tests/deletion/links.rs
+++ b/libs/@local/graph/postgres-store/tests/deletion/links.rs
@@ -38,7 +38,7 @@ async fn purge_error_rejects_with_incoming_links() {
     let err = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(id_b),
                 include_drafts: false,
@@ -89,7 +89,7 @@ async fn purge_ignore_succeeds_with_incoming_links() {
     let summary = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(id_b),
                 include_drafts: false,
@@ -144,7 +144,7 @@ async fn erase_rejects_with_incoming_links() {
     let err = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(id_b),
                 include_drafts: false,
@@ -209,7 +209,7 @@ async fn purge_link_entity_removes_all_edges() {
     let summary = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(id_link),
                 include_drafts: false,
@@ -279,7 +279,7 @@ async fn self_referential_batch_not_counted() {
     let summary = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::Any(vec![
                     Filter::for_entity_by_entity_id(id_a),
@@ -358,7 +358,7 @@ async fn draft_deletion_skips_link_check() {
     let summary = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(draft_entity_id),
                 include_drafts: true,
@@ -419,7 +419,7 @@ async fn incoming_link_count_is_accurate() {
     let err = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(id_b),
                 include_drafts: false,
@@ -460,7 +460,7 @@ async fn self_loop_link() {
     let err = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(id_a),
                 include_drafts: false,
@@ -483,7 +483,7 @@ async fn self_loop_link() {
     let summary = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::Any(vec![
                     Filter::for_entity_by_entity_id(id_a),
@@ -536,7 +536,7 @@ async fn chain_deletion() {
     let err = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(id_b),
                 include_drafts: false,
@@ -559,7 +559,7 @@ async fn chain_deletion() {
     let summary = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(id_b),
                 include_drafts: false,
@@ -611,7 +611,7 @@ async fn bidirectional_links() {
     let err = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(id_a),
                 include_drafts: false,
@@ -634,7 +634,7 @@ async fn bidirectional_links() {
     let summary = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::Any(vec![
                     Filter::for_entity_by_entity_id(id_a),
@@ -686,7 +686,7 @@ async fn erase_batch_excludes_in_batch_links() {
     let summary = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::Any(vec![
                     Filter::for_entity_by_entity_id(id_a),
@@ -752,7 +752,7 @@ async fn erase_link_entity_alone_succeeds() {
     let summary = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(id_link),
                 include_drafts: false,
@@ -817,7 +817,7 @@ async fn purge_archive_archives_incoming_link() {
     let summary = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(id_b),
                 include_drafts: false,
@@ -892,7 +892,7 @@ async fn purge_archive_multiple_incoming_links() {
     let summary = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(id_b),
                 include_drafts: false,
@@ -941,7 +941,7 @@ async fn purge_archive_batch_links_not_archived() {
     let summary = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::Any(vec![
                     Filter::for_entity_by_entity_id(id_a),
@@ -986,7 +986,7 @@ async fn purge_archive_no_incoming_links() {
     let summary = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(id),
                 include_drafts: false,
@@ -1034,7 +1034,7 @@ async fn purge_archive_chain() {
     let summary = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(id_b),
                 include_drafts: false,
@@ -1080,7 +1080,7 @@ async fn purge_archive_self_loop() {
     let summary = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(id_a),
                 include_drafts: false,
@@ -1159,7 +1159,7 @@ async fn purge_archive_includes_draft_link_versions() {
     let summary = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(id_b),
                 include_drafts: false,
@@ -1219,7 +1219,7 @@ async fn erase_rejects_archived_incoming_links() {
     // Purge A with Archive → L gets archived
     api.store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(id_a),
                 include_drafts: false,
@@ -1241,7 +1241,7 @@ async fn erase_rejects_archived_incoming_links() {
     let err = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(id_b),
                 include_drafts: false,
@@ -1278,7 +1278,7 @@ async fn purge_error_ignores_archived_links() {
     // Archive L by purging A
     api.store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(id_a),
                 include_drafts: false,
@@ -1298,7 +1298,7 @@ async fn purge_error_ignores_archived_links() {
     let summary = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(id_b),
                 include_drafts: false,
@@ -1361,7 +1361,7 @@ async fn archive_creates_historical_temporal_rows() {
 
     api.store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(id_b),
                 include_drafts: false,
@@ -1422,7 +1422,7 @@ async fn broad_temporal_axes_find_archived_entities() {
     // Archive L by purging B
     api.store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(id_b),
                 include_drafts: false,
@@ -1440,7 +1440,7 @@ async fn broad_temporal_axes_find_archived_entities() {
     let summary_live = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(id_link),
                 include_drafts: false,
@@ -1460,7 +1460,7 @@ async fn broad_temporal_axes_find_archived_entities() {
     let summary_all = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(id_link),
                 include_drafts: false,
@@ -1508,7 +1508,7 @@ async fn user_deletion_then_reset_graph() {
     // "User deletion": purge A with Archive
     api.store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(id_a),
                 include_drafts: true,
@@ -1528,7 +1528,7 @@ async fn user_deletion_then_reset_graph() {
     let summary = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::Any(vec![
                     Filter::for_entity_by_entity_id(id_a),
@@ -1593,7 +1593,7 @@ async fn archive_already_archived_link_is_noop() {
     // Purge A1 with Archive -> L1 archived
     api.store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(id_a1),
                 include_drafts: false,
@@ -1621,7 +1621,7 @@ async fn archive_already_archived_link_is_noop() {
     // Purge A2 with Archive -> L2 archived, L1 untouched
     api.store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(id_a2),
                 include_drafts: false,

--- a/libs/@local/graph/postgres-store/tests/deletion/main.rs
+++ b/libs/@local/graph/postgres-store/tests/deletion/main.rs
@@ -48,7 +48,7 @@ use type_system::{
         provenance::{OntologyOwnership, ProvidedOntologyEditionProvenance},
     },
     principal::{
-        actor::{ActorEntityUuid, ActorType, UserId},
+        actor::{ActorEntityUuid, ActorId, ActorType, UserId},
         actor_group::WebId,
     },
     provenance::{OriginProvenance, OriginType},
@@ -58,7 +58,7 @@ pub use crate::common::DatabaseTestWrapper;
 
 pub struct DatabaseApi<'pool> {
     pub store: PostgresStore<Transaction<'pool>, InTransaction>,
-    pub account_id: ActorEntityUuid,
+    pub account_id: ActorId,
 }
 
 impl DatabaseTestWrapper {

--- a/libs/@local/graph/postgres-store/tests/deletion/purge.rs
+++ b/libs/@local/graph/postgres-store/tests/deletion/purge.rs
@@ -18,7 +18,10 @@ use type_system::{
             PropertyWithMetadata,
         },
     },
-    principal::{actor::ActorEntityUuid, actor_group::WebId},
+    principal::{
+        actor::{ActorEntityUuid, ActorId},
+        actor_group::WebId,
+    },
 };
 use uuid::Uuid;
 
@@ -83,7 +86,7 @@ async fn published_entity() {
     let summary = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(entity_id),
                 include_drafts: false,
@@ -177,7 +180,7 @@ async fn published_entity_with_history() {
     let summary = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(entity_id),
                 include_drafts: false,
@@ -227,7 +230,7 @@ async fn no_match_is_noop() {
     let summary = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(nonexistent_id),
                 include_drafts: false,
@@ -270,7 +273,7 @@ async fn include_drafts_irrelevant_for_published() {
     let summary_a = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(id_a),
                 include_drafts: false,
@@ -287,7 +290,7 @@ async fn include_drafts_irrelevant_for_published() {
     let summary_b = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(id_b),
                 include_drafts: true,
@@ -329,7 +332,7 @@ async fn purge_error_succeeds_without_incoming_links() {
     let summary = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(entity_id),
                 include_drafts: false,
@@ -372,7 +375,7 @@ async fn tombstone_has_deletion_provenance() {
     let summary = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             purge_params(Filter::for_entity_by_entity_id(entity_id)),
         )
         .await
@@ -393,7 +396,10 @@ async fn tombstone_has_deletion_provenance() {
         .await
         .expect("deletion provenance should exist");
 
-    assert_eq!(deletion.deleted_by_id, api.account_id);
+    assert_eq!(
+        deletion.deleted_by_id,
+        ActorEntityUuid::from(api.account_id)
+    );
 }
 
 /// Verifies all satellite tables are cleaned after purge.
@@ -415,7 +421,7 @@ async fn satellite_tables_cleaned() {
     let summary = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             purge_params(Filter::for_entity_by_entity_id(entity_id)),
         )
         .await
@@ -470,7 +476,7 @@ async fn double_deletion_is_noop() {
     let summary1 = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             purge_params(Filter::for_entity_by_entity_id(entity_id)),
         )
         .await
@@ -492,7 +498,7 @@ async fn double_deletion_is_noop() {
     let summary2 = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             purge_params(Filter::for_entity_by_entity_id(entity_id)),
         )
         .await
@@ -538,7 +544,7 @@ async fn multiple_entities_in_batch() {
 
     let summary = api
         .store
-        .delete_entities(api.account_id.into(), purge_params(filter))
+        .delete_entities(api.account_id, purge_params(filter))
         .await
         .expect("could not delete entities");
 
@@ -575,7 +581,7 @@ async fn other_entity_unaffected() {
     let summary = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             purge_params(Filter::for_entity_by_entity_id(id_a)),
         )
         .await
@@ -633,7 +639,7 @@ async fn batch_with_mixed_entity_states() {
     let summary = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter,
                 include_drafts: true,
@@ -682,7 +688,7 @@ async fn cross_web_batch() {
     let entity_a = create_person(&mut api, alice(), false).await;
     let id_a = entity_a.metadata.record_id.entity_id;
 
-    let second_user: ActorEntityUuid = create_second_user(&mut api).await.into();
+    let second_user: ActorId = create_second_user(&mut api).await.into();
     let entity_b = api
         .store
         .create_entity(
@@ -718,7 +724,7 @@ async fn cross_web_batch() {
 
     let summary = api
         .store
-        .delete_entities(api.account_id.into(), purge_params(filter))
+        .delete_entities(api.account_id, purge_params(filter))
         .await
         .expect("could not delete cross-web batch");
 
@@ -779,7 +785,7 @@ async fn query_after_purge_returns_empty() {
 
     api.store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             purge_params(Filter::for_entity_by_entity_id(entity_id)),
         )
         .await
@@ -807,11 +813,11 @@ async fn different_actor_deleting() {
     let entity_id = entity.metadata.record_id.entity_id;
 
     // Delete as actor B
-    let actor_b: ActorEntityUuid = create_second_user(&mut api).await.into();
+    let actor_b: ActorId = create_second_user(&mut api).await.into();
     let summary = api
         .store
         .delete_entities(
-            actor_b.into(),
+            actor_b,
             purge_params(Filter::for_entity_by_entity_id(entity_id)),
         )
         .await
@@ -830,8 +836,11 @@ async fn different_actor_deleting() {
         .await
         .expect("deletion provenance should exist");
 
-    assert_eq!(deletion.deleted_by_id, actor_b);
-    assert_ne!(deletion.deleted_by_id, api.account_id);
+    assert_eq!(deletion.deleted_by_id, ActorEntityUuid::from(actor_b));
+    assert_ne!(
+        deletion.deleted_by_id,
+        ActorEntityUuid::from(api.account_id)
+    );
 }
 
 /// Purges an entity that has embeddings in `entity_embeddings`.
@@ -877,7 +886,7 @@ async fn entity_with_embeddings() {
     let summary = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             purge_params(Filter::for_entity_by_entity_id(entity_id)),
         )
         .await
@@ -922,7 +931,7 @@ async fn large_batch() {
 
     let summary = api
         .store
-        .delete_entities(api.account_id.into(), purge_params(filter))
+        .delete_entities(api.account_id, purge_params(filter))
         .await
         .expect("could not delete large batch");
 
@@ -965,7 +974,7 @@ async fn filter_by_entity_type() {
     let summary = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_type_id(&person_type),
                 include_drafts: false,
@@ -1031,7 +1040,7 @@ async fn archived_entity() {
     let summary = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             purge_params(Filter::for_entity_by_entity_id(entity_id)),
         )
         .await
@@ -1064,7 +1073,7 @@ async fn provenance_merge_only_adds_deletion_keys() {
 
     api.store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             purge_params(Filter::for_entity_by_entity_id(entity_id)),
         )
         .await
@@ -1074,7 +1083,7 @@ async fn provenance_merge_only_adds_deletion_keys() {
     let created_by_id = get_created_by_id(&api, entity_id.web_id, entity_id.entity_uuid)
         .await
         .expect("entity_ids row should exist");
-    assert_eq!(created_by_id, api.account_id);
+    assert_eq!(created_by_id, ActorEntityUuid::from(api.account_id));
 
     // Deletion provenance must be added to the JSONB.
     assert!(
@@ -1102,7 +1111,7 @@ async fn erase_after_purge_is_noop() {
 
     api.store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             purge_params(Filter::for_entity_by_entity_id(entity_id)),
         )
         .await
@@ -1111,7 +1120,7 @@ async fn erase_after_purge_is_noop() {
     let summary = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(entity_id),
                 include_drafts: false,

--- a/libs/@local/graph/postgres-store/tests/deletion/validation.rs
+++ b/libs/@local/graph/postgres-store/tests/deletion/validation.rs
@@ -44,7 +44,7 @@ async fn decision_time_exceeds_transaction_time() {
     let err = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(entity_id),
                 temporal_axes: QueryTemporalAxesUnresolved::live_only(),
@@ -109,7 +109,7 @@ async fn decision_time_in_past_succeeds() {
     let summary = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(entity_id),
                 temporal_axes: crate::axes_at_decision_time(one_hour_ago),
@@ -157,7 +157,7 @@ async fn decision_time_defaults_to_transaction_time() {
     let summary = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(entity_id),
                 temporal_axes: QueryTemporalAxesUnresolved::live_only(),
@@ -214,7 +214,7 @@ async fn decision_time_before_creation_finds_nothing() {
     let summary = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(entity_id),
                 include_drafts: false,
@@ -320,7 +320,7 @@ async fn past_decision_time_deletes_all_editions() {
     let summary = api
         .store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(entity_id),
                 temporal_axes: crate::axes_at_decision_time(one_hour_ago),

--- a/libs/@local/graph/postgres-store/tests/principals/ai.rs
+++ b/libs/@local/graph/postgres-store/tests/principals/ai.rs
@@ -77,9 +77,7 @@ async fn get_non_existent_ai() -> Result<(), Box<dyn Error>> {
     let (client, actor_id) = db.seed().await?;
 
     let non_existent_id = AiId::new(Uuid::new_v4());
-    let result = client
-        .get_ai_by_id(actor_id.into(), non_existent_id)
-        .await?;
+    let result = client.get_ai_by_id(actor_id, non_existent_id).await?;
 
     assert!(
         result.is_none(),
@@ -154,7 +152,7 @@ async fn ai_role_assignment() -> Result<(), Box<dyn Error>> {
     // Assign the role to the AI
     client
         .assign_role(
-            actor_id.into(),
+            actor_id,
             ai_id.into(),
             web_id.into(),
             RoleName::Administrator,

--- a/libs/@local/graph/postgres-store/tests/principals/machine.rs
+++ b/libs/@local/graph/postgres-store/tests/principals/machine.rs
@@ -120,9 +120,7 @@ async fn get_non_existent_machine() -> Result<(), Box<dyn Error>> {
     let (client, actor_id) = db.seed().await?;
 
     let non_existent_id = MachineId::new(Uuid::new_v4());
-    let result = client
-        .get_machine_by_id(actor_id.into(), non_existent_id)
-        .await?;
+    let result = client.get_machine_by_id(actor_id, non_existent_id).await?;
 
     assert!(
         result.is_none(),
@@ -139,7 +137,7 @@ async fn get_machine() -> Result<(), Box<dyn Error>> {
 
     let machine_id = client.create_machine(None, "test-machine").await?;
     let retrieved = client
-        .get_machine_by_identifier(actor_id.into(), "test-machine")
+        .get_machine_by_identifier(actor_id, "test-machine")
         .await?
         .expect("Machine should exist");
 
@@ -173,7 +171,7 @@ async fn machine_role_assignment() -> Result<(), Box<dyn Error>> {
     // Assign the role to the machine
     client
         .assign_role(
-            actor_id.into(),
+            actor_id,
             machine_id.into(),
             web_id.into(),
             RoleName::Administrator,

--- a/libs/@local/graph/postgres-store/tests/principals/policies.rs
+++ b/libs/@local/graph/postgres-store/tests/principals/policies.rs
@@ -233,7 +233,7 @@ async fn setup_policy_test_environment(
     // 1. Global policies (no principal constraint)
     let global_policy_id = client
         .create_policy(
-            actor_id.into(),
+            actor_id,
             PolicyCreationParams {
                 name: None,
                 effect: Effect::Permit,
@@ -247,7 +247,7 @@ async fn setup_policy_test_environment(
     // 2. Actor type specific policies
     let user_type_policy_id = client
         .create_policy(
-            actor_id.into(),
+            actor_id,
             PolicyCreationParams {
                 name: None,
                 effect: Effect::Permit,
@@ -262,7 +262,7 @@ async fn setup_policy_test_environment(
 
     let machine_type_policy_id = client
         .create_policy(
-            actor_id.into(),
+            actor_id,
             PolicyCreationParams {
                 name: None,
                 effect: Effect::Permit,
@@ -278,7 +278,7 @@ async fn setup_policy_test_environment(
     // 3. Specific actor policies
     let user1_policy_id = client
         .create_policy(
-            actor_id.into(),
+            actor_id,
             PolicyCreationParams {
                 name: None,
                 effect: Effect::Permit,
@@ -294,7 +294,7 @@ async fn setup_policy_test_environment(
     // 4. Role-based policies
     let web1_role_policy_id = client
         .create_policy(
-            actor_id.into(),
+            actor_id,
             PolicyCreationParams {
                 name: None,
                 effect: Effect::Permit,
@@ -311,7 +311,7 @@ async fn setup_policy_test_environment(
     // 5. Team-based policies
     let team1_policy_id = client
         .create_policy(
-            actor_id.into(),
+            actor_id,
             PolicyCreationParams {
                 name: None,
                 effect: Effect::Permit,
@@ -328,7 +328,7 @@ async fn setup_policy_test_environment(
     // 6. Role with actor type constraint
     let web2_role_user_policy_id = client
         .create_policy(
-            actor_id.into(),
+            actor_id,
             PolicyCreationParams {
                 name: None,
                 effect: Effect::Permit,
@@ -345,7 +345,7 @@ async fn setup_policy_test_environment(
     // 7. Deny policies for testing priority
     let deny_user1_policy_id = client
         .create_policy(
-            actor_id.into(),
+            actor_id,
             PolicyCreationParams {
                 name: None,
                 effect: Effect::Forbid,
@@ -977,7 +977,7 @@ async fn resource_constraints_are_preserved() -> Result<(), Box<dyn Error>> {
     // Create a policy with resource constraints
     let resource_policy_id = client
         .create_policy(
-            actor_id.into(),
+            actor_id,
             PolicyCreationParams {
                 name: None,
                 effect: Effect::Permit,
@@ -1077,7 +1077,7 @@ async fn deep_team_hierarchy() -> Result<(), Box<dyn Error>> {
     // Create policies
     let web_policy_id = client
         .create_policy(
-            actor_id.into(),
+            actor_id,
             PolicyCreationParams {
                 name: None,
                 effect: Effect::Permit,
@@ -1093,7 +1093,7 @@ async fn deep_team_hierarchy() -> Result<(), Box<dyn Error>> {
 
     let team1_policy_id = client
         .create_policy(
-            actor_id.into(),
+            actor_id,
             PolicyCreationParams {
                 name: None,
                 effect: Effect::Permit,
@@ -1109,7 +1109,7 @@ async fn deep_team_hierarchy() -> Result<(), Box<dyn Error>> {
 
     let team5_policy_id = client
         .create_policy(
-            actor_id.into(),
+            actor_id,
             PolicyCreationParams {
                 name: None,
                 effect: Effect::Permit,

--- a/libs/@local/graph/postgres-store/tests/principals/role.rs
+++ b/libs/@local/graph/postgres-store/tests/principals/role.rs
@@ -180,7 +180,7 @@ async fn delete_role() -> Result<(), Box<dyn Error>> {
 
     let role_policies = client
         .query_policies(
-            actor_id.into(),
+            actor_id,
             &PolicyFilter {
                 name: None,
                 principal: Some(PrincipalFilter::Constrained(PrincipalConstraint::Role {
@@ -191,9 +191,7 @@ async fn delete_role() -> Result<(), Box<dyn Error>> {
         )
         .await?;
     for policy in role_policies {
-        client
-            .delete_policy_by_id(actor_id.into(), policy.id)
-            .await?;
+        client.delete_policy_by_id(actor_id, policy.id).await?;
     }
 
     // Delete the role

--- a/libs/@local/graph/postgres-store/tests/principals/team.rs
+++ b/libs/@local/graph/postgres-store/tests/principals/team.rs
@@ -35,7 +35,7 @@ async fn create_team() -> Result<(), Box<dyn Error>> {
     assert!(client.is_team(team_id).await?);
 
     let team = client
-        .get_team_by_id(actor_id.into(), team_id)
+        .get_team_by_id(actor_id, team_id)
         .await?
         .expect("Team should exist");
 
@@ -270,7 +270,7 @@ async fn get_team() -> Result<(), Box<dyn Error>> {
 
     // Get the team and verify it matches
     let retrieved = client
-        .get_team_by_id(actor_id.into(), team_id)
+        .get_team_by_id(actor_id, team_id)
         .await?
         .expect("Team should exist");
     assert_eq!(retrieved.id, team_id);
@@ -285,9 +285,7 @@ async fn get_non_existent_team() -> Result<(), Box<dyn Error>> {
 
     // Try to get a non-existent team
     let non_existent_id = TeamId::new(Uuid::new_v4());
-    let result = client
-        .get_team_by_id(actor_id.into(), non_existent_id)
-        .await?;
+    let result = client.get_team_by_id(actor_id, non_existent_id).await?;
 
     // The implementation now returns a PrincipalNotFound error
     assert!(

--- a/libs/@local/graph/postgres-store/tests/principals/user.rs
+++ b/libs/@local/graph/postgres-store/tests/principals/user.rs
@@ -75,9 +75,7 @@ async fn get_non_existent_user() -> Result<(), Box<dyn Error>> {
     let (client, actor_id) = db.seed().await?;
 
     let non_existent_id = UserId::new(Uuid::new_v4());
-    let result = client
-        .get_user_by_id(actor_id.into(), non_existent_id)
-        .await?;
+    let result = client.get_user_by_id(actor_id, non_existent_id).await?;
 
     assert!(
         result.is_none(),

--- a/libs/@local/graph/postgres-store/tests/principals/web.rs
+++ b/libs/@local/graph/postgres-store/tests/principals/web.rs
@@ -35,7 +35,7 @@ async fn create_web() -> Result<(), Box<dyn Error>> {
     assert!(client.is_machine(response.machine_id).await?);
 
     let retrieved = client
-        .get_web_by_id(actor_id.into(), response.web_id)
+        .get_web_by_id(actor_id, response.web_id)
         .await?
         .expect("Web should exist");
     assert_eq!(retrieved.id, response.web_id);
@@ -136,9 +136,7 @@ async fn get_non_existent_web() -> Result<(), Box<dyn Error>> {
     let (client, actor_id) = db.seed().await?;
 
     let non_existent_id = WebId::new(Uuid::new_v4());
-    let result = client
-        .get_web_by_id(actor_id.into(), non_existent_id)
-        .await?;
+    let result = client.get_web_by_id(actor_id, non_existent_id).await?;
 
     assert!(
         result.is_none(),

--- a/libs/@local/graph/postgres-store/tests/semantic_search/main.rs
+++ b/libs/@local/graph/postgres-store/tests/semantic_search/main.rs
@@ -16,7 +16,7 @@ use hash_graph_store::{
     filter::SemanticDistance,
 };
 use hash_graph_types::Embedding;
-use type_system::principal::actor::ActorEntityUuid;
+use type_system::principal::actor::{ActorId, UserId};
 use uuid::Uuid;
 
 use self::common::DatabaseTestWrapper;
@@ -55,7 +55,8 @@ async fn search_with_real_policies() {
         .expect("disabling parallel workers should succeed");
 
     for actor_row in actor_rows {
-        let actor_id = ActorEntityUuid::new(actor_row.get::<_, Uuid>(0));
+        // The rows come from `user_actor`, so the type is known without a lookup.
+        let actor_id = ActorId::User(UserId::new(actor_row.get::<_, Uuid>(0)));
 
         for run in ["cold", "warm"] {
             let started = std::time::Instant::now();

--- a/libs/@local/graph/store/src/account/mod.rs
+++ b/libs/@local/graph/store/src/account/mod.rs
@@ -3,7 +3,7 @@ use hash_graph_authorization::policies::store::CreateWebResponse;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use type_system::principal::{
-    actor::{ActorEntityUuid, Ai, AiId, Machine, MachineId, User, UserId},
+    actor::{ActorEntityUuid, ActorId, Ai, AiId, Machine, MachineId, User, UserId},
     actor_group::{ActorGroupId, Team, TeamId, Web, WebId},
 };
 use uuid::Uuid;
@@ -110,7 +110,7 @@ pub trait AccountStore {
     /// - if creation failed, e.g. because the [`ActorEntityUuid`] already exists.
     fn create_user_actor(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: CreateUserActorParams,
     ) -> impl Future<Output = Result<CreateUserActorResponse, Report<AccountInsertionError>>> + Send;
 
@@ -121,7 +121,7 @@ pub trait AccountStore {
     /// - if creation failed, e.g. because the [`ActorEntityUuid`] already exists.
     fn create_machine_actor(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: CreateMachineActorParams,
     ) -> impl Future<Output = Result<MachineId, Report<AccountInsertionError>>> + Send;
 
@@ -132,7 +132,7 @@ pub trait AccountStore {
     /// - [`GetActorError`] if the actor could not be retrieved.
     fn get_user_by_id(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         id: UserId,
     ) -> impl Future<Output = Result<Option<User>, Report<GetActorError>>> + Send;
 
@@ -153,7 +153,7 @@ pub trait AccountStore {
     /// - [`GetActorError`] if the actor could not be retrieved.
     fn get_machine_by_id(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         id: MachineId,
     ) -> impl Future<Output = Result<Option<Machine>, Report<GetActorError>>> + Send;
 
@@ -164,7 +164,7 @@ pub trait AccountStore {
     /// - [`GetActorError`] if the actor could not be retrieved.
     fn get_machine_by_identifier(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         identifier: &str,
     ) -> impl Future<Output = Result<Option<Machine>, Report<GetActorError>>> + Send;
 
@@ -175,7 +175,7 @@ pub trait AccountStore {
     /// - [`GetActorError`] if the actor could not be retrieved.
     fn get_ai_by_id(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         id: AiId,
     ) -> impl Future<Output = Result<Option<Ai>, Report<GetActorError>>> + Send;
 
@@ -186,7 +186,7 @@ pub trait AccountStore {
     /// - [`GetActorError`] if the actor could not be retrieved.
     fn get_ai_by_identifier(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         identifier: &str,
     ) -> impl Future<Output = Result<Option<Ai>, Report<GetActorError>>> + Send;
 
@@ -197,7 +197,7 @@ pub trait AccountStore {
     /// - if creation failed, e.g. because the [`ActorEntityUuid`] already exists.
     fn create_ai_actor(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: CreateAiActorParams,
     ) -> impl Future<Output = Result<AiId, Report<AccountInsertionError>>> + Send;
 
@@ -208,7 +208,7 @@ pub trait AccountStore {
     /// - If reading the web failed.
     fn get_web_by_id(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         id: WebId,
     ) -> impl Future<Output = Result<Option<Web>, Report<WebRetrievalError>>> + Send;
 
@@ -221,7 +221,7 @@ pub trait AccountStore {
     /// - [`WebUpdateError::StoreError`] if the underlying store operation failed.
     fn update_web_shortname(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         id: WebId,
         shortname: &str,
     ) -> impl Future<Output = Result<(), Report<WebUpdateError>>> + Send;
@@ -233,7 +233,7 @@ pub trait AccountStore {
     /// - If reading the web failed.
     fn get_web_by_shortname(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         shortname: &str,
     ) -> impl Future<Output = Result<Option<Web>, Report<WebRetrievalError>>> + Send;
 
@@ -244,7 +244,7 @@ pub trait AccountStore {
     /// - if insertion failed, e.g. because the [`WebId`] already exists.
     fn create_org_web(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: CreateOrgWebParams,
     ) -> impl Future<Output = Result<CreateWebResponse, Report<WebInsertionError>>> + Send;
 
@@ -255,7 +255,7 @@ pub trait AccountStore {
     /// - if insertion failed, e.g. because the [`TeamId`] already exists.
     fn create_team(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: CreateTeamParams,
     ) -> impl Future<Output = Result<TeamId, Report<AccountGroupInsertionError>>> + Send;
 
@@ -266,7 +266,7 @@ pub trait AccountStore {
     /// - If reading the team failed.
     fn get_team_by_id(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         id: TeamId,
     ) -> impl Future<Output = Result<Option<Team>, Report<TeamRetrievalError>>> + Send;
 
@@ -277,7 +277,7 @@ pub trait AccountStore {
     /// - If reading the team failed.
     fn get_team_by_name(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         name: &str,
     ) -> impl Future<Output = Result<Option<Team>, Report<TeamRetrievalError>>> + Send;
 }

--- a/libs/@local/graph/store/src/data_type/store.rs
+++ b/libs/@local/graph/store/src/data_type/store.rs
@@ -3,9 +3,7 @@ use core::iter;
 use std::collections::{HashMap, HashSet};
 
 use error_stack::Report;
-use hash_graph_authorization::policies::{
-    action::ActionName, principal::actor::AuthenticatedActor,
-};
+use hash_graph_authorization::policies::action::ActionName;
 use hash_graph_temporal_versioning::{Timestamp, TransactionTime};
 use hash_graph_types::{self, Embedding};
 use serde::{Deserialize, Serialize};
@@ -17,7 +15,7 @@ use type_system::{
         },
         provenance::{OntologyOwnership, ProvidedOntologyEditionProvenance},
     },
-    principal::actor::ActorEntityUuid,
+    principal::actor::ActorId,
 };
 
 use crate::{
@@ -267,7 +265,7 @@ pub trait DataTypeStore {
     /// [`BaseUrl`]: type_system::ontology::BaseUrl
     fn create_data_type(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: CreateDataTypeParams,
     ) -> impl Future<Output = Result<DataTypeMetadata, Report<InsertionError>>> + Send
     where
@@ -292,7 +290,7 @@ pub trait DataTypeStore {
     /// [`BaseUrl`]: type_system::ontology::BaseUrl
     fn create_data_types<P>(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: P,
     ) -> impl Future<Output = Result<Vec<DataTypeMetadata>, Report<InsertionError>>> + Send
     where
@@ -300,34 +298,40 @@ pub trait DataTypeStore {
 
     /// Count the number of [`DataType`]s specified by the [`CountDataTypesParams`].
     ///
+    /// [`None`] reads as the public actor.
+    ///
     /// # Errors
     ///
     /// - if the underlying store fails to count the data types.
     fn count_data_types(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         params: CountDataTypesParams<'_>,
     ) -> impl Future<Output = Result<usize, Report<QueryError>>> + Send;
 
     /// Get the [`DataType`]s specified by the [`QueryDataTypesParams`].
+    ///
+    /// [`None`] reads as the public actor.
     ///
     /// # Errors
     ///
     /// - if the requested [`DataType`] doesn't exist.
     fn query_data_types(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         params: QueryDataTypesParams<'_>,
     ) -> impl Future<Output = Result<QueryDataTypesResponse, Report<QueryError>>> + Send;
 
     /// Get the [`Subgraph`] specified by the [`QueryDataTypeSubgraphParams`].
+    ///
+    /// [`None`] reads as the public actor.
     ///
     /// # Errors
     ///
     /// - if the requested [`DataType`] doesn't exist.
     fn query_data_type_subgraph(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         params: QueryDataTypeSubgraphParams<'_>,
     ) -> impl Future<Output = Result<QueryDataTypeSubgraphResponse, Report<QueryError>>> + Send;
 
@@ -338,7 +342,7 @@ pub trait DataTypeStore {
     /// - if the [`DataType`] doesn't exist.
     fn update_data_type(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: UpdateDataTypesParams,
     ) -> impl Future<Output = Result<DataTypeMetadata, Report<UpdateError>>> + Send
     where
@@ -360,7 +364,7 @@ pub trait DataTypeStore {
     /// - if the [`DataType`]s do not exist.
     fn update_data_types<P>(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: P,
     ) -> impl Future<Output = Result<Vec<DataTypeMetadata>, Report<UpdateError>>> + Send
     where
@@ -373,7 +377,7 @@ pub trait DataTypeStore {
     /// - if the [`DataType`] doesn't exist.
     fn archive_data_type(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: ArchiveDataTypeParams,
     ) -> impl Future<Output = Result<OntologyTemporalMetadata, Report<UpdateError>>> + Send;
 
@@ -384,19 +388,22 @@ pub trait DataTypeStore {
     /// - if the [`DataType`] doesn't exist.
     fn unarchive_data_type(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: UnarchiveDataTypeParams,
     ) -> impl Future<Output = Result<OntologyTemporalMetadata, Report<UpdateError>>> + Send;
 
     fn update_data_type_embeddings(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: UpdateDataTypeEmbeddingParams<'_>,
     ) -> impl Future<Output = Result<(), Report<UpdateError>>> + Send;
 
+    /// Find the conversion targets reachable from the given [`DataType`]s.
+    ///
+    /// [`None`] reads as the public actor.
     fn find_data_type_conversion_targets(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         params: FindDataTypeConversionTargetsParams,
     ) -> impl Future<Output = Result<FindDataTypeConversionTargetsResponse, Report<QueryError>>> + Send;
 
@@ -424,7 +431,7 @@ pub trait DataTypeStore {
     /// [`StoreError`]: CheckPermissionError::StoreError
     fn has_permission_for_data_types(
         &self,
-        authenticated_actor: AuthenticatedActor,
+        authenticated_actor: ActorId,
         params: HasPermissionForDataTypesParams<'_>,
     ) -> impl Future<Output = Result<HashSet<VersionedUrl>, Report<CheckPermissionError>>> + Send;
 }

--- a/libs/@local/graph/store/src/entity/store.rs
+++ b/libs/@local/graph/store/src/entity/store.rs
@@ -5,9 +5,7 @@ use std::collections::{HashMap, HashSet};
 use error_stack::Report;
 use futures::TryFutureExt as _;
 use hash_graph_authorization::policies::{
-    Effect,
-    action::ActionName,
-    principal::{PrincipalConstraint, actor::AuthenticatedActor},
+    Effect, action::ActionName, principal::PrincipalConstraint,
 };
 use hash_graph_temporal_versioning::{DecisionTime, Timestamp, TransactionTime};
 use hash_graph_types::{Embedding, knowledge::entity::EntityEmbedding};
@@ -26,7 +24,10 @@ use type_system::{
         },
     },
     ontology::{VersionedUrl, entity_type::ClosedMultiEntityType},
-    principal::{actor::ActorEntityUuid, actor_group::WebId},
+    principal::{
+        actor::{ActorEntityUuid, ActorId},
+        actor_group::WebId,
+    },
 };
 #[cfg(feature = "utoipa")]
 use utoipa::{
@@ -767,7 +768,7 @@ pub trait EntityStore {
     /// [`EntityType`]: type_system::ontology::entity_type::EntityType
     fn create_entity(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: CreateEntityParams,
     ) -> impl Future<Output = Result<Entity, Report<InsertionError>>> + Send {
         self.create_entities(actor_id, vec![params])
@@ -781,7 +782,7 @@ pub trait EntityStore {
     /// Creates new [`Entities`][Entity].
     fn create_entities(
         &mut self,
-        actor_uuid: ActorEntityUuid,
+        actor_id: ActorId,
         params: Vec<CreateEntityParams>,
     ) -> impl Future<Output = Result<Vec<Entity>, Report<InsertionError>>> + Send;
 
@@ -792,7 +793,7 @@ pub trait EntityStore {
     /// - if the validation failed
     fn validate_entity(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: ValidateEntityParams<'_>,
     ) -> impl Future<Output = Result<HashMap<usize, EntityValidationReport>, Report<QueryError>>> + Send
     {
@@ -806,7 +807,7 @@ pub trait EntityStore {
     /// - if the validation failed
     fn validate_entities(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: Vec<ValidateEntityParams<'_>>,
     ) -> impl Future<Output = Result<HashMap<usize, EntityValidationReport>, Report<QueryError>>> + Send;
 
@@ -819,12 +820,14 @@ pub trait EntityStore {
     /// single read-only transaction with an isolation level of at least repeatable read. This
     /// requires mutable access to the store to begin the transaction.
     ///
+    /// [`None`] reads as the public actor.
+    ///
     /// # Errors
     ///
     /// - if the requested [`Entities`][Entity] cannot be retrieved
     fn query_entities(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         params: QueryEntitiesParams<'_>,
     ) -> impl Future<Output = Result<QueryEntitiesResponse<'static>, Report<QueryError>>> + Send;
 
@@ -840,7 +843,7 @@ pub trait EntityStore {
     /// [`query_entities`]: Self::query_entities
     fn search_entities(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: SearchEntitiesParams,
     ) -> impl Future<Output = Result<SearchEntitiesResponse, Report<QueryError>>> + Send;
 
@@ -853,12 +856,14 @@ pub trait EntityStore {
     /// of at least repeatable read. This requires mutable access to the store to begin the
     /// transaction.
     ///
+    /// [`None`] reads as the public actor.
+    ///
     /// # Errors
     ///
     /// - if the requested [`Entities`][Entity] cannot be retrieved
     fn query_entity_subgraph(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         params: QueryEntitySubgraphParams<'_>,
     ) -> impl Future<Output = Result<QueryEntitySubgraphResponse<'static>, Report<QueryError>>> + Send;
 
@@ -871,7 +876,7 @@ pub trait EntityStore {
     /// [`query_entities`]: Self::query_entities
     fn summarize_entities(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: SummarizeEntitiesParams<'_>,
     ) -> impl Future<Output = Result<SummarizeEntitiesResponse, Report<QueryError>>> + Send;
 
@@ -892,13 +897,16 @@ pub trait EntityStore {
     /// [`EntityTableCursor`]: crate::entity::EntityTableCursor
     fn query_entities_table(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: QueryEntitiesTableParams,
     ) -> impl Future<Output = Result<QueryEntitiesTableResponse, Report<QueryError>>> + Send;
 
+    /// Get the latest edition of the [`Entity`], or the one live at the given timestamps.
+    ///
+    /// [`None`] reads as the public actor.
     fn get_entity_by_id(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         entity_id: EntityId,
         transaction_time: Option<Timestamp<TransactionTime>>,
         decision_time: Option<Timestamp<DecisionTime>>,
@@ -906,7 +914,7 @@ pub trait EntityStore {
 
     fn patch_entity(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: PatchEntityParams,
     ) -> impl Future<Output = Result<Entity, Report<UpdateError>>> + Send;
 
@@ -945,13 +953,13 @@ pub trait EntityStore {
     /// [`Filter::for_entity_by_entity_id`]: crate::filter::Filter::for_entity_by_entity_id
     fn delete_entities(
         &mut self,
-        actor_id: AuthenticatedActor,
+        actor_id: ActorId,
         params: DeleteEntitiesParams<'_>,
     ) -> impl Future<Output = Result<DeletionSummary, Report<DeletionError>>> + Send;
 
     fn diff_entity(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: DiffEntityParams,
     ) -> impl Future<Output = Result<DiffEntityResult<'static>, Report<QueryError>>> + Send
     where
@@ -960,7 +968,7 @@ pub trait EntityStore {
         async move {
             let first_entity = self
                 .get_entity_by_id(
-                    actor_id,
+                    Some(actor_id),
                     params.first_entity_id,
                     params.first_transaction_time,
                     params.first_decision_time,
@@ -968,7 +976,7 @@ pub trait EntityStore {
                 .await?;
             let second_entity = self
                 .get_entity_by_id(
-                    actor_id,
+                    Some(actor_id),
                     params.second_entity_id,
                     params.second_transaction_time,
                     params.second_decision_time,
@@ -1016,7 +1024,7 @@ pub trait EntityStore {
 
     fn update_entity_embeddings(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: UpdateEntityEmbeddingsParams<'_>,
     ) -> impl Future<Output = Result<(), Report<UpdateError>>> + Send;
 
@@ -1037,7 +1045,7 @@ pub trait EntityStore {
     /// embedding query fails.
     fn cluster_entities(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: ClusterEntitiesParams,
     ) -> impl Future<Output = Result<ClusterEntitiesResponse, Report<ClusterError>>> + Send;
 
@@ -1065,7 +1073,7 @@ pub trait EntityStore {
     /// [`StoreError`]: CheckPermissionError::StoreError
     fn has_permission_for_entities(
         &self,
-        authenticated_actor: AuthenticatedActor,
+        authenticated_actor: ActorId,
         params: HasPermissionForEntitiesParams<'_>,
     ) -> impl Future<
         Output = Result<HashMap<EntityId, Vec<EntityEditionId>>, Report<CheckPermissionError>>,

--- a/libs/@local/graph/store/src/entity_type/store.rs
+++ b/libs/@local/graph/store/src/entity_type/store.rs
@@ -3,9 +3,7 @@ use core::iter;
 use std::collections::{HashMap, HashSet};
 
 use error_stack::Report;
-use hash_graph_authorization::policies::{
-    action::ActionName, principal::actor::AuthenticatedActor,
-};
+use hash_graph_authorization::policies::action::ActionName;
 use hash_graph_temporal_versioning::{Timestamp, TransactionTime};
 use hash_graph_types::Embedding;
 use serde::{Deserialize, Serialize};
@@ -19,7 +17,10 @@ use type_system::{
         property_type::PropertyType,
         provenance::{OntologyOwnership, ProvidedOntologyEditionProvenance},
     },
-    principal::{actor::ActorEntityUuid, actor_group::WebId},
+    principal::{
+        actor::{ActorEntityUuid, ActorId},
+        actor_group::WebId,
+    },
 };
 
 use crate::{
@@ -418,7 +419,7 @@ pub trait EntityTypeStore {
     /// [`BaseUrl`]: type_system::ontology::BaseUrl
     fn create_entity_type(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: CreateEntityTypeParams,
     ) -> impl Future<Output = Result<EntityTypeMetadata, Report<InsertionError>>> + Send
     where
@@ -443,7 +444,7 @@ pub trait EntityTypeStore {
     /// [`BaseUrl`]: type_system::ontology::BaseUrl
     fn create_entity_types<P>(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: P,
     ) -> impl Future<Output = Result<Vec<EntityTypeMetadata>, Report<InsertionError>>> + Send
     where
@@ -451,34 +452,40 @@ pub trait EntityTypeStore {
 
     /// Count the number of [`EntityType`]s specified by the [`CountEntityTypesParams`].
     ///
+    /// [`None`] reads as the public actor.
+    ///
     /// # Errors
     ///
     /// - if the underlying store fails to count the entity types.
     fn count_entity_types(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         params: CountEntityTypesParams<'_>,
     ) -> impl Future<Output = Result<usize, Report<QueryError>>> + Send;
 
     /// Get the [`Subgraph`]s specified by the [`QueryEntityTypeSubgraphParams`].
+    ///
+    /// [`None`] reads as the public actor.
     ///
     /// # Errors
     ///
     /// - if the requested [`EntityType`] doesn't exist.
     fn query_entity_type_subgraph(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         params: QueryEntityTypeSubgraphParams<'_>,
     ) -> impl Future<Output = Result<QueryEntityTypeSubgraphResponse, Report<QueryError>>> + Send;
 
     /// Get the [`EntityType`]s specified by the [`QueryEntityTypesParams`].
+    ///
+    /// [`None`] reads as the public actor.
     ///
     /// # Errors
     ///
     /// - if the requested [`EntityType`] doesn't exist.
     fn query_entity_types(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         params: QueryEntityTypesParams<'_>,
     ) -> impl Future<Output = Result<QueryEntityTypesResponse, Report<QueryError>>> + Send;
 
@@ -489,7 +496,7 @@ pub trait EntityTypeStore {
     /// - if the requested [`EntityType`]s cannot be retrieved
     fn search_entity_types(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: SearchEntityTypesParams,
     ) -> impl Future<Output = Result<SearchEntityTypesResponse, Report<QueryError>>> + Send;
 
@@ -510,12 +517,14 @@ pub trait EntityTypeStore {
     ///
     /// # Errors
     ///
+    /// [`None`] reads as the public actor.
+    ///
     /// Returns a `QueryError` if:
     /// - Database operations fail when retrieving closed entity type information
     /// - Type resolution fails due to invalid entity type references
     fn get_closed_multi_entity_types<I, J>(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         entity_type_ids: I,
         temporal_axes: QueryTemporalAxesUnresolved,
         include_resolved: Option<IncludeResolvedEntityTypeOption>,
@@ -531,7 +540,7 @@ pub trait EntityTypeStore {
     /// - if the [`EntityType`] doesn't exist.
     fn update_entity_type(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: UpdateEntityTypesParams,
     ) -> impl Future<Output = Result<EntityTypeMetadata, Report<UpdateError>>> + Send
     where
@@ -553,7 +562,7 @@ pub trait EntityTypeStore {
     /// - if the [`EntityType`]s do not exist.
     fn update_entity_types<P>(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: P,
     ) -> impl Future<Output = Result<Vec<EntityTypeMetadata>, Report<UpdateError>>> + Send
     where
@@ -566,7 +575,7 @@ pub trait EntityTypeStore {
     /// - if the [`EntityType`] doesn't exist.
     fn archive_entity_type(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
 
         params: ArchiveEntityTypeParams,
     ) -> impl Future<Output = Result<OntologyTemporalMetadata, Report<UpdateError>>> + Send;
@@ -578,14 +587,14 @@ pub trait EntityTypeStore {
     /// - if the [`EntityType`] doesn't exist.
     fn unarchive_entity_type(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
 
         params: UnarchiveEntityTypeParams,
     ) -> impl Future<Output = Result<OntologyTemporalMetadata, Report<UpdateError>>> + Send;
 
     fn update_entity_type_embeddings(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
 
         params: UpdateEntityTypeEmbeddingParams<'_>,
     ) -> impl Future<Output = Result<(), Report<UpdateError>>> + Send;
@@ -614,7 +623,7 @@ pub trait EntityTypeStore {
     /// [`StoreError`]: CheckPermissionError::StoreError
     fn has_permission_for_entity_types(
         &self,
-        authenticated_actor: AuthenticatedActor,
+        authenticated_actor: ActorId,
         params: HasPermissionForEntityTypesParams<'_>,
     ) -> impl Future<Output = Result<HashSet<VersionedUrl>, Report<CheckPermissionError>>> + Send;
 }

--- a/libs/@local/graph/store/src/filter/mod.rs
+++ b/libs/@local/graph/store/src/filter/mod.rs
@@ -956,17 +956,20 @@ impl<'p> Filter<'p, Entity> {
             EntityResourceFilter::Not { filter } => {
                 Self::Not(Box::new(Self::for_resource_filter(filter, actor_id)))
             }
-            EntityResourceFilter::CreatedByPrincipal => Self::Equal(
-                FilterExpression::Path {
-                    path: EntityQueryPath::CreatedById,
-                },
-                FilterExpression::Parameter {
-                    parameter: Parameter::Uuid(
-                        actor_id
-                            .map_or_else(ActorEntityUuid::public_actor, ActorEntityUuid::from)
-                            .into(),
-                    ),
-                    convert: None,
+            EntityResourceFilter::CreatedByPrincipal => actor_id.map_or_else(
+                // An empty `Any` transpiles to `FALSE`, so a request without an actor matches
+                // no row.
+                || Self::Any(Vec::new()),
+                |actor_id| {
+                    Self::Equal(
+                        FilterExpression::Path {
+                            path: EntityQueryPath::CreatedById,
+                        },
+                        FilterExpression::Parameter {
+                            parameter: Parameter::Uuid(ActorEntityUuid::from(actor_id).into()),
+                            convert: None,
+                        },
+                    )
                 },
             ),
             EntityResourceFilter::IsReadOnly => Self::Equal(

--- a/libs/@local/graph/store/src/property_type/store.rs
+++ b/libs/@local/graph/store/src/property_type/store.rs
@@ -3,9 +3,7 @@ use core::iter;
 use std::collections::HashSet;
 
 use error_stack::Report;
-use hash_graph_authorization::policies::{
-    action::ActionName, principal::actor::AuthenticatedActor,
-};
+use hash_graph_authorization::policies::action::ActionName;
 use hash_graph_temporal_versioning::{Timestamp, TransactionTime};
 use hash_graph_types::Embedding;
 use serde::{Deserialize, Serialize};
@@ -15,7 +13,7 @@ use type_system::{
         property_type::{PropertyType, PropertyTypeMetadata, PropertyTypeWithMetadata},
         provenance::{OntologyOwnership, ProvidedOntologyEditionProvenance},
     },
-    principal::actor::ActorEntityUuid,
+    principal::actor::ActorId,
 };
 
 use crate::{
@@ -268,7 +266,7 @@ pub trait PropertyTypeStore {
     /// [`BaseUrl`]: type_system::ontology::BaseUrl
     fn create_property_type(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: CreatePropertyTypeParams,
     ) -> impl Future<Output = Result<PropertyTypeMetadata, Report<InsertionError>>> + Send
     where
@@ -293,7 +291,7 @@ pub trait PropertyTypeStore {
     /// [`BaseUrl`]: type_system::ontology::BaseUrl
     fn create_property_types<P>(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: P,
     ) -> impl Future<Output = Result<Vec<PropertyTypeMetadata>, Report<InsertionError>>> + Send
     where
@@ -301,27 +299,33 @@ pub trait PropertyTypeStore {
 
     /// Count the number of [`PropertyType`]s specified by the [`CountPropertyTypesParams`].
     ///
+    /// [`None`] reads as the public actor.
+    ///
     /// # Errors
     ///
     /// - if the underlying store fails to count the property types.
     fn count_property_types(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         params: CountPropertyTypesParams<'_>,
     ) -> impl Future<Output = Result<usize, Report<QueryError>>> + Send;
 
     /// Get the [`Subgraph`] specified by the [`QueryPropertyTypeSubgraphParams`].
+    ///
+    /// [`None`] reads as the public actor.
     ///
     /// # Errors
     ///
     /// - if the requested [`PropertyType`] doesn't exist.
     fn query_property_type_subgraph(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         params: QueryPropertyTypeSubgraphParams<'_>,
     ) -> impl Future<Output = Result<QueryPropertyTypeSubgraphResponse, Report<QueryError>>> + Send;
 
     /// Get the [`PropertyTypes`] specified by the [`QueryPropertyTypesParams`].
+    ///
+    /// [`None`] reads as the public actor.
     ///
     /// # Errors
     ///
@@ -330,7 +334,7 @@ pub trait PropertyTypeStore {
     /// [`PropertyTypes`]: PropertyType
     fn query_property_types(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         params: QueryPropertyTypesParams<'_>,
     ) -> impl Future<Output = Result<QueryPropertyTypesResponse, Report<QueryError>>> + Send;
 
@@ -341,7 +345,7 @@ pub trait PropertyTypeStore {
     /// - if the [`PropertyType`] doesn't exist.
     fn update_property_type(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: UpdatePropertyTypesParams,
     ) -> impl Future<Output = Result<PropertyTypeMetadata, Report<UpdateError>>> + Send
     where
@@ -363,7 +367,7 @@ pub trait PropertyTypeStore {
     /// - if the [`PropertyType`]s do not exist.
     fn update_property_types<P>(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: P,
     ) -> impl Future<Output = Result<Vec<PropertyTypeMetadata>, Report<UpdateError>>> + Send
     where
@@ -376,7 +380,7 @@ pub trait PropertyTypeStore {
     /// - if the [`PropertyType`] doesn't exist.
     fn archive_property_type(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
 
         params: ArchivePropertyTypeParams<'_>,
     ) -> impl Future<Output = Result<OntologyTemporalMetadata, Report<UpdateError>>> + Send;
@@ -388,14 +392,14 @@ pub trait PropertyTypeStore {
     /// - if the [`PropertyType`] doesn't exist.
     fn unarchive_property_type(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
 
         params: UnarchivePropertyTypeParams<'_>,
     ) -> impl Future<Output = Result<OntologyTemporalMetadata, Report<UpdateError>>> + Send;
 
     fn update_property_type_embeddings(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
 
         params: UpdatePropertyTypeEmbeddingParams<'_>,
     ) -> impl Future<Output = Result<(), Report<UpdateError>>> + Send;
@@ -412,7 +416,7 @@ pub trait PropertyTypeStore {
     /// [`StoreError`]: CheckPermissionError::StoreError
     fn has_permission_for_property_types(
         &self,
-        authenticated_actor: AuthenticatedActor,
+        authenticated_actor: ActorId,
         params: HasPermissionForPropertyTypesParams<'_>,
     ) -> impl Future<Output = Result<HashSet<VersionedUrl>, Report<CheckPermissionError>>> + Send;
 }

--- a/libs/@local/graph/store/src/user_deletion.rs
+++ b/libs/@local/graph/store/src/user_deletion.rs
@@ -1,7 +1,9 @@
 use error_stack::{Report, ReportSink, ResultExt as _};
-use hash_graph_authorization::policies::principal::actor::AuthenticatedActor;
 use serde::Serialize;
-use type_system::principal::{actor::UserId, actor_group::WebId};
+use type_system::principal::{
+    actor::{ActorId, UserId},
+    actor_group::WebId,
+};
 
 use crate::{
     account::AccountStore,
@@ -114,7 +116,7 @@ pub async fn delete_user<S, I, O, E>(
     identity_provider: &I,
     oauth_provider: &O,
     email_subscription_provider: Option<&E>,
-    actor: AuthenticatedActor,
+    actor: ActorId,
     user_id: UserId,
     kratos_identity_id: Option<String>,
 ) -> Result<UserDeletionOutcome, Report<UserDeletionError>>

--- a/libs/@local/graph/type-fetcher/src/store.rs
+++ b/libs/@local/graph/type-fetcher/src/store.rs
@@ -5,7 +5,6 @@ use std::collections::{HashMap, HashSet};
 use error_stack::{Report, ResultExt as _};
 use hash_graph_authorization::policies::{
     ContextBuilder, Policy, PolicyId, ResolvedPolicy,
-    principal::actor::AuthenticatedActor,
     resource::{DataTypeResource, EntityResource, EntityTypeResource, PropertyTypeResource},
     store::{
         CreateWebParameter, CreateWebResponse, PolicyCreationParams, PolicyFilter, PolicyStore,
@@ -101,7 +100,7 @@ pub trait TypeFetcher {
     /// Fetches the provided type reference and inserts it to the Graph.
     fn insert_external_ontology_type(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         reference: OntologyTypeReference<'_>,
     ) -> impl Future<Output = Result<OntologyTypeMetadata, Report<InsertionError>>> + Send;
 }
@@ -191,7 +190,7 @@ where
 
     async fn get_web_roles(
         &mut self,
-        actor: ActorEntityUuid,
+        actor: ActorId,
         web_id: WebId,
     ) -> Result<HashMap<WebRoleId, WebRole>, Report<WebRoleError>> {
         self.store.get_web_roles(actor, web_id).await
@@ -199,7 +198,7 @@ where
 
     async fn get_team_roles(
         &mut self,
-        actor: ActorEntityUuid,
+        actor: ActorId,
         team_id: TeamId,
     ) -> Result<HashMap<TeamRoleId, TeamRole>, Report<TeamRoleError>> {
         self.store.get_team_roles(actor, team_id).await
@@ -207,7 +206,7 @@ where
 
     async fn assign_role(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         actor_to_assign: ActorEntityUuid,
         actor_group_id: ActorGroupEntityUuid,
         name: RoleName,
@@ -237,7 +236,7 @@ where
 
     async fn unassign_role(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         actor_to_unassign: ActorEntityUuid,
         actor_group_id: ActorGroupEntityUuid,
         name: RoleName,
@@ -250,7 +249,7 @@ where
     async fn determine_actor(
         &self,
         actor_entity_uuid: ActorEntityUuid,
-    ) -> Result<Option<ActorId>, Report<DetermineActorError>> {
+    ) -> Result<ActorId, Report<DetermineActorError>> {
         self.store.determine_actor(actor_entity_uuid).await
     }
 
@@ -271,7 +270,7 @@ where
 {
     async fn create_policy(
         &mut self,
-        authenticated_actor: AuthenticatedActor,
+        authenticated_actor: ActorId,
         policy: PolicyCreationParams,
     ) -> Result<PolicyId, Report<CreatePolicyError>> {
         self.store.create_policy(authenticated_actor, policy).await
@@ -279,7 +278,7 @@ where
 
     async fn get_policy_by_id(
         &self,
-        authenticated_actor: AuthenticatedActor,
+        authenticated_actor: ActorId,
         id: PolicyId,
     ) -> Result<Option<Policy>, Report<GetPoliciesError>> {
         self.store.get_policy_by_id(authenticated_actor, id).await
@@ -287,7 +286,7 @@ where
 
     async fn query_policies(
         &self,
-        authenticated_actor: AuthenticatedActor,
+        authenticated_actor: ActorId,
         filter: &PolicyFilter,
     ) -> Result<Vec<Policy>, Report<GetPoliciesError>> {
         self.store.query_policies(authenticated_actor, filter).await
@@ -295,7 +294,7 @@ where
 
     async fn resolve_policies_for_actor(
         &self,
-        authenticated_actor: AuthenticatedActor,
+        authenticated_actor: Option<ActorId>,
         params: ResolvePoliciesParams<'_>,
     ) -> Result<Vec<ResolvedPolicy>, Report<GetPoliciesError>> {
         self.store
@@ -305,7 +304,7 @@ where
 
     async fn update_policy_by_id(
         &mut self,
-        authenticated_actor: AuthenticatedActor,
+        authenticated_actor: ActorId,
         policy_id: PolicyId,
         operations: &[PolicyUpdateOperation],
     ) -> Result<Policy, Report<UpdatePolicyError>> {
@@ -316,7 +315,7 @@ where
 
     async fn archive_policy_by_id(
         &mut self,
-        authenticated_actor: AuthenticatedActor,
+        authenticated_actor: ActorId,
         policy_id: PolicyId,
     ) -> Result<(), Report<RemovePolicyError>> {
         self.store
@@ -326,7 +325,7 @@ where
 
     async fn delete_policy_by_id(
         &mut self,
-        authenticated_actor: AuthenticatedActor,
+        authenticated_actor: ActorId,
         policy_id: PolicyId,
     ) -> Result<(), Report<RemovePolicyError>> {
         self.store
@@ -420,7 +419,7 @@ where
 {
     async fn contains_ontology_type(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         ontology_type_reference: OntologyTypeReference<'_>,
     ) -> Result<bool, Report<QueryError>> {
         let url = ontology_type_reference.url();
@@ -439,7 +438,7 @@ where
             OntologyTypeReference::DataTypeReference(_) => self
                 .store
                 .query_data_types(
-                    actor_id,
+                    Some(actor_id),
                     QueryDataTypesParams {
                         filter: Filter::for_versioned_url(url),
                         temporal_axes: QueryTemporalAxesUnresolved::live_only(),
@@ -453,7 +452,7 @@ where
             OntologyTypeReference::PropertyTypeReference(_) => self
                 .store
                 .query_property_types(
-                    actor_id,
+                    Some(actor_id),
                     QueryPropertyTypesParams {
                         filter: Filter::for_versioned_url(url),
                         temporal_axes: QueryTemporalAxesUnresolved::live_only(),
@@ -467,7 +466,7 @@ where
             OntologyTypeReference::EntityTypeReference(_) => self
                 .store
                 .query_entity_types(
-                    actor_id,
+                    Some(actor_id),
                     QueryEntityTypesParams {
                         request: CommonQueryEntityTypesParams {
                             filter: Filter::for_versioned_url(url),
@@ -490,7 +489,7 @@ where
     #[tracing::instrument(level = "info", skip(self, ontology_type))]
     async fn collect_external_ontology_types<'o, T: OntologyTypeSchema + Sync>(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         ontology_type: &'o T,
         bypassed_types: &HashSet<&VersionedUrl>,
     ) -> Result<Vec<OntologyTypeReference<'o>>, Report<QueryError>> {
@@ -513,7 +512,7 @@ where
     #[expect(clippy::too_many_lines)]
     async fn fetch_external_ontology_types(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         ontology_type_references: impl IntoIterator<Item = VersionedUrl> + Send,
         bypassed_types: &HashSet<&VersionedUrl>,
     ) -> Result<FetchedOntologyTypes, Report<QueryError>> {
@@ -665,7 +664,7 @@ where
     #[tracing::instrument(level = "info", skip_all)]
     async fn insert_external_types<'o, T: OntologyTypeSchema + Sync + 'o>(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         ontology_types: impl IntoIterator<Item = &'o T, IntoIter: Send> + Send,
         bypassed_types: &HashSet<&VersionedUrl>,
     ) -> Result<(), Report<InsertionError>> {
@@ -764,7 +763,7 @@ where
     #[tracing::instrument(level = "info", skip(self))]
     async fn insert_external_types_by_reference(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         reference: OntologyTypeReference<'_>,
         on_conflict: ConflictBehavior,
         bypassed_types: &HashSet<&VersionedUrl>,
@@ -875,7 +874,7 @@ where
     #[tracing::instrument(level = "info", skip(self))]
     async fn insert_external_ontology_type(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         reference: OntologyTypeReference<'_>,
     ) -> Result<OntologyTypeMetadata, Report<InsertionError>> {
         self.insert_external_types_by_reference(
@@ -965,7 +964,7 @@ where
 {
     async fn create_user_actor(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: CreateUserActorParams,
     ) -> Result<CreateUserActorResponse, Report<AccountInsertionError>> {
         self.store.create_user_actor(actor_id, params).await
@@ -973,7 +972,7 @@ where
 
     async fn create_machine_actor(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: CreateMachineActorParams,
     ) -> Result<MachineId, Report<AccountInsertionError>> {
         self.store.create_machine_actor(actor_id, params).await
@@ -981,7 +980,7 @@ where
 
     async fn create_ai_actor(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: CreateAiActorParams,
     ) -> Result<AiId, Report<AccountInsertionError>> {
         self.store.create_ai_actor(actor_id, params).await
@@ -989,7 +988,7 @@ where
 
     async fn get_user_by_id(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         id: UserId,
     ) -> Result<Option<User>, Report<GetActorError>> {
         self.store.get_user_by_id(actor_id, id).await
@@ -1004,7 +1003,7 @@ where
 
     async fn get_machine_by_id(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         id: MachineId,
     ) -> Result<Option<Machine>, Report<GetActorError>> {
         self.store.get_machine_by_id(actor_id, id).await
@@ -1012,7 +1011,7 @@ where
 
     async fn get_machine_by_identifier(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         identifier: &str,
     ) -> Result<Option<Machine>, Report<GetActorError>> {
         self.store
@@ -1022,7 +1021,7 @@ where
 
     async fn get_ai_by_id(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         id: AiId,
     ) -> Result<Option<Ai>, Report<GetActorError>> {
         self.store.get_ai_by_id(actor_id, id).await
@@ -1030,7 +1029,7 @@ where
 
     async fn get_ai_by_identifier(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         identifier: &str,
     ) -> Result<Option<Ai>, Report<GetActorError>> {
         self.store.get_ai_by_identifier(actor_id, identifier).await
@@ -1038,7 +1037,7 @@ where
 
     async fn get_web_by_id(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         id: WebId,
     ) -> Result<Option<Web>, Report<WebRetrievalError>> {
         self.store.get_web_by_id(actor_id, id).await
@@ -1046,7 +1045,7 @@ where
 
     async fn update_web_shortname(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         id: WebId,
         shortname: &str,
     ) -> Result<(), Report<WebUpdateError>> {
@@ -1057,7 +1056,7 @@ where
 
     async fn get_web_by_shortname(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         shortname: &str,
     ) -> Result<Option<Web>, Report<WebRetrievalError>> {
         self.store.get_web_by_shortname(actor_id, shortname).await
@@ -1065,7 +1064,7 @@ where
 
     async fn create_org_web(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: CreateOrgWebParams,
     ) -> Result<CreateWebResponse, Report<WebInsertionError>> {
         self.store.create_org_web(actor_id, params).await
@@ -1073,7 +1072,7 @@ where
 
     async fn create_team(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: CreateTeamParams,
     ) -> Result<TeamId, Report<AccountGroupInsertionError>> {
         self.store.create_team(actor_id, params).await
@@ -1081,7 +1080,7 @@ where
 
     async fn get_team_by_id(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         id: TeamId,
     ) -> Result<Option<Team>, Report<TeamRetrievalError>> {
         self.store.get_team_by_id(actor_id, id).await
@@ -1089,7 +1088,7 @@ where
 
     async fn get_team_by_name(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         name: &str,
     ) -> Result<Option<Team>, Report<TeamRetrievalError>> {
         self.store.get_team_by_name(actor_id, name).await
@@ -1102,7 +1101,7 @@ where
 {
     async fn create_data_types<P>(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: P,
     ) -> Result<Vec<DataTypeMetadata>, Report<InsertionError>>
     where
@@ -1137,7 +1136,7 @@ where
 
     async fn count_data_types(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         params: CountDataTypesParams<'_>,
     ) -> Result<usize, Report<QueryError>> {
         self.store.count_data_types(actor_id, params).await
@@ -1145,7 +1144,7 @@ where
 
     async fn query_data_types(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         params: QueryDataTypesParams<'_>,
     ) -> Result<QueryDataTypesResponse, Report<QueryError>> {
         self.store.query_data_types(actor_id, params).await
@@ -1153,7 +1152,7 @@ where
 
     async fn query_data_type_subgraph(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         params: QueryDataTypeSubgraphParams<'_>,
     ) -> Result<QueryDataTypeSubgraphResponse, Report<QueryError>> {
         self.store.query_data_type_subgraph(actor_id, params).await
@@ -1161,7 +1160,7 @@ where
 
     async fn update_data_types<P>(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: P,
     ) -> Result<Vec<DataTypeMetadata>, Report<UpdateError>>
     where
@@ -1197,7 +1196,7 @@ where
 
     async fn archive_data_type(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: ArchiveDataTypeParams<'_>,
     ) -> Result<OntologyTemporalMetadata, Report<UpdateError>> {
         self.store.archive_data_type(actor_id, params).await
@@ -1205,7 +1204,7 @@ where
 
     async fn unarchive_data_type(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: UnarchiveDataTypeParams,
     ) -> Result<OntologyTemporalMetadata, Report<UpdateError>> {
         self.store.unarchive_data_type(actor_id, params).await
@@ -1213,7 +1212,7 @@ where
 
     async fn update_data_type_embeddings(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: UpdateDataTypeEmbeddingParams<'_>,
     ) -> Result<(), Report<UpdateError>> {
         self.store
@@ -1223,7 +1222,7 @@ where
 
     async fn find_data_type_conversion_targets(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         params: FindDataTypeConversionTargetsParams,
     ) -> Result<FindDataTypeConversionTargetsResponse, Report<QueryError>> {
         self.store
@@ -1237,7 +1236,7 @@ where
 
     async fn has_permission_for_data_types(
         &self,
-        authenticated_actor: AuthenticatedActor,
+        authenticated_actor: ActorId,
         params: HasPermissionForDataTypesParams<'_>,
     ) -> Result<HashSet<VersionedUrl>, Report<CheckPermissionError>> {
         self.store
@@ -1252,7 +1251,7 @@ where
 {
     async fn create_property_types<P>(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: P,
     ) -> Result<Vec<PropertyTypeMetadata>, Report<InsertionError>>
     where
@@ -1287,7 +1286,7 @@ where
 
     async fn count_property_types(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         params: CountPropertyTypesParams<'_>,
     ) -> Result<usize, Report<QueryError>> {
         self.store.count_property_types(actor_id, params).await
@@ -1295,7 +1294,7 @@ where
 
     async fn query_property_types(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         params: QueryPropertyTypesParams<'_>,
     ) -> Result<QueryPropertyTypesResponse, Report<QueryError>> {
         self.store.query_property_types(actor_id, params).await
@@ -1303,7 +1302,7 @@ where
 
     async fn query_property_type_subgraph(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         params: QueryPropertyTypeSubgraphParams<'_>,
     ) -> Result<QueryPropertyTypeSubgraphResponse, Report<QueryError>> {
         self.store
@@ -1313,7 +1312,7 @@ where
 
     async fn update_property_types<P>(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: P,
     ) -> Result<Vec<PropertyTypeMetadata>, Report<UpdateError>>
     where
@@ -1349,7 +1348,7 @@ where
 
     async fn archive_property_type(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
 
         params: ArchivePropertyTypeParams<'_>,
     ) -> Result<OntologyTemporalMetadata, Report<UpdateError>> {
@@ -1358,7 +1357,7 @@ where
 
     async fn unarchive_property_type(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
 
         params: UnarchivePropertyTypeParams<'_>,
     ) -> Result<OntologyTemporalMetadata, Report<UpdateError>> {
@@ -1367,7 +1366,7 @@ where
 
     async fn update_property_type_embeddings(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
 
         params: UpdatePropertyTypeEmbeddingParams<'_>,
     ) -> Result<(), Report<UpdateError>> {
@@ -1378,7 +1377,7 @@ where
 
     async fn has_permission_for_property_types(
         &self,
-        authenticated_actor: AuthenticatedActor,
+        authenticated_actor: ActorId,
         params: HasPermissionForPropertyTypesParams<'_>,
     ) -> Result<HashSet<VersionedUrl>, Report<CheckPermissionError>> {
         self.store
@@ -1393,7 +1392,7 @@ where
 {
     async fn create_entity_types<P>(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: P,
     ) -> Result<Vec<EntityTypeMetadata>, Report<InsertionError>>
     where
@@ -1428,7 +1427,7 @@ where
 
     async fn count_entity_types(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         params: CountEntityTypesParams<'_>,
     ) -> Result<usize, Report<QueryError>> {
         self.store.count_entity_types(actor_id, params).await
@@ -1436,7 +1435,7 @@ where
 
     async fn query_entity_types(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         params: QueryEntityTypesParams<'_>,
     ) -> Result<QueryEntityTypesResponse, Report<QueryError>> {
         self.store.query_entity_types(actor_id, params).await
@@ -1444,7 +1443,7 @@ where
 
     async fn search_entity_types(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: SearchEntityTypesParams,
     ) -> Result<SearchEntityTypesResponse, Report<QueryError>> {
         self.store.search_entity_types(actor_id, params).await
@@ -1452,7 +1451,7 @@ where
 
     async fn get_closed_multi_entity_types<I, J>(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         entity_type_ids: I,
         temporal_axes: QueryTemporalAxesUnresolved,
         include_resolved: Option<IncludeResolvedEntityTypeOption>,
@@ -1473,7 +1472,7 @@ where
 
     async fn query_entity_type_subgraph(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         params: QueryEntityTypeSubgraphParams<'_>,
     ) -> Result<QueryEntityTypeSubgraphResponse, Report<QueryError>> {
         self.store
@@ -1483,7 +1482,7 @@ where
 
     async fn update_entity_types<P>(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: P,
     ) -> Result<Vec<EntityTypeMetadata>, Report<UpdateError>>
     where
@@ -1519,7 +1518,7 @@ where
 
     async fn archive_entity_type(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
 
         params: ArchiveEntityTypeParams<'_>,
     ) -> Result<OntologyTemporalMetadata, Report<UpdateError>> {
@@ -1528,7 +1527,7 @@ where
 
     async fn unarchive_entity_type(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
 
         params: UnarchiveEntityTypeParams<'_>,
     ) -> Result<OntologyTemporalMetadata, Report<UpdateError>> {
@@ -1537,7 +1536,7 @@ where
 
     async fn update_entity_type_embeddings(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
 
         params: UpdateEntityTypeEmbeddingParams<'_>,
     ) -> Result<(), Report<UpdateError>> {
@@ -1552,7 +1551,7 @@ where
 
     async fn has_permission_for_entity_types(
         &self,
-        authenticated_actor: AuthenticatedActor,
+        authenticated_actor: ActorId,
         params: HasPermissionForEntityTypesParams<'_>,
     ) -> Result<HashSet<VersionedUrl>, Report<CheckPermissionError>> {
         self.store
@@ -1567,7 +1566,7 @@ where
 {
     async fn create_entities(
         &mut self,
-        actor_uuid: ActorEntityUuid,
+        actor_id: ActorId,
         params: Vec<CreateEntityParams>,
     ) -> Result<Vec<Entity>, Report<InsertionError>> {
         let type_ids = params
@@ -1580,7 +1579,7 @@ where
                 url: entity_type_id.clone(),
             };
             self.insert_external_types_by_reference(
-                actor_uuid,
+                actor_id,
                 OntologyTypeReference::EntityTypeReference(&entity_type_reference),
                 ConflictBehavior::Skip,
                 &HashSet::new(),
@@ -1588,12 +1587,12 @@ where
             .await?;
         }
 
-        self.store.create_entities(actor_uuid, params).await
+        self.store.create_entities(actor_id, params).await
     }
 
     async fn validate_entities(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: Vec<ValidateEntityParams<'_>>,
     ) -> Result<HashMap<usize, EntityValidationReport>, Report<QueryError>> {
         self.store.validate_entities(actor_id, params).await
@@ -1601,7 +1600,7 @@ where
 
     async fn query_entities(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         params: QueryEntitiesParams<'_>,
     ) -> Result<QueryEntitiesResponse<'static>, Report<QueryError>> {
         self.store.query_entities(actor_id, params).await
@@ -1609,7 +1608,7 @@ where
 
     async fn search_entities(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: SearchEntitiesParams,
     ) -> Result<SearchEntitiesResponse, Report<QueryError>> {
         self.store.search_entities(actor_id, params).await
@@ -1617,7 +1616,7 @@ where
 
     async fn query_entity_subgraph(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         params: QueryEntitySubgraphParams<'_>,
     ) -> Result<QueryEntitySubgraphResponse<'static>, Report<QueryError>> {
         self.store.query_entity_subgraph(actor_id, params).await
@@ -1625,7 +1624,7 @@ where
 
     async fn get_entity_by_id(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         entity_id: EntityId,
         transaction_time: Option<Timestamp<TransactionTime>>,
         decision_time: Option<Timestamp<DecisionTime>>,
@@ -1637,7 +1636,7 @@ where
 
     async fn summarize_entities(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: SummarizeEntitiesParams<'_>,
     ) -> Result<SummarizeEntitiesResponse, Report<QueryError>> {
         self.store.summarize_entities(actor_id, params).await
@@ -1645,7 +1644,7 @@ where
 
     async fn query_entities_table(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: QueryEntitiesTableParams,
     ) -> Result<QueryEntitiesTableResponse, Report<QueryError>> {
         self.store.query_entities_table(actor_id, params).await
@@ -1653,7 +1652,7 @@ where
 
     async fn patch_entity(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: PatchEntityParams,
     ) -> Result<Entity, Report<UpdateError>> {
         for entity_type_id in &params.entity_type_ids {
@@ -1674,7 +1673,7 @@ where
 
     async fn delete_entities(
         &mut self,
-        actor_id: AuthenticatedActor,
+        actor_id: ActorId,
         params: DeleteEntitiesParams<'_>,
     ) -> Result<DeletionSummary, Report<DeletionError>> {
         self.store.delete_entities(actor_id, params).await
@@ -1682,7 +1681,7 @@ where
 
     async fn update_entity_embeddings(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: UpdateEntityEmbeddingsParams<'_>,
     ) -> Result<(), Report<UpdateError>> {
         self.store.update_entity_embeddings(actor_id, params).await
@@ -1690,7 +1689,7 @@ where
 
     async fn cluster_entities(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: ClusterEntitiesParams,
     ) -> Result<ClusterEntitiesResponse, Report<ClusterError>> {
         self.store.cluster_entities(actor_id, params).await
@@ -1702,7 +1701,7 @@ where
 
     async fn has_permission_for_entities(
         &self,
-        authenticated_actor: AuthenticatedActor,
+        authenticated_actor: ActorId,
         params: HasPermissionForEntitiesParams<'_>,
     ) -> Result<HashMap<EntityId, Vec<EntityEditionId>>, Report<CheckPermissionError>> {
         self.store

--- a/libs/@local/hash-isomorphic-utils/src/graphql/type-defs/knowledge/entity.typedef.ts
+++ b/libs/@local/hash-isomorphic-utils/src/graphql/type-defs/knowledge/entity.typedef.ts
@@ -130,8 +130,6 @@ export const entityTypedef = gql`
       request: QueryEntitySubgraphRequest!
     ): QueryEntitySubgraphResponse!
 
-    isEntityPublic(entityId: EntityId!): Boolean!
-
     getEntityAuthorizationRelationships(
       entityId: EntityId!
     ): [EntityAuthorizationRelationship!]!

--- a/libs/@local/hashql/eval/tests/orchestrator/seed.rs
+++ b/libs/@local/hashql/eval/tests/orchestrator/seed.rs
@@ -28,7 +28,7 @@ use type_system::{
         provenance::{OntologyOwnership, ProvidedOntologyEditionProvenance},
     },
     principal::{
-        actor::{ActorEntityUuid, ActorType, MachineId},
+        actor::{ActorId, ActorType, MachineId},
         actor_group::WebId,
     },
     provenance::{OriginProvenance, OriginType},
@@ -154,7 +154,7 @@ pub(crate) async fn setup(
 /// Seeds all ontology types (data types, property types, entity types).
 async fn seed_ontology(
     store: &mut PostgresStore<Client>,
-    actor_id: ActorEntityUuid,
+    actor_id: ActorId,
     ownership: &OntologyOwnership,
 ) -> Result<(), Report<SetupError>> {
     let ontology_provenance = ProvidedOntologyEditionProvenance {
@@ -239,7 +239,7 @@ async fn seed_ontology(
 /// Creates a non-link entity from a property JSON fixture and entity type JSON.
 async fn create_entity(
     store: &mut PostgresStore<Client>,
-    actor_id: ActorEntityUuid,
+    actor_id: ActorId,
     web_id: WebId,
     entity_type_json: &str,
     properties_json: &str,
@@ -296,7 +296,7 @@ async fn seed_data(
         .attach("could not create test user")?
         .user_id;
 
-    let actor_id: ActorEntityUuid = user_id.into();
+    let actor_id: ActorId = user_id.into();
     let web_id: WebId = user_id.into();
     let ownership = OntologyOwnership::Local { web_id };
 

--- a/tests/graph/benches/graph/scenario/stages/data_type.rs
+++ b/tests/graph/benches/graph/scenario/stages/data_type.rs
@@ -10,7 +10,7 @@ use hash_graph_test_data::seeding::{
 };
 use type_system::{
     ontology::data_type::schema::DataTypeReference,
-    principal::{actor::ActorEntityUuid, actor_group::WebId},
+    principal::{actor::ActorId, actor_group::WebId},
 };
 
 use super::{Runner, web_catalog::InMemoryWebCatalog};
@@ -165,7 +165,7 @@ impl PersistDataTypesStage {
             .change_context(DataTypeError::Persist)?;
 
         // Build web->user map from provided user resources
-        let mut web_actor_by_web: HashMap<WebId, ActorEntityUuid> = HashMap::new();
+        let mut web_actor_by_web: HashMap<WebId, ActorId> = HashMap::new();
         for user_key in &self.inputs.web_to_user {
             let Some(users) = runner.resources.users.get(user_key) else {
                 return Err(Report::new(DataTypeError::MissingConfig {

--- a/tests/graph/benches/graph/scenario/stages/entity.rs
+++ b/tests/graph/benches/graph/scenario/stages/entity.rs
@@ -10,7 +10,7 @@ use hash_graph_test_data::seeding::{
 use type_system::{
     knowledge::entity::EntityId,
     ontology::VersionedUrl,
-    principal::{actor::ActorEntityUuid, actor_group::WebId},
+    principal::{actor::ActorId, actor_group::WebId},
 };
 
 use super::{Runner, web_catalog::InMemoryWebCatalog};
@@ -216,7 +216,7 @@ impl PersistEntitiesStage {
         }
 
         // Build web->user map from provided user resources
-        let mut web_actor_by_web: HashMap<WebId, ActorEntityUuid> = HashMap::new();
+        let mut web_actor_by_web: HashMap<WebId, ActorId> = HashMap::new();
         for user_key in &self.inputs.web_to_user {
             let Some(users) = runner.resources.users.get(user_key) else {
                 return Err(Report::new(EntityError::MissingConfig {

--- a/tests/graph/benches/graph/scenario/stages/entity_queries.rs
+++ b/tests/graph/benches/graph/scenario/stages/entity_queries.rs
@@ -8,7 +8,7 @@ use hash_graph_store::{
     subgraph::temporal_axes::QueryTemporalAxesUnresolved,
 };
 use hash_graph_test_data::seeding::producer::ontology::WebCatalog as _;
-use type_system::principal::actor::{ActorEntityUuid, ActorId, UserId};
+use type_system::principal::actor::{ActorId, UserId};
 
 use super::Runner;
 
@@ -95,7 +95,6 @@ impl QueryEntitiesByUserStage {
                 )))
             })
             .transpose()?;
-        let actor_uuid = actor.map_or_else(ActorEntityUuid::public_actor, ActorEntityUuid::from);
 
         let pool = runner
             .ensure_db()
@@ -109,7 +108,7 @@ impl QueryEntitiesByUserStage {
 
         let entities = store
             .query_entities(
-                actor_uuid,
+                actor,
                 QueryEntitiesParams {
                     filter: Filter::All(Vec::new()),
                     temporal_axes: QueryTemporalAxesUnresolved::all(),

--- a/tests/graph/benches/graph/scenario/stages/entity_type.rs
+++ b/tests/graph/benches/graph/scenario/stages/entity_type.rs
@@ -556,20 +556,14 @@ impl BuildEntityTypeRegistryStage {
             .await
             .change_context(BuildEntityTypeRegistryError::ReadEntityTypes)?;
 
-        let mut store = pool
+        let store = pool
             .acquire(None)
-            .await
-            .change_context(BuildEntityTypeRegistryError::ReadEntityTypes)?;
-
-        // The registry reads as the system machine, the one actor guaranteed to exist here.
-        let machine_id = store
-            .get_or_create_system_machine("h")
             .await
             .change_context(BuildEntityTypeRegistryError::ReadEntityTypes)?;
 
         let get_entity_types_response = store
             .query_entity_types(
-                Some(ActorId::from(machine_id)),
+                None,
                 QueryEntityTypesParams {
                     request: CommonQueryEntityTypesParams {
                         filter: Filter::for_entity_type_uuids(&all_entity_types),

--- a/tests/graph/benches/graph/scenario/stages/entity_type.rs
+++ b/tests/graph/benches/graph/scenario/stages/entity_type.rs
@@ -33,7 +33,7 @@ use type_system::{
         property_type::schema::PropertyTypeReference,
         provenance::OntologyOwnership,
     },
-    principal::{actor::ActorEntityUuid, actor_group::WebId},
+    principal::{actor::ActorId, actor_group::WebId},
 };
 
 use super::{Runner, web_catalog::InMemoryWebCatalog};
@@ -246,7 +246,7 @@ impl PersistEntityTypesStage {
             .change_context(EntityTypeError::Persist)?;
 
         // Build web->user map from provided user resources
-        let mut web_actor_by_web: HashMap<WebId, ActorEntityUuid> = HashMap::new();
+        let mut web_actor_by_web: HashMap<WebId, ActorId> = HashMap::new();
         for user_key in &self.inputs.web_to_user {
             let Some(users) = runner.resources.users.get(user_key) else {
                 return Err(Report::new(EntityTypeError::MissingConfig {
@@ -556,14 +556,20 @@ impl BuildEntityTypeRegistryStage {
             .await
             .change_context(BuildEntityTypeRegistryError::ReadEntityTypes)?;
 
-        let store = pool
+        let mut store = pool
             .acquire(None)
+            .await
+            .change_context(BuildEntityTypeRegistryError::ReadEntityTypes)?;
+
+        // The registry reads as the system machine, the one actor guaranteed to exist here.
+        let machine_id = store
+            .get_or_create_system_machine("h")
             .await
             .change_context(BuildEntityTypeRegistryError::ReadEntityTypes)?;
 
         let get_entity_types_response = store
             .query_entity_types(
-                ActorEntityUuid::public_actor(),
+                Some(ActorId::from(machine_id)),
                 QueryEntityTypesParams {
                     request: CommonQueryEntityTypesParams {
                         filter: Filter::for_entity_type_uuids(&all_entity_types),

--- a/tests/graph/benches/graph/scenario/stages/property_type.rs
+++ b/tests/graph/benches/graph/scenario/stages/property_type.rs
@@ -10,7 +10,7 @@ use hash_graph_test_data::seeding::{
 };
 use type_system::{
     ontology::{property_type::schema::PropertyTypeReference, provenance::OntologyOwnership},
-    principal::{actor::ActorEntityUuid, actor_group::WebId},
+    principal::{actor::ActorId, actor_group::WebId},
 };
 
 use super::{Runner, web_catalog::InMemoryWebCatalog};
@@ -183,7 +183,7 @@ impl PersistPropertyTypesStage {
             .change_context(PropertyTypeError::Persist)?;
 
         // Build web->user map from provided user resources
-        let mut web_actor_by_web: HashMap<WebId, ActorEntityUuid> = HashMap::new();
+        let mut web_actor_by_web: HashMap<WebId, ActorId> = HashMap::new();
         for user_key in &self.inputs.web_to_user {
             let Some(users) = runner.resources.users.get(user_key) else {
                 return Err(Report::new(PropertyTypeError::MissingConfig {

--- a/tests/graph/benches/graph/scenario/stages/reset_db.rs
+++ b/tests/graph/benches/graph/scenario/stages/reset_db.rs
@@ -1,14 +1,14 @@
 use core::error::Error;
 
 use error_stack::{Report, ResultExt as _};
-use hash_graph_authorization::policies::store::PolicyStore as _;
+use hash_graph_authorization::policies::store::{PolicyStore as _, PrincipalStore as _};
 use hash_graph_store::{
     entity::{DeleteEntitiesParams, DeletionScope, EntityStore as _},
     filter::Filter,
     pool::StorePool as _,
     subgraph::temporal_axes::QueryTemporalAxesUnresolved,
 };
-use type_system::principal::actor::ActorEntityUuid;
+use type_system::principal::actor::ActorId;
 
 use crate::scenario::runner::Runner;
 
@@ -38,6 +38,8 @@ pub enum ResetDbError {
     EnsureDb,
     #[display("Failed to acquire store")]
     Acquire,
+    #[display("Failed to resolve the system machine")]
+    ResolveSystemMachine,
     #[display("Failed to delete principals")]
     DeletePrincipals,
     #[display("Failed to delete data types")]
@@ -84,10 +86,19 @@ impl ResetDbStage {
                 .change_context(ResetDbError::Acquire)?;
             let store = conn.store();
 
+            // The principals are about to be erased too, so the reset acts as the system
+            // machine, which is recreated on demand.
+            let actor_id = ActorId::from(
+                store
+                    .get_or_create_system_machine("h")
+                    .await
+                    .change_context(ResetDbError::ResolveSystemMachine)?,
+            );
+
             if self.entities {
                 store
                     .delete_entities(
-                        ActorEntityUuid::new(uuid::Uuid::nil()).into(),
+                        actor_id,
                         DeleteEntitiesParams {
                             filter: Filter::All(Vec::new()),
                             temporal_axes: QueryTemporalAxesUnresolved::all(),
@@ -123,7 +134,7 @@ impl ResetDbStage {
             }
             if self.principals {
                 store
-                    .delete_principals(ActorEntityUuid::new(uuid::Uuid::nil()))
+                    .delete_principals()
                     .await
                     .change_context(ResetDbError::DeletePrincipals)?;
                 reset_db_result.deleted_principals = true;

--- a/tests/graph/benches/manual_queries/entity_queries/all-public-subgraph.json
+++ b/tests/graph/benches/manual_queries/entity_queries/all-public-subgraph.json
@@ -1,6 +1,5 @@
 {
   "type": "queryEntitySubgraph",
-  "actorId": "00000000-0000-0000-0000-000000000000",
   "settings": {
     "sampleSize": 10,
     "parameters": {

--- a/tests/graph/benches/manual_queries/entity_queries/all-public.json
+++ b/tests/graph/benches/manual_queries/entity_queries/all-public.json
@@ -1,6 +1,5 @@
 {
   "type": "queryEntities",
-  "actorId": "00000000-0000-0000-0000-000000000000",
   "settings": {
     "sampleSize": 10,
     "parameters": {

--- a/tests/graph/benches/manual_queries/entity_queries/mod.rs
+++ b/tests/graph/benches/manual_queries/entity_queries/mod.rs
@@ -24,7 +24,7 @@ use serde::{Deserialize as _, Serialize as _};
 use serde_json::Value as JsonValue;
 use tokio::runtime::Runtime;
 use tokio_postgres::NoTls;
-use type_system::principal::actor::ActorEntityUuid;
+use type_system::principal::actor::ActorId;
 use uuid::Uuid;
 use walkdir::WalkDir;
 
@@ -119,7 +119,7 @@ struct Settings<P> {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct QueryEntitiesQueryParameters {
     #[serde(default)]
-    actor_id: Vec<ActorEntityUuid>,
+    actor_id: Vec<ActorId>,
     #[serde(default)]
     limit: Vec<usize>,
 }
@@ -127,7 +127,8 @@ struct QueryEntitiesQueryParameters {
 #[derive(Debug, Clone, serde::Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct QueryEntitiesQuery<'q, 's, 'p> {
-    actor_id: ActorEntityUuid,
+    #[serde(default)]
+    actor_id: Option<ActorId>,
     #[serde(borrow)]
     request: QueryEntitiesRequest<'q, 's, 'p>,
     #[serde(default)]
@@ -140,8 +141,12 @@ impl QueryEntitiesQuery<'_, '_, '_> {
         let modifies_limit = !self.settings.parameters.limit.is_empty();
 
         let actor_id = iter::once(self.actor_id)
-            .chain(mem::take(&mut self.settings.parameters.actor_id))
-            .sorted_by_key(|actor_id| Uuid::from(*actor_id))
+            .chain(
+                mem::take(&mut self.settings.parameters.actor_id)
+                    .into_iter()
+                    .map(Some),
+            )
+            .sorted_by_key(|actor_id| actor_id.map(Uuid::from))
             .dedup();
         let limit = iter::once(self.request.limit)
             .chain(
@@ -155,7 +160,10 @@ impl QueryEntitiesQuery<'_, '_, '_> {
         iproduct!(actor_id, limit).map(move |(actor_id, limit)| {
             let mut parameters = Vec::new();
             if modifies_actor_id {
-                parameters.push(format!("actor_id={actor_id}"));
+                parameters.push(actor_id.map_or_else(
+                    || "actor_id=public".to_owned(),
+                    |actor_id| format!("actor_id={actor_id}"),
+                ));
             }
             if modifies_limit && let Some(limit) = limit {
                 parameters.push(format!("limit={limit}"));
@@ -179,7 +187,7 @@ impl QueryEntitiesQuery<'_, '_, '_> {
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct QueryEntitySubgraphQueryParameters {
     #[serde(default)]
-    actor_id: Vec<ActorEntityUuid>,
+    actor_id: Vec<ActorId>,
     #[serde(default)]
     limit: Vec<usize>,
     #[serde(default)]
@@ -189,7 +197,8 @@ struct QueryEntitySubgraphQueryParameters {
 #[derive(Debug, Clone, serde::Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct QueryEntitySubgraphQuery<'q, 's, 'p> {
-    actor_id: ActorEntityUuid,
+    #[serde(default)]
+    actor_id: Option<ActorId>,
     #[serde(borrow)]
     request: QueryEntitySubgraphRequest<'q, 's, 'p>,
     #[serde(default)]
@@ -236,8 +245,12 @@ impl QueryEntitySubgraphQuery<'_, '_, '_> {
         let (request, traversal_params) = self.request.clone().into_parts();
 
         let actor_id = iter::once(self.actor_id)
-            .chain(mem::take(&mut self.settings.parameters.actor_id))
-            .sorted_by_key(|actor_id| Uuid::from(*actor_id))
+            .chain(
+                mem::take(&mut self.settings.parameters.actor_id)
+                    .into_iter()
+                    .map(Some),
+            )
+            .sorted_by_key(|actor_id| actor_id.map(Uuid::from))
             .dedup();
         let limit = iter::once(request.limit)
             .chain(
@@ -254,7 +267,10 @@ impl QueryEntitySubgraphQuery<'_, '_, '_> {
             move |(actor_id, limit, traversal_params)| {
                 let mut parameters = Vec::new();
                 if modifies_actor_id {
-                    parameters.push(format!("actor_id={actor_id}"));
+                    parameters.push(actor_id.map_or_else(
+                        || "actor_id=public".to_owned(),
+                        |actor_id| format!("actor_id={actor_id}"),
+                    ));
                 }
                 if modifies_limit && let Some(limit) = limit {
                     parameters.push(format!("limit={limit}"));

--- a/tests/graph/benches/policy/benchmark_matrix.rs
+++ b/tests/graph/benches/policy/benchmark_matrix.rs
@@ -3,7 +3,6 @@ use core::str::FromStr as _;
 use criterion::{BenchmarkId, Criterion};
 use hash_graph_authorization::policies::{
     action::ActionName,
-    principal::actor::AuthenticatedActor,
     store::{PolicyStore as _, PrincipalStore as _, ResolvePoliciesParams},
 };
 use hash_graph_postgres_store::store::AsClient as _;
@@ -206,9 +205,9 @@ fn run_benchmark_seed_group(
     seed_level: SeedLevel,
     configs: Vec<BenchConfig>,
 ) {
-    let account_id = type_system::principal::actor::ActorEntityUuid::new(
+    let account_id = ActorId::User(type_system::principal::actor::UserId::new(
         uuid::Uuid::from_str("bf5a9ef5-dc3b-43cf-a291-6210c0321eba").expect("invalid uuid"),
-    );
+    ));
 
     // Use seed level as DB name to share across configs
     let db_name = format!("bench_shared_{}", seed_level.as_str());
@@ -239,7 +238,7 @@ fn run_benchmark_seed_group(
             };
             store_wrapper
                 .store
-                .resolve_policies_for_actor(AuthenticatedActor::Id(test_actor), params)
+                .resolve_policies_for_actor(Some(test_actor), params)
                 .await
                 .expect("Policy resolution failed")
                 .len()
@@ -276,7 +275,7 @@ fn run_benchmark_seed_group(
 
                         store_wrapper
                             .store
-                            .resolve_policies_for_actor(AuthenticatedActor::Id(*test_actor), params)
+                            .resolve_policies_for_actor(Some(*test_actor), params)
                             .await
                             .expect("Policy resolution failed")
                     })

--- a/tests/graph/benches/read_scaling/knowledge/complete/entity.rs
+++ b/tests/graph/benches/read_scaling/knowledge/complete/entity.rs
@@ -29,7 +29,7 @@ use type_system::{
     },
     ontology::entity_type::EntityType,
     principal::{
-        actor::{ActorEntityUuid, ActorId, ActorType},
+        actor::{ActorId, ActorType, UserId},
         actor_group::WebId,
     },
     provenance::{OriginProvenance, OriginType},
@@ -50,7 +50,7 @@ struct DatastoreEntitiesMetadata {
 
 #[expect(clippy::too_many_lines)]
 async fn seed_db(
-    account_id: ActorEntityUuid,
+    account_id: ActorId,
     store_wrapper: &mut StoreWrapper,
     total: usize,
 ) -> DatastoreEntitiesMetadata {
@@ -227,7 +227,7 @@ pub fn bench_get_entity_by_id(
     bencher: &mut Bencher,
     runtime: &Runtime,
     store: &RefCell<&mut Store>,
-    actor_id: ActorEntityUuid,
+    actor_id: ActorId,
     entity_metadata_list: &[Entity],
     traversal_params: &SubgraphTraversalParams,
 ) {
@@ -247,7 +247,7 @@ pub fn bench_get_entity_by_id(
                 store
                     .borrow_mut()
                     .query_entity_subgraph(
-                        actor_id,
+                        Some(actor_id),
                         QueryEntitySubgraphParams::from_parts(
                             QueryEntitiesParams {
                                 filter: Filter::for_entity_by_entity_id(entity_record_id.entity_id),
@@ -283,9 +283,9 @@ fn bench_scaling_read_entity(
 
     // We use a hard-coded UUID to keep it consistent across tests so that we can use it as a
     // parameter argument to criterion and get comparison analysis
-    let account_id = ActorEntityUuid::new(
+    let account_id = ActorId::User(UserId::new(
         Uuid::from_str("bf5a9ef5-dc3b-43cf-a291-6210c0321eba").expect("invalid uuid"),
-    );
+    ));
 
     for size in [1, 5, 10, 25, 50] {
         // TODO: reuse the database if it already exists like we do for representative_read

--- a/tests/graph/benches/read_scaling/knowledge/linkless/entity.rs
+++ b/tests/graph/benches/read_scaling/knowledge/linkless/entity.rs
@@ -23,7 +23,7 @@ use type_system::{
     },
     ontology::entity_type::EntityType,
     principal::{
-        actor::{ActorEntityUuid, ActorId, ActorType},
+        actor::{ActorId, ActorType, UserId},
         actor_group::WebId,
     },
     provenance::{OriginProvenance, OriginType},
@@ -36,7 +36,7 @@ const DB_NAME: &str = "entity_scale";
 
 #[expect(clippy::too_many_lines)]
 async fn seed_db(
-    account_id: ActorEntityUuid,
+    account_id: ActorId,
     store_wrapper: &mut StoreWrapper,
     total: usize,
 ) -> Vec<Entity> {
@@ -165,7 +165,7 @@ pub fn bench_get_entity_by_id(
     bencher: &mut Bencher,
     runtime: &Runtime,
     store: &RefCell<&mut Store>,
-    actor_id: ActorEntityUuid,
+    actor_id: ActorId,
     entity_metadata_list: &[Entity],
 ) {
     bencher.to_async(runtime).iter_batched(
@@ -182,7 +182,7 @@ pub fn bench_get_entity_by_id(
             store
                 .borrow_mut()
                 .query_entities(
-                    actor_id,
+                    Some(actor_id),
                     QueryEntitiesParams {
                         filter: Filter::for_entity_by_entity_id(entity_record_id.entity_id),
                         temporal_axes: QueryTemporalAxesUnresolved::all(),
@@ -210,9 +210,9 @@ fn bench_scaling_read_entity(crit: &mut Criterion) {
     let mut group = crit.benchmark_group(group_id);
     // We use a hard-coded UUID to keep it consistent across tests so that we can use it as a
     // parameter argument to criterion and get comparison analysis
-    let account_id = ActorEntityUuid::new(
+    let account_id = ActorId::User(UserId::new(
         Uuid::from_str("bf5a9ef5-dc3b-43cf-a291-6210c0321eba").expect("invalid uuid"),
-    );
+    ));
 
     for size in [1, 10, 100, 1_000, 10_000] {
         let (runtime, mut store_wrapper) = setup(DB_NAME, true, true, account_id);

--- a/tests/graph/benches/representative_read/knowledge/entity.rs
+++ b/tests/graph/benches/representative_read/knowledge/entity.rs
@@ -15,7 +15,7 @@ use hash_graph_store::{
 };
 use rand::{prelude::IteratorRandom as _, rng};
 use tokio::runtime::Runtime;
-use type_system::{knowledge::entity::id::EntityUuid, principal::actor::ActorEntityUuid};
+use type_system::{knowledge::entity::id::EntityUuid, principal::actor::ActorId};
 
 use crate::util::Store;
 
@@ -28,7 +28,7 @@ pub fn bench_get_entity_by_id(
     bencher: &mut Bencher,
     runtime: &Runtime,
     store: &RefCell<&mut Store>,
-    actor_id: ActorEntityUuid,
+    actor_id: ActorId,
     entity_uuids: &[EntityUuid],
 ) {
     bencher.to_async(runtime).iter_batched(
@@ -43,7 +43,7 @@ pub fn bench_get_entity_by_id(
             let response = store
                 .borrow_mut()
                 .query_entities(
-                    actor_id,
+                    Some(actor_id),
                     QueryEntitiesParams {
                         filter: Filter::Equal(
                             FilterExpression::Path {
@@ -83,7 +83,7 @@ pub fn bench_query_entities_by_property(
     bencher: &mut Bencher,
     runtime: &Runtime,
     store: &RefCell<&mut Store>,
-    actor_id: ActorEntityUuid,
+    actor_id: ActorId,
     traversal_params: &SubgraphTraversalParams,
 ) {
     bencher.to_async(runtime).iter(|| {
@@ -105,7 +105,7 @@ pub fn bench_query_entities_by_property(
             let response = store
                 .borrow_mut()
                 .query_entity_subgraph(
-                    actor_id,
+                    Some(actor_id),
                     QueryEntitySubgraphParams::from_parts(
                         QueryEntitiesParams {
                             filter,
@@ -139,7 +139,7 @@ pub fn bench_get_link_by_target_by_property(
     bencher: &mut Bencher,
     runtime: &Runtime,
     store: &RefCell<&mut Store>,
-    actor_id: ActorEntityUuid,
+    actor_id: ActorId,
     traversal_params: &SubgraphTraversalParams,
 ) {
     bencher.to_async(runtime).iter(|| {
@@ -165,7 +165,7 @@ pub fn bench_get_link_by_target_by_property(
             let response = store
                 .borrow_mut()
                 .query_entity_subgraph(
-                    actor_id,
+                    Some(actor_id),
                     QueryEntitySubgraphParams::from_parts(
                         QueryEntitiesParams {
                             filter,

--- a/tests/graph/benches/representative_read/lib.rs
+++ b/tests/graph/benches/representative_read/lib.rs
@@ -51,7 +51,7 @@ use hash_graph_store::subgraph::edges::{
     EdgeDirection, EntityTraversalEdge, EntityTraversalPath, GraphResolveDepths,
     SubgraphTraversalParams,
 };
-use type_system::principal::actor::ActorEntityUuid;
+use type_system::principal::actor::{ActorId, UserId};
 use uuid::Uuid;
 
 use self::seed::setup_and_extract_samples;
@@ -63,9 +63,9 @@ const DB_NAME: &str = "representative_read";
 fn bench_representative_read_entity(crit: &mut Criterion) {
     // We use a hard-coded UUID to keep it consistent across tests so that we can use it as a
     // parameter argument to criterion and get comparison analysis
-    let account_id = ActorEntityUuid::new(
+    let account_id = ActorId::User(UserId::new(
         Uuid::from_str("bf5a9ef5-dc3b-43cf-a291-6210c0321eba").expect("invalid uuid"),
-    );
+    ));
 
     let group_id = "representative_read_entity";
     let mut group = crit.benchmark_group(group_id);
@@ -103,9 +103,9 @@ fn bench_representative_read_entity(crit: &mut Criterion) {
 fn bench_representative_read_multiple_entities(crit: &mut Criterion) {
     // We use a hard-coded UUID to keep it consistent across tests so that we can use it as a
     // parameter argument to criterion and get comparison analysis
-    let account_id = ActorEntityUuid::new(
+    let account_id = ActorId::User(UserId::new(
         Uuid::from_str("bf5a9ef5-dc3b-43cf-a291-6210c0321eba").expect("invalid uuid"),
-    );
+    ));
 
     let group_id = "representative_read_multiple_entities";
     let mut group = crit.benchmark_group(group_id);
@@ -286,9 +286,9 @@ fn bench_representative_read_multiple_entities(crit: &mut Criterion) {
 fn bench_representative_read_entity_type(crit: &mut Criterion) {
     // We use a hard-coded UUID to keep it consistent across tests so that we can use it as a
     // parameter argument to criterion and get comparison analysis
-    let account_id = ActorEntityUuid::new(
+    let account_id = ActorId::User(UserId::new(
         Uuid::from_str("bf5a9ef5-dc3b-43cf-a291-6210c0321eba").expect("invalid uuid"),
-    );
+    ));
 
     let group_id = "representative_read_entity_type";
     let mut group = crit.benchmark_group(group_id);

--- a/tests/graph/benches/representative_read/ontology/entity_type.rs
+++ b/tests/graph/benches/representative_read/ontology/entity_type.rs
@@ -6,7 +6,7 @@ use hash_graph_store::{
 };
 use rand::{prelude::IteratorRandom as _, rng};
 use tokio::runtime::Runtime;
-use type_system::{ontology::VersionedUrl, principal::actor::ActorEntityUuid};
+use type_system::{ontology::VersionedUrl, principal::actor::ActorId};
 
 use crate::util::Store;
 
@@ -14,7 +14,7 @@ pub fn bench_get_entity_type_by_id(
     bencher: &mut Bencher,
     runtime: &Runtime,
     store: &Store,
-    actor_id: ActorEntityUuid,
+    actor_id: ActorId,
     entity_type_ids: &[VersionedUrl],
 ) {
     bencher.to_async(runtime).iter_batched(
@@ -28,7 +28,7 @@ pub fn bench_get_entity_type_by_id(
         |entity_type_id| async move {
             store
                 .query_entity_types(
-                    actor_id,
+                    Some(actor_id),
                     QueryEntityTypesParams {
                         request: CommonQueryEntityTypesParams {
                             filter: Filter::for_versioned_url(entity_type_id),

--- a/tests/graph/benches/representative_read/seed.rs
+++ b/tests/graph/benches/representative_read/seed.rs
@@ -15,7 +15,7 @@ use type_system::{
     },
     ontology::{VersionedUrl, entity_type::EntityType},
     principal::{
-        actor::{ActorEntityUuid, ActorId, ActorType},
+        actor::{ActorId, ActorType},
         actor_group::WebId,
     },
     provenance::{OriginProvenance, OriginType},
@@ -122,7 +122,7 @@ const SEED_LINKS: &[(&str, usize, usize)] = &[
 /// single point to swap out the seeding of test data when we can invest time in creating a
 /// representative environment.
 #[expect(clippy::too_many_lines)]
-pub(crate) async fn seed_db(account_id: ActorEntityUuid, store_wrapper: &mut StoreWrapper) {
+pub(crate) async fn seed_db(account_id: ActorId, store_wrapper: &mut StoreWrapper) {
     let mut transaction = store_wrapper
         .store
         .transaction()
@@ -286,11 +286,11 @@ pub(crate) async fn seed_db(account_id: ActorEntityUuid, store_wrapper: &mut Sto
 
 /// DOC - TODO.
 pub struct Samples {
-    pub entities: HashMap<ActorEntityUuid, HashMap<VersionedUrl, Vec<EntityUuid>>>,
-    pub entity_types: HashMap<ActorEntityUuid, Vec<VersionedUrl>>,
+    pub entities: HashMap<ActorId, HashMap<VersionedUrl, Vec<EntityUuid>>>,
+    pub entity_types: HashMap<ActorId, Vec<VersionedUrl>>,
 }
 
-async fn get_samples(account_id: ActorEntityUuid, store_wrapper: &StoreWrapper) -> Samples {
+async fn get_samples(account_id: ActorId, store_wrapper: &StoreWrapper) -> Samples {
     let mut entity_types = HashMap::new();
     entity_types.insert(
         account_id,
@@ -363,7 +363,7 @@ async fn get_samples(account_id: ActorEntityUuid, store_wrapper: &StoreWrapper) 
 
 pub async fn setup_and_extract_samples(
     store_wrapper: &mut StoreWrapper,
-    account_id: ActorEntityUuid,
+    account_id: ActorId,
 ) -> Samples {
     // We use the existence of the account ID as a marker for if the DB has been seeded already
     let already_seeded: bool = store_wrapper

--- a/tests/graph/benches/util.rs
+++ b/tests/graph/benches/util.rs
@@ -33,7 +33,7 @@ use type_system::{
         provenance::{OntologyOwnership, ProvidedOntologyEditionProvenance},
     },
     principal::{
-        actor::{ActorEntityUuid, ActorType},
+        actor::{ActorId, ActorType},
         actor_group::WebId,
     },
     provenance::{OriginProvenance, OriginType},
@@ -51,7 +51,7 @@ pub struct StoreWrapper {
     pub store: ManuallyDrop<Store>,
     #[expect(clippy::allow_attributes, reason = "False positive")]
     #[allow(dead_code, reason = "False positive")]
-    pub account_id: ActorEntityUuid,
+    pub account_id: ActorId,
 }
 
 pub fn setup_subscriber(
@@ -71,7 +71,7 @@ impl StoreWrapper {
         bench_db_name: &str,
         fail_on_exists: bool,
         delete_on_drop: bool,
-        account_id: ActorEntityUuid,
+        account_id: ActorId,
     ) -> Self {
         load_env(Environment::Test);
 
@@ -288,7 +288,7 @@ impl Drop for StoreWrapper {
 
 pub async fn seed<D, P, E, C, S>(
     store: &mut PostgresStore<C, S>,
-    account_id: ActorEntityUuid,
+    account_id: ActorId,
     data_types: D,
     property_types: P,
     entity_types: E,
@@ -407,7 +407,7 @@ pub fn setup(
     db_name: &str,
     fail_on_exists: bool,
     delete_on_drop: bool,
-    account_id: ActorEntityUuid,
+    account_id: ActorId,
 ) -> (Runtime, StoreWrapper) {
     let runtime = Runtime::new().expect("could not create runtime");
 

--- a/tests/graph/http/tests/reset-database.http
+++ b/tests/graph/http/tests/reset-database.http
@@ -1,8 +1,31 @@
 
+### Seed default policies
+# Seeds the actions and system policies and creates the system machine the fetch below reads,
+# after a previous reset erased the principals.
+GET http://127.0.0.1:4000/policies/seed
+Content-Type: application/json
+
+> {%
+    client.test("status", function() {
+        client.assert(response.status === 204, "Response status is not 204");
+    });
+%}
+
+### Get the system machine to act as
+GET http://127.0.0.1:4000/actors/machine/identifier/system/h
+Content-Type: application/json
+
+> {%
+    client.test("status", function() {
+        client.assert(response.status === 200, "Response status is not 200");
+    });
+    client.global.set("system_machine_id", response.body);
+%}
+
 ### Delete entities
 POST http://127.0.0.1:4001/entities/delete
 Content-Type: application/json
-X-Authenticated-User-Actor-Id: 00000000-0000-0000-0000-000000000000
+X-Authenticated-User-Actor-Id: {{system_machine_id}}
 
 {
   "filter": { "all": [] },
@@ -31,7 +54,6 @@ X-Authenticated-User-Actor-Id: 00000000-0000-0000-0000-000000000000
 
 ### Delete entity types
 DELETE http://127.0.0.1:4001/entity-types
-X-Authenticated-User-Actor-Id: 00000000-0000-0000-0000-000000000000
 
 > {%
     client.test("status", function() {
@@ -41,7 +63,6 @@ X-Authenticated-User-Actor-Id: 00000000-0000-0000-0000-000000000000
 
 ### Delete property types
 DELETE http://127.0.0.1:4001/property-types
-X-Authenticated-User-Actor-Id: 00000000-0000-0000-0000-000000000000
 
 > {%
     client.test("status", function() {
@@ -51,7 +72,6 @@ X-Authenticated-User-Actor-Id: 00000000-0000-0000-0000-000000000000
 
 ### Delete data types
 DELETE http://127.0.0.1:4001/data-types
-X-Authenticated-User-Actor-Id: 00000000-0000-0000-0000-000000000000
 
 > {%
     client.test("status", function() {
@@ -61,7 +81,6 @@ X-Authenticated-User-Actor-Id: 00000000-0000-0000-0000-000000000000
 
 ### Delete principals
 DELETE http://127.0.0.1:4001/accounts
-X-Authenticated-User-Actor-Id: 00000000-0000-0000-0000-000000000000
 
 > {%
     client.test("status", function() {

--- a/tests/graph/http/tests/service-delegation.http
+++ b/tests/graph/http/tests/service-delegation.http
@@ -8,7 +8,7 @@
 GET http://127.0.0.1:4000/actors/machine/identifier/h
 Content-Type: application/json
 Authorization: HASH-Service hash-svc-wrong
-X-Authenticated-User-Actor-Id: 00000000-0000-0000-0000-000000000000
+X-Authenticated-User-Actor-Id: 11111111-1111-1111-1111-111111111111
 
 > {%
   client.test("status", function() {
@@ -44,11 +44,27 @@ X-Authenticated-User-Actor-Id: not-a-uuid
   });
 %}
 
-### Actor-ID header without the service secret is rejected
+### The valid secret without an actor header names the missing delegated actor
+GET http://127.0.0.1:4000/actors/machine/identifier/h
+Content-Type: application/json
+
+> {%
+  client.test("status", function() {
+    client.assert(response.status === 401, "Response status is not 401");
+  });
+  client.test("message names the delegated actor", function() {
+    client.assert(
+      response.body.message === "the service credential carries no delegated actor",
+      `Unexpected message: ${response.body.message}`
+    );
+  });
+%}
+
+### Actor-ID header without the service secret does not authenticate
 GET http://127.0.0.1:4000/actors/machine/identifier/h
 Content-Type: application/json
 Authorization: <omit>
-X-Authenticated-User-Actor-Id: 00000000-0000-0000-0000-000000000000
+X-Authenticated-User-Actor-Id: 11111111-1111-1111-1111-111111111111
 
 > {%
   client.test("status", function() {
@@ -56,17 +72,17 @@ X-Authenticated-User-Actor-Id: 00000000-0000-0000-0000-000000000000
   });
   client.test("message names the missing credential", function() {
     client.assert(
-      response.body.message === "the request requires the service credential",
-      "Response message is not the client-safe text"
+      response.body.message === "no credentials provided",
+      `Unexpected message: ${response.body.message}`
     );
   });
 %}
 
-### Admin API: the actor-ID header alone is rejected
+### Admin API: the actor-ID header alone does not authenticate
 POST http://127.0.0.1:4001/users/delete
 Content-Type: application/json
 Authorization: <omit>
-X-Authenticated-User-Actor-Id: 00000000-0000-0000-0000-000000000000
+X-Authenticated-User-Actor-Id: 11111111-1111-1111-1111-111111111111
 
 {
   "email": "must-not-be-reached@example.com"
@@ -78,7 +94,7 @@ X-Authenticated-User-Actor-Id: 00000000-0000-0000-0000-000000000000
   });
   client.test("message names the missing credential", function() {
     client.assert(
-      response.body.message === "the request requires the service credential",
+      response.body.message === "no credentials provided",
       `Unexpected message: ${response.body.message}`
     );
   });
@@ -88,7 +104,7 @@ X-Authenticated-User-Actor-Id: 00000000-0000-0000-0000-000000000000
 POST http://127.0.0.1:4001/users/delete
 Content-Type: application/json
 Authorization: HASH-Service hash-svc-wrong
-X-Authenticated-User-Actor-Id: 00000000-0000-0000-0000-000000000000
+X-Authenticated-User-Actor-Id: 11111111-1111-1111-1111-111111111111
 
 {
   "email": "must-not-be-reached@example.com"
@@ -109,6 +125,62 @@ X-Authenticated-User-Actor-Id: 00000000-0000-0000-0000-000000000000
 ### Admin API: the health route stays open
 GET http://127.0.0.1:4001/health
 Authorization: <omit>
+
+> {%
+  client.test("status", function() {
+    client.assert(response.status === 200, "Response status is not 200");
+  });
+%}
+
+### Admin API: a snapshot upload without the secret is rejected
+POST http://127.0.0.1:4001/snapshot
+Authorization: <omit>
+
+> {%
+  client.test("status", function() {
+    client.assert(response.status === 401, "Response status is not 401");
+  });
+  client.test("message names the missing credential", function() {
+    client.assert(
+      response.body.message === "the request requires the service credential",
+      `Unexpected message: ${response.body.message}`
+    );
+  });
+%}
+
+### Admin API: a snapshot upload with a wrong secret is rejected
+POST http://127.0.0.1:4001/snapshot
+Authorization: HASH-Service hash-svc-wrong
+
+> {%
+  client.test("status", function() {
+    client.assert(response.status === 401, "Response status is not 401");
+  });
+  client.test("message names the invalid credential", function() {
+    client.assert(
+      response.body.message === "service credential is invalid",
+      `Unexpected message: ${response.body.message}`
+    );
+  });
+%}
+
+### An anonymous query succeeds without any credential
+POST http://127.0.0.1:4000/entities/query
+Content-Type: application/json
+Authorization: <omit>
+
+{
+  "filter": { "all": [] },
+  "temporalAxes": {
+    "pinned": { "axis": "transactionTime", "timestamp": null },
+    "variable": {
+      "axis": "decisionTime",
+      "interval": { "start": null, "end": null }
+    }
+  },
+  "includeDrafts": false,
+  "includePermissions": false
+}
 
 > {%
   client.test("status", function() {

--- a/tests/graph/integration/postgres/data_type.rs
+++ b/tests/graph/integration/postgres/data_type.rs
@@ -100,7 +100,7 @@ async fn query() {
 
     let data_types = api
         .query_data_types(
-            api.account_id,
+            Some(api.account_id),
             QueryDataTypesParams {
                 filter: Filter::for_versioned_url(&list_v1.id),
                 temporal_axes: QueryTemporalAxesUnresolved::all(),
@@ -119,6 +119,29 @@ async fn query() {
         "expected one data type, got {data_types:?}"
     );
     assert_eq!(data_types[0].schema.id, list_v1.id);
+
+    // The seeded `public-view-ontology` policy has no principal constraint, so a request
+    // without an actor sees the type as well.
+    let data_types = api
+        .query_data_types(
+            None,
+            QueryDataTypesParams {
+                filter: Filter::for_versioned_url(&list_v1.id),
+                temporal_axes: QueryTemporalAxesUnresolved::all(),
+                after: None,
+                limit: None,
+                include_count: false,
+            },
+        )
+        .await
+        .expect("could not get data type as the public actor")
+        .data_types;
+
+    assert_eq!(
+        data_types.len(),
+        1,
+        "the public actor should see the data type, got {data_types:?}"
+    );
 }
 
 #[tokio::test]
@@ -181,7 +204,7 @@ async fn inheritance() {
 
     assert_eq!(
         api.query_data_types(
-            api.account_id,
+            Some(api.account_id),
             create_params(Filter::for_data_type_parents(&[centimeter_id], None))
         )
         .await
@@ -194,7 +217,7 @@ async fn inheritance() {
 
     assert_eq!(
         api.query_data_types(
-            api.account_id,
+            Some(api.account_id),
             create_params(Filter::for_data_type_parents(&[centimeter_id], Some(0)))
         )
         .await
@@ -207,7 +230,7 @@ async fn inheritance() {
 
     assert_eq!(
         api.query_data_types(
-            api.account_id,
+            Some(api.account_id),
             create_params(Filter::for_data_type_parents(&[centimeter_id], Some(1)))
         )
         .await
@@ -224,7 +247,7 @@ async fn inheritance() {
     .expect("could not parse versioned url");
     assert_eq!(
         api.query_data_types(
-            api.account_id,
+            Some(api.account_id),
             create_params(Filter::for_data_type_children(&number_url, None))
         )
         .await
@@ -237,7 +260,7 @@ async fn inheritance() {
 
     assert_eq!(
         api.query_data_types(
-            api.account_id,
+            Some(api.account_id),
             create_params(Filter::for_data_type_children(&number_url, Some(0)))
         )
         .await
@@ -250,7 +273,7 @@ async fn inheritance() {
 
     assert_eq!(
         api.query_data_types(
-            api.account_id,
+            Some(api.account_id),
             create_params(Filter::for_data_type_children(&number_url, Some(1)))
         )
         .await
@@ -470,7 +493,7 @@ async fn update() {
 
     let returned_object_dt_v1 = api
         .query_data_types(
-            api.account_id,
+            Some(api.account_id),
             QueryDataTypesParams {
                 filter: Filter::for_versioned_url(&object_dt_v1.id),
                 temporal_axes: QueryTemporalAxesUnresolved::all(),
@@ -487,7 +510,7 @@ async fn update() {
 
     let returned_object_dt_v2 = api
         .query_data_types(
-            api.account_id,
+            Some(api.account_id),
             QueryDataTypesParams {
                 filter: Filter::for_versioned_url(&object_dt_v2.id),
                 temporal_axes: QueryTemporalAxesUnresolved::all(),

--- a/tests/graph/integration/postgres/drafts.rs
+++ b/tests/graph/integration/postgres/drafts.rs
@@ -76,7 +76,7 @@ fn charles() -> PropertyObject {
 
 #[must_use]
 async fn check_entity_exists(api: &DatabaseApi<'_>, id: EntityId) -> bool {
-    api.get_entity_by_id(api.account_id, id, None, None)
+    api.get_entity_by_id(Some(api.account_id), id, None, None)
         .await
         .is_ok()
 }

--- a/tests/graph/integration/postgres/email_filter_protection.rs
+++ b/tests/graph/integration/postgres/email_filter_protection.rs
@@ -381,7 +381,7 @@ impl DatabaseApi<'_> {
         sorting: EntityQuerySorting<'static>,
     ) -> Vec<Entity> {
         Box::pin(self.query_entities(
-            self.account_id,
+            Some(self.account_id),
             hash_graph_store::entity::QueryEntitiesParams {
                 filter,
                 temporal_axes: standard_temporal_axes(),
@@ -3144,7 +3144,7 @@ async fn subgraph_traversal_masks_linked_user_email() {
     // Query subgraph starting from org, traversing to linked entities (the user)
     let response = api
         .query_entity_subgraph(
-            api.account_id,
+            Some(api.account_id),
             QueryEntitySubgraphParams::ResolveDepths {
                 graph_resolve_depths: GraphResolveDepths::default(),
                 traversal_paths: vec![EntityTraversalPath {

--- a/tests/graph/integration/postgres/entity.rs
+++ b/tests/graph/integration/postgres/entity.rs
@@ -1,9 +1,10 @@
 use std::collections::HashSet;
 
+use hash_graph_authorization::policies::{Effect, action::ActionName};
 use hash_graph_store::{
     entity::{
-        CreateEntityParams, EntityQuerySorting, EntityStore as _, PatchEntityParams,
-        QueryEntitiesParams, SummarizeEntitiesParams,
+        CreateEntityParams, CreateEntityPolicyParams, EntityQuerySorting, EntityStore as _,
+        PatchEntityParams, QueryEntitiesParams, SummarizeEntitiesParams,
     },
     filter::Filter,
     subgraph::temporal_axes::{
@@ -93,7 +94,7 @@ async fn insert() {
         .expect("could not create entity");
 
     let entities = Box::pin(api.query_entities(
-        api.account_id,
+        Some(api.account_id),
         QueryEntitiesParams {
             filter: Filter::for_entity_by_entity_id(entity.metadata.record_id.entity_id),
             temporal_axes: QueryTemporalAxesUnresolved::all(),
@@ -167,7 +168,7 @@ async fn query() {
         .expect("could not create entity");
 
     let queried_organizations = Box::pin(api.query_entities(
-        api.account_id,
+        Some(api.account_id),
         QueryEntitiesParams {
             filter: Filter::for_entity_by_entity_id(entity.metadata.record_id.entity_id),
             temporal_axes: QueryTemporalAxesUnresolved::all(),
@@ -188,6 +189,136 @@ async fn query() {
 
     assert_eq!(queried_organizations.len(), 1);
     assert_eq!(queried_organizations[0].properties, organization);
+}
+
+#[tokio::test]
+#[expect(clippy::too_many_lines)]
+async fn public_actor_reads_only_publicly_permitted_entities() {
+    let organization: PropertyObject =
+        serde_json::from_str(entity::ORGANIZATION_V1).expect("could not parse entity");
+
+    let mut database = DatabaseTestWrapper::new().await;
+    let mut api = database
+        .seed(
+            [data_type::VALUE_V1, data_type::TEXT_V1],
+            [property_type::NAME_V1],
+            [entity_type::ORGANIZATION_V1],
+        )
+        .await
+        .expect("could not seed database");
+
+    let account_id = api.account_id;
+    let create_params = |policies| CreateEntityParams {
+        web_id: WebId::new(account_id),
+        entity_uuid: None,
+        decision_time: None,
+        entity_type_ids: HashSet::from([VersionedUrl {
+            base_url: BaseUrl::new(
+                "https://blockprotocol.org/@alice/types/entity-type/organization/".to_owned(),
+            )
+            .expect("couldn't construct Base URL"),
+            version: OntologyTypeVersion {
+                major: 1,
+                pre_release: None,
+            },
+        }]),
+        properties: PropertyObjectWithMetadata::from_parts(organization.clone(), None)
+            .expect("could not create property with metadata object"),
+        confidence: None,
+        link_data: None,
+        draft: false,
+        policies,
+        provenance: ProvidedEntityEditionProvenance {
+            actor_type: ActorType::User,
+            origin: OriginProvenance::from_empty_type(OriginType::Api),
+            sources: Vec::new(),
+        },
+        read_only: false,
+    };
+
+    let public = api
+        .create_entity(
+            api.account_id,
+            create_params(vec![CreateEntityPolicyParams {
+                name: "entity-test-public-view".to_owned(),
+                effect: Effect::Permit,
+                principal: None,
+                actions: vec![ActionName::ViewEntity],
+            }]),
+        )
+        .await
+        .expect("could not create the publicly viewable entity")
+        .metadata
+        .record_id
+        .entity_id;
+    let private = api
+        .create_entity(api.account_id, create_params(Vec::new()))
+        .await
+        .expect("could not create the private entity")
+        .metadata
+        .record_id
+        .entity_id;
+
+    let query_as_public = |entity_id| QueryEntitiesParams {
+        filter: Filter::for_entity_by_entity_id(entity_id),
+        temporal_axes: QueryTemporalAxesUnresolved::all(),
+        sorting: EntityQuerySorting {
+            paths: Vec::new(),
+            cursor: None,
+        },
+        limit: 1000,
+        conversions: Vec::new(),
+        include_entity_types: None,
+        include_drafts: false,
+        include_permissions: false,
+    };
+
+    let visible = Box::pin(api.query_entities(None, query_as_public(public)))
+        .await
+        .expect("the public read should succeed")
+        .entities;
+    assert_eq!(
+        visible.len(),
+        1,
+        "a policy without a principal constraint should permit the public actor"
+    );
+
+    let hidden = Box::pin(api.query_entities(None, query_as_public(private)))
+        .await
+        .expect("the public read should succeed")
+        .entities;
+    assert!(
+        hidden.is_empty(),
+        "the public actor should not see entities no policy permits it to view"
+    );
+
+    // The subgraph read runs traversal and the permission pass on top of the flat query, so it
+    // exercises the public actor through those paths as well.
+    let mut subgraph_params = query_as_public(public);
+    subgraph_params.include_permissions = true;
+    let subgraph = Box::pin(api.query_entity_subgraph(
+        None,
+        hash_graph_store::entity::QueryEntitySubgraphParams::Paths {
+            traversal_paths: Vec::new(),
+            request: subgraph_params,
+        },
+    ))
+    .await
+    .expect("the public subgraph read should succeed");
+    assert_eq!(
+        subgraph.subgraph.roots.len(),
+        1,
+        "the public actor should see the permitted entity in the subgraph"
+    );
+    let entity_permissions = subgraph
+        .entity_permissions
+        .expect("the response should carry the requested permissions");
+    assert!(
+        entity_permissions
+            .values()
+            .all(|permissions| permissions.update.is_empty()),
+        "the public actor should hold no update permission, got {entity_permissions:?}"
+    );
 }
 
 #[tokio::test]
@@ -292,7 +423,7 @@ async fn update() {
     assert_eq!(num_entities, 2);
 
     let entities = Box::pin(api.query_entities(
-        api.account_id,
+        Some(api.account_id),
         QueryEntitiesParams {
             filter: Filter::for_entity_by_entity_id(v2_entity.metadata.record_id.entity_id),
             temporal_axes: QueryTemporalAxesUnresolved::live_only(),
@@ -319,7 +450,7 @@ async fn update() {
         *v1_entity.metadata.temporal_versioning.decision_time.start();
 
     let mut response_v1 = Box::pin(api.query_entities(
-        api.account_id,
+        Some(api.account_id),
         QueryEntitiesParams {
             filter: Filter::for_entity_by_entity_id(v1_entity.metadata.record_id.entity_id),
             temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {
@@ -349,7 +480,7 @@ async fn update() {
     let ClosedTemporalBound::Inclusive(entity_v2_timestamp) =
         *v2_entity.metadata.temporal_versioning.decision_time.start();
     let mut response_v2 = Box::pin(api.query_entities(
-        api.account_id,
+        Some(api.account_id),
         QueryEntitiesParams {
             filter: Filter::for_entity_by_entity_id(v2_entity.metadata.record_id.entity_id),
             temporal_axes: QueryTemporalAxesUnresolved::DecisionTime {

--- a/tests/graph/integration/postgres/entity_type.rs
+++ b/tests/graph/integration/postgres/entity_type.rs
@@ -103,7 +103,7 @@ async fn query() {
 
     let entity_type = api
         .query_entity_types(
-            api.account_id,
+            Some(api.account_id),
             QueryEntityTypesParams {
                 request: CommonQueryEntityTypesParams {
                     filter: Filter::for_versioned_url(&organization_et.id),
@@ -199,7 +199,7 @@ async fn update() {
 
     let returned_page_et_v1 = api
         .query_entity_types(
-            api.account_id,
+            Some(api.account_id),
             QueryEntityTypesParams {
                 request: CommonQueryEntityTypesParams {
                     filter: Filter::for_versioned_url(&page_et_v1.id),
@@ -221,7 +221,7 @@ async fn update() {
 
     let returned_page_et_v2 = api
         .query_entity_types(
-            api.account_id,
+            Some(api.account_id),
             QueryEntityTypesParams {
                 request: CommonQueryEntityTypesParams {
                     filter: Filter::for_versioned_url(&page_et_v2.id),

--- a/tests/graph/integration/postgres/lib.rs
+++ b/tests/graph/integration/postgres/lib.rs
@@ -27,10 +27,7 @@ mod transaction;
 use std::collections::{HashMap, HashSet};
 
 use error_stack::{Report, ResultExt as _};
-use hash_graph_authorization::policies::{
-    principal::actor::AuthenticatedActor,
-    store::{PolicyStore as _, PrincipalStore as _},
-};
+use hash_graph_authorization::policies::store::{PolicyStore as _, PrincipalStore as _};
 use hash_graph_postgres_store::{
     Environment, load_env,
     store::{
@@ -89,7 +86,7 @@ use type_system::{
         provenance::{OntologyOwnership, ProvidedOntologyEditionProvenance},
     },
     principal::{
-        actor::{ActorEntityUuid, ActorType, AiId, MachineId},
+        actor::{ActorEntityUuid, ActorId, ActorType, AiId, MachineId},
         actor_group::WebId,
         role::RoleName,
     },
@@ -103,7 +100,7 @@ pub struct DatabaseTestWrapper {
 
 pub struct DatabaseApi<'pool> {
     store: PostgresStore<Transaction<'pool>, InTransaction>,
-    account_id: ActorEntityUuid,
+    account_id: ActorId,
 }
 
 impl DatabaseApi<'_> {
@@ -323,7 +320,7 @@ impl DatabaseTestWrapper {
 impl DataTypeStore for DatabaseApi<'_> {
     async fn create_data_types<P>(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: P,
     ) -> Result<Vec<DataTypeMetadata>, Report<InsertionError>>
     where
@@ -334,7 +331,7 @@ impl DataTypeStore for DatabaseApi<'_> {
 
     async fn count_data_types(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         params: CountDataTypesParams<'_>,
     ) -> Result<usize, Report<QueryError>> {
         self.store.count_data_types(actor_id, params).await
@@ -342,7 +339,7 @@ impl DataTypeStore for DatabaseApi<'_> {
 
     async fn query_data_types(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         mut params: QueryDataTypesParams<'_>,
     ) -> Result<QueryDataTypesResponse, Report<QueryError>> {
         let include_count = params.include_count;
@@ -378,7 +375,7 @@ impl DataTypeStore for DatabaseApi<'_> {
 
     async fn query_data_type_subgraph(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         mut params: QueryDataTypeSubgraphParams<'_>,
     ) -> Result<QueryDataTypeSubgraphResponse, Report<QueryError>> {
         let request = params.request_mut();
@@ -418,7 +415,7 @@ impl DataTypeStore for DatabaseApi<'_> {
 
     async fn update_data_types<P>(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: P,
     ) -> Result<Vec<DataTypeMetadata>, Report<UpdateError>>
     where
@@ -429,7 +426,7 @@ impl DataTypeStore for DatabaseApi<'_> {
 
     async fn archive_data_type(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: ArchiveDataTypeParams<'_>,
     ) -> Result<OntologyTemporalMetadata, Report<UpdateError>> {
         self.store.archive_data_type(actor_id, params).await
@@ -437,7 +434,7 @@ impl DataTypeStore for DatabaseApi<'_> {
 
     async fn unarchive_data_type(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: UnarchiveDataTypeParams,
     ) -> Result<OntologyTemporalMetadata, Report<UpdateError>> {
         self.store.unarchive_data_type(actor_id, params).await
@@ -445,7 +442,7 @@ impl DataTypeStore for DatabaseApi<'_> {
 
     async fn update_data_type_embeddings(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: UpdateDataTypeEmbeddingParams<'_>,
     ) -> Result<(), Report<UpdateError>> {
         self.store
@@ -455,7 +452,7 @@ impl DataTypeStore for DatabaseApi<'_> {
 
     async fn find_data_type_conversion_targets(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         params: FindDataTypeConversionTargetsParams,
     ) -> Result<FindDataTypeConversionTargetsResponse, Report<QueryError>> {
         self.store
@@ -469,7 +466,7 @@ impl DataTypeStore for DatabaseApi<'_> {
 
     async fn has_permission_for_data_types(
         &self,
-        authenticated_actor: AuthenticatedActor,
+        authenticated_actor: ActorId,
         params: HasPermissionForDataTypesParams<'_>,
     ) -> Result<HashSet<VersionedUrl>, Report<CheckPermissionError>> {
         self.store
@@ -481,7 +478,7 @@ impl DataTypeStore for DatabaseApi<'_> {
 impl PropertyTypeStore for DatabaseApi<'_> {
     async fn create_property_types<P>(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: P,
     ) -> Result<Vec<PropertyTypeMetadata>, Report<InsertionError>>
     where
@@ -492,7 +489,7 @@ impl PropertyTypeStore for DatabaseApi<'_> {
 
     async fn count_property_types(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         params: CountPropertyTypesParams<'_>,
     ) -> Result<usize, Report<QueryError>> {
         self.store.count_property_types(actor_id, params).await
@@ -500,7 +497,7 @@ impl PropertyTypeStore for DatabaseApi<'_> {
 
     async fn query_property_types(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         mut params: QueryPropertyTypesParams<'_>,
     ) -> Result<QueryPropertyTypesResponse, Report<QueryError>> {
         let include_count = params.include_count;
@@ -536,7 +533,7 @@ impl PropertyTypeStore for DatabaseApi<'_> {
 
     async fn query_property_type_subgraph(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         mut params: QueryPropertyTypeSubgraphParams<'_>,
     ) -> Result<QueryPropertyTypeSubgraphResponse, Report<QueryError>> {
         let request = params.request_mut();
@@ -578,7 +575,7 @@ impl PropertyTypeStore for DatabaseApi<'_> {
 
     async fn update_property_types<P>(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: P,
     ) -> Result<Vec<PropertyTypeMetadata>, Report<UpdateError>>
     where
@@ -589,7 +586,7 @@ impl PropertyTypeStore for DatabaseApi<'_> {
 
     async fn archive_property_type(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: ArchivePropertyTypeParams<'_>,
     ) -> Result<OntologyTemporalMetadata, Report<UpdateError>> {
         self.store.archive_property_type(actor_id, params).await
@@ -597,7 +594,7 @@ impl PropertyTypeStore for DatabaseApi<'_> {
 
     async fn unarchive_property_type(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: UnarchivePropertyTypeParams<'_>,
     ) -> Result<OntologyTemporalMetadata, Report<UpdateError>> {
         self.store.unarchive_property_type(actor_id, params).await
@@ -605,7 +602,7 @@ impl PropertyTypeStore for DatabaseApi<'_> {
 
     async fn update_property_type_embeddings(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: UpdatePropertyTypeEmbeddingParams<'_>,
     ) -> Result<(), Report<UpdateError>> {
         self.store
@@ -615,7 +612,7 @@ impl PropertyTypeStore for DatabaseApi<'_> {
 
     async fn has_permission_for_property_types(
         &self,
-        authenticated_actor: AuthenticatedActor,
+        authenticated_actor: ActorId,
         params: HasPermissionForPropertyTypesParams<'_>,
     ) -> Result<HashSet<VersionedUrl>, Report<CheckPermissionError>> {
         self.store
@@ -627,7 +624,7 @@ impl PropertyTypeStore for DatabaseApi<'_> {
 impl EntityTypeStore for DatabaseApi<'_> {
     async fn create_entity_types<P>(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: P,
     ) -> Result<Vec<EntityTypeMetadata>, Report<InsertionError>>
     where
@@ -638,7 +635,7 @@ impl EntityTypeStore for DatabaseApi<'_> {
 
     async fn count_entity_types(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         params: CountEntityTypesParams<'_>,
     ) -> Result<usize, Report<QueryError>> {
         self.store.count_entity_types(actor_id, params).await
@@ -646,7 +643,7 @@ impl EntityTypeStore for DatabaseApi<'_> {
 
     async fn search_entity_types(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: SearchEntityTypesParams,
     ) -> Result<SearchEntityTypesResponse, Report<QueryError>> {
         self.store.search_entity_types(actor_id, params).await
@@ -654,7 +651,7 @@ impl EntityTypeStore for DatabaseApi<'_> {
 
     async fn query_entity_types(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         mut params: QueryEntityTypesParams<'_>,
     ) -> Result<QueryEntityTypesResponse, Report<QueryError>> {
         let request = &mut params.request;
@@ -692,7 +689,7 @@ impl EntityTypeStore for DatabaseApi<'_> {
 
     async fn get_closed_multi_entity_types<I, J>(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         entity_type_ids: I,
         temporal_axes: QueryTemporalAxesUnresolved,
         include_resolved: Option<IncludeResolvedEntityTypeOption>,
@@ -713,7 +710,7 @@ impl EntityTypeStore for DatabaseApi<'_> {
 
     async fn query_entity_type_subgraph(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         mut params: QueryEntityTypeSubgraphParams<'_>,
     ) -> Result<QueryEntityTypeSubgraphResponse, Report<QueryError>> {
         let request = params.request_mut();
@@ -755,7 +752,7 @@ impl EntityTypeStore for DatabaseApi<'_> {
 
     async fn update_entity_types<P>(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: P,
     ) -> Result<Vec<EntityTypeMetadata>, Report<UpdateError>>
     where
@@ -766,7 +763,7 @@ impl EntityTypeStore for DatabaseApi<'_> {
 
     async fn archive_entity_type(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: ArchiveEntityTypeParams<'_>,
     ) -> Result<OntologyTemporalMetadata, Report<UpdateError>> {
         self.store.archive_entity_type(actor_id, params).await
@@ -774,7 +771,7 @@ impl EntityTypeStore for DatabaseApi<'_> {
 
     async fn unarchive_entity_type(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: UnarchiveEntityTypeParams<'_>,
     ) -> Result<OntologyTemporalMetadata, Report<UpdateError>> {
         self.store.unarchive_entity_type(actor_id, params).await
@@ -782,7 +779,7 @@ impl EntityTypeStore for DatabaseApi<'_> {
 
     async fn update_entity_type_embeddings(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: UpdateEntityTypeEmbeddingParams<'_>,
     ) -> Result<(), Report<UpdateError>> {
         self.store
@@ -796,7 +793,7 @@ impl EntityTypeStore for DatabaseApi<'_> {
 
     async fn has_permission_for_entity_types(
         &self,
-        authenticated_actor: AuthenticatedActor,
+        authenticated_actor: ActorId,
         params: HasPermissionForEntityTypesParams<'_>,
     ) -> Result<HashSet<VersionedUrl>, Report<CheckPermissionError>> {
         self.store
@@ -808,15 +805,15 @@ impl EntityTypeStore for DatabaseApi<'_> {
 impl EntityStore for DatabaseApi<'_> {
     async fn create_entities(
         &mut self,
-        actor_uuid: ActorEntityUuid,
+        actor_id: ActorId,
         params: Vec<CreateEntityParams>,
     ) -> Result<Vec<Entity>, Report<InsertionError>> {
-        self.store.create_entities(actor_uuid, params).await
+        self.store.create_entities(actor_id, params).await
     }
 
     async fn validate_entities(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: Vec<ValidateEntityParams<'_>>,
     ) -> Result<HashMap<usize, EntityValidationReport>, Report<QueryError>> {
         self.store.validate_entities(actor_id, params).await
@@ -824,7 +821,7 @@ impl EntityStore for DatabaseApi<'_> {
 
     async fn query_entities(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         params: QueryEntitiesParams<'_>,
     ) -> Result<QueryEntitiesResponse<'static>, Report<QueryError>> {
         self.store.query_entities(actor_id, params).await
@@ -832,7 +829,7 @@ impl EntityStore for DatabaseApi<'_> {
 
     async fn search_entities(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: SearchEntitiesParams,
     ) -> Result<SearchEntitiesResponse, Report<QueryError>> {
         self.store.search_entities(actor_id, params).await
@@ -840,7 +837,7 @@ impl EntityStore for DatabaseApi<'_> {
 
     async fn query_entity_subgraph(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         params: QueryEntitySubgraphParams<'_>,
     ) -> Result<QueryEntitySubgraphResponse<'static>, Report<QueryError>> {
         self.store.query_entity_subgraph(actor_id, params).await
@@ -848,7 +845,7 @@ impl EntityStore for DatabaseApi<'_> {
 
     async fn summarize_entities(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: SummarizeEntitiesParams<'_>,
     ) -> Result<SummarizeEntitiesResponse, Report<QueryError>> {
         self.store.summarize_entities(actor_id, params).await
@@ -856,7 +853,7 @@ impl EntityStore for DatabaseApi<'_> {
 
     async fn query_entities_table(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: QueryEntitiesTableParams,
     ) -> Result<QueryEntitiesTableResponse, Report<QueryError>> {
         self.store.query_entities_table(actor_id, params).await
@@ -864,7 +861,7 @@ impl EntityStore for DatabaseApi<'_> {
 
     async fn get_entity_by_id(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: Option<ActorId>,
         entity_id: EntityId,
         transaction_time: Option<Timestamp<TransactionTime>>,
         decision_time: Option<Timestamp<DecisionTime>>,
@@ -876,7 +873,7 @@ impl EntityStore for DatabaseApi<'_> {
 
     async fn patch_entity(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: PatchEntityParams,
     ) -> Result<Entity, Report<UpdateError>> {
         self.store.patch_entity(actor_id, params).await
@@ -884,7 +881,7 @@ impl EntityStore for DatabaseApi<'_> {
 
     async fn delete_entities(
         &mut self,
-        actor_id: AuthenticatedActor,
+        actor_id: ActorId,
         params: DeleteEntitiesParams<'_>,
     ) -> Result<DeletionSummary, Report<DeletionError>> {
         self.store.delete_entities(actor_id, params).await
@@ -892,7 +889,7 @@ impl EntityStore for DatabaseApi<'_> {
 
     async fn update_entity_embeddings(
         &mut self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: UpdateEntityEmbeddingsParams<'_>,
     ) -> Result<(), Report<UpdateError>> {
         self.store.update_entity_embeddings(actor_id, params).await
@@ -904,7 +901,7 @@ impl EntityStore for DatabaseApi<'_> {
 
     async fn cluster_entities(
         &self,
-        actor_id: ActorEntityUuid,
+        actor_id: ActorId,
         params: hash_graph_store::entity::ClusterEntitiesParams,
     ) -> Result<
         hash_graph_store::entity::ClusterEntitiesResponse,
@@ -915,7 +912,7 @@ impl EntityStore for DatabaseApi<'_> {
 
     async fn has_permission_for_entities(
         &self,
-        authenticated_actor: AuthenticatedActor,
+        authenticated_actor: ActorId,
         params: HasPermissionForEntitiesParams<'_>,
     ) -> Result<HashMap<EntityId, Vec<EntityEditionId>>, Report<CheckPermissionError>> {
         self.store

--- a/tests/graph/integration/postgres/links.rs
+++ b/tests/graph/integration/postgres/links.rs
@@ -163,7 +163,7 @@ async fn insert() {
     .expect("could not create link");
 
     let entities = Box::pin(api.query_entities(
-        api.account_id,
+        Some(api.account_id),
         QueryEntitiesParams {
             filter: Filter::All(vec![
                 Filter::Equal(
@@ -464,7 +464,7 @@ async fn get_entity_links() {
     .expect("could not create link");
 
     let links_from_source = Box::pin(api.query_entities(
-        api.account_id,
+        Some(api.account_id),
         QueryEntitiesParams {
             filter: Filter::Equal(
                 FilterExpression::Path {

--- a/tests/graph/integration/postgres/multi_type.rs
+++ b/tests/graph/integration/postgres/multi_type.rs
@@ -19,7 +19,10 @@ use type_system::{
         property::{PropertyObject, PropertyObjectWithMetadata},
     },
     ontology::VersionedUrl,
-    principal::{actor::ActorType, actor_group::WebId},
+    principal::{
+        actor::{ActorEntityUuid, ActorType},
+        actor_group::WebId,
+    },
     provenance::{OriginProvenance, OriginType},
 };
 
@@ -142,7 +145,7 @@ async fn initial_person() {
     );
 
     let entities = Box::pin(api.query_entities(
-        api.account_id,
+        Some(api.account_id),
         QueryEntitiesParams {
             filter: Filter::for_entity_by_type_id(&person_entity_type_id()),
             temporal_axes: QueryTemporalAxesUnresolved::live_only(),
@@ -198,7 +201,7 @@ async fn initial_person() {
     );
 
     let updated_person_entities = Box::pin(api.query_entities(
-        api.account_id,
+        Some(api.account_id),
         QueryEntitiesParams {
             filter: Filter::for_entity_by_type_id(&person_entity_type_id()),
             temporal_axes: QueryTemporalAxesUnresolved::live_only(),
@@ -218,7 +221,7 @@ async fn initial_person() {
     .entities;
 
     let updated_org_entities = Box::pin(api.query_entities(
-        api.account_id,
+        Some(api.account_id),
         QueryEntitiesParams {
             filter: Filter::for_entity_by_type_id(&person_entity_type_id()),
             temporal_axes: QueryTemporalAxesUnresolved::live_only(),
@@ -293,7 +296,7 @@ async fn create_multi() {
     );
 
     let person_entities = Box::pin(api.query_entities(
-        api.account_id,
+        Some(api.account_id),
         QueryEntitiesParams {
             filter: Filter::for_entity_by_type_id(&person_entity_type_id()),
             temporal_axes: QueryTemporalAxesUnresolved::live_only(),
@@ -313,7 +316,7 @@ async fn create_multi() {
     .entities;
 
     let org_entities = Box::pin(api.query_entities(
-        api.account_id,
+        Some(api.account_id),
         QueryEntitiesParams {
             filter: Filter::for_entity_by_type_id(&person_entity_type_id()),
             temporal_axes: QueryTemporalAxesUnresolved::live_only(),
@@ -364,7 +367,7 @@ async fn create_multi() {
     );
 
     let updated_person_entities = Box::pin(api.query_entities(
-        api.account_id,
+        Some(api.account_id),
         QueryEntitiesParams {
             filter: Filter::for_entity_by_type_id(&person_entity_type_id()),
             temporal_axes: QueryTemporalAxesUnresolved::live_only(),
@@ -465,11 +468,11 @@ async fn summary_aggregations() {
     );
     assert_eq!(
         response.created_by_ids,
-        Some(HashMap::from([(api.account_id, 2)]))
+        Some(HashMap::from([(ActorEntityUuid::from(api.account_id), 2)]))
     );
     assert_eq!(
         response.edition_created_by_ids,
-        Some(HashMap::from([(api.account_id, 2)]))
+        Some(HashMap::from([(ActorEntityUuid::from(api.account_id), 2)]))
     );
     assert_eq!(
         response.type_ids,

--- a/tests/graph/integration/postgres/partial_updates.rs
+++ b/tests/graph/integration/postgres/partial_updates.rs
@@ -160,7 +160,7 @@ async fn properties_add() {
     .expect("could not patch entity");
 
     let entities = Box::pin(api.query_entities(
-        api.account_id,
+        Some(api.account_id),
         QueryEntitiesParams {
             filter: Filter::for_entity_by_entity_id(entity_id),
             temporal_axes: QueryTemporalAxesUnresolved::live_only(),
@@ -247,7 +247,7 @@ async fn properties_remove() {
     .expect("could not patch entity");
 
     let entities = Box::pin(api.query_entities(
-        api.account_id,
+        Some(api.account_id),
         QueryEntitiesParams {
             filter: Filter::for_entity_by_entity_id(entity_id),
             temporal_axes: QueryTemporalAxesUnresolved::live_only(),
@@ -336,7 +336,7 @@ async fn properties_replace() {
     .expect("could not patch entity");
 
     let entities = Box::pin(api.query_entities(
-        api.account_id,
+        Some(api.account_id),
         QueryEntitiesParams {
             filter: Filter::for_entity_by_entity_id(entity_id),
             temporal_axes: QueryTemporalAxesUnresolved::live_only(),
@@ -418,7 +418,7 @@ async fn type_ids() {
     .expect("could not patch entity");
 
     let entities = Box::pin(api.query_entities(
-        api.account_id,
+        Some(api.account_id),
         QueryEntitiesParams {
             filter: Filter::for_entity_by_entity_id(entity_id),
             temporal_axes: QueryTemporalAxesUnresolved::live_only(),
@@ -467,7 +467,7 @@ async fn type_ids() {
     .expect("could not patch entity");
 
     let entities = Box::pin(api.query_entities(
-        api.account_id,
+        Some(api.account_id),
         QueryEntitiesParams {
             filter: Filter::for_entity_by_entity_id(entity_id),
             temporal_axes: QueryTemporalAxesUnresolved::live_only(),
@@ -518,7 +518,7 @@ async fn type_ids() {
     .expect("could not patch entity");
 
     let entities = Box::pin(api.query_entities(
-        api.account_id,
+        Some(api.account_id),
         QueryEntitiesParams {
             filter: Filter::for_entity_by_entity_id(entity_id),
             temporal_axes: QueryTemporalAxesUnresolved::live_only(),

--- a/tests/graph/integration/postgres/property_type.rs
+++ b/tests/graph/integration/postgres/property_type.rs
@@ -80,7 +80,7 @@ async fn query() {
 
     let property_type = api
         .query_property_types(
-            api.account_id,
+            Some(api.account_id),
             QueryPropertyTypesParams {
                 filter: Filter::for_versioned_url(&favorite_quote_pt.id),
                 temporal_axes: QueryTemporalAxesUnresolved::all(),
@@ -154,7 +154,7 @@ async fn update() {
 
     let returned_user_id_pt_v1 = api
         .query_property_types(
-            api.account_id,
+            Some(api.account_id),
             QueryPropertyTypesParams {
                 filter: Filter::for_versioned_url(&user_id_pt_v1.id),
                 temporal_axes: QueryTemporalAxesUnresolved::all(),
@@ -171,7 +171,7 @@ async fn update() {
 
     let returned_user_id_pt_v2 = api
         .query_property_types(
-            api.account_id,
+            Some(api.account_id),
             QueryPropertyTypesParams {
                 filter: Filter::for_versioned_url(&user_id_pt_v2.id),
                 temporal_axes: QueryTemporalAxesUnresolved::all(),

--- a/tests/graph/integration/postgres/read_only.rs
+++ b/tests/graph/integration/postgres/read_only.rs
@@ -20,7 +20,7 @@ use type_system::{
     },
     ontology::id::{BaseUrl, OntologyTypeVersion, VersionedUrl},
     principal::{
-        actor::{ActorEntityUuid, ActorType},
+        actor::{ActorEntityUuid, ActorId, ActorType},
         actor_group::WebId,
     },
     provenance::{OriginProvenance, OriginType},
@@ -43,8 +43,7 @@ enum Modification<'a> {
 async fn modify(
     api: &mut DatabaseApi<'_>,
     entity_id: EntityId,
-    actor: ActorEntityUuid,
-    actor_type: ActorType,
+    actor: ActorId,
     modification: Modification<'_>,
 ) -> Result<Entity, Report<UpdateError>> {
     let (properties, archived) = match modification {
@@ -78,7 +77,8 @@ async fn modify(
             archived,
             confidence: None,
             provenance: ProvidedEntityEditionProvenance {
-                actor_type,
+                // Derived from the actor, so the recorded type cannot disagree with who acted.
+                actor_type: actor.actor_type(),
                 origin: OriginProvenance::from_empty_type(OriginType::Api),
                 sources: Vec::new(),
             },
@@ -153,10 +153,12 @@ async fn read_only_modification_matrix() {
 
     // All three actors administer the web, so each holds `UpdateEntity`. The read-only forbid is
     // then the only thing that differs between them.
-    let machine = ActorEntityUuid::from(api.create_machine("test-machine").await);
-    let ai = ActorEntityUuid::from(api.create_ai("test-ai").await);
-    api.assign_web_administrator(machine, web_id).await;
-    api.assign_web_administrator(ai, web_id).await;
+    let machine = ActorId::from(api.create_machine("test-machine").await);
+    let ai = ActorId::from(api.create_ai("test-ai").await);
+    api.assign_web_administrator(ActorEntityUuid::from(machine), web_id)
+        .await;
+    api.assign_web_administrator(ActorEntityUuid::from(ai), web_id)
+        .await;
 
     let read_only_entity = api
         .create_entity(
@@ -215,16 +217,11 @@ async fn read_only_modification_matrix() {
         .entity_id;
 
     // Writable entities are editable by every actor type.
-    for (label, actor, actor_type) in [
-        ("user", user, ActorType::User),
-        ("machine", machine, ActorType::Machine),
-        ("ai", ai, ActorType::Ai),
-    ] {
+    for (label, actor) in [("user", user), ("machine", machine), ("ai", ai)] {
         modify(
             &mut api,
             writable_entity,
             actor,
-            actor_type,
             Modification::SetName {
                 property: &name,
                 value: label,
@@ -237,13 +234,12 @@ async fn read_only_modification_matrix() {
     // Read-only entities may only be modified by machine actors. The user and AI actors modified
     // the writable entity above, so they hold the permits — a denial here can only be the forbid,
     // which covers both `UpdateEntity` and `ArchiveEntity`.
-    for (label, actor, actor_type) in [("user", user, ActorType::User), ("ai", ai, ActorType::Ai)] {
+    for (label, actor) in [("user", user), ("ai", ai)] {
         assert_denied(
             modify(
                 &mut api,
                 read_only_entity,
                 actor,
-                actor_type,
                 Modification::SetName {
                     property: &name,
                     value: label,
@@ -254,14 +250,7 @@ async fn read_only_modification_matrix() {
             "update",
         );
         assert_denied(
-            modify(
-                &mut api,
-                read_only_entity,
-                actor,
-                actor_type,
-                Modification::Archive,
-            )
-            .await,
+            modify(&mut api, read_only_entity, actor, Modification::Archive).await,
             label,
             "archive",
         );
@@ -272,7 +261,6 @@ async fn read_only_modification_matrix() {
         &mut api,
         read_only_entity,
         machine,
-        ActorType::Machine,
         Modification::SetName {
             property: &name,
             value: "machine",
@@ -280,13 +268,7 @@ async fn read_only_modification_matrix() {
     )
     .await
     .expect("machine actors should update read-only entities");
-    modify(
-        &mut api,
-        read_only_entity,
-        machine,
-        ActorType::Machine,
-        Modification::Archive,
-    )
-    .await
-    .expect("machine actors should archive read-only entities");
+    modify(&mut api, read_only_entity, machine, Modification::Archive)
+        .await
+        .expect("machine actors should archive read-only entities");
 }

--- a/tests/graph/integration/postgres/semantic_search.rs
+++ b/tests/graph/integration/postgres/semantic_search.rs
@@ -26,7 +26,7 @@ use type_system::{
     },
     ontology::id::{BaseUrl, OntologyTypeVersion, VersionedUrl},
     principal::{
-        actor::{ActorEntityUuid, ActorType},
+        actor::{ActorId, ActorType},
         actor_group::WebId,
     },
     provenance::{OriginProvenance, OriginType},
@@ -163,7 +163,7 @@ async fn insert_embedding(
 
 async fn search(
     api: &mut DatabaseApi<'_>,
-    actor_id: ActorEntityUuid,
+    actor_id: ActorId,
     filter: SearchEntitiesFilter,
     maximum_semantic_distance: f64,
     limit: usize,

--- a/tests/graph/integration/postgres/sorting.rs
+++ b/tests/graph/integration/postgres/sorting.rs
@@ -67,7 +67,7 @@ async fn test_root_sorting(
             definitions: _,
             entity_permissions: _,
         } = Box::pin(api.query_entity_subgraph(
-            actor_id,
+            Some(actor_id),
             QueryEntitySubgraphParams::Paths {
                 traversal_paths: Vec::new(),
                 request: QueryEntitiesParams {

--- a/tests/hash-backend-integration/src/tests/admin-server.ts
+++ b/tests/hash-backend-integration/src/tests/admin-server.ts
@@ -2,7 +2,14 @@ import { createReadStream } from "node:fs";
 
 import fetch from "node-fetch";
 
+import {
+  ensureHashSystemAccountExists,
+  systemAccountId,
+} from "@apps/hash-api/src/graph/system-account";
+import { Logger } from "@local/hash-backend-utils/logger";
 import { StatusCode } from "@local/status";
+
+import { createTestImpureGraphContext } from "./util";
 
 import type { GraphStatus } from "@rust/hash-graph-type-defs/typescript/status";
 
@@ -21,17 +28,39 @@ const assertRunningInSnapshotGroup = (operation: string) => {
 // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
 const port = process.env.HASH_GRAPH_ADMIN_PORT || "4001";
 
-const serviceDelegationHeaders = {
-  Authorization: `HASH-Service ${
-    process.env.HASH_GRAPH_SERVICE_SECRET ?? "hash-svc-local-dev-secret"
-  }`,
-  "X-Authenticated-User-Actor-Id": "00000000-0000-0000-0000-000000000000",
+const serviceSecret =
+  process.env.HASH_GRAPH_SERVICE_SECRET ?? "hash-svc-local-dev-secret";
+
+const logger = new Logger({
+  environment: "test",
+  level: "debug",
+  serviceName: "integration-tests",
+});
+
+const secretHeaders = { Authorization: `HASH-Service ${serviceSecret}` };
+
+/**
+ * Headers naming the system machine as the acting actor.
+ *
+ * Every call re-seeds and re-reads: the operations here wipe the principals and the actions their
+ * policies reference, so neither the machine nor the actions survive between calls.
+ */
+const actorHeaders = async () => {
+  const context = createTestImpureGraphContext();
+
+  await context.graphApi.seedSystemPolicies();
+  await ensureHashSystemAccountExists({ logger, context });
+
+  return {
+    ...secretHeaders,
+    "X-Authenticated-User-Actor-Id": systemAccountId,
+  };
 };
 
 const deleteRecords = async (endpoint: string) => {
   await fetch(`http://127.0.0.1:${port}/${endpoint}`, {
     method: "DELETE",
-    headers: serviceDelegationHeaders,
+    headers: secretHeaders,
   }).then(async (response) => {
     const status = (await response.json()) as GraphStatus;
     if (status.code !== StatusCode.Ok) {
@@ -86,7 +115,7 @@ export const deleteEntities = async () => {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      ...serviceDelegationHeaders,
+      ...(await actorHeaders()),
     },
     body: JSON.stringify({
       filter: { all: [] },
@@ -124,7 +153,7 @@ export const restoreSnapshot = async (snapshotPath: string) => {
 
   await fetch(`http://127.0.0.1:${port}/snapshot`, {
     method: "POST",
-    headers: serviceDelegationHeaders,
+    headers: secretHeaders,
     body: createReadStream(snapshotPath),
   }).then(async (response) => {
     const status = (await response.json()) as GraphStatus;
@@ -146,7 +175,7 @@ export const deleteUser = async (
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      ...serviceDelegationHeaders,
+      ...(await actorHeaders()),
     },
     body: JSON.stringify(params),
   });

--- a/tests/hash-playwright/tests/shared/delete-user.ts
+++ b/tests/hash-playwright/tests/shared/delete-user.ts
@@ -1,5 +1,22 @@
 const graphAdminPort = process.env.HASH_GRAPH_ADMIN_PORT ?? "4001";
-const systemActorId = "00000000-0000-0000-0000-000000000000";
+const graphPort = process.env.HASH_GRAPH_HTTP_PORT ?? "4000";
+
+const serviceSecret =
+  process.env.HASH_GRAPH_SERVICE_SECRET ?? "hash-svc-local-dev-secret";
+
+/** Reads the system machine from the bootstrap route, which takes the secret and no actor. */
+const fetchSystemMachineActorId = async (): Promise<string> => {
+  const response = await fetch(
+    `http://127.0.0.1:${graphPort}/actors/machine/identifier/system/h`,
+    { headers: { Authorization: `HASH-Service ${serviceSecret}` } },
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Failed to get the system machine: HTTP ${response.status} ${await response.text()}`,
+    );
+  }
+  return (await response.json()) as string;
+};
 
 /**
  * Delete a user (Kratos identity + owned Graph entities + Hydra sessions)
@@ -20,10 +37,8 @@ export const deleteUserByEmail = async (email: string): Promise<void> => {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: `HASH-Service ${
-          process.env.HASH_GRAPH_SERVICE_SECRET ?? "hash-svc-local-dev-secret"
-        }`,
-        "X-Authenticated-User-Actor-Id": systemActorId,
+        Authorization: `HASH-Service ${serviceSecret}`,
+        "X-Authenticated-User-Actor-Id": await fetchSystemMachineActorId(),
       },
       body: JSON.stringify({ email }),
     },


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Requests without credentials now resolve to an anonymous caller instead of impersonating the nil UUID. Whether a route serves anonymous callers is expressed in the types: authentication chains resolve to `ActorId` (actor required) or `Option<ActorId>` (anonymous allowed), and the stores take `Option<ActorId>` only on the read paths that serve public data.

## 🔗 Related links

- [BE-764](https://linear.app/hash/issue/BE-764) _(internal)_

## 🚫 Blocked by

- [ ] #9256

## 🔍 What does this change?

- `AuthenticationProvider` is generic over a sealed `Caller` (`ActorId` or `Option<ActorId>`); a chain without a recognized credential resolves through `Caller::anonymous()`, so the REST chain serves anonymous callers while the admin chain rejects them
- `ServiceDelegationProvider` treats the service secret as the credential: the delegated actor is resolved against the principal store, the nil UUID reads as "acting for nobody", and a verified secret without a delegated actor fails as the new `MissingDelegatedActor`
- An actor-ID header without the secret no longer yields 401 — the request resolves as anonymous, since the header alone was never a credential
- Admin router split: `/entities/delete` and `/users/delete` authenticate through the chain and require an actor, while the `unsafe-dev-endpoints` group is gated by the service secret alone
- Store boundary: reads that serve public data take `Option<ActorId>`; everything else (writes, search, validate/diff/cluster, policy CRUD) requires an actor
- Benches, seeds, the AI worker, and tests act as the system machine — fetched through the secret-gated bootstrap route — instead of the nil UUID
- Removes the unused `isEntityPublic` GraphQL field, resolver, and query

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

- `authentication_middleware` takes the service secret only for the bootstrap routes, so the parameter is unused on the admin chain. Kept for a uniform middleware signature — splitting it buys nothing until the bootstrap routes move onto the admin API (BE-771).

## 🐾 Next steps

- BE-771: move the bootstrap routes onto the admin API

## 🛡 What tests cover this?

- Unit tests on the `Caller`/provider chain, the delegation flow, and the middleware (bootstrap admission, secret gate, extractor behaviour)
- Postgres integration tests for public-actor reads (permit/deny pair, empty permission maps in subgraphs)
- The httpyac suite pins the delegation rejection paths and an anonymous entity query end to end

## ❓ How to test this?

1. `cargo nextest run --package hash-graph-authentication --package hash-graph-api --all-features`
2. From `tests/graph/http/`: `yarn reset-database -o none && yarn httpyac send --all tests/service-delegation.http -o none`
