### PR TITLE
BE-779: hgraph: Fuse identity-tuple disjunctions in the peephole optimizer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,6 +278,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "array-init"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7601,6 +7607,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "851ca9db4932932d69f3ea811b1abe63087a0f740a47692619dd40d4899b68be"
 dependencies = [
+ "array-init",
  "bytes",
  "fallible-iterator",
  "postgres-derive",

--- a/libs/@local/graph/postgres-store/Cargo.toml
+++ b/libs/@local/graph/postgres-store/Cargo.toml
@@ -40,7 +40,7 @@ derive-where   = { workspace = true }
 derive_more    = { workspace = true }
 dotenv-flow    = { workspace = true }
 futures        = { workspace = true }
-postgres-types = { workspace = true, features = ["derive", "with-serde_json-1"] }
+postgres-types = { workspace = true, features = ["array-impls", "derive", "with-serde_json-1"] }
 rayon          = { workspace = true }
 refinery       = { workspace = true, features = ["tokio-postgres"] }
 regex          = { workspace = true }

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/compile/peephole/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/compile/peephole/mod.rs
@@ -1,26 +1,29 @@
 //! Peephole rewrites over compiled filters.
 //!
 //! A peephole here is a filter shape whose direct compilation would be wrong or wasteful: an
-//! equality on an array-backed column would compare arrays where the filter means containment,
-//! and a `version = "latest"` equality would bind the text `"latest"` against an int8 column.
-//! [`PeepholeOptimizer`] recognizes those shapes and compiles the rewrite, and every other
-//! filter compiles as written.
+//! equality on an array-backed column would compare arrays where the filter means containment, a
+//! `version = "latest"` equality would bind the text `"latest"` against an int8 column, and a
+//! disjunction of identity tuples plans as one index-scan branch per tuple. [`PeepholeOptimizer`]
+//! recognizes those shapes and compiles the rewrite, and every other filter compiles as written.
 //!
 //! [`PeepholeOptimizer::recognize`] yields at most one [`Peephole`] per filter, so no filter is
 //! rewritten twice, and a filter classified as a plain equality is one no rewrite claims.
+
+mod tuple;
 
 use error_stack::Report;
 use hash_graph_store::filter::{
     Filter, FilterExpression, FilterExpressionList, Parameter, QueryRecord,
 };
 
+use self::tuple::ColumnTupleGroup;
 use super::{FilterGroup, SelectCompiler, SelectCompilerError};
 use crate::store::postgres::query::{
     Alias, Column, ColumnReference, CommonTableExpression, EqualityOperator, Expression, FromItem,
     Function, Identifier, PostgresQueryPath, PostgresRecord, SelectExpression, SimpleSelect, Table,
     WindowDefinition, WithClause,
     postgres_type::PostgresType,
-    table::{FilterColumn as _, OntologyIds},
+    table::{DatabaseColumn as _, FilterColumn as _, OntologyIds},
 };
 
 /// Orientation-normalizes an equality's operands into its path and its parameter.
@@ -99,6 +102,9 @@ enum Peephole<'params, 'filter, R: QueryRecord> {
         parameter: &'params Parameter<'filter>,
         operator: EqualityOperator,
     },
+    /// An `All` group where every child pins a plain scalar column to a parameter: a candidate
+    /// for row-membership bundling when its `Any`-group siblings share the column set.
+    ColumnTuple(Vec<(&'params R::QueryPath<'filter>, &'params Parameter<'filter>)>),
 }
 
 /// The peephole pass over one compiler.
@@ -121,6 +127,7 @@ impl<'compiler, 'params, 'query: 'params, R: PostgresRecord>
     ///
     /// Priority is the match order, and a filter no arm claims compiles as written.
     fn recognize<'filter: 'query>(
+        &self,
         filter: &'params Filter<'filter, R>,
     ) -> Option<Peephole<'params, 'filter, R>>
     where
@@ -150,8 +157,19 @@ impl<'compiler, 'params, 'query: 'params, R: PostgresRecord>
                         operator: EqualityOperator::Equal,
                     })
             }
-            Filter::All(_)
-            | Filter::Any(_)
+            Filter::All(children) => {
+                let members = flattened_children(FilterGroup::All, children);
+                if members.len() < 2 {
+                    return None;
+                }
+
+                members
+                    .into_iter()
+                    .map(|child| self.plain_column_equality(child))
+                    .collect::<Option<Vec<_>>>()
+                    .map(Peephole::ColumnTuple)
+            }
+            Filter::Any(_)
             | Filter::Not(_)
             | Filter::Exists { .. }
             | Filter::Greater(..)
@@ -199,7 +217,46 @@ impl<'compiler, 'params, 'query: 'params, R: PostgresRecord>
         None
     }
 
+    /// Decomposes an equality filter pinning a plain scalar column to a parameter: the unit
+    /// [`Peephole::ColumnTuple`] builds on.
+    ///
+    /// `None` when [`recognize`](Self::recognize) claims the filter (a rewritten filter must
+    /// never be rebuilt as the direct equality whose meaning the rewrite exists to change), when
+    /// the path reaches into a JSON document rather than a whole column, when the column is
+    /// array-backed (an equality there means containment and belongs to the array predicates),
+    /// and when the column carries a column hook (the tuple forms build their column references
+    /// directly, which would silently skip the hook's rewrite). A refused group compiles
+    /// through [`SelectCompiler::compile_filter`], which handles all four.
+    fn plain_column_equality<'filter: 'query>(
+        &self,
+        filter: &'params Filter<'filter, R>,
+    ) -> Option<(&'params R::QueryPath<'filter>, &'params Parameter<'filter>)>
+    where
+        R::QueryPath<'filter>: PostgresQueryPath,
+    {
+        let Filter::Equal(lhs, rhs) = filter else {
+            return None;
+        };
+
+        if self.recognize(filter).is_some() {
+            return None;
+        }
+
+        let (path, parameter) = equality_halves(lhs, rhs)?;
+        let (column, None) = path.terminating_column() else {
+            return None;
+        };
+
+        (!matches!(column.postgres_type(), PostgresType::Array(_))
+            && !self.compiler.column_hooks.contains_key(&column))
+        .then_some((path, parameter))
+    }
+
     /// Rewrites a filter whose shape stands alone, or returns `None` for the plain compile.
+    ///
+    /// [`Peephole::ColumnTuple`] returns `None` here: a lone tuple gains nothing over its own
+    /// conjunction, and tuples fuse only among the siblings of an `Any` group, in
+    /// [`compile_group`](Self::compile_group).
     pub(super) fn try_filter<'filter: 'query>(
         &mut self,
         filter: &'params Filter<'filter, R>,
@@ -207,7 +264,7 @@ impl<'compiler, 'params, 'query: 'params, R: PostgresRecord>
     where
         R::QueryPath<'filter>: PostgresQueryPath,
     {
-        match Self::recognize(filter)? {
+        match self.recognize(filter)? {
             Peephole::LatestOntologyVersion { path, operator } => {
                 Some(self.latest_ontology_version(path, operator))
             }
@@ -222,16 +279,19 @@ impl<'compiler, 'params, 'query: 'params, R: PostgresRecord>
                 // A lone filter has a single parameter, so the group connective is irrelevant.
                 Some(self.array_predicate(column, &[parameter], operator, FilterGroup::All))
             }
+            Peephole::ColumnTuple(_) => None,
         }
     }
 
     /// Compiles the filters of an `All`/`Any` group, fusing siblings that share a backing
     /// shape into one predicate: equality filters backed by the same materialized array
-    /// column collapse into a single array predicate.
+    /// column collapse into a single array predicate, and, in an `Any` group only,
+    /// column-equality `All` tuples over one aliased table collapse into a single
+    /// row-membership predicate over unnested arrays.
     ///
-    /// Bundles are keyed on the *aliased* column: paths terminating in the same column
-    /// through different join chains (e.g. an entity's own types vs. a linked entity's
-    /// types) resolve to different aliases and stay separate predicates.
+    /// Bundles are keyed on the *aliased* column or column set: paths terminating in the
+    /// same column through different join chains (e.g. an entity's own types vs. a linked
+    /// entity's types) resolve to different aliases and stay separate predicates.
     pub(super) fn compile_group<'filter: 'query>(
         &mut self,
         filters: &'params [Filter<'filter, R>],
@@ -247,9 +307,10 @@ impl<'compiler, 'params, 'query: 'params, R: PostgresRecord>
         }
 
         let mut array_bundles: Vec<ArrayPredicateGroup<'params, 'filter>> = Vec::new();
+        let mut tuple_bundles: Vec<ColumnTupleGroup<'params, 'filter>> = Vec::new();
         let mut expressions = Vec::new();
         for filter in flattened_children(group, filters) {
-            match Self::recognize(filter) {
+            match self.recognize(filter) {
                 Some(Peephole::ArrayContainment {
                     path,
                     parameter,
@@ -270,7 +331,15 @@ impl<'compiler, 'params, 'query: 'params, R: PostgresRecord>
                         });
                     }
                 }
-                Some(Peephole::LatestOntologyVersion { .. }) | None => {
+                Some(Peephole::ColumnTuple(halves)) if group == FilterGroup::Any => {
+                    ColumnTupleGroup::bundle(
+                        self.compiler,
+                        halves,
+                        &mut tuple_bundles,
+                        &mut expressions,
+                    );
+                }
+                Some(Peephole::LatestOntologyVersion { .. } | Peephole::ColumnTuple(_)) | None => {
                     expressions.push(self.compiler.compile_filter(filter)?);
                 }
             }
@@ -283,6 +352,10 @@ impl<'compiler, 'params, 'query: 'params, R: PostgresRecord>
                 bundle.operator,
                 group,
             ));
+        }
+
+        for (index, bundle) in tuple_bundles.into_iter().enumerate() {
+            expressions.push(bundle.compile(self.compiler, index));
         }
 
         Ok(expressions)

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/compile/peephole/tuple.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/compile/peephole/tuple.rs
@@ -1,0 +1,425 @@
+//! Column-tuple bundling and its row-membership compilation.
+//!
+//! An `Any` group whose `All` members each pin one set of plain scalar columns states a row
+//! membership over value tuples. [`ColumnTupleGroup`] gathers those members in canonical column
+//! order and compiles the group to one membership predicate over unnested arrays, binding each
+//! column's values as a single array parameter, so neither the statement text nor the parameter
+//! count changes with the tuple count.
+
+use hash_graph_store::filter::Parameter;
+use postgres_types::ToSql;
+
+use crate::store::postgres::query::{
+    Alias, ColumnName, ColumnReference, Correlation, Expression, FromItem, Function,
+    PostgresQueryPath, PostgresRecord, SelectCompiler, SelectExpression, SimpleSelect, TableName,
+    Transpile as _, postgres_type::PostgresType, table::DatabaseColumn,
+};
+
+/// One member of an unnested tuple row, named by its 1-based position.
+///
+/// The vocabulary is positional because the bundled columns are arbitrary: the tuple's width is
+/// its group's column count. Each member carries the stored type of the column it stands for,
+/// which types the array its values arrive in.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TupleElement {
+    /// The member's 1-based position among the bundle's columns.
+    position: usize,
+    /// The stored type of the column this member carries values for.
+    element_type: PostgresType,
+}
+
+impl DatabaseColumn<'_> for TupleElement {
+    fn name(&self) -> ColumnName<'static> {
+        format!("elem_{}", self.position).into()
+    }
+
+    fn postgres_type(&self) -> PostgresType {
+        self.element_type.clone()
+    }
+}
+
+/// The unnested tuple rows inside a column-tuple membership predicate.
+const UNNEST_CORRELATION: Correlation<TupleElement> = Correlation::new("unnest");
+
+/// One parallel-array unnest of aligned tuples, standing as `"unnest_c_d_n"("elem_1", …)` at the
+/// arrays' shared width.
+fn from_unnest(
+    reference: impl Into<TableName<'static>>,
+    arrays: Vec<Expression>,
+    members: &[TupleElement],
+) -> FromItem<'static> {
+    debug_assert_eq!(
+        arrays.len(),
+        members.len(),
+        "every unnested array needs its member alias: an unaliased array would silently lose its \
+         column name and the statement would fail at the server",
+    );
+
+    FromItem::function(Function::Unnest(arrays))
+        .alias(reference)
+        .column_aliases(members.iter().map(DatabaseColumn::name).collect())
+        .build()
+}
+
+/// Collects member `position` of every tuple into one owned array value.
+///
+/// `None` reports a bundle the single-parameter form cannot bind: members of mixed variants, or
+/// a variant no SQL array element carries. The caller then binds every member as its own
+/// parameter inside an array literal, which every variant supports.
+fn column_array(
+    tuples: &[Vec<&Parameter<'_>>],
+    position: usize,
+) -> Option<Box<dyn ToSql + Sync + Send>> {
+    fn collect<T>(
+        tuples: &[Vec<&Parameter<'_>>],
+        position: usize,
+        extract: impl Fn(&Parameter<'_>) -> Option<T>,
+    ) -> Option<Vec<T>> {
+        tuples
+            .iter()
+            .map(|tuple| tuple.get(position).copied().and_then(&extract))
+            .collect()
+    }
+
+    match tuples.first()?.get(position)? {
+        Parameter::Uuid(_) => collect(tuples, position, |parameter| match parameter {
+            Parameter::Uuid(uuid) => Some(*uuid),
+            Parameter::Boolean(_)
+            | Parameter::Decimal(_)
+            | Parameter::Text(_)
+            | Parameter::Vector(_)
+            | Parameter::Any(_)
+            | Parameter::OntologyTypeVersion(_)
+            | Parameter::Timestamp(_) => None,
+        })
+        .map(|values| Box::new(values) as Box<dyn ToSql + Sync + Send>),
+        Parameter::Text(_) => collect(tuples, position, |parameter| match parameter {
+            Parameter::Text(text) => Some(text.to_string()),
+            Parameter::Boolean(_)
+            | Parameter::Decimal(_)
+            | Parameter::Vector(_)
+            | Parameter::Any(_)
+            | Parameter::Uuid(_)
+            | Parameter::OntologyTypeVersion(_)
+            | Parameter::Timestamp(_) => None,
+        })
+        .map(|values| Box::new(values) as Box<dyn ToSql + Sync + Send>),
+        Parameter::Boolean(_) => collect(tuples, position, |parameter| match parameter {
+            Parameter::Boolean(boolean) => Some(*boolean),
+            Parameter::Decimal(_)
+            | Parameter::Text(_)
+            | Parameter::Vector(_)
+            | Parameter::Any(_)
+            | Parameter::Uuid(_)
+            | Parameter::OntologyTypeVersion(_)
+            | Parameter::Timestamp(_) => None,
+        })
+        .map(|values| Box::new(values) as Box<dyn ToSql + Sync + Send>),
+        Parameter::Decimal(_) => collect(tuples, position, |parameter| match parameter {
+            Parameter::Decimal(number) => Some(number.clone()),
+            Parameter::Boolean(_)
+            | Parameter::Text(_)
+            | Parameter::Vector(_)
+            | Parameter::Any(_)
+            | Parameter::Uuid(_)
+            | Parameter::OntologyTypeVersion(_)
+            | Parameter::Timestamp(_) => None,
+        })
+        .map(|values| Box::new(values) as Box<dyn ToSql + Sync + Send>),
+        Parameter::Timestamp(_) => collect(tuples, position, |parameter| match parameter {
+            Parameter::Timestamp(timestamp) => Some(*timestamp),
+            Parameter::Boolean(_)
+            | Parameter::Decimal(_)
+            | Parameter::Text(_)
+            | Parameter::Vector(_)
+            | Parameter::Any(_)
+            | Parameter::Uuid(_)
+            | Parameter::OntologyTypeVersion(_) => None,
+        })
+        .map(|values| Box::new(values) as Box<dyn ToSql + Sync + Send>),
+        Parameter::OntologyTypeVersion(_) => {
+            collect(tuples, position, |parameter| match parameter {
+                Parameter::OntologyTypeVersion(version) => Some(version.as_ref().clone()),
+                Parameter::Boolean(_)
+                | Parameter::Decimal(_)
+                | Parameter::Text(_)
+                | Parameter::Vector(_)
+                | Parameter::Any(_)
+                | Parameter::Uuid(_)
+                | Parameter::Timestamp(_) => None,
+            })
+            .map(|values| Box::new(values) as Box<dyn ToSql + Sync + Send>)
+        }
+        Parameter::Vector(_) | Parameter::Any(_) => None,
+    }
+}
+
+/// One recognized equality with its joins resolved, keyed for canonical ordering.
+struct ResolvedEquality<'params, 'filter> {
+    /// The aliased column's transpiled form, the sort and bundle-match key.
+    identity: String,
+    column: ColumnReference<'static>,
+    element_type: PostgresType,
+    parameter: &'params Parameter<'filter>,
+}
+
+/// The bundle for one recognized column set.
+///
+/// The columns stand in canonical order, and each tuple holds one parameter per column,
+/// aligned to that order.
+pub(super) struct ColumnTupleGroup<'params, 'filter> {
+    /// The tuple's columns in canonical order, each with its stored type.
+    columns: Vec<(ColumnReference<'static>, PostgresType)>,
+    tuples: Vec<Vec<&'params Parameter<'filter>>>,
+}
+
+impl<'params, 'filter> ColumnTupleGroup<'params, 'filter> {
+    /// Resolves a recognized tuple's halves into canonical order, then either merges the
+    /// tuple into the bundle keyed on exactly its column set or pushes its direct
+    /// conjunction.
+    ///
+    /// Sorting by the column's transpiled identity makes the tuple order canonical, so
+    /// bundles match by plain equality with their parameters already aligned, whatever
+    /// order the group wrote the equalities in.
+    pub(super) fn bundle<'query, R>(
+        compiler: &mut SelectCompiler<'params, 'query, R>,
+        tuple: Vec<(&'params R::QueryPath<'filter>, &'params Parameter<'filter>)>,
+        bundles: &mut Vec<Self>,
+        expressions: &mut Vec<Expression>,
+    ) where
+        'query: 'params,
+        'filter: 'query,
+        R: PostgresRecord,
+        R::QueryPath<'filter>: PostgresQueryPath,
+    {
+        let mut halves = tuple
+            .into_iter()
+            .map(|(path, parameter)| {
+                let (column, _) = path.terminating_column();
+                let element_type = column.postgres_type();
+                let alias = compiler.add_join_statements(path);
+                let column = column.aliased(alias);
+
+                ResolvedEquality {
+                    identity: column.transpile_to_string(),
+                    column,
+                    element_type,
+                    parameter,
+                }
+            })
+            .collect::<Vec<_>>();
+        halves.sort_by(|left, right| left.identity.cmp(&right.identity));
+
+        // A repeated column stays a plain conjunction, and a tuple standing on more than one table
+        // stays direct on purpose, because a cross-table membership is a condition above
+        // the join, which the planner answers by materializing the whole join first
+        // (measured at 14x the disjunction's execution time on a two-table pair). The
+        // boundary is one aliased table, base or joined, since same-table memberships on a
+        // joined alias measured index-driven.
+        let bundleable = halves.array_windows::<2>().all(|[left, right]| {
+            left.identity != right.identity && left.column.correlation == right.column.correlation
+        });
+
+        if bundleable {
+            let columns = halves
+                .iter()
+                .map(|half| (half.column.clone(), half.element_type.clone()))
+                .collect::<Vec<_>>();
+
+            let parameters = halves
+                .into_iter()
+                .map(|half| half.parameter)
+                .collect::<Vec<_>>();
+
+            if let Some(bundle) = bundles.iter_mut().find(|bundle| bundle.columns == columns) {
+                bundle.tuples.push(parameters);
+            } else {
+                bundles.push(Self {
+                    columns,
+                    tuples: vec![parameters],
+                });
+            }
+        } else {
+            // Excluded shapes build from the resolved halves; see `conjunction` for why they
+            // are never re-compiled.
+            let conjunction = conjunction(
+                compiler,
+                halves.into_iter().map(|half| (half.column, half.parameter)),
+            );
+            expressions.push(conjunction);
+        }
+    }
+
+    /// Compiles the bundle to its predicate.
+    ///
+    /// One tuple gains nothing over its own conjunction, and the direct form lets the columns'
+    /// own indexes serve it without an unnest, so a singleton bundle compiles to the
+    /// conjunction and every wider bundle compiles to the row membership.
+    pub(super) fn compile<'query, R>(
+        self,
+        compiler: &mut SelectCompiler<'params, 'query, R>,
+        bundle_index: usize,
+    ) -> Expression
+    where
+        'query: 'params,
+        'filter: 'query,
+        R: PostgresRecord,
+    {
+        let Self { columns, tuples } = self;
+
+        if let [tuple] = tuples.as_slice() {
+            conjunction(
+                compiler,
+                columns
+                    .into_iter()
+                    .map(|(reference, _)| reference)
+                    .zip(tuple.iter().copied()),
+            )
+        } else {
+            membership(compiler, columns, &tuples, bundle_index)
+        }
+    }
+}
+
+/// Builds the direct conjunction of `column = parameter` equalities from resolved
+/// tuple halves, in the order given (the recognizer's canonical column order).
+///
+/// Shapes the recognizer gathers and then excludes (a lone tuple, a repeated column,
+/// columns on more than one table) compile from the halves already resolved:
+/// re-compiling the filter would resolve the same joins a second time, which leaves
+/// the first resolution orphaned in the FROM clause when a join was number-bumped.
+/// The recognizer admits no hooked, array-backed, JSON-reaching or otherwise rewritten
+/// column, so the direct equality means what the re-compile's expression would have
+/// meant. The match holds up to member order and operand orientation, since this
+/// conjunction is canonical where the plain path keeps the group's own order and
+/// normalizes a reversed `parameter == path`.
+fn conjunction<'params, 'filter, 'query, R>(
+    compiler: &mut SelectCompiler<'params, 'query, R>,
+    halves: impl IntoIterator<Item = (ColumnReference<'static>, &'params Parameter<'filter>)>,
+) -> Expression
+where
+    'filter: 'params,
+    'query: 'params,
+    R: PostgresRecord,
+{
+    Expression::all(
+        halves
+            .into_iter()
+            .map(|(column, parameter)| {
+                let (expression, _) = compiler.compile_parameter(parameter);
+
+                Expression::equal(Expression::ColumnReference(column), expression)
+            })
+            .collect(),
+    )
+}
+
+/// Compiles column tuple equalities gathered from one `Any` group into a single
+/// row-membership predicate over the unnested tuple arrays.
+///
+/// The N-way disjunction it replaces plans as a `BitmapOr` with one index-scan branch
+/// per tuple, whose planner memory grows linearly and whose planning time grows
+/// quadratically in the tuple count. The membership form binds each column's values as
+/// one owned array parameter and hands the planner one semi-join over the unnested rows
+/// in place of N branches, so a duplicate tuple cannot multiply result rows, it stays a
+/// `WHERE` condition instead of adding a join, and the statement text no longer changes
+/// with the tuple count, so the driver reuses one prepared statement across batch sizes.
+/// Each array's cast names its own column's stored type, so the values arrive exactly
+/// as the direct equality would have bound them. A bundle whose members mix parameter
+/// variants, or carry a variant no SQL array can hold, falls back to binding every
+/// member as its own parameter inside an array literal.
+fn membership<'params, 'filter, 'query, R>(
+    compiler: &mut SelectCompiler<'params, 'query, R>,
+    columns: Vec<(ColumnReference<'static>, PostgresType)>,
+    tuples: &[Vec<&'params Parameter<'filter>>],
+    bundle_index: usize,
+) -> Expression
+where
+    'filter: 'params,
+    'query: 'params,
+    R: PostgresRecord,
+{
+    // The condition index separates unnest aliases across conditions and the bundle index
+    // separates them within one, so two rewrites in one statement render distinct names.
+    let unnest = UNNEST_CORRELATION.at(Alias {
+        condition_index: compiler.artifacts.condition_index,
+        chain_depth: 0,
+        number: bundle_index,
+    });
+    let members: Vec<_> = columns
+        .iter()
+        .enumerate()
+        .map(|(index, (_, element_type))| TupleElement {
+            position: index + 1,
+            element_type: element_type.clone(),
+        })
+        .collect();
+
+    let arrays: Option<Vec<Box<dyn ToSql + Sync + Send>>> = (0..members.len())
+        .map(|position| column_array(tuples, position))
+        .collect();
+
+    // UNNEST($n::<a>[], $m::<b>[]) when every column collects into one owned array,
+    // UNNEST(ARRAY[$n, …]::<a>[], …) with one parameter per member otherwise.
+    let array_expressions: Vec<Expression> = if let Some(arrays) = arrays {
+        arrays
+            .into_iter()
+            .zip(&members)
+            .map(|(array, member)| {
+                compiler
+                    .add_owned_parameter(array)
+                    .cast(PostgresType::Array(Box::new(member.element_type.clone())))
+            })
+            .collect()
+    } else {
+        let mut elements: Vec<Vec<_>> = vec![Vec::new(); members.len()];
+        for tuple in tuples {
+            for (member_elements, parameter) in elements.iter_mut().zip(tuple) {
+                let (expression, _) = compiler.compile_parameter(parameter);
+                member_elements.push(expression);
+            }
+        }
+
+        // Unequal member counts would not fail: `UNNEST` pads the short arrays with
+        // NULLs, and the query would silently return wrong rows.
+        debug_assert!(
+            elements
+                .iter()
+                .all(|member_elements| member_elements.len() == tuples.len()),
+            "every tuple member must contribute one element per tuple"
+        );
+
+        elements
+            .into_iter()
+            .zip(&members)
+            .map(|(elements, member)| {
+                Expression::Function(Function::ArrayLiteral {
+                    elements,
+                    element_type: member.element_type.clone(),
+                })
+            })
+            .collect()
+    };
+
+    // ROW(<a>, <b>, …) = ANY(SELECT "unnest_c_d_n"."elem_1", …
+    //                        FROM UNNEST(…)
+    //                        AS "unnest_c_d_n"("elem_1", …))
+    Expression::Row(
+        columns
+            .into_iter()
+            .map(|(reference, _)| Expression::ColumnReference(reference))
+            .collect(),
+    )
+    .r#in(Expression::Select(Box::new(
+        SimpleSelect::builder()
+            .selects(
+                members
+                    .iter()
+                    .map(|member| SelectExpression::new(unnest.column(member)))
+                    .collect(),
+            )
+            .from(from_unnest(unnest, array_expressions, &members))
+            .build()
+            .into(),
+    )))
+}

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/compile/tests.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/compile/tests.rs
@@ -17,10 +17,11 @@ use hash_graph_store::{
         temporal_axes::QueryTemporalAxesUnresolved,
     },
 };
+use hash_graph_temporal_versioning::Timestamp;
 use hash_graph_types::Embedding;
 use postgres_types::ToSql;
 use type_system::{
-    knowledge::Entity,
+    knowledge::{Entity, PropertyValue},
     ontology::{
         BaseUrl, DataTypeWithMetadata, EntityTypeWithMetadata, PropertyTypeWithMetadata,
         VersionedUrl,
@@ -58,6 +59,17 @@ fn test_compilation<'p, 'q: 'p, T: PostgresRecord + 'static>(
         .collect::<Vec<_>>();
 
     pretty_assertions::assert_eq!(compiled_parameters, expected_parameters);
+}
+
+/// An equality filter pinning `path`'s column to a UUID parameter.
+fn uuid_equality(path: EntityQueryPath<'static>, uuid: Uuid) -> Filter<'static, Entity> {
+    Filter::Equal(
+        FilterExpression::Path { path },
+        FilterExpression::Parameter {
+            parameter: Parameter::Uuid(uuid),
+            convert: None,
+        },
+    )
 }
 
 #[test]
@@ -2021,7 +2033,7 @@ fn transpile_offset() {
 
 mod predefined {
     use type_system::{
-        knowledge::entity::id::{EntityId, EntityUuid},
+        knowledge::entity::id::{DraftId, EntityId, EntityUuid},
         ontology::id::{BaseUrl, OntologyTypeVersion, VersionedUrl},
         principal::actor_group::WebId,
     };
@@ -2093,6 +2105,489 @@ mod predefined {
                 &temporal_axes.variable_interval(),
                 &Uuid::from(entity_id.web_id),
                 &Uuid::from(entity_id.entity_uuid),
+            ],
+        );
+    }
+
+    fn published_entity_id() -> EntityId {
+        EntityId {
+            web_id: WebId::new(Uuid::new_v4()),
+            entity_uuid: EntityUuid::new(Uuid::new_v4()),
+            draft_id: None,
+        }
+    }
+
+    fn drafted_entity_id() -> EntityId {
+        EntityId {
+            web_id: WebId::new(Uuid::new_v4()),
+            entity_uuid: EntityUuid::new(Uuid::new_v4()),
+            draft_id: Some(DraftId::new(Uuid::new_v4())),
+        }
+    }
+
+    /// An `Any` of published-entity identities bundles into one row-membership predicate
+    /// over the unnested pair arrays instead of an N-way disjunction, which planned as a
+    /// `BitmapOr` with one index-scan branch per identity. The tuple's column order is
+    /// canonical (sorted by the column's transpiled identity), so `entity_uuid` leads.
+    #[test]
+    fn for_entity_by_entity_ids_bundle_into_pair_membership() {
+        let ids = [
+            published_entity_id(),
+            published_entity_id(),
+            published_entity_id(),
+        ];
+
+        let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
+        let pinned_timestamp = temporal_axes.pinned_timestamp();
+        let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes), false);
+
+        let filter = Filter::Any(ids.map(Filter::for_entity_by_entity_id).to_vec());
+        compiler.add_filter(&filter).expect("Failed to add filter");
+
+        test_compilation(
+            &compiler,
+            r#"
+            SELECT *
+            FROM "entity_temporal_metadata" AS "entity_temporal_metadata_0_0_0"
+            WHERE ("entity_temporal_metadata_0_0_0"."draft_id" IS NULL)
+              AND ("entity_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ)
+              AND ("entity_temporal_metadata_0_0_0"."decision_time" && $2)
+              AND (ROW("entity_temporal_metadata_0_0_0"."entity_uuid", "entity_temporal_metadata_0_0_0"."web_id") = ANY(SELECT "unnest_0_0_0"."elem_1", "unnest_0_0_0"."elem_2" FROM UNNEST(($3::uuid[]), ($4::uuid[])) AS "unnest_0_0_0"("elem_1", "elem_2")))
+            "#,
+            &[
+                &pinned_timestamp,
+                &temporal_axes.variable_interval(),
+                &[
+                    Uuid::from(ids[0].entity_uuid),
+                    Uuid::from(ids[1].entity_uuid),
+                    Uuid::from(ids[2].entity_uuid),
+                ],
+                &[
+                    Uuid::from(ids[0].web_id),
+                    Uuid::from(ids[1].web_id),
+                    Uuid::from(ids[2].web_id),
+                ],
+            ],
+        );
+    }
+
+    /// A nested `Any` states the same disjunction, so its identities bundle with the outer
+    /// group's into one membership predicate rather than one predicate per nesting level.
+    #[test]
+    fn nested_any_groups_bundle_across_the_boundary() {
+        let ids = [
+            published_entity_id(),
+            published_entity_id(),
+            published_entity_id(),
+        ];
+
+        let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
+        let pinned_timestamp = temporal_axes.pinned_timestamp();
+        let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes), false);
+
+        let filter = Filter::Any(vec![
+            Filter::Any(vec![
+                Filter::for_entity_by_entity_id(ids[0]),
+                Filter::for_entity_by_entity_id(ids[1]),
+            ]),
+            Filter::for_entity_by_entity_id(ids[2]),
+        ]);
+        compiler.add_filter(&filter).expect("Failed to add filter");
+
+        test_compilation(
+            &compiler,
+            r#"
+            SELECT *
+            FROM "entity_temporal_metadata" AS "entity_temporal_metadata_0_0_0"
+            WHERE ("entity_temporal_metadata_0_0_0"."draft_id" IS NULL)
+              AND ("entity_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ)
+              AND ("entity_temporal_metadata_0_0_0"."decision_time" && $2)
+              AND (ROW("entity_temporal_metadata_0_0_0"."entity_uuid", "entity_temporal_metadata_0_0_0"."web_id") = ANY(SELECT "unnest_0_0_0"."elem_1", "unnest_0_0_0"."elem_2" FROM UNNEST(($3::uuid[]), ($4::uuid[])) AS "unnest_0_0_0"("elem_1", "elem_2")))
+            "#,
+            &[
+                &pinned_timestamp,
+                &temporal_axes.variable_interval(),
+                &[
+                    Uuid::from(ids[0].entity_uuid),
+                    Uuid::from(ids[1].entity_uuid),
+                    Uuid::from(ids[2].entity_uuid),
+                ],
+                &[
+                    Uuid::from(ids[0].web_id),
+                    Uuid::from(ids[1].web_id),
+                    Uuid::from(ids[2].web_id),
+                ],
+            ],
+        );
+    }
+
+    /// `All([x])`, `Any([x])` and `x` decide alike, so redundant singleton groups inside an
+    /// identity conjunction dissolve and the conjunction still recognizes as a tuple.
+    #[test]
+    fn singleton_groups_dissolve_before_recognition() {
+        let ids = [published_entity_id(), published_entity_id()];
+
+        let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
+        let pinned_timestamp = temporal_axes.pinned_timestamp();
+        let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes), false);
+
+        let filter = Filter::Any(vec![
+            Filter::All(vec![
+                uuid_equality(EntityQueryPath::WebId, Uuid::from(ids[0].web_id)),
+                Filter::Any(vec![Filter::All(vec![uuid_equality(
+                    EntityQueryPath::Uuid,
+                    Uuid::from(ids[0].entity_uuid),
+                )])]),
+            ]),
+            Filter::for_entity_by_entity_id(ids[1]),
+        ]);
+        compiler.add_filter(&filter).expect("Failed to add filter");
+
+        test_compilation(
+            &compiler,
+            r#"
+            SELECT *
+            FROM "entity_temporal_metadata" AS "entity_temporal_metadata_0_0_0"
+            WHERE ("entity_temporal_metadata_0_0_0"."draft_id" IS NULL)
+              AND ("entity_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ)
+              AND ("entity_temporal_metadata_0_0_0"."decision_time" && $2)
+              AND (ROW("entity_temporal_metadata_0_0_0"."entity_uuid", "entity_temporal_metadata_0_0_0"."web_id") = ANY(SELECT "unnest_0_0_0"."elem_1", "unnest_0_0_0"."elem_2" FROM UNNEST(($3::uuid[]), ($4::uuid[])) AS "unnest_0_0_0"("elem_1", "elem_2")))
+            "#,
+            &[
+                &pinned_timestamp,
+                &temporal_axes.variable_interval(),
+                &[
+                    Uuid::from(ids[0].entity_uuid),
+                    Uuid::from(ids[1].entity_uuid),
+                ],
+                &[Uuid::from(ids[0].web_id), Uuid::from(ids[1].web_id)],
+            ],
+        );
+    }
+
+    /// A single identity gains nothing from an unnest, so it keeps its direct conjunction
+    /// and the identity indexes serve it. The conjunction is built from the recognizer's
+    /// resolved halves, so its column order is canonical (`entity_uuid` before `web_id`)
+    /// rather than the group's own.
+    #[test]
+    fn for_entity_by_entity_id_alone_stays_direct() {
+        let entity_id = published_entity_id();
+
+        let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
+        let pinned_timestamp = temporal_axes.pinned_timestamp();
+        let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes), false);
+
+        let filter = Filter::Any(vec![Filter::for_entity_by_entity_id(entity_id)]);
+        compiler.add_filter(&filter).expect("Failed to add filter");
+
+        test_compilation(
+            &compiler,
+            r#"
+            SELECT *
+            FROM "entity_temporal_metadata" AS "entity_temporal_metadata_0_0_0"
+            WHERE ("entity_temporal_metadata_0_0_0"."draft_id" IS NULL)
+              AND ("entity_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ)
+              AND ("entity_temporal_metadata_0_0_0"."decision_time" && $2)
+              AND (("entity_temporal_metadata_0_0_0"."entity_uuid" = $3) AND ("entity_temporal_metadata_0_0_0"."web_id" = $4))
+            "#,
+            &[
+                &pinned_timestamp,
+                &temporal_axes.variable_interval(),
+                &Uuid::from(entity_id.entity_uuid),
+                &Uuid::from(entity_id.web_id),
+            ],
+        );
+    }
+
+    /// A specially-compiled equality inside a recognized tuple sends the whole group
+    /// back to the plain path. `version == "latest"` passes every scalar check, since
+    /// the version column is a hook-free int8 with no JSON field. Built as a direct
+    /// equality it would drop the latest-version rewrite and bind the text `"latest"`
+    /// against that int8 column, which Postgres rejects at execution (`invalid input
+    /// syntax for type bigint`) after the filter's meaning already changed. The
+    /// recognizer refuses whatever [`SelectCompiler::compile_special_filter`]'s shared
+    /// predicate claims, so the group compiles with the `ontology_ids` CTE exactly as
+    /// it does outside an `Any` group. Review r3 caught this on the live DB; the
+    /// earlier suite was all-uuid, which is why no test here failed.
+    #[test]
+    fn latest_version_pair_in_any_group_keeps_the_cte() {
+        let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
+        let pinned_timestamp = temporal_axes.pinned_timestamp();
+        let mut compiler =
+            SelectCompiler::<DataTypeWithMetadata>::with_asterisk(Some(&temporal_axes), false);
+
+        let filter = Filter::Any(vec![Filter::All(vec![
+            Filter::Equal(
+                FilterExpression::Path {
+                    path: DataTypeQueryPath::Version,
+                },
+                FilterExpression::Parameter {
+                    parameter: Parameter::Text(Cow::Borrowed("latest")),
+                    convert: None,
+                },
+            ),
+            Filter::Equal(
+                FilterExpression::Path {
+                    path: DataTypeQueryPath::BaseUrl,
+                },
+                FilterExpression::Parameter {
+                    parameter: Parameter::Text(Cow::Borrowed(
+                        "https://blockprotocol.org/@blockprotocol/types/data-type/text/",
+                    )),
+                    convert: None,
+                },
+            ),
+        ])]);
+        compiler.add_filter(&filter).expect("Failed to add filter");
+
+        test_compilation(
+            &compiler,
+            r#"
+            WITH "ontology_ids" AS (SELECT *, MAX("ontology_ids_0_0_0"."version") OVER (PARTITION BY "ontology_ids_0_0_0"."base_url") AS "latest_version" FROM "ontology_ids" AS "ontology_ids_0_0_0")
+            SELECT *
+            FROM "ontology_temporal_metadata" AS "ontology_temporal_metadata_0_0_0"
+            INNER JOIN "ontology_ids" AS "ontology_ids_0_1_0"
+              ON "ontology_ids_0_1_0"."ontology_id" = "ontology_temporal_metadata_0_0_0"."ontology_id"
+            WHERE ("ontology_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ)
+              AND (("ontology_ids_0_1_0"."version" = "ontology_ids_0_1_0"."latest_version") AND ("ontology_ids_0_1_0"."base_url" = $2))
+            "#,
+            &[
+                &pinned_timestamp,
+                &"https://blockprotocol.org/@blockprotocol/types/data-type/text/",
+            ],
+        );
+    }
+
+    /// A tuple whose columns stand on two tables is excluded from bundling: its
+    /// membership form would be a condition above the join, which the planner answers by
+    /// materializing the whole join first (measured at 14x the disjunction). The shape is
+    /// client-reachable (the REST filter body deserializes arbitrary `Any`/`All` nesting,
+    /// and a custom web policy builds it through `CreatedByPrincipal`), so it must stay a
+    /// plain disjunction of conjunctions with each qual pushed to its own table.
+    #[test]
+    fn cross_table_uuid_pairs_stay_direct() {
+        let webs = [Uuid::new_v4(), Uuid::new_v4()];
+        let actors = [Uuid::new_v4(), Uuid::new_v4()];
+
+        let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
+        let pinned_timestamp = temporal_axes.pinned_timestamp();
+        let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes), false);
+
+        let filter = Filter::Any(
+            webs.into_iter()
+                .zip(actors)
+                .map(|(web_id, actor_id)| {
+                    Filter::All(vec![
+                        Filter::Equal(
+                            FilterExpression::Path {
+                                path: EntityQueryPath::WebId,
+                            },
+                            FilterExpression::Parameter {
+                                parameter: Parameter::Uuid(web_id),
+                                convert: None,
+                            },
+                        ),
+                        Filter::Equal(
+                            FilterExpression::Path {
+                                path: EntityQueryPath::CreatedById,
+                            },
+                            FilterExpression::Parameter {
+                                parameter: Parameter::Uuid(actor_id),
+                                convert: None,
+                            },
+                        ),
+                    ])
+                })
+                .collect(),
+        );
+        compiler.add_filter(&filter).expect("Failed to add filter");
+
+        test_compilation(
+            &compiler,
+            r#"
+            SELECT *
+            FROM "entity_temporal_metadata" AS "entity_temporal_metadata_0_0_0"
+            INNER JOIN "entity_ids" AS "entity_ids_0_1_0"
+                ON "entity_ids_0_1_0"."web_id" = "entity_temporal_metadata_0_0_0"."web_id"
+                AND "entity_ids_0_1_0"."entity_uuid" = "entity_temporal_metadata_0_0_0"."entity_uuid"
+            WHERE ("entity_temporal_metadata_0_0_0"."draft_id" IS NULL)
+              AND ("entity_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ)
+              AND ("entity_temporal_metadata_0_0_0"."decision_time" && $2)
+              AND (((("entity_ids_0_1_0"."created_by_id" = $3) AND ("entity_temporal_metadata_0_0_0"."web_id" = $4)) OR (("entity_ids_0_1_0"."created_by_id" = $5) AND ("entity_temporal_metadata_0_0_0"."web_id" = $6))))
+            "#,
+            &[
+                &pinned_timestamp,
+                &temporal_axes.variable_interval(),
+                &actors[0],
+                &webs[0],
+                &actors[1],
+                &webs[1],
+            ],
+        );
+    }
+
+    /// Drafted identities carry a third equality, so they bundle as their own
+    /// three-column tuple beside the published pairs: two membership predicates and no
+    /// disjunction tail. Canonical order puts `draft_id` first, then `entity_uuid`, then
+    /// `web_id`.
+    #[test]
+    fn drafted_entity_ids_bundle_as_their_own_triple() {
+        let published = [published_entity_id(), published_entity_id()];
+        let drafted = [drafted_entity_id(), drafted_entity_id()];
+
+        let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
+        let pinned_timestamp = temporal_axes.pinned_timestamp();
+        let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes), true);
+
+        let filter = Filter::Any(vec![
+            Filter::for_entity_by_entity_id(published[0]),
+            Filter::for_entity_by_entity_id(drafted[0]),
+            Filter::for_entity_by_entity_id(published[1]),
+            Filter::for_entity_by_entity_id(drafted[1]),
+        ]);
+        compiler.add_filter(&filter).expect("Failed to add filter");
+
+        test_compilation(
+            &compiler,
+            r#"
+            SELECT *
+            FROM "entity_temporal_metadata" AS "entity_temporal_metadata_0_0_0"
+            WHERE ("entity_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ)
+              AND ("entity_temporal_metadata_0_0_0"."decision_time" && $2)
+              AND (((ROW("entity_temporal_metadata_0_0_0"."entity_uuid", "entity_temporal_metadata_0_0_0"."web_id") = ANY(SELECT "unnest_0_0_0"."elem_1", "unnest_0_0_0"."elem_2" FROM UNNEST(($3::uuid[]), ($4::uuid[])) AS "unnest_0_0_0"("elem_1", "elem_2"))) OR (ROW("entity_temporal_metadata_0_0_0"."draft_id", "entity_temporal_metadata_0_0_0"."entity_uuid", "entity_temporal_metadata_0_0_0"."web_id") = ANY(SELECT "unnest_0_0_1"."elem_1", "unnest_0_0_1"."elem_2", "unnest_0_0_1"."elem_3" FROM UNNEST(($5::uuid[]), ($6::uuid[]), ($7::uuid[])) AS "unnest_0_0_1"("elem_1", "elem_2", "elem_3")))))
+            "#,
+            &[
+                &pinned_timestamp,
+                &temporal_axes.variable_interval(),
+                &[
+                    Uuid::from(published[0].entity_uuid),
+                    Uuid::from(published[1].entity_uuid),
+                ],
+                &[
+                    Uuid::from(published[0].web_id),
+                    Uuid::from(published[1].web_id),
+                ],
+                &[
+                    Uuid::from(drafted[0].draft_id.expect("drafted id")),
+                    Uuid::from(drafted[1].draft_id.expect("drafted id")),
+                ],
+                &[
+                    Uuid::from(drafted[0].entity_uuid),
+                    Uuid::from(drafted[1].entity_uuid),
+                ],
+                &[Uuid::from(drafted[0].web_id), Uuid::from(drafted[1].web_id)],
+            ],
+        );
+    }
+
+    /// A tuple is as wide as its group pins columns: four same-table equalities bundle
+    /// into a four-member membership, whatever order the group wrote them in.
+    #[test]
+    fn four_column_tuples_bundle_at_their_own_width() {
+        let tuples: [[Uuid; 4]; 2] = [
+            [
+                Uuid::new_v4(),
+                Uuid::new_v4(),
+                Uuid::new_v4(),
+                Uuid::new_v4(),
+            ],
+            [
+                Uuid::new_v4(),
+                Uuid::new_v4(),
+                Uuid::new_v4(),
+                Uuid::new_v4(),
+            ],
+        ];
+
+        let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
+        let pinned_timestamp = temporal_axes.pinned_timestamp();
+        let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes), true);
+
+        // Written web → edition → uuid → draft, and canonical order sorts draft_id first.
+        let filter = Filter::Any(
+            tuples
+                .iter()
+                .map(|&[draft, edition, uuid, web]| {
+                    Filter::All(vec![
+                        uuid_equality(EntityQueryPath::WebId, web),
+                        uuid_equality(EntityQueryPath::EditionId, edition),
+                        uuid_equality(EntityQueryPath::Uuid, uuid),
+                        uuid_equality(EntityQueryPath::DraftId, draft),
+                    ])
+                })
+                .collect(),
+        );
+        compiler.add_filter(&filter).expect("Failed to add filter");
+
+        test_compilation(
+            &compiler,
+            r#"
+            SELECT *
+            FROM "entity_temporal_metadata" AS "entity_temporal_metadata_0_0_0"
+            WHERE ("entity_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ)
+              AND ("entity_temporal_metadata_0_0_0"."decision_time" && $2)
+              AND (ROW("entity_temporal_metadata_0_0_0"."draft_id", "entity_temporal_metadata_0_0_0"."entity_edition_id", "entity_temporal_metadata_0_0_0"."entity_uuid", "entity_temporal_metadata_0_0_0"."web_id") = ANY(SELECT "unnest_0_0_0"."elem_1", "unnest_0_0_0"."elem_2", "unnest_0_0_0"."elem_3", "unnest_0_0_0"."elem_4" FROM UNNEST(($3::uuid[]), ($4::uuid[]), ($5::uuid[]), ($6::uuid[])) AS "unnest_0_0_0"("elem_1", "elem_2", "elem_3", "elem_4")))
+            "#,
+            &[
+                &pinned_timestamp,
+                &temporal_axes.variable_interval(),
+                &[tuples[0][0], tuples[1][0]],
+                &[tuples[0][1], tuples[1][1]],
+                &[tuples[0][2], tuples[1][2]],
+                &[tuples[0][3], tuples[1][3]],
+            ],
+        );
+    }
+
+    /// Each member's array carries its own column's stored type, so a tuple mixing a
+    /// timestamp column with a uuid column binds `timestamptz[]` beside `uuid[]`.
+    #[test]
+    fn mixed_type_tuples_type_each_array_from_its_column() {
+        let actors = [Uuid::new_v4(), Uuid::new_v4()];
+
+        let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
+        let pinned_timestamp = temporal_axes.pinned_timestamp();
+        let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes), false);
+
+        let filter = Filter::Any(
+            actors
+                .iter()
+                .map(|&actor| {
+                    Filter::All(vec![
+                        uuid_equality(EntityQueryPath::CreatedById, actor),
+                        Filter::Equal(
+                            FilterExpression::Path {
+                                path: EntityQueryPath::CreatedAtTransactionTime,
+                            },
+                            FilterExpression::Parameter {
+                                parameter: Parameter::Timestamp(Timestamp::UNIX_EPOCH),
+                                convert: None,
+                            },
+                        ),
+                    ])
+                })
+                .collect(),
+        );
+        compiler.add_filter(&filter).expect("Failed to add filter");
+
+        test_compilation(
+            &compiler,
+            r#"
+            SELECT *
+            FROM "entity_temporal_metadata" AS "entity_temporal_metadata_0_0_0"
+            INNER JOIN "entity_ids" AS "entity_ids_0_1_0"
+                ON "entity_ids_0_1_0"."web_id" = "entity_temporal_metadata_0_0_0"."web_id"
+                AND "entity_ids_0_1_0"."entity_uuid" = "entity_temporal_metadata_0_0_0"."entity_uuid"
+            WHERE ("entity_temporal_metadata_0_0_0"."draft_id" IS NULL)
+              AND ("entity_temporal_metadata_0_0_0"."transaction_time" @> $1::TIMESTAMPTZ)
+              AND ("entity_temporal_metadata_0_0_0"."decision_time" && $2)
+              AND (ROW("entity_ids_0_1_0"."created_at_transaction_time", "entity_ids_0_1_0"."created_by_id") = ANY(SELECT "unnest_0_0_0"."elem_1", "unnest_0_0_0"."elem_2" FROM UNNEST(($3::timestamptz[]), ($4::uuid[])) AS "unnest_0_0_0"("elem_1", "elem_2")))
+            "#,
+            &[
+                &pinned_timestamp,
+                &temporal_axes.variable_interval(),
+                &[Timestamp::<()>::UNIX_EPOCH, Timestamp::<()>::UNIX_EPOCH],
+                &[actors[0], actors[1]],
             ],
         );
     }
@@ -2226,6 +2721,371 @@ mod property_masking {
         assert!(
             sql.contains(r#"ORDER BY jsonb_path_query_first(("entity_editions_0_1_0"."properties" - (CASE WHEN"#),
             "ORDER BY should use masked properties expression: {sql}"
+        );
+    }
+}
+
+/// The column-tuple recognizer against its oracle: every shape it gathers and then
+/// excludes must compile to the bytes the plain path produces, and every exclusion must
+/// keep the semantics the plain path owns.
+mod tuple_bundling {
+    use super::*;
+
+    fn compile(filter: &Filter<'_, Entity>) -> (String, Vec<String>) {
+        let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
+        compile_with(&temporal_axes, filter)
+    }
+
+    fn compile_with(
+        temporal_axes: &hash_graph_store::subgraph::temporal_axes::QueryTemporalAxes,
+        filter: &Filter<'_, Entity>,
+    ) -> (String, Vec<String>) {
+        let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(temporal_axes), false);
+        compiler.add_filter(filter).expect("should compile");
+        let (statement, parameters) = compiler.compile();
+        (
+            trim_whitespace(&statement),
+            parameters
+                .map(|parameter| format!("{parameter:?}"))
+                .collect(),
+        )
+    }
+
+    /// For every shape the recognizer gathers and then excludes, the hand-built
+    /// conjunction must be the expression the re-compile would have produced. The oracle
+    /// is the same equalities in canonical order under an `All` group, which the
+    /// recognizer never sees and which therefore still goes through `compile_filter` and
+    /// `compile_path_column`.
+    #[track_caller]
+    fn assert_matches_recompile(
+        recognized: Vec<Filter<'static, Entity>>,
+        canonical_order: Vec<Filter<'static, Entity>>,
+    ) {
+        let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
+        let through_recognizer =
+            compile_with(&temporal_axes, &Filter::Any(vec![Filter::All(recognized)]));
+        let through_compile_filter = compile_with(
+            &temporal_axes,
+            &Filter::All(vec![Filter::All(canonical_order)]),
+        );
+        pretty_assertions::assert_eq!(
+            through_recognizer.0,
+            through_compile_filter.0,
+            "the hand-built conjunction is not what the re-compile produces"
+        );
+        pretty_assertions::assert_eq!(through_recognizer.1, through_compile_filter.1);
+    }
+
+    #[test]
+    fn singleton_pair_matches_recompile() {
+        let web = Uuid::new_v4();
+        let uuid = Uuid::new_v4();
+        assert_matches_recompile(
+            vec![
+                uuid_equality(EntityQueryPath::WebId, web),
+                uuid_equality(EntityQueryPath::Uuid, uuid),
+            ],
+            vec![
+                uuid_equality(EntityQueryPath::Uuid, uuid),
+                uuid_equality(EntityQueryPath::WebId, web),
+            ],
+        );
+    }
+
+    #[test]
+    fn repeated_column_matches_recompile() {
+        let first = Uuid::new_v4();
+        let second = Uuid::new_v4();
+        assert_matches_recompile(
+            vec![
+                uuid_equality(EntityQueryPath::Uuid, first),
+                uuid_equality(EntityQueryPath::Uuid, second),
+            ],
+            vec![
+                uuid_equality(EntityQueryPath::Uuid, first),
+                uuid_equality(EntityQueryPath::Uuid, second),
+            ],
+        );
+    }
+
+    #[test]
+    fn cross_table_pair_matches_recompile() {
+        let web = Uuid::new_v4();
+        let creator = Uuid::new_v4();
+        assert_matches_recompile(
+            vec![
+                uuid_equality(EntityQueryPath::WebId, web),
+                uuid_equality(EntityQueryPath::CreatedById, creator),
+            ],
+            vec![
+                uuid_equality(EntityQueryPath::CreatedById, creator),
+                uuid_equality(EntityQueryPath::WebId, web),
+            ],
+        );
+    }
+
+    #[test]
+    fn cross_table_triple_matches_recompile() {
+        let web = Uuid::new_v4();
+        let uuid = Uuid::new_v4();
+        let creator = Uuid::new_v4();
+        assert_matches_recompile(
+            vec![
+                uuid_equality(EntityQueryPath::WebId, web),
+                uuid_equality(EntityQueryPath::Uuid, uuid),
+                uuid_equality(EntityQueryPath::CreatedById, creator),
+            ],
+            vec![
+                uuid_equality(EntityQueryPath::CreatedById, creator),
+                uuid_equality(EntityQueryPath::Uuid, uuid),
+                uuid_equality(EntityQueryPath::WebId, web),
+            ],
+        );
+    }
+
+    /// A triple standing on three tables at once.
+    #[test]
+    fn three_table_triple_stays_direct() {
+        let (statement, _) = compile(&Filter::Any(vec![Filter::All(vec![
+            uuid_equality(EntityQueryPath::WebId, Uuid::new_v4()),
+            uuid_equality(EntityQueryPath::CreatedById, Uuid::new_v4()),
+            uuid_equality(EntityQueryPath::EditionCreatedById, Uuid::new_v4()),
+        ])]));
+        assert!(
+            !statement.contains("UNNEST"),
+            "a three-table triple was bundled: {statement}"
+        );
+    }
+
+    /// The `bundleable` fold checks `correlation` equality on *adjacent* pairs of the
+    /// sorted halves, which is only sound because the sort key (`<table>.<column>`)
+    /// groups by table. This triple interleaves tables A, B, A when sorted by column name
+    /// alone, so it is the shape that would be wrongly bundled if the sort key ever
+    /// narrowed.
+    #[test]
+    fn interleaving_triple_stays_direct() {
+        let (statement, _) = compile(&Filter::Any(vec![Filter::All(vec![
+            uuid_equality(EntityQueryPath::Uuid, Uuid::new_v4()),
+            uuid_equality(
+                EntityQueryPath::EntityEdge {
+                    edge_kind: KnowledgeGraphEdgeKind::HasLeftEntity,
+                    path: Box::new(EntityQueryPath::Uuid),
+                    direction: EdgeDirection::Outgoing,
+                },
+                Uuid::new_v4(),
+            ),
+            uuid_equality(EntityQueryPath::WebId, Uuid::new_v4()),
+        ])]));
+        assert!(
+            !statement.contains("UNNEST"),
+            "a two-table triple was bundled: {statement}"
+        );
+    }
+
+    /// A column whose members mix parameter variants has no single typed array to bind, so
+    /// the bundle falls back to one parameter per member inside array literals, exactly as
+    /// the direct equalities would have bound them.
+    #[test]
+    fn mixed_variant_members_bind_per_element() {
+        let (statement, parameters) = compile(&Filter::Any(vec![
+            Filter::All(vec![
+                uuid_equality(EntityQueryPath::WebId, Uuid::new_v4()),
+                uuid_equality(EntityQueryPath::Uuid, Uuid::new_v4()),
+            ]),
+            Filter::All(vec![
+                Filter::Equal(
+                    FilterExpression::Path {
+                        path: EntityQueryPath::WebId,
+                    },
+                    FilterExpression::Parameter {
+                        parameter: Parameter::Text(Cow::Borrowed("not-a-uuid")),
+                        convert: None,
+                    },
+                ),
+                uuid_equality(EntityQueryPath::Uuid, Uuid::new_v4()),
+            ]),
+        ]));
+        assert_eq!(
+            statement.matches("FROM UNNEST").count(),
+            1,
+            "the bundle still compiles as one membership predicate: {statement}"
+        );
+        assert!(
+            statement.contains("UNNEST(ARRAY[$"),
+            "a mixed-variant column binds per element: {statement}"
+        );
+        assert_eq!(
+            parameters.len(),
+            6,
+            "two temporal parameters and one parameter per tuple member: {statement}"
+        );
+    }
+
+    /// One `Any` group carrying both bundleable and excluded tuples. The same-table pairs
+    /// bundle into one membership while the cross-table pair stays direct, and no filter
+    /// compiles twice.
+    #[test]
+    fn mixed_group_bundles_only_the_same_table_tuples() {
+        let (statement, parameters) = compile(&Filter::Any(vec![
+            Filter::All(vec![
+                uuid_equality(EntityQueryPath::WebId, Uuid::new_v4()),
+                uuid_equality(EntityQueryPath::Uuid, Uuid::new_v4()),
+            ]),
+            Filter::All(vec![
+                uuid_equality(EntityQueryPath::WebId, Uuid::new_v4()),
+                uuid_equality(EntityQueryPath::Uuid, Uuid::new_v4()),
+            ]),
+            Filter::All(vec![
+                uuid_equality(EntityQueryPath::WebId, Uuid::new_v4()),
+                uuid_equality(EntityQueryPath::CreatedById, Uuid::new_v4()),
+            ]),
+        ]));
+        assert_eq!(
+            statement.matches("FROM UNNEST").count(),
+            1,
+            "expected exactly one membership predicate: {statement}"
+        );
+        assert_eq!(
+            parameters.len(),
+            6,
+            "two temporal parameters, the cross-table pair's two uuids, and one array per bundled \
+             column: {statement}"
+        );
+        assert_eq!(
+            statement.matches("INNER JOIN \"entity_ids\"").count(),
+            1,
+            "the cross-table pair should add exactly one join: {statement}"
+        );
+    }
+
+    /// The excluded-shape fallback builds from the halves already resolved instead of
+    /// re-compiling the filter, because a re-compile resolves the same joins a second
+    /// time and leaves the first resolution orphaned in the FROM clause. Some qual must
+    /// therefore reference every alias standing in FROM.
+    #[test]
+    fn edge_path_tuple_leaves_no_orphan_join() {
+        let edge = |kind, path| EntityQueryPath::EntityEdge {
+            edge_kind: kind,
+            path: Box::new(path),
+            direction: EdgeDirection::Outgoing,
+        };
+        let (statement, _) = compile(&Filter::Any(vec![
+            uuid_equality(
+                edge(
+                    KnowledgeGraphEdgeKind::HasLeftEntity,
+                    EntityQueryPath::EditionId,
+                ),
+                Uuid::new_v4(),
+            ),
+            Filter::All(vec![
+                uuid_equality(
+                    edge(
+                        KnowledgeGraphEdgeKind::HasRightEntity,
+                        EntityQueryPath::EditionId,
+                    ),
+                    Uuid::new_v4(),
+                ),
+                uuid_equality(
+                    edge(
+                        KnowledgeGraphEdgeKind::HasRightEntity,
+                        EntityQueryPath::DraftId,
+                    ),
+                    Uuid::new_v4(),
+                ),
+            ]),
+        ]));
+
+        let joins = statement.matches(" JOIN ").count();
+        let mut orphans = Vec::new();
+        for alias in statement.split(" AS ").skip(1) {
+            let Some(alias) = alias.split_whitespace().next() else {
+                continue;
+            };
+            let alias = alias.trim_end_matches([',', ')']);
+            // Something other than its own definition must reference every alias in
+            // FROM, so `AS "x"` needs at least one `"x"."column"` elsewhere.
+            if statement.matches(&format!("{alias}.")).count() == 0 {
+                orphans.push(alias.to_owned());
+            }
+        }
+        assert!(
+            orphans.is_empty(),
+            "orphaned aliases {orphans:?} in {joins} joins: {statement}"
+        );
+        assert_eq!(joins, 5, "join count drifted: {statement}");
+    }
+
+    /// An equality on an array-backed cache column means containment, never scalar
+    /// equality, so the recognizer refuses the whole group and it compiles through the
+    /// array predicates.
+    #[test]
+    fn array_backed_column_group_matches_recompile_and_keeps_containment() {
+        let web = Uuid::new_v4();
+        let group = || {
+            vec![
+                Filter::Equal(
+                    FilterExpression::Path {
+                        path: EntityQueryPath::EntityTypeEdge {
+                            edge_kind: SharedEdgeKind::IsOfType,
+                            path: EntityTypeQueryPath::VersionedUrl,
+                            inheritance_depth: None,
+                        },
+                    },
+                    FilterExpression::Parameter {
+                        parameter: Parameter::Text(Cow::Borrowed(
+                            "https://example.com/types/entity-type/person/v/1",
+                        )),
+                        convert: None,
+                    },
+                ),
+                uuid_equality(EntityQueryPath::WebId, web),
+            ]
+        };
+        assert_matches_recompile(group(), group());
+        let (statement, _) = compile(&Filter::Any(vec![Filter::All(group())]));
+        assert!(
+            !statement.contains("UNNEST"),
+            "an array-backed column was bundled: {statement}"
+        );
+        assert!(
+            statement.contains("@>"),
+            "the containment predicate is gone: {statement}"
+        );
+    }
+
+    /// A column carrying a column hook never enters a tuple, because the tuple forms
+    /// build their column references directly and would skip the hook's rewrite: a
+    /// masked properties read stays masked when a filter reads it.
+    #[test]
+    fn hooked_column_group_stays_on_the_plain_path() {
+        let config = PropertyProtectionFilterConfig::hash_default();
+        let property_filter = config.to_property_protection_filter(None);
+
+        let temporal_axes = QueryTemporalAxesUnresolved::all().resolve();
+        let mut compiler = SelectCompiler::<Entity>::with_asterisk(Some(&temporal_axes), false);
+        compiler.with_property_masking(&property_filter);
+
+        let filter = Filter::Any(vec![Filter::All(vec![
+            Filter::Equal(
+                FilterExpression::Path {
+                    path: EntityQueryPath::Properties(None),
+                },
+                FilterExpression::Parameter {
+                    parameter: Parameter::Any(PropertyValue::Null),
+                    convert: None,
+                },
+            ),
+            uuid_equality(EntityQueryPath::WebId, Uuid::new_v4()),
+        ])]);
+        compiler.add_filter(&filter).expect("should compile");
+        let (statement, _) = compiler.compile();
+        assert!(
+            !statement.contains("UNNEST"),
+            "a hooked column was bundled: {statement}"
+        );
+        assert!(
+            statement.contains("CASE WHEN"),
+            "the masked read lost its rewrite: {statement}"
         );
     }
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The peephole pass learns column-tuple fusion. An `Any` group whose `All` members each pin the same set of plain scalar columns states a row membership over value tuples. `ColumnTupleGroup` gathers those members in canonical column order and compiles the whole group to one membership predicate over unnested arrays, binding each column's values as a single array parameter. Neither the statement text nor the parameter count changes with the tuple count, so a filter enumerating thousands of rows binds a fixed number of parameters and keeps one statement identity.

Review focus: fusion preserves the unfused semantics exactly, including SQL's tri-valued logic. The oracle tests in `peephole/tuple.rs` compare the fused compilation against the unfused one, null handling included.

## 🔍 What does this change?

- `compile/peephole/tuple.rs`: `ColumnTupleGroup`, recognition and compilation of tuple memberships.
- `compile/peephole/mod.rs`: the `ColumnTuple` rewrite arm. `recognize` becomes a method because the tuple arm needs the compiler.
- `postgres-types` gains the `array-impls` feature, whose sole consumer is the `[Uuid; N]` test fixtures.
- `compile/tests.rs`: fixtures for the fused form.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- The oracle tests in `peephole/tuple.rs` and the fixtures in `compile/tests.rs`.
- The existing postgres-store lib suite covers this, plus the workspace battery: `cargo check`, clippy at zero warnings, `fmt` clean.

## ❓ How to test this?

```bash
cargo nextest run -p hash-graph-postgres-store --lib
```
