### PR TITLE
FE-1500: Add oEmbed discovery and framing security

### DIFF
--- a/apps/petrinaut-website/README.md
+++ b/apps/petrinaut-website/README.md
@@ -2,7 +2,7 @@
 
 A website for demoing Petrinaut (libs/@hashintel/petrinaut).
 
-A SPA plus a single API function that proxies AI requests to OpenAI.
+A SPA with API functions for AI assistance and JSON oEmbed discovery.
 
 ## Quickstart
 
@@ -15,7 +15,23 @@ turbo run dev
 
 The dev server runs at [http://localhost:5173](http://localhost:5173). A plugin in `vite.config.ts` loads the API function.
 
-In production, the function in the `api` folder is automatically deployed as a Vercel Serverless Function.
+In production, the functions in the `api` folder are automatically deployed as
+Vercel Functions.
+
+## Example embeds and oEmbed
+
+Canonical example pages live below `/examples`. The JSON oEmbed endpoint at
+`/api/oembed` accepts their production URLs and returns an
+`/embed/examples/...` iframe. Canonical pages send both CSP `frame-ancestors
+'none'` and `X-Frame-Options: DENY`; only the dedicated embed routes permit
+third-party framing. The returned iframe is sandboxed with
+`allow-scripts allow-same-origin` and does not send a referrer.
+
+Because this is a client-rendered SPA, a static `index.html` discovery link
+cannot include the current example URL. `FullExamplePage` adds the standard
+`application/json+oembed` link to the document head after the route mounts.
+Consumers that do not execute JavaScript must call `/api/oembed` directly or
+use provider-pattern discovery instead.
 
 ### Optimization demo with Petrinaut Opt
 

--- a/apps/petrinaut-website/api/oembed.ts
+++ b/apps/petrinaut-website/api/oembed.ts
@@ -1,0 +1,257 @@
+import {
+  getExampleCatalogEntry,
+  isExampleSlug,
+  PETRINAUT_DEMO_ORIGIN,
+  type ExampleSlug,
+} from "../src/examples/catalog-metadata";
+import {
+  canonicalSearchString,
+  validateSharedExampleSearch,
+} from "../src/examples/example-search";
+
+const DEFAULT_WIDTH = 800;
+const DEFAULT_HEIGHT = 450;
+const SUCCESS_CACHE_CONTROL =
+  "public, max-age=300, s-maxage=86400, stale-while-revalidate=604800";
+
+type OEmbedResponse = Readonly<{
+  type: "rich";
+  version: "1.0";
+  title: string;
+  provider_name: "Petrinaut";
+  provider_url: typeof PETRINAUT_DEMO_ORIGIN;
+  width: number;
+  height: number;
+  html: string;
+}>;
+
+const corsHeaders = (): Headers =>
+  new Headers({
+    "Access-Control-Allow-Headers": "Accept",
+    "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
+    "Access-Control-Allow-Origin": "*",
+  });
+
+const jsonResponse = (
+  body: unknown,
+  init: ResponseInit & { cacheable?: boolean } = {},
+): Response => {
+  const { cacheable = false, ...responseInit } = init;
+  const headers = corsHeaders();
+  for (const [name, value] of new Headers(responseInit.headers)) {
+    headers.set(name, value);
+  }
+  headers.set("Cache-Control", cacheable ? SUCCESS_CACHE_CONTROL : "no-store");
+  headers.set("Content-Type", "application/json; charset=utf-8");
+
+  return new Response(JSON.stringify(body), { ...responseInit, headers });
+};
+
+const errorResponse = (
+  status: 400 | 404 | 405 | 501,
+  error: string,
+): Response => jsonResponse({ error }, { status });
+
+const readPositiveFiniteMaximum = (
+  searchParams: URLSearchParams,
+  name: "maxheight" | "maxwidth",
+): number | undefined | null => {
+  if (!searchParams.has(name)) {
+    return undefined;
+  }
+
+  const rawValue = searchParams.get(name);
+  // A consumer that always appends the optional oEmbed params sends them
+  // empty when the user set no size. That is "no maximum", not a bad request.
+  if (rawValue === null || rawValue.trim() === "") {
+    return undefined;
+  }
+
+  // oEmbed defines these as integers. `Number` would also accept `0x10`,
+  // `1e3` and ` 400 `, which are typos rather than sizes.
+  if (!/^[0-9]+$/u.test(rawValue.trim())) {
+    return null;
+  }
+
+  const value = Number(rawValue.trim());
+  return value > 0 ? value : null;
+};
+
+const fitDimensions = (
+  maxWidth: number | undefined,
+  maxHeight: number | undefined,
+): { width: number; height: number } => {
+  const scale = Math.min(
+    1,
+    maxWidth === undefined ? 1 : maxWidth / DEFAULT_WIDTH,
+    maxHeight === undefined ? 1 : maxHeight / DEFAULT_HEIGHT,
+  );
+
+  // Height follows from the clamped width, so the aspect ratio survives.
+  // Flooring each axis independently turns `?maxwidth=1` into a 1x1 embed.
+  const width = Math.max(1, Math.floor(DEFAULT_WIDTH * scale));
+  return {
+    width,
+    height: Math.max(1, Math.round((width * DEFAULT_HEIGHT) / DEFAULT_WIDTH)),
+  };
+};
+
+const escapeHtmlAttribute = (value: string): string =>
+  value
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+
+type ParsedExampleUrl = Readonly<{
+  slug: ExampleSlug;
+  embedSearch: URLSearchParams;
+}>;
+
+/**
+ * Carry over only state the embed page understands, by decoding the canonical
+ * URL through the shared contract and re-encoding it. One embed-specific rule:
+ * embeds always show a named scenario, so an explicit `none` (valid on the
+ * canonical page) resolves to the model's first scenario instead.
+ */
+const sanitizeEmbedSearch = (source: URLSearchParams): URLSearchParams => {
+  const search = validateSharedExampleSearch(Object.fromEntries(source));
+
+  return new URLSearchParams(
+    canonicalSearchString(
+      search.scenario === "none" ? { ...search, scenario: undefined } : search,
+    ),
+  );
+};
+
+const parseExampleUrl = (
+  rawUrl: string,
+): ParsedExampleUrl | { error: string; status: 400 | 404 } => {
+  let sourceUrl: URL;
+  try {
+    sourceUrl = new URL(rawUrl);
+  } catch {
+    return { error: "The url parameter must be a valid URL", status: 400 };
+  }
+
+  // A well-formed URL this provider cannot embed is 404 rather than 400.
+  // oEmbed 1.0 section 2.3.1 lists 404 for "no response for this url", and
+  // consumers branch on it to fall back to a plain link.
+  if (sourceUrl.origin !== PETRINAUT_DEMO_ORIGIN) {
+    return {
+      error: `The url parameter must use ${PETRINAUT_DEMO_ORIGIN}`,
+      status: 404,
+    };
+  }
+
+  const pathMatch = sourceUrl.pathname.match(/^\/examples\/([^/]+?)\/?$/u);
+  if (!pathMatch) {
+    return {
+      error: "The url parameter is not a canonical example URL",
+      status: 404,
+    };
+  }
+
+  const slug = pathMatch[1]!;
+  if (!isExampleSlug(slug)) {
+    return { error: `Unknown example: ${slug}`, status: 404 };
+  }
+
+  return {
+    slug,
+    embedSearch: sanitizeEmbedSearch(sourceUrl.searchParams),
+  };
+};
+
+const respond = async (request: Request): Promise<Response> => {
+  if (request.method === "OPTIONS") {
+    const headers = corsHeaders();
+    headers.set("Cache-Control", "public, max-age=86400");
+    return new Response(null, { headers, status: 204 });
+  }
+
+  const isHead = request.method === "HEAD";
+  if (request.method !== "GET" && !isHead) {
+    const response = errorResponse(405, "Method not allowed");
+    response.headers.set("Allow", "GET, HEAD, OPTIONS");
+    return response;
+  }
+
+  const endpointUrl = new URL(request.url);
+  // An empty `format=` means the consumer expressed no preference, and the
+  // parameter is case-insensitive in practice.
+  const format =
+    endpointUrl.searchParams.get("format")?.trim().toLowerCase() || null;
+  if (format !== null && format !== "json") {
+    // oEmbed 1.0 section 2.3.1: a format the provider cannot return is 501.
+    return errorResponse(501, "Only the json oEmbed format is supported");
+  }
+
+  const rawSourceUrl = endpointUrl.searchParams.get("url");
+  if (!rawSourceUrl) {
+    return errorResponse(400, "Missing required url parameter");
+  }
+
+  const parsedExampleUrl = parseExampleUrl(rawSourceUrl);
+  if ("error" in parsedExampleUrl) {
+    return errorResponse(parsedExampleUrl.status, parsedExampleUrl.error);
+  }
+
+  const maxWidth = readPositiveFiniteMaximum(
+    endpointUrl.searchParams,
+    "maxwidth",
+  );
+  if (maxWidth === null) {
+    return errorResponse(400, "maxwidth must be a positive integer");
+  }
+  const maxHeight = readPositiveFiniteMaximum(
+    endpointUrl.searchParams,
+    "maxheight",
+  );
+  if (maxHeight === null) {
+    return errorResponse(400, "maxheight must be a positive integer");
+  }
+
+  const { width, height } = fitDimensions(maxWidth, maxHeight);
+  const embedUrl = new URL(
+    `/embed/examples/${parsedExampleUrl.slug}`,
+    PETRINAUT_DEMO_ORIGIN,
+  );
+  embedUrl.search = parsedExampleUrl.embedSearch.toString();
+
+  const catalogEntry = getExampleCatalogEntry(parsedExampleUrl.slug)!;
+  const response: OEmbedResponse = {
+    type: "rich",
+    version: "1.0",
+    title: catalogEntry.title,
+    provider_name: "Petrinaut",
+    provider_url: PETRINAUT_DEMO_ORIGIN,
+    width,
+    height,
+    html: `<iframe src="${escapeHtmlAttribute(embedUrl.href)}" title="${escapeHtmlAttribute(catalogEntry.title)}" width="${width}" height="${height}" style="border:0" loading="lazy" sandbox="allow-scripts allow-same-origin" referrerpolicy="no-referrer" allowfullscreen></iframe>`,
+  };
+
+  return jsonResponse(response, { cacheable: true });
+};
+
+/**
+ * Serve Petrinaut example embeds using the JSON oEmbed 1.0 contract.
+ *
+ * Exported only through the default `{ fetch }` object, matching `chat.ts`, so
+ * Vercel's Node.js runtime treats this as a Web fetch handler and hands us a
+ * `Request`. Without that opt-in the default export is invoked with a Node.js
+ * `IncomingMessage`, which has no `Request` API.
+ *
+ * See https://vercel.com/changelog/node-js-vercel-functions-now-support-fetch-web-handlers
+ */
+const fetch = async (request: Request): Promise<Response> => {
+  const response = await respond(request);
+  // Strip the body at the single exit, so error replies to HEAD are bodiless
+  // too rather than only the 200.
+  return request.method === "HEAD"
+    ? new Response(null, { headers: response.headers, status: response.status })
+    : response;
+};
+
+export default { fetch };

--- a/apps/petrinaut-website/src/examples/catalog-metadata.ts
+++ b/apps/petrinaut-website/src/examples/catalog-metadata.ts
@@ -5,6 +5,8 @@
  * functions that only need to validate a public URL should not bundle every
  * example model and generated simulation artifact.
  */
+export const PETRINAUT_DEMO_ORIGIN = "https://demo.petrinaut.org";
+
 export const exampleSlugs = [
   "gases-1-pn-consumption-trigger",
   "gases-1-pn",

--- a/apps/petrinaut-website/src/examples/full-example-page.tsx
+++ b/apps/petrinaut-website/src/examples/full-example-page.tsx
@@ -3,6 +3,7 @@ import { useEffect } from "react";
 import { css } from "@hashintel/ds-helpers/css";
 import { Petrinaut } from "@hashintel/petrinaut/ui";
 
+import { getOEmbedDiscoveryUrl } from "./oembed-discovery";
 import { getReadonlyExampleHandle } from "./readonly-example-handle";
 import { useSharedSearchNavigation } from "./use-shared-search-navigation";
 
@@ -53,8 +54,20 @@ export const FullExamplePage = ({
     };
   }, [example.catalog.title]);
 
+  // The website is a client-rendered SPA, so the oEmbed discovery link cannot
+  // be baked into index.html; React 19 hoists this <link> into document.head.
+  // Consumers that execute the page's JavaScript can then discover the same
+  // production oEmbed endpoint used by server integrations.
+  const discoveryUrl = getOEmbedDiscoveryUrl(example.catalog.slug, search);
+
   return (
     <main className={pageStyle}>
+      <link
+        href={discoveryUrl}
+        rel="alternate"
+        title={`${example.catalog.title} oEmbed profile`}
+        type="application/json+oembed"
+      />
       <Petrinaut
         handle={handle}
         hideNetManagementControls="all"

--- a/apps/petrinaut-website/src/examples/oembed-discovery.test.ts
+++ b/apps/petrinaut-website/src/examples/oembed-discovery.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { getOEmbedDiscoveryUrl } from "./oembed-discovery";
+
+describe("getOEmbedDiscoveryUrl", () => {
+  it("uses the production origin without leaking a development port", () => {
+    const endpoint = new URL(
+      getOEmbedDiscoveryUrl("gases-1-pn", { scenario: "steady" }),
+    );
+
+    expect(endpoint.origin).toBe("https://demo.petrinaut.org");
+    expect(endpoint.searchParams.get("format")).toBe("json");
+    expect(endpoint.searchParams.get("url")).toBe(
+      "https://demo.petrinaut.org/examples/gases-1-pn?scenario=steady",
+    );
+  });
+
+  it("advertises one endpoint URL per location, whatever the address bar holds", () => {
+    // A foreign parameter is not part of the contract, so it must not produce
+    // a second endpoint URL for a response that is byte-identical.
+    const withoutForeignParam = getOEmbedDiscoveryUrl("gases-1-pn", {
+      scenario: "steady",
+    });
+    const withForeignParam = getOEmbedDiscoveryUrl("gases-1-pn", {
+      scenario: "steady",
+      ...({ utm_source: "twitter" } as Record<string, string>),
+    });
+
+    expect(withForeignParam).toBe(withoutForeignParam);
+  });
+
+  it("orders the contract parameters canonically", () => {
+    expect(
+      getOEmbedDiscoveryUrl("gases-2-spn", {
+        subnet: "subnet-a",
+        scenario: "scenario__drawing",
+      }),
+    ).toBe(
+      getOEmbedDiscoveryUrl("gases-2-spn", {
+        scenario: "scenario__drawing",
+        subnet: "subnet-a",
+      }),
+    );
+  });
+});

--- a/apps/petrinaut-website/src/examples/oembed-discovery.ts
+++ b/apps/petrinaut-website/src/examples/oembed-discovery.ts
@@ -1,0 +1,25 @@
+import { PETRINAUT_DEMO_ORIGIN } from "./catalog-metadata";
+import { canonicalSearchString } from "./example-search";
+
+import type { SharedExampleSearch } from "./example-search";
+
+/**
+ * Builds the oEmbed endpoint URL a consumer should call for this example.
+ *
+ * The advertised `url` is rebuilt from the slug and the validated search
+ * rather than copied from the address bar, so a tracking parameter on the page
+ * does not advertise a distinct endpoint URL for a byte-identical response.
+ */
+export const getOEmbedDiscoveryUrl = (
+  slug: string,
+  search: SharedExampleSearch,
+): string => {
+  const sourceUrl = new URL(`/examples/${slug}`, PETRINAUT_DEMO_ORIGIN);
+  sourceUrl.search = canonicalSearchString(search);
+
+  const endpointUrl = new URL("/api/oembed", PETRINAUT_DEMO_ORIGIN);
+  endpointUrl.searchParams.set("url", sourceUrl.href);
+  endpointUrl.searchParams.set("format", "json");
+
+  return endpointUrl.href;
+};

--- a/apps/petrinaut-website/src/examples/oembed-endpoint.test.ts
+++ b/apps/petrinaut-website/src/examples/oembed-endpoint.test.ts
@@ -1,0 +1,313 @@
+import { describe, expect, it } from "vitest";
+
+// The endpoint lives in `api/`, where every module is deployed as a Vercel
+// function, so its test lives here instead. It is imported through the default
+// export, the only one the module has: a named `fetch` export alongside it
+// stops Vercel's runtime from invoking the function.
+import oembedEndpoint from "../../api/oembed";
+
+const { fetch } = oembedEndpoint;
+
+const endpointRequest = (
+  sourceUrl?: string,
+  options: {
+    format?: string;
+    maxheight?: string;
+    maxwidth?: string;
+    method?: string;
+  } = {},
+): Request => {
+  const endpoint = new URL("https://demo.petrinaut.org/api/oembed");
+  if (sourceUrl !== undefined) {
+    endpoint.searchParams.set("url", sourceUrl);
+  }
+  for (const name of ["format", "maxheight", "maxwidth"] as const) {
+    const value = options[name];
+    if (value !== undefined) {
+      endpoint.searchParams.set(name, value);
+    }
+  }
+  return new Request(endpoint, { method: options.method ?? "GET" });
+};
+
+const responseJson = async (
+  response: Response,
+): Promise<Record<string, unknown>> =>
+  response.json() as Promise<Record<string, unknown>>;
+
+describe("Petrinaut oEmbed endpoint", () => {
+  it("returns a JSON oEmbed response for an unversioned canonical URL", async () => {
+    const response = await fetch(
+      endpointRequest("https://demo.petrinaut.org/examples/gases-1-pn"),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe(
+      "application/json; charset=utf-8",
+    );
+    expect(response.headers.get("access-control-allow-origin")).toBe("*");
+    expect(response.headers.get("cache-control")).toContain("public");
+    expect(await responseJson(response)).toEqual({
+      type: "rich",
+      version: "1.0",
+      title: "Gases 1 — One Customer",
+      provider_name: "Petrinaut",
+      provider_url: "https://demo.petrinaut.org",
+      width: 800,
+      height: 450,
+      html: '<iframe src="https://demo.petrinaut.org/embed/examples/gases-1-pn" title="Gases 1 — One Customer" width="800" height="450" style="border:0" loading="lazy" sandbox="allow-scripts allow-same-origin" referrerpolicy="no-referrer" allowfullscreen></iframe>',
+    });
+  });
+
+  it("preserves only valid embed state from the source URL", async () => {
+    const source = new URL("https://demo.petrinaut.org/examples/gases-2-spn");
+    source.searchParams.set("mode", "simulate");
+    source.searchParams.set("section", "metrics");
+    source.searchParams.set("scenario", "scenario-1");
+    source.searchParams.set("subnet", "subnet-1");
+    source.searchParams.set("itemType", "transition");
+    source.searchParams.set("itemId", "transition-1");
+    source.searchParams.set("unrelated", "discard-me");
+
+    const response = await fetch(
+      endpointRequest(source.href, { format: "json" }),
+    );
+    const body = await responseJson(response);
+
+    expect(response.status).toBe(200);
+    expect(body.html).toBe(
+      '<iframe src="https://demo.petrinaut.org/embed/examples/gases-2-spn?itemId=transition-1&amp;itemType=transition&amp;scenario=scenario-1&amp;subnet=subnet-1" title="Gases 2 — Shared Tanker" width="800" height="450" style="border:0" loading="lazy" sandbox="allow-scripts allow-same-origin" referrerpolicy="no-referrer" allowfullscreen></iframe>',
+    );
+  });
+
+  it("drops an incomplete focused-item pair", async () => {
+    const response = await fetch(
+      endpointRequest(
+        "https://demo.petrinaut.org/examples/gases-1-pn?itemType=script&itemId=place-1",
+      ),
+    );
+    const body = await responseJson(response);
+
+    expect(body.html).not.toContain("itemId");
+    expect(body.html).not.toContain("itemType");
+  });
+
+  it("drops full-page no-scenario state from embeds", async () => {
+    const response = await fetch(
+      endpointRequest(
+        "https://demo.petrinaut.org/examples/gases-1-pn?scenario=none",
+      ),
+    );
+    const body = await responseJson(response);
+
+    expect(body.html).not.toContain("scenario=");
+  });
+
+  it("URL-encodes query values and HTML-escapes the iframe source", async () => {
+    const source = new URL(
+      "https://demo.petrinaut.org/examples/semiconductor-fab-drift",
+    );
+    source.searchParams.set("scenario", '"><script>alert("x")</script>&');
+    source.searchParams.set("subnet", "one&two");
+
+    const response = await fetch(endpointRequest(source.href));
+    const body = await responseJson(response);
+    const html = body.html as string;
+
+    expect(html).not.toContain("<script>");
+    expect(html).toContain(
+      "scenario=%22%3E%3Cscript%3Ealert%28%22x%22%29%3C%2Fscript%3E%26",
+    );
+    expect(html).toContain("&amp;subnet=one%26two");
+  });
+
+  it.each([
+    [{ maxwidth: "400" }, 400, 225],
+    [{ maxheight: "225" }, 400, 225],
+    [{ maxwidth: "320", maxheight: "100" }, 177, 100],
+    [{ maxwidth: "1600", maxheight: "900" }, 800, 450],
+  ] as const)(
+    "fits a 16:9 embed inside %j without upscaling",
+    async (limits, expectedWidth, expectedHeight) => {
+      const response = await fetch(
+        endpointRequest(
+          "https://demo.petrinaut.org/examples/truck-fleet-predictive-maintenance",
+          limits,
+        ),
+      );
+      const body = await responseJson(response);
+
+      expect(body.width).toBe(expectedWidth);
+      expect(body.height).toBe(expectedHeight);
+      expect(body.html).toContain(`width="${expectedWidth}"`);
+      expect(body.html).toContain(`height="${expectedHeight}"`);
+    },
+  );
+
+  it.each([
+    ["maxwidth", "0"],
+    ["maxwidth", "-1"],
+    ["maxwidth", "Infinity"],
+    ["maxwidth", "0x10"],
+    ["maxwidth", "1e3"],
+    ["maxwidth", "1.5"],
+    ["maxheight", "not-a-number"],
+  ] as const)("rejects invalid %s=%j", async (name, value) => {
+    const response = await fetch(
+      endpointRequest("https://demo.petrinaut.org/examples/gases-1-pn", {
+        [name]: value,
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await responseJson(response)).toEqual({
+      error: `${name} must be a positive integer`,
+    });
+  });
+
+  it.each(["maxwidth", "maxheight"] as const)(
+    "treats a blank %s as no maximum",
+    async (name) => {
+      // Consumers that always append the optional params send them empty when
+      // the user set no size.
+      const response = await fetch(
+        endpointRequest("https://demo.petrinaut.org/examples/gases-1-pn", {
+          [name]: "",
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      expect(await responseJson(response)).toMatchObject({
+        width: 800,
+        height: 450,
+      });
+    },
+  );
+
+  it("keeps the aspect ratio when clamping to a maximum", async () => {
+    const response = await fetch(
+      endpointRequest("https://demo.petrinaut.org/examples/gases-1-pn", {
+        maxwidth: "400",
+      }),
+    );
+
+    const body = (await responseJson(response)) as {
+      width: number;
+      height: number;
+    };
+    expect(body.width).toBe(400);
+    expect(body.width / body.height).toBeCloseTo(800 / 450, 2);
+  });
+
+  // 400 is for a request this endpoint cannot read; a well-formed URL it
+  // simply cannot embed is 404, which is the status oEmbed 1.0 section 2.3.1
+  // defines and the one consumers fall back on.
+  it.each([
+    [undefined, 400, "Missing required url parameter"],
+    ["not-a-url", 400, "The url parameter must be a valid URL"],
+    [
+      "https://example.com/examples/gases-1-pn",
+      404,
+      "The url parameter must use https://demo.petrinaut.org",
+    ],
+    [
+      "https://demo.petrinaut.org/embed/examples/gases-1-pn",
+      404,
+      "The url parameter is not a canonical example URL",
+    ],
+    [
+      "https://demo.petrinaut.org/examples/gases-1-pn/versions/1",
+      404,
+      "The url parameter is not a canonical example URL",
+    ],
+    [
+      "https://demo.petrinaut.org/examples/not-an-example",
+      404,
+      "Unknown example: not-an-example",
+    ],
+  ] as const)(
+    "rejects an unsupported source URL (%s)",
+    async (sourceUrl, expectedStatus, expectedError) => {
+      const response = await fetch(endpointRequest(sourceUrl));
+
+      expect(response.status).toBe(expectedStatus);
+      expect(response.headers.get("cache-control")).toBe("no-store");
+      expect(await responseJson(response)).toEqual({ error: expectedError });
+    },
+  );
+
+  it("answers unimplementable format requests with 501", async () => {
+    const response = await fetch(
+      endpointRequest("https://demo.petrinaut.org/examples/gases-1-pn", {
+        format: "xml",
+      }),
+    );
+
+    expect(response.status).toBe(501);
+    expect(await responseJson(response)).toEqual({
+      error: "Only the json oEmbed format is supported",
+    });
+  });
+
+  it("serves HEAD like GET with an empty body", async () => {
+    const response = await fetch(
+      endpointRequest("https://demo.petrinaut.org/examples/gases-1-pn", {
+        method: "HEAD",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe(
+      "application/json; charset=utf-8",
+    );
+    expect(await response.text()).toBe("");
+  });
+
+  it("answers HEAD with an empty body on the error paths too", async () => {
+    const response = await fetch(
+      endpointRequest("https://example.com/examples/gases-1-pn", {
+        method: "HEAD",
+      }),
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.text()).toBe("");
+  });
+
+  it("drops a multi-item selection: an embed URL carries one item", async () => {
+    const source = new URL("https://demo.petrinaut.org/examples/gases-1-pn");
+    source.searchParams.append("items", "place:place-1");
+    source.searchParams.append("items", "transition:transition-1");
+
+    const response = await fetch(endpointRequest(source.href));
+    const body = await responseJson(response);
+
+    expect(body.html).not.toContain("items");
+    expect(body.html).not.toContain("place-1");
+  });
+
+  it("returns a CORS preflight response", async () => {
+    const response = await fetch(
+      endpointRequest(undefined, { method: "OPTIONS" }),
+    );
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get("access-control-allow-origin")).toBe("*");
+    expect(response.headers.get("access-control-allow-methods")).toBe(
+      "GET, HEAD, OPTIONS",
+    );
+  });
+
+  it("rejects unsupported methods", async () => {
+    const response = await fetch(
+      endpointRequest(undefined, { method: "POST" }),
+    );
+
+    expect(response.status).toBe(405);
+    expect(response.headers.get("allow")).toBe("GET, HEAD, OPTIONS");
+    expect(response.headers.get("access-control-allow-origin")).toBe("*");
+    expect(await responseJson(response)).toEqual({
+      error: "Method not allowed",
+    });
+  });
+});

--- a/apps/petrinaut-website/vercel.json
+++ b/apps/petrinaut-website/vercel.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
   "github": {
     "silent": true,
     "autoJobCancelation": true
@@ -7,6 +8,47 @@
   "installCommand": "./vercel-install.sh",
   "devCommand": "turbo run build && yarn preview",
   "outputDirectory": "./dist",
+  "headers": [
+    {
+      "source": "/((?!api(?:/|$)|embed/examples/).*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "frame-ancestors 'none'"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        }
+      ]
+    },
+    {
+      "source": "/embed/examples/:path*",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "frame-ancestors *"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Robots-Tag",
+          "value": "noindex"
+        }
+      ]
+    },
+    {
+      "source": "/api/(.*)",
+      "headers": [
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        }
+      ]
+    }
+  ],
   "rewrites": [
     {
       "source": "/((?!api(?:/|$)).*)",
@@ -16,6 +58,9 @@
   "functions": {
     "api/chat.ts": {
       "maxDuration": 300
+    },
+    "api/oembed.ts": {
+      "maxDuration": 10
     }
   }
 }

--- a/apps/petrinaut-website/vite.config.ts
+++ b/apps/petrinaut-website/vite.config.ts
@@ -21,34 +21,41 @@ const loadServerEnv = (mode: string) => {
   }
 };
 
-// Plugin required to serve the chat endpoint in dev.
-// In production, it will be bundled and served by Vercel.
+const apiModules = [
+  ["/api/chat", "/api/chat.ts"],
+  ["/api/oembed", "/api/oembed.ts"],
+] as const;
+
+// Plugin required to serve the Vercel fetch handlers in dev. In production,
+// each file under /api is bundled and served as its own Vercel Function.
 const petrinautApiDevPlugin = (): Plugin => ({
   name: "petrinaut-api-dev",
   apply: "serve",
   configureServer(server) {
-    // The chat endpoint ships a default `{ fetch }` so Vercel's Node.js
-    // runtime treats it as a Web fetch handler in production. We mirror the
-    // same shape here so dev and prod hit the same code path.
-    const adapter = createServerAdapter(async (request) => {
-      const { default: api } = (await server.ssrLoadModule("/api/chat.ts")) as {
-        default: { fetch: (request: Request) => Promise<Response> };
-      };
+    for (const [route, modulePath] of apiModules) {
+      // The endpoints ship a default `{ fetch }` so Vercel's Node.js runtime
+      // treats them as Web fetch handlers. Mirror that shape in development so
+      // both environments exercise exactly the same handler.
+      const adapter = createServerAdapter(async (request) => {
+        const { default: api } = (await server.ssrLoadModule(modulePath)) as {
+          default: { fetch: (request: Request) => Promise<Response> };
+        };
 
-      try {
-        return await api.fetch(request);
-      } catch (error) {
-        server.ssrFixStacktrace(error as Error);
-        throw error;
-      }
-    });
+        try {
+          return await api.fetch(request);
+        } catch (error) {
+          server.ssrFixStacktrace(error as Error);
+          throw error;
+        }
+      });
 
-    server.middlewares.use(
-      "/api/chat",
-      (request: IncomingMessage, response: ServerResponse) => {
-        void adapter(request, response);
-      },
-    );
+      server.middlewares.use(
+        route,
+        (request: IncomingMessage, response: ServerResponse) => {
+          void adapter(request, response);
+        },
+      );
+    }
   },
 });
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Adds oEmbed support for the example pages: a `/api/oembed` Vercel function that turns a canonical example URL into a sandboxed iframe embed, runtime discovery links on the example pages, and site-wide framing security headers. Stacked on the embed-route PR.

## 🔗 Related links

- [FE-1500](https://linear.app/hash/issue/FE-1500/view-only-iframe-embed-of-a-petrinaut-net)
- [oEmbed 1.0](https://oembed.com/)

## 🔍 What does this change?

- New `api/oembed.ts` fetch handler: validates canonical `https://demo.petrinaut.org/examples/<slug>` URLs against catalog metadata, strips query state down to the embed-supported scenario/subnet/selection keys (single and multi-item selections), fits requested dimensions without upscaling, and returns a `rich` oEmbed response whose iframe targets `/embed/examples/...` with `sandbox="allow-scripts allow-same-origin"`, no referrer, and lazy loading. `allow-same-origin` is required: without it the framed document runs with an opaque origin, module-script fetches fail CORS, and the embed stays blank; the framed content is this site's own app, and framing policy is enforced server-side by the headers below. The sanitizer decodes the canonical URL through the shared contract (#9362) and re-encodes it, so the endpoint cannot drift from what the embed page accepts. That module is React-free by design, and the selection vocabulary it uses comes from a dependency-free `@hashintel/petrinaut-core/selection` entry, so the function bundles neither the editor nor the model.
- Example pages render an `application/json+oembed` discovery `<link>` declaratively; React 19 hoists it into `document.head`. The site is a client-rendered SPA, so discovery works for consumers that execute JavaScript; this limitation is by design.
- `vercel.json` framing policy: `frame-ancestors 'none'` plus `X-Frame-Options: DENY` for the whole site except `/embed/examples/*`, which allows all ancestors and adds `nosniff`.
- Generalizes the Vite dev API plugin from a hardcoded `/api/chat` middleware to a table over `/api/chat` and `/api/oembed`, so development and production run the same handlers.
- Protocol conformance: `format=xml` answers 501 as oEmbed 1.0 requires (a spec-following consumer probes and falls back), and HEAD is served like GET with an empty body.
- Documents the embed and oEmbed URL contract in the website README.
- Review fixes (second round): moved `api/oembed.test.ts` to `src/examples/oembed-endpoint.test.ts`. Vercel deploys every module under `api/` as a function, and staging confirmed it: `/api/oembed.test` answered 500 while an unknown path answered 404, so the test file was live and crashing on invocation. Also: a blank `format=`, `maxwidth=` or `maxheight=` now means "not specified" rather than an error, which a consumer that always appends the optional params was hitting; `maxwidth`/`maxheight` are parsed as integers (`0x10` was read as 16) and the 16:9 ratio survives clamping (`?maxwidth=1` returned a 1x1 embed); a well-formed URL this provider cannot embed answers 404 rather than 400, per oEmbed 1.0 section 2.3.1; HEAD is bodiless on the error paths too; the discovery link is built from the slug and the validated search, so a tracking parameter no longer advertises a second endpoint URL for an identical response; `nosniff` now covers `/api/*`, the one response that reflects input, and `/embed/examples/*` carries `X-Robots-Tag: noindex`.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- New: `api/oembed.test.ts` (URL validation, state sanitization including multi-item selections, dimension fitting, response headers, method and format handling) and `oembed-discovery.test.ts`. The selection allowlist no longer needs a drift guard: there is one list, in core.

## ❓ How to test this?

1. Checkout the branch and run `yarn workspace @apps/petrinaut-website dev`.
2. `curl "http://localhost:5173/api/oembed?url=https%3A%2F%2Fdemo.petrinaut.org%2Fexamples%2Fgases-1-pn&maxwidth=600"`.
3. Confirm a JSON oEmbed response whose `html` iframe targets `/embed/examples/gases-1-pn`, and open an example page to see the discovery `<link>` in `document.head`.



