### PR TITLE
FE-262: Disable form submit when autocomplete is open

### DIFF
--- a/libs/@hashintel/design-system/src/autocomplete.tsx
+++ b/libs/@hashintel/design-system/src/autocomplete.tsx
@@ -56,6 +56,8 @@ export const Autocomplete = <
 >({
   inputHeight = 57,
   open,
+  onOpen,
+  onClose,
   sx,
   inputRef,
   inputPlaceholder,
@@ -85,6 +87,9 @@ export const Autocomplete = <
 
   const [anchorEl, setAnchorEl] = useState<HTMLDivElement | null>(null);
 
+  const [internalOpen, setInternalOpen] = useState(false);
+  const isOpen = open ?? internalOpen;
+
   const popperOpenStyles = joined
     ? {
         ...popperPlacementInputNoRadius,
@@ -111,6 +116,14 @@ export const Autocomplete = <
     <MUIAutocomplete
       noOptionsText="No options found..."
       open={open}
+      onOpen={(event) => {
+        setInternalOpen(true);
+        onOpen?.(event);
+      }}
+      onClose={(event, reason) => {
+        setInternalOpen(false);
+        onClose?.(event, reason);
+      }}
       options={options}
       sx={[{ width: "100%" }, ...(Array.isArray(sx) ? sx : [sx])]}
       /**
@@ -138,6 +151,16 @@ export const Autocomplete = <
           onKeyDown={(event) => {
             if (event.key === "Backspace") {
               event.stopPropagation();
+            }
+            /**
+             * Stop an open dropdown from submitting the surrounding form on
+             * Enter. MUI only calls preventDefault() on Enter when an option
+             * is highlighted, so an open menu with nothing highlighted would
+             * otherwise trigger the form's implicit submission. We don't
+             * stopPropagation so MUI can still select a highlighted option.
+             */
+            if (event.key === "Enter" && isOpen) {
+              event.preventDefault();
             }
           }}
           InputProps={{

--- a/libs/@hashintel/design-system/src/selector-autocomplete.tsx
+++ b/libs/@hashintel/design-system/src/selector-autocomplete.tsx
@@ -173,6 +173,8 @@ export const SelectorAutocomplete = <
   Multiple extends boolean | undefined = undefined,
 >({
   open,
+  onOpen,
+  onClose,
   isOptionEqualToValue,
   optionToRenderData,
   sx,
@@ -203,6 +205,9 @@ export const SelectorAutocomplete = <
 
   const [anchorEl, setAnchorEl] = useState<HTMLDivElement | null>(null);
 
+  const [internalOpen, setInternalOpen] = useState(false);
+  const isOpen = open ?? internalOpen;
+
   const height = inputHeight ?? TYPE_SELECTOR_HEIGHT;
 
   const dropdownContextValue = useMemo(
@@ -220,6 +225,14 @@ export const SelectorAutocomplete = <
         <Autocomplete
           multiple={multiple}
           open={open}
+          onOpen={(event) => {
+            setInternalOpen(true);
+            onOpen?.(event);
+          }}
+          onClose={(event, reason) => {
+            setInternalOpen(false);
+            onClose?.(event, reason);
+          }}
           sx={[{ width: "100%" }, ...(Array.isArray(sx) ? sx : [sx])]}
           /**
            * By default, the anchor element for an autocomplete dropdown is the
@@ -245,6 +258,16 @@ export const SelectorAutocomplete = <
               onKeyDown={(event) => {
                 if (event.key === "Backspace") {
                   event.stopPropagation();
+                }
+                /**
+                 * Stop an open dropdown from submitting the surrounding form on
+                 * Enter. MUI only calls preventDefault() on Enter when an option
+                 * is highlighted, so an open menu with nothing highlighted would
+                 * otherwise trigger the form's implicit submission. We don't
+                 * stopPropagation so MUI can still select a highlighted option.
+                 */
+                if (event.key === "Enter" && isOpen) {
+                  event.preventDefault();
                 }
               }}
               InputProps={{


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The default behaviour of a MUI autocomplete is that enter propogates if no item in the autocomplete is selected. When nested in a form, this triggers the default behaviour of enter submitting a form. The fix is to not have enter submit a form when an autocomplete is in an open state.

Note: Pressing enter when focused on an input inside a form will still submit the form, including if an autocomplete is focused and closed. This is standard behaviour across the web, so chose not to break it. In the originally reported issue, this never happens anyway, because when the autocomplete closes it becomes a completely new component, so hitting enter even on close won't submit the form.

Finally a note on implemenation: the open state is now tracked inside autocomplete components because autocomplete currently can be controlled or uncontrolled - the new state allows us to continue handling both.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change
