### PR TITLE
FE-1512: Place arc weight labels on the Adaptive Bezier curve

### DIFF
--- a/.changeset/adaptive-bezier-label-midpoint.md
+++ b/.changeset/adaptive-bezier-label-midpoint.md
@@ -1,0 +1,5 @@
+---
+"@hashintel/petrinaut": patch
+---
+
+Arc weight labels sit on the Adaptive Bezier curve instead of floating at the straight-line midpoint between the arc's endpoints.

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/components/arc.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/components/arc.tsx
@@ -248,7 +248,6 @@ function getCustomArcPath({
   targetPosition: Position;
 }): [path: string, labelX: number, labelY: number] {
   const dx = targetX - sourceX;
-  const dy = targetY - sourceY;
 
   // Control point offset scales with horizontal distance, with a minimum
   const offset = Math.max(Math.abs(dx) * 0.7, 80);
@@ -260,9 +259,9 @@ function getCustomArcPath({
 
   const path = `M ${sourceX},${sourceY} C ${cp1x},${cp1y} ${cp2x},${cp2y} ${targetX},${targetY}`;
 
-  // Label at the midpoint of the cubic bezier (t=0.5)
-  const labelX = sourceX + dx / 2;
-  const labelY = sourceY + dy / 2;
+  // Label at the midpoint of the cubic bezier: B(0.5) = (P0 + 3·CP1 + 3·CP2 + P3) / 8
+  const labelX = (sourceX + 3 * cp1x + 3 * cp2x + targetX) / 8;
+  const labelY = (sourceY + 3 * cp1y + 3 * cp2y + targetY) / 8;
 
   return [path, labelX, labelY];
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

With the Arcs rendering setting on Adaptive Bezier (the default), arc weight labels were drawn at the straight-line midpoint between the arc's endpoints, despite the code's comment claiming the bezier midpoint. Long arcs sweep far from that line, so the "× n" label floated in empty space with no visible connection to its arc. The label now sits on the curve.

**Before** — the "× 2" floats at the straight-line midpoint, in empty space:

<img width="1660" height="1280" alt="image" src="https://github.com/user-attachments/assets/05d24983-0a61-43b6-a727-18dfaece3f25" />

**After** — the same label sits on its Infection → Infected curve (same net, same framing):

<img width="1660" height="1280" alt="image" src="https://github.com/user-attachments/assets/583e1643-dac5-4075-ad7f-178057b717af" />

## 🔗 Related links

- [FE-1512](https://linear.app/hash/issue/FE-1512/place-arc-weight-labels-on-the-adaptive-bezier-curve)

## 🚫 Blocked by

- [ ] #9352 — stacked on `claude/fe-1510-canvas-single-initial-render`; only the last commit belongs to this PR until that merges.

## 🔍 What does this change?

- `getCustomArcPath` in `arc.tsx` computes the label position as the cubic bezier point at t = 0.5 — `(P0 + 3·CP1 + 3·CP2 + P3) / 8` — from the same control points that define the path. The Square and Bezier renderings already got this right via React Flow's path helpers and are untouched.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] modifies an **npm**-publishable library and **I have added a changeset file(s)**

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

The visual-settings page describes the rendering styles, not label placement.

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- None directly — the function is private to the arc component. Verified in the running app: for every weighted arc, the label's translate now lies on the rendered path (measured 0.7px off via `getPointAtLength` sampling; it was ~100px off for long arcs before).

## ❓ How to test this?

1. `yarn workspace @hashintel/petrinaut dev`, open a net with a weight > 1 arc (e.g. `Petrinaut → Handle Spike With Sir`).
2. Viewport settings → Arcs rendering → Adaptive Bezier (default).
3. Drag the connected nodes far apart vertically: the "× 2" label stays on the curve instead of drifting into empty space.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
