### PR TITLE
BE-784: hgraph: Statement parameters travel as iterators to the Postgres client

### DIFF
--- a/libs/@local/graph/postgres-store/src/store/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/mod.rs
@@ -8,9 +8,10 @@ pub mod postgres;
 pub use self::{
     config::{DatabaseConnectionInfo, DatabasePoolConfig, DatabaseType},
     postgres::{
-        AsClient, BeginReadOnlyTransaction, Context, InTransaction, IsolationLevel, NoTransaction,
-        PostgresStore, PostgresStorePool, PostgresStoreSettings, PostgresStoreTransactionBuilder,
-        Transaction, TransactionBuilder, TransactionOptions, TransactionState,
+        AsClient, BeginReadOnlyTransaction, Context, GenericClientIter, InTransaction,
+        IsolationLevel, NoTransaction, PostgresStore, PostgresStorePool, PostgresStoreSettings,
+        PostgresStoreTransactionBuilder, Transaction, TransactionBuilder, TransactionOptions,
+        TransactionState,
     },
     validation::{StoreCache, StoreProvider},
 };

--- a/libs/@local/graph/postgres-store/src/store/postgres/crud.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/crud.rs
@@ -12,7 +12,7 @@ use tokio_postgres::{GenericClient as _, Row};
 use tracing::Instrument as _;
 
 use crate::store::{
-    AsClient, PostgresStore, TransactionState,
+    AsClient, GenericClientIter as _, PostgresStore, TransactionState,
     postgres::query::{PostgresQueryPath, PostgresRecord, PostgresSorting, SelectCompiler},
 };
 
@@ -112,7 +112,7 @@ where
         let (statement, parameters) = compiler.compile();
         let stream = self
             .as_client()
-            .query_raw(&statement, parameters.iter().copied())
+            .query_raw(&statement, parameters)
             .instrument(tracing::info_span!(
                 "SELECT",
                 otel.kind = "client",
@@ -162,7 +162,7 @@ where
 
         Ok(self
             .as_client()
-            .query_raw(&statement, parameters.iter().copied())
+            .query_raw(&statement, parameters)
             .instrument(tracing::info_span!(
                 "SELECT",
                 otel.kind = "client",
@@ -195,7 +195,7 @@ where
 
         let rows = self
             .as_client()
-            .query(&statement, parameters)
+            .query_params_iter(&statement, parameters)
             .instrument(tracing::info_span!(
                 "SELECT",
                 otel.kind = "client",

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/delete.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/delete.rs
@@ -123,7 +123,7 @@ where
         let mut entity_ids = HashMap::<(WebId, EntityUuid), Vec<DraftId>>::new();
 
         self.as_client()
-            .query_raw(&statement, parameters.iter().copied())
+            .query_raw(&statement, parameters)
             .instrument(tracing::info_span!(
                 "SELECT entities for deletion",
                 otel.kind = "client",

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
@@ -98,7 +98,7 @@ use type_system::{
 use uuid::Uuid;
 
 use crate::store::{
-    AsClient, PostgresStore,
+    AsClient, GenericClientIter as _, PostgresStore,
     error::{EntityDoesNotExist, RaceConditionOnUpdate},
     postgres::{
         BeginReadOnlyTransaction, InTransaction, TransactionState, TraversalContext,
@@ -645,7 +645,7 @@ where
 
         let rows = self
             .as_client()
-            .query(&statement, parameters)
+            .query_params_iter(&statement, parameters)
             .instrument(tracing::info_span!(
                 "SELECT",
                 otel.kind = "client",
@@ -1036,10 +1036,10 @@ where
 {
     /// Rebuilds the entity edition cache and the inherited `entity_is_of_type` rows.
     ///
-    /// This is inherent rather than only an [`EntityStore`] method so that code paths already
-    /// operating inside an enclosing transaction — snapshot restore and entity-type reindexing —
-    /// can rebuild the cache without requiring the [`EntityStore`] impl, whose snapshot-consistent
-    /// reads are only available where [`BeginReadOnlyTransaction`] is implemented.
+    /// This is inherent rather than only an [`EntityStore`] method so that snapshot restore and
+    /// entity-type reindexing, which already operate inside an enclosing transaction, can rebuild
+    /// the cache without requiring the [`EntityStore`] impl, whose snapshot-consistent reads are
+    /// only available where [`BeginReadOnlyTransaction`] is implemented.
     ///
     /// # Errors
     ///
@@ -1103,7 +1103,7 @@ where
     ///
     /// This is inherent rather than only an [`EntityStore`] method because the snapshot-consistent
     /// read implementations invoke it on the [`InTransaction`] store, where the [`EntityStore`]
-    /// impl — bounded on [`BeginReadOnlyTransaction`] — is not available.
+    /// impl, bounded on [`BeginReadOnlyTransaction`], is not available.
     ///
     /// # Errors
     ///
@@ -1163,7 +1163,7 @@ where
         let (statement, parameters) = compiler.compile();
         let () = self
             .as_client()
-            .query_raw(&statement, parameters.iter().copied())
+            .query_raw(&statement, parameters)
             .instrument(tracing::info_span!(
                 "SELECT",
                 otel.kind = "client",
@@ -1993,7 +1993,7 @@ where
 
         let rows = self
             .as_client()
-            .query_raw(&statement, parameters.iter().copied())
+            .query_raw(&statement, parameters)
             .instrument(tracing::info_span!(
                 "SELECT",
                 otel.kind = "client",

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/read.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/read.rs
@@ -271,7 +271,7 @@ where
                     provider
                         .store
                         .as_client()
-                        .query_raw(&statement, parameters.iter().copied())
+                        .query_raw(&statement, parameters)
                         .instrument(tracing::info_span!(
                             "SELECT",
                             otel.kind = "client",

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/search.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/search.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use error_stack::{Report, ResultExt as _};
+use futures::TryStreamExt as _;
 use hash_graph_authorization::policies::{MergePolicies, PolicyComponents, action::ActionName};
 use hash_graph_store::{
     entity::{
@@ -272,9 +273,9 @@ where
         compiler.set_limit(candidate_pool);
 
         let (statement, parameters) = compiler.compile();
-        Ok(self
-            .as_client()
-            .query(&statement, parameters)
+
+        self.as_client()
+            .query_raw(&statement, parameters)
             .instrument(tracing::info_span!(
                 "SELECT",
                 otel.kind = "client",
@@ -284,13 +285,16 @@ where
             ))
             .await
             .change_context(QueryError)?
-            .into_iter()
-            .map(|row| EntityId {
-                web_id: row.get(0),
-                entity_uuid: row.get(1),
-                draft_id: row.get(2),
+            .and_then(|row| {
+                core::future::ready(Ok(EntityId {
+                    web_id: row.get(0),
+                    entity_uuid: row.get(1),
+                    draft_id: row.get(2),
+                }))
             })
-            .collect())
+            .try_collect()
+            .await
+            .change_context(QueryError)
     }
 
     /// Re-scores the candidates against the full vector, applying the distance threshold.

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/search.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/search.rs
@@ -285,12 +285,10 @@ where
             ))
             .await
             .change_context(QueryError)?
-            .and_then(|row| {
-                core::future::ready(Ok(EntityId {
-                    web_id: row.get(0),
-                    entity_uuid: row.get(1),
-                    draft_id: row.get(2),
-                }))
+            .map_ok(|row| EntityId {
+                web_id: row.get(0),
+                entity_uuid: row.get(1),
+                draft_id: row.get(2),
             })
             .try_collect()
             .await

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/table.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/table.rs
@@ -545,9 +545,9 @@ where
 
         let (statement, parameters) = compiler.compile();
 
-        let rows = self
+        let rows: Vec<_> = self
             .as_client()
-            .query(&statement, parameters)
+            .query_raw(&statement, parameters)
             .instrument(tracing::info_span!(
                 "SELECT",
                 otel.kind = "client",
@@ -555,6 +555,9 @@ where
                 peer.service = "Postgres",
                 db.query.text = statement,
             ))
+            .await
+            .change_context(QueryError)?
+            .try_collect()
             .await
             .change_context(QueryError)?;
 
@@ -764,7 +767,7 @@ where
 
         let rows = self
             .as_client()
-            .query_raw(&statement, parameters.iter().copied())
+            .query_raw(&statement, parameters)
             .instrument(tracing::info_span!(
                 "SELECT",
                 otel.kind = "client",
@@ -811,7 +814,7 @@ where
 
         let rows = self
             .as_client()
-            .query_raw(&statement, parameters.iter().copied())
+            .query_raw(&statement, parameters)
             .instrument(tracing::info_span!(
                 "SELECT",
                 otel.kind = "client",

--- a/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
@@ -78,8 +78,8 @@ use uuid::Uuid;
 
 pub use self::{
     pool::{
-        AsClient, InTransaction, NoTransaction, PostgresStorePool, TransactionOptions,
-        TransactionState,
+        AsClient, GenericClientIter, InTransaction, NoTransaction, PostgresStorePool,
+        TransactionOptions, TransactionState,
     },
     traversal_context::TraversalContext,
 };
@@ -2498,7 +2498,7 @@ where
     ///
     /// On a store which is not inside a transaction this issues a plain `BEGIN` using the
     /// database's default transaction characteristics. On a store which is already inside a
-    /// transaction it creates a savepoint instead; a savepoint has no characteristics of its own
+    /// transaction it creates a savepoint instead. A savepoint has no characteristics of its own
     /// and runs within the enclosing transaction.
     ///
     /// Transaction characteristics such as the isolation level can only be configured when
@@ -3318,7 +3318,7 @@ impl Transaction for PostgresStore<tokio_postgres::Transaction<'_>, InTransactio
 ///
 /// - In the [`NoTransaction`] state a `REPEATABLE READ, READ ONLY` transaction is begun, giving all
 ///   statements of the read one shared snapshot.
-/// - In the [`InTransaction`] state — only available with the `test-utils` feature — a savepoint is
+/// - In the [`InTransaction`] state, which only the `test-utils` feature provides, a savepoint is
 ///   created instead: the read runs within the enclosing transaction and observes that
 ///   transaction's snapshot semantics.
 // TODO(BE-688): The `InTransaction` impl exists only for the rollback-isolation test harness,

--- a/libs/@local/graph/postgres-store/src/store/postgres/ontology/data_type.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/ontology/data_type.rs
@@ -55,7 +55,7 @@ use type_system::{
 use crate::store::{
     error::DeletionError,
     postgres::{
-        AsClient, PostgresStore, TransactionState, TraversalContext,
+        AsClient, GenericClientIter as _, PostgresStore, TransactionState, TraversalContext,
         crud::{QueryIndices, QueryRecordDecode, TypedRow},
         ontology::{PostgresOntologyOwnership, read::OntologyTypeTraversalData},
         query::{
@@ -110,7 +110,7 @@ where
                 provider
                     .store
                     .as_client()
-                    .query_raw(&statement, parameters.iter().copied())
+                    .query_raw(&statement, parameters)
                     .instrument(tracing::info_span!(
                         "SELECT",
                         otel.kind = "client",
@@ -220,7 +220,7 @@ where
 
             let data_type_rows = self
                 .as_client()
-                .query(&statement, parameters)
+                .query_params_iter(&statement, parameters)
                 .instrument(tracing::info_span!(
                     "SELECT",
                     otel.kind = "client",
@@ -256,7 +256,7 @@ where
 
         let rows = self
             .as_client()
-            .query(&statement, parameters)
+            .query_params_iter(&statement, parameters)
             .instrument(tracing::info_span!(
                 "SELECT",
                 otel.kind = "client",
@@ -1394,7 +1394,7 @@ where
             let (statement, parameters) = compiler.compile();
 
             self.as_client()
-                .query_raw(&statement, parameters.iter().copied())
+                .query_raw(&statement, parameters)
                 .instrument(tracing::info_span!(
                     "SELECT",
                     otel.kind = "client",
@@ -1645,7 +1645,7 @@ where
 
         let (statement, parameters) = compiler.compile();
         self.as_client()
-            .query_raw(&statement, parameters.iter().copied())
+            .query_raw(&statement, parameters)
             .instrument(tracing::info_span!(
                 "SELECT",
                 otel.kind = "client",

--- a/libs/@local/graph/postgres-store/src/store/postgres/ontology/entity_type.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/ontology/entity_type.rs
@@ -69,7 +69,8 @@ use type_system::{
 use crate::store::{
     error::DeletionError,
     postgres::{
-        AsClient, PostgresStore, ResponseCountMap, TransactionState, TraversalContext,
+        AsClient, GenericClientIter as _, PostgresStore, ResponseCountMap, TransactionState,
+        TraversalContext,
         crud::{QueryIndices, QueryRecordDecode, TypedRow},
         ontology::{PostgresOntologyOwnership, read::OntologyTypeTraversalData},
         query::{
@@ -128,7 +129,7 @@ where
                 provider
                     .store
                     .as_client()
-                    .query_raw(&statement, parameters.iter().copied())
+                    .query_raw(&statement, parameters)
                     .instrument(tracing::info_span!(
                         "SELECT",
                         otel.kind = "client",
@@ -470,7 +471,7 @@ where
 
             let entity_type_rows = self
                 .as_client()
-                .query(&statement, parameters)
+                .query_params_iter(&statement, parameters)
                 .instrument(tracing::info_span!(
                     "SELECT",
                     otel.kind = "client",
@@ -531,7 +532,7 @@ where
 
         let rows = self
             .as_client()
-            .query(&statement, parameters)
+            .query_params_iter(&statement, parameters)
             .instrument(tracing::info_span!(
                 "SELECT",
                 otel.kind = "client",
@@ -598,7 +599,7 @@ where
 
         let stream = self
             .as_client()
-            .query_raw(&statement, parameters.iter().copied())
+            .query_raw(&statement, parameters)
             .instrument(tracing::info_span!(
                 "SELECT",
                 otel.kind = "client",
@@ -1139,7 +1140,7 @@ where
 
         Ok(self
             .as_client()
-            .query_raw(&statement, parameters.iter().copied())
+            .query_raw(&statement, parameters)
             .instrument(tracing::info_span!(
                 "SELECT",
                 otel.kind = "client",
@@ -1256,7 +1257,7 @@ where
         let (candidate_statement, candidate_parameters) = compiler.compile();
         let maximum_distance = maximum_semantic_distance.into_inner();
 
-        let mut parameters = candidate_parameters.to_vec();
+        let mut parameters: Vec<_> = candidate_parameters.collect();
         let embedding_parameter = parameters.len() + 1;
         parameters.push(&embedding);
         let maximum_distance_parameter = parameters.len() + 1;
@@ -2227,7 +2228,7 @@ where
 
             let (statement, parameters) = compiler.compile();
             self.as_client()
-                .query_raw(&statement, parameters.iter().copied())
+                .query_raw(&statement, parameters)
                 .instrument(tracing::info_span!(
                     "SELECT",
                     otel.kind = "client",

--- a/libs/@local/graph/postgres-store/src/store/postgres/ontology/property_type.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/ontology/property_type.rs
@@ -52,7 +52,7 @@ use type_system::{
 use crate::store::{
     error::DeletionError,
     postgres::{
-        AsClient, PostgresStore, TransactionState, TraversalContext,
+        AsClient, GenericClientIter as _, PostgresStore, TransactionState, TraversalContext,
         crud::{QueryIndices, QueryRecordDecode, TypedRow},
         ontology::{PostgresOntologyOwnership, read::OntologyTypeTraversalData},
         query::{
@@ -110,7 +110,7 @@ where
                 provider
                     .store
                     .as_client()
-                    .query_raw(&statement, parameters.iter().copied())
+                    .query_raw(&statement, parameters)
                     .instrument(tracing::info_span!(
                         "SELECT",
                         otel.kind = "client",
@@ -170,7 +170,7 @@ where
 
             let property_type_rows = self
                 .as_client()
-                .query(&statement, parameters)
+                .query_params_iter(&statement, parameters)
                 .instrument(tracing::info_span!(
                     "SELECT",
                     otel.kind = "client",
@@ -205,7 +205,7 @@ where
 
         let rows = self
             .as_client()
-            .query(&statement, parameters)
+            .query_params_iter(&statement, parameters)
             .instrument(tracing::info_span!(
                 "SELECT",
                 otel.kind = "client",
@@ -670,7 +670,7 @@ where
 
         Ok(self
             .as_client()
-            .query_raw(&statement, parameters.iter().copied())
+            .query_raw(&statement, parameters)
             .instrument(tracing::info_span!(
                 "SELECT",
                 otel.kind = "client",
@@ -1190,7 +1190,7 @@ where
 
         let (statement, parameters) = compiler.compile();
         self.as_client()
-            .query_raw(&statement, parameters.iter().copied())
+            .query_raw(&statement, parameters)
             .instrument(tracing::info_span!(
                 "SELECT",
                 otel.kind = "client",

--- a/libs/@local/graph/postgres-store/src/store/postgres/ontology/read.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/ontology/read.rs
@@ -94,7 +94,7 @@ impl<C: AsClient, S: TransactionState> PostgresStore<C, S> {
 
         Ok(self
             .as_client()
-            .query_raw(&statement, parameters.iter().copied())
+            .query_raw(&statement, parameters)
             .instrument(tracing::info_span!(
                 "SELECT",
                 otel.kind = "client",

--- a/libs/@local/graph/postgres-store/src/store/postgres/pool.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/pool.rs
@@ -1,14 +1,17 @@
 use alloc::sync::Arc;
+use core::future::Future;
 
 use deadpool_postgres::{
     Hook, ManagerConfig, Object, Pool, PoolConfig, PoolError, RecyclingMethod, Timeouts,
 };
 use error_stack::{Report, ResultExt as _};
+use futures::TryStreamExt as _;
 use hash_graph_migrations::IsolationLevel;
 use hash_graph_store::pool::StorePool;
 use hash_temporal_client::TemporalClient;
+use postgres_types::BorrowToSql;
 use tokio_postgres::{
-    Client, GenericClient, Socket, Transaction,
+    Client, GenericClient, Row, Socket, ToStatement, Transaction,
     tls::{MakeTlsConnect, TlsConnect},
 };
 
@@ -159,6 +162,44 @@ pub trait AsClient: Send + Sync {
     fn as_client(&self) -> &Self::Client;
     fn as_mut_client(&mut self) -> &mut Self::Client;
 }
+
+/// The iterator-parameter twin of the row-returning [`GenericClient`] conveniences.
+///
+/// The compiler yields its statement parameters as an iterator, and the convenience methods
+/// take a slice they immediately convert back into an iterator, so every call site would
+/// otherwise collect a vector only to satisfy the signature. The twin takes the iterator
+/// directly.
+pub trait GenericClientIter: GenericClient + Sync {
+    /// Executes the statement and collects the resulting rows.
+    ///
+    /// This is the iterator twin of [`GenericClient::query`], for parameters that arrive as
+    /// an iterator rather than a slice.
+    ///
+    /// # Errors
+    ///
+    /// Propagates the client's [`tokio_postgres::Error`] when statement preparation,
+    /// execution or row streaming fails.
+    // The explicit `+ Send` return type stays. An `async fn` here would hide the future's
+    // auto traits from callers generic over the client.
+    fn query_params_iter<T, I>(
+        &self,
+        statement: &T,
+        parameters: I,
+    ) -> impl Future<Output = Result<Vec<Row>, tokio_postgres::Error>> + Send
+    where
+        T: ?Sized + ToStatement + Sync + Send,
+        I: IntoIterator<Item: BorrowToSql, IntoIter: ExactSizeIterator + Send> + Sync + Send,
+    {
+        async move {
+            self.query_raw(statement, parameters)
+                .await?
+                .try_collect()
+                .await
+        }
+    }
+}
+
+impl<C> GenericClientIter for C where C: GenericClient + Sync {}
 
 impl AsClient for Object {
     type Client = Client;

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/ast/expression/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/ast/expression/mod.rs
@@ -939,7 +939,6 @@ mod tests {
         let expected_parameters = compiler
             .compile()
             .1
-            .iter()
             .map(|parameter| format!("{parameter:?}"))
             .collect::<Vec<_>>();
 

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/compile/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/compile/mod.rs
@@ -757,7 +757,12 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
         skip_all,
         fields(statement.shape = tracing::field::Empty)
     )]
-    pub fn compile(&self) -> (String, &[&'p (dyn ToSql + Sync)]) {
+    pub fn compile(
+        &self,
+    ) -> (
+        String,
+        impl ExactSizeIterator<Item = &(dyn ToSql + Sync)> + Sync + Send,
+    ) {
         let (shape, statement) = match self.shape {
             StatementShape::SinglePass => {
                 (StatementShape::SinglePass, self.single_pass_statement())
@@ -774,7 +779,10 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
         };
 
         tracing::Span::current().record("statement.shape", shape.as_str());
-        (statement.transpile_to_string(), &self.artifacts.parameters)
+        (
+            statement.transpile_to_string(),
+            self.artifacts.parameters.iter().copied(),
+        )
     }
 
     /// Lays out the statement as one flat `SELECT` over all joins.

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/compile/tests.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/compile/tests.rs
@@ -50,7 +50,6 @@ fn test_compilation<'p, 'q: 'p, T: PostgresRecord + 'static>(
     );
 
     let compiled_parameters = compiled_parameters
-        .iter()
         .map(|parameter| format!("{parameter:?}"))
         .collect::<Vec<_>>();
     let expected_parameters = expected_parameters

--- a/libs/@local/graph/postgres-store/src/store/postgres/traversal_context.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/traversal_context.rs
@@ -174,7 +174,7 @@ where
 
         let entities: Vec<Entity> = self
             .as_client()
-            .query_raw(&statement, parameters.iter().copied())
+            .query_raw(&statement, parameters)
             .instrument(tracing::info_span!(
                 "SELECT",
                 otel.kind = "client",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Statement parameters reach the Postgres client as iterators. `SelectCompiler::compile` returns an `ExactSizeIterator` over the bound parameters instead of a slice, and the pool grows iterator-taking query paths (`query_params_iter`, `GenericClientIter`), so the fourteen call sites that used to collect parameters into vectors now hand their iterators straight through.

This layer carries the signature change alone, so the two compiler PRs above it (#9300, #9301) stay reviewable as behavior changes rather than plumbing.

Review focus: the client needs the parameter count before the wire message goes out, so each call site keeps the iterator's length in step with the placeholder count in the statement text. The adapted tests in `compile/tests.rs` pin the new return type.

## 🔍 What does this change?

- `pool.rs`: `query_params_iter` and `GenericClientIter`, the iterator-shaped client plumbing.
- `SelectCompiler::compile` returns `impl ExactSizeIterator` over the parameters, and the affected tests adapt.
- Fourteen call sites across `ontology/`, `crud.rs`, `traversal_context.rs`, and `knowledge/entity/` pass iterators through instead of collecting.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- The existing postgres-store lib suite covers this, plus the workspace battery: `cargo check`, clippy at zero warnings, `fmt` clean.

## ❓ How to test this?

```bash
cargo nextest run -p hash-graph-postgres-store --lib
```
