### PR TITLE
BE-758: Add rate limiting to the Graph API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2170,6 +2170,20 @@ name = "darwin-kperf-sys"
 version = "0.1.1"
 
 [[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "dashu-base"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3229,6 +3243,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "governor"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9efcab3c1958580ff1f25a2a41be1668f7603d849bb63af523b208a3cc1223b8"
+dependencies = [
+ "cfg-if",
+ "dashmap",
+ "futures-sink",
+ "futures-timer",
+ "futures-util",
+ "hashbrown 0.16.1",
+ "nonzero_ext",
+ "parking_lot",
+ "portable-atomic",
+ "quanta",
+ "smallvec 1.15.2",
+ "spinning_top",
+ "web-time",
+]
+
+[[package]]
 name = "guppy"
 version = "0.17.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3569,6 +3604,7 @@ dependencies = [
  "frunk",
  "futures",
  "futures-channel",
+ "governor",
  "harpc-client",
  "harpc-codec",
  "harpc-server",
@@ -4094,6 +4130,12 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -5006,9 +5048,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 dependencies = [
  "serde",
 ]
@@ -6347,6 +6389,12 @@ name = "nonmax"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
+
+[[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "nu-ansi-term"
@@ -7834,6 +7882,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5167a477619228a0b284fac2674e3c388cba90631d7b7de620e6f1fcd08da5"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quick-protobuf"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8156,6 +8219,15 @@ dependencies = [
  "time",
  "unicode-segmentation",
  "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -9367,6 +9439,15 @@ name = "spin"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+
+[[package]]
+name = "spinning_top"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spki"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,6 +167,7 @@ futures-sink                       = { version = "0.3.31", default-features = fa
 futures-util                       = { version = "0.3.31", default-features = false }
 glob                               = { version = "0.3.3" }
 globset                            = { version = "0.4.18", default-features = false }
+governor                           = { version = "0.10.4", default-features = false, features = ["dashmap", "quanta", "std"] }
 guppy                              = { version = "0.17.20", default-features = false }
 hashbrown                          = { version = "0.17.0", default-features = false, features = ["inline-more", "nightly", "raw-entry"] }
 hifijson                           = { version = "0.4.0", default-features = false }

--- a/apps/hash-graph/src/subcommand/server.rs
+++ b/apps/hash-graph/src/subcommand/server.rs
@@ -20,6 +20,7 @@ use hash_graph_api::{
         auth::{CloudflareAccessConfig, KratosSessionConfig},
         entity::ClusteringContext,
         hashql::CompilerContext,
+        rate_limit::RateLimitConfig,
         rest_api_router,
     },
     rpc::Dependencies,
@@ -285,6 +286,9 @@ pub struct ServerConfig {
 
     #[clap(flatten)]
     pub api_config: ApiConfig,
+
+    #[clap(flatten)]
+    pub rate_limit: RateLimitConfig,
 
     #[clap(flatten)]
     pub session_auth: KratosSessionAuthConfig,
@@ -554,6 +558,7 @@ where
         session_auth: authentication.session_auth,
         cloudflare_access: authentication.cloudflare_access,
         service_secret: authentication.service_secret,
+        rate_limit: config.rate_limit,
         compiler,
         clustering: Arc::new(ClusteringContext::new(config.clustering_concurrency_limit)),
         serve_api_reference: config.serve_api_reference,

--- a/libs/@local/graph/api/Cargo.toml
+++ b/libs/@local/graph/api/Cargo.toml
@@ -63,6 +63,7 @@ derive_more                        = { workspace = true, features = ["display", 
 error-stack                        = { workspace = true, features = ["futures", "spantrace", "unstable"] }
 frunk                              = { workspace = true }
 futures                            = { workspace = true }
+governor                           = { workspace = true }
 hyper                              = { workspace = true }
 include_dir                        = { workspace = true }
 md-5                               = { workspace = true }
@@ -75,7 +76,7 @@ serde                              = { workspace = true, features = ['derive'] }
 serde_json                         = { workspace = true, features = ["raw_value"] }
 simple-mermaid                     = { workspace = true }
 time                               = { workspace = true }
-tokio                              = { workspace = true }
+tokio                              = { workspace = true, features = ["rt", "time"] }
 tokio-util                         = { workspace = true, features = ["codec", "io"] }
 tower                              = { workspace = true }
 tracing-opentelemetry              = { workspace = true }
@@ -85,7 +86,7 @@ uuid                               = { workspace = true }
 
 [dev-dependencies]
 hash-graph-authentication = { workspace = true, features = ["test-utils"] }
-tokio                     = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio                     = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
 tower                     = { workspace = true, features = ["util"] }
 uuid                      = { workspace = true, features = ["v4"] }
 

--- a/libs/@local/graph/api/src/rest/auth.rs
+++ b/libs/@local/graph/api/src/rest/auth.rs
@@ -5,12 +5,13 @@
 //! service secret with its actor header — and rejects the request when they are invalid. A
 //! request without credentials resolves through the chain's [`Caller`] type: a chain over
 //! [`ActorId`] rejects it, a chain over `Option<ActorId>` verifies it as anonymous. The
-//! resolution is stored as a private request extension. The [`AuthenticatedActorId`] extractor
+//! resolution is stored as a request extension. The [`AuthenticatedActorId`] extractor
 //! hands the acting actor to handlers that need it, and taking it as an `Option` is how a handler
 //! serves anonymous callers.
 //!
-//! The bootstrap routes require the service secret regardless of the chain. The OpenAPI and probe
-//! routes are served outside the middleware.
+//! The bootstrap routes require the service secret regardless of the chain. The OpenAPI routes
+//! carry no credential and resolve as anonymous. The probe route is served outside the
+//! middleware.
 
 use alloc::sync::Arc;
 
@@ -113,7 +114,18 @@ where
 
 /// The resolved authentication of a request, stored as a request extension.
 #[derive(Clone)]
-struct ResolvedAuthentication(Result<Option<ActorId>, AuthenticationError>);
+pub(crate) struct ResolvedAuthentication(Result<Option<ActorId>, AuthenticationError>);
+
+impl ResolvedAuthentication {
+    #[cfg(test)]
+    pub(crate) const fn new(outcome: Result<Option<ActorId>, AuthenticationError>) -> Self {
+        Self(outcome)
+    }
+
+    pub(crate) const fn outcome(&self) -> &Result<Option<ActorId>, AuthenticationError> {
+        &self.0
+    }
+}
 
 /// Converts an authentication failure into the response returned to the client.
 ///

--- a/libs/@local/graph/api/src/rest/mod.rs
+++ b/libs/@local/graph/api/src/rest/mod.rs
@@ -640,7 +640,7 @@ where
         .fold(Router::new(), Router::merge)
         .merge(hashql::HashQlResource::routes())
         .fallback(|| {
-            tracing::error!("404: Not found");
+            tracing::debug!("404: Not found");
             async { StatusCode::NOT_FOUND }
         });
 

--- a/libs/@local/graph/api/src/rest/mod.rs
+++ b/libs/@local/graph/api/src/rest/mod.rs
@@ -16,6 +16,7 @@ pub mod admin;
 pub mod auth;
 pub mod http_tracing_layer;
 pub mod probe;
+pub mod rate_limit;
 
 pub mod hashql;
 mod json;
@@ -38,6 +39,7 @@ use axum::{
 use error_stack::{Report, ResultExt as _};
 use futures::{SinkExt as _, channel::mpsc::Sender};
 use hash_codec::numeric::Real;
+use hash_graph_authentication::provider::{AuthenticationProvider, Caller};
 use hash_graph_authorization::policies::store::{PolicyStore, PrincipalStore};
 use hash_graph_embeddings::{EmbeddingError, EmbeddingGenerator as _, OpenAiEmbeddingClient};
 use hash_graph_postgres_store::store::{PostgresStorePool, error::VersionedUrlAlreadyExists};
@@ -522,6 +524,7 @@ where
     pub session_auth: auth::KratosSessionConfig,
     pub cloudflare_access: Option<auth::CloudflareAccessConfig>,
     pub service_secret: String,
+    pub rate_limit: rate_limit::RateLimitConfig,
     pub compiler: Arc<hashql::CompilerContext>,
     pub clustering: Arc<ClusteringContext>,
     /// Whether to serve an interactive rendering of the `OpenAPI` specification.
@@ -530,8 +533,8 @@ where
     pub serve_api_reference: bool,
 }
 
-/// A [`Router`] that only serves the `OpenAPI` specification (JSON, and necessary subschemas) for
-/// the REST API.
+/// A [`Router`] serving the `OpenAPI` specification (JSON, and necessary subschemas) for the
+/// REST API.
 ///
 /// The specification is served at `/openapi.json`. It references its subschemas by relative path
 /// (`./models/…`), so `/models/{path}` has to stay a sibling of the specification for those
@@ -547,7 +550,6 @@ pub fn openapi_only_router(serve_api_reference: bool) -> Router {
         serve_api_reference.then(|| Html(Scalar::new(open_api_doc.clone()).to_html()));
 
     let mut router = Router::new()
-        .merge(probe::router())
         .route("/openapi.json", get(|| async { Json(open_api_doc) }))
         .route("/models/{*path}", get(serve_static_schema));
 
@@ -558,7 +560,64 @@ pub fn openapi_only_router(serve_api_reference: bool) -> Router {
     router
 }
 
+/// Attaches the three request middlewares, which requests traverse as address gate,
+/// authentication, principal limiter.
+///
+/// `route_layer` keeps the 404 fallback outside authentication and the principal limiter, so an
+/// unmatched path is answered without resolving a credential or drawing on a principal budget.
+/// The gate is a `layer` and so covers the fallback too, which puts a request for an unmatched
+/// path on the same address budget as any other.
+///
+/// `unauthenticated` is merged between the two, so its routes carry the address gate but neither
+/// authentication nor a principal budget. Routes merged after this call carry none of the three.
+fn attach_request_middlewares<P, C>(
+    routes: Router,
+    unauthenticated: Router,
+    provider: Arc<P>,
+    service_secret: Arc<str>,
+    rate_limiters: Arc<rate_limit::RateLimiters>,
+) -> Router
+where
+    P: AuthenticationProvider<C> + Send + Sync + 'static,
+    C: Caller + Send + 'static,
+{
+    let auth_secret = Arc::clone(&service_secret);
+    let gate_secret = Arc::clone(&service_secret);
+    let gate_limiters = Arc::clone(&rate_limiters);
+
+    routes
+        .route_layer(axum::middleware::from_fn(move |request, next| {
+            rate_limit::principal_limit_middleware(
+                Arc::clone(&rate_limiters),
+                Arc::clone(&service_secret),
+                request,
+                next,
+            )
+        }))
+        .route_layer(axum::middleware::from_fn(move |request, next| {
+            auth::authentication_middleware::<_, C>(
+                Arc::clone(&provider),
+                Arc::clone(&auth_secret),
+                request,
+                next,
+            )
+        }))
+        .merge(unauthenticated)
+        .layer(axum::middleware::from_fn(move |request, next| {
+            rate_limit::ip_gate_middleware(
+                Arc::clone(&gate_limiters),
+                Arc::clone(&gate_secret),
+                request,
+                next,
+            )
+        }))
+}
+
 /// A [`Router`] that serves all of the REST API routes, and the `OpenAPI` specification.
+///
+/// # Panics
+///
+/// Panics when called outside a Tokio runtime.
 pub fn rest_api_router<S>(dependencies: RestRouterDependencies<S>) -> Router
 where
     S: StorePool + Send + Sync + 'static,
@@ -572,6 +631,9 @@ where
     ));
     let service_secret: Arc<str> = Arc::from(dependencies.service_secret);
 
+    let rate_limiters = Arc::new(rate_limit::RateLimiters::new(&dependencies.rate_limit));
+    rate_limit::spawn_maintenance(Arc::downgrade(&rate_limiters));
+
     // All api resources are merged together into a super-router.
     let merged_routes = api_resources::<S>()
         .into_iter()
@@ -584,43 +646,35 @@ where
 
     // super-router can then be used as any other router.
     // Make sure extensions are added at the end so they are made available to merged routers.
-    // The `OpenAPI` endpoints are merged in afterwards as we don't want any layers or handlers to
-    // apply to them. We use a `ServiceBuilder` to add the layers in the correct order.
-    //
-    // The authentication middleware is added first so it runs innermost: inside the HTTP tracing
-    // span, where its actor recording targets the request span. `route_layer` keeps the 404
-    // fallback outside the middleware, so unmatched paths return 404 instead of 401.
-    let mut router = merged_routes
-        .route_layer(axum::middleware::from_fn(move |request, next| {
-            let provider = Arc::clone(&authentication_provider);
-            let service_secret = Arc::clone(&service_secret);
-            auth::authentication_middleware::<_, Option<ActorId>>(
-                provider,
-                service_secret,
-                request,
-                next,
-            )
-        }))
-        .layer(
-            ServiceBuilder::new()
-                .layer(NewSentryLayer::new_from_top())
-                .layer(SentryHttpLayer::default().enable_transaction()),
-        )
-        .layer(http_tracing_layer::HttpTracingLayer)
-        .layer(Extension(dependencies.store))
-        .layer(Extension(Arc::new(dependencies.postgres)))
-        .layer(Extension(dependencies.temporal_client))
-        .layer(Extension(dependencies.embedding_client))
-        .layer(Extension(dependencies.domain_regex))
-        .layer(Extension(dependencies.api_config))
-        .layer(Extension(dependencies.compiler))
-        .layer(Extension(dependencies.clustering));
+    let mut router = attach_request_middlewares::<_, Option<ActorId>>(
+        merged_routes,
+        openapi_only_router(dependencies.serve_api_reference),
+        authentication_provider,
+        service_secret,
+        rate_limiters,
+    )
+    .layer(
+        ServiceBuilder::new()
+            .layer(NewSentryLayer::new_from_top())
+            .layer(SentryHttpLayer::default().enable_transaction()),
+    )
+    .layer(http_tracing_layer::HttpTracingLayer)
+    .layer(Extension(dependencies.store))
+    .layer(Extension(Arc::new(dependencies.postgres)))
+    .layer(Extension(dependencies.temporal_client))
+    .layer(Extension(dependencies.embedding_client))
+    .layer(Extension(dependencies.domain_regex))
+    .layer(Extension(dependencies.api_config))
+    .layer(Extension(dependencies.compiler))
+    .layer(Extension(dependencies.clustering));
 
     if let Some(query_logger) = dependencies.query_logger {
         router = router.layer(Extension(query_logger));
     }
 
-    router.merge(openapi_only_router(dependencies.serve_api_reference))
+    // The health probe is merged after the layers, so it is served outside the middlewares and
+    // carries no budget.
+    router.merge(probe::router())
 }
 
 async fn serve_static_schema(Path(path): Path<String>) -> Result<Response, StatusCode> {

--- a/libs/@local/graph/api/src/rest/rate_limit/address.rs
+++ b/libs/@local/graph/api/src/rest/rate_limit/address.rs
@@ -1,0 +1,253 @@
+//! Resolving the client address a request is budgeted against.
+
+use core::{
+    fmt,
+    net::{IpAddr, Ipv6Addr, SocketAddr},
+};
+
+use axum::extract::{ConnectInfo, Request};
+use http::HeaderName;
+
+/// The key an address-keyed budget is charged against.
+///
+/// Canonicalizes the address it wraps: a v4-mapped v6 address shares the key of the v4 address it
+/// names, and every address in an IPv6 /64 shares one key. `::/64` is one such prefix, so IPv6
+/// loopback shares a key with every IPv4-compatible address, and a NAT64 `64:ff9b::/96`
+/// deployment puts all translated clients in one budget.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(super) struct BucketKey(IpAddr);
+
+impl BucketKey {
+    pub(super) fn new(address: IpAddr) -> Self {
+        Self(match address.to_canonical() {
+            v4 @ IpAddr::V4(_) => v4,
+            IpAddr::V6(v6) => IpAddr::V6(Ipv6Addr::from_bits(v6.to_bits() & !u128::from(u64::MAX))),
+        })
+    }
+}
+
+impl fmt::Display for BucketKey {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(fmt)
+    }
+}
+
+/// The outcome of resolving a request's client address, stored as a request extension.
+///
+/// Visible only within `rate_limit`, so no other module can insert one: axum keys extensions by
+/// type. Its presence says the gate ran.
+#[derive(Debug, Clone, Copy)]
+pub(super) enum ResolvedClientAddress {
+    Bucketed(BucketKey),
+    Unknown,
+}
+
+impl ResolvedClientAddress {
+    pub(super) const fn key(self) -> Option<BucketKey> {
+        match self {
+            Self::Bucketed(key) => Some(key),
+            Self::Unknown => None,
+        }
+    }
+}
+
+/// Why the configured header could not supply the address.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum Fallback {
+    HeaderMissing,
+    HeaderNotAscii,
+    Unparsable,
+}
+
+impl Fallback {
+    /// Returns the reason.
+    pub(super) const fn as_str(self) -> &'static str {
+        match self {
+            Self::HeaderMissing => "header_missing",
+            Self::HeaderNotAscii => "header_not_ascii",
+            Self::Unparsable => "unparsable",
+        }
+    }
+}
+
+/// Reads the client address from `header`, or names why it is unusable.
+///
+/// Takes the rightmost entry of the header's last instance. Under a proxy that appends, that is
+/// the address the closest proxy saw and the only entry outside the client's control; under one
+/// that overwrites, it is the whole value. Behind two or more appending proxies it is the address
+/// the closest proxy received from, so every client behind that one shares a budget.
+///
+/// Accepts a bare address or an `address:port` pair.
+pub(super) fn from_header(request: &Request, header: &HeaderName) -> Result<BucketKey, Fallback> {
+    let Some(value) = request.headers().get_all(header).iter().next_back() else {
+        return Err(Fallback::HeaderMissing);
+    };
+    let value = value.to_str().map_err(|_error| Fallback::HeaderNotAscii)?;
+    let last = value.rsplit_once(',').map_or(value, |(_, last)| last);
+    parse(last.trim()).ok_or(Fallback::Unparsable)
+}
+
+/// Returns the address of the connection the request arrived on.
+///
+/// [`None`] when the router was served without [`ConnectInfo`], which leaves nothing to key a
+/// budget by.
+pub(super) fn peer(request: &Request) -> Option<BucketKey> {
+    request
+        .extensions()
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|ConnectInfo(address)| BucketKey::new(address.ip()))
+}
+
+fn parse(address: &str) -> Option<BucketKey> {
+    address
+        .parse::<IpAddr>()
+        .or_else(|_error| address.parse::<SocketAddr>().map(|address| address.ip()))
+        .ok()
+        .map(BucketKey::new)
+}
+
+#[cfg(test)]
+mod tests {
+    use core::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+    use axum::{body::Body, extract::ConnectInfo};
+    use http::{HeaderName, HeaderValue, Request};
+
+    use super::{BucketKey, Fallback, from_header, parse, peer};
+    use crate::rest::rate_limit::config::ClientIpSource;
+
+    fn key(address: &str) -> BucketKey {
+        BucketKey::new(address.parse().expect("the address should parse"))
+    }
+
+    fn forwarded_for() -> &'static HeaderName {
+        ClientIpSource::XForwardedFor
+            .header()
+            .expect("the source should name a header")
+    }
+
+    fn request(peer: IpAddr) -> Request<Body> {
+        let mut request = Request::builder()
+            .uri("/entities")
+            .body(Body::empty())
+            .expect("the request should build");
+        request
+            .extensions_mut()
+            .insert(ConnectInfo(SocketAddr::new(peer, 4000)));
+        request
+    }
+
+    fn with_header(name: &'static str, values: &[&str]) -> Request<Body> {
+        let mut request = request(IpAddr::V4(Ipv4Addr::LOCALHOST));
+        for value in values {
+            request
+                .headers_mut()
+                .append(name, value.parse().expect("the header should parse"));
+        }
+        request
+    }
+
+    #[test]
+    fn ipv6_addresses_in_one_prefix_share_a_key() {
+        assert_eq!(
+            key("2001:db8:1:2:aaaa::1"),
+            key("2001:db8:1:2:bbbb::2"),
+            "a /64 is one allocation, so it should hold one budget"
+        );
+        assert_ne!(
+            key("2001:db8:1:2::1"),
+            key("2001:db8:1:3::1"),
+            "the mask should keep the /64 prefix, not a shorter one"
+        );
+    }
+
+    #[test]
+    fn ipv4_addresses_keep_their_own_keys() {
+        assert_ne!(key("192.0.2.1"), key("192.0.2.2"));
+        assert_eq!(
+            key("::ffff:192.0.2.1"),
+            key("192.0.2.1"),
+            "a v4-mapped v6 address should not open a second budget for one client"
+        );
+    }
+
+    #[test]
+    fn x_forwarded_for_reads_the_rightmost_entry_of_the_last_instance() {
+        let request = with_header(
+            "x-forwarded-for",
+            &["203.0.113.9", "192.0.2.1, 198.51.100.7"],
+        );
+
+        assert_eq!(
+            from_header(&request, forwarded_for()),
+            Ok(key("198.51.100.7")),
+            "only the entry the closest proxy appended is outside the client's control"
+        );
+    }
+
+    #[test]
+    fn cf_connecting_ip_reads_the_last_instance() {
+        let request = with_header("cf-connecting-ip", &["192.0.2.1", "203.0.113.9"]);
+
+        assert_eq!(
+            from_header(
+                &request,
+                ClientIpSource::CfConnectingIp
+                    .header()
+                    .expect("the source should name a header")
+            ),
+            Ok(key("203.0.113.9")),
+            "the last instance is the one the closest proxy wrote"
+        );
+    }
+
+    #[test]
+    fn unusable_headers_name_their_reason() {
+        assert_eq!(
+            from_header(&request(IpAddr::V4(Ipv4Addr::LOCALHOST)), forwarded_for()),
+            Err(Fallback::HeaderMissing)
+        );
+        assert_eq!(
+            from_header(
+                &with_header("x-forwarded-for", &["unknown"]),
+                forwarded_for()
+            ),
+            Err(Fallback::Unparsable)
+        );
+
+        let mut binary = request(IpAddr::V4(Ipv4Addr::LOCALHOST));
+        binary.headers_mut().insert(
+            "x-forwarded-for",
+            HeaderValue::from_bytes(b"\xff").expect("the header should hold arbitrary bytes"),
+        );
+        assert_eq!(
+            from_header(&binary, forwarded_for()),
+            Err(Fallback::HeaderNotAscii)
+        );
+    }
+
+    #[test]
+    fn forwarded_addresses_accept_a_port_suffix() {
+        assert_eq!(parse("192.0.2.1:5678"), Some(key("192.0.2.1")));
+        assert_eq!(parse("[2001:db8::1]:443"), Some(key("2001:db8::1")));
+        assert_eq!(parse("unknown"), None);
+    }
+
+    #[test]
+    fn peer_reads_the_connection_address() {
+        assert_eq!(
+            peer(&request(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)))),
+            Some(key("192.0.2.1"))
+        );
+        assert_eq!(
+            peer(
+                &Request::builder()
+                    .uri("/entities")
+                    .body(Body::empty())
+                    .expect("the request should build")
+            ),
+            None,
+            "a router served without connect info should leave the address unknown"
+        );
+    }
+}

--- a/libs/@local/graph/api/src/rest/rate_limit/config.rs
+++ b/libs/@local/graph/api/src/rest/rate_limit/config.rs
@@ -1,0 +1,131 @@
+//! Configuration for the request rate limits.
+
+use core::num::NonZeroU32;
+
+use http::HeaderName;
+
+static X_FORWARDED_FOR: HeaderName = HeaderName::from_static("x-forwarded-for");
+static CF_CONNECTING_IP: HeaderName = HeaderName::from_static("cf-connecting-ip");
+
+/// Whether a request over its budget is denied or served.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
+pub enum RateLimitMode {
+    /// Deny the request with `429 Too Many Requests`.
+    Enforce,
+    /// Serve the request unchanged, counting the denial in the interval report.
+    #[default]
+    Observe,
+}
+
+/// Where the client address of a request is read from.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
+pub enum ClientIpSource {
+    /// The address of the connection.
+    #[default]
+    ConnectInfo,
+    /// The rightmost address of the last `X-Forwarded-For` header, as appended by the closest
+    /// proxy.
+    XForwardedFor,
+    /// The last `CF-Connecting-IP` header, as written by Cloudflare.
+    CfConnectingIp,
+}
+
+impl ClientIpSource {
+    /// Returns the header carrying the address, or [`None`] when the connection itself does.
+    #[must_use]
+    pub(super) const fn header(self) -> Option<&'static HeaderName> {
+        match self {
+            Self::ConnectInfo => None,
+            Self::XForwardedFor => Some(&X_FORWARDED_FOR),
+            Self::CfConnectingIp => Some(&CF_CONNECTING_IP),
+        }
+    }
+}
+
+/// Configuration for the request rate limits.
+///
+/// The address gate takes a per-second rate, the principal budgets take per-hour rates; each
+/// pairs with a burst allowance naming how many requests a fresh key may send at once.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "clap", derive(clap::Args))]
+pub struct RateLimitConfig {
+    /// Whether a request over its budget is denied or served.
+    #[cfg_attr(
+        feature = "clap",
+        clap(long, env = "HASH_GRAPH_RATE_LIMIT_MODE", default_value_t, value_enum)
+    )]
+    pub rate_limit_mode: RateLimitMode,
+
+    /// Where the client address of a request is read from.
+    ///
+    /// A forwarded header is trustworthy only where a proxy owns the entry that is read; on
+    /// traffic reaching the service directly, it lets a client pick its own budget. Reading from
+    /// the connection instead keys every caller behind a proxy into one shared budget.
+    #[cfg_attr(
+        feature = "clap",
+        clap(long, env = "HASH_GRAPH_CLIENT_IP_SOURCE", default_value_t, value_enum)
+    )]
+    pub client_ip_source: ClientIpSource,
+
+    /// Sustained requests per second each client address may send ahead of authentication.
+    ///
+    /// IPv6 addresses share a budget per /64 prefix, here and for the anonymous budget.
+    #[cfg_attr(
+        feature = "clap",
+        clap(
+            long,
+            env = "HASH_GRAPH_RATE_LIMIT_GATE_PER_SECOND",
+            default_value = "10"
+        )
+    )]
+    pub rate_limit_gate_per_second: NonZeroU32,
+
+    /// Requests a fresh client address may send at once ahead of authentication.
+    #[cfg_attr(
+        feature = "clap",
+        clap(long, env = "HASH_GRAPH_RATE_LIMIT_GATE_BURST", default_value = "50")
+    )]
+    pub rate_limit_gate_burst: NonZeroU32,
+
+    /// Sustained requests per hour each client address may send anonymously.
+    #[cfg_attr(
+        feature = "clap",
+        clap(
+            long,
+            env = "HASH_GRAPH_RATE_LIMIT_ANONYMOUS_PER_HOUR",
+            default_value = "60"
+        )
+    )]
+    pub rate_limit_anonymous_per_hour: NonZeroU32,
+
+    /// Requests a fresh client address may send anonymously at once.
+    #[cfg_attr(
+        feature = "clap",
+        clap(
+            long,
+            env = "HASH_GRAPH_RATE_LIMIT_ANONYMOUS_BURST",
+            default_value = "50"
+        )
+    )]
+    pub rate_limit_anonymous_burst: NonZeroU32,
+
+    /// Sustained requests per hour each actor may send, counted across all its source addresses.
+    #[cfg_attr(
+        feature = "clap",
+        clap(
+            long,
+            env = "HASH_GRAPH_RATE_LIMIT_ACTOR_PER_HOUR",
+            default_value = "6000"
+        )
+    )]
+    pub rate_limit_actor_per_hour: NonZeroU32,
+
+    /// Requests a fresh actor may send at once.
+    #[cfg_attr(
+        feature = "clap",
+        clap(long, env = "HASH_GRAPH_RATE_LIMIT_ACTOR_BURST", default_value = "100")
+    )]
+    pub rate_limit_actor_burst: NonZeroU32,
+}

--- a/libs/@local/graph/api/src/rest/rate_limit/mod.rs
+++ b/libs/@local/graph/api/src/rest/rate_limit/mod.rs
@@ -1,0 +1,501 @@
+//! Rate limiting for the REST API.
+//!
+//! Two middlewares share the limiter state in `RateLimiters`. `ip_gate_middleware` runs ahead of
+//! the authentication middleware and throttles each client address before credential
+//! verification. `principal_limit_middleware` runs behind it and budgets requests by the resolved
+//! principal: the actor for authenticated requests, counted across every address it connects
+//! from, and the client address for anonymous ones.
+//!
+//! Requests presenting the service secret pass both middlewares unchecked.
+//!
+//! A request over its budget receives `429 Too Many Requests` with `Retry-After` in
+//! [`RateLimitMode::Enforce`], and is served unchanged in [`RateLimitMode::Observe`], the
+//! default. `Retry-After` is the whole client-facing contract: a served response says nothing
+//! about the budget it crossed, and what enforcement would have done is read from the sweep
+//! report instead.
+//!
+//! Denials, address fallbacks and unresolvable addresses log at debug. The eviction sweep reports
+//! the store sizes every interval, at warn with the interval's totals whenever it saw one of
+//! those, at info otherwise.
+//!
+//! Limiter state lives in process memory, so enforcement is per instance: a deployment with N
+//! instances admits up to N times the configured rates, and a rolling release starts every budget
+//! over.
+
+mod address;
+mod config;
+#[cfg(test)]
+mod tests;
+
+use alloc::sync::{Arc, Weak};
+use core::{
+    fmt,
+    num::NonZeroU64,
+    sync::atomic::{AtomicU64, Ordering},
+    time::Duration,
+};
+use std::sync::LazyLock;
+
+use axum::{
+    body::Body,
+    extract::Request,
+    middleware::Next,
+    response::{IntoResponse as _, Response},
+};
+use bytes::Bytes;
+use governor::{
+    Quota, RateLimiter,
+    clock::{Clock as _, DefaultClock},
+    middleware::NoOpMiddleware,
+    state::keyed::DefaultKeyedStateStore,
+};
+use hash_graph_authentication::delegation::presents_service_secret;
+use hash_status::{Status, StatusCode};
+use http::{
+    HeaderValue,
+    header::{CONTENT_TYPE, RETRY_AFTER},
+};
+use type_system::principal::actor::ActorId;
+
+use self::address::{BucketKey, ResolvedClientAddress};
+pub use self::config::{ClientIpSource, RateLimitConfig, RateLimitMode};
+use crate::rest::{auth::ResolvedAuthentication, status::status_to_response};
+
+/// How often replenished keys are evicted and the interval is reported.
+const SWEEP_INTERVAL: Duration = Duration::from_secs(60);
+
+type KeyedLimiter<K> = RateLimiter<K, DefaultKeyedStateStore<K>, DefaultClock, NoOpMiddleware>;
+
+/// The budget a request is charged against, and the key it is charged for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Budget {
+    /// Per client address, applied ahead of authentication.
+    Gate(BucketKey),
+    /// Per client address, applied to anonymous requests.
+    Anonymous(BucketKey),
+    /// Per actor, applied wherever the actor connects from.
+    Actor(ActorId),
+}
+
+impl Budget {
+    /// Returns the budget's name.
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Gate(_) => "gate",
+            Self::Anonymous(_) => "anonymous",
+            Self::Actor(_) => "actor",
+        }
+    }
+}
+
+/// The counters one sweep interval reports.
+#[derive(Default)]
+struct Tally {
+    gate_denials: AtomicU64,
+    anonymous_denials: AtomicU64,
+    actor_denials: AtomicU64,
+    address_fallbacks: AtomicU64,
+    unknown_addresses: AtomicU64,
+}
+
+impl Tally {
+    const fn denials(&self, budget: Budget) -> &AtomicU64 {
+        match budget {
+            Budget::Gate(_) => &self.gate_denials,
+            Budget::Anonymous(_) => &self.anonymous_denials,
+            Budget::Actor(_) => &self.actor_denials,
+        }
+    }
+
+    /// Records a request whose client address could not be determined.
+    fn note_unknown_address(&self) {
+        self.unknown_addresses.fetch_add(1, Ordering::Relaxed);
+        tracing::debug!(
+            "client address unavailable, request passes the rate limiter unchecked; the router \
+             has to be served with `into_make_service_with_connect_info`"
+        );
+    }
+
+    /// Reads every counter and resets it.
+    fn take(&self) -> Totals {
+        let Self {
+            gate_denials,
+            anonymous_denials,
+            actor_denials,
+            address_fallbacks,
+            unknown_addresses,
+        } = self;
+        Totals {
+            gate_denials: gate_denials.swap(0, Ordering::Relaxed),
+            anonymous_denials: anonymous_denials.swap(0, Ordering::Relaxed),
+            actor_denials: actor_denials.swap(0, Ordering::Relaxed),
+            address_fallbacks: address_fallbacks.swap(0, Ordering::Relaxed),
+            unknown_addresses: unknown_addresses.swap(0, Ordering::Relaxed),
+        }
+    }
+}
+
+/// One interval's totals.
+struct Totals {
+    gate_denials: u64,
+    anonymous_denials: u64,
+    actor_denials: u64,
+    address_fallbacks: u64,
+    unknown_addresses: u64,
+}
+
+impl Totals {
+    const fn is_empty(&self) -> bool {
+        let Self {
+            gate_denials,
+            anonymous_denials,
+            actor_denials,
+            address_fallbacks,
+            unknown_addresses,
+        } = self;
+        *gate_denials == 0
+            && *anonymous_denials == 0
+            && *actor_denials == 0
+            && *address_fallbacks == 0
+            && *unknown_addresses == 0
+    }
+}
+
+/// A request found to be over its budget.
+struct Denial {
+    /// Whole seconds until the budget admits the request again, at least one.
+    retry_after: NonZeroU64,
+    mode: RateLimitMode,
+}
+
+impl Denial {
+    /// Answers the request, awaiting `served` where the mode does not enforce the denial.
+    async fn apply(self, served: impl Future<Output = Response>) -> Response {
+        match self.mode {
+            RateLimitMode::Enforce => too_many_requests(self.retry_after),
+            RateLimitMode::Observe => served.await,
+        }
+    }
+}
+
+/// The keyed limiters, the mode a denial is answered with, and the source the address is read
+/// from.
+pub(crate) struct RateLimiters {
+    mode: RateLimitMode,
+    client_ip_source: ClientIpSource,
+    gate: KeyedLimiter<BucketKey>,
+    anonymous: KeyedLimiter<BucketKey>,
+    actor: KeyedLimiter<ActorId>,
+    tally: Tally,
+}
+
+impl RateLimiters {
+    /// Creates the limiter state from the configuration.
+    #[must_use]
+    pub(crate) fn new(config: &RateLimitConfig) -> Self {
+        tracing::info!(
+            mode = ?config.rate_limit_mode,
+            client_ip_source = ?config.client_ip_source,
+            gate_per_second = config.rate_limit_gate_per_second,
+            gate_burst = config.rate_limit_gate_burst,
+            anonymous_per_hour = config.rate_limit_anonymous_per_hour,
+            anonymous_burst = config.rate_limit_anonymous_burst,
+            actor_per_hour = config.rate_limit_actor_per_hour,
+            actor_burst = config.rate_limit_actor_burst,
+            "rate limiting active"
+        );
+        Self {
+            mode: config.rate_limit_mode,
+            client_ip_source: config.client_ip_source,
+            gate: RateLimiter::keyed(
+                Quota::per_second(config.rate_limit_gate_per_second)
+                    .allow_burst(config.rate_limit_gate_burst),
+            )
+            .with_middleware(),
+            anonymous: RateLimiter::keyed(
+                Quota::per_hour(config.rate_limit_anonymous_per_hour)
+                    .allow_burst(config.rate_limit_anonymous_burst),
+            )
+            .with_middleware(),
+            actor: RateLimiter::keyed(
+                Quota::per_hour(config.rate_limit_actor_per_hour)
+                    .allow_burst(config.rate_limit_actor_burst),
+            )
+            .with_middleware(),
+            tally: Tally::default(),
+        }
+    }
+
+    /// Reads the budget key of a request from the configured source.
+    ///
+    /// Falls back to the connection's address when the configured header is unusable, which keys
+    /// every client behind that proxy into one budget.
+    fn client_key(&self, request: &Request) -> Option<BucketKey> {
+        let Some(header) = self.client_ip_source.header() else {
+            return address::peer(request);
+        };
+        match address::from_header(request, header) {
+            Ok(key) => Some(key),
+            Err(fallback) => {
+                self.tally.address_fallbacks.fetch_add(1, Ordering::Relaxed);
+                tracing::debug!(
+                    reason = fallback.as_str(),
+                    header = %header,
+                    "client address read from the connection instead of the configured header"
+                );
+                address::peer(request)
+            }
+        }
+    }
+
+    #[cfg(test)]
+    fn tracked_keys(&self) -> usize {
+        self.gate.len() + self.anonymous.len() + self.actor.len()
+    }
+
+    /// Drops keys that regained their full budget, shrinks the stores, and reports the interval.
+    ///
+    /// Eviction is the only mechanism releasing keys, so a store grows with every distinct client
+    /// until this runs.
+    fn sweep(&self) {
+        let Self {
+            mode,
+            client_ip_source: _,
+            gate,
+            anonymous,
+            actor,
+            tally,
+        } = self;
+
+        release(gate);
+        release(anonymous);
+        release(actor);
+
+        let gate_keys = gate.len();
+        let anonymous_keys = anonymous.len();
+        let actor_keys = actor.len();
+        let totals = tally.take();
+        if totals.is_empty() {
+            tracing::info!(
+                gate_keys,
+                anonymous_keys,
+                actor_keys,
+                mode = ?mode,
+                "rate limiter interval report"
+            );
+            return;
+        }
+
+        tracing::warn!(
+            gate_denials = totals.gate_denials,
+            anonymous_denials = totals.anonymous_denials,
+            actor_denials = totals.actor_denials,
+            address_fallbacks = totals.address_fallbacks,
+            unknown_addresses = totals.unknown_addresses,
+            gate_keys,
+            anonymous_keys,
+            actor_keys,
+            mode = ?mode,
+            "rate limiter interval report"
+        );
+    }
+
+    /// Charges one request against the store the budget names.
+    fn charge(&self, budget: Budget) -> Result<(), Denial> {
+        match budget {
+            Budget::Gate(key) => self.charge_key(budget, &self.gate, &key),
+            Budget::Anonymous(key) => self.charge_key(budget, &self.anonymous, &key),
+            Budget::Actor(actor) => self.charge_key(budget, &self.actor, &actor),
+        }
+    }
+
+    /// Charges one request of `key` against `limiter`, recording it when it is over budget.
+    fn charge_key<K>(
+        &self,
+        budget: Budget,
+        limiter: &KeyedLimiter<K>,
+        key: &K,
+    ) -> Result<(), Denial>
+    where
+        K: fmt::Display + Clone + Eq + core::hash::Hash,
+    {
+        let not_until = match limiter.check_key(key) {
+            Ok(()) => return Ok(()),
+            Err(not_until) => not_until,
+        };
+
+        self.tally.denials(budget).fetch_add(1, Ordering::Relaxed);
+        let wait = not_until.wait_time_from(limiter.clock().now());
+        let seconds = wait.as_secs() + u64::from(wait.subsec_nanos() > 0);
+        let retry_after = NonZeroU64::new(seconds).unwrap_or(NonZeroU64::MIN);
+        tracing::debug!(
+            budget = budget.as_str(),
+            key = %key,
+            retry_after_seconds = retry_after.get(),
+            mode = ?self.mode,
+            "request over its rate-limit budget"
+        );
+        Err(Denial {
+            retry_after,
+            mode: self.mode,
+        })
+    }
+}
+
+/// Releases the keys of one store that regained their full budget.
+fn release<K>(limiter: &KeyedLimiter<K>)
+where
+    K: core::hash::Hash + Eq + Clone,
+{
+    limiter.retain_recent();
+    limiter.shrink_to_fit();
+}
+
+/// Spawns the eviction sweep and a watcher reporting its loss.
+///
+/// The sweep holds a weak reference, so it cannot keep the state alive, and ends on the first tick
+/// after the state is dropped.
+///
+/// # Panics
+///
+/// Panics when called outside a Tokio runtime.
+pub(crate) fn spawn_maintenance(limiters: Weak<RateLimiters>) {
+    let sweeper = tokio::spawn(async move {
+        let mut interval = tokio::time::interval(SWEEP_INTERVAL);
+        loop {
+            interval.tick().await;
+            let Some(limiters) = limiters.upgrade() else {
+                tracing::debug!("rate-limiter state dropped, ending the eviction sweep");
+                break;
+            };
+            limiters.sweep();
+        }
+    });
+
+    tokio::spawn(async move {
+        if let Err(error) = sweeper.await {
+            tracing::error!(
+                %error,
+                "rate-limiter eviction sweep stopped, keys are no longer released"
+            );
+        }
+    });
+}
+
+/// Throttles each client address ahead of credential verification.
+///
+/// The service secret is verified against the configured value, so a request merely presenting
+/// the scheme stays gated. A request whose client address cannot be determined passes unchecked.
+pub(crate) async fn ip_gate_middleware(
+    limiters: Arc<RateLimiters>,
+    service_secret: Arc<str>,
+    mut request: Request,
+    next: Next,
+) -> Response {
+    if presents_service_secret(request.headers(), &service_secret) {
+        return next.run(request).await;
+    }
+
+    let resolved = limiters.client_key(&request);
+    request.extensions_mut().insert(resolved.map_or(
+        ResolvedClientAddress::Unknown,
+        ResolvedClientAddress::Bucketed,
+    ));
+    let Some(key) = resolved else {
+        limiters.tally.note_unknown_address();
+        return next.run(request).await;
+    };
+
+    match limiters.charge(Budget::Gate(key)) {
+        Ok(()) => next.run(request).await,
+        Err(denial) => denial.apply(next.run(request)).await,
+    }
+}
+
+/// Budgets requests by the principal the authentication middleware resolved.
+///
+/// Requests presenting the service secret pass unchecked, as does an anonymous request whose
+/// client address the gate could not determine. A route reached without the authentication
+/// middleware or without the address gate is answered with an internal error.
+pub(crate) async fn principal_limit_middleware(
+    limiters: Arc<RateLimiters>,
+    service_secret: Arc<str>,
+    request: Request,
+    next: Next,
+) -> Response {
+    if presents_service_secret(request.headers(), &service_secret) {
+        return next.run(request).await;
+    }
+    let Some(resolved) = request.extensions().get::<ResolvedAuthentication>() else {
+        tracing::error!(
+            path = request.uri().path(),
+            "`principal_limit_middleware` ran on a route without authentication middleware"
+        );
+        return internal_error();
+    };
+    let actor = match resolved.outcome() {
+        Ok(actor) => *actor,
+        Err(error) => {
+            // `authentication_middleware` stores an error only as `MissingDelegatedActor` on a
+            // bootstrap route, and those requests present the service secret and passed above.
+            tracing::error!(%error, "authentication error reached the rate limiter unrejected");
+            return internal_error();
+        }
+    };
+
+    let budget = if let Some(actor) = actor {
+        Budget::Actor(actor)
+    } else {
+        let Some(resolved) = request.extensions().get::<ResolvedClientAddress>() else {
+            tracing::error!(
+                path = request.uri().path(),
+                "`principal_limit_middleware` ran on a route without the address gate"
+            );
+            return internal_error();
+        };
+        let Some(key) = resolved.key() else {
+            // The gate counted the unresolvable address already.
+            return next.run(request).await;
+        };
+        Budget::Anonymous(key)
+    };
+
+    match limiters.charge(budget) {
+        Ok(()) => next.run(request).await,
+        Err(denial) => denial.apply(next.run(request)).await,
+    }
+}
+
+/// The status and body every enforced denial answers with, built once.
+static TOO_MANY_REQUESTS: LazyLock<(http::StatusCode, Bytes)> = LazyLock::new(|| {
+    let status = Status::<()>::new(
+        StatusCode::ResourceExhausted,
+        Some("rate limit exceeded".to_owned()),
+        vec![],
+    );
+    let code = http::StatusCode::from_u16(status.code().to_http_code())
+        .expect("the status code should map to an HTTP status code");
+    let body = serde_json::to_vec(&status).expect("the status should serialize");
+    (code, Bytes::from(body))
+});
+
+/// Builds the 429 response for a denied request.
+fn too_many_requests(retry_after: NonZeroU64) -> Response {
+    let (code, body) = &*TOO_MANY_REQUESTS;
+
+    let mut response = Response::new(Body::from(body.clone()));
+    *response.status_mut() = *code;
+    let headers = response.headers_mut();
+    headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+    headers.insert(RETRY_AFTER, HeaderValue::from(retry_after.get()));
+    response
+}
+
+fn internal_error() -> Response {
+    status_to_response(Status::<()>::new(
+        StatusCode::Internal,
+        Some("internal server error".to_owned()),
+        vec![],
+    ))
+    .into_response()
+}

--- a/libs/@local/graph/api/src/rest/rate_limit/tests.rs
+++ b/libs/@local/graph/api/src/rest/rate_limit/tests.rs
@@ -1,0 +1,891 @@
+//! Tests for the rate-limiting middlewares.
+
+use alloc::sync::Arc;
+use core::{
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+use axum::{
+    Router, body::Body, extract::ConnectInfo, middleware, response::Response, routing::get,
+};
+use hash_graph_authentication::{
+    provider::StaticAuthenticationProvider, request::AuthenticationError,
+};
+use http::{Request, StatusCode};
+use tower::ServiceExt as _;
+use type_system::principal::actor::{ActorEntityUuid, ActorId, UserId};
+use uuid::Uuid;
+
+use super::{
+    ClientIpSource, RateLimitConfig, RateLimitMode, RateLimiters, ip_gate_middleware,
+    principal_limit_middleware,
+};
+use crate::rest::auth::{ResolvedAuthentication, authentication_middleware};
+
+const SERVICE_SECRET: &str = "hash-svc-test-secret";
+
+fn non_zero(value: u32) -> core::num::NonZeroU32 {
+    core::num::NonZeroU32::new(value).expect("the value should be non-zero")
+}
+
+/// A configuration that exercises only the burst: budgets refill once per hour, the gate once per
+/// second, and denials are enforced so a test can read them off the status code.
+fn config(burst: u32) -> RateLimitConfig {
+    RateLimitConfig {
+        rate_limit_mode: RateLimitMode::Enforce,
+        client_ip_source: ClientIpSource::ConnectInfo,
+        rate_limit_gate_per_second: non_zero(1),
+        rate_limit_gate_burst: non_zero(burst),
+        rate_limit_anonymous_per_hour: non_zero(1),
+        rate_limit_anonymous_burst: non_zero(burst),
+        rate_limit_actor_per_hour: non_zero(1),
+        rate_limit_actor_burst: non_zero(burst),
+    }
+}
+
+fn gate_router_with(limiters: &Arc<RateLimiters>) -> Router {
+    let limiters = Arc::clone(limiters);
+    let service_secret: Arc<str> = Arc::from(SERVICE_SECRET);
+    Router::new()
+        .route("/entities", get(async || "ok"))
+        .route_layer(middleware::from_fn(move |request, next| {
+            ip_gate_middleware(
+                Arc::clone(&limiters),
+                Arc::clone(&service_secret),
+                request,
+                next,
+            )
+        }))
+}
+
+fn gate_router(config: &RateLimitConfig) -> Router {
+    gate_router_with(&Arc::new(RateLimiters::new(config)))
+}
+
+fn principal_router(config: &RateLimitConfig) -> Router {
+    let limiters = Arc::new(RateLimiters::new(config));
+    let service_secret: Arc<str> = Arc::from(SERVICE_SECRET);
+    Router::new()
+        .route("/entities", get(async || "ok"))
+        .route_layer(middleware::from_fn(move |request, next| {
+            principal_limit_middleware(
+                Arc::clone(&limiters),
+                Arc::clone(&service_secret),
+                request,
+                next,
+            )
+        }))
+}
+
+/// Stacks the three request middlewares in the order the REST router wires them.
+fn full_stack_router(config: &RateLimitConfig, provider: StaticAuthenticationProvider) -> Router {
+    full_stack_router_with(&Arc::new(RateLimiters::new(config)), provider)
+}
+
+fn full_stack_router_with(
+    limiters: &Arc<RateLimiters>,
+    provider: StaticAuthenticationProvider,
+) -> Router {
+    let limiters = Arc::clone(limiters);
+    let provider = Arc::new(provider);
+    let service_secret: Arc<str> = Arc::from(SERVICE_SECRET);
+    let gate_limiters = Arc::clone(&limiters);
+    let gate_secret = Arc::clone(&service_secret);
+    let principal_secret = Arc::clone(&service_secret);
+    Router::new()
+        .route("/entities", get(async || "ok"))
+        .route_layer(middleware::from_fn(move |request, next| {
+            principal_limit_middleware(
+                Arc::clone(&limiters),
+                Arc::clone(&principal_secret),
+                request,
+                next,
+            )
+        }))
+        .route_layer(middleware::from_fn(move |request, next| {
+            let provider = Arc::clone(&provider);
+            let service_secret = Arc::clone(&service_secret);
+            authentication_middleware::<_, Option<ActorId>>(provider, service_secret, request, next)
+        }))
+        .route_layer(middleware::from_fn(move |request, next| {
+            ip_gate_middleware(
+                Arc::clone(&gate_limiters),
+                Arc::clone(&gate_secret),
+                request,
+                next,
+            )
+        }))
+}
+
+fn request_to(path: &str, peer: IpAddr) -> Request<Body> {
+    let mut request = Request::builder()
+        .uri(path)
+        .body(Body::empty())
+        .expect("the request should build");
+    request
+        .extensions_mut()
+        .insert(ConnectInfo(SocketAddr::new(peer, 4000)));
+    request
+}
+
+fn request(peer: IpAddr) -> Request<Body> {
+    request_to("/entities", peer)
+}
+
+/// A request as a router served without connect info produces.
+fn request_without_peer() -> Request<Body> {
+    Request::builder()
+        .uri("/entities")
+        .body(Body::empty())
+        .expect("the request should build")
+}
+
+fn forwarded_request(peer: IpAddr, header: &'static str, value: &str) -> Request<Body> {
+    let mut request = request(peer);
+    request
+        .headers_mut()
+        .insert(header, value.parse().expect("the header should parse"));
+    request
+}
+
+fn with_credential(mut request: Request<Body>, credential: &str) -> Request<Body> {
+    request.headers_mut().insert(
+        "authorization",
+        credential.parse().expect("the header should parse"),
+    );
+    request
+}
+
+fn credentialed_request(peer: IpAddr, credential: &str) -> Request<Body> {
+    with_credential(request(peer), credential)
+}
+
+fn anonymous_request(peer: IpAddr) -> Request<Body> {
+    let mut request = request(peer);
+    request
+        .extensions_mut()
+        .insert(ResolvedAuthentication::new(Ok(None)));
+    request
+}
+
+fn actor_request(actor_id: ActorId) -> Request<Body> {
+    let mut request = request(IpAddr::V4(Ipv4Addr::LOCALHOST));
+    request
+        .extensions_mut()
+        .insert(ResolvedAuthentication::new(Ok(Some(actor_id))));
+    request
+}
+
+fn random_actor() -> ActorId {
+    ActorId::User(UserId::new(ActorEntityUuid::new(Uuid::new_v4())))
+}
+
+fn address(value: &str) -> IpAddr {
+    value.parse().expect("the address should parse")
+}
+
+fn header(response: &Response, name: &str) -> Option<String> {
+    response.headers().get(name).map(|value| {
+        value
+            .to_str()
+            .expect("the header should be ASCII")
+            .to_owned()
+    })
+}
+
+async fn send(router: &Router, request: Request<Body>) -> Response {
+    router
+        .clone()
+        .oneshot(request)
+        .await
+        .expect("the router should respond")
+}
+
+/// The defaults reach an operator through clap, so they are read back the way clap renders them.
+#[cfg(feature = "clap")]
+#[test]
+fn defaults_leave_enforcement_off() {
+    use clap::Parser as _;
+
+    #[derive(clap::Parser)]
+    struct Wrapper {
+        #[clap(flatten)]
+        rate_limit: RateLimitConfig,
+    }
+
+    let parsed = Wrapper::parse_from(["test"]).rate_limit;
+    assert_eq!(
+        parsed.rate_limit_mode,
+        RateLimitMode::Observe,
+        "nobody should be turned away until the budgets are measured"
+    );
+    assert_eq!(
+        parsed.client_ip_source,
+        ClientIpSource::ConnectInfo,
+        "a forwarded header should only be read where a deployment asks for it"
+    );
+    assert_eq!(
+        parsed.rate_limit_anonymous_burst.get(),
+        50,
+        "an anonymous caller should be able to load a page's worth of requests at once"
+    );
+}
+
+#[tokio::test]
+async fn gate_denies_past_its_burst() {
+    let router = gate_router(&config(1));
+    let client = address("192.0.2.1");
+
+    let admitted = send(&router, request(client)).await;
+    assert_eq!(admitted.status(), StatusCode::OK);
+
+    let denied = send(&router, request(client)).await;
+    assert_eq!(denied.status(), StatusCode::TOO_MANY_REQUESTS);
+    assert_eq!(
+        header(&denied, "retry-after"),
+        Some("1".to_owned()),
+        "a sub-second wait should round up, never telling a client to retry immediately"
+    );
+
+    assert_eq!(
+        send(&router, request(address("192.0.2.2"))).await.status(),
+        StatusCode::OK,
+        "exhausting one address should not spend another's budget"
+    );
+}
+
+#[tokio::test]
+async fn forwarded_header_keys_the_budget_rather_than_the_connection() {
+    let router = gate_router(&RateLimitConfig {
+        client_ip_source: ClientIpSource::CfConnectingIp,
+        ..config(1)
+    });
+    let proxy = address("192.0.2.1");
+
+    for client in ["203.0.113.1", "203.0.113.2"] {
+        let response = send(
+            &router,
+            forwarded_request(proxy, "cf-connecting-ip", client),
+        )
+        .await;
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "two clients behind one proxy should hold separate budgets"
+        );
+    }
+
+    let repeat = send(
+        &router,
+        forwarded_request(address("198.51.100.9"), "cf-connecting-ip", "203.0.113.1"),
+    )
+    .await;
+    assert_eq!(
+        repeat.status(),
+        StatusCode::TOO_MANY_REQUESTS,
+        "one client reaching through a second proxy should keep drawing from its own budget"
+    );
+}
+
+/// Reading the connection is the default, so a client must not be able to pick its own budget by
+/// sending a forwarded header the deployment never asked for.
+#[tokio::test]
+async fn connection_source_ignores_a_forwarded_header() {
+    let router = gate_router(&config(1));
+    let peer = address("192.0.2.1");
+
+    assert_eq!(
+        send(
+            &router,
+            forwarded_request(peer, "x-forwarded-for", "203.0.113.1")
+        )
+        .await
+        .status(),
+        StatusCode::OK
+    );
+
+    assert_eq!(
+        send(
+            &router,
+            forwarded_request(peer, "x-forwarded-for", "203.0.113.2")
+        )
+        .await
+        .status(),
+        StatusCode::TOO_MANY_REQUESTS,
+        "a second forwarded address should not mint a fresh budget for the same connection"
+    );
+}
+
+#[tokio::test]
+async fn unusable_forwarded_header_keys_on_the_connection() {
+    let router = gate_router(&RateLimitConfig {
+        client_ip_source: ClientIpSource::XForwardedFor,
+        ..config(1)
+    });
+    let peer = address("192.0.2.1");
+
+    let admitted = send(
+        &router,
+        forwarded_request(peer, "x-forwarded-for", "unknown"),
+    )
+    .await;
+    assert_eq!(admitted.status(), StatusCode::OK);
+
+    let denied = send(&router, request(peer)).await;
+    assert_eq!(
+        denied.status(),
+        StatusCode::TOO_MANY_REQUESTS,
+        "a garbage header should not mint a budget the missing header would not have"
+    );
+}
+
+#[tokio::test]
+async fn requests_without_a_connection_address_pass_unchecked() {
+    let router = gate_router(&config(1));
+
+    for _ in 0..3 {
+        let response = send(&router, request_without_peer()).await;
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "with nothing to key a budget by, the limiter has to admit rather than deny"
+        );
+    }
+}
+
+#[tokio::test]
+async fn service_secret_bypasses_both_middlewares() {
+    let router = full_stack_router(&config(1), StaticAuthenticationProvider::NotRecognized);
+    let client = address("192.0.2.1");
+
+    for _ in 0..4 {
+        let response = send(
+            &router,
+            credentialed_request(client, &format!("HASH-Service {SERVICE_SECRET}")),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+}
+
+#[tokio::test]
+async fn gate_rejects_the_scheme_without_the_secret() {
+    let router = gate_router(&config(1));
+    let client = address("192.0.2.1");
+
+    let mut statuses = Vec::new();
+    for _ in 0..2 {
+        let response = send(
+            &router,
+            credentialed_request(client, "HASH-Service hash-svc-wrong"),
+        )
+        .await;
+        statuses.push(response.status());
+    }
+    assert_eq!(
+        statuses,
+        [StatusCode::OK, StatusCode::TOO_MANY_REQUESTS],
+        "the gate should verify the secret rather than trust the scheme"
+    );
+}
+
+#[tokio::test]
+async fn actor_budget_rejects_the_scheme_without_the_secret() {
+    let router = principal_router(&config(1));
+    let actor = random_actor();
+
+    let mut statuses = Vec::new();
+    for _ in 0..2 {
+        let credentialed = with_credential(actor_request(actor), "HASH-Service hash-svc-wrong");
+        statuses.push(send(&router, credentialed).await.status());
+    }
+    assert_eq!(
+        statuses,
+        [StatusCode::OK, StatusCode::TOO_MANY_REQUESTS],
+        "the principal limiter should verify the secret rather than trust the scheme"
+    );
+}
+
+#[tokio::test]
+async fn actors_hold_one_budget_across_addresses() {
+    let router = principal_router(&config(1));
+    let actor = random_actor();
+
+    assert_eq!(
+        send(&router, actor_request(actor)).await.status(),
+        StatusCode::OK
+    );
+    assert_eq!(
+        send(&router, actor_request(actor)).await.status(),
+        StatusCode::TOO_MANY_REQUESTS
+    );
+    assert_eq!(
+        send(&router, actor_request(random_actor())).await.status(),
+        StatusCode::OK,
+        "another actor should draw from its own budget"
+    );
+}
+
+/// The anonymous budget is keyed by the address the gate resolved, so this needs the full stack.
+#[tokio::test]
+async fn anonymous_requests_draw_from_their_address_budget() {
+    let router = full_stack_router(
+        &RateLimitConfig {
+            rate_limit_gate_burst: non_zero(10),
+            ..config(1)
+        },
+        StaticAuthenticationProvider::NotRecognized,
+    );
+    let client = address("192.0.2.1");
+
+    assert_eq!(
+        send(&router, request(client)).await.status(),
+        StatusCode::OK
+    );
+    assert_eq!(
+        send(&router, request(client)).await.status(),
+        StatusCode::TOO_MANY_REQUESTS
+    );
+    assert_eq!(
+        send(&router, request(address("192.0.2.2"))).await.status(),
+        StatusCode::OK,
+        "another address should draw from its own budget"
+    );
+}
+
+#[tokio::test]
+async fn route_without_authentication_fails_loudly() {
+    let router = principal_router(&config(1));
+
+    let response = send(&router, request(IpAddr::V4(Ipv4Addr::LOCALHOST))).await;
+    assert_eq!(
+        response.status(),
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "a wiring mistake should fail loudly rather than skip the budget"
+    );
+}
+
+#[tokio::test]
+async fn route_without_the_address_gate_fails_loudly() {
+    let router = principal_router(&config(1));
+
+    let response = send(&router, anonymous_request(address("192.0.2.1"))).await;
+    assert_eq!(
+        response.status(),
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "an anonymous request should not be budgeted where the gate never resolved an address"
+    );
+}
+
+/// Which budget denied is read off the tally, since a response names no budget.
+#[tokio::test]
+async fn gate_runs_ahead_of_authentication() {
+    let limiters = Arc::new(RateLimiters::new(&RateLimitConfig {
+        rate_limit_anonymous_burst: non_zero(10),
+        ..config(1)
+    }));
+    let router = full_stack_router_with(&limiters, StaticAuthenticationProvider::NotRecognized);
+    let client = address("192.0.2.1");
+
+    assert_eq!(
+        send(&router, request(client)).await.status(),
+        StatusCode::OK
+    );
+    assert_eq!(
+        send(&router, request(client)).await.status(),
+        StatusCode::TOO_MANY_REQUESTS
+    );
+
+    let totals = limiters.tally.take();
+    assert_eq!(
+        totals.gate_denials, 1,
+        "the gate should deny before the anonymous budget of 10 is consulted"
+    );
+    assert_eq!(
+        totals.anonymous_denials, 0,
+        "the anonymous budget should never have been charged"
+    );
+}
+
+#[tokio::test]
+async fn authentication_feeds_the_actor_budget() {
+    let limiters = Arc::new(RateLimiters::new(&RateLimitConfig {
+        rate_limit_gate_burst: non_zero(10),
+        rate_limit_anonymous_burst: non_zero(10),
+        ..config(1)
+    }));
+    let router = full_stack_router_with(
+        &limiters,
+        StaticAuthenticationProvider::Verified(random_actor()),
+    );
+    let client = address("192.0.2.1");
+
+    assert_eq!(
+        send(&router, request(client)).await.status(),
+        StatusCode::OK
+    );
+    assert_eq!(
+        send(&router, request(client)).await.status(),
+        StatusCode::TOO_MANY_REQUESTS
+    );
+
+    let totals = limiters.tally.take();
+    assert_eq!(
+        totals.actor_denials, 1,
+        "a verified actor should be charged against the actor budget"
+    );
+    assert_eq!(
+        (totals.gate_denials, totals.anonymous_denials),
+        (0, 0),
+        "neither address budget should have denied at a burst of 10"
+    );
+}
+
+#[tokio::test]
+async fn observing_serves_the_request_and_reports_nothing_to_the_client() {
+    let limiters = Arc::new(RateLimiters::new(&RateLimitConfig {
+        rate_limit_mode: RateLimitMode::Observe,
+        ..config(1)
+    }));
+    let router = full_stack_router_with(&limiters, StaticAuthenticationProvider::NotRecognized);
+    let client = address("192.0.2.1");
+
+    assert_eq!(
+        send(&router, request(client)).await.status(),
+        StatusCode::OK
+    );
+
+    let over_budget = send(&router, request(client)).await;
+    assert_eq!(
+        over_budget.status(),
+        StatusCode::OK,
+        "observing should record the denial without applying it"
+    );
+    assert_eq!(
+        header(&over_budget, "retry-after"),
+        None,
+        "a served request should not tell a client to wait for something it already got"
+    );
+
+    let totals = limiters.tally.take();
+    assert_eq!(
+        totals.gate_denials, 1,
+        "the denial should reach the interval report even where it is not applied"
+    );
+    assert_eq!(
+        totals.anonymous_denials, 1,
+        "observing should keep charging the budgets behind the one that was crossed, so the \
+         report shows what enforcement would have done at each"
+    );
+}
+
+/// Drives `attach_request_middlewares`, the function `rest_api_router` wires the stack with, so
+/// what each route carries is read off the production assembly rather than a copy of it.
+#[tokio::test]
+async fn attaching_budgets_unmatched_paths_and_spares_later_merges() {
+    // Two requests of gate budget: the specification, then one unmatched path before it runs out.
+    let limiters = Arc::new(RateLimiters::new(&RateLimitConfig {
+        rate_limit_gate_burst: non_zero(2),
+        ..config(1)
+    }));
+    let router = crate::rest::attach_request_middlewares::<_, Option<ActorId>>(
+        Router::new()
+            .route("/entities", get(async || "ok"))
+            .fallback(|| async { StatusCode::NOT_FOUND }),
+        Router::new().route("/openapi.json", get(async || "spec")),
+        Arc::new(StaticAuthenticationProvider::Rejected),
+        Arc::from(SERVICE_SECRET),
+        limiters,
+    )
+    .merge(Router::new().route("/health", get(async || "ok")));
+    let client = address("192.0.2.1");
+
+    assert_eq!(
+        send(&router, request_to("/openapi.json", client))
+            .await
+            .status(),
+        StatusCode::OK,
+        "a route merged between the layers should skip authentication, which rejects everything \
+         here"
+    );
+
+    assert_eq!(
+        send(&router, request_to("/does-not-exist", client))
+            .await
+            .status(),
+        StatusCode::NOT_FOUND,
+        "an unmatched path should answer 404 without reaching authentication"
+    );
+    assert_eq!(
+        send(&router, request_to("/does-not-exist", client))
+            .await
+            .status(),
+        StatusCode::TOO_MANY_REQUESTS,
+        "an unmatched path should draw from the address budget like any other request"
+    );
+
+    for _ in 0..3 {
+        assert_eq!(
+            send(&router, request_to("/health", client)).await.status(),
+            StatusCode::OK,
+            "a probe merged after the gate should stay outside it, whatever the budget holds"
+        );
+    }
+}
+
+/// A rejected credential and an exhausted gate answer differently, so the order they run in is
+/// observable from the status code alone.
+#[tokio::test]
+async fn gate_denies_without_consulting_the_provider() {
+    let router = full_stack_router(&config(1), StaticAuthenticationProvider::Rejected);
+    let client = address("192.0.2.1");
+
+    assert_eq!(
+        send(&router, request(client)).await.status(),
+        StatusCode::UNAUTHORIZED,
+        "the provider should have its say while the gate still holds budget"
+    );
+
+    assert_eq!(
+        send(&router, request(client)).await.status(),
+        StatusCode::TOO_MANY_REQUESTS,
+        "an exhausted gate should answer before a credential reaches the identity provider"
+    );
+}
+
+/// Only the innermost service can tell whether an enforced denial reached it.
+#[tokio::test]
+async fn enforced_denials_skip_the_inner_stack() {
+    let reached = Arc::new(AtomicUsize::new(0));
+    let handler_reached = Arc::clone(&reached);
+    // The anonymous budget has headroom, so only the gate denies. Were the inner stack awaited
+    // before the denial answered, the handler would run and be counted.
+    let limiters = Arc::new(RateLimiters::new(&RateLimitConfig {
+        rate_limit_anonymous_burst: non_zero(10),
+        ..config(1)
+    }));
+    let provider = Arc::new(StaticAuthenticationProvider::NotRecognized);
+    let service_secret: Arc<str> = Arc::from(SERVICE_SECRET);
+    let gate_limiters = Arc::clone(&limiters);
+    let gate_secret = Arc::clone(&service_secret);
+    let principal_secret = Arc::clone(&service_secret);
+    let router = Router::new()
+        .route(
+            "/entities",
+            get(async move || {
+                handler_reached.fetch_add(1, Ordering::Relaxed);
+                "ok"
+            }),
+        )
+        .route_layer(middleware::from_fn(move |request, next| {
+            principal_limit_middleware(
+                Arc::clone(&limiters),
+                Arc::clone(&principal_secret),
+                request,
+                next,
+            )
+        }))
+        .route_layer(middleware::from_fn(move |request, next| {
+            let provider = Arc::clone(&provider);
+            let service_secret = Arc::clone(&service_secret);
+            authentication_middleware::<_, Option<ActorId>>(provider, service_secret, request, next)
+        }))
+        .route_layer(middleware::from_fn(move |request, next| {
+            ip_gate_middleware(
+                Arc::clone(&gate_limiters),
+                Arc::clone(&gate_secret),
+                request,
+                next,
+            )
+        }));
+    let client = address("192.0.2.1");
+
+    assert_eq!(
+        send(&router, request(client)).await.status(),
+        StatusCode::OK
+    );
+    assert_eq!(
+        reached.load(Ordering::Relaxed),
+        1,
+        "the admitted request should reach the handler"
+    );
+
+    assert_eq!(
+        send(&router, request(client)).await.status(),
+        StatusCode::TOO_MANY_REQUESTS
+    );
+    assert_eq!(
+        reached.load(Ordering::Relaxed),
+        1,
+        "a denied request should shed load rather than pay for the work it is refused"
+    );
+}
+
+#[tokio::test]
+async fn authentication_error_fails_loudly() {
+    let router = principal_router(&config(1));
+
+    let mut request = request(IpAddr::V4(Ipv4Addr::LOCALHOST));
+    request
+        .extensions_mut()
+        .insert(ResolvedAuthentication::new(Err(
+            AuthenticationError::MissingDelegatedActor,
+        )));
+
+    assert_eq!(
+        send(&router, request).await.status(),
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "an unrejected authentication error should fail loudly rather than skip the budget"
+    );
+}
+
+#[tokio::test]
+async fn one_request_counts_once_without_an_address() {
+    let limiters = Arc::new(RateLimiters::new(&config(1)));
+    let router = full_stack_router_with(&limiters, StaticAuthenticationProvider::NotRecognized);
+
+    assert_eq!(
+        send(&router, request_without_peer()).await.status(),
+        StatusCode::OK
+    );
+
+    let totals = limiters.tally.take();
+    assert_eq!(
+        totals.unknown_addresses, 1,
+        "both middlewares saw one request, so the counter that alarms on this should read one"
+    );
+}
+
+#[tokio::test]
+async fn denials_and_fallbacks_reach_the_interval_report() {
+    let limiters = Arc::new(RateLimiters::new(&RateLimitConfig {
+        client_ip_source: ClientIpSource::XForwardedFor,
+        ..config(1)
+    }));
+    let router = gate_router_with(&limiters);
+    let peer = address("192.0.2.1");
+
+    for _ in 0..2 {
+        send(
+            &router,
+            forwarded_request(peer, "x-forwarded-for", "unknown"),
+        )
+        .await;
+    }
+
+    let totals = limiters.tally.take();
+    assert_eq!(
+        totals.gate_denials, 1,
+        "the second of two requests over a burst of one should be counted"
+    );
+    assert_eq!(
+        totals.address_fallbacks, 2,
+        "both unusable headers should be counted"
+    );
+
+    let reset = limiters.tally.take();
+    assert_eq!(
+        reset.gate_denials, 0,
+        "a report should cover only its own interval"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn maintenance_sweeps_on_its_interval() {
+    let limiters = Arc::new(RateLimiters::new(&RateLimitConfig {
+        rate_limit_gate_per_second: non_zero(u32::MAX),
+        ..config(1)
+    }));
+    let router = gate_router_with(&limiters);
+    super::spawn_maintenance(Arc::downgrade(&limiters));
+
+    send(&router, request(address("192.0.2.1"))).await;
+    assert_eq!(
+        limiters.tracked_keys(),
+        1,
+        "the request should have left a key behind"
+    );
+
+    tokio::time::sleep(super::SWEEP_INTERVAL + core::time::Duration::from_secs(1)).await;
+    assert_eq!(
+        limiters.tracked_keys(),
+        0,
+        "the spawned sweep should release keys without anyone calling it"
+    );
+}
+
+#[tokio::test]
+async fn admitted_requests_carry_no_budget_headers() {
+    let router = principal_router(&config(3));
+
+    let response = send(&router, actor_request(random_actor())).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    for name in ["retry-after", "ratelimit-limit", "ratelimit-remaining"] {
+        assert_eq!(
+            header(&response, name),
+            None,
+            "an admitted request should carry no rate-limit field, standardised or not"
+        );
+    }
+}
+
+/// Populates all three stores, so a sweep that forgets one is caught.
+#[tokio::test]
+async fn sweeping_releases_replenished_keys_from_every_store() {
+    // The largest rates the type holds, so every key is releasable by the time the sweep runs.
+    let quotas = RateLimitConfig {
+        rate_limit_gate_per_second: non_zero(u32::MAX),
+        rate_limit_anonymous_per_hour: non_zero(u32::MAX),
+        rate_limit_actor_per_hour: non_zero(u32::MAX),
+        ..config(1)
+    };
+    let limiters = Arc::new(RateLimiters::new(&quotas));
+    let service_secret: Arc<str> = Arc::from(SERVICE_SECRET);
+    let gate_limiters = Arc::clone(&limiters);
+    let gate_secret = Arc::clone(&service_secret);
+    let principal_limiters = Arc::clone(&limiters);
+    let router = Router::new()
+        .route("/entities", get(async || "ok"))
+        .route_layer(middleware::from_fn(move |request, next| {
+            principal_limit_middleware(
+                Arc::clone(&principal_limiters),
+                Arc::clone(&service_secret),
+                request,
+                next,
+            )
+        }))
+        .route_layer(middleware::from_fn(move |request, next| {
+            ip_gate_middleware(
+                Arc::clone(&gate_limiters),
+                Arc::clone(&gate_secret),
+                request,
+                next,
+            )
+        }));
+
+    let client = address("192.0.2.1");
+    assert_eq!(
+        send(&router, anonymous_request(client)).await.status(),
+        StatusCode::OK
+    );
+
+    let mut authenticated = request(client);
+    authenticated
+        .extensions_mut()
+        .insert(ResolvedAuthentication::new(Ok(Some(random_actor()))));
+    assert_eq!(send(&router, authenticated).await.status(), StatusCode::OK);
+
+    assert_eq!(
+        limiters.tracked_keys(),
+        3,
+        "one gate key shared by both requests, plus one anonymous and one actor key"
+    );
+
+    limiters.sweep();
+    assert_eq!(
+        limiters.tracked_keys(),
+        0,
+        "eviction is the only thing releasing keys, so every store has to be swept"
+    );
+}

--- a/libs/@local/graph/postgres-store/src/store/postgres/query/compile/tests.rs
+++ b/libs/@local/graph/postgres-store/src/store/postgres/query/compile/tests.rs
@@ -2118,9 +2118,8 @@ mod property_masking {
             &compiler,
             r#"
             SELECT ("entity_editions_0_1_0"."properties" - (CASE WHEN
-                ("entity_temporal_metadata_0_0_0"."entity_uuid" != $1)
-                AND ("entity_edition_cache_0_1_0"."base_urls" @> ARRAY[$2]::text[])
-                THEN ARRAY[$3]::text[]
+                ("entity_edition_cache_0_1_0"."base_urls" @> ARRAY[$1]::text[])
+                THEN ARRAY[$2]::text[]
                 ELSE ARRAY[]::text[] END))
             FROM "entity_temporal_metadata" AS "entity_temporal_metadata_0_0_0"
             INNER JOIN "entity_editions" AS "entity_editions_0_1_0"
@@ -2132,7 +2131,6 @@ mod property_masking {
             WHERE "entity_temporal_metadata_0_0_0"."draft_id" IS NULL
             "#,
             &[
-                &Uuid::nil(),
                 &"https://hash.ai/@h/types/entity-type/user/",
                 &"https://hash.ai/@h/types/property-type/email/",
             ],

--- a/libs/@local/graph/store/src/filter/mod.rs
+++ b/libs/@local/graph/store/src/filter/mod.rs
@@ -1242,12 +1242,17 @@ impl<'p> Filter<'p, Entity> {
                 filters
                     .into_iter()
                     .map(|filter| Self::for_property_filter(filter, actor_id))
+                    // A comparison that matches every record constrains nothing within a
+                    // conjunction.
+                    .filter(|filter| !matches!(filter, Self::All(inner) if inner.is_empty()))
                     .collect(),
             ),
             PropertyFilter::Any(filters) => Self::Any(
                 filters
                     .into_iter()
                     .map(|filter| Self::for_property_filter(filter, actor_id))
+                    // A comparison that matches no record adds nothing to a disjunction.
+                    .filter(|filter| !matches!(filter, Self::Any(inner) if inner.is_empty()))
                     .collect(),
             ),
             PropertyFilter::Equal(lhs, rhs) => {
@@ -1272,10 +1277,10 @@ impl<'p> Filter<'p, Entity> {
                 }
             }
             PropertyFilter::In(lhs, rhs) => {
-                match FilterExpression::from_cell_filter_expression(lhs, actor_id) {
-                    Some(lhs) => Self::In(lhs, FilterExpressionList::from(rhs)),
-                    None => Self::Any(Vec::new()),
-                }
+                FilterExpression::from_cell_filter_expression(lhs, actor_id).map_or_else(
+                    || Self::Any(Vec::new()),
+                    |lhs| Self::In(lhs, FilterExpressionList::from(rhs)),
+                )
             }
         }
     }

--- a/libs/@local/graph/store/src/filter/mod.rs
+++ b/libs/@local/graph/store/src/filter/mod.rs
@@ -1235,11 +1235,11 @@ impl<'p> Filter<'p, Entity> {
         }
     }
 
-    #[must_use]
     /// Transforms a property filter into a query filter for the given actor.
     ///
     /// A request without an actor leaves the actor comparison without a value: an equality then
     /// matches no record, an inequality every record.
+    #[must_use]
     fn for_property_filter(filter: PropertyFilter<'p>, actor_id: Option<ActorId>) -> Self {
         match filter {
             PropertyFilter::All(filters) => Self::All(

--- a/libs/@local/graph/store/src/filter/mod.rs
+++ b/libs/@local/graph/store/src/filter/mod.rs
@@ -1236,14 +1236,16 @@ impl<'p> Filter<'p, Entity> {
     }
 
     #[must_use]
+    /// Transforms a property filter into a query filter for the given actor.
+    ///
+    /// A request without an actor leaves the actor comparison without a value: an equality then
+    /// matches no record, an inequality every record.
     fn for_property_filter(filter: PropertyFilter<'p>, actor_id: Option<ActorId>) -> Self {
         match filter {
             PropertyFilter::All(filters) => Self::All(
                 filters
                     .into_iter()
                     .map(|filter| Self::for_property_filter(filter, actor_id))
-                    // A comparison that matches every record constrains nothing within a
-                    // conjunction.
                     .filter(|filter| !matches!(filter, Self::All(inner) if inner.is_empty()))
                     .collect(),
             ),
@@ -1251,7 +1253,6 @@ impl<'p> Filter<'p, Entity> {
                 filters
                     .into_iter()
                     .map(|filter| Self::for_property_filter(filter, actor_id))
-                    // A comparison that matches no record adds nothing to a disjunction.
                     .filter(|filter| !matches!(filter, Self::Any(inner) if inner.is_empty()))
                     .collect(),
             ),
@@ -1261,8 +1262,6 @@ impl<'p> Filter<'p, Entity> {
                     FilterExpression::from_cell_filter_expression(rhs, actor_id),
                 ) {
                     (Some(lhs), Some(rhs)) => Self::Equal(lhs, rhs),
-                    // A request without an actor has no value to compare against, so nothing
-                    // equals it.
                     _ => Self::Any(Vec::new()),
                 }
             }
@@ -1272,7 +1271,6 @@ impl<'p> Filter<'p, Entity> {
                     FilterExpression::from_cell_filter_expression(rhs, actor_id),
                 ) {
                     (Some(lhs), Some(rhs)) => Self::NotEqual(lhs, rhs),
-                    // Everything differs from a value that is not there.
                     _ => Self::All(Vec::new()),
                 }
             }
@@ -1496,8 +1494,7 @@ impl<R: QueryRecord> FilterExpression<'_, R> {
 impl<'p> FilterExpression<'p, Entity> {
     /// Converts a cell filter expression into a query filter expression.
     ///
-    /// Returns [`None`] for [`ActorId`] when the request carries no actor, leaving it to the
-    /// caller to decide what a comparison against a missing actor means.
+    /// Returns [`None`] for [`ActorId`] when the request carries no actor.
     ///
     /// [`ActorId`]: PropertyFilterExpression::ActorId
     #[must_use]

--- a/libs/@local/graph/store/src/filter/mod.rs
+++ b/libs/@local/graph/store/src/filter/mod.rs
@@ -30,7 +30,6 @@ use type_system::{
     },
     principal::actor::{ActorEntityUuid, ActorId},
 };
-use uuid::Uuid;
 
 pub use self::{
     parameter::{
@@ -1251,18 +1250,33 @@ impl<'p> Filter<'p, Entity> {
                     .map(|filter| Self::for_property_filter(filter, actor_id))
                     .collect(),
             ),
-            PropertyFilter::Equal(lhs, rhs) => Self::Equal(
-                FilterExpression::from_cell_filter_expression(lhs, actor_id),
-                FilterExpression::from_cell_filter_expression(rhs, actor_id),
-            ),
-            PropertyFilter::NotEqual(lhs, rhs) => Self::NotEqual(
-                FilterExpression::from_cell_filter_expression(lhs, actor_id),
-                FilterExpression::from_cell_filter_expression(rhs, actor_id),
-            ),
-            PropertyFilter::In(lhs, rhs) => Self::In(
-                FilterExpression::from_cell_filter_expression(lhs, actor_id),
-                FilterExpressionList::from(rhs),
-            ),
+            PropertyFilter::Equal(lhs, rhs) => {
+                match (
+                    FilterExpression::from_cell_filter_expression(lhs, actor_id),
+                    FilterExpression::from_cell_filter_expression(rhs, actor_id),
+                ) {
+                    (Some(lhs), Some(rhs)) => Self::Equal(lhs, rhs),
+                    // A request without an actor has no value to compare against, so nothing
+                    // equals it.
+                    _ => Self::Any(Vec::new()),
+                }
+            }
+            PropertyFilter::NotEqual(lhs, rhs) => {
+                match (
+                    FilterExpression::from_cell_filter_expression(lhs, actor_id),
+                    FilterExpression::from_cell_filter_expression(rhs, actor_id),
+                ) {
+                    (Some(lhs), Some(rhs)) => Self::NotEqual(lhs, rhs),
+                    // Everything differs from a value that is not there.
+                    _ => Self::All(Vec::new()),
+                }
+            }
+            PropertyFilter::In(lhs, rhs) => {
+                match FilterExpression::from_cell_filter_expression(lhs, actor_id) {
+                    Some(lhs) => Self::In(lhs, FilterExpressionList::from(rhs)),
+                    None => Self::Any(Vec::new()),
+                }
+            }
         }
     }
 }
@@ -1475,21 +1489,27 @@ impl<R: QueryRecord> FilterExpression<'_, R> {
 }
 
 impl<'p> FilterExpression<'p, Entity> {
+    /// Converts a cell filter expression into a query filter expression.
+    ///
+    /// Returns [`None`] for [`ActorId`] when the request carries no actor, leaving it to the
+    /// caller to decide what a comparison against a missing actor means.
+    ///
+    /// [`ActorId`]: PropertyFilterExpression::ActorId
     #[must_use]
     pub fn from_cell_filter_expression(
         expression: PropertyFilterExpression<'p>,
         actor_id: Option<ActorId>,
-    ) -> Self {
+    ) -> Option<Self> {
         match expression {
-            PropertyFilterExpression::Path { path } => Self::Path { path },
-            PropertyFilterExpression::Parameter { parameter } => Self::Parameter {
+            PropertyFilterExpression::Path { path } => Some(Self::Path { path }),
+            PropertyFilterExpression::Parameter { parameter } => Some(Self::Parameter {
                 parameter,
                 convert: None,
-            },
-            PropertyFilterExpression::ActorId => Self::Parameter {
-                parameter: Parameter::Uuid(actor_id.map_or_else(Uuid::nil, Uuid::from)),
+            }),
+            PropertyFilterExpression::ActorId => actor_id.map(|actor_id| Self::Parameter {
+                parameter: Parameter::Uuid(actor_id.into()),
                 convert: None,
-            },
+            }),
         }
     }
 }

--- a/libs/@local/graph/store/src/filter/protection.rs
+++ b/libs/@local/graph/store/src/filter/protection.rs
@@ -1412,6 +1412,7 @@ mod tests {
     // =========================================================================
 
     mod transform {
+        use type_system::principal::actor::{ActorEntityUuid, UserId};
         use uuid::Uuid;
 
         use super::*;
@@ -1433,18 +1434,11 @@ mod tests {
             )
         }
 
-        /// Creates `Uuid != ActorId` filter (entity UUID is not the actor's UUID).
-        /// When `actor_id` is `None`, uses `Uuid::nil()`.
+        /// Creates the `Uuid != ActorId` comparison for a request without an actor.
+        ///
+        /// Nothing equals an actor that is not there, so every record differs from it.
         fn uuid_not_actor() -> Filter<'static, Entity> {
-            Filter::NotEqual(
-                FilterExpression::Path {
-                    path: EntityQueryPath::Uuid,
-                },
-                FilterExpression::Parameter {
-                    parameter: Parameter::Uuid(Uuid::nil()),
-                    convert: None,
-                },
-            )
+            Filter::All(Vec::new())
         }
 
         /// Creates the full exclusion filter: `(type = User AND uuid != ActorId)`.
@@ -1639,6 +1633,41 @@ mod tests {
             ]);
 
             assert_eq!(do_transform(input), expected);
+        }
+
+        // -----------------------------------------------------------------
+        // Extra: The actor comparison for a request that carries an actor
+        // -----------------------------------------------------------------
+
+        #[test]
+        fn actor_compares_against_its_own_uuid() {
+            let actor_uuid = Uuid::new_v4();
+            let actor_id = ActorId::User(UserId::new(ActorEntityUuid::new(actor_uuid)));
+
+            let transformed = transform_filter(
+                email_eq("test@example.com"),
+                &email_protection_config(),
+                0,
+                Some(actor_id),
+            );
+
+            let expected = all(vec![
+                email_eq("test@example.com"),
+                not(all(vec![
+                    type_is_user(),
+                    Filter::NotEqual(
+                        FilterExpression::Path {
+                            path: EntityQueryPath::Uuid,
+                        },
+                        FilterExpression::Parameter {
+                            parameter: Parameter::Uuid(actor_uuid),
+                            convert: None,
+                        },
+                    ),
+                ])),
+            ]);
+
+            assert_eq!(transformed, expected);
         }
     }
 }

--- a/libs/@local/graph/store/src/filter/protection.rs
+++ b/libs/@local/graph/store/src/filter/protection.rs
@@ -1434,17 +1434,13 @@ mod tests {
             )
         }
 
-        /// Creates the `Uuid != ActorId` comparison for a request without an actor.
+        /// Creates the exclusion filter of `hash_default()` as it transforms without an actor.
         ///
-        /// Nothing equals an actor that is not there, so every record differs from it.
-        fn uuid_not_actor() -> Filter<'static, Entity> {
-            Filter::All(Vec::new())
-        }
-
-        /// Creates the full exclusion filter: `(type = User AND uuid != ActorId)`.
-        /// This matches the structure from `hash_default()`.
+        /// The rule is `type = User AND uuid != ActorId`. Nothing equals an actor that is not
+        /// there, so every record differs from it and the comparison drops out of the
+        /// conjunction.
         fn exclusion_filter() -> Filter<'static, Entity> {
-            all(vec![type_is_user(), uuid_not_actor()])
+            all(vec![type_is_user()])
         }
 
         /// Creates `NOT(type = User AND uuid != ActorId)` filter.

--- a/libs/@local/graph/store/src/filter/protection.rs
+++ b/libs/@local/graph/store/src/filter/protection.rs
@@ -1434,11 +1434,8 @@ mod tests {
             )
         }
 
-        /// Creates the exclusion filter of `hash_default()` as it transforms without an actor.
-        ///
-        /// The rule is `type = User AND uuid != ActorId`. Nothing equals an actor that is not
-        /// there, so every record differs from it and the comparison drops out of the
-        /// conjunction.
+        /// Creates the `hash_default()` exclusion filter as it transforms without an actor, which
+        /// drops the `uuid != ActorId` comparison.
         fn exclusion_filter() -> Filter<'static, Entity> {
             all(vec![type_is_user()])
         }
@@ -1630,10 +1627,6 @@ mod tests {
 
             assert_eq!(do_transform(input), expected);
         }
-
-        // -----------------------------------------------------------------
-        // Extra: The actor comparison for a request that carries an actor
-        // -----------------------------------------------------------------
 
         #[test]
         fn actor_compares_against_its_own_uuid() {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The Graph enforced no rate limits. Direct API exposure and anonymous access need per-principal limits in the Graph itself, so self-hosted deployments get them without ingress infrastructure. These are proper-use limits — DoS protection stays at the edge.

Two keyed GCRA limiters. An **address gate** ahead of the authentication middleware, so an invented credential is throttled before it reaches the uncached Kratos verification, and a **principal limiter** behind it, keyed by actor for authenticated callers and by address for anonymous ones.

Ships in **observe mode**: over-budget requests are served and recorded, so the budgets can be sized against real traffic before anyone is turned away.

## 🔗 Related links

- BE-758
- https://github.com/hashintel/internal-infra/pull/338 — sets `HASH_GRAPH_CLIENT_IP_SOURCE` and the mode _(internal)_

## 🚫 Blocked by

- [ ] https://github.com/hashintel/internal-infra/pull/338 — without it the limiter falls back to the connection address, and the Service Connect ingress proxy makes that the same peer for every request, collapsing all callers into one budget

## 🔍 What does this change?

- `rest::rate_limit` with the two middlewares, the configuration, and address resolution
- IPv6 addresses group by /64, and a v4-mapped address shares the v4 address's budget — a `BucketKey` newtype makes that the only way an address reaches a limiter, since one /64 allocation would otherwise hold 2^64 budgets and store entries
- The client address is read from a configured source (connection, `X-Forwarded-For`, `CF-Connecting-IP`), because behind a proxy the connection's peer is the proxy
- A denial answers `429` with `Retry-After` and nothing else. The `RateLimit-*` fields are an IETF draft that has since replaced them with a single structured field, so an admitted request carries no rate-limit field at all
- Callers presenting the verified service secret pass both middlewares unchecked
- `attach_request_middlewares` holds the layer stack: the gate is a `layer` and so also covers the 404 fallback, authentication and the principal limiter are `route_layer`s and are not reached by an unmatched path, and the health probe is merged afterwards so it carries none of them
- Keys are evicted on a 60s sweep, which also emits one aggregate log line per interval — store sizes always, the interval's counters at warn when it saw a denial, a fallback or an unresolvable address
- Limiter state lives in process memory, so enforcement is per instance: N instances admit up to N times the configured rates, and a rolling release starts every budget over

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

- **No instrumentation.** The limiter ships with logs only; metrics are tracked in Linear as BE-774. The sweep's interval line carries the denial counters and store sizes, which is enough to size the budgets, but not enough to alert on. Adding metrics later needs no change to the decision path.
- **Per-instance enforcement.** A deployment with N instances admits up to N times the configured rates, and a rolling release starts every budget over. Shared state was considered and rejected: it buys precision these limits do not need, at the cost of a dependency on the request path that would have to fail open anyway.
- **One flat anonymous budget.** Per-endpoint tiers and cost weighting are decided with the public `/v1` route shapes in BE-757, so a generous type read and an expensive query currently draw on the same budget.
- **Store growth is bounded by the sweep interval**, not by a key cap. Eviction is the only mechanism releasing keys, so a burst of distinct addresses is retained until the next sweep. Tuning that interval trades memory against log volume; a cap would decouple them.

## 🐾 Next steps

Tracked in Linear: BE-774 (instrumentation), BE-757 (per-endpoint tiers), BE-791 (a `Secret` type for credential config), BE-795 (carry the authentication `Report` to the rejection), BE-796 (resolve an invalid session as anonymous rather than rejecting it).

## 🛡 What tests cover this?

New behavioural tests in `rest::rate_limit::tests` and `rest::rate_limit::address::tests`, chosen so that removing the code they cover fails a test rather than passing quietly. They pin, among others: the traversal order and that an exhausted gate answers without the identity provider being consulted; that an enforced denial never runs the inner stack; that the gate covers unmatched paths while a router merged afterwards does not; the `/64` and v4-mapped bucketing; that a wrong service secret bypasses nothing; that a missing authentication or gate extension answers 500 rather than skipping a budget; that one request produces exactly one count when its address cannot be resolved; that observe is the default and serves without any rate-limit field; and that the sweep releases every store and the spawned maintenance task drives it.

`attach_request_middlewares` is driven directly, so what each route carries is read off the production assembly rather than a copy of it.

## ❓ How to test this?

1. Check out the branch and start the Graph: `cargo run --bin hash-graph --all-features -- server`
2. The startup line reports the effective mode and every quota
3. `curl -i localhost:4000/entities/query -X POST -d '{}' -H 'content-type: application/json'` past the anonymous burst — the request is served, and the sweep reports the denial within a minute
4. Restart with `HASH_GRAPH_RATE_LIMIT_MODE=enforce HASH_GRAPH_RATE_LIMIT_GATE_BURST=2` and repeat: the third request answers `429` with `Retry-After`
5. `curl -i localhost:4000/health` stays available past any budget, and `hash-graph server --healthcheck` still exits 0
