### PR TITLE
FE-1469: Tighten Petrinaut release notes

### DIFF
--- a/.changeset/bottom-panel-header-polish.md
+++ b/.changeset/bottom-panel-header-polish.md
@@ -2,4 +2,4 @@
 "@hashintel/petrinaut": patch
 ---
 
-Fix the Simulation Settings scenario picker overlapping its action buttons, keep the BottomPanel tab bar a constant height, fade truncated tab labels instead of wrapping, adapt the Timeline header (shrinking metric picker, hidden label) to narrow panels, and let sidebar subview content scroll through the section's full height.
+Improve narrow-panel layouts and scrolling in Simulation Settings, the timeline, bottom-panel tabs, and sidebar subviews.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -14,6 +14,7 @@
     "@tests/*",
     "@hashintel/block-design-system",
     "@hashintel/design-system",
+    "@hashintel/petrinaut-cli",
     "@hashintel/query-editor",
     "@hashintel/type-editor"
   ],

--- a/.changeset/de-brand-ai-assistant-panel.md
+++ b/.changeset/de-brand-ai-assistant-panel.md
@@ -2,4 +2,6 @@
 "@hashintel/petrinaut": patch
 ---
 
-Remove "Petrinaut" branding from the AI assistant panel: the tab now reads "AI", and the empty-state, composer label and auto-layout widget copy refer to the assistant neutrally. The `topBarStart` slot now renders after the built-in sidebar-toggle and menu buttons, immediately before the net title, so hosts can lead into the title with breadcrumbs, and a new `slots.titleStyle` hook lets hosts apply an inline style to the title input (e.g. tinting it as the final crumb).
+author: @vilkinsons
+
+Rename the AI assistant tab to "AI", use neutral assistant copy, place `topBarStart` immediately before the net title, and add `slots.titleStyle` for host-defined title styling.

--- a/.changeset/eight-streams-return.md
+++ b/.changeset/eight-streams-return.md
@@ -3,4 +3,4 @@
 "@hashintel/petrinaut": patch
 ---
 
-Make optimization runs detached and resumable — and make that the only contract. Optimization events carry a server-issued `seq`; the host optimization capability is now `createOptimizationRun`/`attachOptimizationRun`/`cancelOptimizationRun` (all required; attachments accept an `onAttached` callback so UIs can report an honest connection state), and the legacy single-connection `optimize` method is removed. The optimizations UI auto-reconnects dropped event streams by run id and cursor, re-attaching after page reloads where storage allows.
+Replace the `optimize` host capability with `createOptimizationRun`, `attachOptimizationRun`, and `cancelOptimizationRun`, enabling resumable runs and automatic reconnection.

--- a/.changeset/fe-1121-uuid-token-dimension-type.md
+++ b/.changeset/fe-1121-uuid-token-dimension-type.md
@@ -3,4 +3,4 @@
 "@hashintel/petrinaut-core": patch
 ---
 
-Add the `uuid` token attribute type: 128-bit identifiers, `bigint` at runtime, canonical strings at rest. Kernels may omit uuid fields to auto-generate them, or use `Uuid.generate()` / `Uuid.from(value)`.
+Add `uuid` token attributes with automatic generation and `Uuid.generate()` / `Uuid.from()` helpers.

--- a/.changeset/fe-1262-scenario-range-helper.md
+++ b/.changeset/fe-1262-scenario-range-helper.md
@@ -3,4 +3,4 @@
 "@hashintel/petrinaut-core": patch
 ---
 
-Scenario code fixes and helpers: array methods that read `.constructor` internally (`.map`, `.filter`, `.slice`, `.concat`, `.flatMap`) no longer throw inside scenario expressions and "Define as code" initial state; a Python-style `range(end)` / `range(start, end, step?)` helper is now in scope (and typed in the code editors); scenario compilation errors are surfaced in Simulation Settings instead of being silently ignored.
+Add `range()` to scenario code, fix common array methods in scenario expressions, and show scenario compilation errors in Simulation Settings.

--- a/.changeset/fe-1271-predicate-fires-every-frame.md
+++ b/.changeset/fe-1271-predicate-fires-every-frame.md
@@ -2,4 +2,6 @@
 "@hashintel/petrinaut-core": patch
 ---
 
-Fix predicate (boolean guard) transitions not firing on the first simulation frame or on consecutive frames. A true guard now fires in the same step it becomes true, instead of every other frame.
+author: @kube
+
+Fix Predicate transitions so true guards fire on the first and every consecutive simulation frame.

--- a/.changeset/fe-1272-predicate-copy-fires-immediately.md
+++ b/.changeset/fe-1272-predicate-copy-fires-immediately.md
@@ -2,4 +2,6 @@
 "@hashintel/petrinaut": patch
 ---
 
-Clarify the Predicate firing-time info box: it now states that the transition fires immediately — without stochastic delay — once the guard function returns true and input tokens are available.
+author: @YannisZa
+
+Clarify that Predicate transitions fire immediately when their guard is true and input tokens are available.

--- a/.changeset/fe-1353-spurious-unsaved-changes.md
+++ b/.changeset/fe-1353-spurious-unsaved-changes.md
@@ -2,4 +2,6 @@
 "@hashintel/petrinaut-core": patch
 ---
 
-Fix a net being reported as having unsaved changes immediately after loading, without the user editing anything. `sanitizeSDCPNForExtensions` no longer adds the optional `scenarios`, `metrics`, `subnets` and `componentInstances` keys with a value of `undefined` when they are absent on the source, and `isSDCPNEqual` now treats a key set to `undefined` as absent, matching the JSON form a definition is persisted in.
+author: @kube
+
+Prevent newly loaded nets from being marked as changed when optional fields are absent.

--- a/.changeset/inhibitor-arc-styling.md
+++ b/.changeset/inhibitor-arc-styling.md
@@ -2,4 +2,4 @@
 "@hashintel/petrinaut": patch
 ---
 
-Update inhibitor arc styling
+Improve inhibitor arc styling.

--- a/.changeset/net-parameters-in-metrics.md
+++ b/.changeset/net-parameters-in-metrics.md
@@ -3,4 +3,4 @@
 "@hashintel/petrinaut": patch
 ---
 
-Metrics can now read net parameters ambiently as `parameters.<variableName>` (bound to the run's resolved values, including scenario overrides). Scenario parameters remain unavailable to metrics.
+Allow metrics to read resolved net parameters through `parameters.<variableName>`; scenario parameters remain unavailable.

--- a/.changeset/optimization-seeds-per-trial.md
+++ b/.changeset/optimization-seeds-per-trial.md
@@ -2,4 +2,4 @@
 "@hashintel/petrinaut-core": patch
 ---
 
-Add an optional `execution.seedsPerTrial` field to the optimization manifest (1–100, default 1), extend the describe/evaluate contract types with the seeds-per-trial count and per-seed `replicates`, count every trial seed against the total simulation-step budget, and export the Monte Carlo `deriveRunSeed` derivation.
+Add multi-seed optimization trials through `execution.seedsPerTrial`, including per-seed replicates, budget accounting, and the exported `deriveRunSeed` helper.

--- a/.changeset/petrinaut-actual-mode.md
+++ b/.changeset/petrinaut-actual-mode.md
@@ -3,4 +3,4 @@
 "@hashintel/petrinaut-core": patch
 ---
 
-Add Actual mode: a read-only live-execution view fed by a host-provided event stream, with an Actual timeline and Events tab, recording export helpers, and a redesigned timeline series selector.
+Add Actual mode for read-only live execution, including host event streams, a timeline, an event log, and recording exports.

--- a/.changeset/petrinaut-hir-compiler.md
+++ b/.changeset/petrinaut-hir-compiler.md
@@ -3,8 +3,4 @@
 "@hashintel/petrinaut-core": patch
 ---
 
-Compile all user code (dynamics, rates, kernels, metrics) through a new HIR
-to programs reading the packed frame buffers directly, replacing Babel.
-
-Compatibility: code outside the supported TypeScript subset no longer runs —
-it is rejected with an error diagnostic pointing at the offending syntax.
+Replace Babel with the HIR compiler for user code. Unsupported TypeScript now produces diagnostics instead of running.

--- a/.changeset/petrinaut-sdcpn-capabilities.md
+++ b/.changeset/petrinaut-sdcpn-capabilities.md
@@ -3,4 +3,4 @@
 "@hashintel/petrinaut-core": patch
 ---
 
-Add handle capabilities for disabling SDCPN extensions and global parameters.
+Allow hosts to disable SDCPN extensions and global parameters.

--- a/.changeset/petrinaut-settings-right-padding.md
+++ b/.changeset/petrinaut-settings-right-padding.md
@@ -2,4 +2,4 @@
 "@hashintel/petrinaut": patch
 ---
 
-Add a small right inset to the Simulation Settings scenario picker row and parameters list so their controls don't hug the column edge.
+Improve spacing for scenario and parameter controls in Simulation Settings.

--- a/.changeset/satellites-pre-deployed-constellation.md
+++ b/.changeset/satellites-pre-deployed-constellation.md
@@ -3,4 +3,4 @@
 "@hashintel/petrinaut-core": patch
 ---
 
-Add a "Pre-deployed Constellation" scenario to the Probabilistic Satellite Launcher example: its initial state is authored in code mode, building a ring of satellites with `range(...).map(...)` from two scenario parameters (`number_of_satellites`, `initial_altitude`).
+Add a "Pre-deployed Constellation" scenario to the Probabilistic Satellite Launcher example.

--- a/.changeset/token-frame-format-packed-structs.md
+++ b/.changeset/token-frame-format-packed-structs.md
@@ -3,4 +3,4 @@
 "@hashintel/petrinaut": patch
 ---
 
-Packed-struct token frame layout (f64 numbers, u8 booleans, 8-byte strides). `getPlaceTokens(place)` and `buildMetricState(frame, places)` drop unused parameters.
+Use a packed token frame layout and simplify the `getPlaceTokens(place)` and `buildMetricState(frame, places)` APIs.

--- a/.changeset/unify-panda-css-generation.md
+++ b/.changeset/unify-panda-css-generation.md
@@ -2,4 +2,6 @@
 "@hashintel/petrinaut": patch
 ---
 
-Ship Panda static-analysis build info (`@hashintel/petrinaut/panda.buildinfo.json`) and a shared theme preset (`@hashintel/petrinaut/panda-preset`) so host applications can compile Petrinaut's styles through their own Panda pipeline instead of relying on two independently generated, layer-polyfilled bundles. Petrinaut's keyframes are now namespaced (`petrinautFadeIn`, `petrinautExpand`, ...) so they can never collide with — and be deep-merged into — a host theme's keyframes.
+author: @alex-e-leon
+
+Add Panda build metadata and a shared preset for host style generation, and namespace Petrinaut keyframes to prevent theme collisions.


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Prepare the pending Petrinaut package release with concise public changelogs, human attribution, and no release churn for the private CLI.

Linear: [FE-1469](https://linear.app/hash/issue/FE-1469/tighten-petrinaut-changesets-before-package-publishing)

## 🔍 What does this change?

- Rewrites verbose Petrinaut changeset summaries around consumer-visible behavior.
- Overrides five Claude-authored release entries with the human owner of the originating PR.
- Excludes the private `@hashintel/petrinaut-cli` package from Changesets release planning.
- Keeps every pending Petrinaut release declaration as a patch.

This updates the inputs to the generated publishing PR, [#9247](https://github.com/hashintel/hash/pull/9247).

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] updates existing changesets for npm-publishable libraries; no additional changeset is required

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] only affect release metadata and do not require user-guide changes

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- `yarn changeset status --verbose`
- Authenticated `yarn changeset version` generation check
- `git diff --check`

The generation check produced `@hashintel/petrinaut@0.0.17` and `@hashintel/petrinaut-core@0.0.3`, rendered all five human author overrides, and made no changes under `@hashintel/petrinaut-cli`.

## ❓ How to test this?

1. Run `yarn changeset status --verbose` and confirm both Petrinaut packages are patches.
2. Run `GITHUB_TOKEN=<token> yarn changeset version` in a disposable worktree.
3. Confirm the generated Petrinaut changelogs contain the revised summaries and human attributions, with no CLI changelog or version change.
