### PR TITLE
BE-780, BE-788: hgraph: Label property provenance and masked property-summary query paths

### DIFF
--- a/libs/@local/graph/migrations/graph-migrations/v009__entities/up.sql
+++ b/libs/@local/graph/migrations/graph-migrations/v009__entities/up.sql
@@ -42,10 +42,15 @@ CREATE TABLE entity_editions (
 -- `closed_schema.allOf`), ordered by (title, base URL, version DESC); `labels[1]` is
 -- the display/sort label, NULL when the entity has none. Descending sorts reuse the
 -- same element — no min/max flip.
+-- `label_properties` aggregates the winning `labelProperty` path over the same rows in
+-- the same order under the same non-null filter, so `labels[i]` is the value of the
+-- property named by `label_properties[i]`, and `label_properties[1]` names the property
+-- providing the display label. NULL exactly when `labels` is NULL.
 CREATE TABLE entity_edition_cache (
     entity_edition_id UUID PRIMARY KEY REFERENCES entity_editions ON DELETE CASCADE,
     direct_types INT NOT NULL,
     labels TEXT [],
+    label_properties TEXT [],
     type_titles TEXT [] NOT NULL,
     base_urls TEXT [] NOT NULL,
     versions BIGINT [] NOT NULL,

--- a/libs/@local/graph/postgres-store/postgres_migrations/V58__entity_edition_cache_label_properties.sql
+++ b/libs/@local/graph/postgres-store/postgres_migrations/V58__entity_edition_cache_label_properties.sql
@@ -1,0 +1,36 @@
+-- The cache's `labels` keeps the label values and drops which `labelProperty` path produced
+-- each one, so a reader capping or attributing properties has to re-derive the winning path
+-- per read. `label_properties` stores that path per label: both arrays aggregate over the
+-- same rows in the same order under the same non-null filter, so `labels[i]` is the value of
+-- the property named by `label_properties[i]`, and `label_properties[1]` names the property
+-- providing the entity's display label. NULL exactly when `labels` is NULL.
+ALTER TABLE entity_edition_cache ADD COLUMN label_properties TEXT [];
+
+UPDATE entity_edition_cache
+SET label_properties = derived.label_properties
+FROM (
+    SELECT
+        entity_is_of_type.entity_edition_id,
+        array_agg(label_value.path
+            ORDER BY entity_types.schema ->> 'title', ontology_ids.base_url,
+                ontology_ids.version DESC, label_value.ordinality
+        ) FILTER (WHERE label_value.label IS NOT NULL) AS label_properties
+    FROM entity_is_of_type
+    INNER JOIN ontology_ids
+        ON entity_is_of_type.entity_type_ontology_id = ontology_ids.ontology_id
+    INNER JOIN entity_types
+        ON ontology_ids.ontology_id = entity_types.ontology_id
+    INNER JOIN entity_editions
+        ON entity_is_of_type.entity_edition_id = entity_editions.entity_edition_id
+    CROSS JOIN LATERAL (
+        SELECT
+            jsonb_extract_path(entity_editions.properties, label_path.path) #>> '{}' AS label,
+            label_path.path,
+            label_path.ordinality
+        FROM jsonb_array_elements_text(jsonb_path_query_array(entity_types.closed_schema, '$.allOf[*].labelProperty'))
+        WITH ORDINALITY AS label_path (path, ordinality)
+    ) AS label_value
+    WHERE entity_is_of_type.inheritance_depth = 0
+    GROUP BY entity_is_of_type.entity_edition_id
+) AS derived
+WHERE entity_edition_cache.entity_edition_id = derived.entity_edition_id;

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
@@ -2978,6 +2978,7 @@ fn insert_entity_edition_cache_statement(scoped: bool) -> String {
         entity_edition_id,
         direct_types,
         labels,
+        label_properties,
         type_titles,
         base_urls,
         versions,
@@ -2986,6 +2987,7 @@ fn insert_entity_edition_cache_statement(scoped: bool) -> String {
     SELECT types.entity_edition_id,
            types.direct_types,
            labels.labels,
+           labels.label_properties,
            types.type_titles,
            types.base_urls,
            types.versions,
@@ -3028,7 +3030,11 @@ fn insert_entity_edition_cache_statement(scoped: bool) -> String {
                  array_agg(label_value.label
                      ORDER BY entity_types.schema ->> 'title', ontology_ids.base_url,
                               ontology_ids.version DESC, label_value.ordinality
-                 ) FILTER (WHERE label_value.label IS NOT NULL) AS labels
+                 ) FILTER (WHERE label_value.label IS NOT NULL) AS labels,
+                 array_agg(label_value.path
+                     ORDER BY entity_types.schema ->> 'title', ontology_ids.base_url,
+                              ontology_ids.version DESC, label_value.ordinality
+                 ) FILTER (WHERE label_value.label IS NOT NULL) AS label_properties
             FROM entity_is_of_type
             JOIN ontology_ids
               ON entity_is_of_type.entity_type_ontology_id = ontology_ids.ontology_id
@@ -3040,6 +3046,7 @@ fn insert_entity_edition_cache_statement(scoped: bool) -> String {
                SELECT jsonb_extract_path(
                           entity_editions.properties, label_path.path
                       ) #>> '{{}}' AS label,
+                      label_path.path,
                       label_path.ordinality
                  FROM jsonb_array_elements_text(
                           jsonb_path_query_array(

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/compile/tests.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/compile/tests.rs
@@ -2769,30 +2769,30 @@ mod scalar_properties {
             r#"
             SELECT
                 (SELECT jsonb_object_agg("scalar_property"."key", "scalar_property"."value")
-                FROM jsonb_each(("entity_editions_0_1_0"."properties" - (CASE WHEN
-                    ("entity_temporal_metadata_0_0_0"."entity_uuid" != $2)
-                    AND ("entity_edition_cache_0_1_0"."base_urls" @> ARRAY[$3]::text[])
-                    THEN ARRAY[$4]::text[]
-                    ELSE ARRAY[]::text[] END))) AS "scalar_property"("key", "value")
-                WHERE jsonb_typeof("scalar_property"."value") = ANY(($1::text[]))),
+                   FROM jsonb_each(("entity_editions_0_1_0"."properties" -
+                        (CASE WHEN
+                            "entity_edition_cache_0_1_0"."base_urls" @> ARRAY[$2]::text[]
+                            THEN ARRAY[$3]::text[]
+                            ELSE ARRAY[]::text[]
+                        END)))
+                        AS "scalar_property"("key", "value")
+                  WHERE jsonb_typeof("scalar_property"."value") = ANY(($1::text[]))),
                 ((SELECT count(*)
-                FROM jsonb_each(("entity_editions_0_1_0"."properties" - (CASE WHEN
-                    ("entity_temporal_metadata_0_0_0"."entity_uuid" != $2)
-                    AND ("entity_edition_cache_0_1_0"."base_urls" @> ARRAY[$3]::text[])
-                    THEN ARRAY[$4]::text[]
-                    ELSE ARRAY[]::text[] END))) AS "scalar_property"("key", "value"))::int4)
+                    FROM jsonb_each(("entity_editions_0_1_0"."properties" -
+                        (CASE WHEN "entity_edition_cache_0_1_0"."base_urls" @> ARRAY[$2]::text[]
+                            THEN ARRAY[$3]::text[]
+                            ELSE ARRAY[]::text[]
+                        END)))
+                        AS "scalar_property"("key", "value"))::int4)
             FROM "entity_temporal_metadata" AS "entity_temporal_metadata_0_0_0"
             INNER JOIN "entity_editions" AS "entity_editions_0_1_0"
-                ON "entity_editions_0_1_0"."entity_edition_id" =
-                    "entity_temporal_metadata_0_0_0"."entity_edition_id"
+                ON "entity_editions_0_1_0"."entity_edition_id" = "entity_temporal_metadata_0_0_0"."entity_edition_id"
             INNER JOIN "entity_edition_cache" AS "entity_edition_cache_0_1_0"
-                ON "entity_edition_cache_0_1_0"."entity_edition_id" =
-                    "entity_temporal_metadata_0_0_0"."entity_edition_id"
+                ON "entity_edition_cache_0_1_0"."entity_edition_id" = "entity_temporal_metadata_0_0_0"."entity_edition_id"
             WHERE "entity_temporal_metadata_0_0_0"."draft_id" IS NULL
             "#,
             &[
                 &SCALAR_TYPES,
-                &Uuid::nil(),
                 &"https://hash.ai/@h/types/entity-type/user/",
                 &"https://hash.ai/@h/types/property-type/email/",
             ],

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/compile/tests.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/compile/tests.rs
@@ -1949,6 +1949,24 @@ fn semantic_ordering_production_shape() {
 }
 
 #[test]
+fn select_first_label_property() {
+    let mut compiler = SelectCompiler::<Entity>::new(None, false);
+    compiler.add_selection_path(&EntityQueryPath::FirstLabelProperty);
+
+    test_compilation(
+        &compiler,
+        r#"
+        SELECT ("entity_edition_cache_0_1_0"."label_properties")[1]
+        FROM "entity_temporal_metadata" AS "entity_temporal_metadata_0_0_0"
+        INNER JOIN "entity_edition_cache" AS "entity_edition_cache_0_1_0"
+          ON "entity_edition_cache_0_1_0"."entity_edition_id" = "entity_temporal_metadata_0_0_0"."entity_edition_id"
+        WHERE "entity_temporal_metadata_0_0_0"."draft_id" IS NULL
+        "#,
+        &[],
+    );
+}
+
+#[test]
 fn semantic_ordering_rejects_non_embedding_paths() {
     let embedding = Embedding::from(vec![0.0; 3072]);
 
@@ -2722,6 +2740,114 @@ mod property_masking {
             sql.contains(r#"ORDER BY jsonb_path_query_first(("entity_editions_0_1_0"."properties" - (CASE WHEN"#),
             "ORDER BY should use masked properties expression: {sql}"
         );
+    }
+}
+
+mod scalar_properties {
+    use super::*;
+
+    /// The bound scalar type names, in the order the selection binds them.
+    const SCALAR_TYPES: &[&str] = &["string", "number", "boolean", "null"];
+
+    /// Both paths read the properties object through the column hook, so a configured masking
+    /// reaches the aggregated map and the count without either naming it.
+    #[test]
+    fn selection_reads_the_masked_object() {
+        let config = PropertyProtectionFilterConfig::hash_default();
+
+        let mut compiler = SelectCompiler::<Entity>::new(None, false);
+
+        let property_filter = config.to_property_protection_filter(None);
+        compiler.with_property_masking(&property_filter);
+
+        let scalars = compiler.add_selection_path(&EntityQueryPath::ScalarProperties);
+        let total = compiler.add_selection_path(&EntityQueryPath::PropertyCount);
+        assert_eq!((scalars, total), (0, 1));
+
+        test_compilation(
+            &compiler,
+            r#"
+            SELECT
+                (SELECT jsonb_object_agg("scalar_property"."key", "scalar_property"."value")
+                FROM jsonb_each(("entity_editions_0_1_0"."properties" - (CASE WHEN
+                    ("entity_temporal_metadata_0_0_0"."entity_uuid" != $2)
+                    AND ("entity_edition_cache_0_1_0"."base_urls" @> ARRAY[$3]::text[])
+                    THEN ARRAY[$4]::text[]
+                    ELSE ARRAY[]::text[] END))) AS "scalar_property"("key", "value")
+                WHERE jsonb_typeof("scalar_property"."value") = ANY(($1::text[]))),
+                ((SELECT count(*)
+                FROM jsonb_each(("entity_editions_0_1_0"."properties" - (CASE WHEN
+                    ("entity_temporal_metadata_0_0_0"."entity_uuid" != $2)
+                    AND ("entity_edition_cache_0_1_0"."base_urls" @> ARRAY[$3]::text[])
+                    THEN ARRAY[$4]::text[]
+                    ELSE ARRAY[]::text[] END))) AS "scalar_property"("key", "value"))::int4)
+            FROM "entity_temporal_metadata" AS "entity_temporal_metadata_0_0_0"
+            INNER JOIN "entity_editions" AS "entity_editions_0_1_0"
+                ON "entity_editions_0_1_0"."entity_edition_id" =
+                    "entity_temporal_metadata_0_0_0"."entity_edition_id"
+            INNER JOIN "entity_edition_cache" AS "entity_edition_cache_0_1_0"
+                ON "entity_edition_cache_0_1_0"."entity_edition_id" =
+                    "entity_temporal_metadata_0_0_0"."entity_edition_id"
+            WHERE "entity_temporal_metadata_0_0_0"."draft_id" IS NULL
+            "#,
+            &[
+                &SCALAR_TYPES,
+                &Uuid::nil(),
+                &"https://hash.ai/@h/types/entity-type/user/",
+                &"https://hash.ai/@h/types/property-type/email/",
+            ],
+        );
+    }
+
+    /// Without a configured masking both paths read the bare properties column.
+    #[test]
+    fn selection_reads_the_bare_object_without_masking() {
+        let mut compiler = SelectCompiler::<Entity>::new(None, false);
+
+        let scalars = compiler.add_selection_path(&EntityQueryPath::ScalarProperties);
+        let total = compiler.add_selection_path(&EntityQueryPath::PropertyCount);
+        assert_eq!((scalars, total), (0, 1));
+
+        test_compilation(
+            &compiler,
+            r#"
+            SELECT
+                (SELECT jsonb_object_agg("scalar_property"."key", "scalar_property"."value")
+                FROM jsonb_each("entity_editions_0_1_0"."properties")
+                    AS "scalar_property"("key", "value")
+                WHERE jsonb_typeof("scalar_property"."value") = ANY(($1::text[]))),
+                ((SELECT count(*)
+                FROM jsonb_each("entity_editions_0_1_0"."properties")
+                    AS "scalar_property"("key", "value"))::int4)
+            FROM "entity_temporal_metadata" AS "entity_temporal_metadata_0_0_0"
+            INNER JOIN "entity_editions" AS "entity_editions_0_1_0"
+                ON "entity_editions_0_1_0"."entity_edition_id" =
+                    "entity_temporal_metadata_0_0_0"."entity_edition_id"
+            WHERE "entity_temporal_metadata_0_0_0"."draft_id" IS NULL
+            "#,
+            &[&SCALAR_TYPES],
+        );
+    }
+
+    /// A repeated path answers the first selection's position instead of appending a copy.
+    #[test]
+    fn selection_is_added_once() {
+        let mut compiler = SelectCompiler::<Entity>::new(None, false);
+
+        let first = compiler.add_selection_path(&EntityQueryPath::ScalarProperties);
+        let second = compiler.add_selection_path(&EntityQueryPath::ScalarProperties);
+        assert_eq!(
+            first, second,
+            "the second call answers a different position"
+        );
+
+        let (compiled_statement, parameters) = compiler.compile();
+        assert_eq!(
+            compiled_statement.matches("jsonb_object_agg").count(),
+            1,
+            "the second call appended a second subquery: {compiled_statement}"
+        );
+        assert_eq!(parameters.len(), 1, "the second call bound its own copy");
     }
 }
 

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/entity.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/entity.rs
@@ -37,6 +37,8 @@ impl PostgresQueryPath for EntityQueryPath<'_> {
                 vec![Relation::RightEntity]
             }
             Self::Properties(_)
+            | Self::ScalarProperties
+            | Self::PropertyCount
             | Self::Label { .. }
             | Self::EditionProvenance(_)
             | Self::EditionCreatedById
@@ -48,6 +50,7 @@ impl PostgresQueryPath for EntityQueryPath<'_> {
             Self::DirectTypeCount
             | Self::FirstTypeTitle
             | Self::FirstLabel
+            | Self::FirstLabelProperty
             | Self::EntityTypeEdge {
                 edge_kind: SharedEdgeKind::IsOfType,
                 path:
@@ -211,6 +214,14 @@ impl PostgresQueryPath for EntityQueryPath<'_> {
                 Column::EntityEditions(EntityEditions::Properties),
                 path.as_ref().map(JsonField::JsonPath),
             ),
+            Self::ScalarProperties => (
+                Column::EntityEditions(EntityEditions::Properties),
+                Some(JsonField::ScalarEntries),
+            ),
+            Self::PropertyCount => (
+                Column::EntityEditions(EntityEditions::Properties),
+                Some(JsonField::EntryCount),
+            ),
             Self::Label { inheritance_depth } => (
                 Column::EntityEditions(EntityEditions::Properties),
                 Some(JsonField::Label {
@@ -252,6 +263,10 @@ impl PostgresQueryPath for EntityQueryPath<'_> {
             ),
             Self::FirstLabel => (
                 Column::EntityEditionCache(EntityEditionCache::Labels),
+                Some(JsonField::ArrayElement(1)),
+            ),
+            Self::FirstLabelProperty => (
+                Column::EntityEditionCache(EntityEditionCache::LabelProperties),
                 Some(JsonField::ArrayElement(1)),
             ),
         }

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/table.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/table.rs
@@ -845,6 +845,7 @@ pub enum EntityEditionCache {
     EntityEditionId,
     DirectTypes,
     Labels,
+    LabelProperties,
     TypeTitles,
     BaseUrls,
     Versions,
@@ -857,6 +858,7 @@ impl DatabaseColumn<'_> for EntityEditionCache {
             Self::EntityEditionId => "entity_edition_id".into(),
             Self::DirectTypes => "direct_types".into(),
             Self::Labels => "labels".into(),
+            Self::LabelProperties => "label_properties".into(),
             Self::TypeTitles => "type_titles".into(),
             Self::BaseUrls => "base_urls".into(),
             Self::Versions => "versions".into(),
@@ -868,9 +870,11 @@ impl DatabaseColumn<'_> for EntityEditionCache {
         match self {
             Self::EntityEditionId => PostgresType::Uuid,
             Self::DirectTypes => PostgresType::Int4,
-            Self::Labels | Self::TypeTitles | Self::BaseUrls | Self::VersionedUrls => {
-                PostgresType::Array(Box::new(PostgresType::Text))
-            }
+            Self::Labels
+            | Self::LabelProperties
+            | Self::TypeTitles
+            | Self::BaseUrls
+            | Self::VersionedUrls => PostgresType::Array(Box::new(PostgresType::Text)),
             Self::Versions => PostgresType::Array(Box::new(PostgresType::Int8)),
         }
     }
@@ -882,7 +886,9 @@ impl FilterColumn<'_> for EntityEditionCache {
             Self::EntityEditionId => ParameterType::Uuid,
             Self::DirectTypes => ParameterType::Integer,
             Self::Labels | Self::TypeTitles => ParameterType::Vector(Box::new(ParameterType::Text)),
-            Self::BaseUrls => ParameterType::Vector(Box::new(ParameterType::BaseUrl)),
+            Self::LabelProperties | Self::BaseUrls => {
+                ParameterType::Vector(Box::new(ParameterType::BaseUrl))
+            }
             Self::Versions => ParameterType::Vector(Box::new(ParameterType::OntologyTypeVersion)),
             Self::VersionedUrls => ParameterType::Vector(Box::new(ParameterType::VersionedUrl)),
         }

--- a/libs/@local/graph/store/src/entity/query.rs
+++ b/libs/@local/graph/store/src/entity/query.rs
@@ -422,6 +422,27 @@ pub enum EntityQueryPath<'p> {
     /// [`Entity`]: type_system::knowledge::Entity
     /// [`Entity::properties`]: type_system::knowledge::Entity::properties
     Properties(Option<JsonPath<'p>>),
+    /// The scalar entries of [`Entity::properties`], as one `jsonb` map.
+    ///
+    /// The map carries every property whose value is a string, a number, a boolean, or an
+    /// explicit null, and is SQL `NULL` when no entry qualifies. A configured property masking
+    /// removes a protected property here exactly as it does from [`Properties`].
+    ///
+    /// It's currently not possible to query for the scalar properties directly.
+    ///
+    /// [`Entity::properties`]: type_system::knowledge::Entity::properties
+    /// [`Properties`]: Self::Properties
+    ScalarProperties,
+    /// The number of entries of [`Entity::properties`].
+    ///
+    /// The count reads the same masked object as [`ScalarProperties`], so it also counts the
+    /// nested values that map excludes and never counts a masked property.
+    ///
+    /// It's currently not possible to query for the property count directly.
+    ///
+    /// [`Entity::properties`]: type_system::knowledge::Entity::properties
+    /// [`ScalarProperties`]: Self::ScalarProperties
+    PropertyCount,
     /// The property defined as [`label_property`] in the corresponding entity type metadata.
     ///
     /// ```rust
@@ -531,6 +552,15 @@ pub enum EntityQueryPath<'p> {
     /// [`Entity`]: type_system::knowledge::Entity
     /// [`EntityType`]: type_system::ontology::entity_type::EntityType
     FirstLabel,
+    /// Corresponds to the base URL of the property providing [`FirstLabel`].
+    ///
+    /// The value is the `labelProperty` path that produced [`FirstLabel`], so an entity with a
+    /// label always carries the pair, aligned.
+    ///
+    /// It's currently not possible to query for the first label property directly.
+    ///
+    /// [`FirstLabel`]: Self::FirstLabel
+    FirstLabelProperty,
 }
 
 impl fmt::Display for EntityQueryPath<'_> {
@@ -551,6 +581,8 @@ impl fmt::Display for EntityQueryPath<'_> {
             Self::CreatedAtDecisionTime => fmt.write_str("createdAtDecisionTime"),
             Self::Properties(Some(property)) => write!(fmt, "properties.{property}"),
             Self::Properties(None) => fmt.write_str("properties"),
+            Self::ScalarProperties => fmt.write_str("scalarProperties"),
+            Self::PropertyCount => fmt.write_str("propertyCount"),
             Self::Provenance(Some(path)) => write!(fmt, "provenance.{path}"),
             Self::Provenance(None) => fmt.write_str("provenance"),
             Self::Label { .. } => fmt.write_str("label"),
@@ -596,6 +628,7 @@ impl fmt::Display for EntityQueryPath<'_> {
             Self::RightEntityProvenance => fmt.write_str("rightEntityProvenance"),
             Self::FirstTypeTitle => fmt.write_str("firstTypeTitle"),
             Self::FirstLabel => fmt.write_str("firstLabel"),
+            Self::FirstLabelProperty => fmt.write_str("firstLabelProperty"),
         }
     }
 }
@@ -613,8 +646,9 @@ impl QueryPath for EntityQueryPath<'_> {
             Self::CreatedAtTransactionTime | Self::CreatedAtDecisionTime => {
                 ParameterType::Timestamp
             }
-            Self::DirectTypeCount => ParameterType::Integer,
+            Self::DirectTypeCount | Self::PropertyCount => ParameterType::Integer,
             Self::Properties(_)
+            | Self::ScalarProperties
             | Self::Label { .. }
             | Self::Provenance(_)
             | Self::EditionProvenance(_)
@@ -629,6 +663,7 @@ impl QueryPath for EntityQueryPath<'_> {
             Self::EntityTypeEdge { path, .. } => path.expected_type(),
             Self::EntityEdge { path, .. } => path.expected_type(),
             Self::FirstTypeTitle | Self::FirstLabel => ParameterType::Text,
+            Self::FirstLabelProperty => ParameterType::BaseUrl,
         }
     }
 }
@@ -993,6 +1028,8 @@ impl<'de: 'p, 'p> EntityQueryPath<'p> {
                 direction,
             },
             Self::Properties(path) => EntityQueryPath::Properties(path.map(JsonPath::into_owned)),
+            Self::ScalarProperties => EntityQueryPath::ScalarProperties,
+            Self::PropertyCount => EntityQueryPath::PropertyCount,
             Self::Label { inheritance_depth } => EntityQueryPath::Label { inheritance_depth },
             Self::Embedding => EntityQueryPath::Embedding,
             Self::EntityConfidence => EntityQueryPath::EntityConfidence,
@@ -1009,6 +1046,7 @@ impl<'de: 'p, 'p> EntityQueryPath<'p> {
             }
             Self::FirstTypeTitle => EntityQueryPath::FirstTypeTitle,
             Self::FirstLabel => EntityQueryPath::FirstLabel,
+            Self::FirstLabelProperty => EntityQueryPath::FirstLabelProperty,
         }
     }
 }

--- a/libs/@local/graph/store/src/filter/protection.rs
+++ b/libs/@local/graph/store/src/filter/protection.rs
@@ -619,6 +619,11 @@ impl<'p> PropertyProtectionFilterConfig<'p> {
 
     /// Returns the default HASH configuration that protects email on User entities.
     ///
+    /// Every protected property must be a property that no entity type names as its label
+    /// property. Entity labels are materialized into the label cache by extracting the label
+    /// property's value from the stored properties object, and that derivation takes no actor,
+    /// so the label column of a masked entity still carries the protected value.
+    ///
     /// # Panics
     ///
     /// Panics if the hardcoded URLs are invalid (should never happen).
@@ -846,7 +851,9 @@ fn collect_from_path<'f, 'p, I: Extend<&'f PropertyFilter<'p>>>(
             collect_from_json_path(json_path.as_ref(), config, excluded);
         }
         EntityQueryPath::EntityEdge { path, .. } => collect_from_path(path, config, excluded),
-        EntityQueryPath::Label { .. } | EntityQueryPath::FirstLabel => {
+        EntityQueryPath::Label { .. }
+        | EntityQueryPath::FirstLabel
+        | EntityQueryPath::FirstLabelProperty => {
             // TODO(BE-313): check if label_property is protected
         }
         EntityQueryPath::Embedding => {
@@ -859,6 +866,8 @@ fn collect_from_path<'f, 'p, I: Extend<&'f PropertyFilter<'p>>>(
         | EntityQueryPath::DecisionTime
         | EntityQueryPath::TransactionTime
         | EntityQueryPath::DirectTypeCount
+        | EntityQueryPath::ScalarProperties
+        | EntityQueryPath::PropertyCount
         | EntityQueryPath::EntityConfidence
         | EntityQueryPath::LeftEntityConfidence
         | EntityQueryPath::LeftEntityProvenance


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The entity edition cache records which property produced each cached label. `entity_edition_cache` gains `label_properties`. Both arrays aggregate over the same rows in the same order under the same non-null filter. `labels[i]` is therefore the value of the property named by `label_properties[i]`, and the first element names the property behind the display label. A reader capping or attributing properties stops re-deriving the winning path on every read.

The migrations pair up. `V58` alters deployed databases and backfills the column from the closed schemas. The fresh-database schema (`graph-migrations/v009`, the pre-production schema line that is edited in place by design) gains the same column in this PR, so a fresh database and a migrated one agree at this layer.

Review focus: the two arrays stay index-aligned because both aggregates share row set, order, and filter, so the `V58` backfill aggregation and `insert_entity_edition_cache_statement` read well side by side.

## 🔍 What does this change?

- `postgres_migrations/V58__entity_edition_cache_label_properties.sql`: the column and its backfill.
- `graph-migrations/v009__entities/up.sql`: the paired fresh-database column.
- `EntityQueryPath::{FirstLabelProperty, ScalarProperties, PropertyCount}` in `store/src/entity/query.rs`, with compile arms and `filter/protection.rs` support.
- `insert_entity_edition_cache_statement` writes the new column (`knowledge/entity/mod.rs`). `EntityEditionCache::LabelProperties` names it (`query/table.rs`).

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- The `scalar_properties` test module and `select_first_label_property` are new.
- The existing postgres-store lib suite covers this, plus the workspace battery: `cargo check`, clippy at zero warnings, `fmt` clean. The OpenAPI generator reproduces the committed spec byte-exact.

## ❓ How to test this?

```bash
cargo nextest run -p hash-graph-postgres-store --lib
```
