### PR TITLE
FE-1470: Split the Python bindings' transport from the session facade

### DIFF
--- a/libs/@local/petrinaut-python/README.md
+++ b/libs/@local/petrinaut-python/README.md
@@ -59,7 +59,7 @@ session = PetrinautSession.from_model_file(
 ```python
 from petrinaut import OptimizationSession
 
-# `OptimizationSession(manifest_path=...)` reads the manifest from disk instead.
+# `OptimizationSession.from_manifest_file(path)` reads the manifest from disk instead.
 with OptimizationSession(manifest) as session:
     description = session.describe()
     value = session.objective({"production_rate": 112.5, "enabled": True})

--- a/libs/@local/petrinaut-python/src/petrinaut/_transport.py
+++ b/libs/@local/petrinaut-python/src/petrinaut/_transport.py
@@ -1,0 +1,396 @@
+"""The process and wire machinery under both session classes.
+
+A :class:`CliTransport` owns one ``petrinaut serve`` child process: it spawns
+the child with a scrubbed environment and its own process group, writes the
+bootstrap line, waits for readiness on stderr, exchanges one JSON object per
+line with ids checked, bounds every read in size and time, and shuts the
+process group down. The session classes in :mod:`petrinaut.session` and
+:mod:`petrinaut.optimization` each own one transport and put a protocol
+vocabulary on top; nothing here knows what the methods mean.
+
+POSIX only: the transport signals process groups with ``os.killpg`` and polls
+descriptors with ``select.select``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import select
+import signal
+import subprocess
+import threading
+import time
+from collections.abc import Callable, Mapping, Sequence
+from contextlib import suppress
+from typing import Any, cast
+
+from .errors import (
+    PetrinautClientError,
+    PetrinautProtocolError,
+    PetrinautRunError,
+)
+
+_MIB = 1024 * 1024
+MAX_BOOTSTRAP_LINE_BYTES = 8 * _MIB
+MAX_PROTOCOL_LINE_BYTES = 8 * _MIB
+BOOTSTRAP_TIMEOUT_SECONDS = 25
+PROTOCOL_READ_TIMEOUT_SECONDS = 240
+PROCESS_SHUTDOWN_TIMEOUT_SECONDS = 5
+_READ_CHUNK_BYTES = 64 * 1024
+
+
+def _child_environment() -> dict[str, str]:
+    """Avoid exposing the calling process's credentials to model expressions."""
+    environment = {
+        "PATH": "/usr/local/bin:/usr/bin:/bin",
+        "LANG": "C.UTF-8",
+        "LC_ALL": "C.UTF-8",
+        "NO_COLOR": "1",
+        "TZ": "UTC",
+    }
+    node_options = os.environ.get("PETRINAUT_CHILD_NODE_OPTIONS", "").strip()
+    if node_options:
+        environment["NODE_OPTIONS"] = node_options
+    return environment
+
+
+def encode_bootstrap_line(payload: Mapping[str, Any], label: str) -> str:
+    """Serialize a stdin-provided model or manifest, enforcing the line cap.
+
+    Raises ``TypeError`` for a payload that will not serialize to JSON and
+    ``ValueError`` for one over the line cap: both are caller input, found
+    before any process exists, so they are not ``PetrinautClientError``,
+    which means a session's process or transport is gone.
+    """
+    try:
+        line = json.dumps(dict(payload), ensure_ascii=False, separators=(",", ":"))
+    except (TypeError, ValueError) as error:
+        raise TypeError(f"the {label} is not JSON-serializable: {error}") from error
+    if len(line.encode("utf-8")) > MAX_BOOTSTRAP_LINE_BYTES:
+        raise ValueError(
+            f"the {label} exceeds the {MAX_BOOTSTRAP_LINE_BYTES // _MIB} MiB limit"
+        )
+    return line
+
+
+class CliTransport:
+    """One CLI child process and the JSON-lines exchange with it.
+
+    ``request_timeout_seconds`` may be raised after construction — an
+    optimization session scales it by the study's seeds per trial once the
+    study has been described — so the constructor's value is also kept as
+    ``base_request_timeout_seconds`` for that recomputation to start from.
+    """
+
+    def __init__(
+        self,
+        *,
+        serve_arguments: Sequence[str],
+        bootstrap_line: str | None = None,
+        source_label: str = "model",
+        command: Sequence[str] = ("petrinaut",),
+        popen_factory: Callable[..., Any] = subprocess.Popen,
+        bootstrap_timeout_seconds: float = BOOTSTRAP_TIMEOUT_SECONDS,
+        request_timeout_seconds: float = PROTOCOL_READ_TIMEOUT_SECONDS,
+    ) -> None:
+        if not command or any(not part for part in command):
+            raise ValueError("the Petrinaut command must not be empty")
+        if bootstrap_timeout_seconds <= 0 or request_timeout_seconds <= 0:
+            raise ValueError("Petrinaut timeouts must be positive")
+
+        self.command = tuple(command)
+        self._serve_arguments = tuple(serve_arguments)
+        self._bootstrap_line = bootstrap_line
+        self._source_label = source_label
+        self._popen_factory = popen_factory
+        self._bootstrap_timeout_seconds = bootstrap_timeout_seconds
+        self.base_request_timeout_seconds = request_timeout_seconds
+        self.request_timeout_seconds = request_timeout_seconds
+        self._process: subprocess.Popen[bytes] | None = None
+        self._next_id = 1
+        self._state_lock = threading.Lock()
+        self._stdout_buffer = bytearray()
+        self._stderr_buffer = bytearray()
+        self._stderr_thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        """Launch the CLI and wait for its readiness line on stderr."""
+        with self._state_lock:
+            if self._process is not None:
+                return
+            try:
+                process = self._popen_factory(
+                    [*self.command, "serve", *self._serve_arguments],
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    bufsize=0,
+                    close_fds=True,
+                    env=_child_environment(),
+                    start_new_session=True,
+                    umask=0o077,
+                )
+            except (OSError, ValueError) as error:
+                raise PetrinautClientError(
+                    f"failed to start the Petrinaut CLI: {error}"
+                ) from error
+            self._process = process
+
+        if process.stdin is None or process.stdout is None or process.stderr is None:
+            self.close(graceful=False)
+            raise PetrinautClientError("the Petrinaut CLI pipes are unavailable")
+
+        try:
+            if self._bootstrap_line is not None:
+                process.stdin.write((self._bootstrap_line + "\n").encode())
+                process.stdin.flush()
+            status = self._readline(
+                process.stderr,
+                self._stderr_buffer,
+                timeout_seconds=self._bootstrap_timeout_seconds,
+                description="Petrinaut bootstrap",
+            ).strip()
+        except (BrokenPipeError, OSError, ValueError, PetrinautClientError) as error:
+            self.close(graceful=False)
+            raise PetrinautClientError(
+                "failed to bootstrap the Petrinaut CLI"
+            ) from error
+
+        if not status.startswith("Petrinaut stdio ready"):
+            details = status.strip() or f"process exited with code {process.poll()}"
+            self.close(graceful=False)
+            raise PetrinautClientError(
+                f"Petrinaut failed to load the {self._source_label}: {details}"
+            )
+
+        self._stderr_buffer.clear()
+        self._stderr_thread = threading.Thread(
+            target=self._drain_stderr,
+            args=(process.stderr,),
+            daemon=True,
+            name="petrinaut-stderr-drain",
+        )
+        self._stderr_thread.start()
+
+    @staticmethod
+    def _fallback_readline(stream: Any, maximum_bytes: int) -> bytes:
+        """Read test doubles which do not expose a file descriptor."""
+        line = stream.readline(maximum_bytes + 2)
+        if isinstance(line, str):
+            return line.encode()
+        return line
+
+    def _readline(
+        self,
+        stream: Any,
+        buffer: bytearray,
+        *,
+        timeout_seconds: float,
+        description: str,
+    ) -> str:
+        """Read one size- and time-bounded UTF-8 protocol line."""
+
+        def decode(line: bytes) -> str:
+            if len(line) > MAX_PROTOCOL_LINE_BYTES:
+                raise PetrinautProtocolError(
+                    f"{description} exceeded the {MAX_PROTOCOL_LINE_BYTES // _MIB} MiB line limit"
+                )
+            try:
+                return line.decode("utf-8")
+            except UnicodeDecodeError as error:
+                raise PetrinautProtocolError(
+                    f"{description} was not valid UTF-8"
+                ) from error
+
+        try:
+            descriptor = stream.fileno()
+        except (AttributeError, OSError, ValueError):
+            return decode(self._fallback_readline(stream, MAX_PROTOCOL_LINE_BYTES))
+
+        deadline = time.monotonic() + timeout_seconds
+        while True:
+            newline = buffer.find(b"\n")
+            if newline >= 0:
+                line = bytes(buffer[: newline + 1])
+                del buffer[: newline + 1]
+                return decode(line)
+            # Checked before the next read, so an unterminated line cannot grow
+            # the buffer without bound.
+            if len(buffer) > MAX_PROTOCOL_LINE_BYTES:
+                raise PetrinautProtocolError(
+                    f"{description} exceeded the {MAX_PROTOCOL_LINE_BYTES // _MIB} MiB line limit"
+                )
+
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise PetrinautClientError(f"{description} timed out")
+            ready, _, _ = select.select([descriptor], [], [], remaining)
+            if not ready:
+                raise PetrinautClientError(f"{description} timed out")
+            chunk = os.read(descriptor, _READ_CHUNK_BYTES)
+            if not chunk:
+                # EOF with no newline: whatever arrived is the last line.
+                line = bytes(buffer)
+                buffer.clear()
+                return decode(line)
+            buffer.extend(chunk)
+
+    @staticmethod
+    def _drain_stderr(stream: Any) -> None:
+        """Prevent CLI diagnostics from filling and blocking its stderr pipe."""
+        while True:
+            try:
+                chunk = stream.read(_READ_CHUNK_BYTES)
+            except (OSError, ValueError):
+                return
+            if not chunk:
+                return
+
+    def exchange(self, method: str, params: Mapping[str, Any] | None = None) -> Any:
+        """Send one request and return its ``result``, closing on breakage."""
+        process = self._process
+        if process is None or process.stdin is None or process.stdout is None:
+            raise PetrinautClientError("the Petrinaut CLI is not running")
+        if process.poll() is not None:
+            raise PetrinautClientError(
+                f"the Petrinaut CLI exited with code {process.returncode}"
+            )
+
+        request_id = self._next_id
+        request: dict[str, Any] = {"id": request_id, "method": method}
+        if params is not None:
+            request["params"] = dict(params)
+
+        # Encoded before anything is sent: a params value that cannot be
+        # serialized is the caller's bug, so it is a TypeError — not a
+        # PetrinautClientError, which would claim a healthy session is gone.
+        # The id is consumed only once encoding succeeds, so a request that
+        # was never written leaves no gap in the id sequence.
+        try:
+            payload = (json.dumps(request, separators=(",", ":")) + "\n").encode()
+        except (TypeError, ValueError) as error:
+            raise TypeError(
+                f"{method} params are not JSON-serializable: {error}"
+            ) from error
+        self._next_id += 1
+
+        try:
+            process.stdin.write(payload)
+            process.stdin.flush()
+            line = self._readline(
+                process.stdout,
+                self._stdout_buffer,
+                timeout_seconds=self.request_timeout_seconds,
+                description="Petrinaut protocol response",
+            )
+        except (PetrinautProtocolError, PetrinautClientError):
+            # Already says which limit or deadline was hit; keep that message.
+            self.close(graceful=False)
+            raise
+        except (BrokenPipeError, OSError, ValueError) as error:
+            self.close(graceful=False)
+            raise PetrinautClientError(
+                f"failed to communicate with the Petrinaut CLI: {type(error).__name__}"
+            ) from error
+
+        if not line:
+            self.close(graceful=False)
+            raise PetrinautClientError(
+                f"the Petrinaut CLI exited without a response (code {process.poll()})"
+            )
+        try:
+            return self._parse_response(line, request_id)
+        except PetrinautProtocolError:
+            self.close(graceful=False)
+            raise
+
+    @staticmethod
+    def _parse_response(line: str, request_id: int) -> Any:
+        """Validate one response without conflating handled run errors."""
+        try:
+            response = json.loads(line)
+        except json.JSONDecodeError as error:
+            raise PetrinautProtocolError(
+                "the Petrinaut CLI returned invalid JSON"
+            ) from error
+        if not isinstance(response, dict):
+            raise PetrinautProtocolError(
+                "the Petrinaut CLI returned a non-object response"
+            )
+        frame = cast("dict[str, Any]", response)
+        if frame.get("id") != request_id:
+            raise PetrinautProtocolError(
+                "the Petrinaut CLI returned a mismatched response id"
+            )
+        if "error" in frame:
+            message: Any = frame["error"]
+            if isinstance(message, dict):
+                # `json.loads` produced this, so the keys are strings.
+                message = cast("dict[str, Any]", message).get("message", message)
+            raise PetrinautRunError(str(message))
+        if "result" not in frame:
+            raise PetrinautProtocolError(
+                "the Petrinaut CLI response omitted its result"
+            )
+        return frame["result"]
+
+    @staticmethod
+    def _signal_process(process: Any, signal_number: signal.Signals) -> None:
+        """Signal the isolated process group, falling back for test doubles."""
+        process_id = getattr(process, "pid", None)
+        if isinstance(process_id, int):
+            try:
+                os.killpg(process_id, signal_number)
+            except ProcessLookupError:
+                return
+            except OSError:
+                pass
+            else:
+                return
+        if signal_number is signal.SIGTERM:
+            process.terminate()
+        else:
+            process.kill()
+
+    def close(self, *, graceful: bool = True) -> None:
+        """Terminate the owned CLI process; safe to call repeatedly.
+
+        A busy CLI only observes stdin EOF between protocol requests, so the
+        graceful EOF wait is reserved for shutdowns while the CLI is idle.
+        Cancellation, timeouts, and failure paths must pass ``graceful=False``
+        so the process group is signalled immediately instead of after the
+        full shutdown timeout.
+        """
+        with self._state_lock:
+            process = self._process
+            self._process = None
+        if process is None:
+            return
+
+        if process.stdin is not None and not process.stdin.closed:
+            with suppress(BrokenPipeError, OSError, ValueError):
+                process.stdin.close()
+        if process.poll() is None and graceful:
+            with suppress(subprocess.TimeoutExpired):
+                process.wait(timeout=PROCESS_SHUTDOWN_TIMEOUT_SECONDS)
+        if process.poll() is None:
+            self._signal_process(process, signal.SIGTERM)
+            try:
+                process.wait(timeout=PROCESS_SHUTDOWN_TIMEOUT_SECONDS)
+            except subprocess.TimeoutExpired:
+                self._signal_process(process, signal.SIGKILL)
+                with suppress(subprocess.TimeoutExpired):
+                    process.wait(timeout=PROCESS_SHUTDOWN_TIMEOUT_SECONDS)
+        for stream in (process.stdout, process.stderr):
+            if stream is not None and not stream.closed:
+                with suppress(OSError, ValueError):
+                    stream.close()
+
+        stderr_thread = self._stderr_thread
+        self._stderr_thread = None
+        if (
+            stderr_thread is not None
+            and stderr_thread is not threading.current_thread()
+        ):
+            stderr_thread.join(timeout=1)

--- a/libs/@local/petrinaut-python/src/petrinaut/optimization.py
+++ b/libs/@local/petrinaut-python/src/petrinaut/optimization.py
@@ -10,9 +10,10 @@ from typing import Any, TypeVar
 
 from pydantic import BaseModel, ValidationError
 
+from ._transport import encode_bootstrap_line
 from .errors import PetrinautProtocolError, PetrinautRunError
 from .models import OptimizationDescribeResult, OptimizationEvaluateResult
-from .session import PetrinautSession, encode_bootstrap_line
+from .session import PetrinautSession
 
 _ModelT = TypeVar("_ModelT", bound=BaseModel)
 
@@ -26,6 +27,11 @@ class OptimizationSession(PetrinautSession):
     CLI itself when ``manifest_path`` is given). The CLI owns every
     Petrinaut-specific concern: fixed-value injection, scenario compilation,
     simulation, and metric evaluation.
+
+    A manifest embeds a model, and the CLI serves both from one process, so
+    every :class:`~petrinaut.session.PetrinautSession` method works here too;
+    only this class can answer the `optimization.*` methods. Pick the class by
+    naming what the process serves: a model, or a manifest.
     """
 
     def __init__(
@@ -57,6 +63,27 @@ class OptimizationSession(PetrinautSession):
         )
         self._timeout_configured = False
 
+    @staticmethod
+    def from_manifest(
+        manifest: Mapping[str, Any], **options: Any
+    ) -> OptimizationSession:
+        """Serve a manifest object sent as the first stdin line.
+
+        The mirror of :meth:`PetrinautSession.from_model`, so both classes
+        construct the same way: name the source, get the session.
+        """
+        return OptimizationSession(manifest, **options)
+
+    @staticmethod
+    def from_manifest_file(
+        path: str | os.PathLike[str], **options: Any
+    ) -> OptimizationSession:
+        """Serve a manifest JSON file, read by the CLI itself.
+
+        The mirror of :meth:`PetrinautSession.from_model_file`.
+        """
+        return OptimizationSession(manifest_path=path, **options)
+
     def describe(self) -> OptimizationDescribeResult:
         """Return the CLI-owned Optuna study and parameter description."""
         # The generated model bounds seedsPerTrial to the CLI's 1-100 range,
@@ -67,8 +94,8 @@ class OptimizationSession(PetrinautSession):
         )
         # One evaluate may run this many seeded simulations, sequentially in
         # the worst case, so the per-response deadline scales with it.
-        self._request_timeout_seconds = (
-            self._base_request_timeout_seconds * seeds_per_trial
+        self._transport.request_timeout_seconds = (
+            self._transport.base_request_timeout_seconds * seeds_per_trial
         )
         self._timeout_configured = True
         return result

--- a/libs/@local/petrinaut-python/src/petrinaut/session.py
+++ b/libs/@local/petrinaut-python/src/petrinaut/session.py
@@ -1,75 +1,28 @@
-"""One Petrinaut CLI process, spoken to over JSON lines on stdio.
+"""The model-protocol session: what a caller can ask a model process.
 
 A session owns one long-lived ``petrinaut serve`` child process for one model
-(or one optimization manifest, see :mod:`petrinaut.optimization`). The child
-is spawned with a scrubbed environment and its own process group, requests are
-written one JSON object per line, and every read is size- and time-bounded.
+and puts the model-protocol vocabulary on it: ``healthz``, ``metadata``,
+``run``, and the generic ``request``. Everything about *how* the child is
+spawned, read, timed out, and shut down lives in :mod:`petrinaut._transport`;
+this module is the part a consumer reads.
 
-POSIX only: the session signals process groups with ``os.killpg`` and polls
-descriptors with ``select.select``.
+POSIX only, via the transport: process groups and descriptor polling.
 """
 
 from __future__ import annotations
 
-import json
 import os
-import select
-import signal
 import subprocess
-import threading
-import time
 from collections.abc import Callable, Mapping, Sequence
-from contextlib import suppress
 from typing import Any, TypeVar, cast
 
-from .errors import (
-    PetrinautClientError,
-    PetrinautProtocolError,
-    PetrinautRunError,
+from ._transport import (
+    BOOTSTRAP_TIMEOUT_SECONDS,
+    PROTOCOL_READ_TIMEOUT_SECONDS,
+    CliTransport,
+    encode_bootstrap_line,
 )
-
-_MIB = 1024 * 1024
-MAX_BOOTSTRAP_LINE_BYTES = 8 * _MIB
-MAX_PROTOCOL_LINE_BYTES = 8 * _MIB
-BOOTSTRAP_TIMEOUT_SECONDS = 25
-PROTOCOL_READ_TIMEOUT_SECONDS = 240
-PROCESS_SHUTDOWN_TIMEOUT_SECONDS = 5
-_READ_CHUNK_BYTES = 64 * 1024
-
-
-def _child_environment() -> dict[str, str]:
-    """Avoid exposing the calling process's credentials to model expressions."""
-    environment = {
-        "PATH": "/usr/local/bin:/usr/bin:/bin",
-        "LANG": "C.UTF-8",
-        "LC_ALL": "C.UTF-8",
-        "NO_COLOR": "1",
-        "TZ": "UTC",
-    }
-    node_options = os.environ.get("PETRINAUT_CHILD_NODE_OPTIONS", "").strip()
-    if node_options:
-        environment["NODE_OPTIONS"] = node_options
-    return environment
-
-
-def encode_bootstrap_line(payload: Mapping[str, Any], label: str) -> str:
-    """Serialize a stdin-provided model or manifest, enforcing the line cap.
-
-    Raises ``TypeError`` for a payload that will not serialize to JSON and
-    ``ValueError`` for one over the line cap: both are caller input, found
-    before any process exists, so they are not ``PetrinautClientError``,
-    which means a session's process or transport is gone.
-    """
-    try:
-        line = json.dumps(dict(payload), ensure_ascii=False, separators=(",", ":"))
-    except (TypeError, ValueError) as error:
-        raise TypeError(f"the {label} is not JSON-serializable: {error}") from error
-    if len(line.encode("utf-8")) > MAX_BOOTSTRAP_LINE_BYTES:
-        raise ValueError(
-            f"the {label} exceeds the {MAX_BOOTSTRAP_LINE_BYTES // _MIB} MiB limit"
-        )
-    return line
-
+from .errors import PetrinautProtocolError
 
 # The self type for ``__enter__``: a subclass used as a context manager keeps
 # its own type. ``typing.Self`` needs Python 3.11, and this package runs on 3.10.
@@ -90,6 +43,11 @@ class PetrinautSession:
     optimization methods on :class:`~petrinaut.optimization.OptimizationSession`
     return schema-validated pydantic models instead.
 
+    A model process answers only the model protocol: `optimization.*` methods
+    need a manifest-serving process, which is
+    :class:`~petrinaut.optimization.OptimizationSession`'s job — and that
+    class answers everything this one does, since a manifest embeds a model.
+
     ``command`` defaults to the ``petrinaut`` executable on the child's fixed
     ``PATH``; pass an absolute command (for example
     ``(shutil.which("node"), cli_path)``) when the CLI lives elsewhere.
@@ -107,25 +65,20 @@ class PetrinautSession:
         bootstrap_timeout_seconds: float = BOOTSTRAP_TIMEOUT_SECONDS,
         request_timeout_seconds: float = PROTOCOL_READ_TIMEOUT_SECONDS,
     ) -> None:
-        if not command or any(not part for part in command):
-            raise ValueError("the Petrinaut command must not be empty")
-        if bootstrap_timeout_seconds <= 0 or request_timeout_seconds <= 0:
-            raise ValueError("Petrinaut timeouts must be positive")
+        self._transport = CliTransport(
+            serve_arguments=serve_arguments,
+            bootstrap_line=bootstrap_line,
+            source_label=source_label,
+            command=command,
+            popen_factory=popen_factory,
+            bootstrap_timeout_seconds=bootstrap_timeout_seconds,
+            request_timeout_seconds=request_timeout_seconds,
+        )
 
-        self.command = tuple(command)
-        self._serve_arguments = tuple(serve_arguments)
-        self._bootstrap_line = bootstrap_line
-        self._source_label = source_label
-        self._popen_factory = popen_factory
-        self._bootstrap_timeout_seconds = bootstrap_timeout_seconds
-        self._base_request_timeout_seconds = request_timeout_seconds
-        self._request_timeout_seconds = request_timeout_seconds
-        self._process: subprocess.Popen[bytes] | None = None
-        self._next_id = 1
-        self._state_lock = threading.Lock()
-        self._stdout_buffer = bytearray()
-        self._stderr_buffer = bytearray()
-        self._stderr_thread: threading.Thread | None = None
+    @property
+    def command(self) -> tuple[str, ...]:
+        """The executable and arguments the session spawns."""
+        return self._transport.command
 
     # Static rather than classmethods: a subclass serving a manifest has its
     # own constructor, and routing through `cls` would reach it with no
@@ -160,62 +113,16 @@ class PetrinautSession:
 
     def start(self) -> None:
         """Launch the CLI and wait for its readiness line on stderr."""
-        with self._state_lock:
-            if self._process is not None:
-                return
-            try:
-                process = self._popen_factory(
-                    [*self.command, "serve", *self._serve_arguments],
-                    stdin=subprocess.PIPE,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
-                    bufsize=0,
-                    close_fds=True,
-                    env=_child_environment(),
-                    start_new_session=True,
-                    umask=0o077,
-                )
-            except (OSError, ValueError) as error:
-                raise PetrinautClientError(
-                    f"failed to start the Petrinaut CLI: {error}"
-                ) from error
-            self._process = process
+        self._transport.start()
 
-        if process.stdin is None or process.stdout is None or process.stderr is None:
-            self.close(graceful=False)
-            raise PetrinautClientError("the Petrinaut CLI pipes are unavailable")
+    def close(self, *, graceful: bool = True) -> None:
+        """Terminate the owned CLI process; safe to call repeatedly.
 
-        try:
-            if self._bootstrap_line is not None:
-                process.stdin.write((self._bootstrap_line + "\n").encode())
-                process.stdin.flush()
-            status = self._readline(
-                process.stderr,
-                self._stderr_buffer,
-                timeout_seconds=self._bootstrap_timeout_seconds,
-                description="Petrinaut bootstrap",
-            ).strip()
-        except (BrokenPipeError, OSError, ValueError, PetrinautClientError) as error:
-            self.close(graceful=False)
-            raise PetrinautClientError(
-                "failed to bootstrap the Petrinaut CLI"
-            ) from error
-
-        if not status.startswith("Petrinaut stdio ready"):
-            details = status.strip() or f"process exited with code {process.poll()}"
-            self.close(graceful=False)
-            raise PetrinautClientError(
-                f"Petrinaut failed to load the {self._source_label}: {details}"
-            )
-
-        self._stderr_buffer.clear()
-        self._stderr_thread = threading.Thread(
-            target=self._drain_stderr,
-            args=(process.stderr,),
-            daemon=True,
-            name="petrinaut-stderr-drain",
-        )
-        self._stderr_thread.start()
+        The graceful default first waits for an EOF-driven exit, which only an
+        idle CLI observes; ``graceful=False`` signals the child's process
+        group immediately and is what cancellation and failure paths use.
+        """
+        self._transport.close(graceful=graceful)
 
     def request(self, method: str, params: Mapping[str, Any] | None = None) -> Any:
         """Send one protocol request and return its ``result``.
@@ -227,7 +134,7 @@ class PetrinautSession:
         raise :class:`TypeError` before anything is written, leaving the
         session usable.
         """
-        return self._exchange(method, params)
+        return self._transport.exchange(method, params)
 
     def healthz(self) -> dict[str, Any]:
         """Liveness check; returns ``{"ok": True}``."""
@@ -244,230 +151,9 @@ class PetrinautSession:
     def _request_object(
         self, method: str, params: Mapping[str, Any] | None = None
     ) -> dict[str, Any]:
-        result = self._exchange(method, params)
+        result = self._transport.exchange(method, params)
         if not isinstance(result, dict):
             self.close(graceful=False)
             raise PetrinautProtocolError(f"{method} returned a non-object result")
         # `json.loads` produced this, so the keys are strings.
         return cast("dict[str, Any]", result)
-
-    @staticmethod
-    def _fallback_readline(stream: Any, maximum_bytes: int) -> bytes:
-        """Read test doubles which do not expose a file descriptor."""
-        line = stream.readline(maximum_bytes + 2)
-        if isinstance(line, str):
-            return line.encode()
-        return line
-
-    def _readline(
-        self,
-        stream: Any,
-        buffer: bytearray,
-        *,
-        timeout_seconds: float,
-        description: str,
-    ) -> str:
-        """Read one size- and time-bounded UTF-8 protocol line."""
-
-        def decode(line: bytes) -> str:
-            if len(line) > MAX_PROTOCOL_LINE_BYTES:
-                raise PetrinautProtocolError(
-                    f"{description} exceeded the {MAX_PROTOCOL_LINE_BYTES // _MIB} MiB line limit"
-                )
-            try:
-                return line.decode("utf-8")
-            except UnicodeDecodeError as error:
-                raise PetrinautProtocolError(
-                    f"{description} was not valid UTF-8"
-                ) from error
-
-        try:
-            descriptor = stream.fileno()
-        except (AttributeError, OSError, ValueError):
-            return decode(self._fallback_readline(stream, MAX_PROTOCOL_LINE_BYTES))
-
-        deadline = time.monotonic() + timeout_seconds
-        while True:
-            newline = buffer.find(b"\n")
-            if newline >= 0:
-                line = bytes(buffer[: newline + 1])
-                del buffer[: newline + 1]
-                return decode(line)
-            # Checked before the next read, so an unterminated line cannot grow
-            # the buffer without bound.
-            if len(buffer) > MAX_PROTOCOL_LINE_BYTES:
-                raise PetrinautProtocolError(
-                    f"{description} exceeded the {MAX_PROTOCOL_LINE_BYTES // _MIB} MiB line limit"
-                )
-
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                raise PetrinautClientError(f"{description} timed out")
-            ready, _, _ = select.select([descriptor], [], [], remaining)
-            if not ready:
-                raise PetrinautClientError(f"{description} timed out")
-            chunk = os.read(descriptor, _READ_CHUNK_BYTES)
-            if not chunk:
-                # EOF with no newline: whatever arrived is the last line.
-                line = bytes(buffer)
-                buffer.clear()
-                return decode(line)
-            buffer.extend(chunk)
-
-    @staticmethod
-    def _drain_stderr(stream: Any) -> None:
-        """Prevent CLI diagnostics from filling and blocking its stderr pipe."""
-        while True:
-            try:
-                chunk = stream.read(_READ_CHUNK_BYTES)
-            except (OSError, ValueError):
-                return
-            if not chunk:
-                return
-
-    def _exchange(self, method: str, params: Mapping[str, Any] | None = None) -> Any:
-        process = self._process
-        if process is None or process.stdin is None or process.stdout is None:
-            raise PetrinautClientError("the Petrinaut CLI is not running")
-        if process.poll() is not None:
-            raise PetrinautClientError(
-                f"the Petrinaut CLI exited with code {process.returncode}"
-            )
-
-        request_id = self._next_id
-        request: dict[str, Any] = {"id": request_id, "method": method}
-        if params is not None:
-            request["params"] = dict(params)
-
-        # Encoded before anything is sent: a params value that cannot be
-        # serialized is the caller's bug, so it is a TypeError — not a
-        # PetrinautClientError, which would claim a healthy session is gone.
-        # The id is consumed only once encoding succeeds, so a request that
-        # was never written leaves no gap in the id sequence.
-        try:
-            payload = (json.dumps(request, separators=(",", ":")) + "\n").encode()
-        except (TypeError, ValueError) as error:
-            raise TypeError(
-                f"{method} params are not JSON-serializable: {error}"
-            ) from error
-        self._next_id += 1
-
-        try:
-            process.stdin.write(payload)
-            process.stdin.flush()
-            line = self._readline(
-                process.stdout,
-                self._stdout_buffer,
-                timeout_seconds=self._request_timeout_seconds,
-                description="Petrinaut protocol response",
-            )
-        except (PetrinautProtocolError, PetrinautClientError):
-            # Already says which limit or deadline was hit; keep that message.
-            self.close(graceful=False)
-            raise
-        except (BrokenPipeError, OSError, ValueError) as error:
-            self.close(graceful=False)
-            raise PetrinautClientError(
-                f"failed to communicate with the Petrinaut CLI: {type(error).__name__}"
-            ) from error
-
-        if not line:
-            self.close(graceful=False)
-            raise PetrinautClientError(
-                f"the Petrinaut CLI exited without a response (code {process.poll()})"
-            )
-        try:
-            return self._parse_response(line, request_id)
-        except PetrinautProtocolError:
-            self.close(graceful=False)
-            raise
-
-    @staticmethod
-    def _parse_response(line: str, request_id: int) -> Any:
-        """Validate one response without conflating handled run errors."""
-        try:
-            response = json.loads(line)
-        except json.JSONDecodeError as error:
-            raise PetrinautProtocolError(
-                "the Petrinaut CLI returned invalid JSON"
-            ) from error
-        if not isinstance(response, dict):
-            raise PetrinautProtocolError(
-                "the Petrinaut CLI returned a non-object response"
-            )
-        frame = cast("dict[str, Any]", response)
-        if frame.get("id") != request_id:
-            raise PetrinautProtocolError(
-                "the Petrinaut CLI returned a mismatched response id"
-            )
-        if "error" in frame:
-            message: Any = frame["error"]
-            if isinstance(message, dict):
-                # `json.loads` produced this, so the keys are strings.
-                message = cast("dict[str, Any]", message).get("message", message)
-            raise PetrinautRunError(str(message))
-        if "result" not in frame:
-            raise PetrinautProtocolError(
-                "the Petrinaut CLI response omitted its result"
-            )
-        return frame["result"]
-
-    @staticmethod
-    def _signal_process(process: Any, signal_number: signal.Signals) -> None:
-        """Signal the isolated process group, falling back for test doubles."""
-        process_id = getattr(process, "pid", None)
-        if isinstance(process_id, int):
-            try:
-                os.killpg(process_id, signal_number)
-            except ProcessLookupError:
-                return
-            except OSError:
-                pass
-            else:
-                return
-        if signal_number is signal.SIGTERM:
-            process.terminate()
-        else:
-            process.kill()
-
-    def close(self, *, graceful: bool = True) -> None:
-        """Terminate the owned CLI process; safe to call repeatedly.
-
-        A busy CLI only observes stdin EOF between protocol requests, so the
-        graceful EOF wait is reserved for shutdowns while the CLI is idle.
-        Cancellation, timeouts, and failure paths must pass ``graceful=False``
-        so the process group is signalled immediately instead of after the
-        full shutdown timeout.
-        """
-        with self._state_lock:
-            process = self._process
-            self._process = None
-        if process is None:
-            return
-
-        if process.stdin is not None and not process.stdin.closed:
-            with suppress(BrokenPipeError, OSError, ValueError):
-                process.stdin.close()
-        if process.poll() is None and graceful:
-            with suppress(subprocess.TimeoutExpired):
-                process.wait(timeout=PROCESS_SHUTDOWN_TIMEOUT_SECONDS)
-        if process.poll() is None:
-            self._signal_process(process, signal.SIGTERM)
-            try:
-                process.wait(timeout=PROCESS_SHUTDOWN_TIMEOUT_SECONDS)
-            except subprocess.TimeoutExpired:
-                self._signal_process(process, signal.SIGKILL)
-                with suppress(subprocess.TimeoutExpired):
-                    process.wait(timeout=PROCESS_SHUTDOWN_TIMEOUT_SECONDS)
-        for stream in (process.stdout, process.stderr):
-            if stream is not None and not stream.closed:
-                with suppress(OSError, ValueError):
-                    stream.close()
-
-        stderr_thread = self._stderr_thread
-        self._stderr_thread = None
-        if (
-            stderr_thread is not None
-            and stderr_thread is not threading.current_thread()
-        ):
-            stderr_thread.join(timeout=1)

--- a/libs/@local/petrinaut-python/tests/test_e2e_cli.py
+++ b/libs/@local/petrinaut-python/tests/test_e2e_cli.py
@@ -139,7 +139,7 @@ def test_runs_a_seeded_optimization_study_end_to_end() -> None:
     with OptimizationSession(manifest, command=(str(NODE), str(CLI_BUNDLE))) as session:
         description = session.describe()
         assert description.study.seedsPerTrial == 2
-        assert session._request_timeout_seconds == 480
+        assert session._transport.request_timeout_seconds == 480
 
         result = session.evaluate({"infected_ratio": 0.1})
         assert result.objective == pytest.approx(0.1)

--- a/libs/@local/petrinaut-python/tests/test_optimization_session.py
+++ b/libs/@local/petrinaut-python/tests/test_optimization_session.py
@@ -20,7 +20,7 @@ from petrinaut import (
     PetrinautProtocolError,
     PetrinautRunError,
 )
-from petrinaut import session as petrinaut_session
+from petrinaut import _transport as petrinaut_transport
 
 
 def test_bootstraps_an_opaque_manifest_and_uses_optimization_methods(
@@ -110,6 +110,38 @@ def test_optimization_session_from_a_manifest_file(
     session.close()
 
 
+def test_manifest_factories_mirror_the_model_factories(
+    optimization_manifest: dict,
+) -> None:
+    """Both classes construct the same way: name the source, get the session."""
+    from_file = spawn(FakeProcess([]))
+    session = OptimizationSession.from_manifest_file(
+        "./optimize.json", popen_factory=from_file["popen_factory"]
+    )
+    session.start()
+    assert from_file["command"] == [
+        "petrinaut",
+        "serve",
+        "--optimization",
+        "./optimize.json",
+        "--stdio",
+    ]
+    session.close()
+
+    from_object = spawn(FakeProcess([]))
+    session = OptimizationSession.from_manifest(
+        optimization_manifest, popen_factory=from_object["popen_factory"]
+    )
+    session.start()
+    assert from_object["command"] == [
+        "petrinaut",
+        "serve",
+        "--optimization-stdin",
+        "--stdio",
+    ]
+    session.close()
+
+
 def test_optimization_session_requires_exactly_one_source(
     optimization_manifest: dict,
 ) -> None:
@@ -153,7 +185,7 @@ def test_bootstrap_timeout_terminates_a_stuck_process(
     optimization_manifest: dict,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(petrinaut_session, "PROCESS_SHUTDOWN_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(petrinaut_transport, "PROCESS_SHUTDOWN_TIMEOUT_SECONDS", 0.05)
     script = "import sys, time; sys.stdin.readline(); time.sleep(60)"
     model = OptimizationSession(
         optimization_manifest,
@@ -172,7 +204,7 @@ def test_protocol_timeout_terminates_a_stuck_process(
     optimization_manifest: dict,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(petrinaut_session, "PROCESS_SHUTDOWN_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(petrinaut_transport, "PROCESS_SHUTDOWN_TIMEOUT_SECONDS", 0.05)
     script = """
 import sys
 import time
@@ -209,7 +241,7 @@ def test_rejects_an_oversized_protocol_line(
         popen_factory=lambda *_args, **_kwargs: process,
     )
     model.start()
-    monkeypatch.setattr(petrinaut_session, "MAX_PROTOCOL_LINE_BYTES", 8)
+    monkeypatch.setattr(petrinaut_transport, "MAX_PROTOCOL_LINE_BYTES", 8)
 
     with pytest.raises(PetrinautProtocolError, match="line limit"):
         model.describe()
@@ -256,7 +288,7 @@ def test_close_signals_the_isolated_process_group(
     process.wait = wait  # type: ignore[method-assign]
     signals: list[tuple[int, signal.Signals]] = []
     monkeypatch.setattr(
-        petrinaut_session.os,
+        petrinaut_transport.os,
         "killpg",
         lambda pid, sent_signal: signals.append((pid, sent_signal)),
     )
@@ -289,7 +321,7 @@ def test_prompt_close_signals_the_group_before_any_shutdown_wait(
 
     process.wait = wait  # type: ignore[method-assign]
     monkeypatch.setattr(
-        petrinaut_session.os,
+        petrinaut_transport.os,
         "killpg",
         lambda _pid, sent_signal: events.append(
             f"killpg:{signal.Signals(sent_signal).name}"
@@ -438,7 +470,7 @@ def test_scales_the_request_timeout_by_the_described_seeds_per_trial(
     model.start()
 
     assert model.describe() == OptimizationDescribeResult.model_validate(description)
-    assert model._request_timeout_seconds == 1200
+    assert model._transport.request_timeout_seconds == 1200
     model.close()
 
 
@@ -465,7 +497,7 @@ def test_evaluate_without_describe_scales_the_timeout_first(
     model.start()
 
     assert model.evaluate({"rate": 1.0}).objective == 1.5
-    assert model._request_timeout_seconds == 1200
+    assert model._transport.request_timeout_seconds == 1200
     model.close()
 
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Review on #9228 asked when to use `session.py` and when to use `optimization.py`, and the honest answer was hard to see in the code: `session.py` mixed ~300 lines of process machinery with the 50-line model-protocol facade a consumer actually reads, and the two session classes constructed differently. This PR separates the machinery from the vocabulary and makes the two classes construct the same way.

Part of stack #9280: sits on FE-1412 (#9229), with the arch-docs PRs above.

## 🔗 Related links

- [FE-1470](https://linear.app/hash/issue/FE-1470/split-the-python-bindings-transport-from-the-session-facade-and-mirror) *(internal)*: this PR
- #9228 review thread that prompted it

## 🔍 What does this change?

**New private module `_transport.py`.** `CliTransport` owns everything about *how* the child process is driven: spawn with a scrubbed environment, the bootstrap line and readiness wait, size- and time-bounded reads, the JSON-lines exchange with checked ids, and process-group shutdown. The line-cap constants, `encode_bootstrap_line`, and the child environment move with it. Nothing in the module knows what any protocol method means.

**`session.py` is now the part a consumer reads.** `PetrinautSession` keeps the factories, `healthz`/`metadata`/`run`/`request`, and delegates `start`/`close` to the transport it owns. The file drops from ~470 lines to ~160, all of them protocol surface.

**`OptimizationSession` constructs like its base class.** New `from_manifest(manifest)` and `from_manifest_file(path)` mirror `from_model`/`from_model_file`; the positional constructor stays. Choosing a class is now the same gesture in both cases: name what the process serves.

**The superset rule is stated where readers look.** Both class docstrings now say it: a manifest embeds a model and the CLI serves both from one process, so every `PetrinautSession` method works on an `OptimizationSession`, and only the latter answers `optimization.*`.

No public API changes: every exported name, signature, and exception is as before.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] modifies a workspace but **not** a publishable library. `@local/petrinaut-python` is private to the monorepo.

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] require changes to docs which **are made** as part of this PR: the bindings README shows the mirrored factory. The usage manual gains the symmetric construction table in FE-1456 (#9266), where it lives.

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph.

## 🛡 What tests cover this?

The existing 31 bindings tests and 75 `petrinaut-opt` tests run unchanged, apart from three assertions that reached into `_request_timeout_seconds` and two module-level monkeypatches, which follow the constants to `_transport`. One new test pins that the manifest factories spawn the same CLI invocations as the constructor forms.

## ❓ How to test this?

1. `turbo run test:unit lint:ruff lint:types --filter @local/petrinaut-python --filter @apps/petrinaut-opt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

