### PR TITLE
FE-284: Update key for draft type pages to reduce reload

### DIFF
--- a/apps/hash-frontend/src/pages/@/[shortname]/types/data-type/[...slug-maybe-version].page.tsx
+++ b/apps/hash-frontend/src/pages/@/[shortname]/types/data-type/[...slug-maybe-version].page.tsx
@@ -127,7 +127,7 @@ const Page: NextPageWithLayout = () => {
         webId={routeNamespace.webId}
         draftNewDataType={draftDataType}
         dataTypeBaseUrl={dataTypeBaseUrl}
-        key={`${dataTypeBaseUrl}-${requestedVersion?.toString()}`}
+        key={`${draftDataType?.metadata.recordId.baseUrl ?? dataTypeBaseUrl}-${requestedVersion?.toString()}`}
         requestedVersion={requestedVersion}
         onDataTypeUpdated={(dataType) => {
           void router.push(generateLinkParameters(dataType.schema.$id).href);

--- a/apps/hash-frontend/src/pages/@/[shortname]/types/entity-type/[...slug-maybe-version].page.tsx
+++ b/apps/hash-frontend/src/pages/@/[shortname]/types/entity-type/[...slug-maybe-version].page.tsx
@@ -126,7 +126,7 @@ const Page: NextPageWithLayout = () => {
         webId={routeNamespace.webId}
         draftEntityType={draftEntityType}
         entityTypeBaseUrl={entityTypeBaseUrl}
-        key={`${entityTypeBaseUrl}-${requestedVersion?.toString()}`}
+        key={`${draftEntityType?.metadata.recordId.baseUrl ?? entityTypeBaseUrl}-${requestedVersion?.toString()}`}
         requestedVersion={requestedVersion}
       />
       <GlobalStyles


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Minimize ui shift when going from a draft to created type - by correctly keying on the future type id.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change
