### PR TITLE
FE-1511: List the real viewport-control buttons in the visual-settings guide

### DIFF
--- a/.changeset/visual-settings-viewport-buttons.md
+++ b/.changeset/visual-settings-viewport-buttons.md
@@ -1,0 +1,5 @@
+---
+"@hashintel/petrinaut": patch
+---
+
+The visual-settings guide lists the viewport-control buttons that actually exist: zoom in / out, fullscreen, lock view, and the settings gear — there is no fit-to-view button.

--- a/libs/@hashintel/petrinaut/docs/visual-settings.md
+++ b/libs/@hashintel/petrinaut/docs/visual-settings.md
@@ -1,6 +1,6 @@
 # Visual Settings
 
-Access the settings dialog via the **gear icon** in the viewport controls (bottom-right corner of the canvas). The viewport controls are a small floating cluster of buttons -- zoom in / out, fit-to-view, and the gear icon -- anchored to the bottom-right of the canvas.
+Access the settings dialog via the **gear icon** in the viewport controls (bottom-right corner of the canvas). The viewport controls are a small floating cluster of buttons -- zoom in / out, fullscreen (collapses all panels), lock view, and the gear icon -- anchored to the bottom-right of the canvas.
 
 ## Available settings
 


### PR DESCRIPTION
> Superseded by [#9697](https://github.com/hashintel/hash/pull/9697). The new User Settings guide replaces this introduction and removes the incorrect fit-to-view claim.

## 🌟 What is the purpose of this PR?

The visual-settings page of the Petrinaut user guide described the viewport controls as "zoom in / out, fit-to-view, and the gear icon". There is no fit-to-view button. The in-app AI assistant reads this page at runtime, so the wrong button list reached users directly.

## 🔗 Related links

- [FE-1511](https://linear.app/hash/issue/FE-1511/fix-the-viewport-controls-button-list-in-the-visual-settings-guide)

## 🔍 What does this change?

- One sentence in `libs/@hashintel/petrinaut/docs/visual-settings.md`: the button list now matches the actual controls — zoom in / out, fullscreen (collapses all panels), lock view, and the gear icon.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] modifies an **npm**-publishable library and **I have added a changeset file(s)**

The docs ship inside the package (the in-app assistant reads them), so the correction gets a patch changeset.

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] require changes to docs which **are made** as part of this PR

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- The existing docs-content tests (`petrinaut-docs-content.test.ts`, `ai.test.ts`) keep enforcing that the page is registered and bundled; prose accuracy is reviewed by eye.

## ❓ How to test this?

1. Open the visual-settings page of the user guide (or ask the in-app assistant about the viewport controls).
2. Confirm the listed buttons match the cluster in the bottom-right of the canvas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
