### PR TITLE
FE-1499: Fix stochastic transition firing statistics

### DIFF
--- a/.changeset/stochastic-firing-statistics.md
+++ b/.changeset/stochastic-firing-statistics.md
@@ -1,0 +1,5 @@
+---
+"@hashintel/petrinaut-core": patch
+---
+
+Fix stochastic transition firing statistics: fire with the memoryless per-frame probability `1 - e^(-rate * dt)`, advance the RNG state on every evaluation instead of discarding non-firing draws, and compute the seeded LCG with exact integer arithmetic. Firing counts now match Poisson expectations. Identical seeds produce different sequences than earlier releases.

--- a/libs/@hashintel/petrinaut-core/src/simulation/engine/compute-next-frame.test.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/engine/compute-next-frame.test.ts
@@ -201,12 +201,11 @@ describe("computeNextFrame", () => {
       { id: parseUuid(otherUuid), x: 2.0 },
     ]);
 
-    // Step until the transition fires: each step integrates dynamics and
-    // copies the frame; the firing step consumes one token (removal +
-    // compaction). Elapsed time is 0 on the first step, so the Infinity-rate
-    // transition fires on the second.
-    let result = computeNextFrame(simulation);
-    result = computeNextFrame(result.simulation);
+    // One step integrates dynamics, and the Infinity-rate transition fires
+    // in it (the firing test's exposure window is the frame's dt, so there
+    // is no elapsed-time warm-up), consuming one token (removal +
+    // compaction).
+    const result = computeNextFrame(simulation);
     expect(result.transitionFired).toBe(true);
 
     const lastFrame =

--- a/libs/@hashintel/petrinaut-core/src/simulation/engine/compute-possible-transition.test.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/engine/compute-possible-transition.test.ts
@@ -31,6 +31,12 @@ const type1: Color = {
   elements: [{ elementId: "e1", name: "x", type: "real" }],
 };
 
+/**
+ * A rate high enough that exp(-rate * dt) is 0 for any test dt — the
+ * stochastic firing test then passes for every possible RNG draw.
+ */
+const CERTAIN_FIRING_RATE = 1e9;
+
 const transitionState = (timeSinceLastFiringMs = 1.0) => ({
   timeSinceLastFiringMs,
   firedInThisFrame: false,
@@ -156,18 +162,25 @@ function makeSimulation({
   };
 }
 
+/**
+ * Test convenience over the engine call: flattens the result back to the
+ * pre-`firing` shape (`null` when nothing fired), which most assertions here
+ * consume. The RNG state consumed by a non-firing evaluation is advanced by
+ * the caller where it matters (see the firing-statistics tests).
+ */
 function computePossibleTransition(
   frame: TestFrame,
   simulation: SimulationInstance,
   transitionId: string,
   rngState: number,
 ) {
-  return computePossibleTransitionImpl(
+  const { firing, newRngState } = computePossibleTransitionImpl(
     frame,
     { ...simulation, frameLayout: frame.layout },
     transitionId,
     rngState,
   );
+  return firing === null ? null : { ...firing, newRngState };
 }
 
 describe("computePossibleTransition", () => {
@@ -232,7 +245,7 @@ describe("computePossibleTransition", () => {
       ],
       transitions: [transition],
       types: [type1],
-      lambdaFns: new Map([["t1", () => 10.0]]),
+      lambdaFns: new Map([["t1", () => CERTAIN_FIRING_RATE]]),
       kernelFns: new Map<string, HirCompiledBufferKernel>([
         [
           "t1",
@@ -340,7 +353,7 @@ describe("computePossibleTransition", () => {
       ],
       transitions: [transition],
       types: [type1],
-      lambdaFns: new Map([["t1", () => 10.0]]),
+      lambdaFns: new Map([["t1", () => CERTAIN_FIRING_RATE]]),
       kernelFns: new Map<string, HirCompiledBufferKernel>([
         [
           "t1",
@@ -370,6 +383,106 @@ describe("computePossibleTransition", () => {
       result!.add.p2!.map((block) => decodeTokenBlock(type1.elements, block)),
     ).toEqual([{ x: 2 }]);
     expect(result?.newRngState).toBeTypeOf("number");
+  });
+
+  describe("stochastic firing statistics", () => {
+    /**
+     * A source transition (no inputs) with a constant rate, evaluated over
+     * many frames by chaining the returned RNG state. The frame is reused
+     * unchanged: firing must depend only on the rate and the frame's dt.
+     */
+    const countFirings = ({
+      rate,
+      dt,
+      frames,
+    }: {
+      rate: number;
+      dt: number;
+      frames: number;
+    }): number => {
+      const transition = makeTransition({
+        id: "t1",
+        inputArcs: [],
+        outputArcs: [{ placeId: "p1", weight: 1 }],
+      });
+      const simulation = {
+        ...makeSimulation({
+          places: [makePlace("p1", "Place 1", null)],
+          transitions: [transition],
+          lambdaFns: new Map([["t1", () => rate]]),
+        }),
+        dt,
+      };
+      const frame = makeTestFrame({
+        places: { p1: { count: 0 } },
+        transitions: { t1: transitionState() },
+      });
+
+      let fired = 0;
+      let rngState = 42;
+      for (let index = 0; index < frames; index++) {
+        const result = computePossibleTransition(
+          frame,
+          simulation,
+          "t1",
+          rngState,
+        );
+        if (result !== null) {
+          fired += 1;
+          rngState = result.newRngState;
+        } else {
+          // A non-firing evaluation still consumed one draw.
+          [, rngState] = nextRandom(rngState);
+        }
+      }
+      return fired;
+    };
+
+    it.each([
+      { rate: 2.0, dt: 0.1 },
+      { rate: 2.0, dt: 0.02 },
+      { rate: 0.2, dt: 0.1 },
+    ])(
+      "fires with per-frame probability 1 - e^(-rate * dt) (rate $rate, dt $dt)",
+      ({ rate, dt }) => {
+        const frames = 4000;
+        const fired = countFirings({ rate, dt, frames });
+
+        const perFrame = 1 - Math.exp(-rate * dt);
+        const expected = frames * perFrame;
+        // 4 standard deviations of the binomial count: loose enough to be
+        // seed-stable, tight enough to reject the elapsed-time-CDF sampler,
+        // which fires several times more often at these rates.
+        const tolerance = 4 * Math.sqrt(frames * perFrame * (1 - perFrame));
+
+        expect(Math.abs(fired - expected)).toBeLessThanOrEqual(tolerance);
+      },
+    );
+
+    it("keeps the firing rate independent of the time since the last firing", () => {
+      const transition = makeTransition({
+        id: "t1",
+        inputArcs: [],
+        outputArcs: [{ placeId: "p1", weight: 1 }],
+      });
+      const simulation = makeSimulation({
+        places: [makePlace("p1", "Place 1", null)],
+        transitions: [transition],
+        lambdaFns: new Map([["t1", () => 0.5]]),
+      });
+
+      // Identical rng state and rate: an idle spell must not raise the
+      // firing probability.
+      const results = [0, 100].map((timeSinceLastFiringMs) => {
+        const frame = makeTestFrame({
+          places: { p1: { count: 0 } },
+          transitions: { t1: transitionState(timeSinceLastFiringMs) },
+        });
+        return computePossibleTransition(frame, simulation, "t1", 42);
+      });
+
+      expect(results[0] === null).toBe(results[1] === null);
+    });
   });
 
   describe("predicate lambdas", () => {
@@ -477,7 +590,7 @@ describe("computePossibleTransition", () => {
               count: Math.round(f64[(base + 8) / 8]!),
               active: u8[base + 16] !== 0,
             };
-            return 10.0;
+            return CERTAIN_FIRING_RATE;
           },
         ],
       ]),
@@ -552,7 +665,7 @@ describe("computePossibleTransition", () => {
         places: uuidPlaces,
         transitions: [transition],
         types: [uuidColor],
-        lambdaFns: new Map([["t1", () => 10.0]]),
+        lambdaFns: new Map([["t1", () => CERTAIN_FIRING_RATE]]),
         kernelFns: new Map([
           [
             "t1",
@@ -729,7 +842,7 @@ describe("computePossibleTransition", () => {
           places: stringPlaces,
           transitions: [transition],
           types: [stringColor],
-          lambdaFns: new Map([["t1", () => 10.0]]),
+          lambdaFns: new Map([["t1", () => CERTAIN_FIRING_RATE]]),
           kernelFns: new Map([
             [
               "t1",

--- a/libs/@hashintel/petrinaut-core/src/simulation/engine/compute-possible-transition.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/engine/compute-possible-transition.ts
@@ -18,20 +18,26 @@ const EMPTY_TOKEN_BYTES = new Uint8Array(0);
 
 /**
  * Takes an EngineFrame, a SimulationInstance, a TransitionID, and computes the possible transition.
- * Returns null if no transition is possible.
- * Returns a record with:
- * - removed: Map from PlaceID to Set of token indices to remove.
- * - added: Map from PlaceID to array of packed token byte blocks to create.
- * - newRngState: Updated RNG seed after consuming randomness
+ *
+ * Always returns the RNG state after any randomness consumed by the
+ * evaluation — an enabled stochastic transition draws once whether or not it
+ * fires, so the caller must thread `newRngState` forward on every call.
+ * Re-testing the same draw each frame would freeze the outcome.
+ *
+ * `firing` is null when the transition doesn't fire; otherwise it carries:
+ * - remove: Map from PlaceID to Set of token indices to remove.
+ * - add: Map from PlaceID to array of packed token byte blocks to create.
  */
 export function computePossibleTransition(
   frame: EngineFrame,
   simulation: SimulationInstance,
   transitionId: string,
   rngState: number,
-): null | {
-  remove: Record<PlaceID, Set<number> | number>;
-  add: Record<PlaceID, Uint8Array[]>;
+): {
+  firing: null | {
+    remove: Record<PlaceID, Set<number> | number>;
+    add: Record<PlaceID, Uint8Array[]>;
+  };
   newRngState: number;
 } {
   const snapshot = materializeEngineFrame(simulation.frameLayout, frame);
@@ -70,18 +76,17 @@ export function computePossibleTransition(
       : inputPlace.count >= inputPlace.weight,
   );
 
-  // Return null if not enabled
+  // A disabled transition consumes no randomness.
   if (!isTransitionEnabled) {
-    return null;
+    return { firing: null, newRngState: rngState };
   }
 
   //
   // Transition computation logic
   //
 
-  // Generate random number using seeded RNG and update state
+  // One uniform draw per evaluated enabled transition, fired or not.
   const [U1, newRngState] = nextRandom(rngState);
-  const { timeSinceLastFiringMs } = transitionState;
 
   // Shared views over the frame's token byte region.
   const tokenViews = createTokenRegionViews(
@@ -97,8 +102,6 @@ export function computePossibleTransition(
     (place) => place.strideBytes === 0 && place.arcType === "standard",
   );
 
-  // TODO: This should accumulate lambda over time, but for now we just consider that lambda is constant per combination.
-  // (just multiply by time since last transition)
   const tokensCombinations = enumerateWeightedMarkingIndicesGenerator(
     inputPlacesWithTokenValues,
   );
@@ -121,10 +124,6 @@ export function computePossibleTransition(
       );
     }
 
-    // Approximate by just multiplying by elapsed time since last transition,
-    // not a real accumulation over time with lambda varying as the paper suggests.
-    // But prevent having to handle a big buffer of varying lambda values over time,
-    // which should be reordered in case of new tokens arriving.
     let lambdaResult: ReturnType<typeof transition.lambdaFn>;
     try {
       lambdaResult = transition.lambdaFn(
@@ -144,18 +143,23 @@ export function computePossibleTransition(
     }
 
     // Predicate (boolean) lambdas fire in the same step their guard is true —
-    // no stochastic delay. They must not go through the exp() test below:
-    // mapping true to an Infinity rate breaks when timeSinceLastFiringMs is 0
-    // (Infinity * 0 = NaN), which would block firing on the first frame and
-    // on consecutive frames.
+    // no stochastic delay. They must not go through the exp() test below,
+    // which would map true to an Infinity rate.
     //
-    // For numeric rates, find the first combination of tokens where
-    // e^(-lambda) <= U1. We should normally find the minimum for all
-    // possibilities, but we try to reduce as much as we can here.
+    // Numeric rates fire with the memoryless per-frame probability
+    // 1 - e^(-lambda * dt): the exposure window is this frame's dt, so firing
+    // counts converge to Poisson(lambda * t) as dt shrinks. Testing against
+    // the accumulated time since the last firing instead would redraw U1
+    // against an ever-growing CDF, which inflates effective rates — most for
+    // rare events — and makes inter-firing times non-exponential.
+    //
+    // The first combination that passes fires. A shared U1 across
+    // combinations under-approximates the superposition of per-combination
+    // rates; acceptable while at most one firing per transition per frame.
     const fires =
       typeof lambdaResult === "boolean"
         ? lambdaResult
-        : Math.exp(-lambdaResult * timeSinceLastFiringMs) <= U1;
+        : Math.exp(-lambdaResult * simulation.dt) <= U1;
 
     if (fires) {
       // Transition fires! The compiled kernel writes output tokens into the
@@ -195,31 +199,33 @@ export function computePossibleTransition(
       }
 
       return {
-        // Map from place ID to set of token indices to remove
-        // TODO: Need to provide better typing here, to not let TS infer to any[]
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        remove: Object.fromEntries([
-          ...standardInputPlacesWithZeroStride.map((inputPlace) => [
-            inputPlace.placeId,
-            inputPlace.weight,
+        firing: {
+          // Map from place ID to set of token indices to remove
+          // TODO: Need to provide better typing here, to not let TS infer to any[]
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          remove: Object.fromEntries([
+            ...standardInputPlacesWithZeroStride.map((inputPlace) => [
+              inputPlace.placeId,
+              inputPlace.weight,
+            ]),
+            ...tokenCombinationIndices.flatMap(
+              (placeTokenIndices, placeIndex) => {
+                const inputArc = inputPlacesWithTokenValues[placeIndex]!;
+                return inputArc.arcType === "standard"
+                  ? [[inputArc.placeId, new Set(placeTokenIndices)]]
+                  : [];
+              },
+            ),
           ]),
-          ...tokenCombinationIndices.flatMap(
-            (placeTokenIndices, placeIndex) => {
-              const inputArc = inputPlacesWithTokenValues[placeIndex]!;
-              return inputArc.arcType === "standard"
-                ? [[inputArc.placeId, new Set(placeTokenIndices)]]
-                : [];
-            },
-          ),
-        ]),
-        // Map from place ID to array of packed token byte blocks to
-        // create as per transition kernel output
-        add: addMap,
+          // Map from place ID to array of packed token byte blocks to
+          // create as per transition kernel output
+          add: addMap,
+        },
         newRngState: currentRngState,
       };
     }
   }
 
-  // No transition fired
-  return null;
+  // Enabled but not firing this frame; the draw is still consumed.
+  return { firing: null, newRngState };
 }

--- a/libs/@hashintel/petrinaut-core/src/simulation/engine/execute-transitions.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/engine/execute-transitions.ts
@@ -185,24 +185,25 @@ export function executeTransitions(
   // Iterate through all transitions in the frame
   for (const transitionId of simulation.frameLayout.transitionIds) {
     // Compute if this transition can fire based on the current state
-    const result = computePossibleTransition(
+    const { firing, newRngState } = computePossibleTransition(
       currentFrame,
       simulation,
       transitionId,
       currentRngState,
     );
 
-    if (result !== null) {
+    // Every evaluation's randomness is consumed, fired or not — reusing the
+    // state would re-test the same draw next frame and freeze the outcome.
+    currentRngState = newRngState;
+
+    if (firing !== null) {
       // Transition fired!
       transitionsFired.add(transitionId);
-
-      // Update RNG state for deterministic randomness
-      currentRngState = result.newRngState;
 
       // Immediately remove tokens from the current frame
       // Convert the result.remove Record to a Map
       const tokensToRemove = new Map<PlaceID, Set<number> | number>(
-        Object.entries(result.remove),
+        Object.entries(firing.remove),
       );
       currentFrame = removeTokensFromSimulationFrame(
         currentFrame,
@@ -211,7 +212,7 @@ export function executeTransitions(
       );
 
       // Accumulate tokens to add
-      for (const [placeId, tokenValues] of Object.entries(result.add)) {
+      for (const [placeId, tokenValues] of Object.entries(firing.add)) {
         if (!tokensToAdd.has(placeId)) {
           tokensToAdd.set(placeId, []);
         }
@@ -221,9 +222,11 @@ export function executeTransitions(
     }
   }
 
-  // If no transitions fired, return the original frame with unchanged RNG state
+  // If no transitions fired, return the original frame. The RNG state still
+  // moves forward: every evaluated transition consumed a draw, and restoring
+  // the pre-frame state would hand the next frame the same draws again.
   if (transitionsFired.size === 0) {
-    return { frame, rngState, transitionFired: false };
+    return { frame, rngState: currentRngState, transitionFired: false };
   }
 
   // Add all new tokens at once

--- a/libs/@hashintel/petrinaut-core/src/simulation/engine/seeded-rng.test.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/engine/seeded-rng.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { nextRandom } from "./seeded-rng";
+
+describe("nextRandom", () => {
+  it("computes the exact LCG recurrence (no float overflow)", () => {
+    // Reference implementation in arbitrary-precision arithmetic. The float
+    // product `a * seed` overflows 2^53, so an inexact implementation
+    // diverges from this on the first step.
+    let reference = 42n;
+    let seed = 42;
+    for (let step = 0; step < 10_000; step++) {
+      reference = (1103515245n * reference + 12345n) % 2147483648n;
+      const [value, newSeed] = nextRandom(seed);
+      seed = newSeed;
+      expect(seed).toBe(Number(reference));
+      expect(value).toBe(Number(reference) / 2147483648);
+    }
+  });
+
+  it("does not collapse into a short cycle", () => {
+    // The inexact map cycled after ~16k states, starving distribution tails.
+    const seen = new Set<number>();
+    let seed = 42;
+    for (let step = 0; step < 100_000; step++) {
+      [, seed] = nextRandom(seed);
+      expect(seen.has(seed)).toBe(false);
+      seen.add(seed);
+    }
+  });
+
+  it("draws values in [0, 1) with a healthy upper tail", () => {
+    let seed = 7;
+    let above = 0;
+    const draws = 100_000;
+    for (let step = 0; step < draws; step++) {
+      const [value, newSeed] = nextRandom(seed);
+      seed = newSeed;
+      expect(value).toBeGreaterThanOrEqual(0);
+      expect(value).toBeLessThan(1);
+      if (value > 0.98) above += 1;
+    }
+    // Expect ~2% ± 4 binomial standard deviations.
+    expect(Math.abs(above - draws * 0.02)).toBeLessThanOrEqual(
+      4 * Math.sqrt(draws * 0.02 * 0.98),
+    );
+  });
+});

--- a/libs/@hashintel/petrinaut-core/src/simulation/engine/seeded-rng.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/engine/seeded-rng.ts
@@ -16,7 +16,14 @@ const LCG_M = 2147483648; // 2^31
  * randomValue is in range [0, 1)
  */
 export function nextRandom(seed: number): [number, number] {
-  const newSeed = (LCG_A * seed + LCG_C) % LCG_M;
+  // `LCG_A * seed` overflows Number.MAX_SAFE_INTEGER, so plain float
+  // arithmetic computes a *different* map than the LCG above: it diverges
+  // from the exact recurrence on the first step and collapses the state
+  // space to a short cycle (~16k states observed from seed 42), which
+  // starves the distribution's tails. `Math.imul` is the product's exact low
+  // 32 bits; masking to 31 bits is the exact `mod 2^31`.
+  // eslint-disable-next-line no-bitwise -- exact `mod 2^31` on the 32-bit product
+  const newSeed = (Math.imul(LCG_A, seed) + LCG_C) & (LCG_M - 1);
   const randomValue = newSeed / LCG_M;
   return [randomValue, newSeed];
 }

--- a/libs/@hashintel/petrinaut-core/src/simulation/engine/stochastic-rate.integration.test.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/engine/stochastic-rate.integration.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import { compileHirArtifacts } from "../../hir";
+import { buildSimulation } from "./build-simulation";
+import { computeNextFrame } from "./compute-next-frame";
+
+import type { SDCPN } from "../../types/sdcpn";
+
+describe("stochastic firing through the full frame loop", () => {
+  it("fires a source transition at its configured rate across frames", () => {
+    const sdcpn: SDCPN = {
+      places: [
+        {
+          id: "p_sink",
+          name: "Sink",
+          colorId: null,
+          dynamicsEnabled: false,
+          differentialEquationId: null,
+          x: 0,
+          y: 0,
+        },
+      ],
+      transitions: [
+        {
+          id: "t_source",
+          name: "Source",
+          inputArcs: [],
+          outputArcs: [{ placeId: "p_sink", weight: 1 }],
+          lambdaType: "stochastic",
+          lambdaCode: "export default Lambda((input, parameters) => 0.213);",
+          transitionKernelCode: "",
+          x: 0,
+          y: 0,
+        },
+      ],
+      types: [],
+      differentialEquations: [],
+      parameters: [],
+    };
+    const { artifacts, failures } = compileHirArtifacts(sdcpn);
+    expect(failures).toEqual([]);
+    let simulation = buildSimulation({
+      sdcpn,
+      initialMarking: {},
+      parameterValues: {},
+      seed: 7,
+      dt: 0.1,
+      maxTime: null,
+      hirArtifacts: artifacts,
+    });
+    let fires = 0;
+    for (let i = 0; i < 10000; i++) {
+      const result = computeNextFrame(simulation);
+      simulation = result.simulation;
+      if (result.transitionFired) fires++;
+      // keep memory flat like the run loop does
+      simulation = {
+        ...simulation,
+        frames: [simulation.frames[simulation.currentFrameNumber]!],
+        currentFrameNumber: 0,
+      };
+    }
+    // Binomial(10000, 1 - e^(-0.0213)) ≈ 211 ± 14.4; 4 standard deviations.
+    const expected = 10000 * (1 - Math.exp(-0.0213));
+    expect(Math.abs(fires - expected)).toBeLessThanOrEqual(
+      4 * Math.sqrt(expected * (1 - 0.0213)),
+    );
+  });
+});

--- a/libs/@hashintel/petrinaut-core/src/simulation/monte-carlo/advance-run.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/monte-carlo/advance-run.ts
@@ -61,19 +61,25 @@ export function advanceRun(run: MonteCarloRunState): boolean {
         throw new Error(`Compiled transition ${transitionId} not found`);
       }
 
-      const effect = computeTransitionEffect(run, workingFrame, transition);
-      if (!effect) {
+      const { firing, newRngState } = computeTransitionEffect(
+        run,
+        workingFrame,
+        transition,
+      );
+      // Every evaluation's randomness is consumed, fired or not — reusing
+      // the state would re-test the same draw next frame.
+      run.rngState = newRngState;
+      if (!firing) {
         continue;
       }
 
       firedTransitions.add(transitionId);
-      run.rngState = effect.newRngState;
       applyTokenRemovals(
         run.simulation.frameLayout,
         workingFrame,
-        effect.remove,
+        firing.remove,
       );
-      mergeTokenAdditions(tokensToAdd, effect.add);
+      mergeTokenAdditions(tokensToAdd, firing.add);
     }
 
     workingFrame = applyTokenAdditions(run, workingFrame, tokensToAdd);

--- a/libs/@hashintel/petrinaut-core/src/simulation/monte-carlo/internal-types.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/monte-carlo/internal-types.ts
@@ -10,7 +10,6 @@ export type TransitionEffect = {
   remove: Record<PlaceID, Set<number> | number>;
   /** One packed token byte block (strideBytes long) per new token. */
   add: Record<PlaceID, Uint8Array[]>;
-  newRngState: number;
 };
 
 export type MonteCarloRunState = {

--- a/libs/@hashintel/petrinaut-core/src/simulation/monte-carlo/monte-carlo-simulator.test.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/monte-carlo/monte-carlo-simulator.test.ts
@@ -215,6 +215,63 @@ describe("MonteCarloSimulator", () => {
     expect(secondRun.tokenByteCount).toBe(16);
   });
 
+  it("fires a source transition at its configured rate", () => {
+    const rate = 0.213;
+    const dt = 0.1;
+    const frames = 10_000;
+    const sourceNet: SDCPN = {
+      places: [
+        {
+          id: "sink",
+          name: "Sink",
+          colorId: null,
+          dynamicsEnabled: false,
+          differentialEquationId: null,
+          x: 0,
+          y: 0,
+        },
+      ],
+      transitions: [
+        {
+          id: "t_source",
+          name: "Source",
+          inputArcs: [],
+          outputArcs: [{ placeId: "sink", weight: 1 }],
+          lambdaType: "stochastic",
+          lambdaCode: `export default Lambda((input, parameters) => ${rate});`,
+          transitionKernelCode: "",
+          x: 0,
+          y: 0,
+        },
+      ],
+      types: [],
+      differentialEquations: [],
+      parameters: [],
+    };
+
+    const simulator = createMonteCarloSimulator({
+      sdcpn: sourceNet,
+      runCount: 1,
+      initialMarking: {},
+      runs: [{ seed: 7, initialMarking: {} }],
+      dt,
+      maxTime: frames * dt,
+      initialTokenByteCapacity: 0,
+    });
+    simulator.runUntilComplete({ maxBatches: 100_000 });
+
+    const run = simulator.getRunSnapshot(0);
+    const fired = run.placeTokenCounts.sink ?? 0;
+
+    // Binomial(frames, 1 - e^(-rate * dt)) within 4 standard deviations —
+    // rejects both the elapsed-time-CDF sampler and a frozen RNG stream.
+    const perFrame = 1 - Math.exp(-rate * dt);
+    const expected = frames * perFrame;
+    expect(Math.abs(fired - expected)).toBeLessThanOrEqual(
+      4 * Math.sqrt(expected * (1 - perFrame)),
+    );
+  });
+
   it("does not consume tokens read by read arcs", () => {
     const productQualityMetric = createMonteCarloUserDefinedMetric({
       id: "product-quality",

--- a/libs/@hashintel/petrinaut-core/src/simulation/monte-carlo/transition-effect.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/monte-carlo/transition-effect.ts
@@ -6,7 +6,7 @@ import {
 } from "../engine/buffer-transition";
 import { enumerateWeightedMarkingIndicesGenerator } from "../engine/enumerate-weighted-markings";
 import { nextRandom } from "../engine/seeded-rng";
-import { getPlaceIndex, getTransitionIndex } from "./layout";
+import { getPlaceIndex } from "./layout";
 
 import type { CompiledTransition } from "../engine/types";
 import type { MonteCarloFrameBuffer } from "./frame-buffer";
@@ -28,9 +28,8 @@ export function computeTransitionEffect(
   run: MonteCarloRunState,
   frame: MonteCarloFrameBuffer,
   transition: CompiledTransition,
-): TransitionEffect | null {
+): { firing: TransitionEffect | null; newRngState: number } {
   const { frameLayout } = run.simulation;
-  const transitionIndex = getTransitionIndex(frameLayout, transition.id);
 
   const inputPlaces = transition.inputPlaces.map((inputPlace) => {
     const placeIndex = getPlaceIndex(frameLayout, inputPlace.placeId);
@@ -49,13 +48,13 @@ export function computeTransitionEffect(
       ? inputPlace.count < inputPlace.weight
       : inputPlace.count >= inputPlace.weight,
   );
+  // A disabled transition consumes no randomness.
   if (!enabled) {
-    return null;
+    return { firing: null, newRngState: run.rngState };
   }
 
+  // One uniform draw per evaluated enabled transition, fired or not.
   const [u1, candidateRngState] = nextRandom(run.rngState);
-  const timeSinceLastFiring =
-    (frame.transitionElapsedFrames[transitionIndex] ?? 0) * run.simulation.dt;
   const inputPlacesWithValues = inputPlaces.filter(
     (place) => place.strideBytes > 0 && place.arcType !== "inhibitor",
   );
@@ -109,8 +108,9 @@ export function computeTransitionEffect(
           ? Number.POSITIVE_INFINITY
           : 0
         : lambdaResult;
-    const lambdaValue = lambdaNumeric * timeSinceLastFiring;
-    if (Math.exp(-lambdaValue) > u1) {
+    // Memoryless per-frame firing probability 1 - e^(-lambda * dt), matching
+    // the interactive engine (see compute-possible-transition.ts).
+    if (Math.exp(-lambdaNumeric * run.simulation.dt) > u1) {
       continue;
     }
 
@@ -163,11 +163,11 @@ export function computeTransitionEffect(
     }
 
     return {
-      remove,
-      add,
+      firing: { remove, add },
       newRngState: currentRngState,
     };
   }
 
-  return null;
+  // Enabled but not firing this frame; the draw is still consumed.
+  return { firing: null, newRngState: candidateRngState };
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Stochastic transitions fired at inflated, non-exponential rates — ×2–7 the configured rate, worst for rare events — making absolute rate calibration impossible in any model.

Each frame, the firing test drew a fresh uniform `U1` and fired on:

```
e^(−rate · timeSinceLastFiring) ≤ U1
```

That is the exponential CDF at the elapsed time — the longer a transition waited, the more likely each new draw was to pass — so inter-firing times were not exponential. It now fires on the memoryless per-frame probability over the frame's exposure window:

```
e^(−rate · dt) ≤ U1
```

Two further defects compounded the miscalibration (non-firing evaluations discarded their consumed draw; the LCG overflowed float precision). With all three fixed, firing counts match analytic Poisson expectations within sampling noise at every tested `dt`.

## 🔗 Related links

- [FE-1499](https://linear.app/hash/issue/FE-1499/stochastic-transitions-fire-at-inflated-non-exponential-rates) _(internal)_
- [FE-1271](https://linear.app/hash/issue/FE-1271/predicate-transitions-cant-fire-on-the-first-frame-or-consecutive) _(internal)_ — earlier fix in the same firing test

## 🔍 What does this change?

- The firing test uses the frame's exposure window `dt` (see above) instead of the accumulated time since the transition last fired.
- `computePossibleTransition` now always returns the consumed RNG state (`{ firing, newRngState }`), and `executeTransitions` threads it on every evaluation — including its no-fire early return, which previously restored the pre-frame state. Before, frames re-tested the same draw until an unrelated firing advanced the stream; the old growing-CDF test masked this by eventually passing any frozen draw.
- `nextRandom` computes the LCG with exact 32-bit arithmetic (`Math.imul` + mask). The float product `a·seed` overflows 2^53, so the shipped generator diverged from its documented recurrence on the first step and collapsed into a ~16k-state cycle.
- Tests: statistical firing-probability tests at three rate/dt combinations, a frame-loop integration test against the Binomial expectation, RNG exactness/cycle/tail tests, and fixture updates (a "certainly fires" rate constant; one test stepped twice to work around the old first-frame quirk and now steps once).

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] modifies an **npm**-publishable library and **I have added a changeset file(s)**

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

- Same-seed runs necessarily produce different sequences than previous releases (noted in the changeset).
- One shared draw across a transition's token combinations under-approximates the superposition of per-combination rates (at most one firing per transition per frame). Pre-existing, documented in the code.

## 🐾 Next steps

- Consider a generator with better lattice structure than the glibc LCG if distribution quality ever matters beyond rates.

## 🛡 What tests cover this?

- `seeded-rng.test.ts` — exact recurrence vs an arbitrary-precision reference, no short cycles, healthy upper tail.
- `compute-possible-transition.test.ts` — per-frame firing probability matches `1 − e^(−rate·dt)` for three rate/dt pairs; firing independent of time since last firing.
- `stochastic-rate.integration.test.ts` — a source transition through the full frame loop matches the Binomial expectation over 10k frames.

## ❓ How to test this?

1. `turbo --filter @hashintel/petrinaut-cli build`
2. Serve any model with a constant-rate source transition and run it via the JSON-lines protocol (or `turbo run test:unit --filter @hashintel/petrinaut-core`).
3. Confirm event counts ≈ `rate × simulated time`, independent of `dt`. On this branch a 0.213/h source over 1000 h yields 192–225 events across seeds and `dt` ∈ {0.5, 0.1, 0.02}; on `main` it yields ~370–460 (and ~2× beyond ~16k frames as the RNG cycles).

## 📹 Demo

Measured via the CLI (three seeds each, 0.213/h source, 1000 h): before ×1.7–2.2 of nominal; after ×0.90–1.07 of the analytic expectation at all three `dt` values.
