### PR TITLE
BE-778, BE-789, BE-790: hgraph: Typed SQL assembly, peephole filter rewrites, and statement vocabulary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1255,7 +1255,7 @@ version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -2098,36 +2098,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
-dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
-]
-
-[[package]]
-name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.118",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -2145,22 +2121,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
-dependencies = [
- "darling_core 0.21.3",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.23.0",
+ "darling_core",
  "quote",
  "syn 2.0.118",
 ]
@@ -3333,9 +3298,9 @@ checksum = "92620684d99f750bae383ecb3be3748142d6095760afd5cbcf2261e9a279d780"
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -5045,7 +5010,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "indoc",
  "proc-macro2",
  "quote",
@@ -9175,7 +9140,7 @@ version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.118",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1255,7 +1255,7 @@ version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -2098,12 +2098,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2121,11 +2145,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core 0.21.3",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.118",
 ]
@@ -3298,9 +3333,9 @@ checksum = "92620684d99f750bae383ecb3be3748142d6095760afd5cbcf2261e9a279d780"
 
 [[package]]
 name = "h2"
-version = "0.4.18"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -5010,7 +5045,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "indoc",
  "proc-macro2",
  "quote",
@@ -9140,7 +9175,7 @@ version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/table.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/table.rs
@@ -1368,7 +1368,7 @@ mod tests {
                   AND ("entity_temporal_metadata_0_0_0"."decision_time" && $2)
                   AND (("entity_temporal_metadata_0_0_0"."web_id" = ANY($3))
                   AND ("entity_editions_0_1_0"."archived" != $4))
-                  AND (("entity_edition_cache_1_1_0"."versioned_urls" @> ARRAY[$5]::text[]))),
+                  AND ("entity_edition_cache_1_1_0"."versioned_urls" @> ARRAY[$5]::text[])),
                 "limited" AS (SELECT *
                 FROM "roots"
                 ORDER BY "created_at_decision_time" DESC, "entity_uuid" DESC LIMIT 500)

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/ast/assembly.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/ast/assembly.rs
@@ -1,0 +1,445 @@
+//! Typed assembly for statements built as AST values.
+//!
+//! A statement here is a value of the statement AST, composed from shared fragments and
+//! rendered to SQL once, when the finished statement leaves through [`BoundStatement`]. The kit
+//! has one piece per agreement that would otherwise hold by convention:
+//!
+//! - [`Binder`] owns the parameter list. A parameter expression exists only as the return value of
+//!   a bind, so a statement cannot cite a parameter the bind list does not carry, and the indices
+//!   cannot drift from the values because one call assigns both.
+//! - [`SelectList`] owns a statement's output columns. Adding an output expression returns its
+//!   column index, so the decoder that reads the index and the select list that positioned it are
+//!   the same declaration and a reordered select list moves its decoders with it.
+//! - [`Aliased`] binds a base table to the statement-local name it stands under, `meta`, `edition`,
+//!   and to the column vocabulary it can be asked for. The reference is a named constant beside the
+//!   statement that introduces it, so every mention moves in one edit, and qualifying another
+//!   table's column through it fails compilation. Its [`from_item`](Aliased::from_item) is the FROM
+//!   item it introduces, so a join list reads as one [`inner_join_on`]/[`left_join_on`] chain.
+//!   Every constructor carries the table, so a rendered join names the relation it binds and a
+//!   dangling alias cannot be written.
+//! - [`Correlation`] is a derived relation's name - an unnest, subquery, lateral, or CTE output -
+//!   with the same column vocabulary and deliberately no FROM item. A derived FROM item takes it as
+//!   its alias, a CTE declares it through [`CommonTableExpression`] and stands under it through
+//!   [`FromItem::table`], and joining one as if it were a base table fails compilation, which is
+//!   the defect this split removes.
+//!
+//! [`inner_join_on`]: FromItem::inner_join_on
+//! [`left_join_on`]: FromItem::left_join_on
+//! [`CommonTableExpression`]: super::CommonTableExpression
+
+use core::marker::PhantomData;
+
+use tokio_postgres::types::ToSql;
+
+use crate::store::postgres::query::{
+    ColumnReference, Expression, FromItem, SelectExpression, SelectStatement, TableName,
+    TableReference, Transpile as _,
+    table::{Alias, DatabaseColumn, Table},
+};
+
+/// A `$n` parameter slot, created by binding its value.
+///
+/// Converts into [`Expression::Parameter`], which is the only way a statement cites it. Where
+/// the statement needs a type annotation for inference, cast the converted expression.
+#[derive(Debug, Copy, Clone)]
+pub struct Placeholder {
+    /// The 1-based parameter index.
+    index: usize,
+}
+
+impl From<Placeholder> for Expression {
+    fn from(placeholder: Placeholder) -> Self {
+        Self::Parameter(placeholder.index)
+    }
+}
+
+/// The parameter list of one statement under construction.
+///
+/// Every parameter enters through [`bind`](Self::bind), which appends the value and returns the
+/// placeholder that cites it. The finished list leaves through
+/// [`into_parameters`](Self::into_parameters) in placeholder order, which is what makes the order
+/// a construction fact rather than a convention shared between the statement and the call site.
+#[derive(Default)]
+pub struct Binder<'params> {
+    parameters: Vec<&'params (dyn ToSql + Sync)>,
+}
+
+impl<'params> Binder<'params> {
+    /// Binds `value` as the next parameter and returns its placeholder.
+    pub fn bind(&mut self, value: &'params (dyn ToSql + Sync)) -> Placeholder {
+        self.parameters.push(value);
+
+        Placeholder {
+            index: self.parameters.len(),
+        }
+    }
+
+    /// Returns the bound parameters, in placeholder order.
+    #[must_use]
+    pub fn into_parameters(self) -> Vec<&'params (dyn ToSql + Sync)> {
+        self.parameters
+    }
+}
+
+/// A finished statement, carrying its parameters and its output column indices beside the SQL.
+///
+/// Everything leaves one builder together, so no caller can issue a statement with another
+/// statement's binds or decode a row through another statement's columns.
+pub struct BoundStatement<'param, C> {
+    /// The rendered statement text.
+    pub sql: String,
+    /// The bind list, in placeholder order.
+    pub parameters: Vec<&'param (dyn ToSql + Sync)>,
+    /// The output column indices the select list assigned.
+    pub columns: C,
+}
+
+impl<'param, C> BoundStatement<'param, C> {
+    /// Renders `statement` and packs it with the binder's parameters and the output columns.
+    pub fn new(statement: &SelectStatement, binder: Binder<'param>, columns: C) -> Self {
+        Self {
+            sql: statement.transpile_to_string(),
+            parameters: binder.into_parameters(),
+            columns,
+        }
+    }
+}
+
+/// The output columns of one statement under construction.
+///
+/// Each [`output`](Self::output) call appends one select expression and returns its zero-based
+/// column index for the decoder. The finished list leaves through
+/// [`into_selects`](Self::into_selects) as the statement's select clause.
+#[derive(Default)]
+pub struct SelectList {
+    selects: Vec<SelectExpression>,
+}
+
+impl SelectList {
+    /// Appends one output expression and returns its zero-based column index.
+    pub fn output(&mut self, expression: impl Into<Expression>) -> usize {
+        let index = self.selects.len();
+        self.selects.push(SelectExpression::new(expression));
+
+        index
+    }
+
+    /// Returns the select expressions, in index order.
+    #[must_use]
+    pub fn into_selects(self) -> Vec<SelectExpression> {
+        self.selects
+    }
+}
+
+/// A statement-local table reference, bound to the column vocabulary it can be asked for.
+///
+/// The value names one FROM item inside one statement - a CTE standing under its own name, or
+/// the `meta` in `... AS meta` - and lives as a named constant beside the statement that
+/// introduces it, so every mention moves in one edit. The type parameter is the table's column
+/// vocabulary: [`column`](Self::column) accepts exactly that vocabulary, so qualifying another
+/// table's column through the reference fails compilation.
+///
+/// The constructors are monomorphic on purpose: constant contexts admit no `impl Into`
+/// conversion, and the module-level constants are the whole point. [`table`](Self::table) and
+/// [`of`](Self::of) take the schema vocabulary directly, and a CTE's name arrives as the
+/// string constant that names the CTE.
+#[derive(Debug)]
+pub struct Aliased<C> {
+    /// The name the FROM item stands under: the alias, or the table's own name.
+    name: &'static str,
+    /// The base table the name renames, for the `... AS <name>` form.
+    base: Option<&'static str>,
+    columns: PhantomData<fn() -> C>,
+}
+
+impl<C> Clone for Aliased<C> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<C> Copy for Aliased<C> {}
+
+impl<C> Aliased<C> {
+    /// Stands a schema table under its own name.
+    #[must_use]
+    pub const fn table(table: Table) -> Self {
+        Self {
+            name: table.as_str(),
+            base: None,
+            columns: PhantomData,
+        }
+    }
+
+    /// Aliases a schema table: the `<table> AS <name>` form.
+    #[must_use]
+    pub const fn of(table: Table, name: &'static str) -> Self {
+        Self::renaming(table.as_str(), name)
+    }
+
+    /// Aliases a named table: the `<base> AS <name>` form, for renaming a CTE.
+    #[must_use]
+    pub const fn renaming(base: &'static str, name: &'static str) -> Self {
+        Self {
+            name,
+            base: Some(base),
+            columns: PhantomData,
+        }
+    }
+
+    /// Returns the reference other clauses cite the table by: the standing name.
+    #[must_use]
+    pub fn reference(self) -> TableReference<'static> {
+        TableReference {
+            schema: None,
+            name: TableName::from(self.name),
+        }
+    }
+
+    /// Returns the FROM item this reference introduces.
+    #[expect(
+        clippy::wrong_self_convention,
+        reason = "a FROM item is the SQL grammar term, and the method builds this reference's"
+    )]
+    #[must_use]
+    pub fn from_item(self) -> FromItem<'static> {
+        self.base.map_or_else(
+            || FromItem::table(self.reference()).build(),
+            |base| {
+                FromItem::table(TableReference {
+                    schema: None,
+                    name: TableName::from(base),
+                })
+                .alias(self.name)
+                .build()
+            },
+        )
+    }
+}
+
+impl<C: DatabaseColumn<'static>> Aliased<C> {
+    /// Returns the vocabulary's column, qualified through the standing name.
+    #[must_use]
+    pub fn column(self, column: &C) -> Expression {
+        Expression::ColumnReference(ColumnReference {
+            correlation: Some(self.reference()),
+            name: column.name(),
+        })
+    }
+}
+
+/// A derived relation's statement-local name, bound to its column vocabulary.
+///
+/// The relations this names - an unnest, a subquery, a lateral, a CTE - exist only inside the
+/// statement that derives them, so the name introduces nothing on its own and there is
+/// deliberately no FROM item here. A derived FROM item takes one as its `alias`, a CTE declares
+/// one through [`CommonTableExpression`] and stands under it through
+/// [`FromItem::table`], and a base table travels as [`Aliased`] instead, so joining a bare name
+/// where a base table is required fails compilation.
+///
+/// [`CommonTableExpression`]: super::CommonTableExpression
+pub struct Correlation<C> {
+    /// The name the derived relation stands under.
+    name: &'static str,
+    columns: PhantomData<fn() -> C>,
+}
+
+impl<C> Clone for Correlation<C> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<C> Copy for Correlation<C> {}
+
+impl<C> Correlation<C> {
+    /// Names a derived relation.
+    #[must_use]
+    pub const fn new(name: &'static str) -> Self {
+        Self {
+            name,
+            columns: PhantomData,
+        }
+    }
+
+    /// Renames the standing relation: the `<self's name> AS <name>` form, keeping the vocabulary.
+    ///
+    /// The result introduces the renamed relation as a FROM item, which is how a CTE joins under
+    /// a second name.
+    #[must_use]
+    pub const fn renames(self, name: &'static str) -> Aliased<C> {
+        Aliased::renaming(self.name, name)
+    }
+
+    /// Returns the reference other clauses cite the relation by.
+    #[must_use]
+    pub fn reference(self) -> TableReference<'static> {
+        TableReference {
+            schema: None,
+            name: TableName::from(self.name),
+        }
+    }
+
+    /// Stands the relation under an allocator-issued alias: the `"name_c_d_n"` form.
+    ///
+    /// Derived relations of the same kind in one statement render distinct names when each
+    /// takes its own alias.
+    #[must_use]
+    pub const fn at(self, alias: Alias) -> AliasedCorrelation<C> {
+        AliasedCorrelation {
+            name: self.name,
+            alias,
+            columns: PhantomData,
+        }
+    }
+}
+
+impl<C: DatabaseColumn<'static>> Correlation<C> {
+    /// Returns the vocabulary's column, qualified through the standing name.
+    #[must_use]
+    pub fn column(self, column: &C) -> Expression {
+        Expression::ColumnReference(ColumnReference {
+            correlation: Some(self.reference()),
+            name: column.name(),
+        })
+    }
+}
+
+impl<C> From<Correlation<C>> for TableReference<'static> {
+    fn from(relation: Correlation<C>) -> Self {
+        relation.reference()
+    }
+}
+
+impl<C> From<Correlation<C>> for TableName<'static> {
+    fn from(relation: Correlation<C>) -> Self {
+        Self::from(relation.name)
+    }
+}
+
+/// A derived relation standing under the compiler's alias vocabulary, created by
+/// [`Correlation::at`].
+///
+/// It keeps the correlation's column vocabulary: other clauses cite the relation through
+/// [`reference`](Self::reference) and its columns through [`column`](Self::column), both
+/// rendering the `"name_c_d_n"` form.
+pub struct AliasedCorrelation<C> {
+    /// The name the derived relation stands under, before the alias suffix.
+    name: &'static str,
+    /// The allocator-issued alias the rendered name carries.
+    alias: Alias,
+    columns: PhantomData<fn() -> C>,
+}
+
+impl<C> AliasedCorrelation<C> {
+    /// Returns the reference other clauses cite the relation by.
+    #[must_use]
+    pub fn reference(&self) -> TableReference<'static> {
+        TableReference {
+            schema: None,
+            name: self.alias.qualify(self.name),
+        }
+    }
+}
+
+impl<C: DatabaseColumn<'static>> AliasedCorrelation<C> {
+    /// Returns the vocabulary's column, qualified through the standing name.
+    #[must_use]
+    pub fn column(&self, column: &C) -> Expression {
+        Expression::ColumnReference(ColumnReference {
+            correlation: Some(self.reference()),
+            name: column.name(),
+        })
+    }
+}
+
+impl<C> Clone for AliasedCorrelation<C> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<C> Copy for AliasedCorrelation<C> {}
+
+impl<C> From<AliasedCorrelation<C>> for TableReference<'static> {
+    fn from(relation: AliasedCorrelation<C>) -> Self {
+        relation.reference()
+    }
+}
+
+impl<C> From<AliasedCorrelation<C>> for TableName<'static> {
+    fn from(relation: AliasedCorrelation<C>) -> Self {
+        relation.alias.qualify(relation.name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Aliased, Binder, SelectList};
+    use crate::store::postgres::query::{
+        Expression, Transpile as _,
+        table::{EntityEmbeddings, EntityTemporalMetadata, Table},
+    };
+
+    /// Placeholders number from one in bind order, which is the order the parameter list holds.
+    #[test]
+    fn placeholders_number_in_bind_order() {
+        let mut binder = Binder::default();
+
+        let first = binder.bind(&1_i32);
+        let second = binder.bind(&2_i32);
+
+        assert_eq!(Expression::from(first).transpile_to_string(), "$1");
+        assert_eq!(Expression::from(second).transpile_to_string(), "$2");
+        assert_eq!(binder.into_parameters().len(), 2);
+    }
+
+    /// Output indices are zero-based select-list positions, and the list renders in that order.
+    #[test]
+    fn select_list_indices_match_render_order() {
+        const META: Aliased<EntityTemporalMetadata> =
+            Aliased::of(Table::EntityTemporalMetadata, "meta");
+
+        let mut select = SelectList::default();
+
+        let first = select.output(META.column(&EntityTemporalMetadata::WebId));
+        let second = select.output(META.column(&EntityTemporalMetadata::EntityUuid));
+
+        assert_eq!(first, 0);
+        assert_eq!(second, 1);
+
+        let selects = select.into_selects();
+        assert_eq!(selects.len(), 2);
+        assert_eq!(
+            selects[0].transpile_to_string(),
+            "\"meta\".\"web_id\"",
+            "the first output renders at the first position"
+        );
+    }
+
+    /// An alias renders quoted and qualifies exactly its own vocabulary's columns, so a
+    /// reserved word cannot corrupt the statement and a foreign column cannot ride through the
+    /// alias.
+    #[test]
+    fn aliases_render_quoted_and_stay_typed() {
+        const META: Aliased<EntityTemporalMetadata> =
+            Aliased::of(Table::EntityTemporalMetadata, "meta");
+        const EMBEDDING: Aliased<EntityEmbeddings> =
+            Aliased::of(Table::EntityEmbeddings, "embedding");
+
+        assert_eq!(META.reference().transpile_to_string(), "\"meta\"");
+        assert_eq!(
+            META.column(&EntityTemporalMetadata::TransactionTime)
+                .transpile_to_string(),
+            "\"meta\".\"transaction_time\""
+        );
+
+        // `META.column(&EntityEmbeddings::WebId)` is the compile error the type parameter buys.
+        assert_eq!(
+            EMBEDDING
+                .column(&EntityEmbeddings::WebId)
+                .transpile_to_string(),
+            "\"embedding\".\"web_id\""
+        );
+    }
+}

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/ast/clause/from_item.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/ast/clause/from_item.rs
@@ -354,6 +354,42 @@ impl<'id> FromItem<'id> {
         }
     }
 
+    /// Joins with ON conditions: `self INNER JOIN <from> ON <conditions>`.
+    ///
+    /// An empty condition list transpiles to `ON TRUE`, the cartesian product.
+    #[must_use]
+    pub fn inner_join_on(
+        self,
+        from: impl Into<Self>,
+        conditions: impl IntoIterator<Item: Into<Expression>>,
+    ) -> Self {
+        Self::JoinOn {
+            left: Box::new(self),
+            join_type: JoinType::Inner,
+            right: Box::new(from.into()),
+            condition: conditions.into_iter().map(Into::into).collect(),
+        }
+    }
+
+    /// Joins with ON conditions, keeping every left row: `self LEFT OUTER JOIN <from> ON
+    /// <conditions>`.
+    ///
+    /// An empty condition list transpiles to `ON TRUE`, which keeps exactly one right row per
+    /// left row when the right side delivers one, as a `LATERAL` subquery does.
+    #[must_use]
+    pub fn left_join_on(
+        self,
+        from: impl Into<Self>,
+        conditions: impl IntoIterator<Item: Into<Expression>>,
+    ) -> Self {
+        Self::JoinOn {
+            left: Box::new(self),
+            join_type: JoinType::LeftOuter,
+            right: Box::new(from.into()),
+            condition: conditions.into_iter().map(Into::into).collect(),
+        }
+    }
+
     /// Creates a NATURAL JOIN using matching column names.
     #[must_use]
     pub fn natural_join(self, r#type: JoinType, from: impl Into<Self>) -> Self {

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/ast/clause/order_by.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/ast/clause/order_by.rs
@@ -46,6 +46,24 @@ pub struct SortBy {
     pub nulls: Option<NullsOrder>,
 }
 
+impl SortBy {
+    pub fn ascending(
+        expression: impl Into<Expression>,
+    ) -> SortByBuilder<impl sort_by_builder::IsComplete> {
+        Self::builder()
+            .direction(SortDirection::Ascending)
+            .expression(expression.into())
+    }
+
+    pub fn descending(
+        expression: impl Into<Expression>,
+    ) -> SortByBuilder<impl sort_by_builder::IsComplete> {
+        Self::builder()
+            .direction(SortDirection::Descending)
+            .expression(expression.into())
+    }
+}
+
 impl<S> From<SortByBuilder<S>> for NonEmptyVec<SortBy>
 where
     S: sort_by_builder::IsComplete,
@@ -81,6 +99,17 @@ pub struct OrderByClause {
     /// via `NonEmptyVec::try_from`.
     #[builder(into)]
     pub sort_by: NonEmptyVec<SortBy>,
+}
+
+impl<T> From<T> for OrderByClause
+where
+    T: Into<NonEmptyVec<SortBy>>,
+{
+    fn from(sort_by: T) -> Self {
+        Self {
+            sort_by: sort_by.into(),
+        }
+    }
 }
 
 impl Transpile for OrderByClause {

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/ast/clause/select_list.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/ast/clause/select_list.rs
@@ -22,6 +22,29 @@ pub enum SelectExpression {
     Asterisk(Option<TableReference<'static>>),
 }
 
+impl SelectExpression {
+    /// Creates an unaliased select item.
+    #[must_use]
+    pub fn new(expression: impl Into<Expression>) -> Self {
+        Self::Expression {
+            expression: expression.into(),
+            output_name: None,
+        }
+    }
+
+    /// Creates an aliased select item: `<expression> AS "<alias>"`.
+    #[must_use]
+    pub fn aliased(
+        expression: impl Into<Expression>,
+        alias: impl Into<Identifier<'static>>,
+    ) -> Self {
+        Self::Expression {
+            expression: expression.into(),
+            output_name: Some(alias.into()),
+        }
+    }
+}
+
 impl Transpile for SelectExpression {
     fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match self {

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/ast/column_reference.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/ast/column_reference.rs
@@ -10,10 +10,18 @@ use crate::store::postgres::query::{Column, Transpile, table::DatabaseColumn as 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ColumnName<'name>(Identifier<'name>);
 
-impl ColumnName<'_> {
+impl<'name> ColumnName<'name> {
     #[must_use]
     pub fn as_str(&self) -> &str {
         self.0.as_ref()
+    }
+
+    /// Returns the name as a bare identifier, e.g. to alias a select expression.
+    // A `From` impl would collide with the blanket `From<I: Into<Identifier>> for ColumnName`
+    // through the reflexive `From<T> for T`, so the conversion is a method.
+    #[must_use]
+    pub fn into_identifier(self) -> Identifier<'name> {
+        self.0
     }
 }
 

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/ast/expression/binary.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/ast/expression/binary.rs
@@ -59,8 +59,6 @@ pub enum BinaryOperator {
     ArrayContains,
     /// `<lhs> && <rhs>`
     Overlap,
-    /// `<lhs> <=> <rhs>`
-    CosineDistance,
     /// `<lhs> <~> <rhs>`
     HammingDistance,
 }
@@ -87,7 +85,6 @@ impl BinaryOperator {
             Self::JsonAccessAsText => " ->> ",
             Self::TimeIntervalContainsTimestamp | Self::ArrayContains => " @> ",
             Self::Overlap => " && ",
-            Self::CosineDistance => " <=> ",
             Self::HammingDistance => " <~> ",
         };
         fmt.write_str(string)
@@ -116,7 +113,6 @@ impl BinaryOperator {
             | Self::ArrayContains
             | Self::Overlap
             | Self::RegexMatch
-            | Self::CosineDistance
             | Self::HammingDistance => Ok(()),
         }
     }

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/ast/expression/binary.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/ast/expression/binary.rs
@@ -23,6 +23,8 @@ pub enum BinaryOperator {
     LessOrEqual,
     /// `<lhs> = ANY(<rhs>)`
     In,
+    /// `<lhs> ~ <rhs>`
+    RegexMatch,
 
     // --- Arithmetic ---
     /// `<lhs> + <rhs>`
@@ -47,6 +49,8 @@ pub enum BinaryOperator {
     JsonAccess,
     /// `<lhs> ->> <rhs>`
     JsonAccessAsText,
+    /// `<lhs> - <rhs>`
+    JsonDelete,
 
     // --- Domain-specific ---
     /// `<lhs> @> <rhs>::TIMESTAMPTZ`
@@ -55,6 +59,8 @@ pub enum BinaryOperator {
     ArrayContains,
     /// `<lhs> && <rhs>`
     Overlap,
+    /// `<lhs> <=> <rhs>`
+    CosineDistance,
     /// `<lhs> <~> <rhs>`
     HammingDistance,
 }
@@ -69,8 +75,9 @@ impl BinaryOperator {
             Self::Less => " < ",
             Self::LessOrEqual => " <= ",
             Self::In => " = ANY(",
+            Self::RegexMatch => " ~ ",
             Self::Add => " + ",
-            Self::Subtract => " - ",
+            Self::Subtract | Self::JsonDelete => " - ",
             Self::Multiply => " * ",
             Self::Divide => " / ",
             Self::Modulo => " % ",
@@ -80,6 +87,7 @@ impl BinaryOperator {
             Self::JsonAccessAsText => " ->> ",
             Self::TimeIntervalContainsTimestamp | Self::ArrayContains => " @> ",
             Self::Overlap => " && ",
+            Self::CosineDistance => " <=> ",
             Self::HammingDistance => " <~> ",
         };
         fmt.write_str(string)
@@ -104,8 +112,11 @@ impl BinaryOperator {
             | Self::BitwiseOr
             | Self::JsonAccess
             | Self::JsonAccessAsText
+            | Self::JsonDelete
             | Self::ArrayContains
             | Self::Overlap
+            | Self::RegexMatch
+            | Self::CosineDistance
             | Self::HammingDistance => Ok(()),
         }
     }

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/ast/expression/function.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/ast/expression/function.rs
@@ -5,7 +5,7 @@ use core::{
 
 use hash_graph_store::filter::PathToken;
 
-use crate::store::postgres::query::{Expression, PostgresType, Transpile};
+use crate::store::postgres::query::{Expression, OrderByClause, PostgresType, Transpile};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Function {
@@ -14,12 +14,26 @@ pub enum Function {
     JsonAgg(Box<Expression>),
     JsonExtractText(Box<Expression>),
     JsonExtractAsText(Box<Expression>, PathToken<'static>),
+    /// Extracts a JSON field or array element, keeping the `jsonb` type.
+    ///
+    /// Transpiles to `<expr>->'field'` or `<expr>->index`. The text-returning counterpart is
+    /// [`JsonExtractAsText`](Self::JsonExtractAsText).
+    JsonExtract(Box<Expression>, PathToken<'static>),
     JsonExtractPath(Vec<Expression>),
     JsonContains(Box<Expression>, Box<Expression>),
+    /// The type of a `jsonb` value, as text.
+    ///
+    /// Transpiles to `jsonb_typeof(<expr>)`, one of `object`, `array`, `string`, `number`,
+    /// `boolean`, and `null`.
+    JsonTypeof(Box<Expression>),
     JsonScalar(Box<Expression>),
     JsonBuildArray(Vec<Expression>),
     JsonBuildObject(Vec<(Expression, Expression)>),
     JsonPathQueryFirst(Box<Expression>, Box<Expression>),
+    /// Every match of a JSON path inside a `jsonb` value, as a `jsonb` array.
+    ///
+    /// Transpiles to `jsonb_path_query_array(<target>, <path>)`.
+    JsonPathQueryArray(Box<Expression>, Box<Expression>),
     /// Creates an array literal with explicit type cast.
     ///
     /// Transpiles to `ARRAY[{elements}]::{type}[]` in PostgreSQL.
@@ -55,6 +69,99 @@ pub enum Function {
     /// [`BinaryOperator::HammingDistance`]: super::BinaryOperator::HammingDistance
     BinaryQuantize(Box<Expression>),
     Unnest(Vec<Expression>),
+    /// The `row_number` window function: the 1-based position of the row within its window.
+    ///
+    /// Transpiles to `row_number()`. Wrap the resulting expression in [`Expression::Window`] to
+    /// supply the `OVER (...)` clause the function requires.
+    ///
+    /// [`Expression::Window`]: crate::store::postgres::query::Expression::Window
+    RowNumber,
+    /// Aggregates the expression's values into an array.
+    ///
+    /// Transpiles to `array_agg(<expr>)`, or `array_agg(<expr> ORDER BY ...)` when an ordering
+    /// is present. The ordering fixes the array's element order, which is otherwise
+    /// unspecified.
+    ArrayAgg {
+        expression: Box<Expression>,
+        order_by: Option<OrderByClause>,
+    },
+    /// Aggregates key-value pairs into one `jsonb` object.
+    ///
+    /// Transpiles to `jsonb_object_agg(<key>, <value>)`. Aggregating zero rows reads SQL
+    /// `NULL`, so restricting the aggregated set is the surrounding statement's WHERE clause's
+    /// job.
+    JsonObjectAgg {
+        key: Box<Expression>,
+        value: Box<Expression>,
+    },
+    /// Expands a `jsonb` array into one row per element.
+    ///
+    /// Transpiles to `jsonb_array_elements(<expr>)`, a set-returning function that belongs in a
+    /// FROM item.
+    JsonArrayElements(Box<Expression>),
+    /// Expands a `jsonb` array into one row per element, each element as text.
+    ///
+    /// Transpiles to `jsonb_array_elements_text(<expr>)`, a set-returning function that belongs
+    /// in a FROM item.
+    JsonArrayElementsText(Box<Expression>),
+    /// Counts rows or non-NULL values.
+    ///
+    /// Transpiles to `count(*)` when the argument is `None` and `count(<expr>)` otherwise.
+    Count(Option<Box<Expression>>),
+    /// The natural logarithm.
+    ///
+    /// Transpiles to `ln(<expr>)`.
+    Ln(Box<Expression>),
+    /// The MD5 hash of a text value, as a hex string.
+    ///
+    /// Transpiles to `md5(<expr>)`.
+    Md5(Box<Expression>),
+    /// Trims whitespace from both ends of a text value.
+    ///
+    /// Transpiles to `btrim(<expr>)`.
+    Btrim(Box<Expression>),
+    /// The character count of a text value.
+    ///
+    /// Transpiles to `char_length(<expr>)`.
+    CharLength(Box<Expression>),
+    /// Concatenates values with a separator, skipping NULLs.
+    ///
+    /// Transpiles to `concat_ws(<separator>, <expr>, ...)`.
+    ConcatWs {
+        separator: Box<Expression>,
+        expressions: Vec<Expression>,
+    },
+    /// The substring starting at a 1-based character position.
+    ///
+    /// Transpiles to `substring(<string> FROM <start>)`.
+    Substring {
+        string: Box<Expression>,
+        start: Box<Expression>,
+    },
+    /// Replaces every match of a POSIX regular expression.
+    ///
+    /// Transpiles to `regexp_replace(<string>, <pattern>, <replacement>)`.
+    RegexpReplace {
+        string: Box<Expression>,
+        pattern: Box<Expression>,
+        replacement: Box<Expression>,
+    },
+    /// Expands a `jsonb` object into one row per key-value pair.
+    ///
+    /// Transpiles to `jsonb_each(<expr>)`, a set-returning function that belongs in a FROM item.
+    JsonEach(Box<Expression>),
+    /// `pgvector`: rescales a vector to unit l2 norm.
+    ///
+    /// Transpiles to `l2_normalize(<expr>)`.
+    L2Normalize(Box<Expression>),
+    /// `pgvector`: extracts `count` components of `vector`, starting at the 1-based `start`.
+    ///
+    /// Transpiles to `subvector(<expr>, <start>, <count>)`.
+    Subvector {
+        vector: Box<Expression>,
+        start: usize,
+        count: usize,
+    },
     Now,
 }
 
@@ -73,7 +180,12 @@ impl Function {
             | Self::JsonAgg(expr)
             | Self::JsonExtractText(expr)
             | Self::JsonExtractAsText(expr, _)
+            | Self::JsonExtract(expr, _)
+            | Self::JsonTypeof(expr)
             | Self::JsonScalar(expr)
+            | Self::JsonArrayElements(expr)
+            | Self::JsonArrayElementsText(expr)
+            | Self::JsonEach(expr)
             | Self::ToJson(expr)
             | Self::Lower(expr)
             | Self::Upper(expr)
@@ -82,12 +194,36 @@ impl Function {
             | Self::LowerInf(expr)
             | Self::UpperInf(expr)
             | Self::ExtractEpochMs(expr)
-            | Self::BinaryQuantize(expr) => visitor(expr),
+            | Self::BinaryQuantize(expr)
+            | Self::L2Normalize(expr)
+            | Self::Ln(expr)
+            | Self::Md5(expr)
+            | Self::Btrim(expr)
+            | Self::CharLength(expr)
+            | Self::Subvector { vector: expr, .. } => visitor(expr),
             Self::JsonContains(lhs, rhs)
             | Self::JsonPathQueryFirst(lhs, rhs)
-            | Self::Coalesce(lhs, rhs) => {
+            | Self::JsonPathQueryArray(lhs, rhs)
+            | Self::Coalesce(lhs, rhs)
+            | Self::JsonObjectAgg {
+                key: lhs,
+                value: rhs,
+            }
+            | Self::Substring {
+                string: lhs,
+                start: rhs,
+            } => {
                 visitor(lhs)?;
                 visitor(rhs)
+            }
+            Self::RegexpReplace {
+                string,
+                pattern,
+                replacement,
+            } => {
+                visitor(string)?;
+                visitor(pattern)?;
+                visitor(replacement)
             }
             Self::JsonExtractPath(exprs)
             | Self::JsonBuildArray(exprs)
@@ -100,6 +236,16 @@ impl Function {
                 }
                 ControlFlow::Continue(())
             }
+            Self::ConcatWs {
+                separator,
+                expressions,
+            } => {
+                visitor(separator)?;
+                for expr in expressions {
+                    visitor(expr)?;
+                }
+                ControlFlow::Continue(())
+            }
             Self::JsonBuildObject(pairs) => {
                 for (key, value) in pairs {
                     visitor(key)?;
@@ -107,7 +253,25 @@ impl Function {
                 }
                 ControlFlow::Continue(())
             }
-            Self::Now => ControlFlow::Continue(()),
+            Self::ArrayAgg {
+                expression,
+                order_by,
+            } => {
+                visitor(expression)?;
+                if let Some(order_by) = order_by {
+                    for sort_by in &*order_by.sort_by {
+                        visitor(&sort_by.expression)?;
+                    }
+                }
+                ControlFlow::Continue(())
+            }
+            Self::Count(expr) => {
+                if let Some(expr) = expr {
+                    visitor(expr)?;
+                }
+                ControlFlow::Continue(())
+            }
+            Self::Now | Self::RowNumber => ControlFlow::Continue(()),
         }
     }
 
@@ -121,7 +285,12 @@ impl Function {
             | Self::JsonAgg(expr)
             | Self::JsonExtractText(expr)
             | Self::JsonExtractAsText(expr, _)
+            | Self::JsonExtract(expr, _)
+            | Self::JsonTypeof(expr)
             | Self::JsonScalar(expr)
+            | Self::JsonArrayElements(expr)
+            | Self::JsonArrayElementsText(expr)
+            | Self::JsonEach(expr)
             | Self::ToJson(expr)
             | Self::Lower(expr)
             | Self::Upper(expr)
@@ -130,12 +299,36 @@ impl Function {
             | Self::LowerInf(expr)
             | Self::UpperInf(expr)
             | Self::ExtractEpochMs(expr)
-            | Self::BinaryQuantize(expr) => visitor(expr),
+            | Self::BinaryQuantize(expr)
+            | Self::L2Normalize(expr)
+            | Self::Ln(expr)
+            | Self::Md5(expr)
+            | Self::Btrim(expr)
+            | Self::CharLength(expr)
+            | Self::Subvector { vector: expr, .. } => visitor(expr),
             Self::JsonContains(lhs, rhs)
             | Self::JsonPathQueryFirst(lhs, rhs)
-            | Self::Coalesce(lhs, rhs) => {
+            | Self::JsonPathQueryArray(lhs, rhs)
+            | Self::Coalesce(lhs, rhs)
+            | Self::JsonObjectAgg {
+                key: lhs,
+                value: rhs,
+            }
+            | Self::Substring {
+                string: lhs,
+                start: rhs,
+            } => {
                 visitor(lhs)?;
                 visitor(rhs)
+            }
+            Self::RegexpReplace {
+                string,
+                pattern,
+                replacement,
+            } => {
+                visitor(string)?;
+                visitor(pattern)?;
+                visitor(replacement)
             }
             Self::JsonExtractPath(exprs)
             | Self::JsonBuildArray(exprs)
@@ -148,6 +341,16 @@ impl Function {
                 }
                 ControlFlow::Continue(())
             }
+            Self::ConcatWs {
+                separator,
+                expressions,
+            } => {
+                visitor(separator)?;
+                for expr in expressions {
+                    visitor(expr)?;
+                }
+                ControlFlow::Continue(())
+            }
             Self::JsonBuildObject(pairs) => {
                 for (key, value) in pairs {
                     visitor(key)?;
@@ -155,7 +358,25 @@ impl Function {
                 }
                 ControlFlow::Continue(())
             }
-            Self::Now => ControlFlow::Continue(()),
+            Self::ArrayAgg {
+                expression,
+                order_by,
+            } => {
+                visitor(expression)?;
+                if let Some(order_by) = order_by {
+                    for sort_by in &mut *order_by.sort_by {
+                        visitor(&mut sort_by.expression)?;
+                    }
+                }
+                ControlFlow::Continue(())
+            }
+            Self::Count(expr) => {
+                if let Some(expr) = expr {
+                    visitor(expr)?;
+                }
+                ControlFlow::Continue(())
+            }
+            Self::Now | Self::RowNumber => ControlFlow::Continue(()),
         }
     }
 }
@@ -209,11 +430,23 @@ impl Transpile for Function {
                     PathToken::Index(index) => write!(fmt, "->>{index}"),
                 }
             }
+            Self::JsonExtract(expression, key) => {
+                expression.transpile(fmt)?;
+                match key {
+                    PathToken::Field(field) => write!(fmt, "->'{field}'"),
+                    PathToken::Index(index) => write!(fmt, "->{index}"),
+                }
+            }
             Self::JsonContains(json, value) => {
                 fmt.write_str("jsonb_contains(")?;
                 json.transpile(fmt)?;
                 fmt.write_str(", ")?;
                 value.transpile(fmt)?;
+                fmt.write_char(')')
+            }
+            Self::JsonTypeof(expression) => {
+                fmt.write_str("jsonb_typeof(")?;
+                expression.transpile(fmt)?;
                 fmt.write_char(')')
             }
             Self::JsonBuildArray(expressions) => {
@@ -304,11 +537,125 @@ impl Transpile for Function {
 
                 fmt.write_char(')')
             }
+            Self::RowNumber => fmt.write_str("row_number()"),
+            Self::ArrayAgg {
+                expression,
+                order_by,
+            } => {
+                fmt.write_str("array_agg(")?;
+                expression.transpile(fmt)?;
+                if let Some(order_by) = order_by {
+                    fmt.write_char(' ')?;
+                    order_by.transpile(fmt)?;
+                }
+                fmt.write_char(')')
+            }
+            Self::JsonArrayElements(expression) => {
+                fmt.write_str("jsonb_array_elements(")?;
+                expression.transpile(fmt)?;
+                fmt.write_char(')')
+            }
+            Self::JsonArrayElementsText(expression) => {
+                fmt.write_str("jsonb_array_elements_text(")?;
+                expression.transpile(fmt)?;
+                fmt.write_char(')')
+            }
+            Self::Count(None) => fmt.write_str("count(*)"),
+            Self::Count(Some(expression)) => {
+                fmt.write_str("count(")?;
+                expression.transpile(fmt)?;
+                fmt.write_char(')')
+            }
+            Self::Ln(expression) => {
+                fmt.write_str("ln(")?;
+                expression.transpile(fmt)?;
+                fmt.write_char(')')
+            }
+            Self::Md5(expression) => {
+                fmt.write_str("md5(")?;
+                expression.transpile(fmt)?;
+                fmt.write_char(')')
+            }
+            Self::Btrim(expression) => {
+                fmt.write_str("btrim(")?;
+                expression.transpile(fmt)?;
+                fmt.write_char(')')
+            }
+            Self::CharLength(expression) => {
+                fmt.write_str("char_length(")?;
+                expression.transpile(fmt)?;
+                fmt.write_char(')')
+            }
+            Self::ConcatWs {
+                separator,
+                expressions,
+            } => {
+                fmt.write_str("concat_ws(")?;
+                separator.transpile(fmt)?;
+                for expression in expressions {
+                    fmt.write_str(", ")?;
+                    expression.transpile(fmt)?;
+                }
+                fmt.write_char(')')
+            }
+            Self::Substring { string, start } => {
+                fmt.write_str("substring(")?;
+                string.transpile(fmt)?;
+                fmt.write_str(" FROM ")?;
+                start.transpile(fmt)?;
+                fmt.write_char(')')
+            }
+            Self::RegexpReplace {
+                string,
+                pattern,
+                replacement,
+            } => {
+                fmt.write_str("regexp_replace(")?;
+                string.transpile(fmt)?;
+                fmt.write_str(", ")?;
+                pattern.transpile(fmt)?;
+                fmt.write_str(", ")?;
+                replacement.transpile(fmt)?;
+                fmt.write_char(')')
+            }
+            Self::JsonEach(expression) => {
+                fmt.write_str("jsonb_each(")?;
+                expression.transpile(fmt)?;
+                fmt.write_char(')')
+            }
+            Self::L2Normalize(expression) => {
+                fmt.write_str("l2_normalize(")?;
+                expression.transpile(fmt)?;
+                fmt.write_char(')')
+            }
+            Self::Subvector {
+                vector,
+                start,
+                count,
+            } => {
+                fmt.write_str("subvector(")?;
+                vector.transpile(fmt)?;
+                write!(fmt, ", {start}, {count})")
+            }
             Self::JsonPathQueryFirst(target, path) => {
                 fmt.write_str("jsonb_path_query_first(")?;
                 target.transpile(fmt)?;
                 fmt.write_str(", ")?;
                 path.transpile(fmt)?;
+                fmt.write_char(')')
+            }
+            Self::JsonPathQueryArray(target, path) => {
+                fmt.write_str("jsonb_path_query_array(")?;
+                target.transpile(fmt)?;
+                fmt.write_str(", ")?;
+                path.transpile(fmt)?;
+                fmt.write_char(')')
+            }
+            Self::JsonObjectAgg { key, value } => {
+                fmt.write_str("jsonb_object_agg(")?;
+                key.transpile(fmt)?;
+                fmt.write_str(", ")?;
+                value.transpile(fmt)?;
                 fmt.write_char(')')
             }
             Self::ArrayLiteral {

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/ast/expression/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/ast/expression/mod.rs
@@ -296,16 +296,6 @@ impl Expression {
         })
     }
 
-    /// Cosine distance between two `vector` expressions of equal dimension count.
-    #[must_use]
-    pub fn cosine_distance(self, rhs: impl Into<Self>) -> Self {
-        Self::Binary(BinaryExpression {
-            op: BinaryOperator::CosineDistance,
-            left: Box::new(self),
-            right: Box::new(rhs.into()),
-        })
-    }
-
     /// Hamming distance between two `bit` expressions of equal width.
     #[must_use]
     pub fn hamming_distance(lhs: Self, rhs: Self) -> Self {

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/ast/expression/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/ast/expression/mod.rs
@@ -510,9 +510,9 @@ impl From<Constant> for Expression {
 /// Expression-tree traversal.
 ///
 /// Both visitors run in pre-order (the expression itself before its children) and do not descend
-/// into [`Expression::Select`] subqueries: statement-level structures own their traversal. A
-/// visitor with no answer for the tables hiding inside a subquery matches on the variant and
-/// breaks.
+/// into [`Expression::Select`] or [`Expression::Exists`] subqueries. Statement-level structures
+/// own their traversal. A visitor with no answer for the tables hiding inside a subquery matches
+/// on either variant and breaks.
 impl Expression {
     /// Calls `visitor` for this expression and every nested sub-expression, stopping at the first
     /// [`ControlFlow::Break`].

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/ast/expression/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/ast/expression/mod.rs
@@ -73,11 +73,25 @@ pub enum Expression {
         expr: Box<Self>,
         index: usize,
     },
+    /// 1-based array slice access, both bounds inclusive.
+    ///
+    /// Transpiles to `(<expr>)[<lower>:<upper>]` in PostgreSQL. A slice whose bounds select no
+    /// elements is the empty array.
+    ArraySlice {
+        expr: Box<Self>,
+        lower: Box<Self>,
+        upper: Box<Self>,
+    },
     /// Row constructor - builds a composite row value from individual expressions.
     ///
     /// Transpiles to `ROW(e1, e2, ...)` in PostgreSQL.
     Row(Vec<Self>),
     Select(Box<SelectStatement>),
+    /// Subquery existence test.
+    ///
+    /// Transpiles to `EXISTS (SELECT ...)`, which is true when the subquery delivers at least
+    /// one row. Negate with [`not`](Self::not) for `NOT(EXISTS (...))`.
+    Exists(Box<SelectStatement>),
     /// Conditional expression.
     ///
     /// Transpiles to `CASE WHEN {cond1} THEN {result1} WHEN {cond2} THEN {result2} ... ELSE
@@ -151,111 +165,144 @@ impl Expression {
     }
 
     #[must_use]
-    pub fn equal(lhs: Self, rhs: Self) -> Self {
+    pub fn equal(self, rhs: impl Into<Self>) -> Self {
         Self::Binary(BinaryExpression {
             op: BinaryOperator::Equal,
-            left: Box::new(lhs),
-            right: Box::new(rhs),
+            left: Box::new(self),
+            right: Box::new(rhs.into()),
         })
     }
 
     #[must_use]
-    pub fn not_equal(lhs: Self, rhs: Self) -> Self {
+    pub fn not_equal(self, rhs: impl Into<Self>) -> Self {
         Self::Binary(BinaryExpression {
             op: BinaryOperator::NotEqual,
-            left: Box::new(lhs),
-            right: Box::new(rhs),
+            left: Box::new(self),
+            right: Box::new(rhs.into()),
         })
     }
 
     #[must_use]
-    pub fn is_null(expr: Self) -> Self {
+    pub fn exists(statement: SelectStatement) -> Self {
+        Self::Exists(Box::new(statement))
+    }
+
+    #[must_use]
+    #[expect(
+        clippy::wrong_self_convention,
+        reason = "the SQL predicate is named `IS NULL`, and the builder consumes its expression"
+    )]
+    pub fn is_null(self) -> Self {
         Self::Unary(UnaryExpression {
             op: UnaryOperator::IsNull,
-            expr: Box::new(expr),
+            expr: Box::new(self),
         })
     }
 
     #[must_use]
-    pub fn is_not_null(expr: Self) -> Self {
-        Self::is_null(expr).not()
+    #[expect(
+        clippy::wrong_self_convention,
+        reason = "the SQL predicate is named `IS NOT NULL`, and the builder consumes its \
+                  expression"
+    )]
+    pub fn is_not_null(self) -> Self {
+        self.is_null().not()
     }
 
     #[must_use]
-    pub fn less(lhs: Self, rhs: Self) -> Self {
+    pub fn less(self, rhs: impl Into<Self>) -> Self {
         Self::Binary(BinaryExpression {
             op: BinaryOperator::Less,
-            left: Box::new(lhs),
-            right: Box::new(rhs),
+            left: Box::new(self),
+            right: Box::new(rhs.into()),
         })
     }
 
     #[must_use]
-    pub fn less_or_equal(lhs: Self, rhs: Self) -> Self {
+    pub fn less_or_equal(self, rhs: impl Into<Self>) -> Self {
         Self::Binary(BinaryExpression {
             op: BinaryOperator::LessOrEqual,
-            left: Box::new(lhs),
-            right: Box::new(rhs),
+            left: Box::new(self),
+            right: Box::new(rhs.into()),
         })
     }
 
     #[must_use]
-    pub fn greater(lhs: Self, rhs: Self) -> Self {
+    pub fn greater(self, rhs: impl Into<Self>) -> Self {
         Self::Binary(BinaryExpression {
             op: BinaryOperator::Greater,
-            left: Box::new(lhs),
-            right: Box::new(rhs),
+            left: Box::new(self),
+            right: Box::new(rhs.into()),
         })
     }
 
     /// Creates an `expression OVER ( window_definition )` window function call.
     #[must_use]
-    pub fn window(expression: Self, definition: impl Into<WindowDefinition>) -> Self {
-        Self::Window(Box::new(expression), definition.into())
+    pub fn window(self, definition: impl Into<WindowDefinition>) -> Self {
+        Self::Window(Box::new(self), definition.into())
     }
 
     #[must_use]
-    pub fn greater_or_equal(lhs: Self, rhs: Self) -> Self {
+    pub fn greater_or_equal(self, rhs: impl Into<Self>) -> Self {
         Self::Binary(BinaryExpression {
             op: BinaryOperator::GreaterOrEqual,
-            left: Box::new(lhs),
-            right: Box::new(rhs),
+            left: Box::new(self),
+            right: Box::new(rhs.into()),
         })
     }
 
     #[must_use]
-    pub fn r#in(lhs: Self, rhs: Self) -> Self {
+    pub fn r#in(self, rhs: impl Into<Self>) -> Self {
         Self::Binary(BinaryExpression {
             op: BinaryOperator::In,
-            left: Box::new(lhs),
-            right: Box::new(rhs),
+            left: Box::new(self),
+            right: Box::new(rhs.into()),
         })
     }
 
     #[must_use]
-    pub fn time_interval_contains_timestamp(lhs: Self, rhs: Self) -> Self {
+    pub fn regex_match(self, rhs: impl Into<Self>) -> Self {
+        Self::Binary(BinaryExpression {
+            op: BinaryOperator::RegexMatch,
+            left: Box::new(self),
+            right: Box::new(rhs.into()),
+        })
+    }
+
+    #[must_use]
+    pub fn time_interval_contains_timestamp(self, rhs: impl Into<Self>) -> Self {
         Self::Binary(BinaryExpression {
             op: BinaryOperator::TimeIntervalContainsTimestamp,
-            left: Box::new(lhs),
-            right: Box::new(rhs),
+            left: Box::new(self),
+            right: Box::new(rhs.into()),
         })
     }
 
     #[must_use]
-    pub fn overlap(lhs: Self, rhs: Self) -> Self {
+    pub fn overlap(self, rhs: impl Into<Self>) -> Self {
         Self::Binary(BinaryExpression {
             op: BinaryOperator::Overlap,
-            left: Box::new(lhs),
-            right: Box::new(rhs),
+            left: Box::new(self),
+            right: Box::new(rhs.into()),
         })
     }
 
     #[must_use]
-    pub fn array_contains(lhs: Self, rhs: Self) -> Self {
+    pub fn array_contains(self, rhs: impl Into<Self>) -> Self {
         Self::Binary(BinaryExpression {
             op: BinaryOperator::ArrayContains,
-            left: Box::new(lhs),
-            right: Box::new(rhs),
+            left: Box::new(self),
+            right: Box::new(rhs.into()),
+        })
+    }
+
+    /// Cosine distance between two `vector` expressions of equal dimension count.
+    #[must_use]
+    pub fn cosine_distance(self, rhs: impl Into<Self>) -> Self {
+        Self::Binary(BinaryExpression {
+            op: BinaryOperator::CosineDistance,
+            left: Box::new(self),
+            right: Box::new(rhs.into()),
         })
     }
 
@@ -276,89 +323,98 @@ impl Expression {
     #[must_use]
     pub fn binary_quantize(expression: Self) -> Self {
         Self::Function(Function::BinaryQuantize(Box::new(
-            expression.cast(PostgresType::Vector),
+            expression.cast(PostgresType::Vector { dimensions: None }),
         )))
     }
 
     #[must_use]
     #[expect(clippy::should_implement_trait)]
-    pub fn add(lhs: Self, rhs: Self) -> Self {
+    pub fn add(self, rhs: impl Into<Self>) -> Self {
         Self::Binary(BinaryExpression {
             op: BinaryOperator::Add,
-            left: Box::new(lhs),
-            right: Box::new(rhs),
+            left: Box::new(self),
+            right: Box::new(rhs.into()),
         })
     }
 
     #[must_use]
-    pub fn subtract(lhs: Self, rhs: Self) -> Self {
+    pub fn subtract(self, rhs: impl Into<Self>) -> Self {
         Self::Binary(BinaryExpression {
             op: BinaryOperator::Subtract,
-            left: Box::new(lhs),
-            right: Box::new(rhs),
+            left: Box::new(self),
+            right: Box::new(rhs.into()),
         })
     }
 
     #[must_use]
-    pub fn multiply(lhs: Self, rhs: Self) -> Self {
+    pub fn multiply(self, rhs: impl Into<Self>) -> Self {
         Self::Binary(BinaryExpression {
             op: BinaryOperator::Multiply,
-            left: Box::new(lhs),
-            right: Box::new(rhs),
+            left: Box::new(self),
+            right: Box::new(rhs.into()),
         })
     }
 
     #[must_use]
-    pub fn divide(lhs: Self, rhs: Self) -> Self {
+    pub fn divide(self, rhs: impl Into<Self>) -> Self {
         Self::Binary(BinaryExpression {
             op: BinaryOperator::Divide,
-            left: Box::new(lhs),
-            right: Box::new(rhs),
+            left: Box::new(self),
+            right: Box::new(rhs.into()),
         })
     }
 
     #[must_use]
-    pub fn modulo(lhs: Self, rhs: Self) -> Self {
+    pub fn modulo(self, rhs: impl Into<Self>) -> Self {
         Self::Binary(BinaryExpression {
             op: BinaryOperator::Modulo,
-            left: Box::new(lhs),
-            right: Box::new(rhs),
+            left: Box::new(self),
+            right: Box::new(rhs.into()),
         })
     }
 
     #[must_use]
-    pub fn bitwise_and(lhs: Self, rhs: Self) -> Self {
+    pub fn bitwise_and(self, rhs: impl Into<Self>) -> Self {
         Self::Binary(BinaryExpression {
             op: BinaryOperator::BitwiseAnd,
-            left: Box::new(lhs),
-            right: Box::new(rhs),
+            left: Box::new(self),
+            right: Box::new(rhs.into()),
         })
     }
 
     #[must_use]
-    pub fn bitwise_or(lhs: Self, rhs: Self) -> Self {
+    pub fn bitwise_or(self, rhs: impl Into<Self>) -> Self {
         Self::Binary(BinaryExpression {
             op: BinaryOperator::BitwiseOr,
-            left: Box::new(lhs),
-            right: Box::new(rhs),
+            left: Box::new(self),
+            right: Box::new(rhs.into()),
         })
     }
 
     #[must_use]
-    pub fn json_access(lhs: Self, rhs: Self) -> Self {
+    pub fn json_access(self, rhs: impl Into<Self>) -> Self {
         Self::Binary(BinaryExpression {
             op: BinaryOperator::JsonAccess,
-            left: Box::new(lhs),
-            right: Box::new(rhs),
+            left: Box::new(self),
+            right: Box::new(rhs.into()),
         })
     }
 
     #[must_use]
-    pub fn json_access_as_text(lhs: Self, rhs: Self) -> Self {
+    pub fn json_access_as_text(self, rhs: impl Into<Self>) -> Self {
         Self::Binary(BinaryExpression {
             op: BinaryOperator::JsonAccessAsText,
-            left: Box::new(lhs),
-            right: Box::new(rhs),
+            left: Box::new(self),
+            right: Box::new(rhs.into()),
+        })
+    }
+
+    #[must_use]
+    pub fn json_delete(self, rhs: impl Into<Self>) -> Self {
+        Self::Binary(BinaryExpression {
+            op: BinaryOperator::JsonDelete,
+            left: Box::new(self),
+            right: Box::new(rhs.into()),
         })
     }
 
@@ -371,18 +427,18 @@ impl Expression {
     }
 
     #[must_use]
-    pub fn negate(inner: Self) -> Self {
+    pub fn negate(self) -> Self {
         Self::Unary(UnaryExpression {
             op: UnaryOperator::Negate,
-            expr: Box::new(inner),
+            expr: Box::new(self),
         })
     }
 
     #[must_use]
-    pub fn bitwise_not(inner: Self) -> Self {
+    pub fn bitwise_not(self) -> Self {
         Self::Unary(UnaryExpression {
             op: UnaryOperator::BitwiseNot,
-            expr: Box::new(inner),
+            expr: Box::new(self),
         })
     }
 
@@ -392,23 +448,26 @@ impl Expression {
     }
 
     #[must_use]
-    pub fn coalesce(self, fallback: Self) -> Self {
-        Self::Function(Function::Coalesce(Box::new(self), Box::new(fallback)))
+    pub fn coalesce(self, fallback: impl Into<Self>) -> Self {
+        Self::Function(Function::Coalesce(
+            Box::new(self),
+            Box::new(fallback.into()),
+        ))
     }
 
     #[must_use]
-    pub fn starts_with(lhs: Self, rhs: Self) -> Self {
-        Self::StartsWith(Box::new(lhs), Box::new(rhs))
+    pub fn starts_with(self, rhs: impl Into<Self>) -> Self {
+        Self::StartsWith(Box::new(self), Box::new(rhs.into()))
     }
 
     #[must_use]
-    pub fn ends_with(lhs: Self, rhs: Self) -> Self {
-        Self::EndsWith(Box::new(lhs), Box::new(rhs))
+    pub fn ends_with(self, rhs: impl Into<Self>) -> Self {
+        Self::EndsWith(Box::new(self), Box::new(rhs.into()))
     }
 
     #[must_use]
-    pub fn contains_segment(lhs: Self, rhs: Self) -> Self {
-        Self::ContainsSegment(Box::new(lhs), Box::new(rhs))
+    pub fn contains_segment(self, rhs: impl Into<Self>) -> Self {
+        Self::ContainsSegment(Box::new(self), Box::new(rhs.into()))
     }
 
     #[must_use]
@@ -419,6 +478,32 @@ impl Expression {
     #[must_use]
     pub fn json_scalar(self) -> Self {
         Self::Function(Function::JsonScalar(Box::new(self)))
+    }
+
+    #[must_use]
+    pub fn array_element(self, index: usize) -> Self {
+        Self::ArrayElement {
+            expr: Box::new(self),
+            index,
+        }
+    }
+}
+
+impl From<ColumnReference<'static>> for Expression {
+    fn from(value: ColumnReference<'static>) -> Self {
+        Self::ColumnReference(value)
+    }
+}
+
+impl From<Function> for Expression {
+    fn from(value: Function) -> Self {
+        Self::Function(value)
+    }
+}
+
+impl From<Constant> for Expression {
+    fn from(value: Constant) -> Self {
+        Self::Constant(value)
     }
 }
 
@@ -451,14 +536,28 @@ impl Expression {
         visitor: &mut impl FnMut(&Self) -> ControlFlow<B>,
     ) -> ControlFlow<B> {
         match self {
-            Self::ColumnReference(_) | Self::Parameter(_) | Self::Constant(_) | Self::Select(_) => {
-                ControlFlow::Continue(())
-            }
+            Self::ColumnReference(_)
+            | Self::Parameter(_)
+            | Self::Constant(_)
+            | Self::Select(_)
+            | Self::Exists(_) => ControlFlow::Continue(()),
             Self::Function(function) => function.for_each_child(visitor),
+            Self::ArraySlice { expr, lower, upper } => {
+                visitor(expr)?;
+                visitor(lower)?;
+                visitor(upper)
+            }
             Self::Window(expr, window) => {
                 visitor(expr)?;
-                for partition in &*window.partition_by {
+                for partition in window.partition_by.iter().flatten() {
                     visitor(partition)?;
+                }
+                for sort_by in window
+                    .order_by
+                    .iter()
+                    .flat_map(|order_by| order_by.sort_by.iter())
+                {
+                    visitor(&sort_by.expression)?;
                 }
                 ControlFlow::Continue(())
             }
@@ -510,14 +609,28 @@ impl Expression {
         visitor: &mut impl FnMut(&mut Self) -> ControlFlow<B>,
     ) -> ControlFlow<B> {
         match self {
-            Self::ColumnReference(_) | Self::Parameter(_) | Self::Constant(_) | Self::Select(_) => {
-                ControlFlow::Continue(())
-            }
+            Self::ColumnReference(_)
+            | Self::Parameter(_)
+            | Self::Constant(_)
+            | Self::Select(_)
+            | Self::Exists(_) => ControlFlow::Continue(()),
             Self::Function(function) => function.for_each_child_mut(visitor),
+            Self::ArraySlice { expr, lower, upper } => {
+                visitor(expr)?;
+                visitor(lower)?;
+                visitor(upper)
+            }
             Self::Window(expr, window) => {
                 visitor(expr)?;
-                for partition in &mut *window.partition_by {
+                for partition in window.partition_by.iter_mut().flat_map(|list| &mut **list) {
                     visitor(partition)?;
+                }
+                for sort_by in window
+                    .order_by
+                    .iter_mut()
+                    .flat_map(|order_by| &mut *order_by.sort_by)
+                {
+                    visitor(&mut sort_by.expression)?;
                 }
                 ControlFlow::Continue(())
             }
@@ -566,6 +679,10 @@ impl Expression {
 }
 
 impl Transpile for Expression {
+    #[expect(
+        clippy::too_many_lines,
+        reason = "Pattern match for all Expression variants"
+    )]
     fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match self {
             // --- Value expressions ---
@@ -579,6 +696,15 @@ impl Transpile for Expression {
                 fmt.write_char('(')?;
                 expr.transpile(fmt)?;
                 write!(fmt, ")[{index}]")
+            }
+            Self::ArraySlice { expr, lower, upper } => {
+                fmt.write_char('(')?;
+                expr.transpile(fmt)?;
+                fmt.write_str(")[")?;
+                lower.transpile(fmt)?;
+                fmt.write_char(':')?;
+                upper.transpile(fmt)?;
+                fmt.write_char(']')
             }
             Self::ColumnReference(column) => column.transpile(fmt),
             Self::Parameter(index) => write!(fmt, "${index}"),
@@ -608,6 +734,11 @@ impl Transpile for Expression {
                 fmt.write_char(')')
             }
             Self::Select(select) => select.transpile(fmt),
+            Self::Exists(select) => {
+                fmt.write_str("EXISTS (")?;
+                select.transpile(fmt)?;
+                fmt.write_char(')')
+            }
             Self::CaseWhen {
                 conditions,
                 else_result,
@@ -678,14 +809,15 @@ mod tests {
     use hash_codec::numeric::Real;
     use hash_graph_store::{
         data_type::DataTypeQueryPath,
-        filter::{Filter, FilterExpression, Parameter},
+        filter::{Filter, FilterExpression, Parameter, PathToken},
     };
     use postgres_types::ToSql;
     use type_system::ontology::DataTypeWithMetadata;
 
     use super::*;
     use crate::store::postgres::query::{
-        Alias, Identifier, PostgresQueryPath as _, SelectCompiler,
+        Alias, FromItem, Identifier, NonEmptyVec, OrderByClause, PostgresQueryPath as _,
+        SelectCompiler, SelectExpression, SimpleSelect, SortBy, SortDirection, Table,
         test_helper::max_version_expression,
     };
 
@@ -751,6 +883,250 @@ mod tests {
         assert_eq!(
             Expression::Constant(Constant::JsonNull).transpile_to_string(),
             "'null'::jsonb"
+        );
+    }
+
+    #[test]
+    fn transpile_row_number_over_partition() {
+        assert_eq!(
+            Expression::Window(
+                Box::new(Expression::from(Function::RowNumber)),
+                WindowDefinition::builder()
+                    .partition_by(Expression::Parameter(1))
+                    .build(),
+            )
+            .transpile_to_string(),
+            "row_number() OVER (PARTITION BY $1)"
+        );
+    }
+
+    #[test]
+    fn transpile_array_agg_with_ordering() {
+        assert_eq!(
+            Expression::from(Function::ArrayAgg {
+                expression: Box::new(Expression::Parameter(1)),
+                order_by: Some(
+                    OrderByClause::builder()
+                        .sort_by(
+                            SortBy::builder()
+                                .expression(Expression::Parameter(1))
+                                .direction(SortDirection::Ascending),
+                        )
+                        .build(),
+                ),
+            })
+            .transpile_to_string(),
+            "array_agg($1 ORDER BY $1 ASC)"
+        );
+    }
+
+    #[test]
+    fn transpile_array_agg_without_ordering() {
+        assert_eq!(
+            Expression::from(Function::ArrayAgg {
+                expression: Box::new(Expression::Parameter(1)),
+                order_by: None,
+            })
+            .transpile_to_string(),
+            "array_agg($1)"
+        );
+    }
+
+    #[test]
+    fn transpile_normalized_subvector_cast() {
+        assert_eq!(
+            Expression::from(Function::L2Normalize(Box::new(Expression::from(
+                Function::Subvector {
+                    vector: Box::new(Expression::Parameter(1)),
+                    start: 1,
+                    count: 512,
+                }
+            ))))
+            .cast(PostgresType::Vector {
+                dimensions: Some(512),
+            })
+            .transpile_to_string(),
+            "(l2_normalize(subvector($1, 1, 512))::vector(512))"
+        );
+    }
+
+    #[test]
+    fn transpile_json_array_elements() {
+        assert_eq!(
+            Expression::from(Function::JsonArrayElements(Box::new(
+                Expression::Parameter(1)
+            )))
+            .transpile_to_string(),
+            "jsonb_array_elements($1)"
+        );
+        assert_eq!(
+            Expression::from(Function::JsonArrayElementsText(Box::new(
+                Expression::Parameter(1)
+            )))
+            .transpile_to_string(),
+            "jsonb_array_elements_text($1)"
+        );
+    }
+
+    #[test]
+    fn transpile_json_typeof() {
+        assert_eq!(
+            Expression::from(Function::JsonTypeof(Box::new(Expression::Parameter(1))))
+                .transpile_to_string(),
+            "jsonb_typeof($1)"
+        );
+    }
+
+    #[test]
+    fn transpile_json_path_query_array() {
+        assert_eq!(
+            Expression::from(Function::JsonPathQueryArray(
+                Box::new(Expression::Parameter(1)),
+                Box::new(Expression::Parameter(2)),
+            ))
+            .transpile_to_string(),
+            "jsonb_path_query_array($1, $2)"
+        );
+    }
+
+    #[test]
+    fn transpile_json_object_agg() {
+        assert_eq!(
+            Expression::from(Function::JsonObjectAgg {
+                key: Box::new(Expression::Parameter(1)),
+                value: Box::new(Expression::Parameter(2)),
+            })
+            .transpile_to_string(),
+            "jsonb_object_agg($1, $2)"
+        );
+    }
+
+    #[test]
+    fn transpile_count_forms() {
+        assert_eq!(
+            Expression::Window(
+                Box::new(Expression::from(Function::Count(None))),
+                WindowDefinition::builder()
+                    .partition_by(
+                        NonEmptyVec::try_from(vec![
+                            Expression::Parameter(1),
+                            Expression::Parameter(2),
+                        ])
+                        .expect("the partition list is non-empty"),
+                    )
+                    .build(),
+            )
+            .transpile_to_string(),
+            "count(*) OVER (PARTITION BY $1, $2)"
+        );
+        assert_eq!(
+            Expression::from(Function::Count(Some(Box::new(Expression::Parameter(1)))))
+                .transpile_to_string(),
+            "count($1)"
+        );
+    }
+
+    #[test]
+    fn transpile_text_functions() {
+        assert_eq!(
+            Expression::from(Function::Ln(Box::new(Expression::Parameter(1))))
+                .transpile_to_string(),
+            "ln($1)"
+        );
+        assert_eq!(
+            Expression::from(Function::Md5(Box::new(Expression::Parameter(1))))
+                .transpile_to_string(),
+            "md5($1)"
+        );
+        assert_eq!(
+            Expression::from(Function::CharLength(Box::new(Expression::from(
+                Function::Btrim(Box::new(Expression::Parameter(1)))
+            ))))
+            .transpile_to_string(),
+            "char_length(btrim($1))"
+        );
+        assert_eq!(
+            Expression::from(Function::ConcatWs {
+                separator: Box::new(Expression::Parameter(1)),
+                expressions: vec![Expression::Parameter(2), Expression::Parameter(3)],
+            })
+            .transpile_to_string(),
+            "concat_ws($1, $2, $3)"
+        );
+        assert_eq!(
+            Expression::from(Function::Substring {
+                string: Box::new(Expression::Parameter(1)),
+                start: Box::new(Expression::add(
+                    Expression::Parameter(2),
+                    Expression::Constant(Constant::U32(1)),
+                )),
+            })
+            .transpile_to_string(),
+            "substring($1 FROM $2 + 1)"
+        );
+        assert_eq!(
+            Expression::from(Function::RegexpReplace {
+                string: Box::new(Expression::Parameter(1)),
+                pattern: Box::new(Expression::Parameter(2)),
+                replacement: Box::new(Expression::Parameter(3)),
+            })
+            .transpile_to_string(),
+            "regexp_replace($1, $2, $3)"
+        );
+    }
+
+    #[test]
+    fn transpile_regex_match() {
+        assert_eq!(
+            Expression::regex_match(Expression::Parameter(1), Expression::Parameter(2))
+                .transpile_to_string(),
+            "$1 ~ $2"
+        );
+    }
+
+    #[test]
+    fn transpile_array_slice() {
+        assert_eq!(
+            Expression::ArraySlice {
+                expr: Box::new(Expression::Parameter(1)),
+                lower: Box::new(Expression::Constant(Constant::U32(1))),
+                upper: Box::new(Expression::Parameter(2)),
+            }
+            .transpile_to_string(),
+            "($1)[1:$2]"
+        );
+    }
+
+    #[test]
+    fn transpile_json_extract_keeps_jsonb() {
+        assert_eq!(
+            Expression::from(Function::JsonExtract(
+                Box::new(Expression::Parameter(1)),
+                PathToken::Field(Cow::Borrowed("allOf")),
+            ))
+            .transpile_to_string(),
+            "$1->'allOf'"
+        );
+    }
+
+    #[test]
+    fn transpile_exists_and_its_negation() {
+        let statement = || {
+            SelectStatement::from(
+                SimpleSelect::builder()
+                    .selects(vec![SelectExpression::Asterisk(None)])
+                    .from(FromItem::table(Table::OntologyIds).build())
+                    .build(),
+            )
+        };
+
+        assert_eq!(
+            Expression::exists(statement()).transpile_to_string(),
+            "EXISTS (SELECT *\nFROM \"ontology_ids\")"
+        );
+        assert_eq!(
+            Expression::exists(statement()).not().transpile_to_string(),
+            "NOT(EXISTS (SELECT *\nFROM \"ontology_ids\"))"
         );
     }
 
@@ -1011,7 +1387,7 @@ mod tests {
                     convert: None,
                 },
             )]),
-            r#"("data_types_0_1_0"."schema"->>'$id' = $1)"#,
+            r#""data_types_0_1_0"."schema"->>'$id' = $1"#,
             &[&"https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1"],
         );
 
@@ -1060,7 +1436,7 @@ mod tests {
                     convert: None,
                 },
             )]),
-            r#"("data_types_0_1_0"."schema"->>'$id' = $1)"#,
+            r#""data_types_0_1_0"."schema"->>'$id' = $1"#,
             &[&"https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1"],
         );
 
@@ -1176,7 +1552,7 @@ mod tests {
                     path: DataTypeQueryPath::Title,
                 },
             )]),
-            r#"("data_types_0_1_0"."schema"->>'description' = "data_types_0_1_0"."schema"->>'title')"#,
+            r#""data_types_0_1_0"."schema"->>'description' = "data_types_0_1_0"."schema"->>'title'"#,
             &[],
         );
     }

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/ast/expression/window.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/ast/expression/window.rs
@@ -1,12 +1,12 @@
-use core::fmt;
+use core::fmt::{self, Write as _};
 
-use crate::store::postgres::query::{Expression, NonEmptyVec, Transpile};
+use crate::store::postgres::query::{Expression, NonEmptyVec, OrderByClause, Transpile};
 
 /// A `window_definition` of an `OVER` clause.
 ///
-/// Covers `PARTITION BY expression [, ...]` only; `existing_window_name`, the window-level
-/// `ORDER BY` list, `frame_clause`, the statement-level `WINDOW` clause, `OVER window_name`,
-/// and the empty definition (`OVER ()`) are not representable yet.
+/// Covers `PARTITION BY expression [, ...]`, the window-level `ORDER BY` list, and the empty
+/// definition (`OVER ()`); `existing_window_name`, `frame_clause`, the statement-level `WINDOW`
+/// clause, and `OVER window_name` are not representable yet.
 #[derive(Debug, Clone, PartialEq, bon::Builder)]
 #[builder(derive(Debug, Clone, Into))]
 pub struct WindowDefinition {
@@ -15,17 +15,29 @@ pub struct WindowDefinition {
     /// Accepts a single [`Expression`] or a ready-made [`NonEmptyVec`]; parse a [`Vec`]
     /// beforehand via `NonEmptyVec::try_from`.
     #[builder(into)]
-    pub partition_by: NonEmptyVec<Expression>,
+    pub partition_by: Option<NonEmptyVec<Expression>>,
+    /// The window-level `ORDER BY` list, ordering rows within each partition.
+    #[builder(into)]
+    pub order_by: Option<OrderByClause>,
 }
 
 impl Transpile for WindowDefinition {
     fn transpile(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str("PARTITION BY ")?;
-        for (idx, expression) in self.partition_by.iter().enumerate() {
-            if idx > 0 {
-                fmt.write_str(", ")?;
+        if let Some(partition_by) = &self.partition_by {
+            fmt.write_str("PARTITION BY ")?;
+            for (idx, expression) in partition_by.iter().enumerate() {
+                if idx > 0 {
+                    fmt.write_str(", ")?;
+                }
+                expression.transpile(fmt)?;
             }
-            expression.transpile(fmt)?;
+            if self.order_by.is_some() {
+                fmt.write_char(' ')?;
+            }
+        }
+
+        if let Some(order_by) = &self.order_by {
+            order_by.transpile(fmt)?;
         }
 
         Ok(())
@@ -37,7 +49,7 @@ mod tests {
     use hash_graph_store::data_type::DataTypeQueryPath;
 
     use super::*;
-    use crate::store::postgres::query::{Alias, PostgresQueryPath as _};
+    use crate::store::postgres::query::{Alias, PostgresQueryPath as _, SortBy, SortDirection};
 
     fn column(path: &DataTypeQueryPath) -> Expression {
         Expression::ColumnReference(path.terminating_column().0.aliased(Alias {
@@ -62,6 +74,43 @@ mod tests {
         assert_eq!(
             window_definition.transpile_to_string(),
             r#"PARTITION BY "ontology_ids_0_0_0"."base_url", "ontology_ids_0_0_0"."version""#
+        );
+    }
+
+    #[test]
+    fn transpile_order_by_only() {
+        let window_definition = WindowDefinition::builder()
+            .order_by(
+                OrderByClause::builder().sort_by(
+                    SortBy::builder()
+                        .expression(column(&DataTypeQueryPath::Version))
+                        .direction(SortDirection::Ascending),
+                ),
+            )
+            .build();
+
+        assert_eq!(
+            window_definition.transpile_to_string(),
+            r#"ORDER BY "ontology_ids_0_0_0"."version" ASC"#
+        );
+    }
+
+    #[test]
+    fn transpile_partition_by_with_order_by() {
+        let window_definition = WindowDefinition::builder()
+            .partition_by(column(&DataTypeQueryPath::BaseUrl))
+            .order_by(
+                OrderByClause::builder().sort_by(
+                    SortBy::builder()
+                        .expression(column(&DataTypeQueryPath::Version))
+                        .direction(SortDirection::Descending),
+                ),
+            )
+            .build();
+
+        assert_eq!(
+            window_definition.transpile_to_string(),
+            r#"PARTITION BY "ontology_ids_0_0_0"."base_url" ORDER BY "ontology_ids_0_0_0"."version" DESC"#
         );
     }
 }

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/ast/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/ast/mod.rs
@@ -6,6 +6,7 @@
 //! the gram.y nonterminal (`SortBy`, `SimpleSelect`). Doc comments name gram.y productions
 //! where the structure would otherwise be surprising and in "not representable yet" lists.
 
+mod assembly;
 mod clause;
 mod column_reference;
 mod expression;
@@ -16,6 +17,9 @@ mod statement;
 mod table_reference;
 
 pub use self::{
+    assembly::{
+        Aliased, AliasedCorrelation, Binder, BoundStatement, Correlation, Placeholder, SelectList,
+    },
     clause::{
         CommonTableExpression, FromItem, FromItemFunctionBuilder, FromItemJoinBuilder,
         FromItemSubqueryBuilder, FromItemTableBuilder, GroupByClause, GroupingElement, JoinType,

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/ast/non_empty.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/ast/non_empty.rs
@@ -26,6 +26,15 @@ pub struct EmptyVecError;
 impl Error for EmptyVecError {}
 
 impl<T> NonEmptyVec<T> {
+    pub fn from_array<U, const N: usize>(value: [U; N]) -> Self
+    where
+        U: Into<T>,
+    {
+        const { assert!(N != 0) };
+
+        Self(value.into_iter().map(Into::into).collect())
+    }
+
     pub fn push(&mut self, value: T) {
         self.0.push(value);
     }

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/ast/statement/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/ast/statement/mod.rs
@@ -28,3 +28,45 @@ impl From<SelectStatement> for Statement {
         Self::Select(statement)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::postgres::query::{
+        FromItem, SelectClause, SelectExpression, SimpleSelect, Table, TableName,
+    };
+
+    fn select_all_from(table: Table) -> SelectClause {
+        SelectClause::from(
+            SimpleSelect::builder()
+                .selects(vec![SelectExpression::Asterisk(None)])
+                .from(FromItem::table(table).build())
+                .build(),
+        )
+    }
+
+    #[test]
+    fn transpile_union_all() {
+        assert_eq!(
+            select_all_from(Table::DataTypes)
+                .union_all(select_all_from(Table::OntologyIds))
+                .transpile_to_string(),
+            "SELECT *\nFROM \"data_types\"\nUNION ALL\nSELECT *\nFROM \"ontology_ids\""
+        );
+    }
+
+    #[test]
+    fn set_operation_stands_in_a_from_item() {
+        let subquery = FromItem::subquery(
+            select_all_from(Table::DataTypes).union_all(select_all_from(Table::OntologyIds)),
+        )
+        .alias(TableName::from("combined"))
+        .build();
+
+        assert_eq!(
+            subquery.transpile_to_string(),
+            "(SELECT *\nFROM \"data_types\"\nUNION ALL\nSELECT *\nFROM \"ontology_ids\") AS \
+             \"combined\""
+        );
+    }
+}

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/compile/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/compile/mod.rs
@@ -266,7 +266,7 @@ fn collect_referenced_tables(
     tables: &mut HashSet<TableName<'static>>,
 ) -> ControlFlow<Opaque> {
     expression.visit(&mut |node| {
-        if matches!(node, Expression::Select(_)) {
+        if matches!(node, Expression::Select(_) | Expression::Exists(_)) {
             return ControlFlow::Break(Opaque);
         }
         if let Expression::ColumnReference(column) = node
@@ -293,7 +293,7 @@ impl KeyColumns {
         key_tables: &HashSet<TableName<'static>>,
     ) -> ControlFlow<Opaque> {
         expression.visit(&mut |node| {
-            if matches!(node, Expression::Select(_)) {
+            if matches!(node, Expression::Select(_) | Expression::Exists(_)) {
                 return ControlFlow::Break(Opaque);
             }
             if let Expression::ColumnReference(column) = node
@@ -307,6 +307,45 @@ impl KeyColumns {
             }
             ControlFlow::Continue(())
         })
+    }
+}
+
+#[cfg(test)]
+mod collector_tests {
+    use std::collections::HashSet;
+
+    use super::{KeyColumns, collect_referenced_tables};
+    use crate::store::postgres::query::{
+        Expression, SelectExpression, SelectStatement, SimpleSelect,
+    };
+
+    fn subquery() -> SelectStatement {
+        SimpleSelect::builder()
+            .selects(vec![SelectExpression::new(Expression::Parameter(1))])
+            .build()
+            .into()
+    }
+
+    fn subqueries() -> [Expression; 2] {
+        [
+            Expression::Select(Box::new(subquery())),
+            Expression::exists(subquery()),
+        ]
+    }
+
+    #[test]
+    fn table_collector_rejects_subqueries() {
+        for expression in subqueries() {
+            assert!(collect_referenced_tables(&expression, &mut HashSet::new()).is_break());
+        }
+    }
+
+    #[test]
+    fn key_column_collector_rejects_subqueries() {
+        for expression in subqueries() {
+            let mut columns = KeyColumns::default();
+            assert!(columns.collect(&expression, &HashSet::new()).is_break());
+        }
     }
 }
 

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/compile/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/compile/mod.rs
@@ -1,3 +1,4 @@
+mod peephole;
 #[cfg(test)]
 mod tests;
 
@@ -19,18 +20,19 @@ use postgres_types::ToSql;
 use tracing::instrument;
 use type_system::knowledge::Entity;
 
+use self::peephole::PeepholeOptimizer;
 use super::ast::{
     ColumnName, ColumnReference, JoinType, Materialization, TableName, TableReference,
 };
 use crate::store::postgres::query::{
-    Alias, Column, CommonTableExpression, EqualityOperator, Expression, FromItem, Function,
-    Identifier, NonEmptyVec, NullsOrder, OrderByClause, PostgresQueryPath, PostgresRecord,
-    SelectExpression, SelectQuantifier, SelectStatement, SimpleSelect, SortBy, SortDirection,
-    Table, Transpile as _, WindowDefinition, WithClause,
+    Alias, Column, CommonTableExpression, Correlation, Expression, FromItem, Function, Identifier,
+    NonEmptyVec, NullsOrder, OrderByClause, PostgresQueryPath, PostgresRecord, SelectExpression,
+    SelectQuantifier, SelectStatement, SimpleSelect, SortBy, SortDirection, Table, Transpile as _,
+    WithClause,
     postgres_type::PostgresType,
     table::{
-        EntityEditions, EntityEmbeddings, EntityTemporalMetadata, EntityTypeEmbeddings,
-        EntityTypes, FilterColumn as _, JsonField, OntologyIds, OntologyTemporalMetadata,
+        DatabaseColumn, EntityEditions, EntityEmbeddings, EntityTemporalMetadata,
+        EntityTypeEmbeddings, EntityTypes, FilterColumn as _, JsonField, OntologyTemporalMetadata,
     },
 };
 
@@ -50,8 +52,13 @@ pub struct TableInfo<'p> {
     variable_interval_index: Option<usize>,
 }
 
+pub enum SqlParameter<'param> {
+    Owned(Box<dyn ToSql + Sync + Send>),
+    Borrowed(&'param (dyn ToSql + Sync)),
+}
+
 pub struct CompilerArtifacts<'p> {
-    parameters: Vec<&'p (dyn ToSql + Sync)>,
+    parameters: Vec<SqlParameter<'p>>,
     condition_index: usize,
     joins: Vec<CompiledJoin>,
     table_info: TableInfo<'p>,
@@ -390,6 +397,45 @@ impl<'r> KeyColumnRewriter<'r> {
 type TableHook<'p, 'q, T> = fn(&mut SelectCompiler<'p, 'q, T>, Alias) -> Vec<Expression>;
 type ColumnHook<'p, 'q, T> = fn(&mut SelectCompiler<'p, 'q, T>, Expression) -> Expression;
 
+/// The columns of one unnested property inside a scalar-entries or entry-count subquery.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+enum ScalarProperty {
+    /// The property's base URL.
+    Key,
+    /// The property's value.
+    Value,
+}
+
+impl DatabaseColumn<'_> for ScalarProperty {
+    fn name(&self) -> ColumnName<'static> {
+        match self {
+            Self::Key => "key".into(),
+            Self::Value => "value".into(),
+        }
+    }
+
+    fn postgres_type(&self) -> PostgresType {
+        match self {
+            Self::Key => PostgresType::Text,
+            Self::Value => PostgresType::JsonB,
+        }
+    }
+}
+
+/// One unnested property inside a scalar-entries or entry-count subquery.
+const SCALAR_PROPERTY: Correlation<ScalarProperty> = Correlation::new("scalar_property");
+
+/// One `jsonb_each` unnest of a properties object, standing as `"scalar_property"("key", "value")`.
+fn scalar_property_each(properties: Expression) -> FromItem<'static> {
+    FromItem::function(Function::JsonEach(Box::new(properties)))
+        .alias(SCALAR_PROPERTY)
+        .column_aliases(vec![
+            ScalarProperty::Key.name(),
+            ScalarProperty::Value.name(),
+        ])
+        .build()
+}
+
 pub struct SelectCompiler<'p, 'q: 'p, T: QueryRecord> {
     shape: StatementShape,
     distinct_on: Vec<Expression>,
@@ -501,7 +547,9 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
                 .table_info
                 .pinned_timestamp_index
                 .get_or_insert_with(|| {
-                    self.artifacts.parameters.push(&pinned.timestamp);
+                    self.artifacts
+                        .parameters
+                        .push(SqlParameter::Borrowed(&pinned.timestamp));
                     self.artifacts.parameters.len()
                 }),
             (QueryTemporalAxes::DecisionTime { pinned, .. }, TimeAxis::TransactionTime) => *self
@@ -509,7 +557,9 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
                 .table_info
                 .pinned_timestamp_index
                 .get_or_insert_with(|| {
-                    self.artifacts.parameters.push(&pinned.timestamp);
+                    self.artifacts
+                        .parameters
+                        .push(SqlParameter::Borrowed(&pinned.timestamp));
                     self.artifacts.parameters.len()
                 }),
             (QueryTemporalAxes::TransactionTime { variable, .. }, TimeAxis::TransactionTime) => {
@@ -518,7 +568,9 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
                     .table_info
                     .variable_interval_index
                     .get_or_insert_with(|| {
-                        self.artifacts.parameters.push(&variable.interval);
+                        self.artifacts
+                            .parameters
+                            .push(SqlParameter::Borrowed(&variable.interval));
                         self.artifacts.parameters.len()
                     })
             }
@@ -527,7 +579,9 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
                 .table_info
                 .variable_interval_index
                 .get_or_insert_with(|| {
-                    self.artifacts.parameters.push(&variable.interval);
+                    self.artifacts
+                        .parameters
+                        .push(SqlParameter::Borrowed(&variable.interval));
                     self.artifacts.parameters.len()
                 }),
         }
@@ -781,7 +835,13 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
         tracing::Span::current().record("statement.shape", shape.as_str());
         (
             statement.transpile_to_string(),
-            self.artifacts.parameters.iter().copied(),
+            self.artifacts
+                .parameters
+                .iter()
+                .map(|parameter| match parameter {
+                    SqlParameter::Owned(boxed) => boxed.as_ref(),
+                    &SqlParameter::Borrowed(borrowed) => borrowed,
+                }),
         )
     }
 
@@ -1240,16 +1300,32 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
     where
         R::QueryPath<'f>: PostgresQueryPath,
     {
-        if let Some(condition) = self.compile_special_filter(filter) {
+        if let Some(condition) = PeepholeOptimizer::new(self).try_filter(filter) {
             return Ok(condition);
         }
 
         Ok(match filter {
+            // A group compiling to one expression is that expression: `All([x])`, `Any([x])`
+            // and `x` decide alike, and the connective wraps only where a connective remains.
             Filter::All(filters) => {
-                Expression::all(self.compile_filter_group(filters, FilterGroup::All)?)
+                let mut expressions =
+                    PeepholeOptimizer::new(self).compile_group(filters, FilterGroup::All)?;
+
+                if expressions.len() == 1 {
+                    expressions.remove(0)
+                } else {
+                    Expression::all(expressions)
+                }
             }
             Filter::Any(filters) => {
-                Expression::any(self.compile_filter_group(filters, FilterGroup::Any)?)
+                let mut expressions =
+                    PeepholeOptimizer::new(self).compile_group(filters, FilterGroup::Any)?;
+
+                if expressions.len() == 1 {
+                    expressions.remove(0)
+                } else {
+                    Expression::any(expressions)
+                }
             }
             Filter::Not(filter) => self.compile_filter(filter)?.not(),
             Filter::Equal(lhs, rhs) => Expression::equal(
@@ -1284,57 +1360,26 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
             Filter::StartsWith(lhs, rhs) => {
                 Self::ensure_scalar_text_operand(lhs)?;
                 Self::ensure_scalar_text_operand(rhs)?;
-                let (left_filter, left_parameter) = self.compile_filter_expression(lhs)?;
-                let left_filter = if left_parameter == ParameterType::Any {
-                    Expression::Function(Function::JsonExtractText(Box::new(left_filter)))
-                } else {
-                    left_filter
-                };
 
-                let (right_filter, right_parameter) = self.compile_filter_expression(rhs)?;
-                let right_filter = if right_parameter == ParameterType::Any {
-                    Expression::Function(Function::JsonExtractText(Box::new(right_filter)))
-                } else {
-                    right_filter
-                };
+                let left_filter = self.compile_filter_expression_json(lhs)?;
+                let right_filter = self.compile_filter_expression_json(rhs)?;
 
                 Expression::starts_with(left_filter, right_filter)
             }
             Filter::EndsWith(lhs, rhs) => {
                 Self::ensure_scalar_text_operand(lhs)?;
                 Self::ensure_scalar_text_operand(rhs)?;
-                let (left_filter, left_parameter) = self.compile_filter_expression(lhs)?;
-                let left_filter = if left_parameter == ParameterType::Any {
-                    Expression::Function(Function::JsonExtractText(Box::new(left_filter)))
-                } else {
-                    left_filter
-                };
 
-                let (right_filter, right_parameter) = self.compile_filter_expression(rhs)?;
-                let right_filter = if right_parameter == ParameterType::Any {
-                    Expression::Function(Function::JsonExtractText(Box::new(right_filter)))
-                } else {
-                    right_filter
-                };
+                let left_filter = self.compile_filter_expression_json(lhs)?;
+                let right_filter = self.compile_filter_expression_json(rhs)?;
 
                 Expression::ends_with(left_filter, right_filter)
             }
             Filter::ContainsSegment(lhs, rhs) => {
                 Self::ensure_scalar_text_operand(lhs)?;
                 Self::ensure_scalar_text_operand(rhs)?;
-                let (left_filter, left_parameter) = self.compile_filter_expression(lhs)?;
-                let left_filter = if left_parameter == ParameterType::Any {
-                    Expression::Function(Function::JsonExtractText(Box::new(left_filter)))
-                } else {
-                    left_filter
-                };
-
-                let (right_filter, right_parameter) = self.compile_filter_expression(rhs)?;
-                let right_filter = if right_parameter == ParameterType::Any {
-                    Expression::Function(Function::JsonExtractText(Box::new(right_filter)))
-                } else {
-                    right_filter
-                };
+                let left_filter = self.compile_filter_expression_json(lhs)?;
+                let right_filter = self.compile_filter_expression_json(rhs)?;
 
                 Expression::contains_segment(left_filter, right_filter)
             }
@@ -1354,352 +1399,33 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
         if let FilterExpression::Path { path } = operand {
             let (column, json_field) = path.terminating_column();
             ensure!(
-                json_field.is_some() || !Self::is_text_array_column(column),
+                json_field.is_some() || !column.is_text_array(),
                 SelectCompilerError::UnsupportedTextArrayOperation
             );
         }
         Ok(())
     }
 
-    /// Whether the column holds an array of textual values ([`BaseUrl`] and
-    /// [`VersionedUrl`] columns transpile to `text[]`).
-    ///
-    /// [`BaseUrl`]: ParameterType::BaseUrl
-    /// [`VersionedUrl`]: ParameterType::VersionedUrl
-    fn is_text_array_column(column: Column) -> bool {
-        matches!(
-            column.parameter_type(),
-            ParameterType::Vector(inner) if matches!(
-                *inner,
-                ParameterType::Text | ParameterType::BaseUrl | ParameterType::VersionedUrl
-            )
-        )
-    }
-
-    /// Decomposes an equality (`Equal`/`NotEqual`) or membership (`In(parameter, path)`)
-    /// filter on a path terminating in a materialized text-array column.
-    ///
-    /// Returns the path, the text parameter, and whether the filter tests for containment
-    /// (`true`) or its absence (`false`).
-    fn cached_array_equality<'f: 'q>(
-        filter: &'p Filter<'f, R>,
-    ) -> Option<(&'p R::QueryPath<'f>, &'p Parameter<'f>, bool)>
-    where
-        R::QueryPath<'f>: PostgresQueryPath,
-    {
-        let (lhs, rhs, equals) = match filter {
-            Filter::Equal(lhs, rhs) => (lhs, rhs, true),
-            Filter::NotEqual(lhs, rhs) => (lhs, rhs, false),
-            Filter::In(
-                FilterExpression::Parameter {
-                    parameter: parameter @ Parameter::Text(_),
-                    convert: None,
-                },
-                FilterExpressionList::Path { path },
-            ) => {
-                let (column, json_field) = path.terminating_column();
-                return (json_field.is_none() && Self::is_text_array_column(column))
-                    .then_some((path, parameter, true));
-            }
-            Filter::All(_)
-            | Filter::Any(_)
-            | Filter::Not(_)
-            | Filter::Exists { .. }
-            | Filter::Greater(..)
-            | Filter::GreaterOrEqual(..)
-            | Filter::Less(..)
-            | Filter::LessOrEqual(..)
-            | Filter::In(..)
-            | Filter::StartsWith(..)
-            | Filter::EndsWith(..)
-            | Filter::ContainsSegment(..) => return None,
-        };
-        match (lhs, rhs) {
-            (
-                FilterExpression::Path { path },
-                FilterExpression::Parameter {
-                    parameter: parameter @ Parameter::Text(_),
-                    convert: None,
-                },
-            )
-            | (
-                FilterExpression::Parameter {
-                    parameter: parameter @ Parameter::Text(_),
-                    convert: None,
-                },
-                FilterExpression::Path { path },
-            ) => {
-                let (column, json_field) = path.terminating_column();
-                (json_field.is_none() && Self::is_text_array_column(column))
-                    .then_some((path, parameter, equals))
-            }
-            _ => None,
-        }
-    }
-
-    /// Compiles equality filters on a path backed by a materialized array column into a
-    /// single array predicate on that column.
-    ///
-    /// A single parameter compiles to a containment check (`<column> @> ARRAY[$n]::text[]`,
-    /// negated for inequalities). Multiple parameters gathered from one `All`/`Any` group
-    /// bundle into one predicate over the whole value set:
-    ///
-    /// | group | equalities          | inequalities              |
-    /// |-------|---------------------|---------------------------|
-    /// | `All` | `@>` (contains all) | `NOT(&&)` (contains none) |
-    /// | `Any` | `&&` (contains any) | `NOT(@>)` (misses one)    |
-    ///
-    /// A single array predicate replaces per-value joins through the type tables and lets
-    /// a GIN index on the materialized column serve the positive forms.
-    fn compile_cached_array_predicate<'f: 'q>(
-        &mut self,
-        column: ColumnReference<'static>,
-        parameters: &[&'p Parameter<'f>],
-        equals: bool,
-        group: FilterGroup,
-    ) -> Expression
-    where
-        R::QueryPath<'f>: PostgresQueryPath,
-    {
-        let column_reference = Expression::ColumnReference(column);
-        let array = Expression::Function(Function::ArrayLiteral {
-            elements: parameters
-                .iter()
-                .map(|parameter| self.compile_parameter(parameter).0)
-                .collect(),
-            element_type: PostgresType::Text,
-        });
-        // For a single value `@>` and `&&` coincide, so the group connective is irrelevant.
-        if parameters.len() == 1 {
-            let contains = Expression::array_contains(column_reference, array);
-            return if equals { contains } else { contains.not() };
-        }
-        match (group, equals) {
-            (FilterGroup::All, true) => Expression::array_contains(column_reference, array),
-            (FilterGroup::All, false) => Expression::overlap(column_reference, array).not(),
-            (FilterGroup::Any, true) => Expression::overlap(column_reference, array),
-            (FilterGroup::Any, false) => Expression::array_contains(column_reference, array).not(),
-        }
-    }
-
-    /// Compiles the filters of an `All`/`Any` group, bundling equality filters backed by
-    /// the same materialized array column into a single array predicate.
-    ///
-    /// Bundles are keyed on the *aliased* column: paths terminating in the same column
-    /// through different join chains (e.g. an entity's own types vs. a linked entity's
-    /// types) resolve to different aliases and stay separate predicates.
-    fn compile_filter_group<'f: 'q>(
-        &mut self,
-        filters: &'p [Filter<'f, R>],
-        group: FilterGroup,
-    ) -> Result<Vec<Expression>, Report<SelectCompilerError>>
-    where
-        R::QueryPath<'f>: PostgresQueryPath,
-    {
-        struct ArrayPredicateGroup<'c, 'p> {
-            column: ColumnReference<'static>,
-            equals: bool,
-            parameters: Vec<&'c Parameter<'p>>,
-        }
-
-        let mut bundles: Vec<ArrayPredicateGroup<'p, 'f>> = Vec::new();
-        let mut expressions = Vec::new();
-        for filter in filters {
-            if let Some((array_path, parameter, equals)) = Self::cached_array_equality(filter) {
-                let alias = self.add_join_statements(array_path);
-                let column = array_path.terminating_column().0.aliased(alias);
-                if let Some(bundle) = bundles
-                    .iter_mut()
-                    .find(|bundle| bundle.column == column && bundle.equals == equals)
-                {
-                    bundle.parameters.push(parameter);
-                } else {
-                    bundles.push(ArrayPredicateGroup {
-                        column,
-                        equals,
-                        parameters: vec![parameter],
-                    });
-                }
-            } else {
-                expressions.push(self.compile_filter(filter)?);
-            }
-        }
-        for bundle in &bundles {
-            expressions.push(self.compile_cached_array_predicate(
-                bundle.column.clone(),
-                &bundle.parameters,
-                bundle.equals,
-                group,
-            ));
-        }
-        Ok(expressions)
-    }
-
-    /// Compiles the `path` to a condition, which is searching for the latest version.
-    // Warning: This adds a CTE to the statement, which is overwriting the `ontology_ids` table.
-    //          When more CTEs are needed, a test should be added to cover both CTEs in one
-    //          statement to ensure compatibility
-    // TODO: Remove CTE to allow limit or cursor selection
-    //   see https://linear.app/hash/issue/H-1442
-    #[instrument(level = "info", skip_all)]
-    fn compile_latest_ontology_version_filter<'f: 'q>(
-        &mut self,
-        path: &R::QueryPath<'f>,
-        operator: EqualityOperator,
-    ) -> Expression
-    where
-        R::QueryPath<'f>: PostgresQueryPath,
-    {
-        self.artifacts.cursor_disallowed_reason =
-            Some("Cannot use latest version filter with cursor");
-
-        let version_column = Column::OntologyIds(OntologyIds::Version);
-        let alias = Alias {
-            condition_index: 0,
-            chain_depth: 0,
-            number: 0,
-        };
-
-        // Add a WITH expression selecting the partitioned version
-        let latest_version_cte = CommonTableExpression::builder()
-            .name(Table::OntologyIds)
-            .statement(
-                SimpleSelect::builder()
-                    .selects(vec![
-                        SelectExpression::Asterisk(None),
-                        SelectExpression::Expression {
-                            expression: Expression::window(
-                                Expression::Function(Function::Max(Box::new(
-                                    Expression::ColumnReference(version_column.aliased(alias)),
-                                ))),
-                                WindowDefinition::builder().partition_by(
-                                    Expression::ColumnReference(
-                                        Column::OntologyIds(OntologyIds::BaseUrl).aliased(alias),
-                                    ),
-                                ),
-                            ),
-                            output_name: Some(Identifier::from("latest_version")),
-                        },
-                    ])
-                    .from(
-                        FromItem::table(version_column.table())
-                            .alias(version_column.table().aliased_name(alias))
-                            .build(),
-                    ),
-            );
-        match &mut self.with {
-            Some(with) => with.push(latest_version_cte),
-            with @ None => {
-                *with = Some(
-                    WithClause::builder()
-                        .common_table_expressions(latest_version_cte)
-                        .build(),
-                );
-            }
-        }
-
-        let alias = self.add_join_statements(path);
-        // Join the table of `path` and compare the version to the latest version
-        let latest_version_expression = Expression::ColumnReference(
-            Column::OntologyIds(OntologyIds::LatestVersion).aliased(alias),
-        );
-        let version_expression = Expression::ColumnReference(version_column.aliased(alias));
-
-        match operator {
-            EqualityOperator::Equal => {
-                Expression::equal(version_expression, latest_version_expression)
-            }
-            EqualityOperator::NotEqual => {
-                Expression::not_equal(version_expression, latest_version_expression)
-            }
-        }
-    }
-
-    /// Searches for [`Filter`]s, which requires special treatment and returns the corresponding
-    /// condition if any.
-    ///
-    /// The following [`Filter`]s will be special cased:
-    /// - Comparing the `"version"` field on [`Table::OntologyIds`] with `"latest"` for equality.
-    /// - Equality and membership filters on paths terminating in materialized text-array columns,
-    ///   compiled to array predicates (see [`Self::compile_cached_array_predicate`]).
-    fn compile_special_filter<'f: 'q>(&mut self, filter: &'p Filter<'f, R>) -> Option<Expression>
-    where
-        R::QueryPath<'f>: PostgresQueryPath,
-    {
-        if let Some((array_path, parameter, equals)) = Self::cached_array_equality(filter) {
-            let alias = self.add_join_statements(array_path);
-            let column = array_path.terminating_column().0.aliased(alias);
-            // A lone filter has a single parameter, so the group connective is irrelevant.
-            return Some(self.compile_cached_array_predicate(
-                column,
-                &[parameter],
-                equals,
-                FilterGroup::All,
-            ));
-        }
-
-        match filter {
-            Filter::Equal(lhs, rhs) | Filter::NotEqual(lhs, rhs) => match (lhs, rhs) {
-                (
-                    FilterExpression::Path { path },
-                    FilterExpression::Parameter {
-                        parameter: Parameter::Text(parameter),
-                        convert: None,
-                    },
-                )
-                | (
-                    FilterExpression::Parameter {
-                        parameter: Parameter::Text(parameter),
-                        convert: None,
-                    },
-                    FilterExpression::Path { path },
-                ) => match (path.terminating_column().0, filter, parameter.as_ref()) {
-                    (Column::OntologyIds(OntologyIds::Version), Filter::Equal(..), "latest") => {
-                        Some(
-                            self.compile_latest_ontology_version_filter(
-                                path,
-                                EqualityOperator::Equal,
-                            ),
-                        )
-                    }
-                    (Column::OntologyIds(OntologyIds::Version), Filter::NotEqual(..), "latest") => {
-                        Some(self.compile_latest_ontology_version_filter(
-                            path,
-                            EqualityOperator::NotEqual,
-                        ))
-                    }
-                    _ => None,
-                },
-                _ => None,
-            },
-            Filter::All(_)
-            | Filter::Any(_)
-            | Filter::Not(_)
-            | Filter::Exists { .. }
-            | Filter::Greater(..)
-            | Filter::GreaterOrEqual(..)
-            | Filter::Less(..)
-            | Filter::LessOrEqual(..)
-            | Filter::In(..)
-            | Filter::StartsWith(..)
-            | Filter::EndsWith(..)
-            | Filter::ContainsSegment(..) => None,
-        }
-    }
-
     #[instrument(level = "debug", skip_all)]
+    /// Owns the JSON field, binding the parameter a [`JsonField::JsonPath`] carries.
+    fn bind_json_field(&mut self, field: JsonField<'p>) -> JsonField<'static> {
+        let (field, parameter) = field.into_owned(self.artifacts.parameters.len() + 1);
+
+        if let Some(parameter) = parameter {
+            self.artifacts
+                .parameters
+                .push(SqlParameter::Borrowed(parameter));
+        }
+
+        field
+    }
+
     pub fn compile_path_column<'f: 'q>(&mut self, path: &'p R::QueryPath<'f>) -> Expression
     where
         R::QueryPath<'f>: PostgresQueryPath,
     {
         let (column, json_field) = path.terminating_column();
-        let parameter = json_field.map(|field| {
-            let (field, parameter) = field.into_owned(self.artifacts.parameters.len() + 1);
-            if let Some(parameter) = parameter {
-                self.artifacts.parameters.push(parameter);
-            }
-            field
-        });
+        let parameter = json_field.map(|field| self.bind_json_field(field));
 
         let alias = self.add_join_statements(path);
 
@@ -1740,6 +1466,47 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
                 expr: Box::new(column_expression),
                 index,
             },
+            Some(JsonField::ScalarEntries) => {
+                unreachable!("`ScalarEntries` should be handled by now")
+            }
+            Some(JsonField::ScalarEntriesParameter(index)) => {
+                // (SELECT jsonb_object_agg("scalar_property"."key", "scalar_property"."value")
+                //  FROM jsonb_each(<column>) AS "scalar_property"("key", "value")
+                //  WHERE jsonb_typeof("scalar_property"."value") = ANY($n::text[]))
+                Expression::Select(Box::new(
+                    SimpleSelect::builder()
+                        .selects(vec![SelectExpression::new(Function::JsonObjectAgg {
+                            key: Box::new(SCALAR_PROPERTY.column(&ScalarProperty::Key)),
+                            value: Box::new(SCALAR_PROPERTY.column(&ScalarProperty::Value)),
+                        })])
+                        .from(scalar_property_each(column_expression))
+                        .where_clause(
+                            Expression::from(Function::JsonTypeof(Box::new(
+                                SCALAR_PROPERTY.column(&ScalarProperty::Value),
+                            )))
+                            .r#in(
+                                Expression::Parameter(index)
+                                    .cast(PostgresType::Array(Box::new(PostgresType::Text))),
+                            ),
+                        )
+                        .build()
+                        .into(),
+                ))
+                .grouped()
+            }
+            Some(JsonField::EntryCount) => {
+                // ((SELECT count(*) FROM jsonb_each(<column>) AS "scalar_property"("key",
+                // "value"))::int4)
+                Expression::Select(Box::new(
+                    SimpleSelect::builder()
+                        .selects(vec![SelectExpression::new(Function::Count(None))])
+                        .from(scalar_property_each(column_expression))
+                        .build()
+                        .into(),
+                ))
+                .grouped()
+                .cast(PostgresType::Int4)
+            }
             Some(JsonField::Label { inheritance_depth }) => {
                 if let Some(label_path) =
                     <R as QueryRecord>::QueryPath::label_property_path(inheritance_depth)
@@ -1762,7 +1529,20 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
     }
 
     pub fn add_parameter(&mut self, parameter: &'p (dyn ToSql + Sync)) -> Expression {
-        self.artifacts.parameters.push(parameter);
+        self.artifacts
+            .parameters
+            .push(SqlParameter::Borrowed(parameter));
+        Expression::Parameter(self.artifacts.parameters.len())
+    }
+
+    /// Binds one owned value, typically a whole array, as a single statement parameter.
+    ///
+    /// The borrowed twin is [`Self::add_parameter`]. The owned form exists for values built
+    /// during compilation itself, which have no caller-owned home to borrow from.
+    pub fn add_owned_parameter(&mut self, parameter: Box<dyn ToSql + Sync + Send>) -> Expression {
+        self.artifacts
+            .parameters
+            .push(SqlParameter::Owned(parameter));
         Expression::Parameter(self.artifacts.parameters.len())
     }
 
@@ -1773,35 +1553,43 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
     ) -> (Expression, ParameterType) {
         let parameter_type = match parameter {
             Parameter::Decimal(number) => {
-                self.artifacts.parameters.push(number);
+                self.artifacts
+                    .parameters
+                    .push(SqlParameter::Borrowed(number));
                 ParameterType::Decimal
             }
             Parameter::Text(text) => {
-                self.artifacts.parameters.push(text);
+                self.artifacts.parameters.push(SqlParameter::Borrowed(text));
                 ParameterType::Text
             }
             Parameter::Boolean(bool) => {
-                self.artifacts.parameters.push(bool);
+                self.artifacts.parameters.push(SqlParameter::Borrowed(bool));
                 ParameterType::Boolean
             }
             Parameter::Vector(vector) => {
-                self.artifacts.parameters.push(vector);
+                self.artifacts
+                    .parameters
+                    .push(SqlParameter::Borrowed(vector));
                 ParameterType::Vector(Box::new(ParameterType::Decimal))
             }
             Parameter::Any(json) => {
-                self.artifacts.parameters.push(json);
+                self.artifacts.parameters.push(SqlParameter::Borrowed(json));
                 ParameterType::Any
             }
             Parameter::Uuid(uuid) => {
-                self.artifacts.parameters.push(uuid);
+                self.artifacts.parameters.push(SqlParameter::Borrowed(uuid));
                 ParameterType::Uuid
             }
             Parameter::OntologyTypeVersion(version) => {
-                self.artifacts.parameters.push(&**version);
+                self.artifacts
+                    .parameters
+                    .push(SqlParameter::Borrowed(&**version));
                 ParameterType::OntologyTypeVersion
             }
             Parameter::Timestamp(timestamp) => {
-                self.artifacts.parameters.push(timestamp);
+                self.artifacts
+                    .parameters
+                    .push(SqlParameter::Borrowed(timestamp));
                 ParameterType::Timestamp
             }
         };
@@ -1812,13 +1600,13 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
         )
     }
 
-    #[instrument(level = "debug", skip_all)]
     /// Compiles a [`FilterExpression`] to an [`Expression`] and its parameter type.
     ///
     /// # Errors
     ///
     /// Returns [`SelectCompilerError::PendingParameterConversion`] when the parameter still
     /// carries a conversion; conversions have to be resolved before compilation.
+    #[instrument(level = "debug", skip_all)]
     pub fn compile_filter_expression<'f: 'q>(
         &mut self,
         expression: &'p FilterExpression<'f, R>,
@@ -1846,6 +1634,24 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
                 self.compile_parameter(parameter)
             }
         })
+    }
+
+    /// Compiles a filter expression that extracts text from a JSON column.
+    #[instrument(level = "debug", skip_all)]
+    fn compile_filter_expression_json<'f: 'q>(
+        &mut self,
+        lhs: &'p FilterExpression<'f, R>,
+    ) -> Result<Expression, Report<SelectCompilerError>>
+    where
+        R::QueryPath<'f>: PostgresQueryPath,
+    {
+        let (left_filter, left_parameter) = self.compile_filter_expression(lhs)?;
+        let left_filter = if left_parameter == ParameterType::Any {
+            Expression::Function(Function::JsonExtractText(Box::new(left_filter)))
+        } else {
+            left_filter
+        };
+        Ok(left_filter)
     }
 
     #[instrument(level = "debug", skip_all)]
@@ -1881,27 +1687,39 @@ impl<'p, 'q: 'p, R: PostgresRecord> SelectCompiler<'p, 'q, R> {
     ) -> (Expression, ParameterType) {
         let parameter_type = match parameters {
             ParameterList::DataTypeIds(uuids) => {
-                self.artifacts.parameters.push(uuids);
+                self.artifacts
+                    .parameters
+                    .push(SqlParameter::Borrowed(uuids));
                 ParameterType::Uuid
             }
             ParameterList::PropertyTypeIds(uuids) => {
-                self.artifacts.parameters.push(uuids);
+                self.artifacts
+                    .parameters
+                    .push(SqlParameter::Borrowed(uuids));
                 ParameterType::Uuid
             }
             ParameterList::EntityTypeIds(uuids) => {
-                self.artifacts.parameters.push(uuids);
+                self.artifacts
+                    .parameters
+                    .push(SqlParameter::Borrowed(uuids));
                 ParameterType::Uuid
             }
             ParameterList::EntityEditionIds(uuids) => {
-                self.artifacts.parameters.push(uuids);
+                self.artifacts
+                    .parameters
+                    .push(SqlParameter::Borrowed(uuids));
                 ParameterType::Uuid
             }
             ParameterList::EntityUuids(uuids) => {
-                self.artifacts.parameters.push(uuids);
+                self.artifacts
+                    .parameters
+                    .push(SqlParameter::Borrowed(uuids));
                 ParameterType::Uuid
             }
             ParameterList::WebIds(web_ids) => {
-                self.artifacts.parameters.push(web_ids);
+                self.artifacts
+                    .parameters
+                    .push(SqlParameter::Borrowed(web_ids));
                 ParameterType::Uuid
             }
         };

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/compile/peephole/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/compile/peephole/mod.rs
@@ -1,0 +1,416 @@
+//! Peephole rewrites over compiled filters.
+//!
+//! A peephole here is a filter shape whose direct compilation would be wrong or wasteful: an
+//! equality on an array-backed column would compare arrays where the filter means containment,
+//! and a `version = "latest"` equality would bind the text `"latest"` against an int8 column.
+//! [`PeepholeOptimizer`] recognizes those shapes and compiles the rewrite, and every other
+//! filter compiles as written.
+//!
+//! [`PeepholeOptimizer::recognize`] yields at most one [`Peephole`] per filter, so no filter is
+//! rewritten twice, and a filter classified as a plain equality is one no rewrite claims.
+
+use error_stack::Report;
+use hash_graph_store::filter::{
+    Filter, FilterExpression, FilterExpressionList, Parameter, QueryRecord,
+};
+
+use super::{FilterGroup, SelectCompiler, SelectCompilerError};
+use crate::store::postgres::query::{
+    Alias, Column, ColumnReference, CommonTableExpression, EqualityOperator, Expression, FromItem,
+    Function, Identifier, PostgresQueryPath, PostgresRecord, SelectExpression, SimpleSelect, Table,
+    WindowDefinition, WithClause,
+    postgres_type::PostgresType,
+    table::{FilterColumn as _, OntologyIds},
+};
+
+/// Orientation-normalizes an equality's operands into its path and its parameter.
+///
+/// `None` when either side is neither, and when the parameter carries a conversion, whose
+/// compiled form no rewrite reproduces.
+const fn equality_halves<'params, 'filter, R: QueryRecord>(
+    lhs: &'params FilterExpression<'filter, R>,
+    rhs: &'params FilterExpression<'filter, R>,
+) -> Option<(&'params R::QueryPath<'filter>, &'params Parameter<'filter>)> {
+    if let (
+        FilterExpression::Path { path },
+        FilterExpression::Parameter {
+            parameter,
+            convert: None,
+        },
+    )
+    | (
+        FilterExpression::Parameter {
+            parameter,
+            convert: None,
+        },
+        FilterExpression::Path { path },
+    ) = (lhs, rhs)
+    {
+        Some((path, parameter))
+    } else {
+        None
+    }
+}
+
+/// Flattens a group's children through redundant connective boundaries.
+///
+/// A child sharing the group's connective contributes its own children in its place, and a group
+/// of the opposite connective holding exactly one member contributes that member (`All([x])`,
+/// `Any([x])` and `x` decide alike). Both expansions shrink the tree, so the walk reaches their
+/// fixed point in one pass. An empty group keeps its identity (`All([])` holds, `Any([])`
+/// refuses) and stays a child.
+fn flattened_children<'params, 'filter, R: QueryRecord>(
+    group: FilterGroup,
+    children: &'params [Filter<'filter, R>],
+) -> Vec<&'params Filter<'filter, R>> {
+    let mut flat = Vec::with_capacity(children.len());
+    let mut pending: Vec<&'params Filter<'filter, R>> = children.iter().rev().collect();
+
+    while let Some(filter) = pending.pop() {
+        match (group, filter) {
+            (FilterGroup::All, Filter::All(inner)) | (FilterGroup::Any, Filter::Any(inner)) => {
+                pending.extend(inner.iter().rev());
+            }
+            (FilterGroup::All, Filter::Any(inner)) | (FilterGroup::Any, Filter::All(inner))
+                if let [only] = inner.as_slice() =>
+            {
+                pending.push(only);
+            }
+            _ => flat.push(filter),
+        }
+    }
+
+    flat
+}
+
+/// One rewritable filter shape, decomposed into the operands its rewrite uses.
+enum Peephole<'params, 'filter, R: QueryRecord> {
+    /// An equality or inequality pinning the ontology `version` column to the text `"latest"`,
+    /// compiled as a comparison against the partition-wide maximum version.
+    LatestOntologyVersion {
+        path: &'params R::QueryPath<'filter>,
+        operator: EqualityOperator,
+    },
+    /// An equality or membership over a materialized text-array column, compiled as an array
+    /// predicate, because a direct comparison would compare whole arrays where the filter means
+    /// containment.
+    ArrayContainment {
+        path: &'params R::QueryPath<'filter>,
+        parameter: &'params Parameter<'filter>,
+        operator: EqualityOperator,
+    },
+}
+
+/// The peephole pass over one compiler.
+///
+/// A rewrite resolves joins and binds parameters through the compiler it borrows, so a rewritten
+/// filter leaves the same artifacts behind as a plain one, and a filter no rewrite claims
+/// compiles as written.
+pub(super) struct PeepholeOptimizer<'compiler, 'params, 'query: 'params, R: QueryRecord> {
+    compiler: &'compiler mut SelectCompiler<'params, 'query, R>,
+}
+
+impl<'compiler, 'params, 'query: 'params, R: PostgresRecord>
+    PeepholeOptimizer<'compiler, 'params, 'query, R>
+{
+    pub(super) const fn new(compiler: &'compiler mut SelectCompiler<'params, 'query, R>) -> Self {
+        Self { compiler }
+    }
+
+    /// Classifies a filter, yielding at most one rewrite with its operands.
+    ///
+    /// Priority is the match order, and a filter no arm claims compiles as written.
+    fn recognize<'filter: 'query>(
+        filter: &'params Filter<'filter, R>,
+    ) -> Option<Peephole<'params, 'filter, R>>
+    where
+        R::QueryPath<'filter>: PostgresQueryPath,
+    {
+        match filter {
+            Filter::Equal(lhs, rhs) => Self::equality_peephole(lhs, rhs, EqualityOperator::Equal),
+            Filter::NotEqual(lhs, rhs) => {
+                Self::equality_peephole(lhs, rhs, EqualityOperator::NotEqual)
+            }
+            Filter::In(
+                FilterExpression::Parameter {
+                    parameter: parameter @ Parameter::Text(_),
+                    convert: None,
+                },
+                FilterExpressionList::Path { path },
+            ) => {
+                let (column, None) = path.terminating_column() else {
+                    return None;
+                };
+
+                column
+                    .is_text_array()
+                    .then_some(Peephole::ArrayContainment {
+                        path,
+                        parameter,
+                        operator: EqualityOperator::Equal,
+                    })
+            }
+            Filter::All(_)
+            | Filter::Any(_)
+            | Filter::Not(_)
+            | Filter::Exists { .. }
+            | Filter::Greater(..)
+            | Filter::GreaterOrEqual(..)
+            | Filter::Less(..)
+            | Filter::LessOrEqual(..)
+            | Filter::In(..)
+            | Filter::StartsWith(..)
+            | Filter::EndsWith(..)
+            | Filter::ContainsSegment(..) => None,
+        }
+    }
+
+    /// Classifies the `Equal`/`NotEqual` shapes, in priority order.
+    ///
+    /// A plain scalar equality is no rewrite by itself and returns `None`.
+    fn equality_peephole<'filter: 'query>(
+        lhs: &'params FilterExpression<'filter, R>,
+        rhs: &'params FilterExpression<'filter, R>,
+        operator: EqualityOperator,
+    ) -> Option<Peephole<'params, 'filter, R>>
+    where
+        R::QueryPath<'filter>: PostgresQueryPath,
+    {
+        let (path, parameter) = equality_halves(lhs, rhs)?;
+        let (column, None) = path.terminating_column() else {
+            return None;
+        };
+
+        if let Parameter::Text(text) = parameter
+            && text.as_ref() == "latest"
+            && matches!(column, Column::OntologyIds(OntologyIds::Version))
+        {
+            return Some(Peephole::LatestOntologyVersion { path, operator });
+        }
+
+        if matches!(parameter, Parameter::Text(_)) && column.is_text_array() {
+            return Some(Peephole::ArrayContainment {
+                path,
+                parameter,
+                operator,
+            });
+        }
+
+        None
+    }
+
+    /// Rewrites a filter whose shape stands alone, or returns `None` for the plain compile.
+    pub(super) fn try_filter<'filter: 'query>(
+        &mut self,
+        filter: &'params Filter<'filter, R>,
+    ) -> Option<Expression>
+    where
+        R::QueryPath<'filter>: PostgresQueryPath,
+    {
+        match Self::recognize(filter)? {
+            Peephole::LatestOntologyVersion { path, operator } => {
+                Some(self.latest_ontology_version(path, operator))
+            }
+            Peephole::ArrayContainment {
+                path,
+                parameter,
+                operator,
+            } => {
+                let alias = self.compiler.add_join_statements(path);
+                let column = path.terminating_column().0.aliased(alias);
+
+                // A lone filter has a single parameter, so the group connective is irrelevant.
+                Some(self.array_predicate(column, &[parameter], operator, FilterGroup::All))
+            }
+        }
+    }
+
+    /// Compiles the filters of an `All`/`Any` group, fusing siblings that share a backing
+    /// shape into one predicate: equality filters backed by the same materialized array
+    /// column collapse into a single array predicate.
+    ///
+    /// Bundles are keyed on the *aliased* column: paths terminating in the same column
+    /// through different join chains (e.g. an entity's own types vs. a linked entity's
+    /// types) resolve to different aliases and stay separate predicates.
+    pub(super) fn compile_group<'filter: 'query>(
+        &mut self,
+        filters: &'params [Filter<'filter, R>],
+        group: FilterGroup,
+    ) -> Result<Vec<Expression>, Report<SelectCompilerError>>
+    where
+        R::QueryPath<'filter>: PostgresQueryPath,
+    {
+        struct ArrayPredicateGroup<'params, 'filter> {
+            column: ColumnReference<'static>,
+            operator: EqualityOperator,
+            parameters: Vec<&'params Parameter<'filter>>,
+        }
+
+        let mut array_bundles: Vec<ArrayPredicateGroup<'params, 'filter>> = Vec::new();
+        let mut expressions = Vec::new();
+        for filter in flattened_children(group, filters) {
+            match Self::recognize(filter) {
+                Some(Peephole::ArrayContainment {
+                    path,
+                    parameter,
+                    operator,
+                }) => {
+                    let alias = self.compiler.add_join_statements(path);
+                    let column = path.terminating_column().0.aliased(alias);
+                    if let Some(bundle) = array_bundles
+                        .iter_mut()
+                        .find(|bundle| bundle.column == column && bundle.operator == operator)
+                    {
+                        bundle.parameters.push(parameter);
+                    } else {
+                        array_bundles.push(ArrayPredicateGroup {
+                            column,
+                            operator,
+                            parameters: vec![parameter],
+                        });
+                    }
+                }
+                Some(Peephole::LatestOntologyVersion { .. }) | None => {
+                    expressions.push(self.compiler.compile_filter(filter)?);
+                }
+            }
+        }
+
+        for bundle in &array_bundles {
+            expressions.push(self.array_predicate(
+                bundle.column.clone(),
+                &bundle.parameters,
+                bundle.operator,
+                group,
+            ));
+        }
+
+        Ok(expressions)
+    }
+
+    /// Compiles equality filters backed by one materialized array column into a single
+    /// array predicate.
+    fn array_predicate<'filter: 'query>(
+        &mut self,
+        column: ColumnReference<'static>,
+        parameters: &[&'params Parameter<'filter>],
+        operator: EqualityOperator,
+        group: FilterGroup,
+    ) -> Expression
+    where
+        R::QueryPath<'filter>: PostgresQueryPath,
+    {
+        let column_reference = Expression::ColumnReference(column);
+        let array = Expression::Function(Function::ArrayLiteral {
+            elements: parameters
+                .iter()
+                .map(|parameter| self.compiler.compile_parameter(parameter).0)
+                .collect(),
+            element_type: PostgresType::Text,
+        });
+
+        // For a single value `@>` and `&&` coincide, so the group connective is irrelevant.
+        if parameters.len() == 1 {
+            let contains = Expression::array_contains(column_reference, array);
+
+            return match operator {
+                EqualityOperator::Equal => contains,
+                EqualityOperator::NotEqual => contains.not(),
+            };
+        }
+
+        let func: fn(Expression, Expression) -> Expression = match (group, operator) {
+            (FilterGroup::All, EqualityOperator::Equal) => Expression::array_contains,
+            (FilterGroup::All, EqualityOperator::NotEqual) => {
+                |lhs, rhs| Expression::overlap(lhs, rhs).not()
+            }
+            (FilterGroup::Any, EqualityOperator::Equal) => Expression::overlap,
+            (FilterGroup::Any, EqualityOperator::NotEqual) => {
+                |lhs, rhs| Expression::array_contains(lhs, rhs).not()
+            }
+        };
+
+        (func)(column_reference, array)
+    }
+
+    /// Compiles the `path` to a condition, which is searching for the latest version.
+    // Warning: This adds a CTE to the statement, which shadows the `ontology_ids` table.
+    //          The CTE list is a plain push: two `version == "latest"` filters in one
+    //          statement emit this CTE twice under one name, and Postgres rejects the
+    //          statement (`WITH query name "ontology_ids" specified more than once`). The
+    //          defect predates the tuple recognizer and goes away with the CTE's removal
+    //          (H-1442 below).
+    // TODO: Remove CTE to allow limit or cursor selection
+    //   see https://linear.app/hash/issue/H-1442
+    fn latest_ontology_version<'filter: 'query>(
+        &mut self,
+        path: &R::QueryPath<'filter>,
+        operator: EqualityOperator,
+    ) -> Expression
+    where
+        R::QueryPath<'filter>: PostgresQueryPath,
+    {
+        self.compiler.artifacts.cursor_disallowed_reason =
+            Some("Cannot use latest version filter with cursor");
+
+        let version_column = Column::OntologyIds(OntologyIds::Version);
+        let alias = Alias {
+            condition_index: 0,
+            chain_depth: 0,
+            number: 0,
+        };
+
+        // Add a WITH expression selecting the partitioned version
+        let common_table_expression = CommonTableExpression::builder()
+            .name(Table::OntologyIds)
+            .statement(
+                SimpleSelect::builder()
+                    .selects(vec![
+                        SelectExpression::Asterisk(None),
+                        SelectExpression::Expression {
+                            expression: Expression::Function(Function::Max(Box::new(
+                                Expression::ColumnReference(version_column.aliased(alias)),
+                            )))
+                            .window(
+                                WindowDefinition::builder().partition_by(
+                                    Expression::ColumnReference(
+                                        Column::OntologyIds(OntologyIds::BaseUrl).aliased(alias),
+                                    ),
+                                ),
+                            ),
+                            output_name: Some(Identifier::from("latest_version")),
+                        },
+                    ])
+                    .from(
+                        FromItem::table(version_column.table())
+                            .alias(version_column.table().aliased_name(alias))
+                            .build(),
+                    )
+                    .build(),
+            )
+            .build();
+        match &mut self.compiler.with {
+            Some(with) => with.push(common_table_expression),
+            None => {
+                self.compiler.with = Some(
+                    WithClause::builder()
+                        .common_table_expressions(common_table_expression)
+                        .build(),
+                );
+            }
+        }
+
+        // Join the table of `path` and compare the version to the latest version
+        let alias = self.compiler.add_join_statements(path);
+
+        let func: fn(Expression, ColumnReference<'static>) -> Expression = match operator {
+            EqualityOperator::Equal => Expression::equal,
+            EqualityOperator::NotEqual => Expression::not_equal,
+        };
+
+        (func)(
+            Expression::ColumnReference(version_column.aliased(alias)),
+            Column::OntologyIds(OntologyIds::LatestVersion).aliased(alias),
+        )
+    }
+}

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/compile/tests.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/compile/tests.rs
@@ -2117,7 +2117,7 @@ mod property_masking {
             &compiler,
             r#"
             SELECT ("entity_editions_0_1_0"."properties" - (CASE WHEN
-                ("entity_edition_cache_0_1_0"."base_urls" @> ARRAY[$1]::text[])
+                "entity_edition_cache_0_1_0"."base_urls" @> ARRAY[$1]::text[]
                 THEN ARRAY[$2]::text[]
                 ELSE ARRAY[]::text[] END))
             FROM "entity_temporal_metadata" AS "entity_temporal_metadata_0_0_0"

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/compile/tests.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/compile/tests.rs
@@ -1316,7 +1316,7 @@ fn filter_entity_by_any_type_versioned_url() {
         WHERE ("entity_temporal_metadata_0_0_0"."draft_id" IS NULL)
           AND ("entity_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ)
           AND ("entity_temporal_metadata_0_0_0"."decision_time" && $2)
-          AND (("entity_edition_cache_0_1_0"."versioned_urls" && ARRAY[$3, $4]::text[]))
+          AND ("entity_edition_cache_0_1_0"."versioned_urls" && ARRAY[$3, $4]::text[])
         "#,
         &[
             &pinned_timestamp,
@@ -1355,7 +1355,7 @@ fn filter_entity_by_all_type_versioned_url() {
         WHERE ("entity_temporal_metadata_0_0_0"."draft_id" IS NULL)
           AND ("entity_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ)
           AND ("entity_temporal_metadata_0_0_0"."decision_time" && $2)
-          AND (("entity_edition_cache_0_1_0"."versioned_urls" @> ARRAY[$3, $4]::text[]))
+          AND ("entity_edition_cache_0_1_0"."versioned_urls" @> ARRAY[$3, $4]::text[])
         "#,
         &[
             &pinned_timestamp,
@@ -1482,7 +1482,7 @@ fn filter_entity_by_no_type_versioned_url() {
         WHERE ("entity_temporal_metadata_0_0_0"."draft_id" IS NULL)
           AND ("entity_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ)
           AND ("entity_temporal_metadata_0_0_0"."decision_time" && $2)
-          AND ((NOT("entity_edition_cache_0_1_0"."versioned_urls" && ARRAY[$3, $4]::text[])))
+          AND (NOT("entity_edition_cache_0_1_0"."versioned_urls" && ARRAY[$3, $4]::text[]))
         "#,
         &[
             &pinned_timestamp,
@@ -1773,7 +1773,7 @@ fn semantic_ordering_compiles_a_policy_branch() {
          AND "entity_embeddings_2_1_0"."entity_uuid" = "entity_temporal_metadata_0_0_0"."entity_uuid"
         WHERE ("entity_temporal_metadata_0_0_0"."draft_id" IS NULL)
           AND (("entity_temporal_metadata_0_0_0"."web_id" = ANY($1))
-          AND (NOT(("entity_temporal_metadata_0_0_0"."entity_uuid" = $2))))
+          AND (NOT("entity_temporal_metadata_0_0_0"."entity_uuid" = $2)))
           AND ("entity_editions_1_1_0"."archived" = $3)
           AND ("entity_embeddings_2_1_0"."property" IS NULL)
         ORDER BY "entity_embeddings_2_1_0"."embedding_bits" <~> binary_quantize(($4::vector)) ASC
@@ -1845,7 +1845,7 @@ fn semantic_ordering_compiles_the_policy_branch_split() {
              AND "entity_embeddings_1_1_0"."entity_uuid" = "entity_temporal_metadata_0_0_0"."entity_uuid"
             WHERE ("entity_temporal_metadata_0_0_0"."draft_id" IS NULL)
               AND (("entity_temporal_metadata_0_0_0"."entity_uuid" = $1)
-              AND (NOT(("entity_temporal_metadata_0_0_0"."entity_uuid" = $2))))
+              AND (NOT("entity_temporal_metadata_0_0_0"."entity_uuid" = $2)))
               AND ("entity_embeddings_1_1_0"."property" IS NULL)
             ORDER BY "entity_embeddings_1_1_0"."embedding_bits" <~> binary_quantize(($3::vector)) ASC
             LIMIT 400
@@ -1861,7 +1861,7 @@ fn semantic_ordering_compiles_the_policy_branch_split() {
              AND "entity_embeddings_1_1_0"."entity_uuid" = "entity_temporal_metadata_0_0_0"."entity_uuid"
             WHERE ("entity_temporal_metadata_0_0_0"."draft_id" IS NULL)
               AND (("entity_temporal_metadata_0_0_0"."web_id" = ANY($1))
-              AND (NOT(("entity_temporal_metadata_0_0_0"."entity_uuid" = $2))))
+              AND (NOT("entity_temporal_metadata_0_0_0"."entity_uuid" = $2)))
               AND ("entity_embeddings_1_1_0"."property" IS NULL)
             ORDER BY "entity_embeddings_1_1_0"."embedding_bits" <~> binary_quantize(($3::vector)) ASC
             LIMIT 400

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/entity.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/entity.rs
@@ -46,6 +46,8 @@ impl PostgresQueryPath for EntityQueryPath<'_> {
                 vec![Relation::EntityEditions]
             }
             Self::DirectTypeCount
+            | Self::FirstTypeTitle
+            | Self::FirstLabel
             | Self::EntityTypeEdge {
                 edge_kind: SharedEdgeKind::IsOfType,
                 path:
@@ -102,7 +104,6 @@ impl PostgresQueryPath for EntityQueryPath<'_> {
             })
             .chain(path.relations())
             .collect(),
-            Self::FirstTypeTitle | Self::FirstLabel => vec![Relation::EntityEditionCache],
         }
     }
 

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/mod.rs
@@ -88,10 +88,6 @@ pub trait Transpile {
     fn transpile(&self, fmt: &mut Formatter) -> fmt::Result;
 
     /// Adapts the value into a [`Display`] that renders the transpiled SQL.
-    ///
-    /// The adapter borrows the value and writes through the surrounding formatter, so
-    /// interpolating a transpiled name into a larger `format!` or `write!` costs no intermediate
-    /// allocation.
     fn display(&self) -> impl Display {
         struct Transpiler<'a, T: ?Sized>(&'a T);
         impl<T: Transpile + ?Sized> Display for Transpiler<'_, T> {

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/mod.rs
@@ -30,15 +30,16 @@ use type_system::knowledge::{Entity, PropertyValue};
 
 pub use self::{
     ast::{
-        BinaryExpression, BinaryOperator, ColumnName, ColumnReference, CommonTableExpression,
-        Constant, EmptyVecError, EqualityOperator, Expression, FromItem, FromItemFunctionBuilder,
-        FromItemJoinBuilder, FromItemSubqueryBuilder, FromItemTableBuilder, Function,
-        GroupByClause, GroupingElement, Identifier, JoinType, Materialization, NonEmptyVec,
-        NonFinitePercentage, NullsOrder, OnConflict, OrderByClause, SamplePercentage,
-        SamplingMethod, SelectClause, SelectExpression, SelectQuantifier, SelectStatement,
-        SetOperator, SetQuantifier, SimpleSelect, SortBy, SortDirection, Statement, TableName,
-        TableReference, TableSample, UnaryExpression, UnaryOperator, VariadicExpression,
-        VariadicOperator, WindowDefinition, WithClause, bulk_insert,
+        Aliased, AliasedCorrelation, BinaryExpression, BinaryOperator, Binder, BoundStatement,
+        ColumnName, ColumnReference, CommonTableExpression, Constant, Correlation, EmptyVecError,
+        EqualityOperator, Expression, FromItem, FromItemFunctionBuilder, FromItemJoinBuilder,
+        FromItemSubqueryBuilder, FromItemTableBuilder, Function, GroupByClause, GroupingElement,
+        Identifier, JoinType, Materialization, NonEmptyVec, NonFinitePercentage, NullsOrder,
+        OnConflict, OrderByClause, Placeholder, SamplePercentage, SamplingMethod, SelectClause,
+        SelectExpression, SelectList, SelectQuantifier, SelectStatement, SetOperator,
+        SetQuantifier, SimpleSelect, SortBy, SortDirection, Statement, TableName, TableReference,
+        TableSample, UnaryExpression, UnaryOperator, VariadicExpression, VariadicOperator,
+        WindowDefinition, WithClause, bulk_insert,
     },
     compile::{
         Distinctness, QUANTIZED_RANK_OVERFETCH, SelectCompiler, SelectCompilerError, StatementShape,
@@ -86,7 +87,12 @@ pub trait Transpile {
     /// Returns an error if the value cannot be formatted or written to the formatter.
     fn transpile(&self, fmt: &mut Formatter) -> fmt::Result;
 
-    fn transpile_to_string(&self) -> String {
+    /// Adapts the value into a [`Display`] that renders the transpiled SQL.
+    ///
+    /// The adapter borrows the value and writes through the surrounding formatter, so
+    /// interpolating a transpiled name into a larger `format!` or `write!` costs no intermediate
+    /// allocation.
+    fn display(&self) -> impl Display {
         struct Transpiler<'a, T: ?Sized>(&'a T);
         impl<T: Transpile + ?Sized> Display for Transpiler<'_, T> {
             fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
@@ -94,7 +100,11 @@ pub trait Transpile {
             }
         }
 
-        Transpiler(self).to_string()
+        Transpiler(self)
+    }
+
+    fn transpile_to_string(&self) -> String {
+        self.display().to_string()
     }
 }
 

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/postgres_type.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/postgres_type.rs
@@ -26,7 +26,19 @@ pub enum PostgresType {
     JsonB,
     JsonPath,
     // `pgvector` embedding vector
-    Vector,
+    Vector {
+        /// The vector's component count, rendered as `vector(n)` when present.
+        ///
+        /// A cast to a dimensioned vector type asserts the count and fails the query when the
+        /// value disagrees. `None` casts to the undimensioned `vector` type, which accepts any
+        /// length.
+        ///
+        /// The embedding columns declare `None` against a schema storing `vector(3072)`.
+        /// That is the safe direction: the declared type feeds the tuple-membership
+        /// casts, and narrowing the declaration would make those casts assert a count
+        /// the direct equality never checked.
+        dimensions: Option<usize>,
+    },
     // bit string, transpiles without a width and is therefore unusable as a parameter cast
     Bit,
     // `entity_edge_kind` enum
@@ -59,7 +71,10 @@ impl Transpile for PostgresType {
             Self::TstzRange => fmt.write_str(Type::TSTZ_RANGE.name()),
             Self::JsonB => fmt.write_str(Type::JSONB.name()),
             Self::JsonPath => fmt.write_str(Type::JSONPATH.name()),
-            Self::Vector => fmt.write_str("vector"),
+            Self::Vector { dimensions: None } => fmt.write_str("vector"),
+            Self::Vector {
+                dimensions: Some(dimensions),
+            } => write!(fmt, "vector({dimensions})"),
             Self::Bit => fmt.write_str(Type::BIT.name()),
             Self::EntityEdgeKind => fmt.write_str("entity_edge_kind"),
             Self::EdgeDirection => fmt.write_str("edge_direction"),

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/postgres_type.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/postgres_type.rs
@@ -32,11 +32,6 @@ pub enum PostgresType {
         /// A cast to a dimensioned vector type asserts the count and fails the query when the
         /// value disagrees. `None` casts to the undimensioned `vector` type, which accepts any
         /// length.
-        ///
-        /// The embedding columns declare `None` against a schema storing `vector(3072)`.
-        /// That is the safe direction: the declared type feeds the tuple-membership
-        /// casts, and narrowing the declaration would make those casts assert a count
-        /// the direct equality never checked.
         dimensions: Option<usize>,
     },
     // bit string, transpiles without a width and is therefore unusable as a parameter cast

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/table.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/table.rs
@@ -1,5 +1,5 @@
 use core::{
-    fmt::Debug,
+    fmt::{self, Debug},
     hash::Hash,
     iter::{Chain, Once, once},
 };
@@ -330,17 +330,9 @@ impl ReferenceTable {
 
 impl Table {
     /// Renders the alias-qualified table name under the compiler's `{name}_{c}_{d}_{n}` scheme.
-    ///
-    /// This is the only place that knows how alias names are derived from an [`Alias`].
     #[must_use]
     pub fn aliased_name(self, alias: Alias) -> TableName<'static> {
-        TableName::from(format!(
-            "{}_{}_{}_{}",
-            self.as_str(),
-            alias.condition_index,
-            alias.chain_depth,
-            alias.number
-        ))
+        alias.qualify(self.as_str())
     }
 
     #[must_use]
@@ -399,6 +391,9 @@ impl Table {
     }
 }
 
+/// The `jsonb_typeof` names of the values a [`JsonField::ScalarEntries`] read delivers inline.
+const JSON_SCALAR_TYPES: &[&str] = &["string", "number", "boolean", "null"];
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum JsonField<'p> {
     JsonPath(&'p JsonPath<'p>),
@@ -409,6 +404,21 @@ pub enum JsonField<'p> {
     /// Filter parameters against subscripted columns are typed as [`ParameterType::Text`],
     /// so this is only valid for text arrays.
     ArrayElement(usize),
+    /// The object's scalar entries, aggregated into one `jsonb` map.
+    ///
+    /// Compiles to a scalar subquery over `jsonb_each` that keeps every entry whose value is a
+    /// string, a number, a boolean, or an explicit null, and reads SQL `NULL` when no entry
+    /// qualifies. The qualifying type names travel as a bound parameter, so
+    /// [`into_owned`](Self::into_owned) converts this to
+    /// [`ScalarEntriesParameter`](Self::ScalarEntriesParameter).
+    ScalarEntries,
+    /// [`ScalarEntries`](Self::ScalarEntries) with its type names bound at the parameter index.
+    ScalarEntriesParameter(usize),
+    /// The object's whole entry count, as `int4`.
+    ///
+    /// Compiles to a scalar subquery over `jsonb_each`, so it also counts the entries a
+    /// [`ScalarEntries`](Self::ScalarEntries) read of the same column excludes.
+    EntryCount,
     Label {
         inheritance_depth: Option<u32>,
     },
@@ -428,6 +438,12 @@ impl<'p> JsonField<'p> {
             Self::JsonPathParameter(index) => (JsonField::JsonPathParameter(index), None),
             Self::StaticText(text) => (JsonField::StaticText(text), None),
             Self::ArrayElement(index) => (JsonField::ArrayElement(index), None),
+            Self::ScalarEntries => (
+                JsonField::ScalarEntriesParameter(current_parameter_index),
+                Some(&JSON_SCALAR_TYPES),
+            ),
+            Self::ScalarEntriesParameter(index) => (JsonField::ScalarEntriesParameter(index), None),
+            Self::EntryCount => (JsonField::EntryCount, None),
             Self::Label { inheritance_depth } => (JsonField::Label { inheritance_depth }, None),
         }
     }
@@ -452,6 +468,21 @@ pub trait DatabaseColumn<'name> {
 pub trait FilterColumn<'name>: DatabaseColumn<'name> {
     /// The logical type filter values compared against this column must have.
     fn parameter_type(&self) -> ParameterType;
+
+    /// Whether the column holds an array of textual values ([`BaseUrl`] and
+    /// [`VersionedUrl`] columns transpile to `text[]`).
+    ///
+    /// [`BaseUrl`]: ParameterType::BaseUrl
+    /// [`VersionedUrl`]: ParameterType::VersionedUrl
+    fn is_text_array(&self) -> bool {
+        matches!(
+            self.parameter_type(),
+            ParameterType::Vector(inner) if matches!(
+                *inner,
+                ParameterType::Text | ParameterType::BaseUrl | ParameterType::VersionedUrl
+            )
+        )
+    }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -1038,7 +1069,7 @@ impl DatabaseColumn<'_> for DataTypeEmbeddings {
     fn postgres_type(&self) -> PostgresType {
         match self {
             Self::OntologyId => PostgresType::Uuid,
-            Self::Embedding => PostgresType::Vector,
+            Self::Embedding => PostgresType::Vector { dimensions: None },
             Self::UpdatedAtTransactionTime => PostgresType::TimestampTz,
         }
     }
@@ -1106,7 +1137,7 @@ impl DatabaseColumn<'_> for PropertyTypeEmbeddings {
     fn postgres_type(&self) -> PostgresType {
         match self {
             Self::OntologyId => PostgresType::Uuid,
-            Self::Embedding => PostgresType::Vector,
+            Self::Embedding => PostgresType::Vector { dimensions: None },
             Self::UpdatedAtTransactionTime => PostgresType::TimestampTz,
         }
     }
@@ -1146,7 +1177,7 @@ impl DatabaseColumn<'_> for EntityTypeEmbeddings {
     fn postgres_type(&self) -> PostgresType {
         match self {
             Self::OntologyId => PostgresType::Uuid,
-            Self::Embedding => PostgresType::Vector,
+            Self::Embedding => PostgresType::Vector { dimensions: None },
             Self::EmbeddingBits => PostgresType::Bit,
             Self::UpdatedAtTransactionTime => PostgresType::TimestampTz,
         }
@@ -1200,7 +1231,7 @@ impl DatabaseColumn<'_> for EntityEmbeddings {
     fn postgres_type(&self) -> PostgresType {
         match self {
             Self::WebId | Self::EntityUuid | Self::DraftId => PostgresType::Uuid,
-            Self::Embedding => PostgresType::Vector,
+            Self::Embedding => PostgresType::Vector { dimensions: None },
             Self::EmbeddingBits => PostgresType::Bit,
             Self::Property => PostgresType::Text,
             Self::UpdatedAtTransactionTime | Self::UpdatedAtDecisionTime => {
@@ -2055,6 +2086,19 @@ pub struct Alias {
     pub condition_index: usize,
     pub chain_depth: usize,
     pub number: usize,
+}
+
+impl Alias {
+    /// Renders `name` under the compiler's `{name}_{c}_{d}_{n}` alias scheme.
+    ///
+    /// This is the only place that knows how alias names are derived from an [`Alias`].
+    #[must_use]
+    pub fn qualify(self, name: impl fmt::Display) -> TableName<'static> {
+        TableName::from(format!(
+            "{}_{}_{}_{}",
+            name, self.condition_index, self.chain_depth, self.number
+        ))
+    }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The Postgres query compiler assembles statements as a typed AST and renders SQL once at the end. The new `query/ast/` module models statements, clauses, and expressions with node shapes following Postgres' own grammar (`gram.y`): at most the grammar per node, completeness on demand. `SelectCompiler` builds typed nodes where it used to push strings, which makes a statement inspectable and rewritable after assembly. The peephole pass (#9301) is the first consumer of that property.

The PR also moves the old `compile_special_filter` rewrites (`LatestOntologyVersion`, `ArrayContainment`) into `compile/peephole/mod.rs` as structured rewrites. They matter for correctness: a cached-array equality compiled generically emits `text[] = text`, which is invalid SQL rather than slow SQL, and the tests pin both rewrites.

Review focus: the rendered SQL. `compile/tests.rs` carries the updated expectations and is the review anchor, and precedence plus parenthesization in `ast/expression/binary.rs` rewards a close read.

## 🔍 What does this change?

- `query/ast/`: statement, clause, and expression nodes (`SimpleSelect`, `OrderByClause`, `FromItem`, window and function expressions, `NonEmpty` collections). Names follow the SQL keyword first, then the SQL documentation's synopsis term, then the `gram.y` nonterminal.
- `query/ast/assembly.rs`: the single render point.
- `compile/mod.rs`: assembles typed nodes instead of strings.
- `compile/peephole/mod.rs`: the relocated special-filter rewrites.
- `compile/tests.rs`: expectations updated to the rendered output.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- `compile/tests.rs` pins the rendered SQL, including both relocated rewrites.
- The existing postgres-store lib suite covers this, plus the workspace battery: `cargo check`, clippy at zero warnings, `fmt` clean.

## ❓ How to test this?

```bash
cargo nextest run -p hash-graph-postgres-store --lib
```
