### PR TITLE
BE-781: hgraph: Entity event feed with deletion tombstones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3867,6 +3867,7 @@ dependencies = [
  "hash-telemetry",
  "hash-temporal-client",
  "indoc",
+ "pin-project-lite",
  "postgres-types",
  "pretty_assertions",
  "rayon",

--- a/libs/@local/graph/migrations/graph-migrations/v009__entities/up.sql
+++ b/libs/@local/graph/migrations/graph-migrations/v009__entities/up.sql
@@ -119,13 +119,8 @@ CREATE INDEX entity_temporal_metadata_closed_transaction_start
 ON entity_temporal_metadata (lower(transaction_time))
 WHERE draft_id IS NULL AND upper_inf(transaction_time) AND NOT upper_inf(decision_time);
 
--- The feed predicates are expressions, which carry no column statistics, so without these
--- objects the planner sweeps every present row for the ended arm. The mcv object prices the
--- predicate combination both arms share, which bounds the ended arm's anti-join by the
--- candidate count. The expression object gives the transaction-time start a histogram, which
--- fixes the changed arm's cardinality. The bounded plan wins to roughly twenty thousand
--- candidates per poll window. A burst the statistics have not caught up with stretches it to
--- about four times the sweep at a hundred thousand candidates.
+-- Give the planner a histogram for the transaction-time cutoff and multivariate statistics for
+-- the expression predicates shared by the feed arms.
 CREATE STATISTICS entity_temporal_metadata_transaction_start_stats
 ON lower(transaction_time) FROM entity_temporal_metadata;
 CREATE STATISTICS entity_temporal_metadata_feed_stats (MCV)

--- a/libs/@local/graph/migrations/graph-migrations/v009__entities/up.sql
+++ b/libs/@local/graph/migrations/graph-migrations/v009__entities/up.sql
@@ -6,13 +6,28 @@ CREATE TABLE entity_ids (
     created_by_id UUID NOT NULL,
     created_at_transaction_time TIMESTAMP WITH TIME ZONE NOT NULL,
     created_at_decision_time TIMESTAMP WITH TIME ZONE NOT NULL,
-    PRIMARY KEY (web_id, entity_uuid)
+    deleted_by_id UUID,
+    deleted_at_transaction_time TIMESTAMP WITH TIME ZONE,
+    deleted_at_decision_time TIMESTAMP WITH TIME ZONE,
+    PRIMARY KEY (web_id, entity_uuid),
+
+    -- The deletion tombstone is total or absent: either all three deleted_* columns are set, or
+    -- none is.
+    CONSTRAINT entity_ids_deletion_tombstone_total CHECK (
+        ((deleted_by_id IS NULL) = (deleted_at_transaction_time IS NULL))
+        AND ((deleted_by_id IS NULL) = (deleted_at_decision_time IS NULL))
+    )
 );
 
 CREATE INDEX entity_ids_created_at_transaction_time
 ON entity_ids (created_at_transaction_time);
 CREATE INDEX entity_ids_created_at_decision_time
 ON entity_ids (created_at_decision_time);
+
+CREATE INDEX entity_ids_deleted_at_transaction_time
+ON entity_ids (deleted_at_transaction_time)
+INCLUDE (web_id, entity_uuid)
+WHERE deleted_at_transaction_time IS NOT NULL;
 
 CREATE TABLE entity_drafts (
     web_id UUID NOT NULL,
@@ -93,6 +108,29 @@ ON entity_temporal_metadata
 USING gist (web_id, entity_uuid, transaction_time, decision_time);
 CREATE INDEX entity_temporal_metadata_edition_id_idx
 ON entity_temporal_metadata (entity_edition_id);
+
+-- The update feed polls current rows by their transaction-time start. Every predicate it uses
+-- is a function over a column, so only these partial expression indexes can serve it, one per
+-- feed arm: present rows for `changed`, decision-closed current rows for `ended`.
+CREATE INDEX entity_temporal_metadata_present_transaction_start
+ON entity_temporal_metadata (lower(transaction_time))
+WHERE draft_id IS NULL AND upper_inf(transaction_time) AND upper_inf(decision_time);
+CREATE INDEX entity_temporal_metadata_closed_transaction_start
+ON entity_temporal_metadata (lower(transaction_time))
+WHERE draft_id IS NULL AND upper_inf(transaction_time) AND NOT upper_inf(decision_time);
+
+-- The feed predicates are expressions, which carry no column statistics, so without these
+-- objects the planner sweeps every present row for the ended arm. The mcv object prices the
+-- predicate combination both arms share, which bounds the ended arm's anti-join by the
+-- candidate count. The expression object gives the transaction-time start a histogram, which
+-- fixes the changed arm's cardinality. The bounded plan wins to roughly twenty thousand
+-- candidates per poll window. A burst the statistics have not caught up with stretches it to
+-- about four times the sweep at a hundred thousand candidates.
+CREATE STATISTICS entity_temporal_metadata_transaction_start_stats
+ON lower(transaction_time) FROM entity_temporal_metadata;
+CREATE STATISTICS entity_temporal_metadata_feed_stats (MCV)
+ON draft_id, upper_inf(transaction_time), upper_inf(decision_time)
+FROM entity_temporal_metadata;
 
 CREATE TABLE entity_is_of_type (
     entity_edition_id UUID NOT NULL REFERENCES entity_editions,

--- a/libs/@local/graph/postgres-store/Cargo.toml
+++ b/libs/@local/graph/postgres-store/Cargo.toml
@@ -33,25 +33,26 @@ hash-status                    = { workspace = true }
 type-system                    = { workspace = true, features = ["postgres"] }
 
 # Private third-party dependencies
-async-scoped   = { workspace = true, features = ["use-tokio"] }
-bytes          = { workspace = true }
-clap           = { workspace = true, optional = true, features = ["derive", "env"] }
-derive-where   = { workspace = true }
-derive_more    = { workspace = true }
-dotenv-flow    = { workspace = true }
-futures        = { workspace = true }
-postgres-types = { workspace = true, features = ["array-impls", "derive", "with-serde_json-1"] }
-rayon          = { workspace = true }
-refinery       = { workspace = true, features = ["tokio-postgres"] }
-regex          = { workspace = true }
-semver         = { workspace = true, features = ["serde"] }
-serde          = { workspace = true, features = ["derive"] }
-serde_json     = { workspace = true }
-simple-mermaid = { workspace = true }
-time           = { workspace = true }
-tracing        = { workspace = true }
-utoipa         = { workspace = true, optional = true, features = ["uuid"] }
-uuid           = { workspace = true, features = ["v4", "serde"] }
+async-scoped     = { workspace = true, features = ["use-tokio"] }
+bytes            = { workspace = true }
+clap             = { workspace = true, optional = true, features = ["derive", "env"] }
+derive-where     = { workspace = true }
+derive_more      = { workspace = true }
+dotenv-flow      = { workspace = true }
+futures          = { workspace = true }
+pin-project-lite = { workspace = true }
+postgres-types   = { workspace = true, features = ["array-impls", "derive", "with-serde_json-1"] }
+rayon            = { workspace = true }
+refinery         = { workspace = true, features = ["tokio-postgres"] }
+regex            = { workspace = true }
+semver           = { workspace = true, features = ["serde"] }
+serde            = { workspace = true, features = ["derive"] }
+serde_json       = { workspace = true }
+simple-mermaid   = { workspace = true }
+time             = { workspace = true }
+tracing          = { workspace = true }
+utoipa           = { workspace = true, optional = true, features = ["uuid"] }
+uuid             = { workspace = true, features = ["v4", "serde"] }
 
 [dev-dependencies]
 # The crate's own test suites wrap each test in a rollback transaction, so they need the

--- a/libs/@local/graph/postgres-store/postgres_migrations/V59__entity_deletion_provenance_columns.sql
+++ b/libs/@local/graph/postgres-store/postgres_migrations/V59__entity_deletion_provenance_columns.sql
@@ -1,0 +1,26 @@
+ALTER TABLE entity_ids
+    ADD COLUMN deleted_by_id UUID,
+    ADD COLUMN deleted_at_transaction_time TIMESTAMPTZ,
+    ADD COLUMN deleted_at_decision_time TIMESTAMPTZ,
+    -- The deletion tombstone is total or absent: either all three deleted_* columns are set, or
+    -- none is.
+    ADD CONSTRAINT entity_ids_deletion_tombstone_total CHECK (
+        ((deleted_by_id IS NULL) = (deleted_at_transaction_time IS NULL))
+        AND ((deleted_by_id IS NULL) = (deleted_at_decision_time IS NULL))
+    );
+
+UPDATE entity_ids
+    SET deleted_by_id = (provenance ->> 'deletedById')::uuid,
+        deleted_at_transaction_time = (provenance ->> 'deletedAtTransactionTime')::timestamptz,
+        deleted_at_decision_time = (provenance ->> 'deletedAtDecisionTime')::timestamptz
+    WHERE provenance ? 'deletedById';
+
+UPDATE entity_ids
+    SET provenance = provenance
+        - 'deletedById' - 'deletedAtTransactionTime' - 'deletedAtDecisionTime'
+    WHERE provenance ?| array['deletedById', 'deletedAtTransactionTime', 'deletedAtDecisionTime'];
+
+CREATE INDEX entity_ids_deleted_at_transaction_time
+    ON entity_ids (deleted_at_transaction_time)
+    INCLUDE (web_id, entity_uuid)
+    WHERE deleted_at_transaction_time IS NOT NULL;

--- a/libs/@local/graph/postgres-store/postgres_migrations/V60__entity_present_feed_indexes.sql
+++ b/libs/@local/graph/postgres-store/postgres_migrations/V60__entity_present_feed_indexes.sql
@@ -1,0 +1,14 @@
+-- The update feed polls current rows by their transaction-time start. Every predicate it uses
+-- is a function over a column, so only these partial expression indexes can serve it, one per
+-- feed arm: present rows for `changed`, decision-closed current rows for `ended`.
+CREATE INDEX entity_temporal_metadata_present_transaction_start
+    ON entity_temporal_metadata (lower(transaction_time))
+    WHERE draft_id IS NULL
+        AND upper_inf(transaction_time)
+        AND upper_inf(decision_time);
+
+CREATE INDEX entity_temporal_metadata_closed_transaction_start
+    ON entity_temporal_metadata (lower(transaction_time))
+    WHERE draft_id IS NULL
+        AND upper_inf(transaction_time)
+        AND NOT upper_inf(decision_time);

--- a/libs/@local/graph/postgres-store/postgres_migrations/V61__entity_feed_statistics.sql
+++ b/libs/@local/graph/postgres-store/postgres_migrations/V61__entity_feed_statistics.sql
@@ -1,10 +1,5 @@
--- The feed predicates are expressions, which carry no column statistics, so without these
--- objects the planner sweeps every present row for the ended arm. The mcv object prices the
--- predicate combination both arms share, which bounds the ended arm's anti-join by the
--- candidate count. The expression object gives the transaction-time start a histogram, which
--- fixes the changed arm's cardinality. The bounded plan wins to roughly twenty thousand
--- candidates per poll window. A burst the statistics have not caught up with stretches it to
--- about four times the sweep at a hundred thousand candidates.
+-- Give the planner a histogram for the transaction-time cutoff and multivariate statistics for
+-- the expression predicates shared by the feed arms.
 CREATE STATISTICS entity_temporal_metadata_transaction_start_stats
     ON lower(transaction_time) FROM entity_temporal_metadata;
 
@@ -12,6 +7,5 @@ CREATE STATISTICS entity_temporal_metadata_feed_stats (mcv)
     ON draft_id, upper_inf(transaction_time), upper_inf(decision_time)
     FROM entity_temporal_metadata;
 
--- A statistics object is empty until the table is analyzed. Populated stores get real
--- estimates at migration time; the bootstrap's tables are empty and analyze as they grow.
+-- Populate the new statistics for existing stores.
 ANALYZE entity_temporal_metadata;

--- a/libs/@local/graph/postgres-store/postgres_migrations/V61__entity_feed_statistics.sql
+++ b/libs/@local/graph/postgres-store/postgres_migrations/V61__entity_feed_statistics.sql
@@ -1,0 +1,17 @@
+-- The feed predicates are expressions, which carry no column statistics, so without these
+-- objects the planner sweeps every present row for the ended arm. The mcv object prices the
+-- predicate combination both arms share, which bounds the ended arm's anti-join by the
+-- candidate count. The expression object gives the transaction-time start a histogram, which
+-- fixes the changed arm's cardinality. The bounded plan wins to roughly twenty thousand
+-- candidates per poll window. A burst the statistics have not caught up with stretches it to
+-- about four times the sweep at a hundred thousand candidates.
+CREATE STATISTICS entity_temporal_metadata_transaction_start_stats
+    ON lower(transaction_time) FROM entity_temporal_metadata;
+
+CREATE STATISTICS entity_temporal_metadata_feed_stats (mcv)
+    ON draft_id, upper_inf(transaction_time), upper_inf(decision_time)
+    FROM entity_temporal_metadata;
+
+-- A statistics object is empty until the table is analyzed. Populated stores get real
+-- estimates at migration time; the bootstrap's tables are empty and analyze as they grow.
+ANALYZE entity_temporal_metadata;

--- a/libs/@local/graph/postgres-store/src/snapshot/entity/channel.rs
+++ b/libs/@local/graph/postgres-store/src/snapshot/entity/channel.rs
@@ -79,6 +79,18 @@ impl Sink<Entity> for EntitySender {
                 created_by_id: stored_provenance.created_by_id,
                 created_at_transaction_time: stored_provenance.created_at_transaction_time,
                 created_at_decision_time: stored_provenance.created_at_decision_time,
+                deleted_by_id: stored_provenance
+                    .deletion
+                    .as_ref()
+                    .map(|deletion| deletion.deleted_by_id),
+                deleted_at_transaction_time: stored_provenance
+                    .deletion
+                    .as_ref()
+                    .map(|deletion| deletion.deleted_at_transaction_time),
+                deleted_at_decision_time: stored_provenance
+                    .deletion
+                    .as_ref()
+                    .map(|deletion| deletion.deleted_at_decision_time),
                 provenance: stored_provenance.json,
                 read_only: entity.metadata.read_only,
             })

--- a/libs/@local/graph/postgres-store/src/store/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/mod.rs
@@ -8,8 +8,9 @@ pub mod postgres;
 pub use self::{
     config::{DatabaseConnectionInfo, DatabasePoolConfig, DatabaseType},
     postgres::{
-        AsClient, BeginReadOnlyTransaction, Context, GenericClientIter, InTransaction,
-        IsolationLevel, NoTransaction, PostgresStore, PostgresStorePool, PostgresStoreSettings,
+        AsClient, BeginReadOnlyTransaction, Context, EntityDeletion, EntityEnd, EntityEvent,
+        EntityEventStream, EntityUpdate, GenericClientIter, InTransaction, IsolationLevel,
+        NoTransaction, PostgresStore, PostgresStorePool, PostgresStoreSettings,
         PostgresStoreTransactionBuilder, Transaction, TransactionBuilder, TransactionOptions,
         TransactionState,
     },

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/delete.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/delete.rs
@@ -20,10 +20,7 @@ use tracing::Instrument as _;
 use type_system::{
     knowledge::{
         Entity,
-        entity::{
-            id::{DraftId, EntityEditionId, EntityUuid},
-            provenance::EntityDeletionProvenance,
-        },
+        entity::id::{DraftId, EntityEditionId, EntityUuid},
     },
     principal::{
         actor::{ActorEntityUuid, ActorId},
@@ -760,7 +757,14 @@ where
         Ok(row.get::<_, i64>(0).cast_unsigned())
     }
 
-    /// Merges [`EntityDeletionProvenance`] into the existing `entity_ids` provenance JSONB.
+    /// Stamps the deletion tombstone columns on the targets' `entity_ids` rows.
+    ///
+    /// Purge removes every edition and temporal row, so the tombstone is the only record that
+    /// the entity existed and was deleted: who deleted it and when, on both temporal axes. The
+    /// columns mirror [`EntityDeletionProvenance`], and the partial index on
+    /// `deleted_at_transaction_time` makes deletions queryable by recency.
+    ///
+    /// [`EntityDeletionProvenance`]: type_system::knowledge::entity::provenance::EntityDeletionProvenance
     async fn update_entity_ids_provenance(
         &mut self,
         target: &FullEntityDeletionTarget,
@@ -768,26 +772,25 @@ where
         decision_time: Timestamp<DecisionTime>,
         transaction_time: Timestamp<TransactionTime>,
     ) -> Result<u64, Report<DeletionError>> {
-        let provenance = EntityDeletionProvenance {
-            deleted_by_id: ActorEntityUuid::from(actor_id),
-            deleted_at_transaction_time: transaction_time,
-            deleted_at_decision_time: decision_time,
-        };
         self.as_mut_client()
             .execute(
                 "UPDATE entity_ids
-                 SET provenance = provenance || $3::jsonb
+                 SET deleted_by_id = $3,
+                     deleted_at_transaction_time = $4,
+                     deleted_at_decision_time = $5
                  WHERE (web_id, entity_uuid) IN (
                      SELECT * FROM UNNEST($1::UUID[], $2::UUID[])
                  )",
                 &[
                     &target.web_ids,
                     &target.entity_uuids,
-                    &postgres_types::Json(&provenance),
+                    &actor_id,
+                    &transaction_time,
+                    &decision_time,
                 ],
             )
             .instrument(tracing::info_span!(
-                "UPDATE entity_ids provenance",
+                "UPDATE entity_ids tombstone",
                 otel.kind = "client",
                 db.system = "postgresql",
                 peer.service = "Postgres",
@@ -904,10 +907,10 @@ where
         actor_id: ActorId,
         params: DeleteEntitiesParams<'_>,
     ) -> Result<DeletionSummary, Report<DeletionError>> {
-        let transaction_time = Timestamp::<TransactionTime>::now();
+        let transaction_time = Timestamp::<TransactionTime>::now().remove_nanosecond();
         let decision_time = params
             .decision_time
-            .unwrap_or_else(|| transaction_time.cast());
+            .map_or_else(|| transaction_time.cast(), Timestamp::remove_nanosecond);
 
         if decision_time > transaction_time.cast() {
             return Err(Report::new(DeletionError::InvalidDecisionTime));

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/delete.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/delete.rs
@@ -22,10 +22,7 @@ use type_system::{
         Entity,
         entity::id::{DraftId, EntityEditionId, EntityUuid},
     },
-    principal::{
-        actor::{ActorEntityUuid, ActorId},
-        actor_group::WebId,
-    },
+    principal::{actor::ActorId, actor_group::WebId},
 };
 
 use crate::store::{

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/feed.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/feed.rs
@@ -64,51 +64,54 @@ const ENTITY_EVENT_FEED: &str = "
 -- current now. A patch confined to closed decision history never touches this row, so pure
 -- history corrections do not appear. The archived flag lives on the edition rather than the
 -- temporal row, and the foreign key from temporal rows to editions makes the join total.
-SELECT web_id,
-       entity_uuid,
-       entity_edition_id,
-       archived,
-       lower(transaction_time) AS occurred_at,
+SELECT entity_temporal_metadata.web_id,
+       entity_temporal_metadata.entity_uuid,
+       entity_temporal_metadata.entity_edition_id,
+       entity_editions.archived,
+       lower(entity_temporal_metadata.transaction_time) AS occurred_at,
        'updated' AS reason,
        NULL::UUID AS deleted_by_id,
        NULL::TIMESTAMPTZ AS deleted_at_decision_time
 FROM entity_temporal_metadata
 JOIN entity_editions USING (entity_edition_id)
-WHERE draft_id IS NULL
-  AND upper_inf(transaction_time)
-  AND upper_inf(decision_time)
-  AND lower(transaction_time) > $1
+WHERE entity_temporal_metadata.draft_id IS NULL
+  AND upper_inf(entity_temporal_metadata.transaction_time)
+  AND upper_inf(entity_temporal_metadata.decision_time)
+  AND lower(entity_temporal_metadata.transaction_time) > $1
 
 UNION ALL
 
 -- The entity's published present ended without a successor: transaction-current rows remain,
--- every one with a bounded decision axis, and no present row exists anymore. The event's time
--- is the latest write among what remains. No edition travels, because ended means no edition
--- is current. The one production writer of this shape is a purge archiving its target's
--- incoming link entities.
-SELECT closed.web_id,
-       closed.entity_uuid,
+-- every one with a bounded decision axis, and no present row exists anymore. With only decision
+-- and transaction time, a transaction-current row whose decision range closes either has an
+-- open-decision successor or marks the end of the published present. The anti-join distinguishes
+-- those cases. A valid-time axis would require identifying which non-transaction axis ended.
+-- The event's time is the latest write among what remains. No edition travels, because ended
+-- means no edition is current. The one production writer of this shape is a purge archiving its
+-- target's incoming link entities.
+SELECT ended.web_id,
+       ended.entity_uuid,
        NULL::UUID AS entity_edition_id,
        NULL::BOOLEAN AS archived,
-       max(lower(closed.transaction_time)) AS occurred_at,
+       max(lower(ended.transaction_time)) AS occurred_at,
        'ended' AS reason,
        NULL::UUID AS deleted_by_id,
        NULL::TIMESTAMPTZ AS deleted_at_decision_time
-FROM entity_temporal_metadata AS closed
-WHERE closed.draft_id IS NULL
-  AND upper_inf(closed.transaction_time)
-  AND NOT upper_inf(closed.decision_time)
-  AND lower(closed.transaction_time) > $1
+FROM entity_temporal_metadata AS ended
+WHERE ended.draft_id IS NULL
+  AND upper_inf(ended.transaction_time)
+  AND NOT upper_inf(ended.decision_time)
+  AND lower(ended.transaction_time) > $1
   AND NOT EXISTS (
       SELECT 1
       FROM entity_temporal_metadata AS present
-      WHERE present.web_id = closed.web_id
-        AND present.entity_uuid = closed.entity_uuid
+      WHERE present.web_id = ended.web_id
+        AND present.entity_uuid = ended.entity_uuid
         AND present.draft_id IS NULL
         AND upper_inf(present.transaction_time)
         AND upper_inf(present.decision_time)
   )
-GROUP BY closed.web_id, closed.entity_uuid
+GROUP BY ended.web_id, ended.entity_uuid
 
 UNION ALL
 

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/feed.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/feed.rs
@@ -1,0 +1,353 @@
+//! A watermark feed over the published present of the entity store.
+//!
+//! An entity's published present is its temporal-metadata row with no draft id and both
+//! temporal axes open, holding the entity's state at the current decision time. A purge
+//! removes every edition and temporal-metadata row of an entity, so the entity stops
+//! matching entity queries without ever producing a readable event. Consumers that maintain a
+//! derived view of published entities need those events, and this module supplies them as one
+//! feed: [`PostgresStore::entity_events_since`], a stream whose single statement reads the
+//! temporal-metadata rows, the present editions' archived flags, and the `entity_ids` tombstone
+//! columns together.
+//!
+//! The feed takes a transaction-time watermark and yields events that occurred strictly after
+//! it. An event's time comes from the writing process's own wall clock, taken before any write
+//! it marks: creation and patching take theirs before their transactions begin, deletion takes
+//! its inside its transaction before selecting targets. A row therefore becomes visible up to a
+//! whole write request after its recorded time, because everything from the writer's lock waits
+//! through post-write validation sits inside that interval. Concurrent writers on different
+//! clocks add their skew on top of it. A feed opened inside the interval misses a row that
+//! later commits bearing an already-passed time, so a consumer subtracts a safety lag from its
+//! watermark
+//! that exceeds the longest write request plus the largest cross-writer clock skew. The feed
+//! tolerates the re-delivery this produces: reading with an older watermark returns events
+//! already seen, unchanged. A backwards clock step wider than the lag loses events permanently,
+//! and the feed cannot tell such a loss from quiet.
+//!
+//! Only events within one call are mutually consistent, never events across calls, because
+//! each call runs one statement over one snapshot. The kinds share that snapshot, so a purge's
+//! [`Ended`](EntityEvent::Ended) events for the links it archives and its
+//! [`Deleted`](EntityEvent::Deleted) event for the target arrive in the same read. Each call
+//! returns every entity in every web.
+//!
+//! The feed reads watermark-filtered current state rather than an event log, and two writers
+//! violate what that state can promise. Erase removes an entity's rows from every table the
+//! feed reads, including a purge tombstone not yet delivered, so a deletion can vanish before
+//! any call returns it. Snapshot restore inserts rows bearing their historical times, which a
+//! watermark already past them never revisits. A derived view therefore needs periodic full
+//! reconciliation against the store, at a cadence that bounds how long the view can stay wrong,
+//! and a deployment that runs erase or restore while consumers poll is choosing that bound.
+
+use core::{
+    pin::Pin,
+    task::{Context, Poll, ready},
+};
+
+use error_stack::Report;
+use futures::{Stream, future::BoxFuture};
+use hash_graph_store::error::QueryError;
+use hash_graph_temporal_versioning::{Timestamp, TransactionTime};
+use postgres_types::{FromSql, Type};
+use tokio_postgres::{GenericClient as _, Row, RowStream};
+use tracing::{Instrument as _, instrument::Instrumented};
+use type_system::knowledge::entity::{
+    EntityId, id::EntityEditionId, provenance::EntityDeletionProvenance,
+};
+
+use crate::store::postgres::{AsClient, PostgresStore, TransactionState};
+
+/// The feed statement, reading three event kinds from one snapshot in time order.
+const ENTITY_EVENT_FEED: &str = "
+-- The entity's published present changed. The present row is the one temporal-metadata row
+-- per published entity with no draft id and both temporal axes open, and it holds the
+-- entity's state at the current decision time. Writes mutate it in place, so its
+-- transaction-time start is the moment the present last changed and its edition is the one
+-- current now. A patch confined to closed decision history never touches this row, so pure
+-- history corrections do not appear. The archived flag lives on the edition rather than the
+-- temporal row, and the foreign key from temporal rows to editions makes the join total.
+SELECT web_id,
+       entity_uuid,
+       entity_edition_id,
+       archived,
+       lower(transaction_time) AS occurred_at,
+       'updated' AS reason,
+       NULL::UUID AS deleted_by_id,
+       NULL::TIMESTAMPTZ AS deleted_at_decision_time
+FROM entity_temporal_metadata
+JOIN entity_editions USING (entity_edition_id)
+WHERE draft_id IS NULL
+  AND upper_inf(transaction_time)
+  AND upper_inf(decision_time)
+  AND lower(transaction_time) > $1
+
+UNION ALL
+
+-- The entity's published present ended without a successor: transaction-current rows remain,
+-- every one with a bounded decision axis, and no present row exists anymore. The event's time
+-- is the latest write among what remains. No edition travels, because ended means no edition
+-- is current. The one production writer of this shape is a purge archiving its target's
+-- incoming link entities.
+SELECT closed.web_id,
+       closed.entity_uuid,
+       NULL::UUID AS entity_edition_id,
+       NULL::BOOLEAN AS archived,
+       max(lower(closed.transaction_time)) AS occurred_at,
+       'ended' AS reason,
+       NULL::UUID AS deleted_by_id,
+       NULL::TIMESTAMPTZ AS deleted_at_decision_time
+FROM entity_temporal_metadata AS closed
+WHERE closed.draft_id IS NULL
+  AND upper_inf(closed.transaction_time)
+  AND NOT upper_inf(closed.decision_time)
+  AND lower(closed.transaction_time) > $1
+  AND NOT EXISTS (
+      SELECT 1
+      FROM entity_temporal_metadata AS present
+      WHERE present.web_id = closed.web_id
+        AND present.entity_uuid = closed.entity_uuid
+        AND present.draft_id IS NULL
+        AND upper_inf(present.transaction_time)
+        AND upper_inf(present.decision_time)
+  )
+GROUP BY closed.web_id, closed.entity_uuid
+
+UNION ALL
+
+-- The entity was purged: its editions and temporal rows are gone, and the tombstone on its
+-- entity_ids row is the only readable record that it existed and who deleted it. Erase
+-- removes the entity_ids row itself and leaves no tombstone, so an erased entity never
+-- appears here.
+SELECT web_id,
+       entity_uuid,
+       NULL::UUID AS entity_edition_id,
+       NULL::BOOLEAN AS archived,
+       deleted_at_transaction_time AS occurred_at,
+       'deleted' AS reason,
+       deleted_by_id,
+       deleted_at_decision_time
+FROM entity_ids
+WHERE deleted_at_transaction_time > $1
+
+ORDER BY occurred_at, web_id, entity_uuid";
+
+/// A change of an entity's published present, yielded by
+/// [`PostgresStore::entity_events_since`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EntityUpdate {
+    /// The entity whose present changed. Feed events never concern drafts, so the id carries
+    /// no draft id.
+    pub entity: EntityId,
+    /// The edition current at the present, read in the same snapshot that observed the change.
+    pub edition: EntityEditionId,
+    /// The carried edition's archived flag, read in the same snapshot that observed the change.
+    pub archived: bool,
+    /// When the present last changed, on the transaction-time axis.
+    pub changed_at: Timestamp<TransactionTime>,
+}
+
+/// The end of an entity's published present, yielded by
+/// [`PostgresStore::entity_events_since`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EntityEnd {
+    /// The entity whose present ended. Feed events never concern drafts, so the id carries no
+    /// draft id.
+    pub entity: EntityId,
+    /// When the present ended, on the transaction-time axis.
+    pub ended_at: Timestamp<TransactionTime>,
+}
+
+/// A deletion tombstone read back from the `entity_ids` columns, yielded by
+/// [`PostgresStore::entity_events_since`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EntityDeletion {
+    /// The purged entity. Feed events never concern drafts, so the id carries no draft id.
+    pub entity: EntityId,
+    /// Who deleted the entity and when, on both temporal axes.
+    pub provenance: EntityDeletionProvenance,
+}
+
+/// One event from the entity feed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EntityEvent {
+    /// The entity's published present changed, and the carried edition is now current.
+    Updated(EntityUpdate),
+    /// The entity's published present ended without a successor.
+    Ended(EntityEnd),
+    /// The entity was purged, and its tombstone is the only readable record it existed.
+    Deleted(EntityDeletion),
+}
+
+/// The feed's row discriminator, decoded from the statement's `reason` column.
+enum EventKind {
+    Updated,
+    Ended,
+    Deleted,
+}
+
+impl<'row> FromSql<'row> for EventKind {
+    fn from_sql(
+        ty: &Type,
+        raw: &'row [u8],
+    ) -> Result<Self, Box<dyn core::error::Error + Sync + Send>> {
+        match <&str as FromSql>::from_sql(ty, raw)? {
+            "updated" => Ok(Self::Updated),
+            "ended" => Ok(Self::Ended),
+            "deleted" => Ok(Self::Deleted),
+            other => Err(Box::from(format!(
+                "unknown entity feed event kind `{other}`"
+            ))),
+        }
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        <&str as FromSql>::accepts(ty)
+    }
+}
+
+/// Decodes one feed row into its event, dispatching on the `reason` column.
+fn decode_event(row: &Row) -> Result<EntityEvent, tokio_postgres::Error> {
+    let entity = EntityId {
+        web_id: row.try_get(0)?,
+        entity_uuid: row.try_get(1)?,
+        draft_id: None,
+    };
+
+    Ok(match row.try_get(5)? {
+        EventKind::Updated => EntityEvent::Updated(EntityUpdate {
+            entity,
+            edition: row.try_get(2)?,
+            archived: row.try_get(3)?,
+            changed_at: row.try_get(4)?,
+        }),
+        EventKind::Ended => EntityEvent::Ended(EntityEnd {
+            entity,
+            ended_at: row.try_get(4)?,
+        }),
+        EventKind::Deleted => EntityEvent::Deleted(EntityDeletion {
+            entity,
+            provenance: EntityDeletionProvenance {
+                deleted_by_id: row.try_get(6)?,
+                deleted_at_transaction_time: row.try_get(4)?,
+                deleted_at_decision_time: row.try_get(7)?,
+            },
+        }),
+    })
+}
+
+pin_project_lite::pin_project! {
+    /// Where the feed stands: waiting on the statement, or yielding its rows.
+    #[project = FeedStateProj]
+    enum FeedState<'client> {
+        Opening {
+            #[pin]
+            query: Instrumented<BoxFuture<'client, Result<RowStream, tokio_postgres::Error>>>,
+        },
+        Streaming {
+            #[pin]
+            rows: RowStream,
+        },
+    }
+}
+
+pin_project_lite::pin_project! {
+    /// The entity event feed opened by [`PostgresStore::entity_events_since`].
+    pub struct EntityEventStream<'client> {
+        #[pin]
+        state: FeedState<'client>,
+    }
+}
+
+impl Stream for EntityEventStream<'_> {
+    type Item = Result<EntityEvent, Report<QueryError>>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut this = self.project();
+        loop {
+            match this.state.as_mut().project() {
+                FeedStateProj::Opening { query } => match ready!(query.poll(cx)) {
+                    Ok(rows) => this.state.set(FeedState::Streaming { rows }),
+                    Err(error) => {
+                        return Poll::Ready(Some(Err(
+                            Report::new(error).change_context(QueryError)
+                        )));
+                    }
+                },
+                FeedStateProj::Streaming { rows } => {
+                    return Poll::Ready(ready!(rows.poll_next(cx)).map(|row| {
+                        row.and_then(|row| decode_event(&row))
+                            .map_err(|error| Report::new(error).change_context(QueryError))
+                    }));
+                }
+            }
+        }
+    }
+}
+
+impl<C, S> PostgresStore<C, S>
+where
+    C: AsClient,
+    S: TransactionState,
+{
+    /// Opens the entity event feed, yielding events that occurred strictly after `since`.
+    ///
+    /// One statement serves the whole call, so every yielded event describes the same snapshot,
+    /// in time order. The kinds:
+    ///
+    /// - [`EntityEvent::Updated`]: the entity's published present row was written after `since`.
+    ///   The published present is the temporal-metadata row with no draft id and both axes
+    ///   unbounded, and it holds the entity's state at the current decision time. Creating or
+    ///   undrafting an entity, publishing a draft over a live one, and every patch whose decision
+    ///   time falls inside the open present slice all fire this kind, each event carrying only the
+    ///   edition current at the present, with that edition's archived flag, so editions written and
+    ///   replaced between two reads never appear. A patch that only flips the archived flag fires
+    ///   it too, because the flag lives on the new edition rather than on the temporal row, and the
+    ///   carried flag is the value after the flip.
+    /// - [`EntityEvent::Ended`]: the entity has a transaction-time-current row written after
+    ///   `since` whose decision axis is bounded, and no present row remains. The condition ranges
+    ///   over current rows only: an ended entity's transaction-time-closed history keeps unbounded
+    ///   decision axes. Closing the present without a successor is what fires this kind, and the
+    ///   one production writer that does so is a purge archiving its target's incoming link
+    ///   entities. Publishing a draft always installs a successor, so it fires
+    ///   [`Updated`](EntityEvent::Updated) instead. A history correction to an entity whose present
+    ///   already ended rewrites rows this kind ranges over, so it re-delivers the end with a newer
+    ///   time, within the feed's re-delivery tolerance.
+    /// - [`EntityEvent::Deleted`]: the entity was purged after `since`. Purge deletes an entity's
+    ///   editions and temporal rows and writes a tombstone to its `entity_ids` row, so the
+    ///   tombstone is the only readable record that the entity existed and who deleted it. Erase
+    ///   removes the `entity_ids` row itself and leaves no tombstone, so an erased entity never
+    ///   appears, and an erase after a purge removes a tombstone this feed may not have delivered
+    ///   yet.
+    ///
+    /// An event always reflects the entity's state at the current decision time: a write
+    /// confined to closed decision history rewrites rows the feed never selects and is not
+    /// delivered, while one that reaches the open present mutates the present row and is
+    /// delivered.
+    /// To maintain a view of current state, apply [`Updated`](EntityEvent::Updated) as an upsert
+    /// of the carried edition, and [`Ended`](EntityEvent::Ended) and
+    /// [`Deleted`](EntityEvent::Deleted) as removals. A view that excludes archived entities
+    /// reads the carried flag and treats a set flag as a removal. Draft rows never enter the feed,
+    /// and pure history corrections to live entities fire nothing.
+    ///
+    /// The comparison against `since` is strict, so an event that occurred exactly at `since`
+    /// stays
+    /// out. The module documentation describes the commit-visibility window this leaves and the
+    /// safety lag that covers it.
+    ///
+    /// # Errors
+    ///
+    /// The stream yields [`QueryError`] when the feed statement fails or a row fails to decode.
+    pub fn entity_events_since(&self, since: Timestamp<TransactionTime>) -> EntityEventStream<'_> {
+        let query = self
+            .as_client()
+            .query_raw(ENTITY_EVENT_FEED, [since])
+            .instrument(tracing::info_span!(
+                "SELECT entity event feed",
+                otel.kind = "client",
+                db.system = "postgresql",
+                peer.service = "Postgres",
+            ));
+
+        EntityEventStream {
+            state: FeedState::Opening { query },
+        }
+    }
+}

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/feed.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/feed.rs
@@ -43,7 +43,7 @@ use core::{
 };
 
 use error_stack::Report;
-use futures::{Stream, future::BoxFuture};
+use futures::{Stream, future::BoxFuture, stream::FusedStream};
 use hash_graph_store::error::QueryError;
 use hash_graph_temporal_versioning::{Timestamp, TransactionTime};
 use postgres_types::{FromSql, Type};
@@ -237,6 +237,7 @@ pin_project_lite::pin_project! {
     /// Where the feed stands: waiting on the statement, or yielding its rows.
     #[project = FeedStateProj]
     enum FeedState<'client> {
+        Terminated,
         Opening {
             #[pin]
             query: Instrumented<BoxFuture<'client, Result<RowStream, tokio_postgres::Error>>>,
@@ -266,19 +267,35 @@ impl Stream for EntityEventStream<'_> {
                 FeedStateProj::Opening { query } => match ready!(query.poll(cx)) {
                     Ok(rows) => this.state.set(FeedState::Streaming { rows }),
                     Err(error) => {
+                        this.state.set(FeedState::Terminated);
                         return Poll::Ready(Some(Err(
                             Report::new(error).change_context(QueryError)
                         )));
                     }
                 },
                 FeedStateProj::Streaming { rows } => {
-                    return Poll::Ready(ready!(rows.poll_next(cx)).map(|row| {
-                        row.and_then(|row| decode_event(&row))
-                            .map_err(|error| Report::new(error).change_context(QueryError))
-                    }));
+                    let Some(result) = ready!(rows.poll_next(cx)) else {
+                        this.state.set(FeedState::Terminated);
+                        return Poll::Ready(None);
+                    };
+
+                    return Poll::Ready(Some(
+                        result
+                            .and_then(|row| decode_event(&row))
+                            .map_err(|error| Report::new(error).change_context(QueryError)),
+                    ));
+                }
+                FeedStateProj::Terminated => {
+                    return Poll::Ready(None);
                 }
             }
         }
+    }
+}
+
+impl FusedStream for EntityEventStream<'_> {
+    fn is_terminated(&self) -> bool {
+        matches!(self.state, FeedState::Terminated)
     }
 }
 

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/mod.rs
@@ -1,4 +1,5 @@
 mod delete;
+pub(crate) mod feed;
 pub(crate) mod provenance;
 mod query;
 mod read;
@@ -1420,6 +1421,9 @@ where
                 created_by_id: stored_provenance.created_by_id,
                 created_at_transaction_time: stored_provenance.created_at_transaction_time,
                 created_at_decision_time: stored_provenance.created_at_decision_time,
+                deleted_by_id: None,
+                deleted_at_transaction_time: None,
+                deleted_at_decision_time: None,
                 provenance: stored_provenance.json.clone(),
             });
             if let Some(draft_id) = entity_id.draft_id {

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/provenance.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/provenance.rs
@@ -1,9 +1,9 @@
 //! Storage representation of entity provenance, split from the interface types.
 //!
-//! `created_by_id` and the creation timestamps live in dedicated columns rather than the provenance
-//! JSONB, so each datum is stored exactly once. [`SqlEntityProvenance`] and
-//! [`SqlEntityEditionProvenance`] mirror that storage layout: column-backed fields directly on the
-//! struct, the JSONB remainder in the `json` half. The exhaustive destructures in the [`From`]
+//! `created_by_id`, the creation timestamps, and the deletion tombstone live in dedicated columns
+//! rather than the provenance JSONB, so each datum is stored exactly once. [`SqlEntityProvenance`]
+//! and [`SqlEntityEditionProvenance`] mirror that storage layout: column-backed fields directly on
+//! the struct, the JSONB remainder in the `json` half. The exhaustive destructures in the [`From`]
 //! impls turn a new interface field into a compile error until it is routed to either side.
 
 use core::error::Error;
@@ -28,8 +28,6 @@ pub(crate) struct SqlEntityProvenanceJson {
     pub first_non_draft_created_at_transaction_time: Option<Timestamp<TransactionTime>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub first_non_draft_created_at_decision_time: Option<Timestamp<DecisionTime>>,
-    #[serde(default, flatten, skip_serializing_if = "Option::is_none")]
-    pub deletion: Option<EntityDeletionProvenance>,
 }
 
 impl<'a> FromSql<'a> for SqlEntityProvenanceJson {
@@ -142,6 +140,7 @@ pub(crate) struct SqlEntityProvenance {
     pub created_by_id: ActorEntityUuid,
     pub created_at_transaction_time: Timestamp<TransactionTime>,
     pub created_at_decision_time: Timestamp<DecisionTime>,
+    pub deletion: Option<EntityDeletionProvenance>,
     pub json: SqlEntityProvenanceJson,
     pub edition: SqlEntityEditionProvenance,
 }
@@ -161,10 +160,10 @@ impl From<EntityProvenance> for SqlEntityProvenance {
             created_by_id,
             created_at_transaction_time,
             created_at_decision_time,
+            deletion,
             json: SqlEntityProvenanceJson {
                 first_non_draft_created_at_transaction_time,
                 first_non_draft_created_at_decision_time,
-                deletion,
             },
             edition: edition.into(),
         }
@@ -177,11 +176,11 @@ impl From<SqlEntityProvenance> for EntityProvenance {
             created_by_id,
             created_at_transaction_time,
             created_at_decision_time,
+            deletion,
             json:
                 SqlEntityProvenanceJson {
                     first_non_draft_created_at_transaction_time,
                     first_non_draft_created_at_decision_time,
-                    deletion,
                 },
             edition,
         } = stored;

--- a/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/query.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/knowledge/entity/query.rs
@@ -178,6 +178,9 @@ impl QueryRecordDecode for Entity {
                     created_by_id: row.get(indices.created_by_id),
                     created_at_transaction_time: row.get(indices.created_at_transaction_time),
                     created_at_decision_time: row.get(indices.created_at_decision_time),
+                    // A queryable entity always has rows in `entity_temporal_metadata`, therefore
+                    // deletion is never set.
+                    deletion: None,
                     json: row.get(indices.provenance),
                     edition: SqlEntityEditionProvenance {
                         created_by_id: row.get(indices.edition_created_by_id),

--- a/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/mod.rs
@@ -77,6 +77,9 @@ use type_system::{
 use uuid::Uuid;
 
 pub use self::{
+    knowledge::entity::feed::{
+        EntityDeletion, EntityEnd, EntityEvent, EntityEventStream, EntityUpdate,
+    },
     pool::{
         AsClient, GenericClientIter, InTransaction, NoTransaction, PostgresStorePool,
         TransactionOptions, TransactionState,

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/ast/statement/insert.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/ast/statement/insert.rs
@@ -131,7 +131,7 @@ mod tests {
     fn transpile_entity_id_rows() {
         assert_eq!(
             trim_whitespace(&bulk_insert::<EntityIdRow>().rows(&[]).compile().0),
-            r#"INSERT INTO "entity_ids" ("web_id", "entity_uuid", "provenance", "read_only", "created_by_id", "created_at_transaction_time", "created_at_decision_time") SELECT * FROM UNNEST(($1::uuid[]), ($2::uuid[]), ($3::jsonb[]), ($4::bool[]), ($5::uuid[]), ($6::timestamptz[]), ($7::timestamptz[]))"#
+            r#"INSERT INTO "entity_ids" ("web_id", "entity_uuid", "provenance", "read_only", "created_by_id", "created_at_transaction_time", "created_at_decision_time", "deleted_by_id", "deleted_at_transaction_time", "deleted_at_decision_time") SELECT * FROM UNNEST(($1::uuid[]), ($2::uuid[]), ($3::jsonb[]), ($4::bool[]), ($5::uuid[]), ($6::timestamptz[]), ($7::timestamptz[]), ($8::uuid[]), ($9::timestamptz[]), ($10::timestamptz[]))"#
         );
     }
 
@@ -168,7 +168,7 @@ mod tests {
                     .compile()
                     .0
             ),
-            r#"INSERT INTO "entity_ids_tmp" ("web_id", "entity_uuid", "provenance", "read_only", "created_by_id", "created_at_transaction_time", "created_at_decision_time") SELECT DISTINCT * FROM UNNEST(($1::uuid[]), ($2::uuid[]), ($3::jsonb[]), ($4::bool[]), ($5::uuid[]), ($6::timestamptz[]), ($7::timestamptz[])) ON CONFLICT DO NOTHING"#
+            r#"INSERT INTO "entity_ids_tmp" ("web_id", "entity_uuid", "provenance", "read_only", "created_by_id", "created_at_transaction_time", "created_at_decision_time", "deleted_by_id", "deleted_at_transaction_time", "deleted_at_decision_time") SELECT DISTINCT * FROM UNNEST(($1::uuid[]), ($2::uuid[]), ($3::jsonb[]), ($4::bool[]), ($5::uuid[]), ($6::timestamptz[]), ($7::timestamptz[]), ($8::uuid[]), ($9::timestamptz[]), ($10::timestamptz[])) ON CONFLICT DO NOTHING"#
         );
     }
 }

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/rows.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/rows.rs
@@ -458,6 +458,9 @@ pub struct EntityIdRow {
     pub created_by_id: ActorEntityUuid,
     pub created_at_transaction_time: Timestamp<TransactionTime>,
     pub created_at_decision_time: Timestamp<DecisionTime>,
+    pub deleted_by_id: Option<ActorEntityUuid>,
+    pub deleted_at_transaction_time: Option<Timestamp<TransactionTime>>,
+    pub deleted_at_decision_time: Option<Timestamp<DecisionTime>>,
 }
 
 impl PostgresRow for EntityIdRow {
@@ -475,6 +478,9 @@ impl PostgresRow for EntityIdRow {
         let mut created_by_ids = Vec::with_capacity(rows.len());
         let mut created_at_transaction_times = Vec::with_capacity(rows.len());
         let mut created_at_decision_times = Vec::with_capacity(rows.len());
+        let mut deleted_by_ids = Vec::with_capacity(rows.len());
+        let mut deleted_at_transaction_times = Vec::with_capacity(rows.len());
+        let mut deleted_at_decision_times = Vec::with_capacity(rows.len());
         for Self {
             web_id,
             entity_uuid,
@@ -483,6 +489,9 @@ impl PostgresRow for EntityIdRow {
             created_by_id,
             created_at_transaction_time,
             created_at_decision_time,
+            deleted_by_id,
+            deleted_at_transaction_time,
+            deleted_at_decision_time,
         } in rows
         {
             web_ids.push(web_id);
@@ -492,6 +501,9 @@ impl PostgresRow for EntityIdRow {
             created_by_ids.push(created_by_id);
             created_at_transaction_times.push(created_at_transaction_time);
             created_at_decision_times.push(created_at_decision_time);
+            deleted_by_ids.push(deleted_by_id);
+            deleted_at_transaction_times.push(deleted_at_transaction_time);
+            deleted_at_decision_times.push(deleted_at_decision_time);
         }
         vec![
             (EntityIds::WebId, web_ids.into()),
@@ -506,6 +518,15 @@ impl PostgresRow for EntityIdRow {
             (
                 EntityIds::CreatedAtDecisionTime,
                 created_at_decision_times.into(),
+            ),
+            (EntityIds::DeletedById, deleted_by_ids.into()),
+            (
+                EntityIds::DeletedAtTransactionTime,
+                deleted_at_transaction_times.into(),
+            ),
+            (
+                EntityIds::DeletedAtDecisionTime,
+                deleted_at_decision_times.into(),
             ),
         ]
     }

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/table.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/table.rs
@@ -904,6 +904,9 @@ pub enum EntityIds {
     CreatedById,
     CreatedAtTransactionTime,
     CreatedAtDecisionTime,
+    DeletedById,
+    DeletedAtTransactionTime,
+    DeletedAtDecisionTime,
 }
 
 impl DatabaseColumn<'_> for EntityIds {
@@ -916,17 +919,23 @@ impl DatabaseColumn<'_> for EntityIds {
             Self::CreatedById => "created_by_id".into(),
             Self::CreatedAtTransactionTime => "created_at_transaction_time".into(),
             Self::CreatedAtDecisionTime => "created_at_decision_time".into(),
+            Self::DeletedById => "deleted_by_id".into(),
+            Self::DeletedAtTransactionTime => "deleted_at_transaction_time".into(),
+            Self::DeletedAtDecisionTime => "deleted_at_decision_time".into(),
         }
     }
 
     fn postgres_type(&self) -> PostgresType {
         match self {
-            Self::WebId | Self::EntityUuid | Self::CreatedById => PostgresType::Uuid,
+            Self::WebId | Self::EntityUuid | Self::CreatedById | Self::DeletedById => {
+                PostgresType::Uuid
+            }
             Self::Provenance => PostgresType::JsonB,
             Self::ReadOnly => PostgresType::Bool,
-            Self::CreatedAtTransactionTime | Self::CreatedAtDecisionTime => {
-                PostgresType::TimestampTz
-            }
+            Self::CreatedAtTransactionTime
+            | Self::CreatedAtDecisionTime
+            | Self::DeletedAtTransactionTime
+            | Self::DeletedAtDecisionTime => PostgresType::TimestampTz,
         }
     }
 }
@@ -934,12 +943,15 @@ impl DatabaseColumn<'_> for EntityIds {
 impl FilterColumn<'_> for EntityIds {
     fn parameter_type(&self) -> ParameterType {
         match self {
-            Self::WebId | Self::EntityUuid | Self::CreatedById => ParameterType::Uuid,
+            Self::WebId | Self::EntityUuid | Self::CreatedById | Self::DeletedById => {
+                ParameterType::Uuid
+            }
             Self::Provenance => ParameterType::Any,
             Self::ReadOnly => ParameterType::Boolean,
-            Self::CreatedAtTransactionTime | Self::CreatedAtDecisionTime => {
-                ParameterType::Timestamp
-            }
+            Self::CreatedAtTransactionTime
+            | Self::CreatedAtDecisionTime
+            | Self::DeletedAtTransactionTime
+            | Self::DeletedAtDecisionTime => ParameterType::Timestamp,
         }
     }
 }

--- a/libs/@local/graph/postgres-store/tests/deletion/drafts.rs
+++ b/libs/@local/graph/postgres-store/tests/deletion/drafts.rs
@@ -21,9 +21,9 @@ use crate::{
 /// `select_entities_for_deletion` puts the entity in the draft-only bucket. Then
 /// `promote_draft_only_entities` queries `entity_temporal_metadata` (across ALL temporal history,
 /// no time restriction) for rows where `draft_id IS NULL OR NOT (draft_id = ANY(matched_drafts))`.
-/// Since there's no published version and no unmatched drafts, the query returns nothing → draft
-/// vec is cleared → entity becomes a full target → `entity_ids` gets tombstone provenance via
-/// `update_entity_ids_provenance`.
+/// Since there's no published version and no unmatched drafts, the query returns nothing, the
+/// draft vec is cleared, the entity becomes a full target, and `entity_ids` gets its deletion
+/// tombstone written via `update_entity_ids_provenance`.
 #[tokio::test]
 async fn draft_only_entity_promoted_to_full_delete() {
     let mut database = DatabaseTestWrapper::new().await;
@@ -502,8 +502,8 @@ async fn mixed_full_and_draft_targets() {
 /// published version blocks promotion, so `FullEntityDeletionTarget` is empty and
 /// `DraftOnlyDeletionTarget` has the draft. The guards `!full_target.web_ids.is_empty()` and
 /// `!draft_target.draft_ids.is_empty()` must correctly skip the empty branch without errors. In
-/// particular, the empty full target must not trigger `delete_entity_edge`, `count_incoming_links`,
-/// or `update_entity_ids_provenance`.
+/// particular, the empty full target must not trigger `delete_entity_edge`,
+/// `count_incoming_link_edges`, or `update_entity_ids_provenance`.
 #[tokio::test]
 async fn empty_target_guards() {
     let mut database = DatabaseTestWrapper::new().await;

--- a/libs/@local/graph/postgres-store/tests/deletion/erase.rs
+++ b/libs/@local/graph/postgres-store/tests/deletion/erase.rs
@@ -21,9 +21,9 @@ use crate::{
 /// Erases the `entity_ids` row entirely, leaving no tombstone.
 ///
 /// After erase, `entity_ids` has zero rows for the `(web_id, entity_uuid)` pair. Unlike purge
-/// (which calls `update_entity_ids_provenance` to stamp a tombstone), erase calls
-/// `delete_entity_ids` to remove the row completely. `count_incoming_links` always runs for erase
-/// scope to prevent FK violations from `entity_edge.target → entity_ids`.
+/// (which calls `update_entity_ids_provenance` to write a tombstone), erase calls
+/// `delete_entity_ids` to remove the row completely. `count_incoming_link_edges` always runs
+/// for erase scope to prevent FK violations from `entity_edge.target` to `entity_ids`.
 #[tokio::test]
 async fn removes_entity_ids_row() {
     let mut database = DatabaseTestWrapper::new().await;

--- a/libs/@local/graph/postgres-store/tests/deletion/feed.rs
+++ b/libs/@local/graph/postgres-store/tests/deletion/feed.rs
@@ -22,11 +22,14 @@ use hash_graph_store::{
     subgraph::temporal_axes::QueryTemporalAxesUnresolved,
 };
 use hash_graph_temporal_versioning::{DecisionTime, Timestamp, TransactionTime};
-use type_system::knowledge::{
-    Entity,
-    property::{
-        Property, PropertyObject, PropertyPatchOperation, PropertyPath, PropertyWithMetadata,
+use type_system::{
+    knowledge::{
+        Entity,
+        property::{
+            Property, PropertyObject, PropertyPatchOperation, PropertyPath, PropertyWithMetadata,
+        },
     },
+    principal::actor::ActorEntityUuid,
 };
 
 use crate::{
@@ -333,7 +336,7 @@ async fn purge_with_archived_links_ends_link_and_deletes_target() {
 
     api.store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             purge_params(&person_b, LinkDeletionBehavior::Archive),
         )
         .await
@@ -351,7 +354,10 @@ async fn purge_with_archived_links_ends_link_and_deletes_target() {
         deleted[0].entity.entity_uuid,
         person_b.metadata.record_id.entity_id.entity_uuid
     );
-    assert_eq!(deleted[0].provenance.deleted_by_id, api.account_id);
+    assert_eq!(
+        deleted[0].provenance.deleted_by_id,
+        ActorEntityUuid::from(api.account_id)
+    );
 }
 
 /// Purge removes the temporal rows outright, so [`EntityEvent::Deleted`] is the only event it
@@ -366,7 +372,7 @@ async fn purge_fires_deleted_only() {
 
     api.store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             purge_params(&entity, LinkDeletionBehavior::Ignore),
         )
         .await
@@ -399,7 +405,7 @@ async fn erase_fires_nothing() {
 
     api.store
         .delete_entities(
-            api.account_id.into(),
+            api.account_id,
             DeleteEntitiesParams {
                 filter: Filter::for_entity_by_entity_id(entity.metadata.record_id.entity_id),
                 temporal_axes: QueryTemporalAxesUnresolved::live_only(),

--- a/libs/@local/graph/postgres-store/tests/deletion/feed.rs
+++ b/libs/@local/graph/postgres-store/tests/deletion/feed.rs
@@ -1,0 +1,477 @@
+//! Dispatch tests for the entity event feed: which production motion fires which event kind.
+//!
+//! The table under test, one row per motion:
+//!
+//! - create, undraft, update at the present, archived-flag patch, draft publish over a live entity:
+//!   [`EntityEvent::Updated`]
+//! - temporal archive without a successor (purge archiving incoming links): [`EntityEvent::Ended`]
+//! - patch into a closed decision slice (pure backfill): nothing
+//! - purge: [`EntityEvent::Deleted`] alone
+//! - erase, draft-only activity: nothing at all
+
+use std::collections::HashSet;
+
+use futures::TryStreamExt as _;
+use hash_graph_postgres_store::store::{EntityDeletion, EntityEnd, EntityEvent, EntityUpdate};
+use hash_graph_store::{
+    entity::{
+        DeleteEntitiesParams, DeletionScope, EntityStore as _, LinkDeletionBehavior,
+        PatchEntityParams,
+    },
+    filter::Filter,
+    subgraph::temporal_axes::QueryTemporalAxesUnresolved,
+};
+use hash_graph_temporal_versioning::{DecisionTime, Timestamp, TransactionTime};
+use type_system::knowledge::{
+    Entity,
+    property::{
+        Property, PropertyObject, PropertyPatchOperation, PropertyPath, PropertyWithMetadata,
+    },
+};
+
+use crate::{
+    DatabaseApi, DatabaseTestWrapper, alice, bob, create_link, create_person, provenance, seed,
+};
+
+/// Collects the feed at `since` into its three kinds, keeping each kind's time order.
+async fn collect_events(
+    api: &DatabaseApi<'_>,
+    since: Timestamp<TransactionTime>,
+) -> (Vec<EntityUpdate>, Vec<EntityEnd>, Vec<EntityDeletion>) {
+    let events: Vec<EntityEvent> = api
+        .store
+        .entity_events_since(since)
+        .try_collect()
+        .await
+        .expect("could not read the entity event feed");
+    let mut updated = Vec::new();
+    let mut ended = Vec::new();
+    let mut deleted = Vec::new();
+    for event in events {
+        match event {
+            EntityEvent::Updated(update) => updated.push(update),
+            EntityEvent::Ended(end) => ended.push(end),
+            EntityEvent::Deleted(deletion) => deleted.push(deletion),
+        }
+    }
+    (updated, ended, deleted)
+}
+
+/// Returns the latest event time the feed has produced so far, or the epoch.
+///
+/// The feed supplies its own cursors: every event carries the time the next read resumes from,
+/// so the tests never read a clock that could disagree with the store's own.
+async fn feed_cursor(api: &DatabaseApi<'_>) -> Timestamp<TransactionTime> {
+    let (updated, ended, deleted) = collect_events(api, Timestamp::UNIX_EPOCH).await;
+    updated
+        .iter()
+        .map(|update| update.changed_at)
+        .chain(ended.iter().map(|end| end.ended_at))
+        .chain(
+            deleted
+                .iter()
+                .map(|deletion| deletion.provenance.deleted_at_transaction_time),
+        )
+        .max()
+        .unwrap_or(Timestamp::UNIX_EPOCH)
+}
+
+/// Patches the entity's draft flag: `true` creates a draft of it, `false` publishes the draft.
+async fn set_draft(api: &mut DatabaseApi<'_>, entity: &Entity, draft: bool) -> Entity {
+    api.store
+        .patch_entity(
+            api.account_id,
+            PatchEntityParams {
+                entity_id: entity.metadata.record_id.entity_id,
+                decision_time: None,
+                entity_type_ids: HashSet::new(),
+                properties: Vec::new(),
+                draft: Some(draft),
+                archived: None,
+                confidence: None,
+                provenance: provenance(),
+            },
+        )
+        .await
+        .expect("could not change draft state")
+}
+
+/// Patches the entity's archived flag to the given value.
+async fn set_archived(api: &mut DatabaseApi<'_>, entity: &Entity, archived: bool) -> Entity {
+    api.store
+        .patch_entity(
+            api.account_id,
+            PatchEntityParams {
+                entity_id: entity.metadata.record_id.entity_id,
+                decision_time: None,
+                entity_type_ids: HashSet::new(),
+                properties: Vec::new(),
+                draft: None,
+                archived: Some(archived),
+                confidence: None,
+                provenance: provenance(),
+            },
+        )
+        .await
+        .expect("could not change archived state")
+}
+
+/// Patches the entity's properties at the given decision time (`None` means the present).
+async fn patch_properties(
+    api: &mut DatabaseApi<'_>,
+    entity: &Entity,
+    properties: PropertyObject,
+    decision_time: Option<Timestamp<DecisionTime>>,
+) -> Entity {
+    api.store
+        .patch_entity(
+            api.account_id,
+            PatchEntityParams {
+                entity_id: entity.metadata.record_id.entity_id,
+                decision_time,
+                entity_type_ids: HashSet::new(),
+                properties: vec![PropertyPatchOperation::Replace {
+                    path: PropertyPath::default(),
+                    property: PropertyWithMetadata::from_parts(Property::Object(properties), None)
+                        .expect("could not create property with metadata"),
+                }],
+                draft: None,
+                archived: None,
+                confidence: None,
+                provenance: provenance(),
+            },
+        )
+        .await
+        .expect("could not patch entity")
+}
+
+/// A third distinct property object, so a backfill differs from the edition it corrects.
+///
+/// [`patch_entity`](EntityStore::patch_entity) drops a patch whose result equals the locked
+/// edition without writing anything, so a backfill test that reuses the original properties
+/// exercises the no-op path instead of the write it means to observe.
+fn charles() -> PropertyObject {
+    serde_json::from_str(hash_graph_test_data::entity::PERSON_CHARLES_V1)
+        .expect("could not parse entity")
+}
+
+fn purge_params(
+    entity: &Entity,
+    link_behavior: LinkDeletionBehavior,
+) -> DeleteEntitiesParams<'static> {
+    DeleteEntitiesParams {
+        filter: Filter::for_entity_by_entity_id(entity.metadata.record_id.entity_id),
+        temporal_axes: QueryTemporalAxesUnresolved::live_only(),
+        include_drafts: false,
+        scope: DeletionScope::Purge { link_behavior },
+        decision_time: None,
+    }
+}
+
+/// Creation fires [`EntityEvent::Updated`] with the created edition, and the event's own time
+/// is its cursor.
+#[tokio::test]
+async fn create_fires_updated() {
+    let mut database = DatabaseTestWrapper::new().await;
+    let mut api = seed(&mut database).await;
+
+    let cursor = feed_cursor(&api).await;
+    let entity = create_person(&mut api, alice(), false).await;
+
+    let (updated, ended, deleted) = collect_events(&api, cursor).await;
+    assert_eq!(updated.len(), 1);
+    assert!(ended.is_empty());
+    assert!(deleted.is_empty());
+    let update = updated[0];
+    assert_eq!(
+        update.entity.entity_uuid,
+        entity.metadata.record_id.entity_id.entity_uuid
+    );
+    assert_eq!(update.edition, entity.metadata.record_id.edition_id);
+    assert!(!update.archived);
+
+    // Re-reading with an unchanged watermark returns the same events.
+    let (updated_again, ended_again, deleted_again) = collect_events(&api, cursor).await;
+    assert_eq!(updated_again, updated);
+    assert!(ended_again.is_empty());
+    assert!(deleted_again.is_empty());
+
+    // The comparison is strict, so the event's own time excludes it.
+    let (updated_after, ended_after, deleted_after) = collect_events(&api, update.changed_at).await;
+    assert!(updated_after.is_empty());
+    assert!(ended_after.is_empty());
+    assert!(deleted_after.is_empty());
+}
+
+/// An update at the present fires [`EntityEvent::Updated`] with the new edition, and the
+/// decision slice it closes stays out of [`EntityEvent::Ended`] because the present row still
+/// exists.
+#[tokio::test]
+async fn update_at_present_fires_updated_with_new_edition() {
+    let mut database = DatabaseTestWrapper::new().await;
+    let mut api = seed(&mut database).await;
+
+    let entity = create_person(&mut api, alice(), false).await;
+    let cursor = feed_cursor(&api).await;
+
+    let patched = patch_properties(&mut api, &entity, bob(), None).await;
+    assert_ne!(
+        patched.metadata.record_id.edition_id,
+        entity.metadata.record_id.edition_id
+    );
+
+    let (updated, ended, deleted) = collect_events(&api, cursor).await;
+    assert_eq!(updated.len(), 1);
+    assert!(ended.is_empty());
+    assert!(deleted.is_empty());
+    assert_eq!(updated[0].edition, patched.metadata.record_id.edition_id);
+}
+
+/// A patch into a closed decision slice is a pure backfill: it rewrites history rows without
+/// touching the present row, and fires nothing.
+#[tokio::test]
+async fn backdated_patch_into_closed_slice_fires_nothing() {
+    let mut database = DatabaseTestWrapper::new().await;
+    let mut api = seed(&mut database).await;
+
+    let entity = create_person(&mut api, alice(), false).await;
+    let backdate = Timestamp::<DecisionTime>::now();
+    // This present-time patch bounds the creation slice, so `backdate` now falls inside a
+    // closed slice.
+    let present = patch_properties(&mut api, &entity, bob(), None).await;
+    let cursor = feed_cursor(&api).await;
+
+    let backfilled = patch_properties(&mut api, &entity, charles(), Some(backdate)).await;
+    // The backfill minted an edition of its own, so it really wrote rather than hitting the
+    // store's no-op early return.
+    assert_ne!(
+        backfilled.metadata.record_id.edition_id,
+        entity.metadata.record_id.edition_id
+    );
+    assert_ne!(
+        backfilled.metadata.record_id.edition_id,
+        present.metadata.record_id.edition_id
+    );
+
+    let (updated, ended, deleted) = collect_events(&api, cursor).await;
+    assert!(updated.is_empty());
+    assert!(ended.is_empty());
+    assert!(deleted.is_empty());
+}
+
+/// A backdated patch whose decision time falls inside the open present slice rewrites the
+/// present from that date onward, so it fires [`EntityEvent::Updated`] like any other
+/// present-state write.
+#[tokio::test]
+async fn backdated_patch_into_open_slice_fires_updated() {
+    let mut database = DatabaseTestWrapper::new().await;
+    let mut api = seed(&mut database).await;
+
+    let entity = create_person(&mut api, alice(), false).await;
+    let backdate = Timestamp::<DecisionTime>::now();
+    let cursor = feed_cursor(&api).await;
+
+    let patched = patch_properties(&mut api, &entity, bob(), Some(backdate)).await;
+
+    let (updated, ended, deleted) = collect_events(&api, cursor).await;
+    assert_eq!(updated.len(), 1);
+    assert!(ended.is_empty());
+    assert!(deleted.is_empty());
+    assert_eq!(updated[0].edition, patched.metadata.record_id.edition_id);
+}
+
+/// Flipping the archived flag is an edition change at the present, so it fires
+/// [`EntityEvent::Updated`] in both directions, and each event carries the flag's new value on
+/// its edition.
+#[tokio::test]
+async fn archived_flag_patch_fires_updated() {
+    let mut database = DatabaseTestWrapper::new().await;
+    let mut api = seed(&mut database).await;
+
+    let entity = create_person(&mut api, alice(), false).await;
+    let cursor = feed_cursor(&api).await;
+
+    let archived = set_archived(&mut api, &entity, true).await;
+    assert!(archived.metadata.archived);
+
+    let (updated, ended, deleted) = collect_events(&api, cursor).await;
+    assert_eq!(updated.len(), 1);
+    assert!(ended.is_empty());
+    assert!(deleted.is_empty());
+    assert_eq!(updated[0].edition, archived.metadata.record_id.edition_id);
+    assert!(updated[0].archived);
+
+    let cursor = feed_cursor(&api).await;
+    let unarchived = set_archived(&mut api, &archived, false).await;
+    assert!(!unarchived.metadata.archived);
+
+    let (updated, ended, deleted) = collect_events(&api, cursor).await;
+    assert_eq!(updated.len(), 1);
+    assert!(ended.is_empty());
+    assert!(deleted.is_empty());
+    assert_eq!(updated[0].edition, unarchived.metadata.record_id.edition_id);
+    assert!(!updated[0].archived);
+}
+
+/// Purging an entity with `Archive` link behavior ends the incoming link entity's present and
+/// tombstones the target, and one read delivers both: the [`EntityEvent::Ended`] for the link
+/// and the [`EntityEvent::Deleted`] for the target come from the same snapshot.
+#[tokio::test]
+async fn purge_with_archived_links_ends_link_and_deletes_target() {
+    let mut database = DatabaseTestWrapper::new().await;
+    let mut api = seed(&mut database).await;
+
+    let person_a = create_person(&mut api, alice(), false).await;
+    let person_b = create_person(&mut api, bob(), false).await;
+    let link = create_link(
+        &mut api,
+        person_a.metadata.record_id.entity_id,
+        person_b.metadata.record_id.entity_id,
+    )
+    .await;
+    let cursor = feed_cursor(&api).await;
+
+    api.store
+        .delete_entities(
+            api.account_id.into(),
+            purge_params(&person_b, LinkDeletionBehavior::Archive),
+        )
+        .await
+        .expect("could not purge entity");
+
+    let (updated, ended, deleted) = collect_events(&api, cursor).await;
+    assert!(updated.is_empty());
+    assert_eq!(ended.len(), 1);
+    assert_eq!(
+        ended[0].entity.entity_uuid,
+        link.metadata.record_id.entity_id.entity_uuid
+    );
+    assert_eq!(deleted.len(), 1);
+    assert_eq!(
+        deleted[0].entity.entity_uuid,
+        person_b.metadata.record_id.entity_id.entity_uuid
+    );
+    assert_eq!(deleted[0].provenance.deleted_by_id, api.account_id);
+}
+
+/// Purge removes the temporal rows outright, so [`EntityEvent::Deleted`] is the only event it
+/// fires, and the tombstone's own time then excludes it from the next read.
+#[tokio::test]
+async fn purge_fires_deleted_only() {
+    let mut database = DatabaseTestWrapper::new().await;
+    let mut api = seed(&mut database).await;
+
+    let entity = create_person(&mut api, alice(), false).await;
+    let cursor = feed_cursor(&api).await;
+
+    api.store
+        .delete_entities(
+            api.account_id.into(),
+            purge_params(&entity, LinkDeletionBehavior::Ignore),
+        )
+        .await
+        .expect("could not purge entity");
+
+    let (updated, ended, deleted) = collect_events(&api, cursor).await;
+    assert!(updated.is_empty());
+    assert!(ended.is_empty());
+    assert_eq!(deleted.len(), 1);
+    assert_eq!(
+        deleted[0].entity.entity_uuid,
+        entity.metadata.record_id.entity_id.entity_uuid
+    );
+
+    let (updated_after, ended_after, deleted_after) =
+        collect_events(&api, deleted[0].provenance.deleted_at_transaction_time).await;
+    assert!(updated_after.is_empty());
+    assert!(ended_after.is_empty());
+    assert!(deleted_after.is_empty());
+}
+
+/// Erase removes the `entity_ids` row itself, so the feed carries no record of the entity, from
+/// any watermark.
+#[tokio::test]
+async fn erase_fires_nothing() {
+    let mut database = DatabaseTestWrapper::new().await;
+    let mut api = seed(&mut database).await;
+
+    let entity = create_person(&mut api, alice(), false).await;
+
+    api.store
+        .delete_entities(
+            api.account_id.into(),
+            DeleteEntitiesParams {
+                filter: Filter::for_entity_by_entity_id(entity.metadata.record_id.entity_id),
+                temporal_axes: QueryTemporalAxesUnresolved::live_only(),
+                include_drafts: false,
+                scope: DeletionScope::Erase,
+                decision_time: None,
+            },
+        )
+        .await
+        .expect("could not erase entity");
+
+    let (updated, ended, deleted) = collect_events(&api, Timestamp::UNIX_EPOCH).await;
+    assert!(updated.is_empty());
+    assert!(ended.is_empty());
+    assert!(deleted.is_empty());
+}
+
+/// Draft activity never enters the feed, and undrafting is the first event the entity fires.
+#[tokio::test]
+async fn draft_lifecycle_silent_until_undraft() {
+    let mut database = DatabaseTestWrapper::new().await;
+    let mut api = seed(&mut database).await;
+
+    let cursor = feed_cursor(&api).await;
+    let draft = create_person(&mut api, alice(), true).await;
+    let draft_patched = patch_properties(&mut api, &draft, bob(), None).await;
+
+    let (updated, ended, deleted) = collect_events(&api, cursor).await;
+    assert!(updated.is_empty());
+    assert!(ended.is_empty());
+    assert!(deleted.is_empty());
+
+    let published = set_draft(&mut api, &draft_patched, false).await;
+
+    let (updated, ended, deleted) = collect_events(&api, cursor).await;
+    assert_eq!(updated.len(), 1);
+    assert!(ended.is_empty());
+    assert!(deleted.is_empty());
+    assert_eq!(
+        updated[0].entity.entity_uuid,
+        published.metadata.record_id.entity_id.entity_uuid
+    );
+    assert_eq!(updated[0].edition, published.metadata.record_id.edition_id);
+}
+
+/// Publishing a draft over a live entity closes the live decision slice and installs the
+/// published edition as the new present in one motion, so the entity fires
+/// [`EntityEvent::Updated`] and never [`EntityEvent::Ended`]. This is the anti-join's sharpest
+/// case. After the publish, one snapshot carries both a decision-closed current row and a
+/// present row for the entity, and without the anti-join the closed row would enter the ended
+/// kind.
+#[tokio::test]
+async fn draft_supersedes_live_fires_updated_not_ended() {
+    let mut database = DatabaseTestWrapper::new().await;
+    let mut api = seed(&mut database).await;
+
+    let live = create_person(&mut api, alice(), false).await;
+    let draft = set_draft(&mut api, &live, true).await;
+    assert!(draft.metadata.record_id.entity_id.draft_id.is_some());
+    let draft = patch_properties(&mut api, &draft, bob(), None).await;
+
+    let cursor = feed_cursor(&api).await;
+    let published = set_draft(&mut api, &draft, false).await;
+    assert!(published.metadata.record_id.entity_id.draft_id.is_none());
+
+    let (updated, ended, deleted) = collect_events(&api, cursor).await;
+    assert_eq!(updated.len(), 1);
+    assert!(ended.is_empty());
+    assert!(deleted.is_empty());
+    assert_eq!(
+        updated[0].entity.entity_uuid,
+        live.metadata.record_id.entity_id.entity_uuid
+    );
+    assert_eq!(updated[0].edition, published.metadata.record_id.edition_id);
+}

--- a/libs/@local/graph/postgres-store/tests/deletion/links.rs
+++ b/libs/@local/graph/postgres-store/tests/deletion/links.rs
@@ -21,8 +21,9 @@ use crate::{
 /// Rejects purge with [`LinkDeletionBehavior::Error`] when incoming links exist.
 ///
 /// Creates A, B, and link entity L (A→B). L has an immutable `entity_edge` row with `source=L,
-/// target=B`. Purging B with `Error` behavior triggers `count_incoming_links`, which finds L's edge
-/// targeting B (L is outside the deletion batch) and returns [`DeletionError::IncomingLinksExist`].
+/// target=B`. Purging B with `Error` behavior triggers `count_incoming_link_edges`, which finds
+/// L's edge targeting B (L is outside the deletion batch) and returns
+/// [`DeletionError::IncomingLinksExist`].
 #[tokio::test]
 async fn purge_error_rejects_with_incoming_links() {
     let mut database = DatabaseTestWrapper::new().await;
@@ -126,9 +127,11 @@ async fn purge_ignore_succeeds_with_incoming_links() {
 
 /// Rejects erase when incoming links exist, regardless of link behavior.
 ///
-/// [`DeletionScope::Erase`] always runs `count_incoming_links` because `delete_entity_ids` would
-/// violate the FK `entity_edge.target → entity_ids` if incoming edges exist. The explicit check
-/// provides a clean [`DeletionError::IncomingLinksExist`] instead of a raw PostgreSQL FK violation.
+/// [`DeletionScope::Erase`] always runs `count_incoming_link_edges` because `delete_entity_ids`
+/// would violate the FK from `entity_edge.target` to `entity_ids` if incoming edges exist. The
+/// explicit
+/// check provides a clean [`DeletionError::IncomingLinksExist`] instead of a raw PostgreSQL FK
+/// violation.
 #[tokio::test]
 async fn erase_rejects_with_incoming_links() {
     let mut database = DatabaseTestWrapper::new().await;
@@ -256,9 +259,10 @@ async fn purge_link_entity_removes_all_edges() {
 /// Links within the deletion batch are excluded from the incoming-link count.
 ///
 /// Creates A, B, and link L (A→B). Purges all three together with `Error` behavior.
-/// `count_incoming_links` uses `(target_web_id, target_entity_uuid) IN (batch) AND (source_web_id,
-/// source_entity_uuid) NOT IN (batch)`. Since L (the source of the edge to B) is also in the
-/// deletion batch, L's edge is excluded from the count and B's deletion is not blocked.
+/// `count_incoming_link_edges` uses `(target_web_id, target_entity_uuid) IN (batch) AND
+/// (source_web_id, source_entity_uuid) NOT IN (batch)`. Since L (the source of the edge to B)
+/// is also in the deletion batch, L's edge is excluded from the count and B's deletion is not
+/// blocked.
 ///
 /// **Note**: `entity_edge` stores reversed (incoming-direction) rows. For L in the batch, its
 /// reversed rows have `source=A/B, target=L`. If A and B are also in the batch, those sources are
@@ -390,7 +394,7 @@ async fn draft_deletion_skips_link_check() {
 
 /// Verifies [`DeletionError::IncomingLinksExist`] reports the correct count.
 ///
-/// Creates multiple distinct link entities pointing to the same target. `count_incoming_links`
+/// Creates multiple distinct link entities pointing to the same target. `count_incoming_link_edges`
 /// returns `COUNT(*)` from `entity_edge` (as `i64` cast to `u64`). The `count` field in the error
 /// must match the actual number of incoming `entity_edge` rows from sources outside the deletion
 /// batch.
@@ -442,9 +446,9 @@ async fn incoming_link_count_is_accurate() {
 /// Handles a self-loop: entity A links to itself via link L.
 ///
 /// L has `entity_edge` rows with `source=L, target=A` (outgoing) and `source=A, target=L`
-/// (incoming/reversed). Deleting A alone with `Error`: L is outside the batch, L's outgoing edge
-/// targets A → `count_incoming_links` finds it → blocked. Deleting A + L together with `Error`:
-/// L is in the batch, so L's edge is excluded from the count → succeeds.
+/// (incoming/reversed). Deleting A alone with `Error` is blocked: L is outside the batch, so its
+/// outgoing edge targets A and `count_incoming_link_edges` finds it. Deleting A + L together with
+/// `Error` succeeds: L is in the batch, so L's edge is excluded from the count.
 #[tokio::test]
 async fn self_loop_link() {
     let mut database = DatabaseTestWrapper::new().await;
@@ -666,8 +670,8 @@ async fn bidirectional_links() {
 /// Erasing A+B+L together succeeds — in-batch link sources are excluded from the count.
 ///
 /// Same setup as [`self_referential_batch_not_counted`] but with [`DeletionScope::Erase`] instead
-/// of Purge. Erase always runs `count_incoming_links`; the batch-exclusion logic (`source NOT IN
-/// batch`) must work here too. After erase, all three `entity_ids` rows are deleted (not
+/// of Purge. Erase always runs `count_incoming_link_edges`; the batch-exclusion logic (`source
+/// NOT IN batch`) must work here too. After erase, all three `entity_ids` rows are deleted (not
 /// tombstoned) and no FK violation occurs because `delete_entity_edge` removes all edge rows
 /// before `delete_entity_ids`.
 #[tokio::test]
@@ -726,10 +730,10 @@ async fn erase_batch_excludes_in_batch_links() {
 /// Erasing a link entity alone succeeds — denormalized edges are not real incoming links.
 ///
 /// `entity_edge` stores `direction = 'incoming'` rows (source=endpoint, target=L) as denormalized
-/// copies for query optimization. `count_incoming_links` only counts `direction = 'outgoing'` edges
-/// (real link relationships from other link entities). Since no other link entity points TO L,
-/// the count is 0 and erase proceeds. `delete_entity_edge` cleans up all 4 rows (both outgoing
-/// and incoming-direction) before `delete_entity_ids` removes L's row.
+/// copies for query optimization. `count_incoming_link_edges` only counts `direction =
+/// 'outgoing'` edges (real link relationships from other link entities). Since no other link
+/// entity points TO L, the count is 0 and erase proceeds. `delete_entity_edge` cleans up all
+/// 4 rows (both outgoing and incoming-direction) before `delete_entity_ids` removes L's row.
 #[tokio::test]
 async fn erase_link_entity_alone_succeeds() {
     let mut database = DatabaseTestWrapper::new().await;

--- a/libs/@local/graph/postgres-store/tests/deletion/main.rs
+++ b/libs/@local/graph/postgres-store/tests/deletion/main.rs
@@ -6,6 +6,7 @@ mod common;
 mod created_by_columns;
 mod drafts;
 mod erase;
+mod feed;
 mod links;
 mod purge;
 mod validation;
@@ -180,11 +181,12 @@ pub(crate) async fn raw_count(
         .get(0)
 }
 
-/// Returns the [`EntityDeletionProvenance`] flattened into the `entity_ids` provenance JSONB, or
-/// `None` if the row is missing or the entity has not been deleted.
+/// Returns the [`EntityDeletionProvenance`] from the `entity_ids` tombstone columns, or `None`
+/// if the row is missing or the entity has not been deleted.
 ///
-/// The deletion fields are extracted into their own object so they deserialize independently of
-/// the other JSONB-resident provenance fields.
+/// The `entity_ids_deletion_tombstone_total` CHECK guarantees the three columns are set
+/// together, so the helper still reads each one individually to catch a partial stamp as a
+/// panic rather than mask it.
 pub(crate) async fn get_deletion_provenance(
     api: &DatabaseApi<'_>,
     web_id: WebId,
@@ -193,23 +195,42 @@ pub(crate) async fn get_deletion_provenance(
     api.store
         .as_client()
         .query_opt(
-            "SELECT jsonb_build_object(
-                 'deletedById', provenance -> 'deletedById',
-                 'deletedAtTransactionTime', provenance -> 'deletedAtTransactionTime',
-                 'deletedAtDecisionTime', provenance -> 'deletedAtDecisionTime'
-             ) FROM entity_ids WHERE web_id = $1 AND entity_uuid = $2",
+            "SELECT
+                deleted_by_id,
+                deleted_at_transaction_time,
+                deleted_at_decision_time
+             FROM entity_ids
+             WHERE web_id = $1
+               AND entity_uuid = $2",
             &[&web_id, &entity_uuid],
         )
         .await
         .expect("provenance query failed")
-        .map(|row| row.get::<_, serde_json::Value>(0))
-        .filter(|deletion| {
-            !(deletion["deletedById"].is_null()
-                && deletion["deletedAtTransactionTime"].is_null()
-                && deletion["deletedAtDecisionTime"].is_null())
-        })
-        .map(|deletion| {
-            serde_json::from_value(deletion).expect("deletion fields should deserialize")
+        .and_then(|row| {
+            let deleted_by_id = row.get(0);
+            let deleted_at_transaction_time = row.get(1);
+            let deleted_at_decision_time = row.get(2);
+
+            match (
+                deleted_by_id,
+                deleted_at_transaction_time,
+                deleted_at_decision_time,
+            ) {
+                (
+                    Some(deleted_by_id),
+                    Some(deleted_at_transaction_time),
+                    Some(deleted_at_decision_time),
+                ) => Some(EntityDeletionProvenance {
+                    deleted_by_id,
+                    deleted_at_transaction_time,
+                    deleted_at_decision_time,
+                }),
+                (None, None, None) => None,
+                partial => unreachable!(
+                    "database has a constraint which prevents partial deletion information: \
+                     {partial:?}"
+                ),
+            }
         })
 }
 
@@ -586,5 +607,31 @@ pub(crate) async fn raw_entity_ids_exists(
         )
         .await
         .expect("raw entity_ids exists query failed")
+        .get(0)
+}
+
+/// Returns whether the `entity_ids` provenance JSONB carries any deletion key.
+///
+/// Post-V58 the tombstone lives in dedicated columns and the JSONB must stay free of the
+/// retired keys, so `true` here means the old write path resurfaced.
+pub(crate) async fn provenance_jsonb_has_deletion_keys(
+    api: &DatabaseApi<'_>,
+    web_id: WebId,
+    entity_uuid: EntityUuid,
+) -> bool {
+    api.store
+        .as_client()
+        .query_one(
+            "SELECT EXISTS(
+                 SELECT 1 FROM entity_ids
+                 WHERE web_id = $1 AND entity_uuid = $2
+                   AND provenance ?| array[
+                       'deletedById', 'deletedAtTransactionTime', 'deletedAtDecisionTime'
+                   ]
+             )",
+            &[&web_id, &entity_uuid],
+        )
+        .await
+        .expect("provenance JSONB deletion-key query failed")
         .get(0)
 }

--- a/libs/@local/graph/postgres-store/tests/deletion/purge.rs
+++ b/libs/@local/graph/postgres-store/tests/deletion/purge.rs
@@ -28,7 +28,7 @@ use uuid::Uuid;
 use crate::{
     DatabaseTestWrapper, alice, bob, count_entities, create_link, create_person,
     create_second_user, get_created_by_id, get_deletion_provenance, person_type_id, provenance,
-    raw_count, raw_entity_ids_exists, seed,
+    provenance_jsonb_has_deletion_keys, raw_count, raw_entity_ids_exists, seed,
 };
 
 /// Helper: purge with default settings (`include_drafts=false`, Ignore link behavior).
@@ -317,10 +317,10 @@ async fn include_drafts_irrelevant_for_published() {
 
 /// `Purge` with [`LinkDeletionBehavior::Error`] succeeds when no incoming links exist.
 ///
-/// All other purge tests use `Ignore` link behavior, skipping `count_incoming_links` entirely.
-/// This test exercises the `Error` path: `count_incoming_links` runs, finds 0 incoming edges from
-/// sources outside the batch, and deletion proceeds normally. Confirms the happy path through the
-/// link check doesn't spuriously block deletion.
+/// All other purge tests use `Ignore` link behavior, skipping `count_incoming_link_edges` entirely.
+/// This test exercises the `Error` path: `count_incoming_link_edges` runs, finds 0 incoming
+/// edges from sources outside the batch, and deletion proceeds normally. Confirms the happy
+/// path through the link check doesn't spuriously block deletion.
 #[tokio::test]
 async fn purge_error_succeeds_without_incoming_links() {
     let mut database = DatabaseTestWrapper::new().await;
@@ -360,10 +360,9 @@ async fn purge_error_succeeds_without_incoming_links() {
 
 /// Verifies the tombstone carries correct deletion provenance.
 ///
-/// After purge, the `entity_ids` row persists with `provenance->'deletion'` containing
-/// `deletedById` (matching the acting actor), `deletedAtTransactionTime`, and
-/// `deletedAtDecisionTime`. The provenance is merged into the existing JSONB via
-/// `update_entity_ids_provenance` using PostgreSQL's `||` operator. Verified via raw SQL.
+/// After purge, the `entity_ids` row persists with the `deleted_by_id` (matching the acting
+/// actor), `deleted_at_transaction_time`, and `deleted_at_decision_time` columns set, written
+/// by `update_entity_ids_provenance`. Verified via raw SQL.
 #[tokio::test]
 async fn tombstone_has_deletion_provenance() {
     let mut database = DatabaseTestWrapper::new().await;
@@ -800,9 +799,8 @@ async fn query_after_purge_returns_empty() {
 /// Verifies provenance records the deleting actor, not the creating actor.
 ///
 /// Actor A creates the entity, Actor B deletes it. `update_entity_ids_provenance` receives the
-/// `actor_id` from the `delete_entities` caller and stores it as `deleted_by_id` in
-/// [`EntityDeletionProvenance`]. The tombstone's `provenance->'deletion'->'deletedById'` must be
-/// Actor B's ID, not A's.
+/// `actor_id` from the `delete_entities` caller and stores it in the `deleted_by_id` column.
+/// The tombstone's `deleted_by_id` must be Actor B's ID, not A's.
 #[tokio::test]
 async fn different_actor_deleting() {
     let mut database = DatabaseTestWrapper::new().await;
@@ -1059,12 +1057,13 @@ async fn archived_entity() {
     assert!(raw_entity_ids_exists(&api, entity_id.web_id, entity_id.entity_uuid).await);
 }
 
-/// Verifies the soft-delete's provenance merge only adds deletion keys.
+/// Verifies the tombstone stamp touches only the deletion columns.
 ///
-/// The deletion is written as a JSONB `||` merge into `entity_ids.provenance`, which must leave
-/// the creator column and any other JSONB-resident keys untouched.
+/// The deletion is written into the three `deleted_*` columns. The creator column stays
+/// untouched, and the provenance JSONB gains no keys: each datum is stored exactly once since
+/// V58, so a deletion key surfacing in the JSONB means the retired write path is back.
 #[tokio::test]
-async fn provenance_merge_only_adds_deletion_keys() {
+async fn provenance_touches_only_deletion_columns() {
     let mut database = DatabaseTestWrapper::new().await;
     let mut api = seed(&mut database).await;
 
@@ -1085,12 +1084,18 @@ async fn provenance_merge_only_adds_deletion_keys() {
         .expect("entity_ids row should exist");
     assert_eq!(created_by_id, ActorEntityUuid::from(api.account_id));
 
-    // Deletion provenance must be added to the JSONB.
+    // Deletion provenance must be present in the columns.
     assert!(
         get_deletion_provenance(&api, entity_id.web_id, entity_id.entity_uuid)
             .await
             .is_some(),
         "deletion provenance must be present"
+    );
+
+    // And the JSONB must not have gained any deletion keys.
+    assert!(
+        !provenance_jsonb_has_deletion_keys(&api, entity_id.web_id, entity_id.entity_uuid).await,
+        "the provenance JSONB must not carry deletion keys"
     );
 }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Entities gain deletion tombstones and an event feed. A deletion now writes who deleted and when (transaction and decision time) into `entity_ids`, with a check constraint holding the tombstone total or absent. The new feed module serves ordered change events polled from current rows in two arms: `changed` for present rows and `ended` for decision-closed ones. Consumers that mirror entity state can now hear about deletions, which the store previously forgot.

The migrations pair as in #9302: `V59` (deletion provenance columns), `V60` (feed indexes), and `V61` (feed statistics) alter deployed databases, and the same schema enters the fresh-database `v009` here. The `V60`/`V61` objects exist because the feed's predicates are expressions, which carry no column statistics. The migration comments state what each object fixes and the measured plan bounds.

Review focus: feed completeness at the poll-window edges (an event exactly on a boundary) and across the split between the two arms. The `tests/deletion` suite exercises the crossings.

## 🔍 What does this change?

- `graph-migrations/v009__entities/up.sql`: tombstone columns with their totality constraint and partial index, plus the feed indexes and extended statistics.
- `postgres_migrations/V59`, `V60`, `V61`: the same schema for deployed databases.
- `knowledge/entity/feed.rs`: the feed. `snapshot/entity/channel.rs` carries the deletion fields through snapshots.
- `delete.rs`: tombstone writes. `provenance.rs`: the deletion provenance column.
- `rows.rs`, `table.rs`, `insert.rs`: the `Deleted*` row vocabulary and fixtures.
- `Cargo.toml`: `pin-project-lite` for the feed stream plumbing.
- `tests/deletion/`: a new integration suite (drafts, erase, feed, links, purge).

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- `tests/deletion/` under the integration harness, which provisions its own scratch database.
- The existing postgres-store lib suite covers this, plus the workspace battery: `cargo check` including all test targets, clippy at zero warnings, `fmt` clean.

## ❓ How to test this?

```bash
cargo nextest run -p hash-graph-postgres-store --lib
turbo run test:integration --filter @rust/hash-graph-postgres-store
```
