### PR TITLE
FE-1415: Generate import edges for Python packages

### DIFF
--- a/libs/@local/petrinaut-arch-docs/content/index.mdx
+++ b/libs/@local/petrinaut-arch-docs/content/index.mdx
@@ -76,7 +76,7 @@ Python optimizer service drive; its [usage manual](doc:cli/usage-manual) covers
 the transports, the protocol, and optimization studies.
 
 `apps/petrinaut-opt` (the Python Optuna service) and `@local/petrinaut-python`
-(its CLI bindings) are covered as layers too, though Python files contribute
-no import edges yet. One package is not covered at all:
+(its CLI bindings) are covered too, with their layers and import edges derived
+the same way as the TypeScript ones. One package is not covered at all:
 `@apps/petrinaut-website`. Adding a package is a matter of declaring layers in
 its source; see [Declaring layers](doc:maintaining/declaring-layers).

--- a/libs/@local/petrinaut-arch-docs/src/build.ts
+++ b/libs/@local/petrinaut-arch-docs/src/build.ts
@@ -98,7 +98,7 @@ export const buildBundle = async (options: {
 
   const graph = await buildGraph({
     repoRoot,
-    packages: packages.filter((pkg) => pkg.language === "typescript"),
+    packages,
     tsconfigPath: join(
       repoRoot,
       "libs/@local/petrinaut-arch-docs/dependency-cruiser.tsconfig.json",

--- a/libs/@local/petrinaut-arch-docs/src/emit/components/layer-relations.tsx
+++ b/libs/@local/petrinaut-arch-docs/src/emit/components/layer-relations.tsx
@@ -85,7 +85,7 @@ export const LayerRelations = ({
     <Direction title="Depended on by" entries={dependedOnBy} />
     <Direction title="Depends on" entries={dependsOn} />
     <p className="arch-rel-note">
-      Counts are file-level imports, aggregated from TypeScript packages only.
+      Counts are file-level imports, aggregated across every covered package.
       Dashed labels are <code>@talksTo</code> declarations: the protocol text is
       the annotation's claim, and only the endpoints are checked.
     </p>

--- a/libs/@local/petrinaut-arch-docs/src/graph.test.ts
+++ b/libs/@local/petrinaut-arch-docs/src/graph.test.ts
@@ -1,9 +1,13 @@
-import { describe, expect, it } from "vitest";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
-import { resolveDeclaredEdges } from "./graph";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { buildGraph, resolveDeclaredEdges } from "./graph";
 
 import type { TalksToDeclaration } from "./extract";
-import type { Edge, Layer } from "./model";
+import type { ArchitecturePackage, Edge, Layer } from "./model";
 
 /**
  * A declared edge is the one kind an annotation draws rather than the import
@@ -146,5 +150,94 @@ describe("resolveDeclaredEdges", () => {
 
     expect(edges).toEqual([]);
     expect(diagnostics).toEqual([]);
+  });
+});
+
+/**
+ * Python records go through the same aggregation as TypeScript ones, so one
+ * end-to-end case pins the whole chain: parse, resolve across packages, map to
+ * layers, drop the intra-layer imports, and mark the package crossing.
+ */
+describe("buildGraph with Python packages", () => {
+  let root: string;
+
+  const pythonPackage = (name: string, path: string): ArchitecturePackage => ({
+    name,
+    path,
+    description: `${name} test package`,
+    language: "python",
+    sourceDirectory: "src",
+  });
+
+  const write = async (
+    relativePath: string,
+    contents: string,
+  ): Promise<void> => {
+    const absolute = join(root, relativePath);
+    await mkdir(join(absolute, ".."), { recursive: true });
+    await writeFile(absolute, contents, "utf8");
+  };
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "arch-docs-graph-"));
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("aggregates a cross-package Python import into an imports edge", async () => {
+    await write(
+      "libs/py/src/petrinaut/__init__.py",
+      "from .session import Session\n",
+    );
+    await write("libs/py/src/petrinaut/session.py", "import json\n");
+    await write("apps/opt/src/__init__.py", "");
+    await write(
+      "apps/opt/src/api.py",
+      "from petrinaut import Session\nfrom src.utils import helper\n",
+    );
+    await write("apps/opt/src/utils.py", "def helper(): ...\n");
+
+    const files: [string, string][] = [
+      ["libs/py/src/petrinaut/__init__.py", "bindings"],
+      ["libs/py/src/petrinaut/session.py", "bindings"],
+      ["apps/opt/src/__init__.py", "optimizer"],
+      ["apps/opt/src/api.py", "optimizer"],
+      ["apps/opt/src/utils.py", "optimizer"],
+    ];
+
+    const { edges, diagnostics } = await buildGraph({
+      repoRoot: root,
+      packages: [
+        pythonPackage("@test/py", "libs/py"),
+        pythonPackage("@test/opt", "apps/opt"),
+      ],
+      tsconfigPath: "unused-without-typescript-packages.json",
+      ignoredDirectories: [],
+      ignoredFilePattern: /\.test\.py$/u,
+      fileLayers: new Map(files),
+      layers: [layer("bindings", "@test/py"), layer("optimizer", "@test/opt")],
+      talksTo: [],
+    });
+
+    expect(diagnostics).toEqual([]);
+    // The intra-layer imports (`.session`, `src.utils`) and the stdlib import
+    // are all dropped; the cross-package one is the only edge left.
+    expect(edges).toEqual([
+      {
+        from: "optimizer",
+        to: "bindings",
+        provenance: "imports",
+        fileDependencies: 1,
+        examples: [
+          {
+            from: "apps/opt/src/api.py",
+            to: "libs/py/src/petrinaut/__init__.py",
+          },
+        ],
+        crossesPackage: true,
+      },
+    ]);
   });
 });

--- a/libs/@local/petrinaut-arch-docs/src/graph.ts
+++ b/libs/@local/petrinaut-arch-docs/src/graph.ts
@@ -1,7 +1,8 @@
 /**
- * Turns the real TypeScript import graph into layer-level edges.
+ * Turns the real import graphs into layer-level edges.
  *
- * dependency-cruiser supplies the file-level truth; the layer assignment comes
+ * One provider per language supplies the file-level truth: dependency-cruiser
+ * for TypeScript, `python-imports.ts` for Python. The layer assignment comes
  * from `extract.ts`. Aggregating one against the other is what makes the
  * diagrams trustworthy: an import edge appears because imports exist, never
  * because someone drew it. The one annotation-drawn kind, a `@talksTo` edge for
@@ -26,6 +27,7 @@ import extractTSConfig from "dependency-cruiser/config-utl/extract-ts-config";
 
 import { error, warning, type Diagnostic } from "./diagnostics";
 import { toPosix } from "./paths";
+import { collectPythonImports } from "./python-imports";
 import {
   exclusionPattern,
   sourceExtensions,
@@ -38,6 +40,14 @@ import type { ArchitecturePackage, DeclaredEdge, Edge, Layer } from "./model";
 
 /** How many representative file pairs to record per edge. */
 const examplesPerEdge = 3;
+
+/** One file-level import, the record every language provider emits. */
+export interface FileDependency {
+  /** Repo-relative posix path of the importing file. */
+  from: string;
+  /** Repo-relative posix path of the imported file. */
+  to: string;
+}
 
 interface Alias {
   alias: string;
@@ -132,7 +142,7 @@ const deriveAliases = (
 
 export interface GraphOptions {
   repoRoot: string;
-  /** TypeScript packages only; callers filter before reaching here. */
+  /** Every covered package; `buildGraph` splits them by language. */
   packages: ArchitecturePackage[];
   tsconfigPath: string;
   ignoredDirectories: string[];
@@ -326,22 +336,60 @@ export const resolveDeclaredEdges = (options: {
   return { edges, diagnostics };
 };
 
-export const buildGraph = async (
+/**
+ * Runs dependency-cruiser over the TypeScript packages and flattens the result
+ * to file-level records, so aggregation reads one shape from every language.
+ */
+const collectTypeScriptImports = async (
   options: GraphOptions,
-): Promise<GraphResult> => {
-  const { repoRoot, fileLayers, layers } = options;
+): Promise<{ dependencies: FileDependency[]; diagnostics: Diagnostic[] }> => {
+  // Nothing to cruise; also keeps Python-only tests off dependency-cruiser.
+  if (options.packages.length === 0) {
+    return { dependencies: [], diagnostics: [] };
+  }
 
   const aliases: Alias[] = [];
   const diagnostics: Diagnostic[] = [];
 
   for (const pkg of options.packages) {
-    const derived = deriveAliases(repoRoot, pkg);
+    const derived = deriveAliases(options.repoRoot, pkg);
     aliases.push(...derived.aliases);
     diagnostics.push(...derived.diagnostics);
   }
 
   const modules = await cruiseModules(options, aliases);
-  diagnostics.push(...checkCoverage(modules, fileLayers));
+  diagnostics.push(...checkCoverage(modules, options.fileLayers));
+
+  const dependencies: FileDependency[] = modules.flatMap((module) =>
+    module.dependencies.map((dependency) => ({
+      from: toPosix(module.source),
+      to: toPosix(dependency.resolved),
+    })),
+  );
+
+  return { dependencies, diagnostics };
+};
+
+export const buildGraph = async (
+  options: GraphOptions,
+): Promise<GraphResult> => {
+  const { repoRoot, fileLayers, layers } = options;
+
+  const byLanguage = (language: ArchitecturePackage["language"]) =>
+    options.packages.filter((pkg) => pkg.language === language);
+
+  const typescript = await collectTypeScriptImports({
+    ...options,
+    packages: byLanguage("typescript"),
+  });
+  const python = await collectPythonImports({
+    repoRoot,
+    packages: byLanguage("python"),
+    fileLayers,
+  });
+
+  const dependencies = [...typescript.dependencies, ...python.dependencies];
+  const diagnostics = [...typescript.diagnostics, ...python.diagnostics];
 
   interface EdgeAccumulator {
     fileDependencies: number;
@@ -350,39 +398,35 @@ export const buildGraph = async (
 
   const accumulated = new Map<string, EdgeAccumulator>();
 
-  for (const module of modules) {
-    const fromFile = toPosix(module.source);
+  for (const { from: fromFile, to: toFile } of dependencies) {
     const fromLayer = fileLayers.get(fromFile);
+    const toLayer = fileLayers.get(toFile);
 
     if (fromLayer === undefined) {
       continue;
     }
 
-    for (const dependency of module.dependencies) {
-      const toFile = toPosix(dependency.resolved);
-      const toLayer = fileLayers.get(toFile);
-
-      // Imports landing outside any layer: node_modules, uncovered packages.
-      // A file *inside* the covered roots is reported by `checkCoverage`.
-      if (toLayer === undefined || toLayer === fromLayer) {
-        continue;
-      }
-
-      // `>` cannot occur in a layer id, which is dot-separated kebab-case, so
-      // the pair round-trips. An earlier version used a NUL byte for this and
-      // left two raw NULs in the file, which made every text tool treat the
-      // source as binary.
-      const key = `${fromLayer}>${toLayer}`;
-      const edge = accumulated.get(key) ?? {
-        fileDependencies: 0,
-        examples: [],
-      };
-      edge.fileDependencies += 1;
-      if (edge.examples.length < examplesPerEdge) {
-        edge.examples.push({ from: fromFile, to: toFile });
-      }
-      accumulated.set(key, edge);
+    // Imports landing outside any layer: node_modules, uncovered packages.
+    // A file *inside* the covered roots is reported by `checkCoverage` for
+    // TypeScript and by `extract` for Python.
+    if (toLayer === undefined || toLayer === fromLayer) {
+      continue;
     }
+
+    // `>` cannot occur in a layer id, which is dot-separated kebab-case, so
+    // the pair round-trips. An earlier version used a NUL byte for this and
+    // left two raw NULs in the file, which made every text tool treat the
+    // source as binary.
+    const key = `${fromLayer}>${toLayer}`;
+    const edge = accumulated.get(key) ?? {
+      fileDependencies: 0,
+      examples: [],
+    };
+    edge.fileDependencies += 1;
+    if (edge.examples.length < examplesPerEdge) {
+      edge.examples.push({ from: fromFile, to: toFile });
+    }
+    accumulated.set(key, edge);
   }
 
   const packageOf = new Map(layers.map((layer) => [layer.id, layer.package]));

--- a/libs/@local/petrinaut-arch-docs/src/python-imports.test.ts
+++ b/libs/@local/petrinaut-arch-docs/src/python-imports.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  indexPythonModules,
+  parsePythonImports,
+  resolvePythonImport,
+} from "./python-imports";
+
+import type { ArchitecturePackage } from "./model";
+import type { PythonImport } from "./python-imports";
+
+/**
+ * The parser is conservative: an import it misses loses one edge, an import it
+ * invents puts a false claim in the docs. The non-matches are therefore pinned
+ * as firmly as the matches: comments, docstring bodies and string literals
+ * must contribute nothing.
+ */
+
+const pythonImport = (overrides: Partial<PythonImport>): PythonImport => ({
+  kind: "from",
+  module: "",
+  level: 0,
+  names: [],
+  ...overrides,
+});
+
+describe("parsePythonImports", () => {
+  it("parses absolute imports, including aliases and comma lists", () => {
+    expect(parsePythonImports("import a.b\nimport os, c.d as x\n")).toEqual([
+      pythonImport({ kind: "import", module: "a.b" }),
+      pythonImport({ kind: "import", module: "os" }),
+      pythonImport({ kind: "import", module: "c.d" }),
+    ]);
+  });
+
+  it("parses from-imports with their bound names", () => {
+    expect(parsePythonImports("from a.b import c, d as e\n")).toEqual([
+      pythonImport({ module: "a.b", names: ["c", "d"] }),
+    ]);
+  });
+
+  it("parses relative imports at each level", () => {
+    expect(
+      parsePythonImports(
+        "from .x import y\nfrom ..pkg import z\nfrom . import session\n",
+      ),
+    ).toEqual([
+      pythonImport({ module: "x", level: 1, names: ["y"] }),
+      pythonImport({ module: "pkg", level: 2, names: ["z"] }),
+      pythonImport({ module: "", level: 1, names: ["session"] }),
+    ]);
+  });
+
+  it("keeps the base module when names are a star or spill onto later lines", () => {
+    expect(
+      parsePythonImports("from a import *\nfrom b.c import (\n    d,\n)\n"),
+    ).toEqual([pythonImport({ module: "a" }), pythonImport({ module: "b.c" })]);
+  });
+
+  it("matches imports indented inside a function body", () => {
+    expect(parsePythonImports("def main():\n    import uvicorn\n")).toEqual([
+      pythonImport({ kind: "import", module: "uvicorn" }),
+    ]);
+  });
+
+  it("ignores comments and string literals", () => {
+    expect(
+      parsePythonImports('# import os\nname = "import os"\nx = 1  # from a\n'),
+    ).toEqual([]);
+  });
+
+  it("ignores import statements inside docstrings", () => {
+    const source = [
+      '"""Usage:',
+      "import petrinaut",
+      "from petrinaut import Session",
+      '"""',
+      "import real",
+      '"""import inline"""',
+      "'''",
+      "from also import skipped",
+      "'''",
+    ].join("\n");
+
+    expect(parsePythonImports(source)).toEqual([
+      pythonImport({ kind: "import", module: "real" }),
+    ]);
+  });
+});
+
+const bindingsPackage: ArchitecturePackage = {
+  name: "@test/bindings",
+  path: "libs/py",
+  description: "bindings",
+  language: "python",
+  sourceDirectory: "src",
+};
+
+const optimizerPackage: ArchitecturePackage = {
+  name: "@test/optimizer",
+  path: "apps/opt",
+  description: "optimizer",
+  language: "python",
+  sourceDirectory: "src",
+};
+
+const files = [
+  "libs/py/src/petrinaut/__init__.py",
+  "libs/py/src/petrinaut/session.py",
+  "libs/py/src/petrinaut/errors.py",
+  "apps/opt/src/__init__.py",
+  "apps/opt/src/utils.py",
+  "apps/opt/src/api.py",
+];
+
+const index = indexPythonModules([bindingsPackage, optimizerPackage], files);
+
+describe("indexPythonModules", () => {
+  it("roots modules at the source root when it is not itself a package", () => {
+    expect(index.moduleFiles.get("petrinaut")).toBe(
+      "libs/py/src/petrinaut/__init__.py",
+    );
+    expect(index.moduleFiles.get("petrinaut.session")).toBe(
+      "libs/py/src/petrinaut/session.py",
+    );
+  });
+
+  it("roots modules at the package root when the source root has an __init__", () => {
+    expect(index.moduleFiles.get("src")).toBe("apps/opt/src/__init__.py");
+    expect(index.moduleFiles.get("src.utils")).toBe("apps/opt/src/utils.py");
+  });
+
+  it("reports no diagnostics for the disjoint fixture packages", () => {
+    expect(index.diagnostics).toEqual([]);
+  });
+
+  it("errors when two packages claim one module name", () => {
+    const secondApp: ArchitecturePackage = {
+      ...optimizerPackage,
+      name: "@test/other",
+      path: "apps/other",
+    };
+    const clashing = indexPythonModules(
+      [optimizerPackage, secondApp],
+      [
+        "apps/opt/src/__init__.py",
+        "apps/opt/src/utils.py",
+        "apps/other/src/__init__.py",
+        "apps/other/src/utils.py",
+      ],
+    );
+
+    // `src` and `src.utils` both clash; the first package's mapping stands.
+    expect(clashing.moduleFiles.get("src.utils")).toBe("apps/opt/src/utils.py");
+    expect(clashing.diagnostics).toHaveLength(2);
+    expect(clashing.diagnostics[0]?.severity).toBe("error");
+    expect(clashing.diagnostics[0]?.message).toContain("already claims");
+  });
+});
+
+describe("resolvePythonImport", () => {
+  it("resolves an absolute from-import of another covered package", () => {
+    expect(
+      resolvePythonImport(
+        pythonImport({ module: "petrinaut", names: ["Session"] }),
+        "apps/opt/src/api.py",
+        index,
+      ),
+    ).toEqual(["libs/py/src/petrinaut/__init__.py"]);
+  });
+
+  it("resolves a bound name to its submodule when one exists", () => {
+    expect(
+      resolvePythonImport(
+        pythonImport({ module: "petrinaut", names: ["session"] }),
+        "apps/opt/src/api.py",
+        index,
+      ),
+    ).toEqual(["libs/py/src/petrinaut/session.py"]);
+  });
+
+  it("resolves a plain dotted import", () => {
+    expect(
+      resolvePythonImport(
+        pythonImport({ kind: "import", module: "src.utils" }),
+        "apps/opt/src/api.py",
+        index,
+      ),
+    ).toEqual(["apps/opt/src/utils.py"]);
+  });
+
+  it("resolves relative imports against the importer's package", () => {
+    expect(
+      resolvePythonImport(
+        pythonImport({ module: "errors", level: 1, names: ["X"] }),
+        "libs/py/src/petrinaut/session.py",
+        index,
+      ),
+    ).toEqual(["libs/py/src/petrinaut/errors.py"]);
+
+    expect(
+      resolvePythonImport(
+        pythonImport({ module: "", level: 1, names: ["session"] }),
+        "libs/py/src/petrinaut/__init__.py",
+        index,
+      ),
+    ).toEqual(["libs/py/src/petrinaut/session.py"]);
+  });
+
+  it("drops a relative import that climbs past the top-level package", () => {
+    expect(
+      resolvePythonImport(
+        pythonImport({ module: "other", level: 2, names: ["x"] }),
+        "libs/py/src/petrinaut/session.py",
+        index,
+      ),
+    ).toEqual([]);
+  });
+
+  it("drops imports of modules nothing covered provides", () => {
+    expect(
+      resolvePythonImport(
+        pythonImport({ kind: "import", module: "optuna" }),
+        "apps/opt/src/api.py",
+        index,
+      ),
+    ).toEqual([]);
+  });
+});

--- a/libs/@local/petrinaut-arch-docs/src/python-imports.ts
+++ b/libs/@local/petrinaut-arch-docs/src/python-imports.ts
@@ -1,0 +1,306 @@
+/**
+ * Python counterpart of the dependency-cruiser stage: reads `import` and
+ * `from ... import` statements in the covered Python packages and resolves them
+ * to files, so Python edges carry the same imports provenance as TypeScript
+ * ones. Imports that resolve to nothing covered (stdlib, third-party) are
+ * dropped, exactly as dependency-cruiser edges leaving the covered roots are.
+ *
+ * The parser is line-based and conservative: a missed import loses one edge,
+ * while an invented one would put a false claim in the docs. Docstring bodies
+ * are skipped so a code example in one cannot contribute an edge.
+ */
+
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { error, type Diagnostic } from "./diagnostics";
+import { sourceRootOf } from "./scope";
+
+import type { FileDependency } from "./graph";
+import type { ArchitecturePackage } from "./model";
+
+/** One parsed import statement. */
+export interface PythonImport {
+  kind: "import" | "from";
+  /** Dotted module path; empty for `from . import x`. */
+  module: string;
+  /** Leading dots on a relative `from` import; 0 when absolute. */
+  level: number;
+  /** Names a `from` import binds; empty for `import a.b` and `import *`. */
+  names: string[];
+}
+
+const importPattern = /^\s*import\s+([^#]+)/u;
+const fromPattern = /^\s*from\s+(\.*)([\w.]*)\s+import\s*([^#]*)/u;
+const identifierPattern = /^\s*([A-Za-z_]\w*)/u;
+const modulePattern = /^\s*([A-Za-z_][\w.]*)/u;
+
+const tripleQuotes = ['"""', "'''"] as const;
+
+/** The triple-quote delimiter `text` leaves open, or null when balanced. */
+const openDelimiterAfter = (text: string): string | null => {
+  // Naive comment strip: a `#` inside a string followed by a real opening on
+  // the same line would be mis-tracked, which no covered file comes close to.
+  // Likewise a single-quoted literal containing a triple quote (`x = '"""'`)
+  // reads as an unclosed docstring and drops imports until the next `"""` —
+  // erring toward losing an edge, never inventing one.
+  let rest = text.split("#")[0] ?? "";
+
+  for (;;) {
+    const opening = tripleQuotes
+      .map((delimiter) => ({ delimiter, index: rest.indexOf(delimiter) }))
+      .filter(({ index }) => index !== -1)
+      .sort((left, right) => left.index - right.index)[0];
+
+    if (opening === undefined) {
+      return null;
+    }
+
+    const close = rest.indexOf(opening.delimiter, opening.index + 3);
+    if (close === -1) {
+      return opening.delimiter;
+    }
+    rest = rest.slice(close + 3);
+  }
+};
+
+const parseNames = (text: string): string[] =>
+  text
+    .replace(/[()\\]/gu, " ")
+    .split(",")
+    .flatMap((part) => {
+      const name = identifierPattern.exec(part)?.[1];
+      return name === undefined ? [] : [name];
+    });
+
+/**
+ * Extracts the import statements of one Python source file. Line-based:
+ * a statement's module part always sits on its first line, and names spilling
+ * onto continuation lines only cost the submodule-name refinement.
+ */
+export const parsePythonImports = (source: string): PythonImport[] => {
+  const imports: PythonImport[] = [];
+  let openDelimiter: string | null = null;
+
+  for (const line of source.split("\n")) {
+    if (openDelimiter !== null) {
+      const close = line.indexOf(openDelimiter);
+      if (close === -1) {
+        continue;
+      }
+      openDelimiter = openDelimiterAfter(line.slice(close + 3));
+      continue;
+    }
+
+    const fromMatch = fromPattern.exec(line);
+    if (fromMatch !== null) {
+      imports.push({
+        kind: "from",
+        module: fromMatch[2] ?? "",
+        level: (fromMatch[1] ?? "").length,
+        names: parseNames(fromMatch[3] ?? ""),
+      });
+      continue;
+    }
+
+    const importMatch = importPattern.exec(line);
+    if (importMatch !== null) {
+      for (const part of (importMatch[1] ?? "").split(",")) {
+        const module = modulePattern.exec(part)?.[1];
+        if (module !== undefined) {
+          imports.push({ kind: "import", module, level: 0, names: [] });
+        }
+      }
+      continue;
+    }
+
+    openDelimiter = openDelimiterAfter(line);
+  }
+
+  return imports;
+};
+
+/** Both directions of the module↔file mapping for the covered packages. */
+export interface PythonModuleIndex {
+  /** Dotted module path → repo-relative file. */
+  moduleFiles: Map<string, string>;
+  /** Repo-relative file → dotted module path. */
+  fileModules: Map<string, string>;
+  /** Errors found while indexing, e.g. two packages claiming one name. */
+  diagnostics: Diagnostic[];
+}
+
+/**
+ * Maps every covered Python file to its importable dotted name. The import
+ * root is the package root when the source directory is itself a package
+ * (petrinaut-opt imports `src.utils`), the source root otherwise
+ * (petrinaut-python imports `petrinaut.session`).
+ *
+ * The index is one namespace across every covered package. Two packages
+ * producing the same dotted name (two apps whose `src/` is itself a package
+ * would both claim `src.utils`) is an error rather than last-write-wins: the
+ * winner would depend on config order, and an import in one app could resolve
+ * to a file in the other, drawing a cross-package edge that does not exist.
+ */
+export const indexPythonModules = (
+  packages: ArchitecturePackage[],
+  /** Repo-relative posix paths of the covered `.py` files. */
+  files: string[],
+): PythonModuleIndex => {
+  const moduleFiles = new Map<string, string>();
+  const fileModules = new Map<string, string>();
+  const diagnostics: Diagnostic[] = [];
+
+  for (const pkg of packages) {
+    const root = sourceRootOf(pkg);
+    const packageFiles = files.filter((file) => file.startsWith(`${root}/`));
+    const rootIsPackage = packageFiles.includes(`${root}/__init__.py`);
+    const importRoot = rootIsPackage ? pkg.path : root;
+
+    for (const file of packageFiles) {
+      const segments = file
+        .slice(importRoot.length + 1)
+        .replace(/\.py$/u, "")
+        .split("/");
+
+      if (segments[segments.length - 1] === "__init__") {
+        segments.pop();
+      }
+      if (segments.length === 0) {
+        continue;
+      }
+
+      const moduleName = segments.join(".");
+      const rival = moduleFiles.get(moduleName);
+      if (rival !== undefined) {
+        diagnostics.push(
+          error(
+            file,
+            `resolves to the module name \`${moduleName}\`, which ${rival} already claims; imports of it would resolve to whichever package comes later in the config`,
+          ),
+        );
+        continue;
+      }
+      moduleFiles.set(moduleName, file);
+      fileModules.set(file, moduleName);
+    }
+  }
+
+  return { moduleFiles, fileModules, diagnostics };
+};
+
+/**
+ * Resolves one import to covered files. A `from` import may bind submodules
+ * (`from . import session, errors` is two edges), so each bound name is tried
+ * as a module first, with the base module as the fallback.
+ */
+export const resolvePythonImport = (
+  imported: PythonImport,
+  /** Repo-relative file carrying the import. */
+  importer: string,
+  index: PythonModuleIndex,
+): string[] => {
+  let baseSegments: string[];
+
+  if (imported.level === 0) {
+    baseSegments = imported.module.split(".");
+  } else {
+    const importerModule = index.fileModules.get(importer);
+    if (importerModule === undefined) {
+      return [];
+    }
+
+    // The package containing the importer: an `__init__.py`'s module name is
+    // already its package, any other file drops its final segment.
+    const packageSegments = importerModule.split(".");
+    if (!importer.endsWith("/__init__.py")) {
+      packageSegments.pop();
+    }
+
+    // Each dot beyond the first climbs one package; past the top is invalid.
+    if (imported.level > packageSegments.length) {
+      return [];
+    }
+
+    baseSegments = [
+      ...packageSegments.slice(
+        0,
+        packageSegments.length - (imported.level - 1),
+      ),
+      ...(imported.module === "" ? [] : imported.module.split(".")),
+    ];
+  }
+
+  const base = baseSegments.join(".");
+  if (base === "") {
+    return [];
+  }
+
+  if (imported.kind === "import") {
+    const file = index.moduleFiles.get(base);
+    return file === undefined ? [] : [file];
+  }
+
+  const targets: string[] = [];
+  let dependsOnBase = imported.names.length === 0;
+
+  for (const name of imported.names) {
+    const submodule = index.moduleFiles.get(`${base}.${name}`);
+    if (submodule === undefined) {
+      dependsOnBase = true;
+    } else {
+      targets.push(submodule);
+    }
+  }
+
+  if (dependsOnBase) {
+    const baseFile = index.moduleFiles.get(base);
+    if (baseFile !== undefined) {
+      targets.push(baseFile);
+    }
+  }
+
+  return targets;
+};
+
+/**
+ * Collects file-level dependency records for the covered Python packages.
+ * The files come from `fileLayers`, so this stage reads exactly what the
+ * extractor claimed: an unclaimed Python file is already an error there.
+ */
+export const collectPythonImports = async (options: {
+  repoRoot: string;
+  /** Python packages only; `buildGraph` splits by language. */
+  packages: ArchitecturePackage[];
+  /** Repo-relative source file → layer id, from `extract`. */
+  fileLayers: Map<string, string>;
+}): Promise<{ dependencies: FileDependency[]; diagnostics: Diagnostic[] }> => {
+  const files = [...options.fileLayers.keys()].filter((file) =>
+    file.endsWith(".py"),
+  );
+  const index = indexPythonModules(options.packages, files);
+  const dependencies: FileDependency[] = [];
+  const diagnostics = index.diagnostics;
+
+  for (const [file] of index.fileModules) {
+    const source = await readFile(join(options.repoRoot, file), "utf8");
+    const targets = new Set<string>();
+
+    for (const imported of parsePythonImports(source)) {
+      for (const target of resolvePythonImport(imported, file, index)) {
+        if (target !== file) {
+          targets.add(target);
+        }
+      }
+    }
+
+    // One record per file pair, matching dependency-cruiser's counting.
+    for (const target of [...targets].sort((left, right) =>
+      left.localeCompare(right),
+    )) {
+      dependencies.push({ from: file, to: target });
+    }
+  }
+
+  return { dependencies, diagnostics };
+};

--- a/libs/@local/petrinaut-arch-docs/src/scope.ts
+++ b/libs/@local/petrinaut-arch-docs/src/scope.ts
@@ -18,8 +18,7 @@ import type { ArchitecturePackage } from "./model";
  *
  * `.js` variants are absent on purpose: these packages are TypeScript, and a
  * committed `.js` file under `src` would be build output that no layer should
- * claim. The graph builder reads this list directly — it only ever receives
- * TypeScript packages.
+ * claim. The TypeScript provider's coverage check reads this list directly.
  */
 export const sourceExtensions = [".ts", ".tsx", ".mts", ".cts"] as const;
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Python packages had layers but no edges, because the import graph came from dependency-cruiser, which reads TypeScript only. The optimizer's real dependency on the Python bindings was invisible, and its diagram suggested dead code. The bundle now derives Python import edges the same way as TypeScript ones:

```json
{ "from": "optimizer", "to": "python-bindings", "provenance": "imports", "fileDependencies": 2, "crossesPackage": true }
```

FE-1447 (#9264) sits below in this stack and FE-1456 (#9266) above.

## 🔗 Related links

- [FE-1415](https://linear.app/hash/issue/FE-1415/arch-docs-generate-import-edges-for-python-packages) *(internal)*: this PR
- [FE-1443](https://linear.app/hash/issue/FE-1443/arch-docs-declared-protocol-edges-for-import-invisible-boundaries) *(internal)*: complementary. No Python import crosses the subprocess boundary, so the declared `python-bindings → cli` edge stays declared, and the duplicate check confirms the two never overlap.

## 🔍 What does this change?

`libs/@local/petrinaut-arch-docs`:

- **`graph.ts`**: `buildGraph` splits covered packages by language. TypeScript goes through dependency-cruiser as before, Python through a new collector, and both emit the same file-level records, so aggregation, intra-layer dropping, example pairs, `crossesPackage`, rules, and the declared-edge duplicate check apply to Python unchanged.
- **`python-imports.ts`** (new, no dependencies): a line-based parser for `import a.b` and `from a.b import c`, covering aliases, comma lists, parenthesised continuations and relative imports; a module index over the covered packages; and a resolver. Imports resolving to nothing covered drop silently, as the TypeScript ones do. The parser skips strings and comments conservatively, because a missed import loses one edge while an invented one puts a false claim in the docs. Two packages claiming one dotted module name is an error, since last-write-wins would let an import in one app resolve into another's file and invent a cross-package edge.
- **Captions**: the relations note and `content/index.mdx` no longer say Python contributes no edges.

The one new edge is the optimizer's import of the bindings. Intra-package Python imports aggregate away as intra-layer, as they should.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] modifies a workspace but **not** a publishable library

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] require changes to docs which **are made** as part of this PR

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- `python-imports.test.ts` (new): parsing (absolute, from-imports, aliases, relative, continuations, comment and string non-matches), module indexing, the module-name collision diagnostic, and resolution.
- `graph.test.ts`: a full-chain assertion that a Python cross-package import aggregates into an edge.
- `lint:arch-docs` exercises the real repo with zero diagnostics.

## ❓ How to test this?

1. `yarn workspace @local/petrinaut-arch-docs lint:arch-docs` passes.
2. `turbo run dev --filter @apps/petrinaut-docs`: the `optimizer` page shows `python-bindings` under "Depends on" with an import count, and the overview diagram draws the solid edge beside the dashed declared one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


