### PR TITLE
FE-1456: Add a usage manual for the Python bindings

### DIFF
--- a/libs/@local/petrinaut-arch-docs/content/cli/usage-manual.mdx
+++ b/libs/@local/petrinaut-arch-docs/content/cli/usage-manual.mdx
@@ -310,53 +310,22 @@ experiment-backend interface.
 
 ## Driving the CLI from Python
 
-The CLI speaks one JSON object per line, so a Python driver needs only
-`subprocess` and `json`. The wrapper below starts one CLI process for a
-manifest and turns each response line into a return value or an exception:
+The [python-bindings](layer:python-bindings) package wraps this protocol: a
+session owns one CLI process, each request is a method, and an error frame
+raises. Its [usage manual](doc:python-bindings/usage-manual) covers the session
+lifecycle, the timeouts, and the exception types.
 
 ```python
-import json
-import subprocess
+from petrinaut import OptimizationSession
 
-
-class PetrinautOptimization:
-    def __init__(self, manifest_path: str):
-        self.process = subprocess.Popen(
-            [
-                "petrinaut",
-                "serve",
-                "--optimization",
-                manifest_path,
-                "--stdio",
-            ],
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            text=True,
-            bufsize=1,
-        )
-        self.request_id = 0
-
-    def request(self, method: str, params: dict | None = None) -> dict:
-        self.request_id += 1
-        request = {"id": self.request_id, "method": method}
-        if params is not None:
-            request["params"] = params
-
-        assert self.process.stdin and self.process.stdout
-        self.process.stdin.write(json.dumps(request) + "\n")
-        self.process.stdin.flush()
-        response = json.loads(self.process.stdout.readline())
-        if "error" in response:
-            raise RuntimeError(response["error"]["message"])
-        return response["result"]
-
-    def close(self) -> None:
-        self.process.terminate()
-        self.process.wait()
+with OptimizationSession(manifest_path="optimization.json") as session:
+    description = session.describe()
+    print([parameter.identifier for parameter in description.parameters])
+    # Send every — and only — described parameter.
+    value = session.objective({"production_rate": 112.5, "enabled": True})
 ```
 
-An Optuna study calls `optimization.describe` once and maps each described
-parameter to the `suggest_*` call from the table above; its objective function
-sends the suggested values to `optimization.evaluate` and returns the
-`objective` from the response. The manifest and the CLI own the Petrinaut
-types, the scenario compilation, and the fixed values.
+An Optuna study calls `describe()` once and maps each described
+parameter to the `suggest_*` call from the table above. Its objective function
+passes the suggested values to `objective()`. The manifest and the CLI own the
+Petrinaut types, the scenario compilation, and the fixed values.

--- a/libs/@local/petrinaut-arch-docs/content/index.mdx
+++ b/libs/@local/petrinaut-arch-docs/content/index.mdx
@@ -76,7 +76,7 @@ Python optimizer service drive; its [usage manual](doc:cli/usage-manual) covers
 the transports, the protocol, and optimization studies.
 
 `apps/petrinaut-opt` (the Python Optuna service) and `@local/petrinaut-python`
-(its CLI bindings) are covered as layers too, though Python files contribute
-no import edges yet. One package is not covered at all:
+(its CLI bindings) are covered too, with their layers and import edges derived
+the same way as the TypeScript ones. One package is not covered at all:
 `@apps/petrinaut-website`. Adding a package is a matter of declaring layers in
 its source; see [Declaring layers](doc:maintaining/declaring-layers).

--- a/libs/@local/petrinaut-arch-docs/content/python-bindings/usage-manual.mdx
+++ b/libs/@local/petrinaut-arch-docs/content/python-bindings/usage-manual.mdx
@@ -147,10 +147,10 @@ CLI serves both from one process, so every `PetrinautSession` method works on
 an `OptimizationSession` too; only an `OptimizationSession` can answer the
 `optimization.*` methods. Pick the class by naming what the process serves:
 
-| You have        | Construct                                   | CLI invocation                        |
-| --------------- | ------------------------------------------- | ------------------------------------- |
-| a model file    | `PetrinautSession.from_model_file(path)`    | `serve --model <path> --stdio`        |
-| a model dict    | `PetrinautSession.from_model(model)`        | `serve --model-stdin --stdio`         |
+| You have        | Construct                                      | CLI invocation                        |
+| --------------- | ---------------------------------------------- | ------------------------------------- |
+| a model file    | `PetrinautSession.from_model_file(path)`       | `serve --model <path> --stdio`        |
+| a model dict    | `PetrinautSession.from_model(model)`           | `serve --model-stdin --stdio`         |
 | a manifest file | `OptimizationSession.from_manifest_file(path)` | `serve --optimization <path> --stdio` |
 | a manifest dict | `OptimizationSession.from_manifest(manifest)`  | `serve --optimization-stdin --stdio`  |
 

--- a/libs/@local/petrinaut-arch-docs/content/python-bindings/usage-manual.mdx
+++ b/libs/@local/petrinaut-arch-docs/content/python-bindings/usage-manual.mdx
@@ -1,0 +1,299 @@
+---
+title: Usage manual
+description: Installing the package, opening a session, run requests, optimization studies, and the exceptions each failure raises.
+sidebar_order: 10
+attachTo: python-bindings
+---
+
+`@local/petrinaut-python` drives the Petrinaut CLI from Python. A
+`PetrinautSession` owns **one long-lived `petrinaut serve` child process** for
+one model, writes requests as JSON lines on its stdin, and reads one response
+line per request from its stdout.
+
+The package's one runtime dependency is pydantic, which validates
+optimization responses against the CLI's published protocol schema; it
+requires Python `>=3.10`. It is **POSIX-only**:
+`os.killpg` for process-group signalling and `select.select` for descriptor
+polling have no Windows fallback.
+
+The child is spawned with a scrubbed environment, so a model expression never
+reads the calling process's credentials: `PATH` is fixed to
+`/usr/local/bin:/usr/bin:/bin`, `LANG` and `LC_ALL` to `C.UTF-8`, `NO_COLOR`
+to `1`, `TZ` to `UTC`. The only variable that passes through is
+`PETRINAUT_CHILD_NODE_OPTIONS`, forwarded as the child's `NODE_OPTIONS`. The
+process also gets its own process group, `umask` `0o077`, and `close_fds`.
+
+## Depending on the package
+
+The package is internal to this monorepo and is consumed as a uv path
+dependency. `apps/petrinaut-opt` is the reference consumer: it names
+`petrinaut-python` in `[project].dependencies` and points uv at the path.
+
+```toml
+[tool.uv.sources]
+petrinaut-python = { path = "../../libs/@local/petrinaut-python", editable = true }
+```
+
+Nothing runs without the CLI bundle at
+`libs/@hashintel/petrinaut-cli/dist/cli.js`. The package declares
+`@hashintel/petrinaut-cli` as a workspace dependency, and the root
+`test:unit` task depends on `^build`, so running the suite through Turborepo
+builds the bundle first:
+
+```bash
+turbo run test:unit --filter @local/petrinaut-python
+```
+
+Plain `uv run pytest` skips the end-to-end tests when the bundle is missing.
+To build it on its own:
+
+```bash
+turbo run build --filter @hashintel/petrinaut-cli
+```
+
+## Opening a session
+
+Two factories name the model source, matching the CLI's two model flags:
+
+| Constructor                              | CLI invocation                 |
+| ---------------------------------------- | ------------------------------ |
+| `PetrinautSession.from_model_file(path)` | `serve --model <path> --stdio` |
+| `PetrinautSession.from_model(model)`     | `serve --model-stdin --stdio`  |
+
+`from_model` serializes the model object to the CLI's first stdin line, which
+suits read-only containers and callers already holding the snapshot. The
+object's shape is the same one `--model-stdin` documents in the
+[CLI usage manual](doc:cli/usage-manual).
+
+Both are context managers: `__enter__` calls `start()` and `__exit__` calls
+`close()`. `start()` writes the bootstrap line if there is one, then waits for
+a stderr line beginning `Petrinaut stdio ready`. Any other line closes the
+process and raises `PetrinautClientError`, quoting the CLI's own message or
+its exit code.
+
+```python
+from petrinaut import PetrinautSession
+
+with PetrinautSession.from_model_file("./sir-model.json") as session:
+    metadata = session.metadata()
+```
+
+Calling `start()` and `close()` by hand works too; `start()` returns
+immediately when the process is already running, and `close()` is safe to call
+repeatedly.
+
+Every keyword argument other than the source is forwarded to the constructor:
+
+| Option                      | Default            | Effect                                               |
+| --------------------------- | ------------------ | ---------------------------------------------------- |
+| `command`                   | `("petrinaut",)`   | The executable, resolved on the child's fixed `PATH` |
+| `bootstrap_timeout_seconds` | `25`               | Spawn to readiness line                              |
+| `request_timeout_seconds`   | `240`              | One protocol response                                |
+| `popen_factory`             | `subprocess.Popen` | Substitutes the spawned process in tests             |
+
+Pass an absolute `command` when the CLI is not installed on that `PATH`, which
+is the normal case in development:
+
+```python
+import shutil
+
+session = PetrinautSession.from_model_file(
+    "./sir-model.json",
+    command=(shutil.which("node"), "libs/@hashintel/petrinaut-cli/dist/cli.js"),
+)
+```
+
+An empty `command`, or one with an empty part, raises `ValueError`, as does a
+timeout of zero or less.
+
+## Run requests
+
+Three methods cover the model-source protocol, and `request` reaches any
+method by name:
+
+| Method                            | Returns                                              |
+| --------------------------------- | ---------------------------------------------------- |
+| `session.healthz()`               | `{"ok": True}`                                       |
+| `session.metadata()`              | The compiled model's parameters, places, and metrics |
+| `session.run(params)`             | One simulation's summary result                      |
+| `session.request(method, params)` | That method's raw `result`                           |
+
+`params` for `run` is the CLI's run config verbatim: `parameters`,
+`initialState` or `scenario`, `metrics`, `maxSteps` or `maxTime`, `dt`, and
+`seed`. Every key, alias-resolution rule, bound, and response field is
+specified in the [CLI usage manual](doc:cli/usage-manual); the Python layer
+passes the mapping through and adds only the transport guarantees:
+
+- Request ids are assigned and checked. The counter starts at `1` and
+  increments per request; a response carrying a different id raises
+  `PetrinautProtocolError`.
+- `healthz`, `metadata`, and `run` require a JSON object result. A non-object
+  closes the session and raises `PetrinautProtocolError`. `request` returns
+  whatever `result` holds, without that check.
+- An error frame becomes `PetrinautRunError` carrying the frame's
+  `error.message`.
+
+Request ids and the stdout buffer are unsynchronized, and the CLI answers
+serially, so one session serves one caller at a time. For parallel work, give
+each worker its own session. The one cross-thread guarantee is `close()`: it
+may be called from another thread, which is how a supervisor cancels a session
+mid-request.
+
+## Optimization studies
+
+`OptimizationSession` subclasses `PetrinautSession` and boots the CLI from an
+optimization manifest instead of a model. A manifest embeds a model, and the
+CLI serves both from one process, so every `PetrinautSession` method works on
+an `OptimizationSession` too; only an `OptimizationSession` can answer the
+`optimization.*` methods. Pick the class by naming what the process serves:
+
+| You have        | Construct                                   | CLI invocation                        |
+| --------------- | ------------------------------------------- | ------------------------------------- |
+| a model file    | `PetrinautSession.from_model_file(path)`    | `serve --model <path> --stdio`        |
+| a model dict    | `PetrinautSession.from_model(model)`        | `serve --model-stdin --stdio`         |
+| a manifest file | `OptimizationSession.from_manifest_file(path)` | `serve --optimization <path> --stdio` |
+| a manifest dict | `OptimizationSession.from_manifest(manifest)`  | `serve --optimization-stdin --stdio`  |
+
+`OptimizationSession(manifest)` and `OptimizationSession(manifest_path=path)`
+construct the same sessions as the two manifest factories; exactly one source
+is required, or the constructor raises `ValueError`.
+
+The manifest is opaque to Python. The CLI validates it, injects fixed values,
+compiles the scenario, simulates, and evaluates the metric.
+
+| Method                                | Returns                                                 |
+| ------------------------------------- | ------------------------------------------------------- |
+| `session.describe()`                  | The direction, study settings, and non-fixed parameters |
+| `session.evaluate(parameter_values)`  | The full trial result, `replicates` included            |
+| `session.objective(parameter_values)` | The trial's objective as a finite `float`               |
+
+`describe_optimization` remains as an alias for `describe`. `describe` and
+`evaluate` return pydantic models
+(`OptimizationDescribeResult`, `OptimizationEvaluateResult`) generated from the
+CLI's published protocol schema; a response outside that schema raises
+`PetrinautProtocolError` and closes the session.
+
+`describe` also configures the deadline. It reads the manifest's
+`execution.seedsPerTrial`, reported back as `study.seedsPerTrial` in the
+response, defaulting to `1` when the study omits it. The generated model
+bounds it to the CLI's `1`–`100` range, so an out-of-range value fails
+validation and closes the session with `PetrinautProtocolError`. One
+`evaluate` may run that many seeded simulations sequentially, so the
+per-response deadline becomes `request_timeout_seconds × seedsPerTrial`: a
+manifest setting `execution.seedsPerTrial` to `2` gives each response 480
+seconds.
+
+`evaluate` describes once itself when the session has not been described yet,
+because a seeded trial needs the scaled deadline before its first evaluation.
+`objective` calls `evaluate` and reads its `.objective`, raising
+`PetrinautRunError` when the value is not finite, and leaving the session
+usable. A boolean or non-numeric objective fails schema validation first,
+which raises `PetrinautProtocolError` and closes the session.
+With more than one seed the objective is the mean and `evaluate` reports each
+seed's value under `replicates`.
+
+```python
+from petrinaut import OptimizationSession
+
+# `OptimizationSession(manifest_path=...)` reads the manifest from disk instead.
+with OptimizationSession(manifest) as session:
+    description = session.describe()
+    for parameter in description.parameters:
+        print(parameter.identifier, parameter.type)
+
+    value = session.objective({"production_rate": 112.5, "enabled": True})
+```
+
+The [CLI usage manual](doc:cli/usage-manual) carries the manifest contract,
+the parameter-type table with its Optuna suggestion calls, the work budgets,
+and the common-random-numbers seed derivation.
+
+## Errors
+
+Three exception types, and the hierarchy decides whether the session survives:
+
+| Exception                | Base                   | Raised when                                                | Session |
+| ------------------------ | ---------------------- | ---------------------------------------------------------- | ------- |
+| `PetrinautRunError`      | `RuntimeError`         | The CLI answered one request with an error frame           | Usable  |
+| `PetrinautClientError`   | `RuntimeError`         | The process failed to start, bootstrap, or communicate     | Closed  |
+| `PetrinautProtocolError` | `PetrinautClientError` | The response was not valid framing, JSON, UTF-8, or object | Closed  |
+
+`PetrinautRunError` is a sibling of `PetrinautClientError`, not a subclass, so
+catching `PetrinautClientError` catches transport and protocol failures
+without swallowing a rejected request. `objective` also raises
+`PetrinautRunError` for a non-finite objective, leaving the session usable.
+
+`PetrinautClientError` covers the bootstrap process paths as well: a failed
+spawn, unavailable pipes, and a readiness line that never arrives. Caller
+input that fails before anything is written raises the plain built-ins
+instead, leaving the session exactly as it was: request `params`, a model, or
+a manifest that will not serialize to JSON raise `TypeError`, and a bootstrap
+payload over the 8 MiB line cap raises `ValueError`.
+
+## Timeouts, limits, and shutdown
+
+| Bound                             | Value |
+| --------------------------------- | ----- |
+| Bootstrap, spawn to readiness     | 25 s  |
+| One protocol response             | 240 s |
+| Process shutdown, each wait stage | 5 s   |
+| Bootstrap line                    | 8 MiB |
+| Protocol line                     | 8 MiB |
+
+The first two are constructor options; for an optimization session the
+response deadline is scaled as described above. A read that exceeds its
+deadline raises `PetrinautClientError` and closes the session; a line over
+8 MiB raises `PetrinautProtocolError`.
+
+The CLI's stderr is drained on a daemon thread for the life of the session, so
+its diagnostics cannot fill the pipe and block it.
+
+A dead child is reported rather than waited on. `_exchange` checks before
+writing, so a request against a session that was never started or has been
+closed raises `PetrinautClientError` reading `the Petrinaut CLI is not
+running`, and one against an exited process reports its exit code. A process
+that exits mid-request, giving no response line, raises the same type.
+
+`close()` closes stdin first. The graceful default then waits up to 5 seconds
+for the CLI to exit on EOF, which only a CLI that is idle between requests
+will observe. After that, or immediately under `close(graceful=False)`, it
+sends `SIGTERM` to the child's process group, waits 5 seconds, escalates to
+`SIGKILL`, and waits 5 seconds again. Cancellation, timeouts, and every
+failure path inside the session use `graceful=False`.
+
+## End to end
+
+Against a model saved from the editor, from the repository root, with the bundle
+built:
+
+```python
+import shutil
+
+from petrinaut import PetrinautSession
+
+CLI = "libs/@hashintel/petrinaut-cli/dist/cli.js"
+MODEL = "./sir-model.json"
+
+with PetrinautSession.from_model_file(
+    MODEL, command=(shutil.which("node"), CLI)
+) as session:
+    assert session.healthz() == {"ok": True}
+
+    metadata = session.metadata()
+    assert "Infected Fraction" in {metric["name"] for metric in metadata["metrics"]}
+
+    result = session.run(
+        {
+            "parameters": {"infection_rate": 1.5, "recovery_rate": 0.8},
+            "initialState": {"Susceptible": 990, "Infected": 10, "Recovered": 0},
+            "metrics": ["Infected Fraction"],
+            "maxSteps": 50,
+            "dt": 0.1,
+            "seed": 4242,
+        }
+    )
+    print(result["status"], result["metrics"]["Infected Fraction"])
+```
+
+Passing the same `seed` again returns the same metrics, which is what
+`tests/test_e2e_cli.py` asserts.

--- a/libs/@local/petrinaut-arch-docs/src/build.ts
+++ b/libs/@local/petrinaut-arch-docs/src/build.ts
@@ -98,7 +98,7 @@ export const buildBundle = async (options: {
 
   const graph = await buildGraph({
     repoRoot,
-    packages: packages.filter((pkg) => pkg.language === "typescript"),
+    packages,
     tsconfigPath: join(
       repoRoot,
       "libs/@local/petrinaut-arch-docs/dependency-cruiser.tsconfig.json",

--- a/libs/@local/petrinaut-arch-docs/src/emit/components/layer-relations.tsx
+++ b/libs/@local/petrinaut-arch-docs/src/emit/components/layer-relations.tsx
@@ -85,7 +85,7 @@ export const LayerRelations = ({
     <Direction title="Depended on by" entries={dependedOnBy} />
     <Direction title="Depends on" entries={dependsOn} />
     <p className="arch-rel-note">
-      Counts are file-level imports, aggregated from TypeScript packages only.
+      Counts are file-level imports, aggregated across every covered package.
       Dashed labels are <code>@talksTo</code> declarations: the protocol text is
       the annotation's claim, and only the endpoints are checked.
     </p>

--- a/libs/@local/petrinaut-arch-docs/src/graph.test.ts
+++ b/libs/@local/petrinaut-arch-docs/src/graph.test.ts
@@ -1,9 +1,13 @@
-import { describe, expect, it } from "vitest";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
-import { resolveDeclaredEdges } from "./graph";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { buildGraph, resolveDeclaredEdges } from "./graph";
 
 import type { TalksToDeclaration } from "./extract";
-import type { Edge, Layer } from "./model";
+import type { ArchitecturePackage, Edge, Layer } from "./model";
 
 /**
  * A declared edge is the one kind an annotation draws rather than the import
@@ -146,5 +150,94 @@ describe("resolveDeclaredEdges", () => {
 
     expect(edges).toEqual([]);
     expect(diagnostics).toEqual([]);
+  });
+});
+
+/**
+ * Python records go through the same aggregation as TypeScript ones, so one
+ * end-to-end case pins the whole chain: parse, resolve across packages, map to
+ * layers, drop the intra-layer imports, and mark the package crossing.
+ */
+describe("buildGraph with Python packages", () => {
+  let root: string;
+
+  const pythonPackage = (name: string, path: string): ArchitecturePackage => ({
+    name,
+    path,
+    description: `${name} test package`,
+    language: "python",
+    sourceDirectory: "src",
+  });
+
+  const write = async (
+    relativePath: string,
+    contents: string,
+  ): Promise<void> => {
+    const absolute = join(root, relativePath);
+    await mkdir(join(absolute, ".."), { recursive: true });
+    await writeFile(absolute, contents, "utf8");
+  };
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "arch-docs-graph-"));
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("aggregates a cross-package Python import into an imports edge", async () => {
+    await write(
+      "libs/py/src/petrinaut/__init__.py",
+      "from .session import Session\n",
+    );
+    await write("libs/py/src/petrinaut/session.py", "import json\n");
+    await write("apps/opt/src/__init__.py", "");
+    await write(
+      "apps/opt/src/api.py",
+      "from petrinaut import Session\nfrom src.utils import helper\n",
+    );
+    await write("apps/opt/src/utils.py", "def helper(): ...\n");
+
+    const files: [string, string][] = [
+      ["libs/py/src/petrinaut/__init__.py", "bindings"],
+      ["libs/py/src/petrinaut/session.py", "bindings"],
+      ["apps/opt/src/__init__.py", "optimizer"],
+      ["apps/opt/src/api.py", "optimizer"],
+      ["apps/opt/src/utils.py", "optimizer"],
+    ];
+
+    const { edges, diagnostics } = await buildGraph({
+      repoRoot: root,
+      packages: [
+        pythonPackage("@test/py", "libs/py"),
+        pythonPackage("@test/opt", "apps/opt"),
+      ],
+      tsconfigPath: "unused-without-typescript-packages.json",
+      ignoredDirectories: [],
+      ignoredFilePattern: /\.test\.py$/u,
+      fileLayers: new Map(files),
+      layers: [layer("bindings", "@test/py"), layer("optimizer", "@test/opt")],
+      talksTo: [],
+    });
+
+    expect(diagnostics).toEqual([]);
+    // The intra-layer imports (`.session`, `src.utils`) and the stdlib import
+    // are all dropped; the cross-package one is the only edge left.
+    expect(edges).toEqual([
+      {
+        from: "optimizer",
+        to: "bindings",
+        provenance: "imports",
+        fileDependencies: 1,
+        examples: [
+          {
+            from: "apps/opt/src/api.py",
+            to: "libs/py/src/petrinaut/__init__.py",
+          },
+        ],
+        crossesPackage: true,
+      },
+    ]);
   });
 });

--- a/libs/@local/petrinaut-arch-docs/src/graph.ts
+++ b/libs/@local/petrinaut-arch-docs/src/graph.ts
@@ -1,7 +1,8 @@
 /**
- * Turns the real TypeScript import graph into layer-level edges.
+ * Turns the real import graphs into layer-level edges.
  *
- * dependency-cruiser supplies the file-level truth; the layer assignment comes
+ * One provider per language supplies the file-level truth: dependency-cruiser
+ * for TypeScript, `python-imports.ts` for Python. The layer assignment comes
  * from `extract.ts`. Aggregating one against the other is what makes the
  * diagrams trustworthy: an import edge appears because imports exist, never
  * because someone drew it. The one annotation-drawn kind, a `@talksTo` edge for
@@ -26,6 +27,7 @@ import extractTSConfig from "dependency-cruiser/config-utl/extract-ts-config";
 
 import { error, warning, type Diagnostic } from "./diagnostics";
 import { toPosix } from "./paths";
+import { collectPythonImports } from "./python-imports";
 import {
   exclusionPattern,
   sourceExtensions,
@@ -38,6 +40,14 @@ import type { ArchitecturePackage, DeclaredEdge, Edge, Layer } from "./model";
 
 /** How many representative file pairs to record per edge. */
 const examplesPerEdge = 3;
+
+/** One file-level import, the record every language provider emits. */
+export interface FileDependency {
+  /** Repo-relative posix path of the importing file. */
+  from: string;
+  /** Repo-relative posix path of the imported file. */
+  to: string;
+}
 
 interface Alias {
   alias: string;
@@ -132,7 +142,7 @@ const deriveAliases = (
 
 export interface GraphOptions {
   repoRoot: string;
-  /** TypeScript packages only; callers filter before reaching here. */
+  /** Every covered package; `buildGraph` splits them by language. */
   packages: ArchitecturePackage[];
   tsconfigPath: string;
   ignoredDirectories: string[];
@@ -326,22 +336,60 @@ export const resolveDeclaredEdges = (options: {
   return { edges, diagnostics };
 };
 
-export const buildGraph = async (
+/**
+ * Runs dependency-cruiser over the TypeScript packages and flattens the result
+ * to file-level records, so aggregation reads one shape from every language.
+ */
+const collectTypeScriptImports = async (
   options: GraphOptions,
-): Promise<GraphResult> => {
-  const { repoRoot, fileLayers, layers } = options;
+): Promise<{ dependencies: FileDependency[]; diagnostics: Diagnostic[] }> => {
+  // Nothing to cruise; also keeps Python-only tests off dependency-cruiser.
+  if (options.packages.length === 0) {
+    return { dependencies: [], diagnostics: [] };
+  }
 
   const aliases: Alias[] = [];
   const diagnostics: Diagnostic[] = [];
 
   for (const pkg of options.packages) {
-    const derived = deriveAliases(repoRoot, pkg);
+    const derived = deriveAliases(options.repoRoot, pkg);
     aliases.push(...derived.aliases);
     diagnostics.push(...derived.diagnostics);
   }
 
   const modules = await cruiseModules(options, aliases);
-  diagnostics.push(...checkCoverage(modules, fileLayers));
+  diagnostics.push(...checkCoverage(modules, options.fileLayers));
+
+  const dependencies: FileDependency[] = modules.flatMap((module) =>
+    module.dependencies.map((dependency) => ({
+      from: toPosix(module.source),
+      to: toPosix(dependency.resolved),
+    })),
+  );
+
+  return { dependencies, diagnostics };
+};
+
+export const buildGraph = async (
+  options: GraphOptions,
+): Promise<GraphResult> => {
+  const { repoRoot, fileLayers, layers } = options;
+
+  const byLanguage = (language: ArchitecturePackage["language"]) =>
+    options.packages.filter((pkg) => pkg.language === language);
+
+  const typescript = await collectTypeScriptImports({
+    ...options,
+    packages: byLanguage("typescript"),
+  });
+  const python = await collectPythonImports({
+    repoRoot,
+    packages: byLanguage("python"),
+    fileLayers,
+  });
+
+  const dependencies = [...typescript.dependencies, ...python.dependencies];
+  const diagnostics = [...typescript.diagnostics, ...python.diagnostics];
 
   interface EdgeAccumulator {
     fileDependencies: number;
@@ -350,39 +398,35 @@ export const buildGraph = async (
 
   const accumulated = new Map<string, EdgeAccumulator>();
 
-  for (const module of modules) {
-    const fromFile = toPosix(module.source);
+  for (const { from: fromFile, to: toFile } of dependencies) {
     const fromLayer = fileLayers.get(fromFile);
+    const toLayer = fileLayers.get(toFile);
 
     if (fromLayer === undefined) {
       continue;
     }
 
-    for (const dependency of module.dependencies) {
-      const toFile = toPosix(dependency.resolved);
-      const toLayer = fileLayers.get(toFile);
-
-      // Imports landing outside any layer: node_modules, uncovered packages.
-      // A file *inside* the covered roots is reported by `checkCoverage`.
-      if (toLayer === undefined || toLayer === fromLayer) {
-        continue;
-      }
-
-      // `>` cannot occur in a layer id, which is dot-separated kebab-case, so
-      // the pair round-trips. An earlier version used a NUL byte for this and
-      // left two raw NULs in the file, which made every text tool treat the
-      // source as binary.
-      const key = `${fromLayer}>${toLayer}`;
-      const edge = accumulated.get(key) ?? {
-        fileDependencies: 0,
-        examples: [],
-      };
-      edge.fileDependencies += 1;
-      if (edge.examples.length < examplesPerEdge) {
-        edge.examples.push({ from: fromFile, to: toFile });
-      }
-      accumulated.set(key, edge);
+    // Imports landing outside any layer: node_modules, uncovered packages.
+    // A file *inside* the covered roots is reported by `checkCoverage` for
+    // TypeScript and by `extract` for Python.
+    if (toLayer === undefined || toLayer === fromLayer) {
+      continue;
     }
+
+    // `>` cannot occur in a layer id, which is dot-separated kebab-case, so
+    // the pair round-trips. An earlier version used a NUL byte for this and
+    // left two raw NULs in the file, which made every text tool treat the
+    // source as binary.
+    const key = `${fromLayer}>${toLayer}`;
+    const edge = accumulated.get(key) ?? {
+      fileDependencies: 0,
+      examples: [],
+    };
+    edge.fileDependencies += 1;
+    if (edge.examples.length < examplesPerEdge) {
+      edge.examples.push({ from: fromFile, to: toFile });
+    }
+    accumulated.set(key, edge);
   }
 
   const packageOf = new Map(layers.map((layer) => [layer.id, layer.package]));

--- a/libs/@local/petrinaut-arch-docs/src/python-imports.test.ts
+++ b/libs/@local/petrinaut-arch-docs/src/python-imports.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  indexPythonModules,
+  parsePythonImports,
+  resolvePythonImport,
+} from "./python-imports";
+
+import type { ArchitecturePackage } from "./model";
+import type { PythonImport } from "./python-imports";
+
+/**
+ * The parser is conservative: an import it misses loses one edge, an import it
+ * invents puts a false claim in the docs. The non-matches are therefore pinned
+ * as firmly as the matches: comments, docstring bodies and string literals
+ * must contribute nothing.
+ */
+
+const pythonImport = (overrides: Partial<PythonImport>): PythonImport => ({
+  kind: "from",
+  module: "",
+  level: 0,
+  names: [],
+  ...overrides,
+});
+
+describe("parsePythonImports", () => {
+  it("parses absolute imports, including aliases and comma lists", () => {
+    expect(parsePythonImports("import a.b\nimport os, c.d as x\n")).toEqual([
+      pythonImport({ kind: "import", module: "a.b" }),
+      pythonImport({ kind: "import", module: "os" }),
+      pythonImport({ kind: "import", module: "c.d" }),
+    ]);
+  });
+
+  it("parses from-imports with their bound names", () => {
+    expect(parsePythonImports("from a.b import c, d as e\n")).toEqual([
+      pythonImport({ module: "a.b", names: ["c", "d"] }),
+    ]);
+  });
+
+  it("parses relative imports at each level", () => {
+    expect(
+      parsePythonImports(
+        "from .x import y\nfrom ..pkg import z\nfrom . import session\n",
+      ),
+    ).toEqual([
+      pythonImport({ module: "x", level: 1, names: ["y"] }),
+      pythonImport({ module: "pkg", level: 2, names: ["z"] }),
+      pythonImport({ module: "", level: 1, names: ["session"] }),
+    ]);
+  });
+
+  it("keeps the base module when names are a star or spill onto later lines", () => {
+    expect(
+      parsePythonImports("from a import *\nfrom b.c import (\n    d,\n)\n"),
+    ).toEqual([pythonImport({ module: "a" }), pythonImport({ module: "b.c" })]);
+  });
+
+  it("matches imports indented inside a function body", () => {
+    expect(parsePythonImports("def main():\n    import uvicorn\n")).toEqual([
+      pythonImport({ kind: "import", module: "uvicorn" }),
+    ]);
+  });
+
+  it("ignores comments and string literals", () => {
+    expect(
+      parsePythonImports('# import os\nname = "import os"\nx = 1  # from a\n'),
+    ).toEqual([]);
+  });
+
+  it("ignores import statements inside docstrings", () => {
+    const source = [
+      '"""Usage:',
+      "import petrinaut",
+      "from petrinaut import Session",
+      '"""',
+      "import real",
+      '"""import inline"""',
+      "'''",
+      "from also import skipped",
+      "'''",
+    ].join("\n");
+
+    expect(parsePythonImports(source)).toEqual([
+      pythonImport({ kind: "import", module: "real" }),
+    ]);
+  });
+});
+
+const bindingsPackage: ArchitecturePackage = {
+  name: "@test/bindings",
+  path: "libs/py",
+  description: "bindings",
+  language: "python",
+  sourceDirectory: "src",
+};
+
+const optimizerPackage: ArchitecturePackage = {
+  name: "@test/optimizer",
+  path: "apps/opt",
+  description: "optimizer",
+  language: "python",
+  sourceDirectory: "src",
+};
+
+const files = [
+  "libs/py/src/petrinaut/__init__.py",
+  "libs/py/src/petrinaut/session.py",
+  "libs/py/src/petrinaut/errors.py",
+  "apps/opt/src/__init__.py",
+  "apps/opt/src/utils.py",
+  "apps/opt/src/api.py",
+];
+
+const index = indexPythonModules([bindingsPackage, optimizerPackage], files);
+
+describe("indexPythonModules", () => {
+  it("roots modules at the source root when it is not itself a package", () => {
+    expect(index.moduleFiles.get("petrinaut")).toBe(
+      "libs/py/src/petrinaut/__init__.py",
+    );
+    expect(index.moduleFiles.get("petrinaut.session")).toBe(
+      "libs/py/src/petrinaut/session.py",
+    );
+  });
+
+  it("roots modules at the package root when the source root has an __init__", () => {
+    expect(index.moduleFiles.get("src")).toBe("apps/opt/src/__init__.py");
+    expect(index.moduleFiles.get("src.utils")).toBe("apps/opt/src/utils.py");
+  });
+
+  it("reports no diagnostics for the disjoint fixture packages", () => {
+    expect(index.diagnostics).toEqual([]);
+  });
+
+  it("errors when two packages claim one module name", () => {
+    const secondApp: ArchitecturePackage = {
+      ...optimizerPackage,
+      name: "@test/other",
+      path: "apps/other",
+    };
+    const clashing = indexPythonModules(
+      [optimizerPackage, secondApp],
+      [
+        "apps/opt/src/__init__.py",
+        "apps/opt/src/utils.py",
+        "apps/other/src/__init__.py",
+        "apps/other/src/utils.py",
+      ],
+    );
+
+    // `src` and `src.utils` both clash; the first package's mapping stands.
+    expect(clashing.moduleFiles.get("src.utils")).toBe("apps/opt/src/utils.py");
+    expect(clashing.diagnostics).toHaveLength(2);
+    expect(clashing.diagnostics[0]?.severity).toBe("error");
+    expect(clashing.diagnostics[0]?.message).toContain("already claims");
+  });
+});
+
+describe("resolvePythonImport", () => {
+  it("resolves an absolute from-import of another covered package", () => {
+    expect(
+      resolvePythonImport(
+        pythonImport({ module: "petrinaut", names: ["Session"] }),
+        "apps/opt/src/api.py",
+        index,
+      ),
+    ).toEqual(["libs/py/src/petrinaut/__init__.py"]);
+  });
+
+  it("resolves a bound name to its submodule when one exists", () => {
+    expect(
+      resolvePythonImport(
+        pythonImport({ module: "petrinaut", names: ["session"] }),
+        "apps/opt/src/api.py",
+        index,
+      ),
+    ).toEqual(["libs/py/src/petrinaut/session.py"]);
+  });
+
+  it("resolves a plain dotted import", () => {
+    expect(
+      resolvePythonImport(
+        pythonImport({ kind: "import", module: "src.utils" }),
+        "apps/opt/src/api.py",
+        index,
+      ),
+    ).toEqual(["apps/opt/src/utils.py"]);
+  });
+
+  it("resolves relative imports against the importer's package", () => {
+    expect(
+      resolvePythonImport(
+        pythonImport({ module: "errors", level: 1, names: ["X"] }),
+        "libs/py/src/petrinaut/session.py",
+        index,
+      ),
+    ).toEqual(["libs/py/src/petrinaut/errors.py"]);
+
+    expect(
+      resolvePythonImport(
+        pythonImport({ module: "", level: 1, names: ["session"] }),
+        "libs/py/src/petrinaut/__init__.py",
+        index,
+      ),
+    ).toEqual(["libs/py/src/petrinaut/session.py"]);
+  });
+
+  it("drops a relative import that climbs past the top-level package", () => {
+    expect(
+      resolvePythonImport(
+        pythonImport({ module: "other", level: 2, names: ["x"] }),
+        "libs/py/src/petrinaut/session.py",
+        index,
+      ),
+    ).toEqual([]);
+  });
+
+  it("drops imports of modules nothing covered provides", () => {
+    expect(
+      resolvePythonImport(
+        pythonImport({ kind: "import", module: "optuna" }),
+        "apps/opt/src/api.py",
+        index,
+      ),
+    ).toEqual([]);
+  });
+});

--- a/libs/@local/petrinaut-arch-docs/src/python-imports.ts
+++ b/libs/@local/petrinaut-arch-docs/src/python-imports.ts
@@ -1,0 +1,306 @@
+/**
+ * Python counterpart of the dependency-cruiser stage: reads `import` and
+ * `from ... import` statements in the covered Python packages and resolves them
+ * to files, so Python edges carry the same imports provenance as TypeScript
+ * ones. Imports that resolve to nothing covered (stdlib, third-party) are
+ * dropped, exactly as dependency-cruiser edges leaving the covered roots are.
+ *
+ * The parser is line-based and conservative: a missed import loses one edge,
+ * while an invented one would put a false claim in the docs. Docstring bodies
+ * are skipped so a code example in one cannot contribute an edge.
+ */
+
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { error, type Diagnostic } from "./diagnostics";
+import { sourceRootOf } from "./scope";
+
+import type { FileDependency } from "./graph";
+import type { ArchitecturePackage } from "./model";
+
+/** One parsed import statement. */
+export interface PythonImport {
+  kind: "import" | "from";
+  /** Dotted module path; empty for `from . import x`. */
+  module: string;
+  /** Leading dots on a relative `from` import; 0 when absolute. */
+  level: number;
+  /** Names a `from` import binds; empty for `import a.b` and `import *`. */
+  names: string[];
+}
+
+const importPattern = /^\s*import\s+([^#]+)/u;
+const fromPattern = /^\s*from\s+(\.*)([\w.]*)\s+import\s*([^#]*)/u;
+const identifierPattern = /^\s*([A-Za-z_]\w*)/u;
+const modulePattern = /^\s*([A-Za-z_][\w.]*)/u;
+
+const tripleQuotes = ['"""', "'''"] as const;
+
+/** The triple-quote delimiter `text` leaves open, or null when balanced. */
+const openDelimiterAfter = (text: string): string | null => {
+  // Naive comment strip: a `#` inside a string followed by a real opening on
+  // the same line would be mis-tracked, which no covered file comes close to.
+  // Likewise a single-quoted literal containing a triple quote (`x = '"""'`)
+  // reads as an unclosed docstring and drops imports until the next `"""` —
+  // erring toward losing an edge, never inventing one.
+  let rest = text.split("#")[0] ?? "";
+
+  for (;;) {
+    const opening = tripleQuotes
+      .map((delimiter) => ({ delimiter, index: rest.indexOf(delimiter) }))
+      .filter(({ index }) => index !== -1)
+      .sort((left, right) => left.index - right.index)[0];
+
+    if (opening === undefined) {
+      return null;
+    }
+
+    const close = rest.indexOf(opening.delimiter, opening.index + 3);
+    if (close === -1) {
+      return opening.delimiter;
+    }
+    rest = rest.slice(close + 3);
+  }
+};
+
+const parseNames = (text: string): string[] =>
+  text
+    .replace(/[()\\]/gu, " ")
+    .split(",")
+    .flatMap((part) => {
+      const name = identifierPattern.exec(part)?.[1];
+      return name === undefined ? [] : [name];
+    });
+
+/**
+ * Extracts the import statements of one Python source file. Line-based:
+ * a statement's module part always sits on its first line, and names spilling
+ * onto continuation lines only cost the submodule-name refinement.
+ */
+export const parsePythonImports = (source: string): PythonImport[] => {
+  const imports: PythonImport[] = [];
+  let openDelimiter: string | null = null;
+
+  for (const line of source.split("\n")) {
+    if (openDelimiter !== null) {
+      const close = line.indexOf(openDelimiter);
+      if (close === -1) {
+        continue;
+      }
+      openDelimiter = openDelimiterAfter(line.slice(close + 3));
+      continue;
+    }
+
+    const fromMatch = fromPattern.exec(line);
+    if (fromMatch !== null) {
+      imports.push({
+        kind: "from",
+        module: fromMatch[2] ?? "",
+        level: (fromMatch[1] ?? "").length,
+        names: parseNames(fromMatch[3] ?? ""),
+      });
+      continue;
+    }
+
+    const importMatch = importPattern.exec(line);
+    if (importMatch !== null) {
+      for (const part of (importMatch[1] ?? "").split(",")) {
+        const module = modulePattern.exec(part)?.[1];
+        if (module !== undefined) {
+          imports.push({ kind: "import", module, level: 0, names: [] });
+        }
+      }
+      continue;
+    }
+
+    openDelimiter = openDelimiterAfter(line);
+  }
+
+  return imports;
+};
+
+/** Both directions of the module↔file mapping for the covered packages. */
+export interface PythonModuleIndex {
+  /** Dotted module path → repo-relative file. */
+  moduleFiles: Map<string, string>;
+  /** Repo-relative file → dotted module path. */
+  fileModules: Map<string, string>;
+  /** Errors found while indexing, e.g. two packages claiming one name. */
+  diagnostics: Diagnostic[];
+}
+
+/**
+ * Maps every covered Python file to its importable dotted name. The import
+ * root is the package root when the source directory is itself a package
+ * (petrinaut-opt imports `src.utils`), the source root otherwise
+ * (petrinaut-python imports `petrinaut.session`).
+ *
+ * The index is one namespace across every covered package. Two packages
+ * producing the same dotted name (two apps whose `src/` is itself a package
+ * would both claim `src.utils`) is an error rather than last-write-wins: the
+ * winner would depend on config order, and an import in one app could resolve
+ * to a file in the other, drawing a cross-package edge that does not exist.
+ */
+export const indexPythonModules = (
+  packages: ArchitecturePackage[],
+  /** Repo-relative posix paths of the covered `.py` files. */
+  files: string[],
+): PythonModuleIndex => {
+  const moduleFiles = new Map<string, string>();
+  const fileModules = new Map<string, string>();
+  const diagnostics: Diagnostic[] = [];
+
+  for (const pkg of packages) {
+    const root = sourceRootOf(pkg);
+    const packageFiles = files.filter((file) => file.startsWith(`${root}/`));
+    const rootIsPackage = packageFiles.includes(`${root}/__init__.py`);
+    const importRoot = rootIsPackage ? pkg.path : root;
+
+    for (const file of packageFiles) {
+      const segments = file
+        .slice(importRoot.length + 1)
+        .replace(/\.py$/u, "")
+        .split("/");
+
+      if (segments[segments.length - 1] === "__init__") {
+        segments.pop();
+      }
+      if (segments.length === 0) {
+        continue;
+      }
+
+      const moduleName = segments.join(".");
+      const rival = moduleFiles.get(moduleName);
+      if (rival !== undefined) {
+        diagnostics.push(
+          error(
+            file,
+            `resolves to the module name \`${moduleName}\`, which ${rival} already claims; imports of it would resolve to whichever package comes later in the config`,
+          ),
+        );
+        continue;
+      }
+      moduleFiles.set(moduleName, file);
+      fileModules.set(file, moduleName);
+    }
+  }
+
+  return { moduleFiles, fileModules, diagnostics };
+};
+
+/**
+ * Resolves one import to covered files. A `from` import may bind submodules
+ * (`from . import session, errors` is two edges), so each bound name is tried
+ * as a module first, with the base module as the fallback.
+ */
+export const resolvePythonImport = (
+  imported: PythonImport,
+  /** Repo-relative file carrying the import. */
+  importer: string,
+  index: PythonModuleIndex,
+): string[] => {
+  let baseSegments: string[];
+
+  if (imported.level === 0) {
+    baseSegments = imported.module.split(".");
+  } else {
+    const importerModule = index.fileModules.get(importer);
+    if (importerModule === undefined) {
+      return [];
+    }
+
+    // The package containing the importer: an `__init__.py`'s module name is
+    // already its package, any other file drops its final segment.
+    const packageSegments = importerModule.split(".");
+    if (!importer.endsWith("/__init__.py")) {
+      packageSegments.pop();
+    }
+
+    // Each dot beyond the first climbs one package; past the top is invalid.
+    if (imported.level > packageSegments.length) {
+      return [];
+    }
+
+    baseSegments = [
+      ...packageSegments.slice(
+        0,
+        packageSegments.length - (imported.level - 1),
+      ),
+      ...(imported.module === "" ? [] : imported.module.split(".")),
+    ];
+  }
+
+  const base = baseSegments.join(".");
+  if (base === "") {
+    return [];
+  }
+
+  if (imported.kind === "import") {
+    const file = index.moduleFiles.get(base);
+    return file === undefined ? [] : [file];
+  }
+
+  const targets: string[] = [];
+  let dependsOnBase = imported.names.length === 0;
+
+  for (const name of imported.names) {
+    const submodule = index.moduleFiles.get(`${base}.${name}`);
+    if (submodule === undefined) {
+      dependsOnBase = true;
+    } else {
+      targets.push(submodule);
+    }
+  }
+
+  if (dependsOnBase) {
+    const baseFile = index.moduleFiles.get(base);
+    if (baseFile !== undefined) {
+      targets.push(baseFile);
+    }
+  }
+
+  return targets;
+};
+
+/**
+ * Collects file-level dependency records for the covered Python packages.
+ * The files come from `fileLayers`, so this stage reads exactly what the
+ * extractor claimed: an unclaimed Python file is already an error there.
+ */
+export const collectPythonImports = async (options: {
+  repoRoot: string;
+  /** Python packages only; `buildGraph` splits by language. */
+  packages: ArchitecturePackage[];
+  /** Repo-relative source file → layer id, from `extract`. */
+  fileLayers: Map<string, string>;
+}): Promise<{ dependencies: FileDependency[]; diagnostics: Diagnostic[] }> => {
+  const files = [...options.fileLayers.keys()].filter((file) =>
+    file.endsWith(".py"),
+  );
+  const index = indexPythonModules(options.packages, files);
+  const dependencies: FileDependency[] = [];
+  const diagnostics = index.diagnostics;
+
+  for (const [file] of index.fileModules) {
+    const source = await readFile(join(options.repoRoot, file), "utf8");
+    const targets = new Set<string>();
+
+    for (const imported of parsePythonImports(source)) {
+      for (const target of resolvePythonImport(imported, file, index)) {
+        if (target !== file) {
+          targets.add(target);
+        }
+      }
+    }
+
+    // One record per file pair, matching dependency-cruiser's counting.
+    for (const target of [...targets].sort((left, right) =>
+      left.localeCompare(right),
+    )) {
+      dependencies.push({ from: file, to: target });
+    }
+  }
+
+  return { dependencies, diagnostics };
+};

--- a/libs/@local/petrinaut-arch-docs/src/scope.ts
+++ b/libs/@local/petrinaut-arch-docs/src/scope.ts
@@ -18,8 +18,7 @@ import type { ArchitecturePackage } from "./model";
  *
  * `.js` variants are absent on purpose: these packages are TypeScript, and a
  * committed `.js` file under `src` would be build output that no layer should
- * claim. The graph builder reads this list directly — it only ever receives
- * TypeScript packages.
+ * claim. The TypeScript provider's coverage check reads this list directly.
  */
 export const sourceExtensions = [".ts", ".tsx", ".mts", ".cts"] as const;
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The CLI has a usage manual attached to its layer; the Python bindings had only a package README and docstrings. A caller who wants to drive Petrinaut from Python now has the same kind of guide in the docs site, attached to the `python-bindings` layer.

FE-1415 (#9265) sits below in this stack and FE-1457 (#9267) above.

## 🔗 Related links

- [FE-1456](https://linear.app/hash/issue/FE-1456/arch-docs-usage-manual-for-the-python-bindings) *(internal)*: this PR
- [FE-1270](https://linear.app/hash/issue/FE-1270/create-python-bindings-to-petrinaut-core) *(internal)*: the package this documents
- [FE-1413](https://linear.app/hash/issue/FE-1413/arch-docs-cover-petrinaut-cli-and-attach-a-usage-manual) *(internal)*: the CLI manual this is modelled on

## 🔍 What does this change?

One new authored page, `content/python-bindings/usage-manual.mdx`, covers depending on the package, opening a session, run requests, optimization studies, errors, timeouts and shutdown, with an end-to-end example. It documents the Python layer and links to the CLI manual for the protocol detail rather than repeating it. In the other direction, the CLI manual's "Driving the CLI from Python" section replaces its hand-written subprocess wrapper with a short example that uses the bindings.

Every symbol, default and limit was checked against the source. Claims the package README implies, which the manual corrects:

| Claim | What the source says |
| --- | --- |
| Line caps | The bindings enforce their own 8 MiB cap on bootstrap and protocol lines; the CLI's 10 MiB request cap is a separate limit |
| Error hierarchy | `PetrinautRunError` extends `RuntimeError` directly; only `PetrinautProtocolError` extends `PetrinautClientError` |
| `seedsPerTrial` | Defaults to 1 when the study omits it; the generated model bounds it to the CLI's 1–100 range |
| Response deadline | 240 s per seed, so a two-seed study allows 480 s |
| Child environment | Only `PETRINAUT_CHILD_NODE_OPTIONS` is forwarded, as the child's `NODE_OPTIONS` |
| Concurrency | The lock guards start and close only, so one session serves one caller |

The manual states each failure separately: a non-finite objective raises `PetrinautRunError` and leaves the session usable; a non-numeric one fails schema validation and raises `PetrinautProtocolError`; request `params` that fail JSON serialization raise `PetrinautClientError` before anything is written. `close()` may be called from another thread. The package's one runtime dependency is pydantic.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] modifies a workspace but **not** a publishable library

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] require changes to docs which **are made** as part of this PR

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

`lint:arch-docs` validates `attachTo` and every `doc:`/`layer:` target, so a stale link fails the build.

## ❓ How to test this?

1. `turbo run dev --filter @apps/petrinaut-docs`
2. Open `/architecture/python-bindings/usage-manual`: it appears under the `python-bindings` layer beside its Overview, and its links to the CLI manual resolve.

## 🐾 Next steps

The CLI manual keeps its em dashes, so the two pages differ in punctuation style. Bringing the older page in line with the prose rules is a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


