### PR TITLE
FE-855: Prevent extending types without create permission in UI

### DIFF
--- a/apps/hash-api/src/graph/ontology/primitive/entity-type.ts
+++ b/apps/hash-api/src/graph/ontology/primitive/entity-type.ts
@@ -72,6 +72,51 @@ export const checkPermissionsOnEntityType: ImpureGraphFunction<
 };
 
 /**
+ * Check the requesting user's permissions on multiple entity types at once.
+ *
+ * Uses the bulk `hasPermissionForEntityTypes` check per action, so the number of
+ * graph calls is fixed regardless of how many entity types are passed.
+ */
+export const checkPermissionsOnEntityTypes: ImpureGraphFunction<
+  { entityTypeIds: VersionedUrl[] },
+  Promise<
+    { entityTypeId: VersionedUrl; permissions: UserPermissionsOnEntityType }[]
+  >
+> = async (graphContext, { actorId }, params) => {
+  const { entityTypeIds } = params;
+
+  if (entityTypeIds.length === 0) {
+    return [];
+  }
+
+  const isPublicUser = actorId === publicUserAccountId;
+
+  const [editableIds, instantiableIds] = isPublicUser
+    ? [new Set<VersionedUrl>(), new Set<VersionedUrl>()]
+    : await Promise.all([
+        hasPermissionForEntityTypes(
+          graphContext.graphApi,
+          { actorId },
+          { entityTypeIds, action: "updateEntityType" },
+        ).then((permitted) => new Set(permitted)),
+        hasPermissionForEntityTypes(
+          graphContext.graphApi,
+          { actorId },
+          { entityTypeIds, action: "instantiate" },
+        ).then((permitted) => new Set(permitted)),
+      ]);
+
+  return entityTypeIds.map((entityTypeId) => ({
+    entityTypeId,
+    permissions: {
+      edit: editableIds.has(entityTypeId),
+      instantiate: instantiableIds.has(entityTypeId),
+      view: true,
+    },
+  }));
+};
+
+/**
  * Create an entity type.
  *
  * @param params.webId - the id of the account who owns the entity type

--- a/apps/hash-api/src/graphql/resolvers/index.ts
+++ b/apps/hash-api/src/graphql/resolvers/index.ts
@@ -96,6 +96,7 @@ import {
 import {
   archiveEntityTypeResolver,
   checkUserPermissionsOnEntityTypeResolver,
+  checkUserPermissionsOnEntityTypesResolver,
   createEntityTypeResolver,
   getClosedMultiEntityTypesResolver,
   queryEntityTypesResolver,
@@ -143,6 +144,8 @@ export const resolvers: Omit<Resolvers, "Query" | "Mutation"> & {
     queryEntityTypes: queryEntityTypesResolver,
     searchEntityTypes: searchEntityTypesResolver,
     queryEntityTypeSubgraph: queryEntityTypeSubgraphResolver,
+    checkUserPermissionsOnEntityTypes:
+      checkUserPermissionsOnEntityTypesResolver,
     getClosedMultiEntityTypes: getClosedMultiEntityTypesResolver,
 
     /** Logged in users (who may not have completed signup) */

--- a/apps/hash-api/src/graphql/resolvers/ontology/entity-type.ts
+++ b/apps/hash-api/src/graphql/resolvers/ontology/entity-type.ts
@@ -9,6 +9,7 @@ import {
 import {
   archiveEntityType,
   checkPermissionsOnEntityType,
+  checkPermissionsOnEntityTypes,
   createEntityType,
   unarchiveEntityType,
   updateEntityType,
@@ -17,12 +18,14 @@ import {
 import { graphQLContextToImpureGraphContext } from "../util";
 
 import type {
+  EntityTypePermissionsRecord,
   MutationArchiveEntityTypeArgs,
   MutationCreateEntityTypeArgs,
   MutationUnarchiveEntityTypeArgs,
   MutationUpdateEntityTypeArgs,
   MutationUpdateEntityTypesArgs,
   QueryCheckUserPermissionsOnEntityTypeArgs,
+  QueryCheckUserPermissionsOnEntityTypesArgs,
   QueryGetClosedMultiEntityTypesArgs,
   QueryQueryEntityTypesArgs,
   QueryQueryEntityTypeSubgraphArgs,
@@ -152,6 +155,18 @@ export const checkUserPermissionsOnEntityTypeResolver: ResolverFn<
     { ...dataSources, provenance },
     authentication,
     params,
+  );
+
+export const checkUserPermissionsOnEntityTypesResolver: ResolverFn<
+  EntityTypePermissionsRecord[],
+  Record<string, never>,
+  GraphQLContext,
+  QueryCheckUserPermissionsOnEntityTypesArgs
+> = async (_, params, graphQLContext) =>
+  checkPermissionsOnEntityTypes(
+    graphQLContextToImpureGraphContext(graphQLContext),
+    graphQLContext.authentication,
+    { entityTypeIds: params.entityTypeIds },
   );
 
 export const archiveEntityTypeResolver: ResolverFn<

--- a/apps/hash-frontend/src/graphql/queries/ontology/entity-type.queries.ts
+++ b/apps/hash-frontend/src/graphql/queries/ontology/entity-type.queries.ts
@@ -69,3 +69,12 @@ export const checkUserPermissionsOnEntityTypeQuery = gql`
     checkUserPermissionsOnEntityType(entityTypeId: $entityTypeId)
   }
 `;
+
+export const checkUserPermissionsOnEntityTypesQuery = gql`
+  query checkUserPermissionsOnEntityTypes($entityTypeIds: [VersionedUrl!]!) {
+    checkUserPermissionsOnEntityTypes(entityTypeIds: $entityTypeIds) {
+      entityTypeId
+      permissions
+    }
+  }
+`;

--- a/apps/hash-frontend/src/pages/shared/entity-type-page/definition-tab.tsx
+++ b/apps/hash-frontend/src/pages/shared/entity-type-page/definition-tab.tsx
@@ -93,6 +93,9 @@ export const DefinitionTab = ({
       dataTypeOptions={dataTypeOptions}
       entityType={entityTypeAndPropertyTypes.entityType}
       entityTypeOptions={entityTypeOptions}
+      entityTypePermissions={
+        entityTypesContext.entityTypePermissions ?? undefined
+      }
       key={entityTypeAndPropertyTypes.entityType.schema.$id} // Reset state when switching entity types, helps avoid state mismatch issues
       ontologyFunctions={ontologyFunctions}
       propertyTypeOptions={propertyTypeOptions}

--- a/apps/hash-frontend/src/pages/shared/entity-type-page/shared/entity-type-header.tsx
+++ b/apps/hash-frontend/src/pages/shared/entity-type-page/shared/entity-type-header.tsx
@@ -36,6 +36,7 @@ import type {
 import type { EntityTypeEditorFormData } from "@hashintel/type-editor";
 
 interface EntityTypeHeaderProps {
+  canInstantiate: boolean;
   currentVersion: OntologyTypeVersion;
   entityTypeSchema: EntityType;
   isArchived: boolean;
@@ -47,6 +48,7 @@ interface EntityTypeHeaderProps {
 }
 
 export const EntityTypeHeader = ({
+  canInstantiate,
   currentVersion,
   entityTypeSchema,
   isArchived,
@@ -246,7 +248,8 @@ export const EntityTypeHeader = ({
               {isLink && <EntityTypeInverse readonly={isReadonly} />}
             </Stack>
           </Stack>
-          {!isDraft && !isArchived ? (
+          {/* Extending requires permission to instantiate the parent type */}
+          {!isDraft && !isArchived && canInstantiate ? (
             <Button
               onClick={() => setShowExtendTypeModal(true)}
               variant="secondary"

--- a/apps/hash-frontend/src/pages/shared/entity-type.tsx
+++ b/apps/hash-frontend/src/pages/shared/entity-type.tsx
@@ -564,6 +564,7 @@ export const EntityType = ({
               <Box ref={titleWrapperRef} sx={typeHeaderContainerStyles}>
                 <EntityTypeTabHeaderContainer isInSlide={isInSlide}>
                   <EntityTypeHeader
+                    canInstantiate={!!userPermissions?.instantiate}
                     currentVersion={currentVersion}
                     entityTypeSchema={entityType.schema}
                     isArchived={isArchived}

--- a/apps/hash-frontend/src/shared/entity-types-context/provider/use-entity-types-context-value.ts
+++ b/apps/hash-frontend/src/shared/entity-types-context/provider/use-entity-types-context-value.ts
@@ -1,13 +1,19 @@
+import { useLazyQuery } from "@apollo/client";
 import { useCallback, useMemo, useRef, useState } from "react";
 
 import { getEntityTypes } from "@blockprotocol/graph/stdlib";
 
 import { useBlockProtocolQueryEntityTypes } from "../../../components/hooks/block-protocol-functions/ontology/use-block-protocol-query-entity-types";
+import { checkUserPermissionsOnEntityTypesQuery } from "../../../graphql/queries/ontology/entity-type.queries";
 import {
   getParentIds,
   isSpecialEntityType,
 } from "../shared/is-special-entity-type";
 
+import type {
+  CheckUserPermissionsOnEntityTypesQuery,
+  CheckUserPermissionsOnEntityTypesQueryVariables,
+} from "../../../graphql/api-types.gen";
 import type {
   EntityTypesContextValue,
   SpecialEntityTypeRecord,
@@ -16,10 +22,14 @@ import type {
   EntityTypeWithMetadata,
   VersionedUrl,
 } from "@blockprotocol/type-system";
+import type { UserPermissionsOnEntityType } from "@local/hash-graph-sdk/authorization";
 
 export const useEntityTypesContextValue = (): EntityTypesContextValue => {
   const [types, setTypes] = useState<
-    Omit<EntityTypesContextValue, "refetch" | "ensureFetched">
+    Omit<
+      EntityTypesContextValue,
+      "refetch" | "ensureFetched" | "entityTypePermissions"
+    >
   >({
     entityTypes: null,
     isSpecialEntityTypeLookup: null,
@@ -29,7 +39,19 @@ export const useEntityTypesContextValue = (): EntityTypesContextValue => {
     subgraph: null,
   });
 
+  const [entityTypePermissions, setEntityTypePermissions] = useState<Record<
+    VersionedUrl,
+    UserPermissionsOnEntityType
+  > | null>(null);
+
   const { queryEntityTypes } = useBlockProtocolQueryEntityTypes();
+
+  const [checkEntityTypePermissions] = useLazyQuery<
+    CheckUserPermissionsOnEntityTypesQuery,
+    CheckUserPermissionsOnEntityTypesQueryVariables
+  >(checkUserPermissionsOnEntityTypesQuery, {
+    fetchPolicy: "cache-and-network",
+  });
 
   const controllerRef = useRef<AbortController | null>(null);
 
@@ -105,7 +127,29 @@ export const useEntityTypesContextValue = (): EntityTypesContextValue => {
       subgraph: subgraph ?? null,
       loading: false,
     });
-  }, [queryEntityTypes]);
+
+    // Fetch permissions separately so the types above aren't blocked on it
+    const entityTypeIds = entityTypes.map((type) => type.schema.$id);
+    if (entityTypeIds.length === 0) {
+      setEntityTypePermissions({});
+    } else {
+      void checkEntityTypePermissions({
+        variables: { entityTypeIds },
+      }).then(({ data }) => {
+        if (controller.signal.aborted || !data) {
+          return;
+        }
+        setEntityTypePermissions(
+          Object.fromEntries(
+            data.checkUserPermissionsOnEntityTypes.map((record) => [
+              record.entityTypeId,
+              record.permissions,
+            ]),
+          ),
+        );
+      });
+    }
+  }, [checkEntityTypePermissions, queryEntityTypes]);
 
   const ensureFetched = useCallback(() => {
     if (!fetched.current) {
@@ -115,7 +159,7 @@ export const useEntityTypesContextValue = (): EntityTypesContextValue => {
   }, [fetch]);
 
   return useMemo(
-    () => ({ ...types, refetch: fetch, ensureFetched }),
-    [fetch, types, ensureFetched],
+    () => ({ ...types, entityTypePermissions, refetch: fetch, ensureFetched }),
+    [fetch, types, entityTypePermissions, ensureFetched],
   );
 };

--- a/apps/hash-frontend/src/shared/entity-types-context/shared/context-types.ts
+++ b/apps/hash-frontend/src/shared/entity-types-context/shared/context-types.ts
@@ -3,6 +3,7 @@ import type {
   EntityTypeWithMetadata,
   VersionedUrl,
 } from "@blockprotocol/type-system";
+import type { UserPermissionsOnEntityType } from "@local/hash-graph-sdk/authorization";
 
 export type SpecialEntityTypeRecord = {
   isFile: boolean;
@@ -24,6 +25,11 @@ export type EntityTypesContextValue = {
     | null
     | ((entityTypeIds: VersionedUrl[]) => SpecialEntityTypeRecord);
   subgraph: Subgraph<EntityTypeRootType> | null;
+  // the requesting user's permissions on each entity type, keyed by entity type id
+  entityTypePermissions: Record<
+    VersionedUrl,
+    UserPermissionsOnEntityType
+  > | null;
   loading: boolean;
 
   refetch: () => Promise<void>;

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar/shared/entity-or-type-sidebar-item/entity-type-menu.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar/shared/entity-or-type-sidebar-item/entity-type-menu.tsx
@@ -8,6 +8,7 @@ import { ArrowUpRightIcon } from "@hashintel/design-system";
 
 import { useEntityTypesContextRequired } from "../../../../../entity-types-context/hooks/use-entity-types-context-required";
 import { useFrozenValue } from "../../../../../frozen";
+import { useUserPermissionsOnEntityType } from "../../../../../use-user-permissions-on-entity-type";
 import { FavoriteMenuItem } from "./shared/favorite-menu-item";
 import { SidebarMenuItem } from "./shared/sidebar-menu-item";
 
@@ -38,9 +39,16 @@ export const EntityTypeMenu: FunctionComponent<EntityTypeMenuProps> = ({
 
   const isLinkEntityType = isSpecialEntityTypeLookup?.[entityTypeId]?.isLink;
 
+  // Only fetch permissions while the menu is open to avoid a query per sidebar item
+  const { userPermissions } = useUserPermissionsOnEntityType(
+    popupState.isOpen ? entityTypeId : undefined,
+  );
+
+  const canInstantiate = !!userPermissions?.instantiate;
+
   return (
     <Menu {...bindMenu(popupState)}>
-      {isLinkEntityType ? null : (
+      {isLinkEntityType || !canInstantiate ? null : (
         <SidebarMenuItem
           title={`Create new ${title}`}
           icon={faAdd}
@@ -65,12 +73,15 @@ export const EntityTypeMenu: FunctionComponent<EntityTypeMenuProps> = ({
           }, 2000);
         }}
       />
-      <SidebarMenuItem
-        title="Extend this type"
-        icon={<ArrowUpRightIcon sx={{ fontSize: 16 }} />}
-        href={`/new/types/entity-type?extends=${entityTypeId}`}
-        popupState={popupState}
-      />
+      {/* Extending requires permission to instantiate the parent type */}
+      {canInstantiate ? (
+        <SidebarMenuItem
+          title="Extend this type"
+          icon={<ArrowUpRightIcon sx={{ fontSize: 16 }} />}
+          href={`/new/types/entity-type?extends=${entityTypeId}`}
+          popupState={popupState}
+        />
+      ) : null}
       <SidebarMenuItem
         title={`View all ${isLinkEntityType ? `${title} links` : titlePlural}`}
         icon={faList}

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar/shared/entity-or-type-sidebar-item/entity-type-menu.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar/shared/entity-or-type-sidebar-item/entity-type-menu.tsx
@@ -39,10 +39,9 @@ export const EntityTypeMenu: FunctionComponent<EntityTypeMenuProps> = ({
 
   const isLinkEntityType = isSpecialEntityTypeLookup?.[entityTypeId]?.isLink;
 
-  // Only fetch permissions while the menu is open to avoid a query per sidebar item
-  const { userPermissions } = useUserPermissionsOnEntityType(
-    popupState.isOpen ? entityTypeId : undefined,
-  );
+  // Fetch on mount, not on open, so permission-gated items are already resolved
+  // by the time the menu opens – avoids the list shifting under the cursor
+  const { userPermissions } = useUserPermissionsOnEntityType(entityTypeId);
 
   const canInstantiate = !!userPermissions?.instantiate;
 

--- a/libs/@hashintel/type-editor/src/entity-type-editor.tsx
+++ b/libs/@hashintel/type-editor/src/entity-type-editor.tsx
@@ -15,6 +15,7 @@ import { OntologyFunctionsContext } from "./shared/ontology-functions-context";
 import { PropertyTypesOptionsContextProvider } from "./shared/property-types-options-context";
 import { ReadonlyContext } from "./shared/read-only-context";
 
+import type { EntityTypePermissions } from "./shared/entity-types-options-context";
 import type { EditorOntologyFunctions } from "./shared/ontology-functions-context";
 import type {
   DataType,
@@ -52,6 +53,9 @@ export type EntityTypeEditorProps = {
   entityType: EntityTypeWithMetadata;
   // The entity types available for (a) extending or (b) constraining the destination of a link, INCLUDING those used on this entity
   entityTypeOptions: Record<VersionedUrl, EntityTypeWithMetadata>;
+  // The requesting user's permissions on each entity type. When provided, types the
+  // user cannot instantiate are hidden as options for extending (adding as a parent).
+  entityTypePermissions?: Record<VersionedUrl, EntityTypePermissions>;
   // The property types available for assigning to an entity type or property type object, INCLUDING those used on this entity
   propertyTypeOptions: Record<VersionedUrl, PropertyTypeWithMetadata>;
   // functions for creating and updating types. Pass 'null' if not available (editor will be forced into readonly)
@@ -65,6 +69,7 @@ export const EntityTypeEditor = ({
   dataTypeOptions,
   entityType,
   entityTypeOptions,
+  entityTypePermissions,
   propertyTypeOptions,
   ontologyFunctions,
   readonly,
@@ -76,6 +81,7 @@ export const EntityTypeEditor = ({
           <OntologyFunctionsContext.Provider value={ontologyFunctions}>
             <EntityTypesOptionsContextProvider
               entityTypeOptions={entityTypeOptions}
+              entityTypePermissions={entityTypePermissions}
             >
               <PropertyTypesOptionsContextProvider
                 propertyTypeOptions={propertyTypeOptions}

--- a/libs/@hashintel/type-editor/src/entity-type-editor/inheritance-row.tsx
+++ b/libs/@hashintel/type-editor/src/entity-type-editor/inheritance-row.tsx
@@ -62,7 +62,8 @@ export const InheritanceRow = ({
     name: "links",
   });
 
-  const { entityTypes, linkTypes } = useEntityTypesOptions();
+  const { entityTypes, linkTypes, entityTypePermissions } =
+    useEntityTypesOptions();
 
   const { entityTypesArray, directParents } = useMemo(() => {
     const isLinkType = directParentEntityTypeIds.find((id) => linkTypes[id]);
@@ -101,6 +102,18 @@ export const InheritanceRow = ({
       { $id: linkEntityTypeUrl },
     ],
   });
+
+  // A user can only extend a type they have permission to instantiate. When
+  // permission info is available, hide the types they cannot instantiate.
+  const instantiableEntityTypeOptions = useMemo(() => {
+    if (!entityTypePermissions) {
+      return entityTypeOptions;
+    }
+
+    return entityTypeOptions.filter(
+      (option) => entityTypePermissions[option.$id]?.instantiate,
+    );
+  }, [entityTypeOptions, entityTypePermissions]);
 
   const isReadonly = useIsReadonly();
 
@@ -243,7 +256,7 @@ export const InheritanceRow = ({
             onAdd={addParent}
             onCancel={() => setSelectorVisibility(false)}
             onSearchTextChange={setTypeSelectorSearchText}
-            options={entityTypeOptions}
+            options={instantiableEntityTypeOptions}
             searchText={typeSelectorSearchText}
             sx={{ width: 500 }}
             variant="entity type"

--- a/libs/@hashintel/type-editor/src/shared/entity-types-options-context.tsx
+++ b/libs/@hashintel/type-editor/src/shared/entity-types-options-context.tsx
@@ -13,9 +13,19 @@ export type EntityTypesByVersionedUrl = Record<
   VersionedUrl,
   EntityTypeWithMetadata
 >;
+
+export type EntityTypePermissions = {
+  edit: boolean;
+  instantiate: boolean;
+  view: boolean;
+};
+
 export type EntityTypesContextValue = {
   entityTypes: EntityTypesByVersionedUrl;
   linkTypes: EntityTypesByVersionedUrl;
+  // the requesting user's permissions on each entity type, keyed by entity type id.
+  // undefined when the consumer does not supply permission information.
+  entityTypePermissions?: Record<VersionedUrl, EntityTypePermissions>;
 };
 
 export const EntityTypesOptionsContext =
@@ -67,10 +77,17 @@ export const useEntityTypesOptionsContextValue = (
 export const EntityTypesOptionsContextProvider = ({
   children,
   entityTypeOptions,
+  entityTypePermissions,
 }: PropsWithChildren<{
   entityTypeOptions: Record<VersionedUrl, EntityTypeWithMetadata>;
+  entityTypePermissions?: Record<VersionedUrl, EntityTypePermissions>;
 }>) => {
-  const value = useEntityTypesOptionsContextValue(entityTypeOptions);
+  const typeValue = useEntityTypesOptionsContextValue(entityTypeOptions);
+
+  const value = useMemo(
+    () => ({ ...typeValue, entityTypePermissions }),
+    [typeValue, entityTypePermissions],
+  );
 
   return (
     <EntityTypesOptionsContext.Provider value={value}>

--- a/libs/@local/hash-isomorphic-utils/src/graphql/type-defs/ontology/entity-type.typedef.ts
+++ b/libs/@local/hash-isomorphic-utils/src/graphql/type-defs/ontology/entity-type.typedef.ts
@@ -16,6 +16,11 @@ export const entityTypeTypedef = gql`
   scalar Filter
   scalar UserPermissionsOnEntityType
 
+  type EntityTypePermissionsRecord {
+    entityTypeId: VersionedUrl!
+    permissions: UserPermissionsOnEntityType!
+  }
+
   extend type Query {
     queryEntityTypes(
       request: QueryEntityTypesParams!
@@ -39,6 +44,14 @@ export const entityTypeTypedef = gql`
     checkUserPermissionsOnEntityType(
       entityTypeId: VersionedUrl!
     ): UserPermissionsOnEntityType!
+
+    """
+    Check the requesting user's permissions on multiple entity types at once,
+    returning the permissions for each requested type.
+    """
+    checkUserPermissionsOnEntityTypes(
+      entityTypeIds: [VersionedUrl!]!
+    ): [EntityTypePermissionsRecord!]!
   }
 
   input EntityTypeUpdate {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Hide extending a type when user does not have create permission for that type in UI. Note that there is another ticket for the BE to prevent this behaviour as well: https://linear.app/hash/issue/BE-786/validate-instantiate-permissions-when-extending-types

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change
