### PR TITLE
FE-1443: Declare protocol edges for import-invisible boundaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,10 +111,11 @@ If a change ships without doc updates, call that out in your summary so the user
 
 Distinct from the user guide above: the **architecture** docs describe the shape of the code for the people (and agents) working on it. They are generated from annotations in the source by `@local/petrinaut-arch-docs`, and building the bundle fails when they drift.
 
-The architecture is declared **next to the code it describes** — never in a central mapping file. Two tags, and that is the whole vocabulary:
+The architecture is declared **next to the code it describes** — never in a central mapping file. Three tags, and that is the whole vocabulary:
 
 - `@layerRoot <id>` plus `@role <one line>` in a doc comment on a folder's primary file declares a layer. Prefer this — it needs no new file.
 - A folder's `README.md` frontmatter (`layer` and `role`) does the same, and the prose below becomes that layer's page. Use it when the folder has real prose to carry, or when no single file is the obvious host.
+- `@talksTo <layer-id> via <protocol>` in any scanned doc comment or docstring declares an edge no import produces, such as a spawned subprocess or a postMessage channel. The declaring file's own layer is the edge source; the build fails on an unknown target or on a pair the imports already prove.
 - Files with no annotation inherit from the nearest declaring ancestor, so 37 declarations cover 412 files. Do not annotate every file.
 
 Any other tag is ignored, so do not add one expecting it to appear in the docs. In a declaring README's frontmatter, `layer` and `role` are the only keys and anything else fails the build.

--- a/libs/@local/petrinaut-arch-docs/README.md
+++ b/libs/@local/petrinaut-arch-docs/README.md
@@ -40,16 +40,17 @@ A declaration is two lines — an id and a one-line role:
  */
 ```
 
-That is the whole vocabulary. `@layerRoot` names the layer this folder _and its
-descendants_ form; `@role` says what it is for. Between them they place a node in
-the graph and label it, which is the whole of what these docs assert — anything
-more would be a claim the generator cannot check.
+`@layerRoot` names the layer this folder _and its descendants_ form; `@role`
+says what it is for. Between them they place a node in the graph and label it.
+One more tag, `@talksTo`, declares an edge no import produces (see below). That
+is the whole vocabulary, because anything more would be a claim the generator
+cannot check.
 
 Tags are read from any block comment, only at the start of a line, so mentioning
 `@layerRoot` in prose declares nothing. A tag's text wraps across lines until the
 next tag or a blank line. Any other tag is ignored — `@param`, `@deprecated`
 and the rest are someone else's business — except a miscasing of one of these
-two, which is reported as a probable typo.
+three, which is reported as a probable typo.
 
 ### Declaring from a README instead
 
@@ -76,6 +77,29 @@ left alone as an ordinary document, and is linked from its layer page under
 
 Layer ids are dotted and hierarchical, and every ancestor must itself be
 declared — `core.simulation.monte-carlo` requires `core.simulation` and `core`.
+
+### Declaring a protocol edge
+
+Some dependencies cross no import: the Python bindings spawn the CLI and speak
+JSON lines to it over stdio. `@talksTo` records such an edge, in the same doc
+comment or docstring the scanner already reads:
+
+```python
+"""One Petrinaut CLI process, spoken to over JSON lines on stdio.
+
+@talksTo cli via JSON lines over stdio (spawned subprocess)
+"""
+```
+
+The declaring file's own layer is the edge source, the id before `via` is the
+target, and the text after `via` is required and becomes the edge label. The
+tag is repeatable. Declared edges render dashed with their protocol in every
+diagram that shows the pair, and sit in their own "Declared" table on the
+layer pages, apart from the edges aggregated from imports.
+
+The build fails when the target is not a declared layer, and when the pair is
+already derived from imports; remove the declaration in the second case, since
+the imports already prove the edge.
 
 ### Inheritance is what keeps this small
 
@@ -150,8 +174,10 @@ A neighbourhood draws only edges _incident to the focus_. Edges among the
 neighbours are real but belong to those layers' own pages; drawing them rebuilds
 the tangle the overview exists to avoid.
 
-Aggregation never invents a dependency: an edge appears because imports exist,
-and its count sums real `fileDependencies`. Neighbours are capped at twelve, and
+Aggregation never invents a dependency: an import edge appears because imports
+exist, and its count sums real `fileDependencies`. A `@talksTo` edge is the one
+annotation-drawn kind, and it is always dashed with its protocol as the label,
+so the two kinds cannot be confused. Neighbours are capped at twelve, and
 the remainder becomes a single dashed "+N further layers" node carrying their
 combined count — elided where it would be unreadable, never dropped where it
 would read as absent.

--- a/libs/@local/petrinaut-arch-docs/README.md
+++ b/libs/@local/petrinaut-arch-docs/README.md
@@ -99,7 +99,9 @@ layer pages, apart from the edges aggregated from imports.
 
 The build fails when the target is not a declared layer, and when the pair is
 already derived from imports; remove the declaration in the second case, since
-the imports already prove the edge.
+the imports already prove the edge. A layer rule applies to a declared edge as
+it does to an imported one: a rule states which layers may couple, whatever
+carries the coupling.
 
 ### Inheritance is what keeps this small
 

--- a/libs/@local/petrinaut-arch-docs/content/maintaining/declaring-layers.mdx
+++ b/libs/@local/petrinaut-arch-docs/content/maintaining/declaring-layers.mdx
@@ -154,4 +154,5 @@ from the edges aggregated from imports.
 
 The check fails when the target is not a declared layer. It also fails when the
 pair is already derived from imports; the import edge is the record in that
-case, so remove the declaration.
+case, so remove the declaration. A declared edge is held to the layer rules
+too, so declaring a boundary cannot express a dependency the rules forbid.

--- a/libs/@local/petrinaut-arch-docs/content/maintaining/declaring-layers.mdx
+++ b/libs/@local/petrinaut-arch-docs/content/maintaining/declaring-layers.mdx
@@ -33,8 +33,8 @@ instead:
 ```
 
 Use one mechanism or the other, never both on the same folder. `layer` and
-`role` are the only frontmatter keys, and `@layerRoot` and `@role` the only
-tags; anything else is either an error or ignored.
+`role` are the only frontmatter keys, and `@layerRoot`, `@role` and `@talksTo`
+the only tags; anything else is either an error or ignored.
 
 ## You do not need to annotate every file
 
@@ -131,3 +131,27 @@ graph:
 Add one only when the code already satisfies it — a rule is a statement of fact
 that CI keeps true, not an aspiration. Check first with a build; if there are
 existing violations, either fix them in the same change or leave the rule out.
+
+## Declaring a protocol edge
+
+Some dependencies cross no import. The Python bindings spawn the CLI and speak
+JSON lines to it over stdio, so the import graph cannot see the pair. Declare
+such an edge with `@talksTo` in the same doc comment or docstring the scanner
+already reads:
+
+```python
+"""One Petrinaut CLI process, spoken to over JSON lines on stdio.
+
+@talksTo cli via JSON lines over stdio (spawned subprocess)
+"""
+```
+
+The edge starts at the declaring file's own layer. The word before `via` is the
+target layer id; the text after `via` is required and becomes the edge label.
+The tag is repeatable, one target per tag. Declared edges are drawn dashed in
+the diagrams and listed under "Declared" in the dependency tables, separate
+from the edges aggregated from imports.
+
+The check fails when the target is not a declared layer. It also fails when the
+pair is already derived from imports; the import edge is the record in that
+case, so remove the declaration.

--- a/libs/@local/petrinaut-arch-docs/content/optimizer/subprocess-boundary.mdx
+++ b/libs/@local/petrinaut-arch-docs/content/optimizer/subprocess-boundary.mdx
@@ -7,10 +7,11 @@ attachTo: optimizer
 
 The optimizer never imports Petrinaut. The [optimizer](layer:optimizer) and
 the [CLI](layer:cli) meet at a **process boundary**: one `petrinaut serve`
-child per optimization run, spoken to over JSON lines on stdio. No generated
-diagram shows this edge, and none ever will — the import graph records static
-module references, and claiming runtime facts it cannot check is exactly what
-the model refuses to do. This page is the missing arrow.
+child per optimization run, spoken to over JSON lines on stdio. The diagrams
+draw this as a dashed edge, declared by a `@talksTo` tag on the
+[Python bindings](layer:python-bindings) — the side that spawns the process —
+because no import produces it. This page carries what a one-line edge label
+cannot: the contract at the boundary and what each side owns.
 
 ## The contract
 

--- a/libs/@local/petrinaut-arch-docs/src/build.ts
+++ b/libs/@local/petrinaut-arch-docs/src/build.ts
@@ -36,6 +36,7 @@ import {
 import { extract } from "./extract";
 import { buildGraph } from "./graph";
 import {
+  ARCHITECTURE_MODEL_VERSION,
   architectureModelSchema,
   packageSchema,
   type ArchitectureModel,
@@ -105,12 +106,13 @@ export const buildBundle = async (options: {
     ignoredFilePattern: settings.ignoredFilePattern,
     fileLayers: extraction.fileLayers,
     layers: extraction.layers,
+    talksTo: extraction.talksTo,
   });
 
   diagnostics.push(...graph.diagnostics);
 
   const model: ArchitectureModel = {
-    version: 1,
+    version: ARCHITECTURE_MODEL_VERSION,
     packages,
     layers: extraction.layers,
     edges: graph.edges,

--- a/libs/@local/petrinaut-arch-docs/src/check.test.ts
+++ b/libs/@local/petrinaut-arch-docs/src/check.test.ts
@@ -7,7 +7,6 @@ import {
   checkRules,
   withinScope,
 } from "./check";
-
 import { ARCHITECTURE_MODEL_VERSION } from "./model";
 
 import type { ArchitectureModel, Edge, Layer } from "./model";

--- a/libs/@local/petrinaut-arch-docs/src/check.test.ts
+++ b/libs/@local/petrinaut-arch-docs/src/check.test.ts
@@ -8,6 +8,8 @@ import {
   withinScope,
 } from "./check";
 
+import { ARCHITECTURE_MODEL_VERSION } from "./model";
+
 import type { ArchitectureModel, Edge, Layer } from "./model";
 
 /**
@@ -37,13 +39,14 @@ const layer = (overrides: Partial<Layer> & Pick<Layer, "id">): Layer => ({
 const edge = (from: string, to: string, count = 1): Edge => ({
   from,
   to,
+  provenance: "imports",
   fileDependencies: count,
   examples: [{ from: `src/${from}.ts`, to: `src/${to}.ts` }],
   crossesPackage: false,
 });
 
 const model = (layers: Layer[], edges: Edge[] = []): ArchitectureModel => ({
-  version: 1,
+  version: ARCHITECTURE_MODEL_VERSION,
   packages: [],
   layers,
   edges,

--- a/libs/@local/petrinaut-arch-docs/src/check.test.ts
+++ b/libs/@local/petrinaut-arch-docs/src/check.test.ts
@@ -44,6 +44,16 @@ const edge = (from: string, to: string, count = 1): Edge => ({
   crossesPackage: false,
 });
 
+const declaredEdge = (from: string, to: string): Edge => ({
+  from,
+  to,
+  provenance: "declared",
+  protocol: "JSON lines over stdio",
+  declaredIn: `src/${from}/boundary.ts`,
+  line: 7,
+  crossesPackage: true,
+});
+
 const model = (layers: Layer[], edges: Edge[] = []): ArchitectureModel => ({
   version: ARCHITECTURE_MODEL_VERSION,
   packages: [],
@@ -154,6 +164,30 @@ describe("checkRules", () => {
     expect(diagnostics[0]?.message).toContain("4 imports");
     // Names a real file so the fix does not begin with a search.
     expect(diagnostics[0]?.file).toBe("src/core.engine.ts");
+  });
+
+  it("fires on a declared edge, naming the annotation to remove", () => {
+    const diagnostics = checkRules(
+      model(layers, [declaredEdge("core.engine", "ui.views")]),
+      [{ from: "core", to: "ui", reason: "core stays headless" }],
+    );
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain("core stays headless");
+    expect(diagnostics[0]?.message).toContain(
+      "@talksTo via JSON lines over stdio",
+    );
+    // The annotation's own location, so the fix does not begin with a search.
+    expect(diagnostics[0]?.file).toBe("src/core.engine/boundary.ts");
+    expect(diagnostics[0]?.line).toBe(7);
+  });
+
+  it("stays quiet on a declared edge the rules permit", () => {
+    expect(
+      checkRules(model(layers, [declaredEdge("ui.views", "core.engine")]), [
+        { from: "core", to: "ui", reason: "core stays headless" },
+      ]),
+    ).toEqual([]);
   });
 
   it("stays quiet on the permitted direction", () => {

--- a/libs/@local/petrinaut-arch-docs/src/check.ts
+++ b/libs/@local/petrinaut-arch-docs/src/check.ts
@@ -15,7 +15,7 @@
  */
 
 import { error, warning, type Diagnostic } from "./diagnostics";
-import { ancestorLayerIds } from "./model";
+import { ancestorLayerIds, isImportEdge } from "./model";
 
 import type { LayerRule } from "../architecture.config";
 import type { ArchitectureModel } from "./model";
@@ -59,6 +59,9 @@ export const checkRules = (
 ): Diagnostic[] =>
   rules.flatMap((rule) =>
     model.edges
+      // Rules are claims about the import graph. A `@talksTo` edge has its own
+      // checks in `graph.ts` and cannot violate an import rule.
+      .filter(isImportEdge)
       .filter(
         (edge) =>
           withinScope(edge.from, rule.from) && withinScope(edge.to, rule.to),

--- a/libs/@local/petrinaut-arch-docs/src/check.ts
+++ b/libs/@local/petrinaut-arch-docs/src/check.ts
@@ -59,15 +59,24 @@ export const checkRules = (
 ): Diagnostic[] =>
   rules.flatMap((rule) =>
     model.edges
-      // Rules are checked against import edges only: the message names the
-      // files behind an edge, and a `@talksTo` edge carries none. `graph.ts`
-      // checks its endpoints instead.
-      .filter(isImportEdge)
       .filter(
         (edge) =>
           withinScope(edge.from, rule.from) && withinScope(edge.to, rule.to),
       )
       .map((edge) => {
+        const forbidden = `\`${edge.from}\` must not depend on \`${edge.to}\` (${rule.reason})`;
+
+        // A declared edge names the annotation to remove, since it has no
+        // importing file to point at. Both provenances are checked: a rule
+        // states which layers may couple, whatever carries the coupling.
+        if (!isImportEdge(edge)) {
+          return error(
+            edge.declaredIn,
+            `${forbidden}; declared with @talksTo via ${edge.protocol}`,
+            edge.line,
+          );
+        }
+
         const example = edge.examples[0];
         const imports =
           edge.fileDependencies === 1
@@ -76,7 +85,7 @@ export const checkRules = (
 
         return error(
           example?.from ?? edge.from,
-          `\`${edge.from}\` must not depend on \`${edge.to}\` (${rule.reason}); ${imports}, e.g. ${example ? `${example.from} → ${example.to}` : "unknown"}`,
+          `${forbidden}; ${imports}, e.g. ${example ? `${example.from} → ${example.to}` : "unknown"}`,
         );
       }),
   );

--- a/libs/@local/petrinaut-arch-docs/src/check.ts
+++ b/libs/@local/petrinaut-arch-docs/src/check.ts
@@ -59,8 +59,9 @@ export const checkRules = (
 ): Diagnostic[] =>
   rules.flatMap((rule) =>
     model.edges
-      // Rules are claims about the import graph. A `@talksTo` edge has its own
-      // checks in `graph.ts` and cannot violate an import rule.
+      // Rules are checked against import edges only: the message names the
+      // files behind an edge, and a `@talksTo` edge carries none. `graph.ts`
+      // checks its endpoints instead.
       .filter(isImportEdge)
       .filter(
         (edge) =>

--- a/libs/@local/petrinaut-arch-docs/src/emit/bundle-outputs.ts
+++ b/libs/@local/petrinaut-arch-docs/src/emit/bundle-outputs.ts
@@ -6,7 +6,12 @@
  * single file, which is cheaper for a model to read than fetching thirty pages.
  */
 
-import { ARCHITECTURE_MODEL_VERSION, type ArchitectureModel } from "../model";
+import {
+  ARCHITECTURE_MODEL_VERSION,
+  isDeclaredEdge,
+  isImportEdge,
+  type ArchitectureModel,
+} from "../model";
 
 import type { AuthoredPage } from "../content";
 import type { GeneratedPage } from "./mdx";
@@ -116,14 +121,23 @@ export const buildSingleFileArchitecture = (
     );
 
     const outgoing = model.edges.filter((edge) => edge.from === layer.id);
+    const imports = outgoing.filter(isImportEdge);
+    const declared = outgoing.filter(isDeclaredEdge);
 
-    if (outgoing.length > 0) {
-      const rendered = outgoing
+    if (imports.length > 0) {
+      const rendered = imports
         .slice()
         .sort((left, right) => right.fileDependencies - left.fileDependencies)
         .map((edge) => `\`${edge.to}\` (${edge.fileDependencies})`)
         .join(", ");
       lines.push(`- Depends on: ${rendered}`);
+    }
+
+    if (declared.length > 0) {
+      const rendered = declared
+        .map((edge) => `\`${edge.to}\` via ${edge.protocol}`)
+        .join("; ");
+      lines.push(`- Talks to: ${rendered}`);
     }
 
     if (layer.references.length > 0) {

--- a/libs/@local/petrinaut-arch-docs/src/emit/d2.test.ts
+++ b/libs/@local/petrinaut-arch-docs/src/emit/d2.test.ts
@@ -28,8 +28,17 @@ const layer = (id: string, name = id): Layer => ({
 const edge = (from: string, to: string, count = 1): Edge => ({
   from,
   to,
+  provenance: "imports",
   fileDependencies: count,
   examples: [],
+  crossesPackage: false,
+});
+
+const declaredEdge = (from: string, to: string, protocol: string): Edge => ({
+  from,
+  to,
+  provenance: "declared",
+  protocol,
   crossesPackage: false,
 });
 
@@ -81,6 +90,19 @@ describe("buildNeighbourhoodDiagram", () => {
     const diagram = build("core.a", layers, [edge("core", "core.b")]);
 
     expect(diagram).toContain("no dependencies either way");
+  });
+
+  it("draws a declared edge dashed, labelled with its protocol", () => {
+    const diagram = build("core.a", layers, [
+      declaredEdge("core.a", "core.b", "JSON lines over stdio"),
+    ]);
+
+    expect(diagram).toContain(
+      'core_a -> core_b: "JSON lines over stdio" {class: declared',
+    );
+    // The declared neighbour gets a node even though no import reaches it.
+    expect(diagram).toContain("core_b: {class: core");
+    expect(diagram).not.toContain("no dependencies either way");
   });
 
   describe("when a layer has more neighbours than fit", () => {

--- a/libs/@local/petrinaut-arch-docs/src/emit/d2.test.ts
+++ b/libs/@local/petrinaut-arch-docs/src/emit/d2.test.ts
@@ -39,6 +39,8 @@ const declaredEdge = (from: string, to: string, protocol: string): Edge => ({
   to,
   provenance: "declared",
   protocol,
+  declaredIn: `src/${from}/boundary.ts`,
+  line: 1,
   crossesPackage: false,
 });
 

--- a/libs/@local/petrinaut-arch-docs/src/emit/d2.ts
+++ b/libs/@local/petrinaut-arch-docs/src/emit/d2.ts
@@ -22,7 +22,13 @@
 
 import { spawnSync } from "node:child_process";
 
-import type { Edge, Layer } from "../model";
+import {
+  isDeclaredEdge,
+  isImportEdge,
+  type DeclaredEdge,
+  type Edge,
+  type Layer,
+} from "../model";
 
 const quote = (text: string): string => JSON.stringify(text);
 
@@ -40,6 +46,7 @@ const styleClasses = [
   `  optimizer: {style.fill: "#e0f2f1"; style.stroke: "#2b7a72"}`,
   `  other: {style.fill: "#f2f2f2"; style.stroke: "#777777"}`,
   `  boundary: {style.stroke-dash: 4}`,
+  `  declared: {style.stroke-dash: 2}`,
   `  focus: {style.stroke-width: 3; style.bold: true}`,
   `  elided: {style.fill: "#ffffff"; style.stroke: "#aaaaaa"; style.stroke-dash: 3; style.italic: true}`,
   `}`,
@@ -73,6 +80,18 @@ const header = (generatedBy: string): string =>
  * alongside each other regardless of where they live in the taxonomy.
  */
 const flatKey = (id: string): string => id.replace(/\./gu, "_");
+
+/** Tooltip shared by every rendering of a `@talksTo` edge. */
+const declaredTooltip =
+  "declared with @talksTo; no import crosses this boundary";
+
+/** A declared edge: dashed, labelled with the protocol the annotation names. */
+const declaredEdgeLine = (
+  from: string,
+  to: string,
+  edge: DeclaredEdge,
+): string =>
+  `${from} -> ${to}: ${quote(edge.protocol)} {class: declared; tooltip: ${quote(declaredTooltip)}}`;
 
 /**
  * How many neighbours a neighbourhood diagram draws before eliding the rest.
@@ -114,12 +133,25 @@ export const buildNeighbourhoodDiagram = (
   };
 
   for (const edge of edges) {
+    if (!isImportEdge(edge)) {
+      continue;
+    }
     if (edge.from === focusId && edge.to !== focusId) {
       record(edge.to, "out", edge.fileDependencies);
     } else if (edge.to === focusId && edge.from !== focusId) {
       record(edge.from, "in", edge.fileDependencies);
     }
   }
+
+  // Declared edges bypass the neighbour cap: each is a hand-written annotation,
+  // so their number stays small, and eliding one would hide the only record of
+  // a boundary no import reaches.
+  const declaredEdges = edges
+    .filter(isDeclaredEdge)
+    .filter(
+      (edge) =>
+        (edge.from === focusId || edge.to === focusId) && edge.from !== edge.to,
+    );
 
   const ranked = [...neighbours.entries()].sort(
     ([leftId, left], [rightId, right]) =>
@@ -141,6 +173,21 @@ export const buildNeighbourhoodDiagram = (
       )}; tooltip: ${quote(layer?.role ?? id)}}`;
     }),
   ];
+
+  const drawnIds = new Set(shown.map(([id]) => id));
+  for (const edge of declaredEdges) {
+    const otherId = edge.from === focusId ? edge.to : edge.from;
+    if (drawnIds.has(otherId)) {
+      continue;
+    }
+    drawnIds.add(otherId);
+    const other = layersById.get(otherId);
+    nodeLines.push(
+      `${flatKey(otherId)}: {class: ${classFor(otherId)}; label: ${quote(
+        other?.name ?? otherId,
+      )}; tooltip: ${quote(other?.role ?? otherId)}}`,
+    );
+  }
 
   const elidedOut = elided.reduce((sum, [, counts]) => sum + counts.out, 0);
   const elidedIn = elided.reduce((sum, [, counts]) => sum + counts.in, 0);
@@ -181,6 +228,12 @@ export const buildNeighbourhoodDiagram = (
         )}}`,
       );
     }
+  }
+
+  for (const edge of declaredEdges) {
+    edgeLines.push(
+      declaredEdgeLine(flatKey(edge.from), flatKey(edge.to), edge),
+    );
   }
 
   // Drawn dashed and in whichever directions the elided layers actually use, so
@@ -274,6 +327,9 @@ export const buildSubtreeDiagram = (
 
   const aggregated = new Map<string, number>();
   for (const edge of edges) {
+    if (!isImportEdge(edge)) {
+      continue;
+    }
     const from = childScopeOf(edge.from);
     const to = childScopeOf(edge.to);
     if (from === null || to === null || from === to) {
@@ -294,6 +350,17 @@ export const buildSubtreeDiagram = (
         pluralise(count, "file-level dependency", "file-level dependencies"),
       )}}`;
     });
+
+  // Declared edges keep their individual protocol labels rather than being
+  // aggregated: two protocols between the same pair are two facts.
+  for (const edge of edges.filter(isDeclaredEdge)) {
+    const from = childScopeOf(edge.from);
+    const to = childScopeOf(edge.to);
+    if (from === null || to === null || from === to) {
+      continue;
+    }
+    edgeLines.push(declaredEdgeLine(key(from), key(to), edge));
+  }
 
   return [
     header(generatedBy),
@@ -334,6 +401,9 @@ export const buildOverviewDiagram = (
 
   const aggregated = new Map<string, number>();
   for (const edge of edges) {
+    if (!isImportEdge(edge)) {
+      continue;
+    }
     const from = rootSegment(edge.from);
     const to = rootSegment(edge.to);
     if (from === to) {
@@ -360,6 +430,15 @@ export const buildOverviewDiagram = (
         pluralise(count, "file-level dependency", "file-level dependencies"),
       )}}`;
     });
+
+  for (const edge of edges.filter(isDeclaredEdge)) {
+    const from = rootSegment(edge.from);
+    const to = rootSegment(edge.to);
+    if (from === to) {
+      continue;
+    }
+    edgeLines.push(declaredEdgeLine(from, to, edge));
+  }
 
   return [
     header(generatedBy),

--- a/libs/@local/petrinaut-arch-docs/src/emit/mdx.test.ts
+++ b/libs/@local/petrinaut-arch-docs/src/emit/mdx.test.ts
@@ -216,6 +216,8 @@ describe("buildPages with a declared edge", () => {
         to: "cli",
         provenance: "declared",
         protocol: "JSON lines over stdio",
+        declaredIn: "py/src/session.py",
+        line: 3,
         crossesPackage: true,
       },
     ],

--- a/libs/@local/petrinaut-arch-docs/src/emit/mdx.test.ts
+++ b/libs/@local/petrinaut-arch-docs/src/emit/mdx.test.ts
@@ -1,13 +1,12 @@
 import { describe, expect, it } from "vitest";
 
+import { ARCHITECTURE_MODEL_VERSION } from "../model";
 import {
   buildPages,
   resolveAuthoredLinks,
   resolveDiagramImages,
   layerSlug,
 } from "./mdx";
-
-import { ARCHITECTURE_MODEL_VERSION } from "../model";
 
 import type { ArchitectureModel, Layer } from "../model";
 

--- a/libs/@local/petrinaut-arch-docs/src/emit/mdx.test.ts
+++ b/libs/@local/petrinaut-arch-docs/src/emit/mdx.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from "vitest";
 
-import { resolveAuthoredLinks, resolveDiagramImages, layerSlug } from "./mdx";
+import {
+  buildPages,
+  resolveAuthoredLinks,
+  resolveDiagramImages,
+  layerSlug,
+} from "./mdx";
+
+import { ARCHITECTURE_MODEL_VERSION } from "../model";
+
+import type { ArchitectureModel, Layer } from "../model";
 
 /**
  * An authored page's final slug depends on its `attachTo`, so it cannot write a
@@ -180,5 +189,60 @@ describe("resolveDiagramImages", () => {
 
     expect(unresolved).toEqual(["@diagrams/missing.svg"]);
     expect(contents).toBe("![Flow](@diagrams/missing.svg)");
+  });
+});
+
+describe("buildPages with a declared edge", () => {
+  const testLayer = (id: string): Layer => ({
+    id,
+    name: id,
+    parent: null,
+    package: "@test/pkg",
+    role: `role of ${id}`,
+    declaredIn: `src/${id}/index.ts`,
+    prose: null,
+    references: [],
+    files: [`src/${id}/index.ts`],
+    fileCount: 1,
+    lineCount: 1,
+  });
+
+  const model: ArchitectureModel = {
+    version: ARCHITECTURE_MODEL_VERSION,
+    packages: [],
+    layers: [testLayer("bindings"), testLayer("cli")],
+    edges: [
+      {
+        from: "bindings",
+        to: "cli",
+        provenance: "declared",
+        protocol: "JSON lines over stdio",
+        crossesPackage: true,
+      },
+    ],
+    rules: [],
+  };
+
+  const pages = buildPages(model, {
+    sourceUrlPrefix: "https://example.com/",
+    overviewDiagram: null,
+    neighbourhoodDiagrams: new Map(),
+    subtreeDiagrams: new Map(),
+  });
+
+  it("lists the edge in a Declared block with its protocol, both directions", () => {
+    const bindings = pages.find((page) => page.slug === layerSlug("bindings"));
+    expect(bindings?.contents).toContain("## Depends on");
+    expect(bindings?.contents).toContain("### Declared");
+    expect(bindings?.contents).toContain("| JSON lines over stdio |");
+
+    const cli = pages.find((page) => page.slug === layerSlug("cli"));
+    expect(cli?.contents).toContain("## Depended on by");
+    expect(cli?.contents).toContain("### Declared");
+  });
+
+  it("keeps the declared edge out of the import table", () => {
+    const bindings = pages.find((page) => page.slug === layerSlug("bindings"));
+    expect(bindings?.contents).not.toContain("| Layer | Imports |");
   });
 });

--- a/libs/@local/petrinaut-arch-docs/src/emit/mdx.ts
+++ b/libs/@local/petrinaut-arch-docs/src/emit/mdx.ts
@@ -14,6 +14,8 @@
 
 import { posix } from "node:path";
 
+import { isDeclaredEdge, isImportEdge } from "../model";
+
 import type { ArchitectureModel, Edge, Layer } from "../model";
 
 export interface GeneratedPage {
@@ -273,58 +275,83 @@ const describeEdges = (
   const outgoing = edges.filter((edge) => edge.from === layer.id);
   const incoming = edges.filter((edge) => edge.to === layer.id);
 
-  const sections: string[] = [];
+  const layerLink = (otherId: string): string => {
+    const other = layersById.get(otherId);
+    const label = other ? other.name : otherId;
+    return `[${escapeTableCell(label)}](${relativeTo(slug, layerSlug(otherId))})`;
+  };
 
-  const table = (
+  /**
+   * Import edges and declared edges never share a table: one kind is aggregated
+   * from real imports, the other is an annotation someone wrote, and a reader
+   * should not mistake the second kind for the first.
+   */
+  const section = (
     heading: string,
     intro: string,
     rows: Edge[],
     direction: "to" | "from",
   ): string[] => {
-    if (rows.length === 0) {
+    const imports = rows.filter(isImportEdge);
+    const declared = rows.filter(isDeclaredEdge);
+
+    if (imports.length === 0 && declared.length === 0) {
       return [];
     }
 
-    return [
-      `## ${heading}`,
-      "",
-      intro,
-      "",
-      "| Layer | Imports | Package boundary |",
-      "| --- | --- | --- |",
-      ...rows
-        .slice()
-        .sort((left, right) => right.fileDependencies - left.fileDependencies)
-        .map((edge) => {
+    const lines: string[] = [`## ${heading}`, ""];
+
+    if (imports.length > 0) {
+      lines.push(
+        intro,
+        "",
+        "| Layer | Imports | Package boundary |",
+        "| --- | --- | --- |",
+        ...imports
+          .slice()
+          .sort((left, right) => right.fileDependencies - left.fileDependencies)
+          .map((edge) => {
+            const otherId = direction === "to" ? edge.to : edge.from;
+            const crosses = edge.crossesPackage ? "crossed" : "—";
+            return `| ${layerLink(otherId)} | ${edge.fileDependencies} | ${crosses} |`;
+          }),
+        "",
+      );
+    }
+
+    if (declared.length > 0) {
+      lines.push(
+        "### Declared",
+        "",
+        "Declared with `@talksTo` in the source, for boundaries no import crosses. The protocol text is the annotation's claim; only the endpoints are checked.",
+        "",
+        "| Layer | Protocol |",
+        "| --- | --- |",
+        ...declared.map((edge) => {
           const otherId = direction === "to" ? edge.to : edge.from;
-          const other = layersById.get(otherId);
-          const label = other ? other.name : otherId;
-          const link = `[${escapeTableCell(label)}](${relativeTo(slug, layerSlug(otherId))})`;
-          const crosses = edge.crossesPackage ? "crossed" : "—";
-          return `| ${link} | ${edge.fileDependencies} | ${crosses} |`;
+          return `| ${layerLink(otherId)} | ${escapeTableCell(edge.protocol)} |`;
         }),
-      "",
-    ];
+        "",
+      );
+    }
+
+    return lines;
   };
 
-  sections.push(
-    ...table(
+  return [
+    ...section(
       "Depends on",
       "Aggregated from real TypeScript imports.",
       outgoing,
       "to",
     ),
-  );
-  sections.push(
-    ...table(
+    ...section(
       "Depended on by",
       "Who reaches into this layer.",
       incoming,
       "from",
     ),
-  );
-
-  return sections;
+  ];
 };
 
 const buildLayerPage = (

--- a/libs/@local/petrinaut-arch-docs/src/extract.ts
+++ b/libs/@local/petrinaut-arch-docs/src/extract.ts
@@ -37,10 +37,25 @@ interface LayerAccumulator {
   lineCount: number;
 }
 
+/**
+ * One `@talksTo` occurrence, kept against its file so the graph stage can
+ * resolve the declaring file's layer and report errors with a location.
+ */
+export interface TalksToDeclaration {
+  /** Repo-relative source file carrying the annotation. */
+  file: string;
+  line: number;
+  /** Layer id on the receiving end of the protocol. */
+  target: string;
+  protocol: string;
+}
+
 export interface ExtractionResult {
   layers: Layer[];
   /** Repo-relative source file → layer id, for the graph stage. */
   fileLayers: Map<string, string>;
+  /** `@talksTo` declarations, resolved into edges by the graph stage. */
+  talksTo: TalksToDeclaration[];
   diagnostics: Diagnostic[];
 }
 
@@ -141,6 +156,7 @@ export const extract = async (
   const diagnostics: Diagnostic[] = [];
 
   const accumulators = new Map<string, LayerAccumulator>();
+  const talksTo: TalksToDeclaration[] = [];
   /** Folder → layer id it declares. */
   const scopes = new Map<string, string>();
   /** Layer id → the file that declared it, for duplicate reporting. */
@@ -247,6 +263,15 @@ export const extract = async (
         );
       }
 
+      for (const declaration of tags.talksTo) {
+        talksTo.push({
+          file: entry.path,
+          line: declaration.line,
+          target: declaration.target,
+          protocol: declaration.protocol,
+        });
+      }
+
       if (tags.layerRoot) {
         const id = tags.layerRoot.value;
         const segments = id.split(".");
@@ -314,9 +339,8 @@ export const extract = async (
         continue;
       }
 
-      // Only line counts are read here: with no per-file tags left in the
-      // vocabulary, a file's contents say nothing about the architecture beyond
-      // which layer's folder it sits in.
+      // Only line counts are read here: pass 1 already collected every tag,
+      // so at this point a file's contents add nothing beyond its size.
       const contents = await readFile(entry.absolutePath, "utf8");
 
       accumulator.files.push(entry.path);
@@ -373,5 +397,5 @@ export const extract = async (
     })
     .sort((left, right) => left.id.localeCompare(right.id));
 
-  return { layers, fileLayers, diagnostics };
+  return { layers, fileLayers, talksTo, diagnostics };
 };

--- a/libs/@local/petrinaut-arch-docs/src/graph.test.ts
+++ b/libs/@local/petrinaut-arch-docs/src/graph.test.ts
@@ -64,6 +64,8 @@ describe("resolveDeclaredEdges", () => {
         to: "cli",
         provenance: "declared",
         protocol: "JSON lines over stdio",
+        declaredIn: "py/src/session.py",
+        line: 3,
         crossesPackage: true,
       },
     ]);

--- a/libs/@local/petrinaut-arch-docs/src/graph.test.ts
+++ b/libs/@local/petrinaut-arch-docs/src/graph.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveDeclaredEdges } from "./graph";
+
+import type { TalksToDeclaration } from "./extract";
+import type { Edge, Layer } from "./model";
+
+/**
+ * A declared edge is the one kind an annotation draws rather than the import
+ * graph proving, so both refusals are pinned: a target nobody declared, and a
+ * pair the imports already carry. Either accepted silently would let the docs
+ * assert an edge the model cannot stand behind.
+ */
+
+const layer = (id: string, pkg = "@test/pkg"): Layer => ({
+  id,
+  name: id,
+  parent: id.includes(".") ? id.slice(0, id.lastIndexOf(".")) : null,
+  package: pkg,
+  role: `role of ${id}`,
+  declaredIn: `src/${id}/index.ts`,
+  prose: null,
+  references: [],
+  files: [`src/${id}/index.ts`],
+  fileCount: 1,
+  lineCount: 1,
+});
+
+const importEdge = (from: string, to: string): Edge => ({
+  from,
+  to,
+  provenance: "imports",
+  fileDependencies: 1,
+  examples: [],
+  crossesPackage: false,
+});
+
+const declaration = (
+  overrides: Partial<TalksToDeclaration> = {},
+): TalksToDeclaration => ({
+  file: "py/src/session.py",
+  line: 3,
+  target: "cli",
+  protocol: "JSON lines over stdio",
+  ...overrides,
+});
+
+const layers = [layer("bindings", "@test/py"), layer("cli", "@test/cli")];
+const fileLayers = new Map([["py/src/session.py", "bindings"]]);
+
+describe("resolveDeclaredEdges", () => {
+  it("builds an edge from the declaring file's layer to the target", () => {
+    const { edges, diagnostics } = resolveDeclaredEdges({
+      talksTo: [declaration()],
+      fileLayers,
+      layers,
+      importEdges: [],
+    });
+
+    expect(diagnostics).toEqual([]);
+    expect(edges).toEqual([
+      {
+        from: "bindings",
+        to: "cli",
+        provenance: "declared",
+        protocol: "JSON lines over stdio",
+        crossesPackage: true,
+      },
+    ]);
+  });
+
+  it("errors when the target is not a declared layer", () => {
+    const { edges, diagnostics } = resolveDeclaredEdges({
+      talksTo: [declaration({ target: "clii" })],
+      fileLayers,
+      layers,
+      importEdges: [],
+    });
+
+    expect(edges).toEqual([]);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.severity).toBe("error");
+    expect(diagnostics[0]?.file).toBe("py/src/session.py");
+    expect(diagnostics[0]?.line).toBe(3);
+    expect(diagnostics[0]?.message).toContain("not a declared layer");
+  });
+
+  it("errors when the target is the declaring file's own layer", () => {
+    const { edges, diagnostics } = resolveDeclaredEdges({
+      talksTo: [declaration({ target: "bindings" })],
+      fileLayers,
+      layers,
+      importEdges: [],
+    });
+
+    expect(edges).toEqual([]);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain("own layer");
+  });
+
+  it("errors when the pair is already derived from imports", () => {
+    const { edges, diagnostics } = resolveDeclaredEdges({
+      talksTo: [declaration()],
+      fileLayers,
+      layers,
+      importEdges: [importEdge("bindings", "cli")],
+    });
+
+    expect(edges).toEqual([]);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain("already derived from imports");
+    expect(diagnostics[0]?.message).toContain("remove the declaration");
+  });
+
+  it("errors when the same pair is declared twice", () => {
+    const { edges, diagnostics } = resolveDeclaredEdges({
+      talksTo: [
+        declaration(),
+        declaration({ file: "py/src/other.py", protocol: "a socket" }),
+      ],
+      fileLayers: new Map([
+        ["py/src/session.py", "bindings"],
+        ["py/src/other.py", "bindings"],
+      ]),
+      layers,
+      importEdges: [],
+    });
+
+    expect(edges).toHaveLength(1);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.file).toBe("py/src/other.py");
+    expect(diagnostics[0]?.message).toContain(
+      "already declared in py/src/session.py",
+    );
+  });
+
+  it("skips a file no layer resolves for, which extract already reports", () => {
+    const { edges, diagnostics } = resolveDeclaredEdges({
+      talksTo: [declaration({ file: "py/src/orphan.py" })],
+      fileLayers,
+      layers,
+      importEdges: [],
+    });
+
+    expect(edges).toEqual([]);
+    expect(diagnostics).toEqual([]);
+  });
+});

--- a/libs/@local/petrinaut-arch-docs/src/graph.ts
+++ b/libs/@local/petrinaut-arch-docs/src/graph.ts
@@ -3,8 +3,10 @@
  *
  * dependency-cruiser supplies the file-level truth; the layer assignment comes
  * from `extract.ts`. Aggregating one against the other is what makes the
- * diagrams trustworthy: an edge appears because imports exist, never because
- * someone drew it.
+ * diagrams trustworthy: an import edge appears because imports exist, never
+ * because someone drew it. The one annotation-drawn kind, a `@talksTo` edge for
+ * a boundary no import crosses, is resolved here after aggregation, and it may
+ * neither restate an import edge nor name a layer that does not exist.
  *
  * Package subpath aliases are derived from each package's `exports` map rather
  * than hand-listed, so a new entry point cannot drop out of the graph unnoticed.
@@ -31,7 +33,8 @@ import {
   sourceRootPattern,
 } from "./scope";
 
-import type { ArchitecturePackage, Edge, Layer } from "./model";
+import type { TalksToDeclaration } from "./extract";
+import type { ArchitecturePackage, DeclaredEdge, Edge, Layer } from "./model";
 
 /** How many representative file pairs to record per edge. */
 const examplesPerEdge = 3;
@@ -137,6 +140,8 @@ export interface GraphOptions {
   /** Repo-relative source file → layer id, from `extract`. */
   fileLayers: Map<string, string>;
   layers: Layer[];
+  /** `@talksTo` declarations from `extract`, from any covered language. */
+  talksTo: TalksToDeclaration[];
 }
 
 export interface GraphResult {
@@ -217,6 +222,108 @@ const checkCoverage = (
       ),
     );
 
+/**
+ * Resolves `@talksTo` declarations into declared edges.
+ *
+ * Separate from `buildGraph` so the error cases are testable without running
+ * dependency-cruiser. Each error names the annotation's file and line: an
+ * unknown target would otherwise draw an edge to a node no page describes, and
+ * a pair the import graph already carries would double an edge whose truth is
+ * the imports, so both refuse the declaration instead.
+ */
+export const resolveDeclaredEdges = (options: {
+  talksTo: TalksToDeclaration[];
+  /** Repo-relative source file → layer id, from `extract`. */
+  fileLayers: Map<string, string>;
+  layers: Layer[];
+  importEdges: Edge[];
+}): { edges: DeclaredEdge[]; diagnostics: Diagnostic[] } => {
+  const diagnostics: Diagnostic[] = [];
+  const edges: DeclaredEdge[] = [];
+
+  const packageOf = new Map(
+    options.layers.map((layer) => [layer.id, layer.package]),
+  );
+  const importPairs = new Set(
+    options.importEdges.map((edge) => `${edge.from}>${edge.to}`),
+  );
+  /** Pair → file that declared it, so a repeat is reported with its rival. */
+  const declaredPairs = new Map<string, string>();
+
+  for (const declaration of options.talksTo) {
+    const from = options.fileLayers.get(declaration.file);
+
+    // A file no layer resolves for is already an error in `extract`.
+    if (from === undefined) {
+      continue;
+    }
+
+    if (!packageOf.has(declaration.target)) {
+      diagnostics.push(
+        error(
+          declaration.file,
+          `@talksTo names \`${declaration.target}\`, which is not a declared layer`,
+          declaration.line,
+        ),
+      );
+      continue;
+    }
+
+    if (declaration.target === from) {
+      diagnostics.push(
+        error(
+          declaration.file,
+          `@talksTo names \`${declaration.target}\`, the declaring file's own layer; declare the edge on the calling side only`,
+          declaration.line,
+        ),
+      );
+      continue;
+    }
+
+    const pair = `${from}>${declaration.target}`;
+
+    if (importPairs.has(pair)) {
+      diagnostics.push(
+        error(
+          declaration.file,
+          `@talksTo declares \`${from}\` → \`${declaration.target}\`, but that edge is already derived from imports; remove the declaration`,
+          declaration.line,
+        ),
+      );
+      continue;
+    }
+
+    const rival = declaredPairs.get(pair);
+    if (rival !== undefined) {
+      diagnostics.push(
+        error(
+          declaration.file,
+          `\`${from}\` → \`${declaration.target}\` is already declared in ${rival}`,
+          declaration.line,
+        ),
+      );
+      continue;
+    }
+    declaredPairs.set(pair, declaration.file);
+
+    const fromPackage = packageOf.get(from);
+    const toPackage = packageOf.get(declaration.target);
+
+    edges.push({
+      from,
+      to: declaration.target,
+      provenance: "declared",
+      protocol: declaration.protocol,
+      crossesPackage:
+        fromPackage !== undefined &&
+        toPackage !== undefined &&
+        fromPackage !== toPackage,
+    });
+  }
+
+  return { edges, diagnostics };
+};
+
 export const buildGraph = async (
   options: GraphOptions,
 ): Promise<GraphResult> => {
@@ -278,27 +385,36 @@ export const buildGraph = async (
 
   const packageOf = new Map(layers.map((layer) => [layer.id, layer.package]));
 
-  const edges: Edge[] = [...accumulated.entries()]
-    .map(([key, edge]) => {
-      const [from = "", to = ""] = key.split(">");
-      const fromPackage = packageOf.get(from);
-      const toPackage = packageOf.get(to);
+  const importEdges: Edge[] = [...accumulated.entries()].map(([key, edge]) => {
+    const [from = "", to = ""] = key.split(">");
+    const fromPackage = packageOf.get(from);
+    const toPackage = packageOf.get(to);
 
-      return {
-        from,
-        to,
-        fileDependencies: edge.fileDependencies,
-        examples: edge.examples,
-        crossesPackage:
-          fromPackage !== undefined &&
-          toPackage !== undefined &&
-          fromPackage !== toPackage,
-      };
-    })
-    .sort(
-      (left, right) =>
-        left.from.localeCompare(right.from) || left.to.localeCompare(right.to),
-    );
+    return {
+      from,
+      to,
+      provenance: "imports" as const,
+      fileDependencies: edge.fileDependencies,
+      examples: edge.examples,
+      crossesPackage:
+        fromPackage !== undefined &&
+        toPackage !== undefined &&
+        fromPackage !== toPackage,
+    };
+  });
+
+  const declared = resolveDeclaredEdges({
+    talksTo: options.talksTo,
+    fileLayers,
+    layers,
+    importEdges,
+  });
+  diagnostics.push(...declared.diagnostics);
+
+  const edges: Edge[] = [...importEdges, ...declared.edges].sort(
+    (left, right) =>
+      left.from.localeCompare(right.from) || left.to.localeCompare(right.to),
+  );
 
   return { edges, diagnostics };
 };

--- a/libs/@local/petrinaut-arch-docs/src/graph.ts
+++ b/libs/@local/petrinaut-arch-docs/src/graph.ts
@@ -314,6 +314,8 @@ export const resolveDeclaredEdges = (options: {
       to: declaration.target,
       provenance: "declared",
       protocol: declaration.protocol,
+      declaredIn: declaration.file,
+      line: declaration.line,
       crossesPackage:
         fromPackage !== undefined &&
         toPackage !== undefined &&

--- a/libs/@local/petrinaut-arch-docs/src/model.ts
+++ b/libs/@local/petrinaut-arch-docs/src/model.ts
@@ -76,6 +76,10 @@ export const declaredEdgeSchema = edgeBaseSchema.extend({
   provenance: z.literal("declared"),
   /** The `via` text from the annotation, e.g. "JSON lines over stdio". */
   protocol: z.string().min(1),
+  /** Repo-relative file carrying the annotation. */
+  declaredIn: z.string().min(1),
+  /** Line of the annotation within `declaredIn`. */
+  line: z.number().int().positive(),
 });
 
 export const edgeSchema = z.discriminatedUnion("provenance", [

--- a/libs/@local/petrinaut-arch-docs/src/model.ts
+++ b/libs/@local/petrinaut-arch-docs/src/model.ts
@@ -8,7 +8,7 @@
 
 import { z } from "zod";
 
-export const ARCHITECTURE_MODEL_VERSION = 1;
+export const ARCHITECTURE_MODEL_VERSION = 2;
 
 /**
  * A layer: one node in the architecture, and one page in the docs.
@@ -43,14 +43,9 @@ export const layerSchema = z.object({
 
 export type Layer = z.infer<typeof layerSchema>;
 
-/** An aggregated import relationship between two layers. */
-export const edgeSchema = z.object({
+const edgeBaseSchema = z.object({
   from: z.string().min(1),
   to: z.string().min(1),
-  /** How many file-level imports collapse into this edge. */
-  fileDependencies: z.number().int().positive(),
-  /** A few representative imports, so a reader can jump to real code. */
-  examples: z.array(z.object({ from: z.string(), to: z.string() })),
   /**
    * Whether the two layers live in different workspace packages.
    *
@@ -63,7 +58,40 @@ export const edgeSchema = z.object({
   crossesPackage: z.boolean(),
 });
 
+/** An aggregated import relationship between two layers. */
+export const importEdgeSchema = edgeBaseSchema.extend({
+  provenance: z.literal("imports"),
+  /** How many file-level imports collapse into this edge. */
+  fileDependencies: z.number().int().positive(),
+  /** A few representative imports, so a reader can jump to real code. */
+  examples: z.array(z.object({ from: z.string(), to: z.string() })),
+});
+
+/**
+ * A relationship declared with `@talksTo`, for a boundary no import crosses:
+ * a spawned subprocess, a postMessage channel. The protocol text is the
+ * annotation's claim; only the endpoints are checked against the model.
+ */
+export const declaredEdgeSchema = edgeBaseSchema.extend({
+  provenance: z.literal("declared"),
+  /** The `via` text from the annotation, e.g. "JSON lines over stdio". */
+  protocol: z.string().min(1),
+});
+
+export const edgeSchema = z.discriminatedUnion("provenance", [
+  importEdgeSchema,
+  declaredEdgeSchema,
+]);
+
+export type ImportEdge = z.infer<typeof importEdgeSchema>;
+export type DeclaredEdge = z.infer<typeof declaredEdgeSchema>;
 export type Edge = z.infer<typeof edgeSchema>;
+
+export const isImportEdge = (edge: Edge): edge is ImportEdge =>
+  edge.provenance === "imports";
+
+export const isDeclaredEdge = (edge: Edge): edge is DeclaredEdge =>
+  edge.provenance === "declared";
 
 export const packageSchema = z.object({
   name: z.string().min(1),

--- a/libs/@local/petrinaut-arch-docs/src/tags.test.ts
+++ b/libs/@local/petrinaut-arch-docs/src/tags.test.ts
@@ -109,6 +109,94 @@ line three
   });
 });
 
+describe("scanTags @talksTo", () => {
+  it("reads a target and protocol from a TypeScript comment", () => {
+    const { tags, diagnostics } = scanTags(`/**
+ * @layerRoot bindings
+ * @role Python bindings for the CLI protocol
+ * @talksTo cli via JSON lines over stdio (spawned subprocess)
+ */`);
+
+    expect(diagnostics).toEqual([]);
+    expect(tags.talksTo).toEqual([
+      {
+        target: "cli",
+        protocol: "JSON lines over stdio (spawned subprocess)",
+        line: 4,
+      },
+    ]);
+  });
+
+  it("is repeatable, one target per tag", () => {
+    const { tags, diagnostics } = scanTags(`/**
+ * @talksTo cli via JSON lines over stdio
+ * @talksTo core.simulation.worker via postMessage
+ */`);
+
+    expect(diagnostics).toEqual([]);
+    expect(tags.talksTo.map((tag) => tag.target)).toEqual([
+      "cli",
+      "core.simulation.worker",
+    ]);
+  });
+
+  it("reads the tag from a Python module docstring", () => {
+    const { tags, diagnostics } = scanTags(
+      `"""One CLI process, spoken to over JSON lines on stdio.
+
+@talksTo cli via JSON lines over stdio (spawned subprocess)
+"""
+`,
+      "python",
+    );
+
+    expect(diagnostics).toEqual([]);
+    expect(tags.talksTo[0]?.target).toBe("cli");
+    expect(tags.talksTo[0]?.protocol).toBe(
+      "JSON lines over stdio (spawned subprocess)",
+    );
+  });
+
+  it("does not extend the protocol with following prose lines", () => {
+    const { tags } = scanTags(`/**
+ * @talksTo cli via JSON lines over stdio
+ * The child is spawned per run and shut down with its process group.
+ */`);
+
+    expect(tags.talksTo[0]?.protocol).toBe("JSON lines over stdio");
+  });
+
+  it("reports a tag with no via clause", () => {
+    const { tags, diagnostics } = scanTags(`/**
+ * @talksTo cli
+ */`);
+
+    expect(tags.talksTo).toEqual([]);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain("via <protocol>");
+  });
+
+  it("reports a target that is not a well-formed layer id", () => {
+    const { tags, diagnostics } = scanTags(`/**
+ * @talksTo Not_A_Layer via stdio
+ */`);
+
+    expect(tags.talksTo).toEqual([]);
+    expect(diagnostics).toHaveLength(1);
+  });
+
+  it("suggests a correction for a miscased tag", () => {
+    const { diagnostics } = scanTags(`/**
+ * @talksto cli via stdio
+ */`);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toBe(
+      "unknown tag @talksto; did you mean @talksTo?",
+    );
+  });
+});
+
 describe("scanTags for Python", () => {
   it("reads a layer declaration from a module docstring", () => {
     const { tags, diagnostics } = scanTags(

--- a/libs/@local/petrinaut-arch-docs/src/tags.ts
+++ b/libs/@local/petrinaut-arch-docs/src/tags.ts
@@ -6,10 +6,10 @@
  * prose then becomes the layer's page. Files with no tags inherit from the
  * nearest declaring ancestor.
  *
- * The vocabulary is deliberately two tags: an id and a one-line role. Both are
- * needed to place a layer in the graph and to label it — anything more is a
- * claim the generator cannot check, and this version does not make claims it
- * cannot keep.
+ * The vocabulary is three tags. `@layerRoot` and `@role` place a layer in the
+ * graph and label it. `@talksTo` declares an edge no import produces, such as a
+ * spawned subprocess or a postMessage channel; anything more is a claim the
+ * generator cannot check, and this version does not make claims it cannot keep.
  *
  * Tags are recognised only at the start of a line inside a doc comment — a
  * `/** ... *​/` block in TypeScript, a triple-quoted docstring in Python — so a
@@ -30,6 +30,15 @@ export interface TagValue {
   line: number;
 }
 
+/** One `@talksTo` occurrence: a dependency on `target` over `protocol`. */
+export interface TalksToTag {
+  /** Layer id on the receiving end of the protocol. */
+  target: string;
+  /** The text after `via`, e.g. "JSON lines over stdio". */
+  protocol: string;
+  line: number;
+}
+
 export interface ParsedTags {
   /**
    * `@layerRoot` — declares that this file's folder *and its descendants* form
@@ -39,6 +48,12 @@ export interface ParsedTags {
   layerRoot: TagValue | null;
   /** `@role` — one-line statement of what the layer is responsible for. */
   role: TagValue | null;
+  /**
+   * `@talksTo <layer-id> via <protocol>` — declares a dependency no import
+   * produces, such as a spawned subprocess or a postMessage channel. The
+   * declaring file's own layer is the edge source. Repeatable.
+   */
+  talksTo: TalksToTag[];
 }
 
 export interface TagDiagnostic {
@@ -54,6 +69,7 @@ export interface TagScanResult {
 const emptyTags = (): ParsedTags => ({
   layerRoot: null,
   role: null,
+  talksTo: [],
 });
 
 /** Tags that may appear at most once per file. */
@@ -61,7 +77,14 @@ const singularTags = ["layerRoot", "role"] as const;
 
 type SingularTag = (typeof singularTags)[number];
 
-const knownTagNames = new Set<string>(singularTags);
+const knownTagNames = new Set<string>([...singularTags, "talksTo"]);
+
+/**
+ * `<layer-id> via <protocol>`: the id grammar matches `layerSchema` in
+ * `model.ts`, and the protocol is required free text.
+ */
+const talksToPattern =
+  /^([a-z0-9]+(?:-[a-z0-9]+)*(?:\.[a-z0-9]+(?:-[a-z0-9]+)*)*)\s+via\s+(\S.*)$/u;
 
 /** The language a file's doc comments are written for. */
 export type CommentLanguage = "typescript" | "python";
@@ -135,7 +158,8 @@ interface RawTag {
 /**
  * Collects tags from one comment body. A tag's text continues onto following
  * lines until the next tag or the end of the comment, so multi-line notes stay
- * readable in source.
+ * readable in source. `@talksTo` is the exception: its text becomes a diagram
+ * edge label, so it ends at its own line and following prose stays prose.
  */
 const collectRawTags = (lines: { text: string; line: number }[]): RawTag[] => {
   const tags: RawTag[] = [];
@@ -149,6 +173,10 @@ const collectRawTags = (lines: { text: string; line: number }[]): RawTag[] => {
         tags.push(current);
       }
       current = { name: match[1] ?? "", text: match[2] ?? "", line };
+      if (current.name === "talksTo") {
+        tags.push(current);
+        current = null;
+      }
       continue;
     }
 
@@ -222,6 +250,24 @@ export const scanTags = (
 
       if (singularTags.includes(name as SingularTag)) {
         assignSingular(name as SingularTag, rawTag);
+        continue;
+      }
+
+      if (name === "talksTo") {
+        const parsed = talksToPattern.exec(rawTag.text);
+        if (parsed) {
+          tags.talksTo.push({
+            target: parsed[1] ?? "",
+            protocol: (parsed[2] ?? "").trim(),
+            line,
+          });
+        } else {
+          diagnostics.push({
+            line,
+            message:
+              "@talksTo expects `@talksTo <layer-id> via <protocol>`, e.g. `@talksTo cli via JSON lines over stdio`",
+          });
+        }
         continue;
       }
 

--- a/libs/@local/petrinaut-python/src/petrinaut/session.py
+++ b/libs/@local/petrinaut-python/src/petrinaut/session.py
@@ -7,6 +7,8 @@ spawned, read, timed out, and shut down lives in :mod:`petrinaut._transport`;
 this module is the part a consumer reads.
 
 POSIX only, via the transport: process groups and descriptor polling.
+
+@talksTo cli via JSON lines over stdio (spawned subprocess)
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Every edge in the architecture graph comes from an import, so a coupling that crosses a process boundary is invisible. The Python bindings spawn the CLI and speak JSON lines with no import in either direction, and the `cli` layer showed no consumers. One annotation now declares such a boundary, written in the boundary file's doc comment or docstring:

```
@talksTo cli via JSON lines over stdio (spawned subprocess)
```

The declaring file's own layer is the edge source, and the edge renders dashed with the protocol as its label.

FE-1414 (#9230) sits below in this stack and FE-1447 (#9264) above.

## 🔗 Related links

- [FE-1443](https://linear.app/hash/issue/FE-1443/arch-docs-declared-protocol-edges-for-import-invisible-boundaries) *(internal)*: this PR
- [FE-1415](https://linear.app/hash/issue/FE-1415/arch-docs-generate-import-edges-for-python-packages) *(internal)*: complementary. No Python import crosses the subprocess boundary either, so both are needed.

## 🔍 What does this change?

`libs/@local/petrinaut-arch-docs`:

- **`tags.ts`**: the TypeScript-comment and Python-docstring scan collects `@talksTo <layer-id> via <protocol>`. The tag is repeatable, a malformed tag is a diagnostic, and the label runs from `via` to the end of that line, so prose on the next line stays out of it.
- **`model.ts`**: `Edge` becomes a discriminated union on `provenance` (`"imports"` | `"declared"`), declared edges carry a `protocol`, and `ARCHITECTURE_MODEL_VERSION` rises to 2.
- **`graph.ts`**: declared edges append after import aggregation. The build errors on an unknown target, on the declaring file's own layer, on a pair the imports already prove, and on a duplicate declaration.
- **`d2.ts`**: declared edges render dashed with the protocol label in all three diagram kinds, at `stroke-dash: 2` to stay distinct from the boundary class's 4. A declared neighbour bypasses the 12-neighbour cap.
- **`mdx.ts`**: a "Declared" table (Layer | Protocol) sits under "Depends on" and "Depended on by".
- **`check.ts`**: forbidden-edge rules apply to declared edges as well as imported ones, because a rule states which layers may couple whatever carries the coupling. A declared edge carries the file and line of its annotation, so the violation names what to remove.
- **First use**: the bindings package declares its edge to `cli`.
- **Docs**: "Declaring a protocol edge" in the maintaining guide and the README, three tags in `AGENTS.md`, and `subprocess-boundary.mdx` updated to say the diagrams draw the boundary.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] modifies a workspace but **not** a publishable library

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] require changes to docs which **are made** as part of this PR

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- `tags.test.ts`: parsing in TypeScript comments and Python docstrings, the line-terminated protocol text, malformed tags, and the miscasing suggestion.
- `graph.test.ts` (new): resolution, an unknown target, a self-target, a pair the imports already prove, and a duplicate declaration.
- `d2.test.ts` / `mdx.test.ts`: the dashed edge with its protocol label, and the Declared table in both directions.

## ❓ How to test this?

1. `yarn workspace @local/petrinaut-arch-docs lint:arch-docs` passes with the declared edge in place.
2. `turbo run dev --filter @apps/petrinaut-docs`: the `python-bindings` and `cli` layer pages show the declared edge dashed in their neighbourhood diagrams and in a "Declared" table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



