### PR TITLE
BE-776, BE-777, BE-775: HashQL: Const-evaluable typed IDs, IdMatrix, and fixed-endianness ID byte layouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4203,6 +4203,7 @@ dependencies = [
  "pretty",
  "proptest",
  "rapidfuzz",
+ "rayon",
  "roaring",
  "rstest",
  "serde",
@@ -4213,6 +4214,7 @@ dependencies = [
  "tracing",
  "unicase",
  "unicode-segmentation",
+ "zerocopy",
 ]
 
 [[package]]
@@ -11893,18 +11895,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -313,6 +313,7 @@ wasm-bindgen                       = { version = "0.2.100", default-features = f
 wasm-bindgen-test                  = { version = "0.3.50", default-features = false }
 winnow                             = { version = "1.0.0", default-features = false }
 xxhash-rust                        = { version = "0.8.15", default-features = false }
+zerocopy                           = { version = "0.8.55" }
 
 [profile.dev]
 # TODO: Use `codegen-backend = "cranelift"`

--- a/libs/@local/graph/api/src/rest/hashql/compile.rs
+++ b/libs/@local/graph/api/src/rest/hashql/compile.rs
@@ -179,6 +179,7 @@ impl<'heap> Compilation<'heap> {
         })
     }
 
+    #[expect(clippy::missing_const_for_fn, reason = "false positive")]
     pub(crate) fn context(&self) -> CodeExecutionContext<'_, 'heap, &'heap Heap> {
         CodeExecutionContext {
             env: &self.env,

--- a/libs/@local/hashql/core/Cargo.toml
+++ b/libs/@local/hashql/core/Cargo.toml
@@ -17,8 +17,10 @@ anstyle   = { workspace = true, public = true }
 foldhash  = { workspace = true, public = true }
 hashbrown = { workspace = true, public = true }
 pretty    = { workspace = true, public = true }
+rayon     = { workspace = true, optional = true, public = true }
 smallvec  = { workspace = true, public = true }
 text-size = { workspace = true, public = true }
+zerocopy  = { workspace = true, optional = true, public = true, features = ["derive"] }
 
 # Private workspace dependencies
 
@@ -38,12 +40,6 @@ tracing              = { workspace = true }
 unicase              = { workspace = true, features = ["nightly"] }
 unicode-segmentation = { workspace = true }
 
-[features]
-serde = ["dep:serde", "text-size/serde"]
-
-[lints]
-workspace = true
-
 [dev-dependencies]
 codspeed-criterion-compat = { workspace = true }
 darwin-kperf-criterion    = { workspace = true, features = ["codspeed"] }
@@ -51,6 +47,16 @@ insta                     = { workspace = true }
 proptest                  = { workspace = true }
 rstest                    = { workspace = true }
 test-strategy             = { workspace = true }
+zerocopy                  = { workspace = true, features = ["derive"] }
+
+
+[features]
+serde    = ["dep:serde", "text-size/serde"]
+rayon    = ["dep:rayon"]
+zerocopy = ["dep:zerocopy"]
+
+[lints]
+workspace = true
 
 [[bench]]
 name    = "type_system"

--- a/libs/@local/hashql/core/docs/dependency-diagram.mmd
+++ b/libs/@local/hashql/core/docs/dependency-diagram.mmd
@@ -12,45 +12,49 @@ graph TD
     1[<a href="../hash_codec/index.html">hash-codec</a>]
     2[<a href="../hash_codegen/index.html">hash-codegen</a>]
     3[<a href="../hash_graph_api/index.html">hash-graph-api</a>]
-    4[<a href="../harpc_types/index.html">harpc-types</a>]
-    5[<a href="../harpc_wire_protocol/index.html">harpc-wire-protocol</a>]
-    6[<a href="../hashql_ast/index.html">hashql-ast</a>]
-    7[<a href="../hashql_compiletest/index.html">hashql-compiletest</a>]
-    8[hashql-core]
-    class 8 root
-    9[<a href="../hashql_diagnostics/index.html">hashql-diagnostics</a>]
-    10[<a href="../hashql_eval/index.html">hashql-eval</a>]
-    11[<a href="../hashql_hir/index.html">hashql-hir</a>]
-    12[<a href="../hashql_macros/index.html">hashql-macros</a>]
-    13[<a href="../hashql_mir/index.html">hashql-mir</a>]
-    14[<a href="../hashql_syntax_jexpr/index.html">hashql-syntax-jexpr</a>]
-    15[<a href="../darwin_kperf/index.html">darwin-kperf</a>]
-    16[<a href="../darwin_kperf_criterion/index.html">darwin-kperf-criterion</a>]
-    17[<a href="../darwin_kperf_events/index.html">darwin-kperf-events</a>]
-    18[<a href="../darwin_kperf_sys/index.html">darwin-kperf-sys</a>]
-    19[<a href="../error_stack/index.html">error-stack</a>]
-    20[<a href="../hash_graph_benches/index.html">hash-graph-benches</a>]
+    4[<a href="../hash_graph_atlas/index.html">hash-graph-atlas</a>]
+    5[<a href="../harpc_types/index.html">harpc-types</a>]
+    6[<a href="../harpc_wire_protocol/index.html">harpc-wire-protocol</a>]
+    7[<a href="../hashql_ast/index.html">hashql-ast</a>]
+    8[<a href="../hashql_compiletest/index.html">hashql-compiletest</a>]
+    9[hashql-core]
+    class 9 root
+    10[<a href="../hashql_diagnostics/index.html">hashql-diagnostics</a>]
+    11[<a href="../hashql_eval/index.html">hashql-eval</a>]
+    12[<a href="../hashql_hir/index.html">hashql-hir</a>]
+    13[<a href="../hashql_macros/index.html">hashql-macros</a>]
+    14[<a href="../hashql_mir/index.html">hashql-mir</a>]
+    15[<a href="../hashql_syntax_jexpr/index.html">hashql-syntax-jexpr</a>]
+    16[<a href="../darwin_kperf/index.html">darwin-kperf</a>]
+    17[<a href="../darwin_kperf_criterion/index.html">darwin-kperf-criterion</a>]
+    18[<a href="../darwin_kperf_events/index.html">darwin-kperf-events</a>]
+    19[<a href="../darwin_kperf_sys/index.html">darwin-kperf-sys</a>]
+    20[<a href="../error_stack/index.html">error-stack</a>]
+    21[<a href="../hash_graph_benches/index.html">hash-graph-benches</a>]
     0 --> 3
+    0 --> 4
     1 -.-> 2
-    1 --> 5
-    3 --> 10
-    3 --> 14
-    5 -.-> 4
-    5 --> 4
-    5 --> 19
-    6 -.-> 7
-    7 --> 10
-    7 --> 14
-    8 --> 1
-    8 --> 9
-    8 --> 12
-    8 -.-> 16
-    10 --> 13
-    11 -.-> 7
-    13 --> 11
-    14 --> 6
-    14 --> 8
-    15 --> 17
-    15 --> 18
-    16 --> 15
-    20 -.-> 3
+    1 --> 6
+    3 --> 11
+    3 --> 15
+    4 --> 9
+    4 --> 20
+    6 -.-> 5
+    6 --> 5
+    6 --> 20
+    7 -.-> 8
+    8 --> 11
+    8 --> 15
+    9 --> 1
+    9 --> 10
+    9 --> 13
+    9 -.-> 17
+    11 --> 14
+    12 -.-> 8
+    14 --> 12
+    15 --> 7
+    15 --> 9
+    16 --> 18
+    16 --> 19
+    17 --> 16
+    21 -.-> 3

--- a/libs/@local/hashql/core/docs/dependency-diagram.mmd
+++ b/libs/@local/hashql/core/docs/dependency-diagram.mmd
@@ -12,49 +12,45 @@ graph TD
     1[<a href="../hash_codec/index.html">hash-codec</a>]
     2[<a href="../hash_codegen/index.html">hash-codegen</a>]
     3[<a href="../hash_graph_api/index.html">hash-graph-api</a>]
-    4[<a href="../hash_graph_atlas/index.html">hash-graph-atlas</a>]
-    5[<a href="../harpc_types/index.html">harpc-types</a>]
-    6[<a href="../harpc_wire_protocol/index.html">harpc-wire-protocol</a>]
-    7[<a href="../hashql_ast/index.html">hashql-ast</a>]
-    8[<a href="../hashql_compiletest/index.html">hashql-compiletest</a>]
-    9[hashql-core]
-    class 9 root
-    10[<a href="../hashql_diagnostics/index.html">hashql-diagnostics</a>]
-    11[<a href="../hashql_eval/index.html">hashql-eval</a>]
-    12[<a href="../hashql_hir/index.html">hashql-hir</a>]
-    13[<a href="../hashql_macros/index.html">hashql-macros</a>]
-    14[<a href="../hashql_mir/index.html">hashql-mir</a>]
-    15[<a href="../hashql_syntax_jexpr/index.html">hashql-syntax-jexpr</a>]
-    16[<a href="../darwin_kperf/index.html">darwin-kperf</a>]
-    17[<a href="../darwin_kperf_criterion/index.html">darwin-kperf-criterion</a>]
-    18[<a href="../darwin_kperf_events/index.html">darwin-kperf-events</a>]
-    19[<a href="../darwin_kperf_sys/index.html">darwin-kperf-sys</a>]
-    20[<a href="../error_stack/index.html">error-stack</a>]
-    21[<a href="../hash_graph_benches/index.html">hash-graph-benches</a>]
+    4[<a href="../harpc_types/index.html">harpc-types</a>]
+    5[<a href="../harpc_wire_protocol/index.html">harpc-wire-protocol</a>]
+    6[<a href="../hashql_ast/index.html">hashql-ast</a>]
+    7[<a href="../hashql_compiletest/index.html">hashql-compiletest</a>]
+    8[hashql-core]
+    class 8 root
+    9[<a href="../hashql_diagnostics/index.html">hashql-diagnostics</a>]
+    10[<a href="../hashql_eval/index.html">hashql-eval</a>]
+    11[<a href="../hashql_hir/index.html">hashql-hir</a>]
+    12[<a href="../hashql_macros/index.html">hashql-macros</a>]
+    13[<a href="../hashql_mir/index.html">hashql-mir</a>]
+    14[<a href="../hashql_syntax_jexpr/index.html">hashql-syntax-jexpr</a>]
+    15[<a href="../darwin_kperf/index.html">darwin-kperf</a>]
+    16[<a href="../darwin_kperf_criterion/index.html">darwin-kperf-criterion</a>]
+    17[<a href="../darwin_kperf_events/index.html">darwin-kperf-events</a>]
+    18[<a href="../darwin_kperf_sys/index.html">darwin-kperf-sys</a>]
+    19[<a href="../error_stack/index.html">error-stack</a>]
+    20[<a href="../hash_graph_benches/index.html">hash-graph-benches</a>]
     0 --> 3
-    0 --> 4
     1 -.-> 2
-    1 --> 6
-    3 --> 11
-    3 --> 15
-    4 --> 9
-    4 --> 20
-    6 -.-> 5
-    6 --> 5
-    6 --> 20
-    7 -.-> 8
-    8 --> 11
-    8 --> 15
-    9 --> 1
-    9 --> 10
-    9 --> 13
-    9 -.-> 17
-    11 --> 14
-    12 -.-> 8
-    14 --> 12
-    15 --> 7
-    15 --> 9
-    16 --> 18
-    16 --> 19
-    17 --> 16
-    21 -.-> 3
+    1 --> 5
+    3 --> 10
+    3 --> 14
+    5 -.-> 4
+    5 --> 4
+    5 --> 19
+    6 -.-> 7
+    7 --> 10
+    7 --> 14
+    8 --> 1
+    8 --> 9
+    8 --> 12
+    8 -.-> 16
+    10 --> 13
+    11 -.-> 7
+    13 --> 11
+    14 --> 6
+    14 --> 8
+    15 --> 17
+    15 --> 18
+    16 --> 15
+    20 -.-> 3

--- a/libs/@local/hashql/core/src/graph/algorithms/dominators/mod.rs
+++ b/libs/@local/hashql/core/src/graph/algorithms/dominators/mod.rs
@@ -400,7 +400,10 @@ where
     N: Id,
 {
     /// Returns true if node is reachable from the start node.
-    pub fn is_reachable(&self, node: N) -> bool {
+    pub const fn is_reachable(&self, node: N) -> bool
+    where
+        N: [const] Id,
+    {
         match &self.kind {
             Kind::Path => true,
             Kind::General(g) => g.time[node].start != 0,

--- a/libs/@local/hashql/core/src/graph/algorithms/tarjan/mod.rs
+++ b/libs/@local/hashql/core/src/graph/algorithms/tarjan/mod.rs
@@ -291,12 +291,18 @@ where
     M: Metadata<N, S>,
 {
     /// Returns the SCC identifier containing the given node.
-    pub fn scc(&self, node: N) -> S {
+    pub const fn scc(&self, node: N) -> S
+    where
+        N: [const] Id,
+    {
         self.data.nodes[node]
     }
 
     /// Returns the metadata annotation for the given SCC.
-    pub fn annotation(&self, scc: S) -> &M::Annotation {
+    pub const fn annotation(&self, scc: S) -> &M::Annotation
+    where
+        S: [const] Id,
+    {
         &self.data.components[scc].annotation
     }
 

--- a/libs/@local/hashql/core/src/graph/linked.rs
+++ b/libs/@local/hashql/core/src/graph/linked.rs
@@ -473,7 +473,11 @@ impl<N, E, A: Allocator> LinkedGraph<N, E, A> {
     /// assert_eq!(outgoing.len(), 2);
     /// ```
     #[must_use]
-    pub fn incident_edges(&self, node: NodeId, direction: Direction) -> IncidentEdges<'_, N, E, A> {
+    pub const fn incident_edges(
+        &self,
+        node: NodeId,
+        direction: Direction,
+    ) -> IncidentEdges<'_, N, E, A> {
         IncidentEdges::new(self, direction, node)
     }
 
@@ -500,7 +504,7 @@ impl<N, E, A: Allocator> LinkedGraph<N, E, A> {
     /// assert_eq!(incoming.len(), 2);
     /// ```
     #[must_use]
-    pub fn incoming_edges(&self, node: NodeId) -> IncidentEdges<'_, N, E, A> {
+    pub const fn incoming_edges(&self, node: NodeId) -> IncidentEdges<'_, N, E, A> {
         IncidentEdges::new(self, Direction::Incoming, node)
     }
 
@@ -527,7 +531,7 @@ impl<N, E, A: Allocator> LinkedGraph<N, E, A> {
     /// assert_eq!(outgoing.len(), 2);
     /// ```
     #[must_use]
-    pub fn outgoing_edges(&self, node: NodeId) -> IncidentEdges<'_, N, E, A> {
+    pub const fn outgoing_edges(&self, node: NodeId) -> IncidentEdges<'_, N, E, A> {
         IncidentEdges::new(self, Direction::Outgoing, node)
     }
 
@@ -652,7 +656,7 @@ impl<'graph, N, E, A: Allocator> IncidentEdges<'graph, N, E, A> {
     ///
     /// Starts iteration from the head of the appropriate linked list for the given
     /// node and direction.
-    fn new(graph: &'graph LinkedGraph<N, E, A>, direction: Direction, node: NodeId) -> Self {
+    const fn new(graph: &'graph LinkedGraph<N, E, A>, direction: Direction, node: NodeId) -> Self {
         let next = graph.nodes[node].edges[direction as usize];
         Self {
             graph,

--- a/libs/@local/hashql/core/src/graph/mod.rs
+++ b/libs/@local/hashql/core/src/graph/mod.rs
@@ -39,8 +39,8 @@ use self::algorithms::{
 pub use self::linked::LinkedGraph;
 use crate::id::{HasId, Id, newtype};
 
-newtype!(#[id(crate = crate)] pub struct NodeId(u32 is 0..=u32::MAX));
-newtype!(#[id(crate = crate)] pub struct EdgeId(u32 is 0..=u32::MAX));
+newtype!(#[id(crate = crate, const)] pub struct NodeId(u32 is 0..=u32::MAX));
+newtype!(#[id(crate = crate, const)] pub struct EdgeId(u32 is 0..=u32::MAX));
 
 /// Direction of edge traversal in a directed graph.
 ///

--- a/libs/@local/hashql/core/src/heap/allocator.rs
+++ b/libs/@local/hashql/core/src/heap/allocator.rs
@@ -1,4 +1,4 @@
-//! Internal allocator wrapper around bumpalo.
+//! Internal allocator wrapper around bump-scope.
 
 use core::{alloc, mem, ptr};
 

--- a/libs/@local/hashql/core/src/id/array.rs
+++ b/libs/@local/hashql/core/src/id/array.rs
@@ -1,3 +1,8 @@
+#![cfg_attr(
+    feature = "zerocopy",
+    expect(clippy::empty_enums, reason = "zerocopy uses them in the derive")
+)]
+
 use core::{
     array,
     borrow::{Borrow, BorrowMut},
@@ -29,6 +34,17 @@ use super::{Id, IdSlice};
 /// ```
 ///
 /// [`IdVec`]: super::IdVec
+#[cfg_attr(
+    feature = "zerocopy",
+    derive(
+        zerocopy::FromBytes,
+        zerocopy::IntoBytes,
+        zerocopy::KnownLayout,
+        zerocopy::Immutable,
+        zerocopy::Unaligned
+    )
+)]
+#[repr(transparent)]
 pub struct IdArray<I, T, const N: usize> {
     raw: [T; N],
     _marker: PhantomData<fn(&I)>,

--- a/libs/@local/hashql/core/src/id/bit_vec/matrix/mod.rs
+++ b/libs/@local/hashql/core/src/id/bit_vec/matrix/mod.rs
@@ -26,10 +26,6 @@ use crate::id::{Id, IdVec};
 #[cfg(test)]
 mod tests;
 
-// =============================================================================
-// RowRef — immutable view into a matrix row
-// =============================================================================
-
 /// An immutable view into a single row of a [`BitMatrix`] or [`SparseBitMatrix`].
 ///
 /// Borrows directly into the matrix's backing storage — no allocation, no copy.
@@ -149,10 +145,6 @@ impl<'a, C: Id> IntoIterator for RowRef<'a, C> {
         self.iter()
     }
 }
-
-// =============================================================================
-// RowMut — mutable view into a matrix row
-// =============================================================================
 
 /// A mutable view into a single row of a [`BitMatrix`].
 ///
@@ -322,10 +314,6 @@ impl<'row, C: Id> IntoIterator for &'row RowMut<'_, C> {
     }
 }
 
-// =============================================================================
-// BitMatrix — dense, contiguous, fixed-size 2D bit matrix
-// =============================================================================
-
 /// A fixed-size 2D bit matrix with a dense, contiguous representation.
 ///
 /// All row data lives in a single `Vec<Word, A>`, laid out row-by-row. This makes
@@ -460,8 +448,6 @@ impl<R: Id, C: Id, A: Allocator> BitMatrix<R, C, A> {
         RowMut::new(self.row_words_mut(row), col_domain_size)
     }
 
-    // --- element-level operations ---
-
     /// Sets the cell at `(row, col)` to true. Returns `true` if the matrix changed.
     ///
     /// # Panics
@@ -502,8 +488,6 @@ impl<R: Id, C: Id, A: Allocator> BitMatrix<R, C, A> {
         (self.words[flat_index] & mask) != 0
     }
 
-    // --- row-level clearing ---
-
     /// Clears all bits in `row`.
     #[inline]
     pub fn clear_row(&mut self, row: R) {
@@ -521,8 +505,6 @@ impl<R: Id, C: Id, A: Allocator> BitMatrix<R, C, A> {
     pub fn insert_all_into_row(&mut self, row: R) {
         self.row_mut(row).insert_all();
     }
-
-    // --- row-to-row operations ---
 
     /// `write |= read`. Returns `true` if `write` changed.
     ///
@@ -573,8 +555,6 @@ impl<R: Id, C: Id, A: Allocator> BitMatrix<R, C, A> {
         result
     }
 
-    // --- row-to-DenseBitSet operations ---
-
     /// `row |= other`. Returns `true` if the row changed.
     #[inline]
     pub fn union_row_with(&mut self, row: R, other: &DenseBitSet<C>) -> bool {
@@ -592,8 +572,6 @@ impl<R: Id, C: Id, A: Allocator> BitMatrix<R, C, A> {
     pub fn intersect_row_with(&mut self, row: R, other: &DenseBitSet<C>) -> bool {
         self.row_mut(row).intersect_dense(other)
     }
-
-    // --- inspection ---
 
     /// Returns `true` if no bits are set in `row`.
     #[inline]
@@ -621,8 +599,6 @@ impl<R: Id, C: Id, A: Allocator> BitMatrix<R, C, A> {
     pub const fn words(&self) -> &[Word] {
         &self.words
     }
-
-    // --- internal helpers ---
 
     /// Validates `(row, col)` and returns the flat word index plus the bit mask.
     ///
@@ -738,10 +714,6 @@ impl<R: Id, C: Id, A: Allocator> fmt::Debug for BitMatrix<R, C, A> {
         fmt.debug_set().entries(items).finish()
     }
 }
-
-// =============================================================================
-// SparseBitMatrix — arena-backed sparse 2D bit matrix
-// =============================================================================
 
 /// Metadata for a row slot in the arena-backed sparse matrix.
 ///
@@ -886,8 +858,6 @@ impl<R: Id, C: Id, A: Allocator> SparseBitMatrix<R, C, A> {
         self.index.iter().filter(|slot| slot.is_some()).count()
     }
 
-    // --- element-level operations ---
-
     /// Sets the cell at `(row, col)` to true. Returns `true` if the matrix changed.
     ///
     /// Allocates the row on first access.
@@ -933,8 +903,6 @@ impl<R: Id, C: Id, A: Allocator> SparseBitMatrix<R, C, A> {
         self.row(row).is_some_and(|row_ref| row_ref.contains(col))
     }
 
-    // --- row-level clearing ---
-
     /// Clears all bits in `row` and returns its slot to the free-list.
     #[inline]
     pub fn clear_row(&mut self, row: R) {
@@ -963,8 +931,6 @@ impl<R: Id, C: Id, A: Allocator> SparseBitMatrix<R, C, A> {
         words.fill(!0);
         clear_excess_bits_in_final_word(self.col_domain_size, words);
     }
-
-    // --- row-to-row operations ---
 
     /// `write |= read`. Returns `true` if `write` changed.
     ///
@@ -1051,8 +1017,6 @@ impl<R: Id, C: Id, A: Allocator> SparseBitMatrix<R, C, A> {
         changed != 0
     }
 
-    // --- row-to-DenseBitSet operations ---
-
     /// `row |= other`. Returns `true` if the row changed.
     #[inline]
     pub fn union_row_with(&mut self, row: R, other: &DenseBitSet<C>) -> bool {
@@ -1090,8 +1054,6 @@ impl<R: Id, C: Id, A: Allocator> SparseBitMatrix<R, C, A> {
         };
         bitwise(words, &other.words, |lhs, rhs| lhs & rhs)
     }
-
-    // --- inspection ---
 
     /// Returns `true` if `row` has no set bits (or is unallocated).
     #[inline]

--- a/libs/@local/hashql/core/src/id/bit_vec/mod.rs
+++ b/libs/@local/hashql/core/src/id/bit_vec/mod.rs
@@ -78,7 +78,7 @@ const CHUNK_BITS: usize = CHUNK_WORDS * WORD_BITS; // 2048 bits
 type ChunkSize = u16;
 const _: () = assert!(CHUNK_BITS <= ChunkSize::MAX as usize);
 
-pub const trait BitRelations<Rhs> {
+pub const trait BitRelations<Rhs: ?Sized> {
     fn union(&mut self, other: &Rhs) -> bool;
     fn subtract(&mut self, other: &Rhs) -> bool;
     fn intersect(&mut self, other: &Rhs) -> bool;
@@ -112,6 +112,16 @@ impl<T> DenseBitSet<T> {
     #[must_use]
     pub const fn domain_size(&self) -> usize {
         self.domain_size
+    }
+
+    /// The backing words, 64 bits per word in ascending domain order.
+    ///
+    /// Bit `i` of word `i / 64` marks element `i`, and every bit at a position greater than or
+    /// equal to the domain size is zero, so word-level readers need no masking.
+    #[inline]
+    #[must_use]
+    pub fn words(&self) -> &[u64] {
+        &self.words
     }
 }
 

--- a/libs/@local/hashql/core/src/id/index.rs
+++ b/libs/@local/hashql/core/src/id/index.rs
@@ -5,15 +5,15 @@ use core::{
 
 use super::Id;
 
-pub trait IntoSliceIndex<I, T: ?Sized> {
+pub const trait IntoSliceIndex<I, T: ?Sized> {
     type SliceIndex: SliceIndex<T>;
 
     fn into_slice_index(self) -> Self::SliceIndex;
 }
 
-impl<I, T> IntoSliceIndex<I, [T]> for I
+const impl<I, T> IntoSliceIndex<I, [T]> for I
 where
-    I: Id,
+    I: [const] Id,
 {
     type SliceIndex = usize;
 
@@ -23,21 +23,32 @@ where
     }
 }
 
-impl<I, T> IntoSliceIndex<I, [T]> for (Bound<I>, Bound<I>)
+const fn map_bounds<I>(bound: Bound<I>) -> Bound<usize>
 where
-    I: Id,
+    I: [const] Id,
+{
+    match bound {
+        Bound::Included(index) => Bound::Included(index.as_usize()),
+        Bound::Excluded(index) => Bound::Excluded(index.as_usize()),
+        Bound::Unbounded => Bound::Unbounded,
+    }
+}
+
+const impl<I, T> IntoSliceIndex<I, [T]> for (Bound<I>, Bound<I>)
+where
+    I: [const] Id,
 {
     type SliceIndex = (Bound<usize>, Bound<usize>);
 
     #[inline]
     fn into_slice_index(self) -> Self::SliceIndex {
-        (self.0.map(Id::as_usize), self.1.map(Id::as_usize))
+        (map_bounds(self.0), map_bounds(self.1))
     }
 }
 
-impl<I, T> IntoSliceIndex<I, [T]> for Range<I>
+const impl<I, T> IntoSliceIndex<I, [T]> for Range<I>
 where
-    I: Id,
+    I: [const] Id,
 {
     type SliceIndex = Range<usize>;
 
@@ -50,9 +61,9 @@ where
     }
 }
 
-impl<I, T> IntoSliceIndex<I, [T]> for RangeFrom<I>
+const impl<I, T> IntoSliceIndex<I, [T]> for RangeFrom<I>
 where
-    I: Id,
+    I: [const] Id,
 {
     type SliceIndex = RangeFrom<usize>;
 
@@ -64,9 +75,9 @@ where
     }
 }
 
-impl<I, T> IntoSliceIndex<I, [T]> for RangeFull
+const impl<I, T> IntoSliceIndex<I, [T]> for RangeFull
 where
-    I: Id,
+    I: [const] Id,
 {
     type SliceIndex = Self;
 
@@ -76,9 +87,9 @@ where
     }
 }
 
-impl<I, T> IntoSliceIndex<I, [T]> for RangeInclusive<I>
+const impl<I, T> IntoSliceIndex<I, [T]> for RangeInclusive<I>
 where
-    I: Id,
+    I: [const] Id,
 {
     type SliceIndex = RangeInclusive<usize>;
 
@@ -90,9 +101,9 @@ where
     }
 }
 
-impl<I, T> IntoSliceIndex<I, [T]> for RangeTo<I>
+const impl<I, T> IntoSliceIndex<I, [T]> for RangeTo<I>
 where
-    I: Id,
+    I: [const] Id,
 {
     type SliceIndex = RangeTo<usize>;
 
@@ -104,9 +115,9 @@ where
     }
 }
 
-impl<I, T> IntoSliceIndex<I, [T]> for RangeToInclusive<I>
+const impl<I, T> IntoSliceIndex<I, [T]> for RangeToInclusive<I>
 where
-    I: Id,
+    I: [const] Id,
 {
     type SliceIndex = RangeToInclusive<usize>;
 

--- a/libs/@local/hashql/core/src/id/matrix.rs
+++ b/libs/@local/hashql/core/src/id/matrix.rs
@@ -161,6 +161,10 @@ where
     #[inline]
     fn index(&self, (row, column): (R, C)) -> &T {
         assert!(
+            row.as_usize() < self.rows(),
+            "the row must lie inside the row domain"
+        );
+        assert!(
             column.as_usize() < self.columns,
             "the column must lie inside the column domain",
         );

--- a/libs/@local/hashql/core/src/id/matrix.rs
+++ b/libs/@local/hashql/core/src/id/matrix.rs
@@ -1,0 +1,324 @@
+use alloc::{alloc::Global, vec::Vec};
+use core::{
+    alloc::Allocator,
+    fmt::{self, Debug},
+    hash::{Hash, Hasher},
+    marker::PhantomData,
+    ops::Index,
+};
+
+use super::{Id, slice::IdSlice};
+
+/// A dense rectangular matrix addressed by typed IDs on both axes.
+///
+/// `IdMatrix<R, C, T>` stores every cell in a single row-major `Vec<T>`: a row is a contiguous
+/// slice, and the indexing arithmetic lives in one place. Rows are addressed by `R`, columns by
+/// `C`, one [`Id`] newtype per axis, so mixing up a row index and a column index is a type error.
+///
+/// A row borrows as an [`IdSlice<C, T>`], so per-row indexing, iteration, and ids come from the
+/// slice type.
+///
+/// The API is not complete by design, new methods will be added as needed.
+///
+/// # Examples
+///
+/// ```
+/// # use hashql_core::id::{Id as _, IdMatrix, newtype};
+/// # newtype!(struct QueryId(u32 is 0..=0xFFFF_FF00));
+/// # newtype!(struct SlotId(u32 is 0..=0xFFFF_FF00));
+/// let matrix: IdMatrix<QueryId, SlotId, u32> =
+///     IdMatrix::from_rows([vec![1, 2, 3], vec![4, 5, 6]], 3);
+///
+/// assert_eq!(matrix.rows(), 2);
+/// assert_eq!(matrix.columns(), 3);
+/// assert_eq!(matrix[(QueryId::from_u32(1), SlotId::from_u32(2))], 6);
+/// assert_eq!(matrix.row(QueryId::from_u32(0)).as_raw(), &[1, 2, 3]);
+/// ```
+pub struct IdMatrix<R, C, T, A: Allocator = Global> {
+    cells: Vec<T, A>,
+    columns: usize,
+    _marker: PhantomData<fn(&R, &C)>,
+}
+
+impl<R: Id, C: Id, T> IdMatrix<R, C, T> {
+    /// Creates a matrix from row-major cells at the given column count.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic when `columns` is zero or does not divide the cell count exactly.
+    #[must_use]
+    pub fn from_rows(rows: impl IntoIterator<Item = Vec<T>>, columns: usize) -> Self {
+        Self::from_rows_in(rows, columns, Global)
+    }
+}
+
+impl<R: Id, C: Id, T, A: Allocator> IdMatrix<R, C, T, A> {
+    /// Creates a matrix from a flat row-major buffer at the given column count.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic when `columns` is zero or does not divide the buffer length
+    /// exactly.
+    #[must_use]
+    pub fn from_flat(cells: Vec<T, A>, columns: usize) -> Self {
+        assert!(
+            columns > 0 && cells.len().is_multiple_of(columns),
+            "the columns must be nonzero and divide the cell count exactly",
+        );
+
+        Self {
+            cells,
+            columns,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Creates a matrix from row-major cells at the given column count, using `alloc`.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic when `columns` is zero, a row's length differs from `columns`, or
+    /// the resulting
+    /// cell count does not divide exactly.
+    #[must_use]
+    pub fn from_rows_in(rows: impl IntoIterator<Item = Vec<T>>, columns: usize, alloc: A) -> Self {
+        let mut cells = Vec::new_in(alloc);
+        for row in rows {
+            assert_eq!(row.len(), columns, "every row must hold `columns` cells");
+            cells.extend(row);
+        }
+
+        Self::from_flat(cells, columns)
+    }
+
+    /// Returns the row count.
+    #[expect(
+        clippy::integer_division,
+        clippy::integer_division_remainder_used,
+        reason = "the constructor guarantees the columns divide the cell count exactly"
+    )]
+    #[inline]
+    #[must_use]
+    pub const fn rows(&self) -> usize {
+        self.cells.len() / self.columns
+    }
+
+    /// Returns the column count.
+    #[inline]
+    #[must_use]
+    pub const fn columns(&self) -> usize {
+        self.columns
+    }
+
+    /// Borrows one row as a column-indexed slice.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic when `row` lies outside the row domain.
+    #[inline]
+    #[must_use]
+    pub const fn row(&self, row: R) -> &IdSlice<C, T>
+    where
+        R: [const] Id,
+    {
+        let start = row.as_usize() * self.columns;
+
+        IdSlice::from_raw(&self.cells[start..start + self.columns])
+    }
+
+    /// Iterates one column across every row, in row order.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic when `column` lies outside the column domain.
+    pub fn column(&self, column: C) -> impl ExactSizeIterator<Item = &T> {
+        assert!(
+            column.as_usize() < self.columns,
+            "the column must lie inside the column domain",
+        );
+
+        self.cells
+            .get(column.as_usize()..)
+            .unwrap_or_default()
+            .iter()
+            .step_by(self.columns)
+    }
+}
+
+const impl<R, C, T, A> Index<(R, C)> for IdMatrix<R, C, T, A>
+where
+    R: [const] Id,
+    C: [const] Id,
+    A: Allocator,
+{
+    type Output = T;
+
+    /// Borrows the cell at `row`, `column`.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic when `row` or `column` lies outside the matrix.
+    #[inline]
+    fn index(&self, (row, column): (R, C)) -> &T {
+        assert!(
+            column.as_usize() < self.columns,
+            "the column must lie inside the column domain",
+        );
+
+        let cells: &[T] = &self.cells;
+        &cells[row.as_usize() * self.columns + column.as_usize()]
+    }
+}
+
+impl<R, C, T: Clone, A: Allocator + Clone> Clone for IdMatrix<R, C, T, A> {
+    fn clone(&self) -> Self {
+        Self {
+            cells: self.cells.clone(),
+            columns: self.columns,
+            _marker: PhantomData,
+        }
+    }
+
+    fn clone_from(&mut self, source: &Self) {
+        self.cells.clone_from(&source.cells);
+        self.columns = source.columns;
+    }
+}
+
+impl<R, C, T, U, A, B> PartialEq<IdMatrix<R, C, U, B>> for IdMatrix<R, C, T, A>
+where
+    T: PartialEq<U>,
+    A: Allocator,
+    B: Allocator,
+{
+    #[inline]
+    fn eq(&self, other: &IdMatrix<R, C, U, B>) -> bool {
+        self.columns == other.columns && self.cells == other.cells
+    }
+}
+
+impl<R, C, T, A> Eq for IdMatrix<R, C, T, A>
+where
+    T: Eq,
+    A: Allocator,
+{
+}
+
+impl<R, C, T, A> Hash for IdMatrix<R, C, T, A>
+where
+    T: Hash,
+    A: Allocator,
+{
+    #[inline]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.columns.hash(state);
+        self.cells.hash(state);
+    }
+}
+
+impl<R, C, T: Debug, A: Allocator> Debug for IdMatrix<R, C, T, A> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.debug_struct("IdMatrix")
+            .field("cells", &self.cells)
+            .field("columns", &self.columns)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+
+    use super::IdMatrix;
+    use crate::id::Id as _;
+
+    crate::id::newtype!(
+        #[id(crate = crate)]
+        struct Row(u32)
+    );
+    crate::id::newtype!(
+        #[id(crate = crate)]
+        struct Column(u32)
+    );
+
+    #[test]
+    fn from_rows_indexes_row_major() {
+        let matrix: IdMatrix<Row, Column, u32> =
+            IdMatrix::from_rows([vec![1, 2, 3], vec![4, 5, 6]], 3);
+
+        assert_eq!(matrix.rows(), 2);
+        assert_eq!(matrix.columns(), 3);
+        assert_eq!(matrix[(Row::from_u32(0), Column::from_u32(0))], 1);
+        assert_eq!(matrix[(Row::from_u32(1), Column::from_u32(2))], 6);
+    }
+
+    #[test]
+    fn row_borrows_as_a_column_indexed_slice() {
+        let matrix: IdMatrix<Row, Column, u32> =
+            IdMatrix::from_rows([vec![1, 2, 3], vec![4, 5, 6]], 3);
+
+        let row = matrix.row(Row::from_u32(1));
+        assert_eq!(row.as_raw(), &[4, 5, 6]);
+        assert_eq!(row[Column::from_u32(1)], 5);
+    }
+
+    #[test]
+    fn column_walks_every_row_in_order() {
+        let matrix: IdMatrix<Row, Column, u32> =
+            IdMatrix::from_rows([vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9]], 3);
+
+        let column: alloc::vec::Vec<u32> = matrix.column(Column::from_u32(1)).copied().collect();
+        assert_eq!(column, [2, 5, 8]);
+    }
+
+    #[test]
+    fn an_empty_matrix_has_no_rows_and_empty_columns() {
+        let matrix: IdMatrix<Row, Column, u32> = IdMatrix::from_flat(vec![], 3);
+
+        assert_eq!(matrix.rows(), 0);
+        assert_eq!(matrix.column(Column::from_u32(2)).count(), 0);
+    }
+
+    #[test]
+    fn equal_matrices_compare_and_hash_alike() {
+        let left: IdMatrix<Row, Column, u32> =
+            IdMatrix::from_rows([vec![1, 2, 3], vec![4, 5, 6]], 3);
+        let right: IdMatrix<Row, Column, u32> =
+            IdMatrix::from_rows([vec![1, 2, 3], vec![4, 5, 6]], 3);
+
+        assert_eq!(left, right);
+
+        let state = std::hash::RandomState::new();
+        assert_eq!(
+            core::hash::BuildHasher::hash_one(&state, &left),
+            core::hash::BuildHasher::hash_one(&state, &right),
+        );
+    }
+
+    #[test]
+    fn the_same_cells_at_a_different_width_are_unequal() {
+        let two_by_three: IdMatrix<Row, Column, u32> =
+            IdMatrix::from_flat(vec![1, 2, 3, 4, 5, 6], 3);
+        let three_by_two: IdMatrix<Row, Column, u32> =
+            IdMatrix::from_flat(vec![1, 2, 3, 4, 5, 6], 2);
+
+        assert_ne!(two_by_three, three_by_two);
+
+        let narrow_empty: IdMatrix<Row, Column, u32> = IdMatrix::from_flat(vec![], 2);
+        let wide_empty: IdMatrix<Row, Column, u32> = IdMatrix::from_flat(vec![], 3);
+
+        assert_ne!(narrow_empty, wide_empty);
+    }
+
+    #[test]
+    #[should_panic(expected = "divide the cell count exactly")]
+    fn a_ragged_flat_buffer_is_refused() {
+        let _matrix: IdMatrix<Row, Column, u32> = IdMatrix::from_flat(vec![1, 2, 3, 4], 3);
+    }
+
+    #[test]
+    #[should_panic(expected = "every row must hold")]
+    fn a_ragged_row_is_refused() {
+        let _matrix: IdMatrix<Row, Column, u32> = IdMatrix::from_rows([vec![1, 2, 3], vec![4]], 3);
+    }
+}

--- a/libs/@local/hashql/core/src/id/mod.rs
+++ b/libs/@local/hashql/core/src/id/mod.rs
@@ -1,8 +1,11 @@
 mod array;
 pub mod bit_vec;
 mod index;
+mod matrix;
 mod slice;
 pub mod snapshot_vec;
+#[cfg(test)]
+mod tests;
 mod union_find;
 mod vec;
 
@@ -17,8 +20,8 @@ use ::core::sync::atomic;
 pub use hashql_macros::{Id, define_id as newtype};
 
 pub use self::{
-    array::IdArray, index::IntoSliceIndex, slice::IdSlice, snapshot_vec::IdSnapshotVec,
-    union_find::IdUnionFind, vec::IdVec,
+    array::IdArray, index::IntoSliceIndex, matrix::IdMatrix, slice::IdSlice,
+    snapshot_vec::IdSnapshotVec, union_find::IdUnionFind, vec::IdVec,
 };
 
 /// Represents errors that can occur when converting values to an [`Id`].
@@ -57,6 +60,8 @@ pub const trait Id:
     + Hash
     + Debug
     + Display
+    + Send
+    + Sync
     + [const] TryFrom<u32, Error = IdError>
     + [const] TryFrom<u64, Error = IdError>
     + [const] TryFrom<usize, Error = IdError>
@@ -162,6 +167,17 @@ pub const trait Id:
     #[inline]
     fn decrement_by(&mut self, amount: usize) {
         *self = self.minus(amount);
+    }
+
+    #[inline]
+    fn next(self) -> Option<Self> {
+        match self.as_u64().checked_add(1) {
+            Some(next) => match Self::try_from(next) {
+                Ok(next) => Some(next),
+                Err(_) => None,
+            },
+            None => None,
+        }
     }
 
     /// Returns the previous ID in sequence, if it exists.

--- a/libs/@local/hashql/core/src/id/slice.rs
+++ b/libs/@local/hashql/core/src/id/slice.rs
@@ -26,6 +26,16 @@ use rayon::{
 
 use super::{Id, index::IntoSliceIndex, vec::IdVec};
 
+/// Returns the greatest chunk-start offset, or zero when the slice is empty.
+#[inline]
+#[expect(
+    clippy::integer_division,
+    reason = "integer division rounds the slice end down to the containing chunk start"
+)]
+const fn greatest_chunk_start(length: usize, size: NonZero<usize>) -> usize {
+    length.saturating_sub(1) / size * size.get()
+}
+
 /// A slice that uses typed IDs for indexing instead of raw `usize` values.
 ///
 /// `IdSlice<I, T>` is a transparent wrapper around `[T]` that enforces type-safe indexing
@@ -233,6 +243,10 @@ where
     ///
     /// This is equivalent to the ID that would be assigned to a new element if one were added.
     /// Useful for bounds checking: `id < slice.bound()` tests if `id` is valid for this slice.
+    ///
+    /// # Panics
+    ///
+    /// The slice occupies the complete ID domain and no successor ID exists.
     #[inline]
     pub fn bound(&self) -> I {
         I::from_usize(self.len())
@@ -383,7 +397,7 @@ where
     ///
     /// # Panics
     ///
-    /// Panics if either `lhs` or `rhs` is out of bounds.
+    /// Either `lhs` or `rhs` is out of bounds.
     ///
     /// [`slice::swap`]: slice::swap
     #[inline]
@@ -457,7 +471,7 @@ where
         size: NonZero<usize>,
     ) -> impl DoubleEndedIterator<Item = (I, &[T])> + ExactSizeIterator + Clone {
         // Elide bound checks from subsequent calls to `I::from_usize`
-        let _: I = I::from_usize(self.len());
+        let _: I = I::from_usize(greatest_chunk_start(self.len(), size));
 
         self.raw
             .chunks(size.get())
@@ -479,7 +493,7 @@ where
     {
         use rayon::slice::ParallelSlice as _;
         // Elide bound checks from subsequent calls to `I::from_usize`
-        let _: I = I::from_usize(self.len());
+        let _: I = I::from_usize(greatest_chunk_start(self.len(), size));
 
         self.raw
             .par_chunks(size.get())
@@ -525,7 +539,7 @@ where
         size: NonZero<usize>,
     ) -> impl DoubleEndedIterator<Item = (I, &mut [T])> + ExactSizeIterator {
         // Elide bound checks from subsequent calls to `I::from_usize`
-        let _: I = I::from_usize(self.len());
+        let _: I = I::from_usize(greatest_chunk_start(self.len(), size));
 
         self.raw
             .chunks_mut(size.get())
@@ -547,7 +561,7 @@ where
     {
         use rayon::slice::ParallelSliceMut as _;
         // Elide bound checks from subsequent calls to `I::from_usize`
-        let _: I = I::from_usize(self.len());
+        let _: I = I::from_usize(greatest_chunk_start(self.len(), size));
 
         self.raw
             .par_chunks_mut(size.get())
@@ -626,6 +640,11 @@ where
     /// # Errors
     ///
     /// Returns the ID where a matching element could be inserted while maintaining sorted order.
+    ///
+    /// # Panics
+    ///
+    /// The insertion position lies beyond the ID domain. This occurs when the slice occupies the
+    /// complete domain and `item` belongs after every element.
     #[inline]
     pub fn binary_search(&self, item: &T) -> Result<I, I>
     where
@@ -658,22 +677,38 @@ where
         IdVec::from_raw(self.raw.to_vec_in(alloc))
     }
 
+    /// Returns the ID of the first element for which `predicate` is false.
+    ///
+    /// See [`slice::partition_point`](prim@slice#method.partition_point) for details.
+    ///
+    /// # Panics
+    ///
+    /// Every element satisfies `predicate` and the exclusive end lies beyond the ID domain.
     #[inline]
     pub fn partition_point(&self, predicate: impl Fn(&T) -> bool) -> I {
         let index = self.raw.partition_point(predicate);
         I::from_usize(index)
     }
 
+    /// Returns the final element, or [`None`] when the slice is empty.
+    ///
+    /// See [`slice::last`](prim@slice#method.last) for details.
     #[inline]
     pub const fn last(&self) -> Option<&T> {
         self.raw.last()
     }
 
+    /// Returns the first element, or [`None`] when the slice is empty.
+    ///
+    /// See [`slice::first`](prim@slice#method.first) for details.
     #[inline]
     pub const fn first(&self) -> Option<&T> {
         self.raw.first()
     }
 
+    /// Fills the slice by cloning `value` into every element.
+    ///
+    /// See [`slice::fill`](prim@slice#method.fill) for details.
     #[inline]
     pub fn fill(&mut self, value: T)
     where
@@ -928,7 +963,7 @@ where
 mod tests {
     #![expect(unsafe_code, clippy::cast_possible_truncation)]
     use alloc::boxed::Box;
-    use core::mem::MaybeUninit;
+    use core::{mem::MaybeUninit, num::NonZero};
 
     use super::IdSlice;
     use crate::id::Id as _;
@@ -936,6 +971,11 @@ mod tests {
     hashql_macros::define_id! {
         #[id(crate = crate)]
         struct TestId(u32 is 0..=0xFFFF_FF00)
+    }
+
+    hashql_macros::define_id! {
+        #[id(crate = crate)]
+        struct FourElementId(u8 is 0..=3)
     }
 
     #[test]
@@ -983,6 +1023,83 @@ mod tests {
 
         assert_eq!(slice.windows_enumerated::<2>().len(), 0);
         assert_eq!(slice.windows_enumerated::<2>().next(), None);
+    }
+
+    #[test]
+    fn chunks_enumerated_full_id_domain() {
+        let mut data = [10, 20, 30, 40];
+        let slice = IdSlice::<FourElementId, _>::from_raw(&data);
+        let chunks: alloc::vec::Vec<_> = slice
+            .chunks_enumerated(NonZero::new(2).expect("two is nonzero"))
+            .collect();
+        assert_eq!(
+            chunks,
+            [
+                (FourElementId::new(0), &[10, 20][..]),
+                (FourElementId::new(2), &[30, 40][..]),
+            ]
+        );
+
+        let slice = IdSlice::<FourElementId, _>::from_raw_mut(&mut data);
+        let starts: alloc::vec::Vec<_> = slice
+            .chunks_enumerated_mut(NonZero::new(3).expect("three is nonzero"))
+            .map(|(id, _)| id)
+            .collect();
+        assert_eq!(starts, [FourElementId::new(0), FourElementId::new(3)]);
+    }
+
+    #[test]
+    #[should_panic(expected = "id value must be between 0<=3")]
+    fn binary_search_after_full_id_domain() {
+        let data = [10, 20, 30, 40];
+        let slice = IdSlice::<FourElementId, _>::from_raw(&data);
+
+        let _result = slice.binary_search(&50);
+    }
+
+    #[test]
+    #[should_panic(expected = "id value must be between 0<=3")]
+    fn partition_point_full_id_domain() {
+        let data = [10, 20, 30, 40];
+        let slice = IdSlice::<FourElementId, _>::from_raw(&data);
+
+        let _partition = slice.partition_point(|_| true);
+    }
+
+    #[test]
+    #[should_panic(expected = "id value must be between 0<=3")]
+    fn bound_full_id_domain() {
+        let data = [10, 20, 30, 40];
+        let slice = IdSlice::<FourElementId, _>::from_raw(&data);
+
+        let _bound = slice.bound();
+    }
+
+    #[cfg(feature = "rayon")]
+    #[test]
+    fn parallel_chunks_enumerated_full_id_domain() {
+        use rayon::iter::ParallelIterator as _;
+
+        let mut data = [10, 20, 30, 40];
+        let slice = IdSlice::<FourElementId, _>::from_raw(&data);
+        let chunks: alloc::vec::Vec<_> = slice
+            .par_chunks_enumerated(NonZero::new(2).expect("two is nonzero"))
+            .map(|(id, chunk)| (id, chunk.to_vec()))
+            .collect();
+        assert_eq!(
+            chunks,
+            [
+                (FourElementId::new(0), alloc::vec![10, 20]),
+                (FourElementId::new(2), alloc::vec![30, 40]),
+            ]
+        );
+
+        let slice = IdSlice::<FourElementId, _>::from_raw_mut(&mut data);
+        let starts: alloc::vec::Vec<_> = slice
+            .par_chunks_enumerated_mut(NonZero::new(3).expect("three is nonzero"))
+            .map(|(id, _)| id)
+            .collect();
+        assert_eq!(starts, [FourElementId::new(0), FourElementId::new(3)]);
     }
 
     #[test]

--- a/libs/@local/hashql/core/src/id/slice.rs
+++ b/libs/@local/hashql/core/src/id/slice.rs
@@ -1,11 +1,27 @@
+#![cfg_attr(
+    feature = "zerocopy",
+    expect(clippy::empty_enums, reason = "zerocopy uses them in the derive")
+)]
+
 use core::{
     alloc::Allocator,
+    cmp,
     fmt::{self, Debug},
     marker::PhantomData,
     mem::MaybeUninit,
+    num::NonZero,
     ops::{Index, IndexMut},
     ptr,
     slice::{self, GetDisjointMutError, GetDisjointMutIndex, SliceIndex},
+};
+
+#[cfg(feature = "rayon")]
+use rayon::{
+    iter::{
+        IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator as _,
+        IntoParallelRefMutIterator as _, ParallelIterator as _,
+    },
+    slice::ParallelSliceMut as _,
 };
 
 use super::{Id, index::IntoSliceIndex, vec::IdVec};
@@ -29,6 +45,16 @@ use super::{Id, index::IntoSliceIndex, vec::IdVec};
 /// assert_eq!(slice[user_id], 20);
 /// ```
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(
+    feature = "zerocopy",
+    derive(
+        zerocopy::FromBytes,
+        zerocopy::IntoBytes,
+        zerocopy::Immutable,
+        zerocopy::Unaligned,
+        zerocopy::KnownLayout
+    )
+)]
 #[repr(transparent)]
 pub struct IdSlice<I, T> {
     _marker: PhantomData<fn(&I)>,
@@ -87,6 +113,20 @@ where
 
         // SAFETY: `IdSlice` is repr(transparent) and we simply cast the underlying pointer.
         unsafe { Box::from_raw_in(ptr as *mut Self, alloc) }
+    }
+
+    /// Converts a boxed `IdSlice` back into its raw boxed slice.
+    ///
+    /// The inverse of [`from_boxed_slice`](Self::from_boxed_slice), dropping only the typed index
+    /// domain. Intended for the boundaries where a typed collection leaves the domain-indexed
+    /// world, such as handing storage to an external format that speaks raw indices.
+    #[inline]
+    #[expect(unsafe_code, reason = "repr(transparent)")]
+    pub fn into_boxed_raw<A: Allocator>(slice: Box<Self, A>) -> Box<[T], A> {
+        let (ptr, alloc) = Box::into_raw_with_allocator(slice);
+
+        // SAFETY: `IdSlice` is repr(transparent) and we simply cast the underlying pointer.
+        unsafe { Box::from_raw_in(ptr as *mut [T], alloc) }
     }
 
     /// Converts to `Box<IdSlice<I, T>, A>`.
@@ -155,6 +195,32 @@ where
             .get_disjoint_mut(index.map(IntoSliceIndex::into_slice_index))
     }
 
+    /// Returns the prefix of the slice below `bound`, keeping the index domain.
+    ///
+    /// Range indexing returns a raw slice because a general sub-slice re-bases its indices to
+    /// offsets; a prefix never re-bases (every element keeps its original ID), so the typed view
+    /// is the honest return.
+    ///
+    /// # Panics
+    ///
+    /// When `bound` exceeds the slice length.
+    #[inline]
+    pub fn prefix(&self, bound: I) -> &Self {
+        Self::from_raw(&self.raw[..bound.as_usize()])
+    }
+
+    /// Returns the mutable prefix of the slice below `bound`, keeping the index domain.
+    ///
+    /// The mutable form of [`prefix`](Self::prefix).
+    ///
+    /// # Panics
+    ///
+    /// When `bound` exceeds the slice length.
+    #[inline]
+    pub fn prefix_mut(&mut self, bound: I) -> &mut Self {
+        Self::from_raw_mut(&mut self.raw[..bound.as_usize()])
+    }
+
     /// Returns the number of elements in the slice.
     ///
     /// See [`slice::len`] for details.
@@ -192,12 +258,37 @@ where
         (0..length).map(I::from_usize)
     }
 
+    /// Returns a parallel iterator over all valid IDs for this slice.
+    ///
+    /// The parallel counterpart of [`Self::ids`].
+    #[cfg(feature = "rayon")]
+    pub fn par_ids(&self) -> impl IndexedParallelIterator<Item = I> + 'static {
+        let length = self.len();
+
+        // Elide bound checks from subsequent calls to `I::from_usize`
+        let _: I = I::from_usize(length.saturating_sub(1));
+
+        (0..length).into_par_iter().map(I::from_usize)
+    }
+
     /// Returns an iterator over the elements.
     ///
     /// See [`slice::iter`] for details.
     #[inline]
     pub fn iter(&self) -> slice::Iter<'_, T> {
         self.raw.iter()
+    }
+
+    /// Returns a parallel iterator over the elements.
+    ///
+    /// The parallel counterpart of [`Self::iter`].
+    #[cfg(feature = "rayon")]
+    #[inline]
+    pub fn par_iter(&self) -> rayon::slice::Iter<'_, T>
+    where
+        T: Sync,
+    {
+        self.raw.par_iter()
     }
 
     /// Returns an iterator over ID-element pairs.
@@ -215,12 +306,42 @@ where
             .map(|(index, value)| (I::from_usize(index), value))
     }
 
+    /// Returns a parallel iterator over ID-element pairs.
+    ///
+    /// The parallel counterpart of [`Self::iter_enumerated`]: yields typed IDs instead of `usize`
+    /// indices.
+    #[cfg(feature = "rayon")]
+    pub fn par_iter_enumerated(&self) -> impl IndexedParallelIterator<Item = (I, &T)>
+    where
+        T: Sync,
+    {
+        // Elide bound checks from subsequent calls to `I::from_usize`
+        let _: I = I::from_usize(self.len().saturating_sub(1));
+
+        self.raw
+            .par_iter()
+            .enumerate()
+            .map(|(index, value)| (I::from_usize(index), value))
+    }
+
     /// Returns a mutable iterator over the elements.
     ///
     /// See [`slice::iter_mut`] for details.
     #[inline]
     pub fn iter_mut(&mut self) -> slice::IterMut<'_, T> {
         self.raw.iter_mut()
+    }
+
+    /// Returns a parallel mutable iterator over the elements.
+    ///
+    /// The parallel counterpart of [`Self::iter_mut`].
+    #[cfg(feature = "rayon")]
+    #[inline]
+    pub fn par_iter_mut(&mut self) -> rayon::slice::IterMut<'_, T>
+    where
+        T: Send,
+    {
+        self.raw.par_iter_mut()
     }
 
     /// Returns a mutable iterator over ID-element pairs.
@@ -234,6 +355,24 @@ where
 
         self.raw
             .iter_mut()
+            .enumerate()
+            .map(|(index, value)| (I::from_usize(index), value))
+    }
+
+    /// Returns a parallel mutable iterator over ID-element pairs.
+    ///
+    /// The parallel counterpart of [`Self::iter_enumerated_mut`]: yields typed IDs instead of
+    /// `usize` indices.
+    #[cfg(feature = "rayon")]
+    pub fn par_iter_enumerated_mut(&mut self) -> impl IndexedParallelIterator<Item = (I, &mut T)>
+    where
+        T: Send,
+    {
+        // Elide bound checks from subsequent calls to `I::from_usize`
+        let _: I = I::from_usize(self.len().saturating_sub(1));
+
+        self.raw
+            .par_iter_mut()
             .enumerate()
             .map(|(index, value)| (I::from_usize(index), value))
     }
@@ -258,6 +397,289 @@ where
     #[inline]
     pub fn windows<const N: usize>(&self) -> impl ExactSizeIterator<Item = &[T; N]> {
         self.raw.array_windows()
+    }
+
+    /// Returns an iterator over ID-window pairs for windows of size `N`.
+    ///
+    /// Each window carries the ID of its first element, so a window at `(id, [a, b])` spans
+    /// `id` and `id.plus(1)`. See [`slice::array_windows`] for the window semantics.
+    #[inline]
+    pub fn windows_enumerated<const N: usize>(
+        &self,
+    ) -> impl DoubleEndedIterator<Item = (I, &[T; N])> + ExactSizeIterator + Clone {
+        // Elide bound checks from subsequent calls to `I::from_usize`
+        let _: I = I::from_usize(self.len().saturating_sub(N));
+
+        self.raw
+            .array_windows()
+            .enumerate()
+            .map(|(index, window)| (I::from_usize(index), window))
+    }
+
+    /// Returns an iterator over chunks of size `size`.
+    ///
+    /// Each chunk is a slice of `size` elements, except the last chunk may be smaller.
+    ///
+    /// See [`slice::chunks`](prim@slice#method.chunks) for details.
+    #[inline]
+    pub fn chunks(
+        &self,
+        size: NonZero<usize>,
+    ) -> impl DoubleEndedIterator<Item = &[T]> + ExactSizeIterator + Clone {
+        self.raw.chunks(size.get())
+    }
+
+    /// Returns a parallel iterator over chunks of size `size`.
+    ///
+    /// The parallel counterpart of [`Self::chunks`].
+    #[cfg(feature = "rayon")]
+    #[inline]
+    pub fn par_chunks(
+        &self,
+        size: NonZero<usize>,
+    ) -> impl IndexedParallelIterator<Item = &[T]> + Clone
+    where
+        T: Sync,
+    {
+        use rayon::slice::ParallelSlice as _;
+
+        self.raw.par_chunks(size.get())
+    }
+
+    /// Returns an iterator over chunks of size `size`, each with the ID of its first element.
+    ///
+    /// Each chunk is a slice of `size` elements, except the last chunk may be smaller. A chunk
+    /// at `(id, chunk)` spans `id` through `id.plus(chunk.len() - 1)`, mirroring
+    /// [`Self::windows_enumerated`].
+    #[inline]
+    pub fn chunks_enumerated(
+        &self,
+        size: NonZero<usize>,
+    ) -> impl DoubleEndedIterator<Item = (I, &[T])> + ExactSizeIterator + Clone {
+        // Elide bound checks from subsequent calls to `I::from_usize`
+        let _: I = I::from_usize(self.len());
+
+        self.raw
+            .chunks(size.get())
+            .enumerate()
+            .map(move |(index, chunk)| (I::from_usize(index * size.get()), chunk))
+    }
+
+    /// Returns a parallel iterator over chunks, each with the ID of its first element.
+    ///
+    /// The parallel counterpart of [`Self::chunks_enumerated`].
+    #[cfg(feature = "rayon")]
+    #[inline]
+    pub fn par_chunks_enumerated(
+        &self,
+        size: NonZero<usize>,
+    ) -> impl IndexedParallelIterator<Item = (I, &[T])> + Clone
+    where
+        T: Sync,
+    {
+        use rayon::slice::ParallelSlice as _;
+        // Elide bound checks from subsequent calls to `I::from_usize`
+        let _: I = I::from_usize(self.len());
+
+        self.raw
+            .par_chunks(size.get())
+            .enumerate()
+            .map(move |(index, chunk)| (I::from_usize(index * size.get()), chunk))
+    }
+
+    /// Returns a mutable iterator over chunks of size `size`.
+    ///
+    /// Each chunk is a mutable slice of `size` elements, except the last chunk may be smaller.
+    ///
+    /// See [`slice::chunks_mut`](prim@slice#method.chunks_mut) for details.
+    #[inline]
+    pub fn chunks_mut(&mut self, size: NonZero<usize>) -> slice::ChunksMut<'_, T> {
+        self.raw.chunks_mut(size.get())
+    }
+
+    /// Returns a parallel mutable iterator over chunks of size `size`.
+    ///
+    /// The parallel counterpart of [`Self::chunks_mut`].
+    #[cfg(feature = "rayon")]
+    #[inline]
+    pub fn par_chunks_mut(
+        &mut self,
+        size: NonZero<usize>,
+    ) -> impl IndexedParallelIterator<Item = &mut [T]>
+    where
+        T: Send,
+    {
+        use rayon::slice::ParallelSliceMut as _;
+
+        self.raw.par_chunks_mut(size.get())
+    }
+
+    /// Returns a mutable iterator over chunks, each with the ID of its first element.
+    ///
+    /// Each chunk is a mutable slice of `size` elements, except the last chunk may be smaller. A
+    /// chunk at `(id, chunk)` spans `id` through `id.plus(chunk.len() - 1)`, mirroring
+    /// [`Self::chunks_enumerated`].
+    #[inline]
+    pub fn chunks_enumerated_mut(
+        &mut self,
+        size: NonZero<usize>,
+    ) -> impl DoubleEndedIterator<Item = (I, &mut [T])> + ExactSizeIterator {
+        // Elide bound checks from subsequent calls to `I::from_usize`
+        let _: I = I::from_usize(self.len());
+
+        self.raw
+            .chunks_mut(size.get())
+            .enumerate()
+            .map(move |(index, chunk)| (I::from_usize(index * size.get()), chunk))
+    }
+
+    /// Returns a parallel mutable iterator over chunks, each with the ID of its first element.
+    ///
+    /// The parallel counterpart of [`Self::chunks_enumerated_mut`].
+    #[cfg(feature = "rayon")]
+    #[inline]
+    pub fn par_chunks_enumerated_mut(
+        &mut self,
+        size: NonZero<usize>,
+    ) -> impl IndexedParallelIterator<Item = (I, &mut [T])>
+    where
+        T: Send,
+    {
+        use rayon::slice::ParallelSliceMut as _;
+        // Elide bound checks from subsequent calls to `I::from_usize`
+        let _: I = I::from_usize(self.len());
+
+        self.raw
+            .par_chunks_mut(size.get())
+            .enumerate()
+            .map(move |(index, chunk)| (I::from_usize(index * size.get()), chunk))
+    }
+
+    /// Sorts the slice in place with the given comparator, in unstable order.
+    ///
+    /// See [`slice::sort_unstable_by`](prim@slice#method.sort_unstable_by) for details.
+    #[inline]
+    pub fn sort_unstable_by(&mut self, compare: impl Fn(&T, &T) -> cmp::Ordering) {
+        self.raw.sort_unstable_by(compare);
+    }
+
+    /// Sorts the slice in place with the given comparator, in parallel and unstable order.
+    ///
+    /// The parallel counterpart of [`slice::sort_unstable_by`](prim@slice#method.sort_unstable_by).
+    #[cfg(feature = "rayon")]
+    #[inline]
+    pub fn par_sort_unstable_by(&mut self, compare: impl Fn(&T, &T) -> cmp::Ordering + Sync)
+    where
+        T: Send,
+    {
+        self.raw.par_sort_unstable_by(compare);
+    }
+
+    /// Sorts the slice in place using the given key function, in unstable order.
+    ///
+    /// See [`slice::sort_unstable_by_key`](prim@slice#method.sort_unstable_by_key) for details.
+    #[inline]
+    pub fn sort_unstable_by_key<K>(&mut self, func: impl FnMut(&T) -> K)
+    where
+        K: Ord,
+    {
+        self.raw.sort_unstable_by_key(func);
+    }
+
+    /// Sorts the slice in place using the given key function, in parallel and unstable order.
+    ///
+    /// The parallel counterpart of [`Self::sort_unstable_by_key`].
+    #[cfg(feature = "rayon")]
+    #[inline]
+    pub fn par_sort_unstable_by_key<K>(&mut self, func: impl Fn(&T) -> K + Sync)
+    where
+        T: Send,
+        K: Ord + Send,
+    {
+        self.raw.par_sort_unstable_by_key(func);
+    }
+
+    /// Returns `true` if the slice is sorted.
+    ///
+    /// See [`slice::is_sorted`](prim@slice#method.is_sorted) for details.
+    #[inline]
+    pub fn is_sorted(&self) -> bool
+    where
+        T: Ord,
+    {
+        self.raw.is_sorted()
+    }
+
+    /// Returns `true` if the slice is sorted by the given comparator.
+    ///
+    /// See [`slice::is_sorted_by`](prim@slice#method.is_sorted_by) for details.
+    #[inline]
+    pub fn is_sorted_by(&self, compare: impl Fn(&T, &T) -> bool) -> bool {
+        self.raw.is_sorted_by(compare)
+    }
+
+    /// Searches for an item in the slice using binary search, returning the index of the item if
+    /// found.
+    ///
+    /// See [`slice::binary_search`](prim@slice#method.binary_search) for details.
+    ///
+    /// # Errors
+    ///
+    /// Returns the ID where a matching element could be inserted while maintaining sorted order.
+    #[inline]
+    pub fn binary_search(&self, item: &T) -> Result<I, I>
+    where
+        T: Ord,
+    {
+        self.raw
+            .binary_search(item)
+            .map(I::from_usize)
+            .map_err(I::from_usize)
+    }
+
+    /// Clones the slice into a new [`IdVec`].
+    ///
+    /// See [`slice::to_vec`](prim@slice#method.to_vec) for details.
+    pub fn to_vec(&self) -> IdVec<I, T>
+    where
+        T: Clone,
+    {
+        IdVec::from_raw(self.raw.to_vec())
+    }
+
+    /// Clones the slice into a new [`IdVec`] using the given allocator.
+    ///
+    /// See [`slice::to_vec_in`](prim@slice#method.to_vec_in) for details.
+    pub fn to_vec_in<A>(&self, alloc: A) -> IdVec<I, T, A>
+    where
+        A: Allocator,
+        T: Clone,
+    {
+        IdVec::from_raw(self.raw.to_vec_in(alloc))
+    }
+
+    #[inline]
+    pub fn partition_point(&self, predicate: impl Fn(&T) -> bool) -> I {
+        let index = self.raw.partition_point(predicate);
+        I::from_usize(index)
+    }
+
+    #[inline]
+    pub const fn last(&self) -> Option<&T> {
+        self.raw.last()
+    }
+
+    #[inline]
+    pub const fn first(&self) -> Option<&T> {
+        self.raw.first()
+    }
+
+    #[inline]
+    pub fn fill(&mut self, value: T)
+    where
+        T: Clone,
+    {
+        self.raw.fill(value);
     }
 }
 
@@ -379,7 +801,6 @@ where
 
 impl<I, T> Debug for IdSlice<I, T>
 where
-    I: Id,
     T: Debug,
 {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -387,9 +808,10 @@ where
     }
 }
 
-impl<I, T, R> Index<R> for IdSlice<I, T>
+const impl<I, T, R> Index<R> for IdSlice<I, T>
 where
-    R: IntoSliceIndex<I, [T]>,
+    R: [const] IntoSliceIndex<I, [T]>,
+    <R as IntoSliceIndex<I, [T]>>::SliceIndex: [const] core::slice::SliceIndex<[T]>,
 {
     type Output = <R::SliceIndex as SliceIndex<[T]>>::Output;
 
@@ -398,9 +820,10 @@ where
     }
 }
 
-impl<I, T, R> IndexMut<R> for IdSlice<I, T>
+const impl<I, T, R> IndexMut<R> for IdSlice<I, T>
 where
-    R: IntoSliceIndex<I, [T]>,
+    R: [const] IntoSliceIndex<I, [T]>,
+    <R as IntoSliceIndex<I, [T]>>::SliceIndex: [const] core::slice::SliceIndex<[T]>,
 {
     fn index_mut(&mut self, index: R) -> &mut Self::Output {
         self.raw.index_mut(index.into_slice_index())
@@ -422,6 +845,48 @@ impl<'this, I, T> IntoIterator for &'this mut IdSlice<I, T> {
 
     fn into_iter(self) -> Self::IntoIter {
         self.raw.iter_mut()
+    }
+}
+
+#[cfg(feature = "rayon")]
+impl<'this, I, T> IntoParallelIterator for &'this IdSlice<I, T>
+where
+    T: Sync,
+{
+    type Item = &'this T;
+    type Iter = rayon::slice::Iter<'this, T>;
+
+    fn into_par_iter(self) -> Self::Iter {
+        self.raw.par_iter()
+    }
+}
+
+#[cfg(feature = "rayon")]
+impl<'this, I, T> IntoParallelIterator for &'this mut IdSlice<I, T>
+where
+    T: Send,
+{
+    type Item = &'this mut T;
+    type Iter = rayon::slice::IterMut<'this, T>;
+
+    fn into_par_iter(self) -> Self::Iter {
+        self.raw.par_iter_mut()
+    }
+}
+
+impl<I, T, A> Clone for Box<IdSlice<I, T>, A>
+where
+    I: Id,
+    T: Clone,
+    A: Allocator + Clone,
+{
+    fn clone(&self) -> Self {
+        let raw = self
+            .as_raw()
+            .to_vec_in(Self::allocator(self).clone())
+            .into_boxed_slice();
+
+        IdSlice::from_boxed_slice(raw)
     }
 }
 
@@ -490,6 +955,34 @@ mod tests {
         let slice = IdSlice::<TestId, _>::from_raw(&data);
 
         assert!(slice.is_empty());
+    }
+
+    #[test]
+    fn array_windows_enumerated_pairs_each_window_with_its_first_id() {
+        let data = [10, 20, 30, 40];
+        let slice = IdSlice::<TestId, _>::from_raw(&data);
+
+        let windows: alloc::vec::Vec<_> = slice.windows_enumerated::<2>().collect();
+        assert_eq!(
+            windows,
+            [
+                (TestId::from_usize(0), &[10, 20]),
+                (TestId::from_usize(1), &[20, 30]),
+                (TestId::from_usize(2), &[30, 40]),
+            ]
+        );
+
+        let mut reversed = slice.windows_enumerated::<2>().rev();
+        assert_eq!(reversed.next(), Some((TestId::from_usize(2), &[30, 40])));
+    }
+
+    #[test]
+    fn array_windows_enumerated_is_empty_on_a_short_slice() {
+        let data = [10];
+        let slice = IdSlice::<TestId, _>::from_raw(&data);
+
+        assert_eq!(slice.windows_enumerated::<2>().len(), 0);
+        assert_eq!(slice.windows_enumerated::<2>().next(), None);
     }
 
     #[test]

--- a/libs/@local/hashql/core/src/id/snapshot_vec.rs
+++ b/libs/@local/hashql/core/src/id/snapshot_vec.rs
@@ -587,7 +587,7 @@ where
     /// ```
     #[inline]
     #[must_use]
-    pub fn as_slice(&self) -> &IdSlice<I, T> {
+    pub const fn as_slice(&self) -> &IdSlice<I, T> {
         &self.inner
     }
 }

--- a/libs/@local/hashql/core/src/id/tests.rs
+++ b/libs/@local/hashql/core/src/id/tests.rs
@@ -1,0 +1,239 @@
+#![expect(clippy::empty_enums, reason = "zerocopy uses them in the derive")]
+
+use zerocopy::{FromBytes as _, IntoBytes as _, TryFromBytes as _};
+
+use super::{Id as _, IdError, newtype};
+
+newtype!(
+    #[id(crate = crate)]
+    struct UnboundedId(u64)
+);
+
+newtype!(
+    #[id(crate = crate)]
+    struct NarrowUnboundedId(u16)
+);
+
+newtype!(
+    #[id(crate = crate, endian = little, unaligned)]
+    struct LittleId(u64)
+);
+
+newtype!(
+    #[id(crate = crate, endian = big, unaligned)]
+    struct BigId(u32)
+);
+
+newtype!(
+    #[id(crate = crate, unaligned)]
+    struct NativeBytesId(u16)
+);
+
+#[test]
+fn unbounded_id_covers_backing_type() {
+    assert_eq!(UnboundedId::MIN.as_u64(), 0);
+    assert_eq!(UnboundedId::MAX.as_u64(), u64::MAX);
+    assert_eq!(
+        UnboundedId::try_from(u64::MAX),
+        Ok(UnboundedId::new(u64::MAX))
+    );
+}
+
+#[test]
+fn unbounded_id_rejects_values_wider_than_backing_type() {
+    let above = u64::from(u16::MAX) + 1;
+
+    assert_eq!(
+        NarrowUnboundedId::try_from(above),
+        Err(IdError::OutOfRange {
+            value: above,
+            min: 0,
+            max: u64::from(u16::MAX),
+        })
+    );
+    assert_eq!(
+        NarrowUnboundedId::try_from(u64::from(u16::MAX)),
+        Ok(NarrowUnboundedId::new(u16::MAX))
+    );
+}
+
+#[test]
+fn byte_encoded_id_has_alignment_one() {
+    assert_eq!(align_of::<LittleId>(), 1);
+    assert_eq!(size_of::<LittleId>(), 8);
+    assert_eq!(align_of::<BigId>(), 1);
+    assert_eq!(size_of::<BigId>(), 4);
+    assert_eq!(align_of::<NativeBytesId>(), 1);
+    assert_eq!(size_of::<NativeBytesId>(), 2);
+}
+
+#[test]
+fn little_endian_id_encodes_low_byte_first() {
+    let id = LittleId::new(0x0102_0304_0506_0708);
+
+    assert_eq!(id.as_bytes(), [8, 7, 6, 5, 4, 3, 2, 1]);
+}
+
+#[test]
+fn big_endian_id_encodes_high_byte_first() {
+    let id = BigId::new(0x0102_0304);
+
+    assert_eq!(id.as_bytes(), [1, 2, 3, 4]);
+}
+
+#[test]
+fn byte_encoded_id_reads_back_from_bytes() {
+    let id = LittleId::new(0xDEAD_BEEF);
+
+    assert_eq!(
+        LittleId::read_from_bytes(id.as_bytes()).expect("encoding is its own byte source"),
+        id
+    );
+}
+
+#[test]
+fn byte_encoded_id_orders_by_value() {
+    // Byte-lexicographic order over little-endian encodings would invert this pair.
+    assert!(LittleId::new(2) < LittleId::new(256));
+}
+
+#[test]
+fn byte_encoded_id_formats_value() {
+    assert_eq!(LittleId::new(42).to_string(), "42");
+    assert_eq!(format!("{:?}", BigId::new(7)), "BigId(7)");
+}
+
+newtype!(
+    #[id(crate = crate, endian = big, unaligned)]
+    struct WindowId(u16 is 10..=20)
+);
+
+#[test]
+fn get_returns_the_raw_scalar() {
+    const IN_CONST: u64 = UnboundedId::new(3).get();
+
+    assert_eq!(UnboundedId::new(7).get(), 7_u64);
+    assert_eq!(LittleId::new(9).get(), 9_u64);
+    assert_eq!(NarrowUnboundedId::new(3).get(), 3_u16);
+    assert_eq!(IN_CONST, 3);
+}
+
+#[test]
+fn bounded_byte_id_reads_only_in_range_bytes() {
+    let id = WindowId::try_read_from_bytes(&[0, 20]).expect("20 lies in the range");
+    assert_eq!(id, WindowId::new(20));
+    assert_eq!(
+        WindowId::try_read_from_bytes(&[0, 10]).expect("10 lies in the range"),
+        WindowId::new(10)
+    );
+
+    WindowId::try_read_from_bytes(&[0, 21]).expect_err("21 lies above the range");
+    WindowId::try_read_from_bytes(&[0, 9]).expect_err("9 lies below the range");
+    WindowId::try_read_from_bytes(&[0, 0]).expect_err("zero lies below the range");
+    WindowId::try_read_from_bytes(&[255, 255]).expect_err("the maximum lies above the range");
+}
+
+#[test]
+fn bounded_byte_id_still_writes_bytes() {
+    let id = WindowId::new(18);
+
+    assert_eq!(id.as_bytes(), [0, 18]);
+}
+
+#[test]
+fn native_bytes_id_round_trips() {
+    let id = NativeBytesId::new(0x1234);
+
+    assert_eq!(
+        NativeBytesId::read_from_bytes(id.as_bytes()).expect("encoding is its own byte source"),
+        id
+    );
+    assert_eq!(id.as_u64(), 0x1234);
+}
+
+#[cfg(feature = "rayon")]
+mod par {
+    use alloc::{vec, vec::Vec};
+
+    use rayon::iter::{IntoParallelIterator as _, ParallelExtend as _, ParallelIterator as _};
+
+    use super::UnboundedId;
+    use crate::id::{Id as _, IdVec};
+
+    #[test]
+    fn par_iter_enumerated_matches_serial() {
+        let vec: IdVec<UnboundedId, u32> = IdVec::from_raw(vec![10, 20, 30]);
+
+        let serial: Vec<(UnboundedId, u32)> = vec
+            .iter_enumerated()
+            .map(|(id, &value)| (id, value))
+            .collect();
+        let parallel: Vec<(UnboundedId, u32)> = vec
+            .par_iter_enumerated()
+            .map(|(id, &value)| (id, value))
+            .collect();
+
+        assert_eq!(parallel, serial);
+    }
+
+    #[test]
+    fn par_ids_matches_ids() {
+        let vec: IdVec<UnboundedId, u32> = IdVec::from_raw(vec![1, 2, 3, 4]);
+
+        let serial: Vec<UnboundedId> = vec.ids().collect();
+        let parallel: Vec<UnboundedId> = vec.par_ids().collect();
+
+        assert_eq!(parallel, serial);
+    }
+
+    #[test]
+    fn par_collect_and_extend_preserve_order() {
+        let collected: IdVec<UnboundedId, u32> = (0..64_u32).into_par_iter().collect();
+        assert_eq!(collected.as_raw(), (0..64).collect::<Vec<u32>>());
+
+        let mut extended: IdVec<UnboundedId, u32> = IdVec::new();
+        extended.par_extend((0..64_u32).into_par_iter());
+        assert_eq!(extended.as_raw(), collected.as_raw());
+    }
+
+    #[test]
+    fn into_par_iter_enumerated_yields_typed_ids() {
+        let vec: IdVec<UnboundedId, u32> = IdVec::from_raw(vec![7, 8]);
+
+        let pairs: Vec<(UnboundedId, u32)> = vec.into_par_iter_enumerated().collect();
+
+        assert_eq!(
+            pairs,
+            [
+                (UnboundedId::from_usize(0), 7),
+                (UnboundedId::from_usize(1), 8)
+            ]
+        );
+    }
+}
+
+#[cfg(feature = "zerocopy")]
+mod bytes {
+    use zerocopy::{FromBytes as _, IntoBytes as _};
+
+    use super::UnboundedId;
+    use crate::id::{IdArray, IdSlice};
+
+    #[test]
+    fn id_slice_writes_its_elements_bytes() {
+        let data: [u32; 3] = [1, 2, 3];
+        let slice = IdSlice::<UnboundedId, u32>::from_raw(&data);
+
+        assert_eq!(slice.as_bytes(), data.as_bytes());
+    }
+
+    #[test]
+    fn id_array_round_trips_through_bytes() {
+        let array = IdArray::<UnboundedId, u32, 3>::from_raw([4, 5, 6]);
+
+        let back = <IdArray<UnboundedId, u32, 3>>::read_from_bytes(array.as_bytes())
+            .expect("the encoding is its own byte source");
+
+        assert_eq!(back, array);
+    }
+}

--- a/libs/@local/hashql/core/src/id/vec.rs
+++ b/libs/@local/hashql/core/src/id/vec.rs
@@ -352,6 +352,10 @@ where
         Self::from_raw(vec)
     }
 
+    /// Converts the vector into a boxed [`IdSlice`] without copying its elements.
+    ///
+    /// The allocation and typed index domain are preserved. See [`Vec::into_boxed_slice`] for the
+    /// capacity behavior of the underlying vector.
     pub fn into_boxed_slice(self) -> Box<IdSlice<I, T>, A> {
         IdSlice::from_boxed_slice(self.raw.into_boxed_slice())
     }

--- a/libs/@local/hashql/core/src/id/vec.rs
+++ b/libs/@local/hashql/core/src/id/vec.rs
@@ -10,6 +10,13 @@ use core::{
     slice,
 };
 
+#[cfg(feature = "rayon")]
+use rayon::iter::{
+    FromParallelIterator, IndexedParallelIterator, IntoParallelIterator,
+    IntoParallelRefIterator as _, IntoParallelRefMutIterator as _, ParallelExtend,
+    ParallelIterator as _,
+};
+
 use super::{Id, slice::IdSlice};
 use crate::heap::{FromIteratorIn, TryCloneIn};
 
@@ -149,6 +156,28 @@ where
             _marker: PhantomData,
             raw,
         }
+    }
+
+    /// Consumes the `IdVec` and returns the raw [`Vec`].
+    ///
+    /// The inverse of [`from_raw`](Self::from_raw): the elements and their order are unchanged,
+    /// only the typed index domain is dropped. Intended for the boundaries where a typed
+    /// collection leaves the domain-indexed world, such as handing storage to an external format
+    /// or library that speaks raw indices.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use hashql_core::id::{IdVec, Id as _, newtype};
+    /// # newtype!(struct NodeId(u32 is 0..=100));
+    /// let vec = IdVec::<NodeId, _>::from_raw(vec!["a", "b", "c"]);
+    /// let raw = vec.into_raw();
+    ///
+    /// assert_eq!(raw, vec!["a", "b", "c"]);
+    /// ```
+    #[inline]
+    pub fn into_raw(self) -> Vec<T, A> {
+        self.raw
     }
 
     /// Creates a new, empty `IdVec` with a custom allocator.
@@ -321,6 +350,10 @@ where
         }
 
         Self::from_raw(vec)
+    }
+
+    pub fn into_boxed_slice(self) -> Box<IdSlice<I, T>, A> {
+        IdSlice::from_boxed_slice(self.raw.into_boxed_slice())
     }
 
     /// Appends an element to the back of the vector and returns its ID.
@@ -517,6 +550,28 @@ where
     }
 }
 
+#[cfg(feature = "rayon")]
+impl<I, T> IdVec<I, T>
+where
+    I: Id,
+    T: Send,
+{
+    /// Consumes the vector and returns a parallel iterator over ID-element pairs.
+    ///
+    /// The parallel counterpart of [`Self::into_iter_enumerated`]: yields typed IDs instead of
+    /// `usize` indices.
+    #[must_use]
+    pub fn into_par_iter_enumerated(self) -> impl IndexedParallelIterator<Item = (I, T)> {
+        // Elide bound checks from subsequent calls to `I::from_usize`
+        let _: I = I::from_usize(self.len().saturating_sub(1));
+
+        self.raw
+            .into_par_iter()
+            .enumerate()
+            .map(|(index, value)| (I::from_usize(index), value))
+    }
+}
+
 // Map-like APIs for IdVec<I, Option<T>>
 impl<I, T, A: Allocator> IdVec<I, Option<T>, A>
 where
@@ -645,7 +700,7 @@ where
     }
 }
 
-impl<I, T, A> Deref for IdVec<I, T, A>
+const impl<I, T, A> Deref for IdVec<I, T, A>
 where
     I: Id,
     A: Allocator,
@@ -658,7 +713,7 @@ where
     }
 }
 
-impl<I, T, A> DerefMut for IdVec<I, T, A>
+const impl<I, T, A> DerefMut for IdVec<I, T, A>
 where
     I: Id,
     A: Allocator,
@@ -733,6 +788,50 @@ where
     }
 }
 
+#[cfg(feature = "rayon")]
+impl<I, T> IntoParallelIterator for IdVec<I, T>
+where
+    I: Id,
+    T: Send,
+{
+    type Item = T;
+    type Iter = rayon::vec::IntoIter<T>;
+
+    fn into_par_iter(self) -> Self::Iter {
+        self.raw.into_par_iter()
+    }
+}
+
+#[cfg(feature = "rayon")]
+impl<'this, I, T, A> IntoParallelIterator for &'this IdVec<I, T, A>
+where
+    I: Id,
+    T: Sync,
+    A: Allocator,
+{
+    type Item = &'this T;
+    type Iter = rayon::slice::Iter<'this, T>;
+
+    fn into_par_iter(self) -> Self::Iter {
+        self.raw.par_iter()
+    }
+}
+
+#[cfg(feature = "rayon")]
+impl<'this, I, T, A> IntoParallelIterator for &'this mut IdVec<I, T, A>
+where
+    I: Id,
+    T: Send,
+    A: Allocator,
+{
+    type Item = &'this mut T;
+    type Iter = rayon::slice::IterMut<'this, T>;
+
+    fn into_par_iter(self) -> Self::Iter {
+        self.raw.par_iter_mut()
+    }
+}
+
 impl<I, T> Default for IdVec<I, T, Global>
 where
     I: Id,
@@ -763,6 +862,20 @@ where
     }
 }
 
+#[cfg(feature = "rayon")]
+impl<I, T> ParallelExtend<T> for IdVec<I, T>
+where
+    I: Id,
+    T: Send,
+{
+    fn par_extend<U>(&mut self, par_iter: U)
+    where
+        U: IntoParallelIterator<Item = T>,
+    {
+        self.raw.par_extend(par_iter);
+    }
+}
+
 impl<I, T, A, B> TryCloneIn<B> for IdVec<I, T, A>
 where
     I: Id,
@@ -783,6 +896,19 @@ where
     }
 }
 
+impl<I, T> FromIterator<T> for IdVec<I, T>
+where
+    I: Id,
+{
+    #[inline]
+    fn from_iter<U>(iter: U) -> Self
+    where
+        U: IntoIterator<Item = T>,
+    {
+        Self::from_raw(Vec::from_iter(iter))
+    }
+}
+
 impl<I, T, A> FromIteratorIn<T, A> for IdVec<I, T, A>
 where
     I: Id,
@@ -794,5 +920,19 @@ where
         U: IntoIterator<Item = T>,
     {
         Self::from_raw(Vec::from_iter_in(iter, alloc))
+    }
+}
+
+#[cfg(feature = "rayon")]
+impl<I, T> FromParallelIterator<T> for IdVec<I, T>
+where
+    I: Id,
+    T: Send,
+{
+    fn from_par_iter<U>(par_iter: U) -> Self
+    where
+        U: IntoParallelIterator<Item = T>,
+    {
+        Self::from_raw(Vec::from_par_iter(par_iter))
     }
 }

--- a/libs/@local/hashql/core/src/lib.rs
+++ b/libs/@local/hashql/core/src/lib.rs
@@ -38,7 +38,9 @@
     step_trait,
     sync_nonpoison,
     try_trait_v2,
-    variant_count
+    variant_count,
+    const_range_bounds,
+    const_index
 )]
 
 extern crate alloc;

--- a/libs/@local/hashql/core/src/module/universe.rs
+++ b/libs/@local/hashql/core/src/module/universe.rs
@@ -1268,7 +1268,7 @@ where
     /// assert_eq!(realms.get(Universe::Type, 1), Some(&20));
     /// assert_eq!(realms.get(Universe::Type, 3), None);
     /// ```
-    pub fn get(&self, universe: Universe, index: usize) -> Option<&T> {
+    pub const fn get(&self, universe: Universe, index: usize) -> Option<&T> {
         self.of(universe).get(index)
     }
 
@@ -1291,7 +1291,7 @@ where
     ///
     /// assert_eq!(realms.of(Universe::Type), &vec![10, 40, 30]);
     /// ```
-    pub fn get_mut(&mut self, universe: Universe, index: usize) -> Option<&mut T> {
+    pub const fn get_mut(&mut self, universe: Universe, index: usize) -> Option<&mut T> {
         self.of_mut(universe).get_mut(index)
     }
 

--- a/libs/@local/hashql/core/src/type/inference/solver/graph.rs
+++ b/libs/@local/hashql/core/src/type/inference/solver/graph.rs
@@ -353,7 +353,7 @@ impl Graph {
         self.nodes.iter().map(|node| node.id)
     }
 
-    pub(crate) fn node(&self, index: usize) -> VariableId {
+    pub(crate) const fn node(&self, index: usize) -> VariableId {
         self.nodes[index].id
     }
 

--- a/libs/@local/hashql/diagnostics/docs/dependency-diagram.mmd
+++ b/libs/@local/hashql/diagnostics/docs/dependency-diagram.mmd
@@ -10,29 +10,26 @@ graph TD
     %% ---> : Build dependency
     0[<a href="../hash_graph/index.html">hash-graph</a>]
     1[<a href="../hash_graph_api/index.html">hash-graph-api</a>]
-    2[<a href="../hash_graph_atlas/index.html">hash-graph-atlas</a>]
-    3[<a href="../hashql_ast/index.html">hashql-ast</a>]
-    4[<a href="../hashql_compiletest/index.html">hashql-compiletest</a>]
-    5[<a href="../hashql_core/index.html">hashql-core</a>]
-    6[hashql-diagnostics]
-    class 6 root
-    7[<a href="../hashql_eval/index.html">hashql-eval</a>]
-    8[<a href="../hashql_hir/index.html">hashql-hir</a>]
-    9[<a href="../hashql_mir/index.html">hashql-mir</a>]
-    10[<a href="../hashql_syntax_jexpr/index.html">hashql-syntax-jexpr</a>]
-    11[<a href="../hash_graph_benches/index.html">hash-graph-benches</a>]
+    2[<a href="../hashql_ast/index.html">hashql-ast</a>]
+    3[<a href="../hashql_compiletest/index.html">hashql-compiletest</a>]
+    4[<a href="../hashql_core/index.html">hashql-core</a>]
+    5[hashql-diagnostics]
+    class 5 root
+    6[<a href="../hashql_eval/index.html">hashql-eval</a>]
+    7[<a href="../hashql_hir/index.html">hashql-hir</a>]
+    8[<a href="../hashql_mir/index.html">hashql-mir</a>]
+    9[<a href="../hashql_syntax_jexpr/index.html">hashql-syntax-jexpr</a>]
+    10[<a href="../hash_graph_benches/index.html">hash-graph-benches</a>]
     0 --> 1
-    0 --> 2
-    1 --> 7
-    1 --> 10
-    2 --> 5
-    3 -.-> 4
-    4 --> 7
-    4 --> 10
-    5 --> 6
-    7 --> 9
-    8 -.-> 4
-    9 --> 8
-    10 --> 3
-    10 --> 5
-    11 -.-> 1
+    1 --> 6
+    1 --> 9
+    2 -.-> 3
+    3 --> 6
+    3 --> 9
+    4 --> 5
+    6 --> 8
+    7 -.-> 3
+    8 --> 7
+    9 --> 2
+    9 --> 4
+    10 -.-> 1

--- a/libs/@local/hashql/diagnostics/docs/dependency-diagram.mmd
+++ b/libs/@local/hashql/diagnostics/docs/dependency-diagram.mmd
@@ -10,26 +10,29 @@ graph TD
     %% ---> : Build dependency
     0[<a href="../hash_graph/index.html">hash-graph</a>]
     1[<a href="../hash_graph_api/index.html">hash-graph-api</a>]
-    2[<a href="../hashql_ast/index.html">hashql-ast</a>]
-    3[<a href="../hashql_compiletest/index.html">hashql-compiletest</a>]
-    4[<a href="../hashql_core/index.html">hashql-core</a>]
-    5[hashql-diagnostics]
-    class 5 root
-    6[<a href="../hashql_eval/index.html">hashql-eval</a>]
-    7[<a href="../hashql_hir/index.html">hashql-hir</a>]
-    8[<a href="../hashql_mir/index.html">hashql-mir</a>]
-    9[<a href="../hashql_syntax_jexpr/index.html">hashql-syntax-jexpr</a>]
-    10[<a href="../hash_graph_benches/index.html">hash-graph-benches</a>]
+    2[<a href="../hash_graph_atlas/index.html">hash-graph-atlas</a>]
+    3[<a href="../hashql_ast/index.html">hashql-ast</a>]
+    4[<a href="../hashql_compiletest/index.html">hashql-compiletest</a>]
+    5[<a href="../hashql_core/index.html">hashql-core</a>]
+    6[hashql-diagnostics]
+    class 6 root
+    7[<a href="../hashql_eval/index.html">hashql-eval</a>]
+    8[<a href="../hashql_hir/index.html">hashql-hir</a>]
+    9[<a href="../hashql_mir/index.html">hashql-mir</a>]
+    10[<a href="../hashql_syntax_jexpr/index.html">hashql-syntax-jexpr</a>]
+    11[<a href="../hash_graph_benches/index.html">hash-graph-benches</a>]
     0 --> 1
-    1 --> 6
-    1 --> 9
-    2 -.-> 3
-    3 --> 6
-    3 --> 9
-    4 --> 5
-    6 --> 8
-    7 -.-> 3
-    8 --> 7
-    9 --> 2
-    9 --> 4
-    10 -.-> 1
+    0 --> 2
+    1 --> 7
+    1 --> 10
+    2 --> 5
+    3 -.-> 4
+    4 --> 7
+    4 --> 10
+    5 --> 6
+    7 --> 9
+    8 -.-> 4
+    9 --> 8
+    10 --> 3
+    10 --> 5
+    11 -.-> 1

--- a/libs/@local/hashql/eval/src/lib.rs
+++ b/libs/@local/hashql/eval/src/lib.rs
@@ -11,6 +11,8 @@
 
     // Library Features
     allocator_api,
+    const_convert,
+    const_trait_impl,
     iter_array_chunks,
     maybe_uninit_fill,
     impl_trait_in_assoc_type,

--- a/libs/@local/hashql/eval/src/postgres/parameters.rs
+++ b/libs/@local/hashql/eval/src/postgres/parameters.rs
@@ -25,7 +25,7 @@ use hashql_mir::{
 
 id::newtype!(
     /// Index of a SQL parameter in the compiled query, rendered as `$N` by the SQL formatter.
-    #[id(display = !)]
+    #[id(display = !, const)]
     pub struct ParameterIndex(u32 is 0..=u32::MAX)
 );
 
@@ -208,12 +208,12 @@ impl<'heap, A: Allocator> Parameters<'heap, A> {
     }
 
     /// Returns the number of distinct parameters allocated so far.
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         self.reverse.len()
     }
 
     /// Returns `true` if no parameters have been allocated.
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.reverse.is_empty()
     }
 

--- a/libs/@local/hashql/hir/src/lib.rs
+++ b/libs/@local/hashql/hir/src/lib.rs
@@ -13,6 +13,9 @@
 
     // Library Features
     allocator_api,
+    const_convert,
+    const_index,
+    const_trait_impl,
     try_trait_v2,
     unwrap_infallible,
 )]

--- a/libs/@local/hashql/hir/src/map.rs
+++ b/libs/@local/hashql/hir/src/map.rs
@@ -58,7 +58,7 @@ impl<'heap> HirMap<'heap> {
     /// [`TypeId::PLACEHOLDER`] if no data has been assigned yet.
     #[inline]
     #[must_use]
-    pub fn type_id(&self, id: HirId) -> TypeId {
+    pub const fn type_id(&self, id: HirId) -> TypeId {
         self.types[id]
     }
 

--- a/libs/@local/hashql/hir/src/node/mod.rs
+++ b/libs/@local/hashql/hir/src/node/mod.rs
@@ -29,6 +29,7 @@ id::newtype!(
     /// The value space is restricted to 0..=0xFFFF_FF00, reserving the last 256 for niches.
     /// As real pattern types are an experimental feature in Rust, these can currently only be
     /// used by directly modifying and accessing the `NodeId`'s internal value.
+    #[id(const)]
     pub struct HirId(u32 is 0..=0xFFFF_FF00)
 );
 

--- a/libs/@local/hashql/macros/src/grammar.rs
+++ b/libs/@local/hashql/macros/src/grammar.rs
@@ -16,6 +16,11 @@ keyword! {
     pub KIs = "is";
     pub KCrate = "crate";
     pub KConst = "const";
+    pub KEndian = "endian";
+    pub KUnaligned = "unaligned";
+    pub KLittle = "little";
+    pub KBig = "big";
+    pub KNative = "native";
     pub KU8 = "u8";
     pub KU16 = "u16";
     pub KU32 = "u32";

--- a/libs/@local/hashql/macros/src/id/attr.rs
+++ b/libs/@local/hashql/macros/src/id/attr.rs
@@ -1,5 +1,6 @@
 use alloc::collections::BTreeSet;
 
+use proc_macro2::Ident;
 use unsynn::{ToTokens as _, TokenStream, TokenTree, quote};
 
 use super::grammar::{self, AttributeBody, IdAttribute};
@@ -11,9 +12,22 @@ pub(crate) enum DisplayAttribute {
     Format(TokenTree),
 }
 
+pub(crate) struct Spanned<T> {
+    pub value: T,
+    pub span: proc_macro::Span,
+}
+
 #[derive(Debug, Copy, Clone, PartialOrd, Ord, PartialEq, Eq)]
 pub(crate) enum Trait {
     Step,
+}
+
+/// Byte order selected by the `endian` attribute.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub(crate) enum Endianness {
+    Native,
+    Little,
+    Big,
 }
 
 pub(crate) struct Attributes {
@@ -21,6 +35,10 @@ pub(crate) struct Attributes {
     pub r#const: TokenStream,
     pub display: DisplayAttribute,
     pub traits: BTreeSet<Trait>,
+
+    pub endian: Option<Spanned<Endianness>>,
+    /// The `unaligned` keyword token; presence turns the mode on, kept for error spans.
+    pub unaligned: Option<proc_macro::Span>,
 
     pub extra: TokenStream,
 }
@@ -51,6 +69,25 @@ impl Attributes {
                     self.display = DisplayAttribute::Format(token_tree);
                 }
             },
+            IdAttribute::Endian {
+                _endian: endian,
+                _eq,
+                value,
+            } => {
+                self.endian = Some(Spanned {
+                    value: match value {
+                        grammar::EndianValue::Little(_) => Endianness::Little,
+                        grammar::EndianValue::Big(_) => Endianness::Big,
+                        grammar::EndianValue::Native(_) => Endianness::Native,
+                    },
+                    span: AsRef::<Ident>::as_ref(&endian).span().unwrap(),
+                });
+            }
+            IdAttribute::Unaligned {
+                _unaligned: unaligned,
+            } => {
+                self.unaligned = Some(AsRef::<Ident>::as_ref(&unaligned).span().unwrap());
+            }
         }
     }
 
@@ -60,6 +97,8 @@ impl Attributes {
             r#const: TokenStream::new(),
             display: DisplayAttribute::Auto,
             traits: BTreeSet::new(),
+            endian: None,
+            unaligned: None,
             extra: TokenStream::new(),
         };
 

--- a/libs/@local/hashql/macros/src/id/enum.rs
+++ b/libs/@local/hashql/macros/src/id/enum.rs
@@ -2,10 +2,13 @@ use proc_macro2::{Literal, TokenStream};
 use quote::{quote, quote_spanned};
 use unsynn::ToTokens as _;
 
-use super::grammar;
-use crate::id::{
-    attr::{Attributes, DisplayAttribute, Trait},
-    common::IntegerScalar,
+use super::{attr::Spanned, grammar};
+use crate::{
+    emit_error,
+    id::{
+        attr::{Attributes, DisplayAttribute, Trait},
+        common::IntegerScalar,
+    },
 };
 
 #[expect(
@@ -29,9 +32,18 @@ pub(super) fn expand_enum(
         r#const: konst,
         display,
         traits,
+        endian,
+        unaligned,
         extra: _,
     } = Attributes::parse(attributes);
     let vis = visibility.into_token_stream();
+
+    if let Some(Spanned { value: _, span }) = endian {
+        emit_error(span, "`endian` apply to struct ids only");
+    }
+    if let Some(span) = unaligned {
+        emit_error(span, "`unaligned` apply to struct ids only");
+    }
 
     let mut variants: Vec<_> = Vec::new();
     for variant in &*body.content {

--- a/libs/@local/hashql/macros/src/id/mod.rs
+++ b/libs/@local/hashql/macros/src/id/mod.rs
@@ -18,8 +18,9 @@ mod grammar {
     };
 
     use crate::grammar::{
-        AngleTokenTree, Attribute, KConst, KCrate, KDerive, KDisplay, KEnum, KId, KIs, KStep,
-        KStruct, KU8, KU16, KU32, KU64, KU128, ModPath, VerbatimUntil, Visibility,
+        AngleTokenTree, Attribute, KBig, KConst, KCrate, KDerive, KDisplay, KEndian, KEnum, KId,
+        KIs, KLittle, KNative, KStep, KStruct, KU8, KU16, KU32, KU64, KU128, KUnaligned, ModPath,
+        VerbatimUntil, Visibility,
     };
 
     pub(super) type AttributeIdBody = CommaDelimitedVec<IdAttribute>;
@@ -46,6 +47,13 @@ mod grammar {
             Format(TokenTree)
         }
 
+        /// The value after `endian =`: a byte-order name.
+        pub(super) enum EndianValue {
+            Little(KLittle),
+            Big(KBig),
+            Native(KNative)
+        }
+
         /// A single key-value entry inside `#[id(...)]`.
         pub(super) enum IdAttribute {
             /// `crate = path`: overrides the path to `hashql_core` in generated code.
@@ -70,6 +78,17 @@ mod grammar {
                 _eq: Assign,
 
                 format: IdDisplay
+            },
+            /// `endian = little|big|native`: byte order of the stored value.
+            Endian {
+                _endian: KEndian,
+                _eq: Assign,
+
+                value: EndianValue
+            },
+            /// `unaligned`: stores the id as its byte encoding with alignment 1.
+            Unaligned {
+                _unaligned: KUnaligned
             }
         }
 
@@ -88,14 +107,19 @@ mod grammar {
             U128(KU128),
         }
 
-        /// The parenthesized body of a struct: `(u32 is 0..=MAX)`.
-        pub(super) struct StructBody {
-            pub r#type: StructScalar,
+        /// The bounds clause in a struct body: `is start..=end` or `is start..end`.
+        pub(super) struct StructBounds {
             pub _is: KIs,
 
             pub start: VerbatimUntil<RangeOp>,
             pub op: RangeOp,
             pub end: Vec<AngleTokenTree>
+        }
+
+        /// The parenthesized body of a struct: `(u32 is 0..=MAX)` or `(u32)`.
+        pub(super) struct StructBody {
+            pub r#type: StructScalar,
+            pub bounds: Option<StructBounds>
         }
 
         /// A complete struct definition for `define_id!`.

--- a/libs/@local/hashql/macros/src/id/struct.rs
+++ b/libs/@local/hashql/macros/src/id/struct.rs
@@ -2,12 +2,18 @@ use core::cmp;
 
 use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
-use unsynn::ToTokens as _;
+use unsynn::{ParenthesisGroupContaining, ToTokens as _};
 
-use super::grammar::{self, StructBody, StructScalar};
-use crate::id::{
-    attr::{Attributes, DisplayAttribute, Trait},
-    common::IntegerScalar,
+use super::{
+    attr::Spanned,
+    grammar::{self, StructBody, StructScalar},
+};
+use crate::{
+    emit_error,
+    id::{
+        attr::{Attributes, DisplayAttribute, Endianness, Trait},
+        common::IntegerScalar,
+    },
 };
 
 impl From<StructScalar> for IntegerScalar {
@@ -36,6 +42,7 @@ impl From<grammar::RangeOp> for RangeKind {
     }
 }
 
+/// An explicit `is start..=end` bounds clause, ready for code generation.
 struct Constraint {
     scalar: IntegerScalar,
 
@@ -46,6 +53,15 @@ struct Constraint {
 }
 
 impl Constraint {
+    fn new(scalar: IntegerScalar, bounds: grammar::StructBounds) -> Self {
+        Self {
+            scalar,
+            min: bounds.start.into_token_stream(),
+            max: bounds.end.into_token_stream(),
+            kind: bounds.op.into(),
+        }
+    }
+
     fn message(&self) -> String {
         let op = match self.kind {
             RangeKind::Inclusive => "<=",
@@ -82,21 +98,75 @@ impl Constraint {
     }
 }
 
-impl From<StructBody> for Constraint {
-    fn from(
-        StructBody {
-            r#type,
-            _is,
-            start,
-            op,
-            end,
-        }: StructBody,
-    ) -> Self {
-        Self {
-            scalar: r#type.into(),
-            min: start.into_token_stream(),
-            max: end.into_token_stream(),
-            kind: op.into(),
+/// Guard asserted when converting a possibly wider integer into an unbounded id.
+///
+/// Empty when the parameter type cannot exceed the backing type.
+fn width_assertion(
+    scalar: IntegerScalar,
+    ident: &Ident,
+    ident_scalar: IntegerScalar,
+) -> TokenStream {
+    if ident_scalar <= scalar {
+        return TokenStream::new();
+    }
+
+    let message = format!("id value must fit in `{scalar}`");
+
+    quote! {
+        assert!((#ident as #ident_scalar) <= (#scalar::MAX as #ident_scalar), #message);
+    }
+}
+
+/// The stored form of an id is a native scalar or a zerocopy byteorder integer.
+struct Storage {
+    ty: TokenStream,
+    byteorder: bool,
+}
+
+impl Storage {
+    fn new(scalar: IntegerScalar, endian: Endianness, bytes: bool) -> Self {
+        // u8 is its own byte encoding. The byteorder family starts at 16 bits.
+        let byteorder = bytes && scalar != IntegerScalar::U8;
+
+        let ty = if byteorder {
+            let width = match scalar {
+                IntegerScalar::U16 => quote!(U16),
+                IntegerScalar::U32 => quote!(U32),
+                IntegerScalar::U64 => quote!(U64),
+                IntegerScalar::U128 => quote!(U128),
+                IntegerScalar::U8 => unreachable!("u8 never selects the byteorder form"),
+            };
+            let order = match endian {
+                Endianness::Native => quote!(NativeEndian),
+                Endianness::Little => quote!(LittleEndian),
+                Endianness::Big => quote!(BigEndian),
+            };
+
+            quote!(::zerocopy::#width<::zerocopy::#order>)
+        } else {
+            quote!(#scalar)
+        };
+
+        Self { ty, byteorder }
+    }
+
+    /// Expression storing a scalar value expression as the field's type.
+    fn wrap(&self, value: &TokenStream) -> TokenStream {
+        if self.byteorder {
+            let ty = &self.ty;
+
+            quote!(<#ty>::new(#value))
+        } else {
+            value.clone()
+        }
+    }
+
+    /// Expression reading the scalar value back out of a field place expression.
+    fn read(&self, place: &TokenStream) -> TokenStream {
+        if self.byteorder {
+            quote!(#place.get())
+        } else {
+            place.clone()
         }
     }
 }
@@ -112,88 +182,211 @@ pub(super) fn expand_struct(
         visibility,
         _struct: r#struct,
         name,
-        body,
+        body:
+            ParenthesisGroupContaining {
+                content: StructBody { r#type, bounds },
+            },
     }: grammar::ParsedStruct,
 ) -> TokenStream {
     let mut output = TokenStream::new();
+
     let Attributes {
         krate,
         r#const: konst,
         display,
         traits,
+        mut endian,
+        unaligned,
         extra,
     } = Attributes::parse(attributes);
     let vis = visibility.into_token_stream();
 
-    let int = body.content.r#type.to_token_stream();
+    let scalar = IntegerScalar::from(r#type);
 
-    let constraint = Constraint::from(body.content);
-    let scalar = constraint.scalar;
+    if scalar == IntegerScalar::U8
+        && let Some(Spanned {
+            value: ref mut value @ (Endianness::Big | Endianness::Little),
+            span,
+        }) = endian
+    {
+        emit_error(
+            span,
+            "`u8` has no byte order; use `unaligned` without `endian`",
+        );
+
+        *value = Endianness::Native;
+    }
+
+    if unaligned.is_none()
+        && let Some(Spanned {
+            value: Endianness::Big | Endianness::Little,
+            span,
+        }) = endian
+    {
+        emit_error(
+            span,
+            "`endian` requires `unaligned`: an endian-pinned id is stored as its byte encoding, \
+             which has alignment 1",
+        );
+    }
+
+    let endian = endian.map_or(Endianness::Native, |Spanned { value, .. }| value);
+
+    // Error recovery treats a lone `endian` as if `unaligned` had been written.
+    let bytes = unaligned.is_some() || endian != Endianness::Native;
+
+    let storage = Storage::new(scalar, endian, bytes);
+    let int = &storage.ty;
+
+    let constraint = bounds.map(|bounds| Constraint::new(scalar, bounds));
 
     let value_ident = format_ident!("value");
-    let new_assertion = constraint.assertion(&value_ident, scalar);
-    let u32_assertion = constraint.assertion(&value_ident, IntegerScalar::U32);
-    let u64_assertion = constraint.assertion(&value_ident, IntegerScalar::U64);
-    let usize_assertion = constraint.assertion(&value_ident, IntegerScalar::U64); // u64 to be safe, even on 32-bit systems
+    let self_place = quote!(self._internal_do_not_use);
+    let self_value = storage.read(&self_place);
+    let stored_value = storage.wrap(&quote!(value));
+    let stored_cast = storage.wrap(&quote!(value as #scalar));
+    let prev_value = storage.wrap(&quote!(#self_value - 1));
 
-    let min = &constraint.min;
-    let max = &constraint.max;
+    let [u32_assertion, u64_assertion, usize_assertion] = [
+        IntegerScalar::U32,
+        IntegerScalar::U64,
+        IntegerScalar::U64, // u64 to be safe, even on 32-bit systems
+    ]
+    .map(|ident_scalar| {
+        constraint.as_ref().map_or_else(
+            || width_assertion(scalar, &value_ident, ident_scalar),
+            |constraint| constraint.assertion(&value_ident, ident_scalar),
+        )
+    });
 
-    let max_value = match constraint.kind {
-        RangeKind::Inclusive => quote! { #max },
-        RangeKind::Exclusive => quote! { #max - 1 },
-    };
+    let (min_value, max_value) = constraint.as_ref().map_or_else(
+        || (quote! { 0 }, quote! { #scalar::MAX }),
+        |constraint| {
+            let max = &constraint.max;
+            let max_value = match constraint.kind {
+                RangeKind::Inclusive => quote! { #max },
+                RangeKind::Exclusive => quote! { #max - 1 },
+            };
 
-    let range_assertion = match constraint.kind {
-        RangeKind::Inclusive => quote! {
-            const _: () = assert!((#min as #scalar) <= (#max as #scalar), "inclusive range requires min <= max");
+            (constraint.min.clone(), max_value)
         },
-        RangeKind::Exclusive => quote! {
-            const _: () = assert!((#min as #scalar) < (#max as #scalar), "exclusive range requires min < max");
-        },
-    };
+    );
 
-    let range_end = match constraint.kind {
-        RangeKind::Inclusive => format!("{max}]"),
-        RangeKind::Exclusive => format!("{max})"),
+    let constructors = constraint.as_ref().map_or_else(
+        || {
+            quote! {
+                /// Creates a new id from a raw scalar value.
+                #[must_use]
+                #[inline]
+                #vis const fn new(value: #scalar) -> Self {
+                    Self { _internal_do_not_use: #stored_value }
+                }
+            }
+        },
+        |constraint| {
+            let new_assertion = constraint.assertion(&value_ident, scalar);
+            let min = &constraint.min;
+            let max = &constraint.max;
+            let range_end = match constraint.kind {
+                RangeKind::Inclusive => format!("{max}]"),
+                RangeKind::Exclusive => format!("{max})"),
+            };
+            let new_panic_doc = format!("Panics if `value` is not in `[{min}, {range_end}`.");
+            let unchecked_safety_doc =
+                format!("The caller must ensure that `value` is in `[{min}, {range_end}`.");
+
+            quote! {
+                /// Creates a new id from a raw scalar value.
+                ///
+                /// # Panics
+                ///
+                #[doc = #new_panic_doc]
+                #[must_use]
+                #[inline]
+                #vis const fn new(value: #scalar) -> Self {
+                    #new_assertion
+
+                    Self { _internal_do_not_use: #stored_value }
+                }
+
+                /// Creates a new id from a raw scalar value without bounds checking.
+                ///
+                /// # Safety
+                ///
+                #[doc = #unchecked_safety_doc]
+                #[must_use]
+                #[inline]
+                #vis const unsafe fn new_unchecked(value: #scalar) -> Self {
+                    Self { _internal_do_not_use: #stored_value }
+                }
+            }
+        },
+    );
+
+    let range_assertion = constraint.as_ref().map_or_else(TokenStream::new, |constraint| {
+            let min = &constraint.min;
+            let max = &constraint.max;
+
+            match constraint.kind {
+                RangeKind::Inclusive => quote! {
+                    const _: () = assert!((#min as #scalar) <= (#max as #scalar), "inclusive range requires min <= max");
+                },
+                RangeKind::Exclusive => quote! {
+                    const _: () = assert!((#min as #scalar) < (#max as #scalar), "exclusive range requires min < max");
+                },
+            }
+        });
+
+    let derives = if bytes {
+        // Bounded ids reject `FromBytes` (and its `FromZeros` supertrait): both construct
+        // from arbitrary byte sources without running the range check. Their byte door is
+        // the hand-written `TryFromBytes` impl emitted below.
+        let from_bytes = if constraint.is_none() {
+            quote!(::zerocopy::FromBytes,)
+        } else {
+            TokenStream::new()
+        };
+
+        quote! {
+            #[derive(
+                Copy,
+                Clone,
+                PartialOrd,
+                Ord,
+                ::zerocopy::ByteEq,
+                ::zerocopy::ByteHash,
+                ::zerocopy::IntoBytes,
+                #from_bytes
+                ::zerocopy::Immutable,
+                ::zerocopy::Unaligned,
+                ::zerocopy::KnownLayout,
+            )]
+            #[repr(transparent)]
+        }
+    } else {
+        quote! {
+            #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        }
     };
-    let new_panic_doc = format!("Panics if `value` is not in `[{min}, {range_end}`.");
-    let unchecked_safety_doc =
-        format!("The caller must ensure that `value` is in `[{min}, {range_end}`.");
 
     let kw = r#struct.into_token_stream();
 
     output.extend(quote! {
         #extra
-        #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        #derives
         #vis #kw #name {
             #[doc(hidden)]
             _internal_do_not_use: #int
         }
 
         impl #name {
-            /// Creates a new id from a raw scalar value.
-            ///
-            /// # Panics
-            ///
-            #[doc = #new_panic_doc]
+            #constructors
+
+            /// Returns the raw scalar value.
             #[must_use]
             #[inline]
-            #vis const fn new(value: #scalar) -> Self {
-                #new_assertion
-
-                Self { _internal_do_not_use: value }
-            }
-
-            /// Creates a new id from a raw scalar value without bounds checking.
-            ///
-            /// # Safety
-            ///
-            #[doc = #unchecked_safety_doc]
-            #[must_use]
-            #[inline]
-            #vis const unsafe fn new_unchecked(value: #scalar) -> Self {
-                Self { _internal_do_not_use: value }
+            #vis const fn get(self) -> #scalar {
+                #self_value
             }
         }
 
@@ -202,48 +395,48 @@ pub(super) fn expand_struct(
         #[automatically_derived]
         #[expect(clippy::cast_possible_truncation, clippy::cast_lossless)]
         #konst impl #krate::id::Id for #name {
-            const MIN: Self = Self::new(#min);
+            const MIN: Self = Self::new(#min_value);
             const MAX: Self = Self::new(#max_value);
 
             fn from_u32(value: u32) -> Self {
                 #u32_assertion
 
-                Self { _internal_do_not_use: value as #scalar }
+                Self { _internal_do_not_use: #stored_cast }
             }
 
             fn from_u64(value: u64) -> Self {
                 #u64_assertion
 
-                Self { _internal_do_not_use: value as #scalar }
+                Self { _internal_do_not_use: #stored_cast }
             }
 
             fn from_usize(value: usize) -> Self {
                 #usize_assertion
 
-                Self { _internal_do_not_use: value as #scalar }
+                Self { _internal_do_not_use: #stored_cast }
             }
 
             #[inline]
             fn as_u32(self) -> u32 {
-                self._internal_do_not_use as u32
+                #self_value as u32
             }
 
             #[inline]
             fn as_u64(self) -> u64 {
-                self._internal_do_not_use as u64
+                #self_value as u64
             }
 
             #[inline]
             fn as_usize(self) -> usize {
-                self._internal_do_not_use as usize
+                #self_value as usize
             }
 
             #[inline]
             fn prev(self) -> ::core::option::Option<Self> {
-                if self._internal_do_not_use == #min {
+                if #self_value == #min_value {
                     ::core::option::Option::None
                 } else {
-                    ::core::option::Option::Some(Self { _internal_do_not_use: self._internal_do_not_use - 1 })
+                    ::core::option::Option::Some(Self { _internal_do_not_use: #prev_value })
                 }
             }
         }
@@ -259,12 +452,52 @@ pub(super) fn expand_struct(
         }
     });
 
+    // Bounded byte-encoded ids get `TryFromBytes` by hand, with the range check as the
+    // validity predicate: the derive cannot see non-structural constraints, and `FromBytes`
+    // would admit out-of-range bit patterns at the byte door. The impl provides zerocopy's
+    // doc(hidden) items directly. Upstream reserves the right to change them.
+    if bytes && let Some(constraint) = &constraint {
+        let storage_value = if storage.byteorder {
+            quote!(storage.unaligned_as_ref().get())
+        } else {
+            quote!(*storage.unaligned_as_ref())
+        };
+        let comparison = constraint.comparison(&value_ident, scalar);
+
+        output.extend(quote! {
+            // SAFETY: `is_bit_valid` returns `true` exactly when the stored scalar lies in
+            // the id's declared range - the type's only validity requirement beyond its
+            // storage, whose every initialized bit pattern is valid. The check is the same
+            // comparison `new` asserts on construction.
+            #[automatically_derived]
+            unsafe impl ::zerocopy::TryFromBytes for #name {
+                fn only_derive_is_allowed_to_implement_this_trait() {}
+
+                #[inline]
+                fn is_bit_valid<A>(candidate: ::zerocopy::Maybe<'_, Self, A>) -> bool
+                where
+                    A: ::zerocopy::invariant::Alignment,
+                {
+                    let storage = candidate.transmute_with::<
+                        #int,
+                        ::zerocopy::invariant::Valid,
+                        ::zerocopy::pointer::cast::CastSizedExact,
+                        ::zerocopy::BecauseImmutable,
+                    >();
+                    let value = #storage_value;
+
+                    #comparison
+                }
+            }
+        });
+    }
+
     // Debug
     output.extend(quote! {
         impl ::core::fmt::Debug for #name {
             fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
                 fmt.debug_tuple(stringify!(#name))
-                    .field(&self._internal_do_not_use)
+                    .field(&#self_value)
                     .finish()
             }
         }
@@ -276,16 +509,14 @@ pub(super) fn expand_struct(
         (quote!(u64), IntegerScalar::U64),
         (quote!(usize), IntegerScalar::U64), // u64 to be safe on 32-bit
     ] {
-        let comparison = constraint.comparison(&value_ident, param_scalar);
+        let body = match &constraint {
+            Some(constraint) => {
+                let comparison = constraint.comparison(&value_ident, param_scalar);
+                let min = &constraint.min;
 
-        output.extend(quote! {
-            #[automatically_derived]
-            impl ::core::convert::TryFrom<#param> for #name {
-                type Error = #krate::id::IdError;
-
-                fn try_from(value: #param) -> ::core::result::Result<Self, Self::Error> {
+                quote! {
                     if #comparison {
-                        ::core::result::Result::Ok(Self { _internal_do_not_use: value as #scalar })
+                        ::core::result::Result::Ok(Self { _internal_do_not_use: #stored_cast })
                     } else {
                         ::core::result::Result::Err(#krate::id::IdError::OutOfRange {
                             value: value as u64,
@@ -293,6 +524,31 @@ pub(super) fn expand_struct(
                             max: (#max_value) as u64,
                         })
                     }
+                }
+            }
+            None if param_scalar > scalar => quote! {
+                if (value as #param_scalar) <= (#scalar::MAX as #param_scalar) {
+                    ::core::result::Result::Ok(Self { _internal_do_not_use: #stored_cast })
+                } else {
+                    ::core::result::Result::Err(#krate::id::IdError::OutOfRange {
+                        value: value as u64,
+                        min: 0,
+                        max: #scalar::MAX as u64,
+                    })
+                }
+            },
+            None => quote! {
+                ::core::result::Result::Ok(Self { _internal_do_not_use: #stored_cast })
+            },
+        };
+
+        output.extend(quote! {
+            #[automatically_derived]
+            #konst impl ::core::convert::TryFrom<#param> for #name {
+                type Error = #krate::id::IdError;
+
+                fn try_from(value: #param) -> ::core::result::Result<Self, Self::Error> {
+                    #body
                 }
             }
         });
@@ -305,7 +561,7 @@ pub(super) fn expand_struct(
             output.extend(quote! {
                 impl ::core::fmt::Display for #name {
                     fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-                        fmt.write_fmt(format_args!(#format, self._internal_do_not_use))
+                        fmt.write_fmt(format_args!(#format, #self_value))
                     }
                 }
             });
@@ -314,7 +570,7 @@ pub(super) fn expand_struct(
             output.extend(quote! {
                 impl ::core::fmt::Display for #name {
                     fn fmt(&self, fmt: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-                        ::core::fmt::Display::fmt(&self._internal_do_not_use, fmt)
+                        ::core::fmt::Display::fmt(&#self_value, fmt)
                     }
                 }
             });

--- a/libs/@local/hashql/macros/src/lib.rs
+++ b/libs/@local/hashql/macros/src/lib.rs
@@ -50,9 +50,9 @@ pub fn derive_id(item: TokenStream) -> TokenStream {
 
 /// Defines a struct as an [`Id`] type.
 ///
-/// Creates a newtype wrapper around an integer with a valid range. This is a
-/// function-like macro because the struct body syntax (`u32 is 0..=MAX`) is not
-/// valid Rust.
+/// Creates a newtype wrapper around an integer, optionally restricted to a
+/// valid range. This is a function-like macro because the struct body syntax
+/// (`u32 is 0..=MAX`) is not valid Rust.
 ///
 /// For enum Id types, use `#[derive(Id)]` instead.
 ///
@@ -66,26 +66,62 @@ pub fn derive_id(item: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
+/// An id stored as its little-endian byte encoding, suitable for reading and
+/// writing file formats without conversion:
+///
+/// ```ignore
+/// define_id! {
+///     /// A row in the node table.
+///     #[id(endian = little, unaligned)]
+///     pub struct NodeRowId(u64)
+/// }
+/// ```
+///
 /// Supported backing types: `u8`, `u16`, `u32`, `u64`, `u128`. `usize` is
 /// intentionally excluded: proc macros are compiled for and run on the host,
 /// so they cannot determine the target's pointer width. This makes it
 /// impossible to select the correct widening cast for range assertions during
 /// cross-compilation.
 ///
-/// The range bound determines valid values. Inclusive (`..=`) and exclusive (`..`)
-/// ranges are both supported.
+/// The `is` bounds clause is optional. With bounds, valid values are limited
+/// to the given range. Inclusive (`..=`) and exclusive (`..`) ranges are both
+/// supported. Without bounds, every value of the backing type is valid: `new`
+/// is total, no `new_unchecked` is generated, and conversions only reject
+/// values the backing type cannot hold.
 ///
 /// # Attributes
 ///
 /// Placed inside an `#[id(...)]` annotation on the item:
 ///
-/// - `crate = path` — path to the `hashql_core` crate (default: `::hashql_core`)
-/// - `const` — add `const` to trait impl blocks
-/// - `derive(Step)` — implement [`core::iter::Step`]
-/// - `display = "format"` — implement [`Display`] with a format string
-/// - `display = !` — suppress the [`Display`] implementation
+/// - `crate = path`: path to the `hashql_core` crate (default: `::hashql_core`)
+/// - `const`: add `const` to trait impl blocks
+/// - `derive(Step)`: implement [`core::iter::Step`]
+/// - `display = "format"`: implement [`Display`] with a format string
+/// - `display = !`: suppress the [`Display`] implementation
+/// - `unaligned`: store the id as its byte encoding with alignment 1
+/// - `endian = little` / `endian = big` / `endian = native`: byte order of the stored value
+///   (default: `native`). Requires `unaligned`
 ///
 /// By default, a [`Display`] implementation is generated using the inner value.
+///
+/// # Byte-encoded ids
+///
+/// With `unaligned`, the id stores its value as a byte array with alignment 1
+/// and implements zerocopy's byte traits (`IntoBytes`, `Immutable`,
+/// `Unaligned`, `KnownLayout`, plus `ByteEq` and `ByteHash`), so slices of ids
+/// can be reinterpreted directly from file or wire bytes. `endian` pins the
+/// byte order of that encoding; `endian = little` and `endian = big` make the
+/// encoding identical on every target, which is what a persisted format needs.
+/// Comparison and ordering always follow the numeric value, never the byte
+/// encoding. The calling crate must depend on `zerocopy` with the `derive`
+/// feature. `u8` accepts `unaligned` (a single byte is its own encoding) but
+/// has no byte order to pin.
+///
+/// The byte-source trait follows the bounds: an unbounded id implements
+/// `FromBytes` (every bit pattern is a valid id), while a range-bounded id
+/// implements `TryFromBytes` with the range as its validity predicate, so
+/// fallible reads reject out-of-range bytes and infallible byte constructors
+/// do not exist for it.
 ///
 /// # Generated items
 ///
@@ -93,7 +129,8 @@ pub fn derive_id(item: TokenStream) -> TokenStream {
 /// - `HasId` trait implementation
 /// - [`TryFrom<u32>`], [`TryFrom<u64>`], [`TryFrom<usize>`] implementations
 /// - [`Debug`] and (by default) [`Display`] implementations
-/// - `new`, `new_unchecked` constructors
+/// - `new` constructor, plus `new_unchecked` for range-bounded ids
+/// - `get` accessor returning the raw scalar at its native width
 #[proc_macro]
 pub fn define_id(item: TokenStream) -> TokenStream {
     id::expand_define(item.into()).into()

--- a/libs/@local/hashql/mir/src/body/basic_block.rs
+++ b/libs/@local/hashql/mir/src/body/basic_block.rs
@@ -19,7 +19,7 @@ id::newtype!(
     ///
     /// The value space is restricted to `0..=0xFFFF_FF00`, reserving the last 256
     /// values for niche optimizations in `Option<BasicBlockId>` and similar types.
-    #[id(display = "bb{}")]
+    #[id(display = "bb{}", const)]
     pub struct BasicBlockId(u32 is 0..=0xFFFF_FF00)
 );
 

--- a/libs/@local/hashql/mir/src/body/local.rs
+++ b/libs/@local/hashql/mir/src/body/local.rs
@@ -26,7 +26,7 @@ id::newtype!(
     /// Each [`Local`] is valid within the scope of a single function body. The MIR
     /// uses explicit storage management through [`StorageLive`] and [`StorageDead`]
     /// statements to track when local variables are active.
-    #[id(derive(Step), display = "%{}")]
+    #[id(derive(Step), display = "%{}", const)]
     pub struct Local(u32 is 0..=u32::MAX)
 );
 

--- a/libs/@local/hashql/mir/src/body/terminator/switch_int.rs
+++ b/libs/@local/hashql/mir/src/body/terminator/switch_int.rs
@@ -270,7 +270,7 @@ impl<'heap> SwitchTargets<'heap> {
     /// assert!(multi.as_if().is_none());
     /// ```
     #[must_use]
-    pub fn as_if(&self) -> Option<SwitchIf<'heap>> {
+    pub const fn as_if(&self) -> Option<SwitchIf<'heap>> {
         if let [0, 1] = self.values[..]
             && let [r#else, then] = self.targets[..]
         {
@@ -323,7 +323,7 @@ impl<'heap> SwitchTargets<'heap> {
     /// ```
     #[must_use]
     #[inline]
-    pub fn otherwise(&self) -> Option<Target<'heap>> {
+    pub const fn otherwise(&self) -> Option<Target<'heap>> {
         self.targets.get(self.values.len()).copied()
     }
 

--- a/libs/@local/hashql/mir/src/interpret/value/struct.rs
+++ b/libs/@local/hashql/mir/src/interpret/value/struct.rs
@@ -508,14 +508,14 @@ impl<'heap, A: Allocator, const N: usize> StructBuilder<'heap, A, N> {
 
     /// Returns the field names pushed so far.
     #[must_use]
-    pub fn fields(&self) -> &[Symbol<'heap>] {
+    pub const fn fields(&self) -> &[Symbol<'heap>] {
         // SAFETY: `fields[..initialized]` is fully initialized by invariant.
         unsafe { self.fields[..self.initialized].assume_init_ref() }
     }
 
     /// Returns the field values pushed so far.
     #[must_use]
-    pub fn values(&self) -> &[Value<'heap, A>] {
+    pub const fn values(&self) -> &[Value<'heap, A>] {
         // SAFETY: `values[..initialized]` is fully initialized by invariant.
         unsafe { self.values[..self.initialized].assume_init_ref() }
     }

--- a/libs/@local/hashql/mir/src/lib.rs
+++ b/libs/@local/hashql/mir/src/lib.rs
@@ -17,6 +17,7 @@
     binary_heap_drain_sorted,
     clone_from_ref,
     const_convert,
+    const_index,
     const_type_name,
     get_mut_unchecked,
     iter_array_chunks,

--- a/libs/@local/hashql/mir/src/pass/analysis/data_dependency/graph.rs
+++ b/libs/@local/hashql/mir/src/pass/analysis/data_dependency/graph.rs
@@ -365,7 +365,7 @@ impl<'heap, A: Allocator> DataDependencyGraph<'heap, A> {
         }
     }
 
-    pub(crate) fn outgoing_edges<'this>(
+    pub(crate) const fn outgoing_edges<'this>(
         &'this self,
         local: Local,
     ) -> IncidentEdges<'this, Local, EdgeData<'heap>, A> {

--- a/libs/@local/hashql/mir/src/pass/analysis/size_estimation/dynamic.rs
+++ b/libs/@local/hashql/mir/src/pass/analysis/size_estimation/dynamic.rs
@@ -78,7 +78,7 @@ impl Eval {
     }
 
     /// Borrows the footprint, resolving `Copy` variants against the domain.
-    pub(crate) fn as_ref<'domain, A: Allocator>(
+    pub(crate) const fn as_ref<'domain, A: Allocator>(
         &'domain self,
         domain: &'domain BodyFootprint<A>,
     ) -> &'domain Footprint {

--- a/libs/@local/hashql/mir/src/pass/analysis/size_estimation/mod.rs
+++ b/libs/@local/hashql/mir/src/pass/analysis/size_estimation/mod.rs
@@ -102,7 +102,7 @@ impl PendingDataflow {
     }
 
     /// Returns the synthetic local used to track whether the return type needs dynamic analysis.
-    fn return_slot(&self) -> Local {
+    const fn return_slot(&self) -> Local {
         Local::from_usize(self.inner.domain_size() - 1)
     }
 

--- a/libs/@local/hashql/mir/src/pass/execution/cost/analysis.rs
+++ b/libs/@local/hashql/mir/src/pass/execution/cost/analysis.rs
@@ -63,7 +63,7 @@ pub(crate) struct BasicBlockCostVec<A: Allocator> {
 
 impl<A: Allocator> BasicBlockCostVec<A> {
     /// Returns the set of candidate targets for `block`.
-    pub(crate) fn assignments(&self, block: BasicBlockId) -> TargetBitSet {
+    pub(crate) const fn assignments(&self, block: BasicBlockId) -> TargetBitSet {
         self.inner[block].targets
     }
 

--- a/libs/@local/hashql/mir/src/pass/mod.rs
+++ b/libs/@local/hashql/mir/src/pass/mod.rs
@@ -255,7 +255,7 @@ impl<A: Allocator> OwnedGlobalTransformState<A> {
     ///
     /// This allows passing the state to [`GlobalTransformPass::run`] while retaining
     /// ownership for subsequent iterations.
-    pub fn as_mut(&mut self) -> GlobalTransformState<'_> {
+    pub const fn as_mut(&mut self) -> GlobalTransformState<'_> {
         GlobalTransformState::new(&mut self.changed)
     }
 }

--- a/libs/@local/hashql/mir/src/pass/transform/administrative_reduction/mod.rs
+++ b/libs/@local/hashql/mir/src/pass/transform/administrative_reduction/mod.rs
@@ -117,7 +117,7 @@ impl<A: Allocator> Reducable<A> {
         self.inner.contains(id)
     }
 
-    fn is_empty(&self) -> bool {
+    const fn is_empty(&self) -> bool {
         self.inner.is_empty()
     }
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

HashQL's typed ID system gains three coupled capabilities: const-evaluable ID construction (BE-776), a dense `IdMatrix` addressed by typed IDs on both axes plus parallel iteration over the ID containers (BE-777), and fixed-endianness byte layouts through `zerocopy` (BE-775). The consumer driving all three is the atlas (#9305), which stores ID-indexed columns in on-disk artifacts that must read identically across machines, and iterates ID domains large enough for `rayon` to pay.

These land as one PR because the file topology couples them: `core/src/id/slice.rs` carries the const constructors, the `rayon` impls, and the `zerocopy` derives in one file, and a finer split would invent intermediate file states nobody wrote.

Review focus: the `zerocopy` derives pin byte layouts that read identically across targets. The second focus is the `const` support in the ID macros (`macros/src/id/`), the expansion downstream code relies on.

## 🔍 What does this change?

- `hashql-core/src/id/`: ID construction usable in `const` contexts, `IdMatrix` as a dense rectangular matrix addressed by typed IDs on both axes, `rayon` parallel iterators for the ID containers, and `zerocopy`-derived byte layouts with fixed endianness.
- `hashql-macros/src/id/`: the `#[id]` attribute gains `const` support (`#[id(display = !, const)]`) and emits the layouts above.
- `hashql-mir`, `hashql-hir`, `hashql-eval`: existing call sites (dominators, Tarjan, data-dependency graph, size estimation) adopt the new container APIs.
- `hash-graph-api`: one `#[expect(clippy::missing_const_for_fn)]` where the lint reports a false positive against the new const machinery.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- `core/src/id/tests.rs` covers the containers and layouts.
- The mir and type-inference suites exercise the adopted call sites.
- The workspace battery: `cargo check`, clippy at zero warnings across targets and features, `fmt` clean, `cargo metadata --locked` clean.

## ❓ How to test this?

```bash
cargo nextest run -p hashql-core --lib
```
