### PR TITLE
H-6791: Stop @local/harpc-client unit tests from running twice after a package build

### DIFF
--- a/libs/@local/harpc/client/typescript/tsconfig.build.json
+++ b/libs/@local/harpc/client/typescript/tsconfig.build.json
@@ -3,7 +3,10 @@
   "compilerOptions": {
     "declaration": true,
     "outDir": "dist",
+    "rootDir": ".",
     "paths": {},
-    "stripInternal": true
-  }
+    "stripInternal": true,
+    "types": ["node"]
+  },
+  "include": ["src"]
 }

--- a/libs/@local/harpc/client/typescript/vitest.config.ts
+++ b/libs/@local/harpc/client/typescript/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     target: "esnext",
   },
   test: {
+    // eslint-disable-next-line unicorn/prevent-abbreviations -- Vitest configuration property
     dir: "tests",
     coverage: {
       enabled: process.env.TEST_COVERAGE === "true",

--- a/libs/@local/harpc/client/typescript/vitest.config.ts
+++ b/libs/@local/harpc/client/typescript/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     target: "esnext",
   },
   test: {
+    dir: "tests",
     coverage: {
       enabled: process.env.TEST_COVERAGE === "true",
       provider: "istanbul",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Stop `@local/harpc-client` unit tests from running twice after a package build. Vitest 4 no longer excludes `dist/` by default, and this package's TypeScript build was emitting compiled tests there.

## 🔗 Related links

- [H-6791](https://linear.app/hash/issue/H-6791/stop-localharpc-client-unit-tests-from-running-twice-after-a-package) _(internal)_

## 🚫 Blocked by

- [ ] n/a

## 🔍 What does this change?

- Restrict `tsconfig.build.json` to `src` so tests are not emitted into `dist/`
- Keep `rootDir` at `.` so package exports continue to resolve `dist/src/`
- Declare `types: ["node"]` on the build config, which previously came in transitively via `vitest.config.ts`
- Set Vitest `test.dir` to `tests` so a leftover `dist/` cannot be rediscovered

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

Wire-protocol encode/decode tests still need the `@rust/harpc-wire-protocol` codec CLI (`turbo.json` already depends on that build). That is unrelated to this change.

## 🐾 Next steps

- Other Vitest 4 packages that compile tests into `dist/` could hit the same discovery issue; this PR only fixes `@local/harpc-client`.

## 🛡 What tests cover this?

Existing unit tests. After `yarn workspace @local/harpc-client build`, `vitest list` reports only `tests/**/*.test.ts` and no `dist/tests/**/*.test.js`.

## ❓ How to test this?

1. `yarn workspace @local/harpc-client build`
2. `yarn workspace @local/harpc-client exec vitest list --run`
3. Confirm the list contains source tests under `tests/` and nothing under `dist/`
4. Confirm `dist/src/index.js` still exists (package exports)

## 📹 Demo

n/a
