### PR TITLE
FE-1455: Tighten the docs site chrome

### DIFF
--- a/apps/petrinaut-docs/README.md
+++ b/apps/petrinaut-docs/README.md
@@ -64,6 +64,34 @@ output, which would otherwise reach the root-hoisted `cookie@0.7.2` that
 `express` pins and fail on a missing `parseCookie` export. Nesting keeps Astro on
 its own `cookie@2.x` without changing hoisting for the rest of the monorepo.
 
+## Chrome overrides
+
+[`src/styles/chrome.css`](src/styles/chrome.css), registered as Starlight's
+`customCss`, narrows both side panels to give the content column more width,
+tones down the header, and rounds the corners on markdown images so the embedded
+diagrams match the bordered cards beside them. The left nav takes its own
+`--pnd-sidebar-width` because Starlight sizes both panels from
+`--sl-sidebar-width`, and collapsing the nav has to zero one of them without
+flattening the other. The collapse toggle and resize handle come from
+`components.SiteTitle`, the header's leftmost slot, next to the rail they act
+on — and the fixed header is the one piece of chrome still on screen once the
+nav is gone. Both
+controls remember their state in `localStorage`, restored by a `head` script so
+a collapsed sidebar does not render open and then jump.
+
+## The code font
+
+Code renders in JetBrains Mono, requested through Astro's font support in
+[`astro.config.mjs`](astro.config.mjs) and emitted by `<Font>` in
+[`src/components/Head.astro`](src/components/Head.astro).
+
+A build downloads one variable file covering weights 400 to 700, subsets it to
+latin, and writes it beside the other assets, so a reader makes no request to a
+font host. The head carries a `preload` link and `font-display: swap`, and Astro
+generates a metric-matched fallback, which is what keeps text from shifting when
+the file arrives. The downloaded originals are cached under `.astro/`, which is
+ignored.
+
 ## Deployment
 
 Vercel builds the site from [`vercel.json`](vercel.json), which runs

--- a/apps/petrinaut-docs/astro.config.mjs
+++ b/apps/petrinaut-docs/astro.config.mjs
@@ -4,7 +4,7 @@ import { fileURLToPath } from "node:url";
 
 import react from "@astrojs/react";
 import starlight from "@astrojs/starlight";
-import { defineConfig } from "astro/config";
+import { defineConfig, fontProviders } from "astro/config";
 
 /**
  * Renders the architecture bundle produced by `@local/petrinaut-arch-docs`.
@@ -213,12 +213,29 @@ export default defineConfig({
   trailingSlash: "never",
   build: { format: "file" },
 
+  /*
+   * One variable file covers every weight the code blocks use, downloaded and
+   * subset at build time so a reader makes no request to a font host. Italic is
+   * left out: no code style in the docs uses it.
+   */
+  fonts: [
+    {
+      provider: fontProviders.fontsource(),
+      name: "JetBrains Mono",
+      cssVariable: "--pnd-font-mono",
+      weights: ["400 700"],
+      styles: ["normal"],
+      subsets: ["latin"],
+      fallbacks: ["ui-monospace", "SFMono-Regular", "Menlo", "monospace"],
+    },
+  ],
+
   integrations: [
     // Generated layer pages import the bundle's facts and relations cards, and
     // authored pages may import its diagram components; both are React.
     react(),
     starlight({
-      title: "Architecture Docs",
+      title: "Docs",
       description:
         "How the Petrinaut packages fit together — generated from annotations in the source.",
       // The helmet carries the Petrinaut identity, so the title beside it names
@@ -229,6 +246,26 @@ export default defineConfig({
         replacesTitle: false,
       },
       favicon: "/favicon.ico",
+      // Narrows both side panels and rounds the images, and styles the collapse
+      // controls that `components.SiteTitle` renders. See `chrome.css`.
+      customCss: ["./src/styles/chrome.css"],
+      components: {
+        Head: "./src/components/Head.astro",
+        SiteTitle: "./src/components/SiteTitle.astro",
+      },
+      // Restores the collapsed state before first paint. In the component's own
+      // script the sidebar would render at full width and then jump.
+      head: [
+        {
+          tag: "script",
+          content: `try {
+  const stored = localStorage.getItem("pnd:sidebar");
+  const width = localStorage.getItem("pnd:sidebar-width");
+  if (stored === "collapsed") document.documentElement.dataset.pndSidebar = stored;
+  if (width) document.documentElement.style.setProperty("--pnd-sidebar-open-width", width);
+} catch {}`,
+        },
+      ],
       social: [
         {
           icon: "github",

--- a/apps/petrinaut-docs/src/components/Head.astro
+++ b/apps/petrinaut-docs/src/components/Head.astro
@@ -1,0 +1,14 @@
+---
+/**
+ * Starlight's head, plus the font faces and preload links for the code font.
+ *
+ * Astro's `<Font>` emits both, so the family has to be requested from a
+ * component in the head rather than from configuration alone.
+ */
+
+import Default from "@astrojs/starlight/components/Head.astro";
+import { Font } from "astro:assets";
+---
+
+<Default><slot /></Default>
+<Font cssVariable="--pnd-font-mono" preload />

--- a/apps/petrinaut-docs/src/components/SiteTitle.astro
+++ b/apps/petrinaut-docs/src/components/SiteTitle.astro
@@ -1,0 +1,157 @@
+---
+import Default from "@astrojs/starlight/components/SiteTitle.astro";
+
+/**
+ * Adds the desktop sidebar collapse toggle and resize handle beside the title.
+ *
+ * They hang off `SiteTitle` because it is the header's leftmost slot, next to
+ * the rail's edge where the controls act, and the fixed header is the only
+ * chrome still on screen once the sidebar pane itself is collapsed away. Both
+ * are display: none unless the page has a sidebar (see `chrome.css`), so the
+ * splash-template 404 page does not grow controls with nothing to control.
+ */
+---
+
+<button
+  class="pnd-sidebar-toggle"
+  type="button"
+  aria-controls="starlight__sidebar"
+  aria-expanded="true"
+  aria-label="Toggle sidebar"
+>
+  <svg
+    aria-hidden="true"
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linejoin="round"
+  >
+    <rect x="3" y="3" width="18" height="18" rx="2"></rect>
+    <path d="M9 3v18"></path>
+  </svg>
+</button>
+
+<Default><slot /></Default>
+
+<div
+  class="pnd-sidebar-resize"
+  role="separator"
+  aria-orientation="vertical"
+  aria-label="Resize sidebar"
+  tabindex="0"
+>
+</div>
+
+<script is:inline>
+  (() => {
+    const root = document.documentElement;
+    const toggle = /** @type {HTMLButtonElement | null} */ (
+      document.querySelector(".pnd-sidebar-toggle")
+    );
+    const handle = /** @type {HTMLElement | null} */ (
+      document.querySelector(".pnd-sidebar-resize")
+    );
+
+    if (!toggle || !handle) {
+      return;
+    }
+
+    /**
+     * @param {string} key
+     * @param {string} value
+     */
+    const remember = (key, value) => {
+      try {
+        localStorage.setItem(key, value);
+      } catch {
+        // Private browsing denies storage; the control still works this session.
+      }
+    };
+
+    toggle.setAttribute(
+      "aria-expanded",
+      String(root.dataset.pndSidebar !== "collapsed"),
+    );
+
+    toggle.addEventListener("click", () => {
+      const collapsed = root.dataset.pndSidebar !== "collapsed";
+
+      if (collapsed) {
+        root.dataset.pndSidebar = "collapsed";
+      } else {
+        delete root.dataset.pndSidebar;
+      }
+
+      toggle.setAttribute("aria-expanded", String(!collapsed));
+      remember("pnd:sidebar", collapsed ? "collapsed" : "expanded");
+    });
+
+    /** @param {number} edge Where the pane's trailing edge should land, in px. */
+    const resizeTo = (edge) => {
+      const width = `${Math.round(Math.min(Math.max(edge, 224), 480))}px`;
+
+      root.style.setProperty("--pnd-sidebar-open-width", width);
+      remember("pnd:sidebar-width", width);
+    };
+
+    handle.addEventListener("pointerdown", (event) => {
+      handle.setPointerCapture(event.pointerId);
+
+      /** @param {PointerEvent} move */
+      const onMove = (move) => resizeTo(move.clientX);
+
+      handle.addEventListener("pointermove", onMove);
+      handle.addEventListener(
+        "pointerup",
+        () => handle.removeEventListener("pointermove", onMove),
+        { once: true },
+      );
+    });
+
+    handle.addEventListener("keydown", (event) => {
+      const step =
+        event.key === "ArrowLeft" ? -16 : event.key === "ArrowRight" ? 16 : 0;
+
+      if (step !== 0) {
+        event.preventDefault();
+        resizeTo(handle.getBoundingClientRect().left + 3 + step);
+      }
+    });
+
+    // A gradient cannot ask whether the text fits, so the labels that do not
+    // fit are marked here and the fade keys off the mark. Deferred because this
+    // script is in the header, which the browser parses before the sidebar.
+    const markLabels = () => {
+      const pane = document.querySelector(".sidebar-content");
+
+      if (!pane) {
+        return;
+      }
+
+      const labels = pane.querySelectorAll("a > span, .group-label > span");
+
+      const markClipped = () => {
+        for (const label of labels) {
+          label.toggleAttribute(
+            "data-pnd-clipped",
+            label.scrollWidth > label.clientWidth + 1,
+          );
+        }
+      };
+
+      markClipped();
+      // Fires on the pane's own resize and when expanding a group changes it.
+      new ResizeObserver(markClipped).observe(pane);
+      pane.addEventListener("toggle", markClipped, { capture: true });
+    };
+
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", markLabels, { once: true });
+    } else {
+      markLabels();
+    }
+  })();
+</script>

--- a/apps/petrinaut-docs/src/components/SiteTitle.astro
+++ b/apps/petrinaut-docs/src/components/SiteTitle.astro
@@ -150,10 +150,25 @@ import Default from "@astrojs/starlight/components/SiteTitle.astro";
       pane.addEventListener("toggle", markClipped, { capture: true });
     };
 
-    if (document.readyState === "loading") {
-      document.addEventListener("DOMContentLoaded", markLabels, { once: true });
-    } else {
+    // Two frames, so the group state Starlight restores has painted once
+    // before `chrome.css` starts transitioning `::details-content`.
+    const allowGroupAnimation = () => {
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          root.dataset.pndReady = "";
+        });
+      });
+    };
+
+    const onReady = () => {
       markLabels();
+      allowGroupAnimation();
+    };
+
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", onReady, { once: true });
+    } else {
+      onReady();
     }
   })();
 </script>

--- a/apps/petrinaut-docs/src/components/SiteTitle.astro
+++ b/apps/petrinaut-docs/src/components/SiteTitle.astro
@@ -104,8 +104,10 @@ import Default from "@astrojs/starlight/components/SiteTitle.astro";
       const onMove = (move) => resizeTo(move.clientX);
 
       handle.addEventListener("pointermove", onMove);
+      // `lostpointercapture` covers the cancelled gesture as well as the
+      // released one, so the drag cannot outlive the pointer holding it.
       handle.addEventListener(
-        "pointerup",
+        "lostpointercapture",
         () => handle.removeEventListener("pointermove", onMove),
         { once: true },
       );

--- a/apps/petrinaut-docs/src/styles/chrome.css
+++ b/apps/petrinaut-docs/src/styles/chrome.css
@@ -1,0 +1,207 @@
+/*
+ * Chrome overrides for the architecture docs site, registered as Starlight's
+ * `customCss`. Custom CSS is unlayered, so these rules win over Starlight's
+ * `@layer starlight.core` without needing extra specificity to fight it. The
+ * exception is `Page.astro`'s inline `<style>` block, which is also unlayered:
+ * `--sl-content-inline-start` and the no-sidebar `--sl-content-width` are set
+ * there, so the `:root[data-has-sidebar]` prefixes below are load-bearing
+ * specificity, not decoration.
+ *
+ * Every sidebar rule is gated on `[data-has-sidebar]`: the 404 page uses the
+ * splash template, which has no sidebar to toggle, resize, or collapse.
+ */
+
+:root {
+  /*
+   * Starlight derives both side panels from `--sl-sidebar-width`. The left nav
+   * takes its own width so collapsing it can zero that one without flattening
+   * the on-this-page column, which keeps this variable for the right panel.
+   */
+  --sl-sidebar-width: 15rem;
+  --sl-content-width: 56rem;
+
+  /* Set inline on `<html>` by the resize handle, then restored on load. */
+  --pnd-sidebar-open-width: 15.5rem;
+  --pnd-sidebar-width: var(--pnd-sidebar-open-width);
+}
+
+/* Collapsing hands the width the nav gives up to the content column. */
+:root[data-has-sidebar][data-pnd-sidebar="collapsed"] {
+  --pnd-sidebar-width: 0rem;
+  --sl-content-width: 64rem;
+}
+
+/* 50rem is where Starlight turns the mobile drawer into a fixed rail. */
+@media (min-width: 50rem) {
+  :root[data-has-sidebar] {
+    --sl-content-inline-start: var(--pnd-sidebar-width);
+  }
+
+  .sidebar-pane {
+    width: var(--pnd-sidebar-width);
+  }
+
+  :root[data-pnd-sidebar="collapsed"] .sidebar-pane {
+    display: none;
+  }
+
+  /* Not zero: below 72rem nothing else insets the column from the edge. */
+  :root[data-has-sidebar][data-pnd-sidebar="collapsed"] {
+    --sl-content-inline-start: 2rem;
+  }
+}
+
+/* Code font -------------------------------------------------------------- */
+
+/* Starlight composes its own system stack after this, so it stays the fallback. */
+:root {
+  --sl-font-mono: var(--pnd-font-mono);
+}
+
+/* Header ---------------------------------------------------------------- */
+
+.site-title {
+  gap: 0.6rem;
+  font-size: var(--sl-text-sm);
+  font-weight: 500;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.site-title img {
+  height: 1.5rem;
+}
+
+/* Sidebar controls ------------------------------------------------------ */
+
+/* Both controls belong to the desktop rail; the mobile drawer has its own. */
+.pnd-sidebar-toggle,
+.pnd-sidebar-resize {
+  display: none;
+}
+
+@media (min-width: 50rem) {
+  :root[data-has-sidebar] .pnd-sidebar-toggle {
+    display: flex;
+    flex: none;
+    align-items: center;
+    justify-content: center;
+    /* The wrapper has no gap, so the separation from the logo is set here.
+       The negative start pulls the button in from the header padding — only
+       as far as the title wrapper's own negative margin, since its
+       `overflow: clip` cuts anything past that. */
+    margin-inline: -0.25rem 0.85rem;
+    width: var(--sl-menu-button-size);
+    height: var(--sl-menu-button-size);
+    padding: 0;
+    border: 0;
+    border-radius: 0.25rem;
+    background: none;
+    color: var(--sl-color-gray-3);
+    cursor: pointer;
+  }
+
+  .pnd-sidebar-toggle:hover {
+    /* One step lighter than the header's own background, which in dark mode
+       is `--sl-color-gray-6` itself — that value would make hover invisible. */
+    background: var(--sl-color-gray-5);
+    color: var(--sl-color-white);
+  }
+
+  /*
+   * Rendered in the header but positioned against the viewport, so it sits on
+   * the pane's trailing edge and escapes the title wrapper's `overflow: clip`.
+   */
+  :root[data-has-sidebar] .pnd-sidebar-resize {
+    display: block;
+    position: fixed;
+    z-index: var(--sl-z-index-menu);
+    inset-block: var(--sl-nav-height) 0;
+    inset-inline-start: calc(var(--pnd-sidebar-width) - 3px);
+    width: 6px;
+    cursor: col-resize;
+    touch-action: none;
+  }
+
+  .pnd-sidebar-resize:hover,
+  .pnd-sidebar-resize:focus-visible {
+    background: var(--sl-color-accent);
+    outline: none;
+  }
+
+  :root[data-pnd-sidebar="collapsed"] .pnd-sidebar-resize {
+    display: none;
+  }
+}
+
+/* Sidebar labels -------------------------------------------------------- */
+
+/*
+ * One line per item. A label that outgrows the rail fades out at its trailing
+ * edge rather than wrapping to a second line, so the rail keeps one rhythm and
+ * a narrow sidebar stays readable.
+ */
+.sidebar-content a > span,
+.sidebar-content .group-label > span {
+  display: block;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+/* Marked by the header script, so a label that fits keeps its last letters. */
+.sidebar-content [data-pnd-clipped] {
+  mask-image: linear-gradient(to right, #000 calc(100% - 1.25rem), transparent);
+}
+
+/*
+ * The label fills the row rather than shrink-wrapping its text. Left as a flex
+ * item sized to content, the fade landed on the last word of every group
+ * header instead of at the rail's edge. `min-width: 0` is what lets this flex
+ * item shrink below its content at all.
+ */
+.sidebar-content .group-label {
+  flex: 1;
+  min-width: 0;
+}
+
+/* Sidebar groups -------------------------------------------------------- */
+
+/*
+ * A group grows and shrinks instead of snapping. `::details-content` is the box
+ * to animate, and `interpolate-size` is what makes the `auto` keyword a
+ * transition target; `allow-discrete` keeps the content painted for the whole
+ * collapse rather than dropping it on the first frame. Both features are recent,
+ * so the rule is guarded and older browsers keep the instant toggle.
+ */
+@supports selector(::details-content) and (interpolate-size: allow-keywords) {
+  @media (prefers-reduced-motion: no-preference) {
+    :root {
+      interpolate-size: allow-keywords;
+    }
+
+    .sidebar-content details::details-content {
+      block-size: 0;
+      overflow: hidden;
+      transition:
+        block-size 220ms ease,
+        content-visibility 220ms allow-discrete;
+    }
+
+    .sidebar-content details[open]::details-content {
+      block-size: auto;
+    }
+  }
+}
+
+/* Content --------------------------------------------------------------- */
+
+/*
+ * Rendered diagrams arrive as plain markdown images with a white background
+ * baked into the SVG, so they read as cards once their edge matches the layer
+ * cards beside them. Radius and border are `.arch-card`'s own values, which is
+ * why the border is a `color-mix` rather than a Starlight hairline token.
+ */
+.sl-markdown-content img {
+  border: 1px solid color-mix(in srgb, currentColor 22%, transparent);
+  border-radius: 0.5rem;
+}

--- a/apps/petrinaut-docs/src/styles/chrome.css
+++ b/apps/petrinaut-docs/src/styles/chrome.css
@@ -172,6 +172,11 @@
  * transition target; `allow-discrete` keeps the content painted for the whole
  * collapse rather than dropping it on the first frame. Both features are recent,
  * so the rule is guarded and older browsers keep the instant toggle.
+ *
+ * The transition waits for `data-pnd-ready`, which lands after the first paint.
+ * Starlight restores group state from `sessionStorage` while the page loads, and
+ * a transition already in effect would replay every restored group on each
+ * navigation instead of showing the saved tree.
  */
 @supports selector(::details-content) and (interpolate-size: allow-keywords) {
   @media (prefers-reduced-motion: no-preference) {
@@ -179,7 +184,7 @@
       interpolate-size: allow-keywords;
     }
 
-    .sidebar-content details::details-content {
+    :root[data-pnd-ready] .sidebar-content details::details-content {
       block-size: 0;
       overflow: hidden;
       transition:
@@ -187,7 +192,7 @@
         content-visibility 220ms allow-discrete;
     }
 
-    .sidebar-content details[open]::details-content {
+    :root[data-pnd-ready] .sidebar-content details[open]::details-content {
       block-size: auto;
     }
   }

--- a/apps/petrinaut-docs/vercel-build.sh
+++ b/apps/petrinaut-docs/vercel-build.sh
@@ -18,5 +18,9 @@ rm -f .env
 # Run through Turborepo rather than `yarn workspace ... build`: the package
 # script alone skips `sync:bundle`, and would build whatever content happened to
 # be on disk.
-echo "Building Petrinaut architecture docs"
+#
+# Source links follow the commit being built rather than `main`: the generator
+# reads `VERCEL_GIT_COMMIT_SHA` and `VERCEL_GIT_COMMIT_REF`, declared in
+# `libs/@local/petrinaut-arch-docs/turbo.json`, and logs the prefix it used.
+echo "Building Petrinaut architecture docs from ${VERCEL_GIT_COMMIT_SHA:-a local checkout}"
 turbo build --filter='@apps/petrinaut-docs' --env-mode=loose

--- a/libs/@local/petrinaut-arch-docs/README.md
+++ b/libs/@local/petrinaut-arch-docs/README.md
@@ -147,6 +147,32 @@ required. In particular the bundle asks for **no Markdown or Rehype
 plugins** — a host renders it with its Markdown pipeline exactly as configured,
 which is what keeps "render the bundle" a small job rather than a negotiation.
 
+### Source links
+
+Generated pages link back to the source they describe: each layer's "Declared
+in" link, its source root, its further-reading list, and any relative link in a
+declaring README's prose. Those URLs carry a git ref, resolved once per build
+from the first of these variables that holds a value:
+
+| Variable                         | Set by                        |
+| -------------------------------- | ----------------------------- |
+| `PETRINAUT_ARCH_DOCS_SOURCE_REF` | You, overriding the rest      |
+| `VERCEL_GIT_COMMIT_SHA`          | Vercel                        |
+| `GITHUB_SHA`                     | GitHub Actions                |
+| `VERCEL_GIT_COMMIT_REF`          | Vercel (branch name)          |
+| `GITHUB_HEAD_REF`                | GitHub Actions (pull request) |
+| `GITHUB_REF_NAME`                | GitHub Actions (push)         |
+
+A commit SHA beats a branch name, because the link still resolves once the
+branch has moved on or been deleted. The branch-name fallbacks assume the
+branch lives in `hashintel/hash`: on a pull request from a fork,
+`GITHUB_HEAD_REF` names a branch this repository does not have, so those links
+404 — the SHA variables, which win when present, resolve regardless. With none of them set the ref is `main`,
+which is what a local build gets; set `PETRINAUT_ARCH_DOCS_SOURCE_REF` to aim a
+local build at another ref. A preview deployment of `apps/petrinaut-docs`
+reads Vercel's variables, so its links point at the commit it was built from
+instead of at a file `main` may not have yet.
+
 ### Embedding the bundle elsewhere
 
 A host reads `manifest.json`, maps each page's `slug` onto its own URL space, and

--- a/libs/@local/petrinaut-arch-docs/architecture.config.ts
+++ b/libs/@local/petrinaut-arch-docs/architecture.config.ts
@@ -8,6 +8,8 @@
  * exercise. Resist the temptation to add a path→layer mapping here.
  */
 
+import { resolveSourceUrlPrefix } from "./src/source-url";
+
 import type { ArchitecturePackageInput } from "./src/model";
 
 export interface LayerRule {
@@ -27,7 +29,7 @@ export interface ArchitectureConfig {
   outputDirectory: string;
   /** Where hand-written MDX is read from, repo-relative. */
   contentDirectory: string;
-  /** Base URL for source links in generated pages. */
+  /** Base URL for source links in generated pages, including the git ref. */
   sourceUrlPrefix: string;
 }
 
@@ -132,5 +134,10 @@ export const config: ArchitectureConfig = {
    */
   outputDirectory: "libs/@local/petrinaut-arch-docs/bundle",
   contentDirectory: "libs/@local/petrinaut-arch-docs/content",
-  sourceUrlPrefix: "https://github.com/hashintel/hash/blob/main/",
+  /**
+   * Resolved from the build environment rather than pinned to `main`, so a
+   * preview deployment links to the commit it was built from. See
+   * `src/source-url.ts` for the variables and their precedence.
+   */
+  sourceUrlPrefix: resolveSourceUrlPrefix(process.env),
 };

--- a/libs/@local/petrinaut-arch-docs/content/cli/usage-manual.mdx
+++ b/libs/@local/petrinaut-arch-docs/content/cli/usage-manual.mdx
@@ -310,53 +310,22 @@ experiment-backend interface.
 
 ## Driving the CLI from Python
 
-The CLI speaks one JSON object per line, so a Python driver needs only
-`subprocess` and `json`. The wrapper below starts one CLI process for a
-manifest and turns each response line into a return value or an exception:
+The [python-bindings](layer:python-bindings) package wraps this protocol: a
+session owns one CLI process, each request is a method, and an error frame
+raises. Its [usage manual](doc:python-bindings/usage-manual) covers the session
+lifecycle, the timeouts, and the exception types.
 
 ```python
-import json
-import subprocess
+from petrinaut import OptimizationSession
 
-
-class PetrinautOptimization:
-    def __init__(self, manifest_path: str):
-        self.process = subprocess.Popen(
-            [
-                "petrinaut",
-                "serve",
-                "--optimization",
-                manifest_path,
-                "--stdio",
-            ],
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            text=True,
-            bufsize=1,
-        )
-        self.request_id = 0
-
-    def request(self, method: str, params: dict | None = None) -> dict:
-        self.request_id += 1
-        request = {"id": self.request_id, "method": method}
-        if params is not None:
-            request["params"] = params
-
-        assert self.process.stdin and self.process.stdout
-        self.process.stdin.write(json.dumps(request) + "\n")
-        self.process.stdin.flush()
-        response = json.loads(self.process.stdout.readline())
-        if "error" in response:
-            raise RuntimeError(response["error"]["message"])
-        return response["result"]
-
-    def close(self) -> None:
-        self.process.terminate()
-        self.process.wait()
+with OptimizationSession(manifest_path="optimization.json") as session:
+    description = session.describe()
+    print([parameter.identifier for parameter in description.parameters])
+    # Send every — and only — described parameter.
+    value = session.objective({"production_rate": 112.5, "enabled": True})
 ```
 
-An Optuna study calls `optimization.describe` once and maps each described
-parameter to the `suggest_*` call from the table above; its objective function
-sends the suggested values to `optimization.evaluate` and returns the
-`objective` from the response. The manifest and the CLI own the Petrinaut
-types, the scenario compilation, and the fixed values.
+An Optuna study calls `describe()` once and maps each described
+parameter to the `suggest_*` call from the table above. Its objective function
+passes the suggested values to `objective()`. The manifest and the CLI own the
+Petrinaut types, the scenario compilation, and the fixed values.

--- a/libs/@local/petrinaut-arch-docs/content/python-bindings/usage-manual.mdx
+++ b/libs/@local/petrinaut-arch-docs/content/python-bindings/usage-manual.mdx
@@ -147,10 +147,10 @@ CLI serves both from one process, so every `PetrinautSession` method works on
 an `OptimizationSession` too; only an `OptimizationSession` can answer the
 `optimization.*` methods. Pick the class by naming what the process serves:
 
-| You have        | Construct                                   | CLI invocation                        |
-| --------------- | ------------------------------------------- | ------------------------------------- |
-| a model file    | `PetrinautSession.from_model_file(path)`    | `serve --model <path> --stdio`        |
-| a model dict    | `PetrinautSession.from_model(model)`        | `serve --model-stdin --stdio`         |
+| You have        | Construct                                      | CLI invocation                        |
+| --------------- | ---------------------------------------------- | ------------------------------------- |
+| a model file    | `PetrinautSession.from_model_file(path)`       | `serve --model <path> --stdio`        |
+| a model dict    | `PetrinautSession.from_model(model)`           | `serve --model-stdin --stdio`         |
 | a manifest file | `OptimizationSession.from_manifest_file(path)` | `serve --optimization <path> --stdio` |
 | a manifest dict | `OptimizationSession.from_manifest(manifest)`  | `serve --optimization-stdin --stdio`  |
 

--- a/libs/@local/petrinaut-arch-docs/content/python-bindings/usage-manual.mdx
+++ b/libs/@local/petrinaut-arch-docs/content/python-bindings/usage-manual.mdx
@@ -1,0 +1,299 @@
+---
+title: Usage manual
+description: Installing the package, opening a session, run requests, optimization studies, and the exceptions each failure raises.
+sidebar_order: 10
+attachTo: python-bindings
+---
+
+`@local/petrinaut-python` drives the Petrinaut CLI from Python. A
+`PetrinautSession` owns **one long-lived `petrinaut serve` child process** for
+one model, writes requests as JSON lines on its stdin, and reads one response
+line per request from its stdout.
+
+The package's one runtime dependency is pydantic, which validates
+optimization responses against the CLI's published protocol schema; it
+requires Python `>=3.10`. It is **POSIX-only**:
+`os.killpg` for process-group signalling and `select.select` for descriptor
+polling have no Windows fallback.
+
+The child is spawned with a scrubbed environment, so a model expression never
+reads the calling process's credentials: `PATH` is fixed to
+`/usr/local/bin:/usr/bin:/bin`, `LANG` and `LC_ALL` to `C.UTF-8`, `NO_COLOR`
+to `1`, `TZ` to `UTC`. The only variable that passes through is
+`PETRINAUT_CHILD_NODE_OPTIONS`, forwarded as the child's `NODE_OPTIONS`. The
+process also gets its own process group, `umask` `0o077`, and `close_fds`.
+
+## Depending on the package
+
+The package is internal to this monorepo and is consumed as a uv path
+dependency. `apps/petrinaut-opt` is the reference consumer: it names
+`petrinaut-python` in `[project].dependencies` and points uv at the path.
+
+```toml
+[tool.uv.sources]
+petrinaut-python = { path = "../../libs/@local/petrinaut-python", editable = true }
+```
+
+Nothing runs without the CLI bundle at
+`libs/@hashintel/petrinaut-cli/dist/cli.js`. The package declares
+`@hashintel/petrinaut-cli` as a workspace dependency, and the root
+`test:unit` task depends on `^build`, so running the suite through Turborepo
+builds the bundle first:
+
+```bash
+turbo run test:unit --filter @local/petrinaut-python
+```
+
+Plain `uv run pytest` skips the end-to-end tests when the bundle is missing.
+To build it on its own:
+
+```bash
+turbo run build --filter @hashintel/petrinaut-cli
+```
+
+## Opening a session
+
+Two factories name the model source, matching the CLI's two model flags:
+
+| Constructor                              | CLI invocation                 |
+| ---------------------------------------- | ------------------------------ |
+| `PetrinautSession.from_model_file(path)` | `serve --model <path> --stdio` |
+| `PetrinautSession.from_model(model)`     | `serve --model-stdin --stdio`  |
+
+`from_model` serializes the model object to the CLI's first stdin line, which
+suits read-only containers and callers already holding the snapshot. The
+object's shape is the same one `--model-stdin` documents in the
+[CLI usage manual](doc:cli/usage-manual).
+
+Both are context managers: `__enter__` calls `start()` and `__exit__` calls
+`close()`. `start()` writes the bootstrap line if there is one, then waits for
+a stderr line beginning `Petrinaut stdio ready`. Any other line closes the
+process and raises `PetrinautClientError`, quoting the CLI's own message or
+its exit code.
+
+```python
+from petrinaut import PetrinautSession
+
+with PetrinautSession.from_model_file("./sir-model.json") as session:
+    metadata = session.metadata()
+```
+
+Calling `start()` and `close()` by hand works too; `start()` returns
+immediately when the process is already running, and `close()` is safe to call
+repeatedly.
+
+Every keyword argument other than the source is forwarded to the constructor:
+
+| Option                      | Default            | Effect                                               |
+| --------------------------- | ------------------ | ---------------------------------------------------- |
+| `command`                   | `("petrinaut",)`   | The executable, resolved on the child's fixed `PATH` |
+| `bootstrap_timeout_seconds` | `25`               | Spawn to readiness line                              |
+| `request_timeout_seconds`   | `240`              | One protocol response                                |
+| `popen_factory`             | `subprocess.Popen` | Substitutes the spawned process in tests             |
+
+Pass an absolute `command` when the CLI is not installed on that `PATH`, which
+is the normal case in development:
+
+```python
+import shutil
+
+session = PetrinautSession.from_model_file(
+    "./sir-model.json",
+    command=(shutil.which("node"), "libs/@hashintel/petrinaut-cli/dist/cli.js"),
+)
+```
+
+An empty `command`, or one with an empty part, raises `ValueError`, as does a
+timeout of zero or less.
+
+## Run requests
+
+Three methods cover the model-source protocol, and `request` reaches any
+method by name:
+
+| Method                            | Returns                                              |
+| --------------------------------- | ---------------------------------------------------- |
+| `session.healthz()`               | `{"ok": True}`                                       |
+| `session.metadata()`              | The compiled model's parameters, places, and metrics |
+| `session.run(params)`             | One simulation's summary result                      |
+| `session.request(method, params)` | That method's raw `result`                           |
+
+`params` for `run` is the CLI's run config verbatim: `parameters`,
+`initialState` or `scenario`, `metrics`, `maxSteps` or `maxTime`, `dt`, and
+`seed`. Every key, alias-resolution rule, bound, and response field is
+specified in the [CLI usage manual](doc:cli/usage-manual); the Python layer
+passes the mapping through and adds only the transport guarantees:
+
+- Request ids are assigned and checked. The counter starts at `1` and
+  increments per request; a response carrying a different id raises
+  `PetrinautProtocolError`.
+- `healthz`, `metadata`, and `run` require a JSON object result. A non-object
+  closes the session and raises `PetrinautProtocolError`. `request` returns
+  whatever `result` holds, without that check.
+- An error frame becomes `PetrinautRunError` carrying the frame's
+  `error.message`.
+
+Request ids and the stdout buffer are unsynchronized, and the CLI answers
+serially, so one session serves one caller at a time. For parallel work, give
+each worker its own session. The one cross-thread guarantee is `close()`: it
+may be called from another thread, which is how a supervisor cancels a session
+mid-request.
+
+## Optimization studies
+
+`OptimizationSession` subclasses `PetrinautSession` and boots the CLI from an
+optimization manifest instead of a model. A manifest embeds a model, and the
+CLI serves both from one process, so every `PetrinautSession` method works on
+an `OptimizationSession` too; only an `OptimizationSession` can answer the
+`optimization.*` methods. Pick the class by naming what the process serves:
+
+| You have        | Construct                                   | CLI invocation                        |
+| --------------- | ------------------------------------------- | ------------------------------------- |
+| a model file    | `PetrinautSession.from_model_file(path)`    | `serve --model <path> --stdio`        |
+| a model dict    | `PetrinautSession.from_model(model)`        | `serve --model-stdin --stdio`         |
+| a manifest file | `OptimizationSession.from_manifest_file(path)` | `serve --optimization <path> --stdio` |
+| a manifest dict | `OptimizationSession.from_manifest(manifest)`  | `serve --optimization-stdin --stdio`  |
+
+`OptimizationSession(manifest)` and `OptimizationSession(manifest_path=path)`
+construct the same sessions as the two manifest factories; exactly one source
+is required, or the constructor raises `ValueError`.
+
+The manifest is opaque to Python. The CLI validates it, injects fixed values,
+compiles the scenario, simulates, and evaluates the metric.
+
+| Method                                | Returns                                                 |
+| ------------------------------------- | ------------------------------------------------------- |
+| `session.describe()`                  | The direction, study settings, and non-fixed parameters |
+| `session.evaluate(parameter_values)`  | The full trial result, `replicates` included            |
+| `session.objective(parameter_values)` | The trial's objective as a finite `float`               |
+
+`describe_optimization` remains as an alias for `describe`. `describe` and
+`evaluate` return pydantic models
+(`OptimizationDescribeResult`, `OptimizationEvaluateResult`) generated from the
+CLI's published protocol schema; a response outside that schema raises
+`PetrinautProtocolError` and closes the session.
+
+`describe` also configures the deadline. It reads the manifest's
+`execution.seedsPerTrial`, reported back as `study.seedsPerTrial` in the
+response, defaulting to `1` when the study omits it. The generated model
+bounds it to the CLI's `1`–`100` range, so an out-of-range value fails
+validation and closes the session with `PetrinautProtocolError`. One
+`evaluate` may run that many seeded simulations sequentially, so the
+per-response deadline becomes `request_timeout_seconds × seedsPerTrial`: a
+manifest setting `execution.seedsPerTrial` to `2` gives each response 480
+seconds.
+
+`evaluate` describes once itself when the session has not been described yet,
+because a seeded trial needs the scaled deadline before its first evaluation.
+`objective` calls `evaluate` and reads its `.objective`, raising
+`PetrinautRunError` when the value is not finite, and leaving the session
+usable. A boolean or non-numeric objective fails schema validation first,
+which raises `PetrinautProtocolError` and closes the session.
+With more than one seed the objective is the mean and `evaluate` reports each
+seed's value under `replicates`.
+
+```python
+from petrinaut import OptimizationSession
+
+# `OptimizationSession(manifest_path=...)` reads the manifest from disk instead.
+with OptimizationSession(manifest) as session:
+    description = session.describe()
+    for parameter in description.parameters:
+        print(parameter.identifier, parameter.type)
+
+    value = session.objective({"production_rate": 112.5, "enabled": True})
+```
+
+The [CLI usage manual](doc:cli/usage-manual) carries the manifest contract,
+the parameter-type table with its Optuna suggestion calls, the work budgets,
+and the common-random-numbers seed derivation.
+
+## Errors
+
+Three exception types, and the hierarchy decides whether the session survives:
+
+| Exception                | Base                   | Raised when                                                | Session |
+| ------------------------ | ---------------------- | ---------------------------------------------------------- | ------- |
+| `PetrinautRunError`      | `RuntimeError`         | The CLI answered one request with an error frame           | Usable  |
+| `PetrinautClientError`   | `RuntimeError`         | The process failed to start, bootstrap, or communicate     | Closed  |
+| `PetrinautProtocolError` | `PetrinautClientError` | The response was not valid framing, JSON, UTF-8, or object | Closed  |
+
+`PetrinautRunError` is a sibling of `PetrinautClientError`, not a subclass, so
+catching `PetrinautClientError` catches transport and protocol failures
+without swallowing a rejected request. `objective` also raises
+`PetrinautRunError` for a non-finite objective, leaving the session usable.
+
+`PetrinautClientError` covers the bootstrap process paths as well: a failed
+spawn, unavailable pipes, and a readiness line that never arrives. Caller
+input that fails before anything is written raises the plain built-ins
+instead, leaving the session exactly as it was: request `params`, a model, or
+a manifest that will not serialize to JSON raise `TypeError`, and a bootstrap
+payload over the 8 MiB line cap raises `ValueError`.
+
+## Timeouts, limits, and shutdown
+
+| Bound                             | Value |
+| --------------------------------- | ----- |
+| Bootstrap, spawn to readiness     | 25 s  |
+| One protocol response             | 240 s |
+| Process shutdown, each wait stage | 5 s   |
+| Bootstrap line                    | 8 MiB |
+| Protocol line                     | 8 MiB |
+
+The first two are constructor options; for an optimization session the
+response deadline is scaled as described above. A read that exceeds its
+deadline raises `PetrinautClientError` and closes the session; a line over
+8 MiB raises `PetrinautProtocolError`.
+
+The CLI's stderr is drained on a daemon thread for the life of the session, so
+its diagnostics cannot fill the pipe and block it.
+
+A dead child is reported rather than waited on. `_exchange` checks before
+writing, so a request against a session that was never started or has been
+closed raises `PetrinautClientError` reading `the Petrinaut CLI is not
+running`, and one against an exited process reports its exit code. A process
+that exits mid-request, giving no response line, raises the same type.
+
+`close()` closes stdin first. The graceful default then waits up to 5 seconds
+for the CLI to exit on EOF, which only a CLI that is idle between requests
+will observe. After that, or immediately under `close(graceful=False)`, it
+sends `SIGTERM` to the child's process group, waits 5 seconds, escalates to
+`SIGKILL`, and waits 5 seconds again. Cancellation, timeouts, and every
+failure path inside the session use `graceful=False`.
+
+## End to end
+
+Against a model saved from the editor, from the repository root, with the bundle
+built:
+
+```python
+import shutil
+
+from petrinaut import PetrinautSession
+
+CLI = "libs/@hashintel/petrinaut-cli/dist/cli.js"
+MODEL = "./sir-model.json"
+
+with PetrinautSession.from_model_file(
+    MODEL, command=(shutil.which("node"), CLI)
+) as session:
+    assert session.healthz() == {"ok": True}
+
+    metadata = session.metadata()
+    assert "Infected Fraction" in {metric["name"] for metric in metadata["metrics"]}
+
+    result = session.run(
+        {
+            "parameters": {"infection_rate": 1.5, "recovery_rate": 0.8},
+            "initialState": {"Susceptible": 990, "Infected": 10, "Recovered": 0},
+            "metrics": ["Infected Fraction"],
+            "maxSteps": 50,
+            "dt": 0.1,
+            "seed": 4242,
+        }
+    )
+    print(result["status"], result["metrics"]["Infected Fraction"])
+```
+
+Passing the same `seed` again returns the same metrics, which is what
+`tests/test_e2e_cli.py` asserts.

--- a/libs/@local/petrinaut-arch-docs/src/cli.ts
+++ b/libs/@local/petrinaut-arch-docs/src/cli.ts
@@ -156,7 +156,12 @@ const main = async (): Promise<number> => {
     return 1;
   }
 
-  process.stdout.write(`Wrote ${config.outputDirectory}\n`);
+  // The prefix is logged because it varies by build: a preview deployment
+  // points its source links at the previewed commit, and a wrong ref is
+  // otherwise only visible by clicking a link on the published page.
+  process.stdout.write(
+    `Wrote ${config.outputDirectory}, source links to ${config.sourceUrlPrefix}\n`,
+  );
   return 0;
 };
 

--- a/libs/@local/petrinaut-arch-docs/src/source-url.test.ts
+++ b/libs/@local/petrinaut-arch-docs/src/source-url.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveSourceRef, resolveSourceUrlPrefix } from "./source-url";
+
+describe("resolveSourceRef", () => {
+  it("falls back to `main` when the environment names no ref", () => {
+    expect(resolveSourceRef({})).toBe("main");
+  });
+
+  it("ignores a variable that is set but empty", () => {
+    expect(resolveSourceRef({ GITHUB_SHA: "  " })).toBe("main");
+  });
+
+  it("prefers a commit SHA over a branch name", () => {
+    expect(
+      resolveSourceRef({
+        GITHUB_HEAD_REF: "cf/fe-1457-x",
+        GITHUB_SHA: "0123456789abcdef0123456789abcdef01234567",
+      }),
+    ).toBe("0123456789abcdef0123456789abcdef01234567");
+
+    expect(
+      resolveSourceRef({
+        VERCEL_GIT_COMMIT_REF: "cf/fe-1457-x",
+        VERCEL_GIT_COMMIT_SHA: "89abcdef",
+      }),
+    ).toBe("89abcdef");
+  });
+
+  it("prefers the explicit override over anything the CI provides", () => {
+    expect(
+      resolveSourceRef({
+        GITHUB_SHA: "0123456789abcdef",
+        PETRINAUT_ARCH_DOCS_SOURCE_REF: "my-local-branch",
+        VERCEL_GIT_COMMIT_SHA: "89abcdef",
+      }),
+    ).toBe("my-local-branch");
+  });
+
+  it("takes a branch name when no SHA is present", () => {
+    expect(resolveSourceRef({ GITHUB_REF_NAME: "main" })).toBe("main");
+    expect(resolveSourceRef({ GITHUB_HEAD_REF: "cf/fe-1457-x" })).toBe(
+      "cf/fe-1457-x",
+    );
+  });
+});
+
+describe("resolveSourceUrlPrefix", () => {
+  it("points at `main` by default", () => {
+    expect(resolveSourceUrlPrefix({})).toBe(
+      "https://github.com/hashintel/hash/blob/main/",
+    );
+  });
+
+  it("keeps the slashes in a branch name, which are path separators", () => {
+    expect(resolveSourceUrlPrefix({ GITHUB_HEAD_REF: "cf/fe-1457-x" })).toBe(
+      "https://github.com/hashintel/hash/blob/cf/fe-1457-x/",
+    );
+  });
+
+  it("encodes a character that would otherwise change the URL", () => {
+    expect(resolveSourceUrlPrefix({ GITHUB_HEAD_REF: "cf/a#b" })).toBe(
+      "https://github.com/hashintel/hash/blob/cf/a%23b/",
+    );
+  });
+});

--- a/libs/@local/petrinaut-arch-docs/src/source-url.ts
+++ b/libs/@local/petrinaut-arch-docs/src/source-url.ts
@@ -1,0 +1,63 @@
+/**
+ * Which git ref the generated source links point at.
+ *
+ * `main` 404s for a file the branch adds and shows the pre-change version of
+ * one it edits, so the ref comes from the build environment instead.
+ */
+
+/** Repository the source links resolve against. */
+const REPO_URL = "https://github.com/hashintel/hash";
+
+/** Ref used when the environment names none, such as a local build. */
+const DEFAULT_SOURCE_REF = "main";
+
+/**
+ * Environment variables carrying a ref, highest precedence first. A commit SHA
+ * beats a branch name because the link still resolves once the branch has moved
+ * on or been deleted.
+ *
+ * Mirrored by the `env` list in this package's `turbo.json`: a variable added
+ * here and not there is hidden by strict env mode and silently ignored.
+ */
+const REF_VARIABLES = [
+  "PETRINAUT_ARCH_DOCS_SOURCE_REF",
+  "VERCEL_GIT_COMMIT_SHA",
+  "GITHUB_SHA",
+  "VERCEL_GIT_COMMIT_REF",
+  "GITHUB_HEAD_REF",
+  "GITHUB_REF_NAME",
+] as const;
+
+export const resolveSourceRef = (
+  env: Record<string, string | undefined>,
+): string => {
+  for (const variable of REF_VARIABLES) {
+    const value = env[variable]?.trim();
+
+    if (value !== undefined && value !== "") {
+      return value;
+    }
+  }
+
+  return DEFAULT_SOURCE_REF;
+};
+
+/**
+ * Slashes are left literal: they separate path segments in a blob URL, so a
+ * `cf/fe-1457-x` branch only resolves with them intact. Everything else is
+ * encoded, since `#` or `%` in a ref would otherwise break the URL. Empty and
+ * dot-only segments are dropped: git refnames forbid them, so they can only
+ * arrive through a mistyped override, where `blob//main/` or a traversing URL
+ * would be worse than a merely wrong ref.
+ */
+const encodeRef = (ref: string): string =>
+  ref
+    .split("/")
+    .filter((segment) => segment !== "" && segment !== "." && segment !== "..")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+
+/** Base URL for source links, ending in the slash paths are appended to. */
+export const resolveSourceUrlPrefix = (
+  env: Record<string, string | undefined>,
+): string => `${REPO_URL}/blob/${encodeRef(resolveSourceRef(env))}/`;

--- a/libs/@local/petrinaut-arch-docs/turbo.json
+++ b/libs/@local/petrinaut-arch-docs/turbo.json
@@ -12,7 +12,19 @@
       "cache": false,
       // Declared so consumers can depend on this task rather than on the
       // directory existing, and so `turbo run` prunes it on a clean.
-      "outputs": ["bundle/**"]
+      "outputs": ["bundle/**"],
+      // The ref the source links point at. Declared because the default strict
+      // env mode hides anything unlisted, which would leave a preview build
+      // emitting `main` links. Mirrors REF_VARIABLES in `src/source-url.ts`;
+      // keep the two lists identical.
+      "env": [
+        "PETRINAUT_ARCH_DOCS_SOURCE_REF",
+        "VERCEL_GIT_COMMIT_SHA",
+        "GITHUB_SHA",
+        "VERCEL_GIT_COMMIT_REF",
+        "GITHUB_HEAD_REF",
+        "GITHUB_REF_NAME"
+      ]
     },
     "lint:arch-docs": {
       "cache": false


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The docs site ran on Starlight's defaults, which spent most of the width on the two side panels, and the header carried an oversized logo and title. Diagrams sat in square-cornered frames next to rounded content blocks. This PR narrows the chrome, hands the width to the content column, and makes the sidebar collapsible and resizable.

FE-1457 (#9267) sits below in this stack and FE-1314 (#9162) above.

## 🔗 Related links

- [FE-1455](https://linear.app/hash/issue/FE-1455/petrinaut-docs-site-tighter-chrome-and-more-room-for-content) *(internal)*: this PR
- [FE-1447](https://linear.app/hash/issue/FE-1447/arch-docs-emit-layer-facts-and-relations-as-structured-data-with-card) *(internal)*: the components whose radius and border the images now match

## 🔍 What does this change?

`apps/petrinaut-docs` only; the bundle stays host-neutral.

- **Widths** (`src/styles/chrome.css`, registered as Starlight `customCss`): the sidebar narrows from 18.75rem to 15.5rem, and the content column widens from 45rem to 56rem, or 64rem with the sidebar collapsed. The left nav takes its own `--pnd-sidebar-width`, because Starlight sizes both side panels from `--sl-sidebar-width` and collapsing the nav must zero one without giving the table of contents a negative width.
- **Collapse and resize** (`src/components/SiteTitle.astro`): a toggle button and a drag handle, in the header's leftmost slot beside the rail they act on. Collapsing sets `data-pnd-sidebar` on the root; the handle resizes between 224px and 480px and takes arrow keys. Both persist in `localStorage`, restored by a `head` script that runs before first paint, so a collapsed sidebar never renders open and then jumps. Every sidebar rule requires `[data-has-sidebar]`, so the splash-template 404 page gets no controls.
- **Header**: the logo drops to 1.5rem, the title from 20px semibold to 14px medium, uppercase with `0.09em` letter-spacing, and the Starlight title becomes "Docs" beside the Petrinaut logo.
- **Sidebar labels**: labels render on one line and fade at the trailing edge instead of wrapping. Group open and close animate where `::details-content` and `interpolate-size` are supported, with an instant toggle elsewhere.
- **Code font**: JetBrains Mono through Astro's font support, downloaded and subset at build time so a reader makes no request to a font host. `Head.astro` emits the faces and the preload link.
- **Images**: `0.5rem` radius and a `color-mix` border, the same values `.arch-card` uses, so a diagram frame matches the layer components in both themes. The SVG interior is untouched.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] modifies a workspace but **not** a publishable library

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] require changes to docs which **are made** as part of this PR
  - The app README describes the chrome overrides, the `SiteTitle` override, and the code font.

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

Presentation only, so there are no unit tests. `turbo run build --filter @apps/petrinaut-docs` passes and `lint:tsc` covers the component.

Checked in the browser on generated and authored pages, in dev and in the production preview, at 1440px, 1024px and 375px, in light and dark. The toggle persists across a reload with no flash, drag and arrow keys resize and clamp, both controls hide at 375px where the mobile drawer still works, and no page overflows horizontally.

## ❓ How to test this?

1. `turbo run dev --filter @apps/petrinaut-docs`
2. Toggle the sidebar from the header control, drag its right edge, then reload: the state comes back.

## 🐾 Next steps

Collapsed content width is 64rem rather than the 68rem a 1440px viewport allows, because at 68rem the column sat flush against the edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


