### PR TITLE
BE-773: Drop the nil-UUID sentinel from the created-by filter

### DIFF
--- a/libs/@local/graph/postgres-store/src/store/postgres/query/compile/tests.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/compile/tests.rs
@@ -2118,9 +2118,8 @@ mod property_masking {
             &compiler,
             r#"
             SELECT ("entity_editions_0_1_0"."properties" - (CASE WHEN
-                ("entity_temporal_metadata_0_0_0"."entity_uuid" != $1)
-                AND ("entity_edition_cache_0_1_0"."base_urls" @> ARRAY[$2]::text[])
-                THEN ARRAY[$3]::text[]
+                ("entity_edition_cache_0_1_0"."base_urls" @> ARRAY[$1]::text[])
+                THEN ARRAY[$2]::text[]
                 ELSE ARRAY[]::text[] END))
             FROM "entity_temporal_metadata" AS "entity_temporal_metadata_0_0_0"
             INNER JOIN "entity_editions" AS "entity_editions_0_1_0"
@@ -2132,7 +2131,6 @@ mod property_masking {
             WHERE "entity_temporal_metadata_0_0_0"."draft_id" IS NULL
             "#,
             &[
-                &Uuid::nil(),
                 &"https://hash.ai/@h/types/entity-type/user/",
                 &"https://hash.ai/@h/types/property-type/email/",
             ],

--- a/libs/@local/graph/store/src/filter/mod.rs
+++ b/libs/@local/graph/store/src/filter/mod.rs
@@ -1242,12 +1242,17 @@ impl<'p> Filter<'p, Entity> {
                 filters
                     .into_iter()
                     .map(|filter| Self::for_property_filter(filter, actor_id))
+                    // A comparison that matches every record constrains nothing within a
+                    // conjunction.
+                    .filter(|filter| !matches!(filter, Self::All(inner) if inner.is_empty()))
                     .collect(),
             ),
             PropertyFilter::Any(filters) => Self::Any(
                 filters
                     .into_iter()
                     .map(|filter| Self::for_property_filter(filter, actor_id))
+                    // A comparison that matches no record adds nothing to a disjunction.
+                    .filter(|filter| !matches!(filter, Self::Any(inner) if inner.is_empty()))
                     .collect(),
             ),
             PropertyFilter::Equal(lhs, rhs) => {
@@ -1272,10 +1277,10 @@ impl<'p> Filter<'p, Entity> {
                 }
             }
             PropertyFilter::In(lhs, rhs) => {
-                match FilterExpression::from_cell_filter_expression(lhs, actor_id) {
-                    Some(lhs) => Self::In(lhs, FilterExpressionList::from(rhs)),
-                    None => Self::Any(Vec::new()),
-                }
+                FilterExpression::from_cell_filter_expression(lhs, actor_id).map_or_else(
+                    || Self::Any(Vec::new()),
+                    |lhs| Self::In(lhs, FilterExpressionList::from(rhs)),
+                )
             }
         }
     }

--- a/libs/@local/graph/store/src/filter/mod.rs
+++ b/libs/@local/graph/store/src/filter/mod.rs
@@ -1235,11 +1235,11 @@ impl<'p> Filter<'p, Entity> {
         }
     }
 
-    #[must_use]
     /// Transforms a property filter into a query filter for the given actor.
     ///
     /// A request without an actor leaves the actor comparison without a value: an equality then
     /// matches no record, an inequality every record.
+    #[must_use]
     fn for_property_filter(filter: PropertyFilter<'p>, actor_id: Option<ActorId>) -> Self {
         match filter {
             PropertyFilter::All(filters) => Self::All(

--- a/libs/@local/graph/store/src/filter/mod.rs
+++ b/libs/@local/graph/store/src/filter/mod.rs
@@ -1236,14 +1236,16 @@ impl<'p> Filter<'p, Entity> {
     }
 
     #[must_use]
+    /// Transforms a property filter into a query filter for the given actor.
+    ///
+    /// A request without an actor leaves the actor comparison without a value: an equality then
+    /// matches no record, an inequality every record.
     fn for_property_filter(filter: PropertyFilter<'p>, actor_id: Option<ActorId>) -> Self {
         match filter {
             PropertyFilter::All(filters) => Self::All(
                 filters
                     .into_iter()
                     .map(|filter| Self::for_property_filter(filter, actor_id))
-                    // A comparison that matches every record constrains nothing within a
-                    // conjunction.
                     .filter(|filter| !matches!(filter, Self::All(inner) if inner.is_empty()))
                     .collect(),
             ),
@@ -1251,7 +1253,6 @@ impl<'p> Filter<'p, Entity> {
                 filters
                     .into_iter()
                     .map(|filter| Self::for_property_filter(filter, actor_id))
-                    // A comparison that matches no record adds nothing to a disjunction.
                     .filter(|filter| !matches!(filter, Self::Any(inner) if inner.is_empty()))
                     .collect(),
             ),
@@ -1261,8 +1262,6 @@ impl<'p> Filter<'p, Entity> {
                     FilterExpression::from_cell_filter_expression(rhs, actor_id),
                 ) {
                     (Some(lhs), Some(rhs)) => Self::Equal(lhs, rhs),
-                    // A request without an actor has no value to compare against, so nothing
-                    // equals it.
                     _ => Self::Any(Vec::new()),
                 }
             }
@@ -1272,7 +1271,6 @@ impl<'p> Filter<'p, Entity> {
                     FilterExpression::from_cell_filter_expression(rhs, actor_id),
                 ) {
                     (Some(lhs), Some(rhs)) => Self::NotEqual(lhs, rhs),
-                    // Everything differs from a value that is not there.
                     _ => Self::All(Vec::new()),
                 }
             }
@@ -1496,8 +1494,7 @@ impl<R: QueryRecord> FilterExpression<'_, R> {
 impl<'p> FilterExpression<'p, Entity> {
     /// Converts a cell filter expression into a query filter expression.
     ///
-    /// Returns [`None`] for [`ActorId`] when the request carries no actor, leaving it to the
-    /// caller to decide what a comparison against a missing actor means.
+    /// Returns [`None`] for [`ActorId`] when the request carries no actor.
     ///
     /// [`ActorId`]: PropertyFilterExpression::ActorId
     #[must_use]

--- a/libs/@local/graph/store/src/filter/mod.rs
+++ b/libs/@local/graph/store/src/filter/mod.rs
@@ -30,7 +30,6 @@ use type_system::{
     },
     principal::actor::{ActorEntityUuid, ActorId},
 };
-use uuid::Uuid;
 
 pub use self::{
     parameter::{
@@ -1251,18 +1250,33 @@ impl<'p> Filter<'p, Entity> {
                     .map(|filter| Self::for_property_filter(filter, actor_id))
                     .collect(),
             ),
-            PropertyFilter::Equal(lhs, rhs) => Self::Equal(
-                FilterExpression::from_cell_filter_expression(lhs, actor_id),
-                FilterExpression::from_cell_filter_expression(rhs, actor_id),
-            ),
-            PropertyFilter::NotEqual(lhs, rhs) => Self::NotEqual(
-                FilterExpression::from_cell_filter_expression(lhs, actor_id),
-                FilterExpression::from_cell_filter_expression(rhs, actor_id),
-            ),
-            PropertyFilter::In(lhs, rhs) => Self::In(
-                FilterExpression::from_cell_filter_expression(lhs, actor_id),
-                FilterExpressionList::from(rhs),
-            ),
+            PropertyFilter::Equal(lhs, rhs) => {
+                match (
+                    FilterExpression::from_cell_filter_expression(lhs, actor_id),
+                    FilterExpression::from_cell_filter_expression(rhs, actor_id),
+                ) {
+                    (Some(lhs), Some(rhs)) => Self::Equal(lhs, rhs),
+                    // A request without an actor has no value to compare against, so nothing
+                    // equals it.
+                    _ => Self::Any(Vec::new()),
+                }
+            }
+            PropertyFilter::NotEqual(lhs, rhs) => {
+                match (
+                    FilterExpression::from_cell_filter_expression(lhs, actor_id),
+                    FilterExpression::from_cell_filter_expression(rhs, actor_id),
+                ) {
+                    (Some(lhs), Some(rhs)) => Self::NotEqual(lhs, rhs),
+                    // Everything differs from a value that is not there.
+                    _ => Self::All(Vec::new()),
+                }
+            }
+            PropertyFilter::In(lhs, rhs) => {
+                match FilterExpression::from_cell_filter_expression(lhs, actor_id) {
+                    Some(lhs) => Self::In(lhs, FilterExpressionList::from(rhs)),
+                    None => Self::Any(Vec::new()),
+                }
+            }
         }
     }
 }
@@ -1475,21 +1489,27 @@ impl<R: QueryRecord> FilterExpression<'_, R> {
 }
 
 impl<'p> FilterExpression<'p, Entity> {
+    /// Converts a cell filter expression into a query filter expression.
+    ///
+    /// Returns [`None`] for [`ActorId`] when the request carries no actor, leaving it to the
+    /// caller to decide what a comparison against a missing actor means.
+    ///
+    /// [`ActorId`]: PropertyFilterExpression::ActorId
     #[must_use]
     pub fn from_cell_filter_expression(
         expression: PropertyFilterExpression<'p>,
         actor_id: Option<ActorId>,
-    ) -> Self {
+    ) -> Option<Self> {
         match expression {
-            PropertyFilterExpression::Path { path } => Self::Path { path },
-            PropertyFilterExpression::Parameter { parameter } => Self::Parameter {
+            PropertyFilterExpression::Path { path } => Some(Self::Path { path }),
+            PropertyFilterExpression::Parameter { parameter } => Some(Self::Parameter {
                 parameter,
                 convert: None,
-            },
-            PropertyFilterExpression::ActorId => Self::Parameter {
-                parameter: Parameter::Uuid(actor_id.map_or_else(Uuid::nil, Uuid::from)),
+            }),
+            PropertyFilterExpression::ActorId => actor_id.map(|actor_id| Self::Parameter {
+                parameter: Parameter::Uuid(actor_id.into()),
                 convert: None,
-            },
+            }),
         }
     }
 }

--- a/libs/@local/graph/store/src/filter/protection.rs
+++ b/libs/@local/graph/store/src/filter/protection.rs
@@ -1412,6 +1412,7 @@ mod tests {
     // =========================================================================
 
     mod transform {
+        use type_system::principal::actor::{ActorEntityUuid, UserId};
         use uuid::Uuid;
 
         use super::*;
@@ -1433,18 +1434,11 @@ mod tests {
             )
         }
 
-        /// Creates `Uuid != ActorId` filter (entity UUID is not the actor's UUID).
-        /// When `actor_id` is `None`, uses `Uuid::nil()`.
+        /// Creates the `Uuid != ActorId` comparison for a request without an actor.
+        ///
+        /// Nothing equals an actor that is not there, so every record differs from it.
         fn uuid_not_actor() -> Filter<'static, Entity> {
-            Filter::NotEqual(
-                FilterExpression::Path {
-                    path: EntityQueryPath::Uuid,
-                },
-                FilterExpression::Parameter {
-                    parameter: Parameter::Uuid(Uuid::nil()),
-                    convert: None,
-                },
-            )
+            Filter::All(Vec::new())
         }
 
         /// Creates the full exclusion filter: `(type = User AND uuid != ActorId)`.
@@ -1639,6 +1633,41 @@ mod tests {
             ]);
 
             assert_eq!(do_transform(input), expected);
+        }
+
+        // -----------------------------------------------------------------
+        // Extra: The actor comparison for a request that carries an actor
+        // -----------------------------------------------------------------
+
+        #[test]
+        fn actor_compares_against_its_own_uuid() {
+            let actor_uuid = Uuid::new_v4();
+            let actor_id = ActorId::User(UserId::new(ActorEntityUuid::new(actor_uuid)));
+
+            let transformed = transform_filter(
+                email_eq("test@example.com"),
+                &email_protection_config(),
+                0,
+                Some(actor_id),
+            );
+
+            let expected = all(vec![
+                email_eq("test@example.com"),
+                not(all(vec![
+                    type_is_user(),
+                    Filter::NotEqual(
+                        FilterExpression::Path {
+                            path: EntityQueryPath::Uuid,
+                        },
+                        FilterExpression::Parameter {
+                            parameter: Parameter::Uuid(actor_uuid),
+                            convert: None,
+                        },
+                    ),
+                ])),
+            ]);
+
+            assert_eq!(transformed, expected);
         }
     }
 }

--- a/libs/@local/graph/store/src/filter/protection.rs
+++ b/libs/@local/graph/store/src/filter/protection.rs
@@ -1434,17 +1434,13 @@ mod tests {
             )
         }
 
-        /// Creates the `Uuid != ActorId` comparison for a request without an actor.
+        /// Creates the exclusion filter of `hash_default()` as it transforms without an actor.
         ///
-        /// Nothing equals an actor that is not there, so every record differs from it.
-        fn uuid_not_actor() -> Filter<'static, Entity> {
-            Filter::All(Vec::new())
-        }
-
-        /// Creates the full exclusion filter: `(type = User AND uuid != ActorId)`.
-        /// This matches the structure from `hash_default()`.
+        /// The rule is `type = User AND uuid != ActorId`. Nothing equals an actor that is not
+        /// there, so every record differs from it and the comparison drops out of the
+        /// conjunction.
         fn exclusion_filter() -> Filter<'static, Entity> {
-            all(vec![type_is_user(), uuid_not_actor()])
+            all(vec![type_is_user()])
         }
 
         /// Creates `NOT(type = User AND uuid != ActorId)` filter.

--- a/libs/@local/graph/store/src/filter/protection.rs
+++ b/libs/@local/graph/store/src/filter/protection.rs
@@ -1434,11 +1434,8 @@ mod tests {
             )
         }
 
-        /// Creates the exclusion filter of `hash_default()` as it transforms without an actor.
-        ///
-        /// The rule is `type = User AND uuid != ActorId`. Nothing equals an actor that is not
-        /// there, so every record differs from it and the comparison drops out of the
-        /// conjunction.
+        /// Creates the `hash_default()` exclusion filter as it transforms without an actor, which
+        /// drops the `uuid != ActorId` comparison.
         fn exclusion_filter() -> Filter<'static, Entity> {
             all(vec![type_is_user()])
         }
@@ -1630,10 +1627,6 @@ mod tests {
 
             assert_eq!(do_transform(input), expected);
         }
-
-        // -----------------------------------------------------------------
-        // Extra: The actor comparison for a request that carries an actor
-        // -----------------------------------------------------------------
 
         #[test]
         fn actor_compares_against_its_own_uuid() {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The property-protection filter compiled a request without an actor to a nil-UUID parameter, the last place in the query layer that read the nil UUID as the public actor. The comparison now says what it means: nothing equals an actor that is not there.

## 🔗 Related links

- [BE-773](https://linear.app/hash/issue/BE-773) _(internal)_

## 🚫 Blocked by

-  #9279

## 🔍 What does this change?

- `FilterExpression::from_cell_filter_expression` returns [`None`] for the actor expression when the request carries no actor, instead of substituting the nil UUID
- `Filter::for_property_filter` decides per comparison what a missing actor means: an equality matches no record, an inequality matches every record, and an `IN` matches no record
- Covers the actor-present branch, which had no test

Behaviour is unchanged: an empty `All` transpiles to `TRUE` and an empty `Any` to `FALSE`, which is what `uuid != nil` and `uuid = nil` evaluated to for every real row.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

- The remaining `Uuid::nil()` uses in `entity/table.rs` are cursor and fixture values in tests, not actor sentinels, so they stay.

## 🐾 Next steps

- BE-758: rate limiting, ahead of the versioned public API surface

## 🛡 What tests cover this?

- The property-protection transform cases, whose fixtures now pin the anonymous case as a tautology rather than a nil comparison
- A new case pinning that a request with an actor compares against that actor's UUID

## ❓ How to test this?

1. `cargo nextest run --package hash-graph-store --all-features`
2. `cargo clippy --all-features --package hash-graph-store --all-targets`
