### PR TITLE
FE-1502: Document the record-key interim design

### DIFF
--- a/libs/@local/petrinaut-arch-docs/content/simulation/untrusted-names.mdx
+++ b/libs/@local/petrinaut-arch-docs/content/simulation/untrusted-names.mdx
@@ -95,9 +95,22 @@ Two concrete failures this caused before the guards existed:
 />
 
 The shared vocabulary lives in [`core.validation`](layer:core.validation)
-(`record-keys.ts`): the `DANGEROUS_RECORD_KEYS` list, the two container
-helpers, and `findDangerousSdcpnKeys`, which walks a net and returns every
-identity string on the list.
+(`record-keys.ts`): the `DANGEROUS_RECORD_KEYS` list, the container helpers,
+and `findDangerousSdcpnKeys`, which walks a net and returns every identity
+string on the list.
+
+:::danger[Interim design]
+Plain JavaScript objects are the wrong container for user-keyed data; the
+three defences make them safe rather than right. The reserved-name ban exists
+because plain objects inherit from `Object.prototype`, and because the
+`__proto__` / `constructor` / `prototype` triple is the sanitizer set CodeQL
+and Semgrep recognise, which keeps the scanners quiet without suppressions.
+Its cost: users cannot name a parameter `constructor` or a token attribute
+`toString`. The durable fix is `Map`s (or interned ids, as the engine frame
+layout already uses) behind codecs at the JSON edges, which lifts the ban and
+deletes the guard discipline. Tracked in
+[FE-1502](https://linear.app/hash/issue/FE-1502/replace-user-keyed-records-with-maps-and-lift-the-reserved-name-ban).
+:::
 
 ## Why one layer is not enough
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Records, in the architecture docs, that the record-key guard discipline from #9222/#9332 is an interim design, and links the tracked replacement.

The *Untrusted names* page gains a red `danger` aside after the three-defences section: plain JavaScript objects are the wrong container for user-keyed data; the reserved-name ban (`__proto__`/`constructor`/`prototype` plus the other `Object.prototype` members) exists because plain objects inherit from `Object.prototype` and because that triple is the sanitizer set CodeQL and Semgrep recognise; the durable fix is `Map`s (or interned ids) behind codecs at the JSON edges, which lifts the ban and deletes the guard helpers. Tracked in [FE-1502](https://linear.app/hash/issue/FE-1502/replace-user-keyed-records-with-maps-and-lift-the-reserved-name-ban).

The Starlight site renders the aside as a red callout (verified in the built HTML: `starlight-aside--danger`).

## 🔗 Related links

- [FE-1502](https://linear.app/hash/issue/FE-1502/replace-user-keyed-records-with-maps-and-lift-the-reserved-name-ban)
- Stacked on [#9332](https://github.com/hashintel/hash/pull/9332), which is stacked on [#9222](https://github.com/hashintel/hash/pull/9222)

## 🚫 Blocked by

- [ ] #9332 (this branch is stacked on it)

## 🔍 What does this change?

- One `:::danger[Interim design]` aside in `libs/@local/petrinaut-arch-docs/content/simulation/untrusted-names.mdx`, linking FE-1502.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] require changes to docs which **are made** as part of this PR

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

None.

## 🐾 Next steps

- FE-1502 itself: the `Record` to `Map` migration behind JSON codecs, a deliberate breaking release for `@hashintel/petrinaut-core` consumers.

## 🛡 What tests cover this?

Docs-only. `lint:arch-docs` passes and the Starlight site builds with the aside rendered.

## ❓ How to test this?

Run `turbo run dev --filter @apps/petrinaut-docs` and open the *Untrusted names* page under `core.simulation.engine`: the red "Interim design" callout sits after the three-defences section.

## 📹 Demo

Not applicable.
