### PR TITLE
FE-1515: Give sidebar list labels the full row width until the row menu shows

### DIFF
--- a/.changeset/adaptive-bezier-label-midpoint.md
+++ b/.changeset/adaptive-bezier-label-midpoint.md
@@ -1,0 +1,5 @@
+---
+"@hashintel/petrinaut": patch
+---
+
+Arc weight labels sit on the Adaptive Bezier curve instead of floating at the straight-line midpoint between the arc's endpoints.

--- a/.changeset/sidebar-row-label-width.md
+++ b/.changeset/sidebar-row-label-width.md
@@ -1,0 +1,5 @@
+---
+"@hashintel/petrinaut": patch
+---
+
+Sidebar list labels use the full row width and truncate with an ellipsis consistently; the row menu button only takes space while hovering the row or while its menu is open.

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/LeftSideBar/subviews/filterable-list-sub-view.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/LeftSideBar/subviews/filterable-list-sub-view.tsx
@@ -52,22 +52,15 @@ const listItemRowStyle = cva({
       true: {
         cursor: "pointer",
 
-        /* Reveal the action button on hover or when its menu is open */
+        /* Reveal the action button on hover or when its menu is open. Hidden
+           with `display` rather than `opacity` so it takes no space and the
+           label keeps the full row width until the button is shown. */
         "& [data-row-action]": {
-          opacity: "[0]",
-          transition: "[opacity 150ms ease-out]",
-        },
-        "& [data-row-action] svg": {
-          transform: "[translateX(2px)]",
-          transition: "[transform 150ms ease-out]",
+          display: "none",
         },
         "&:hover [data-row-action], & [data-row-action][data-state=open]": {
-          opacity: "[1]",
+          display: "flex",
         },
-        "&:hover [data-row-action] svg, & [data-row-action][data-state=open] svg":
-          {
-            transform: "none",
-          },
       },
     },
     isSelected: {
@@ -118,6 +111,7 @@ const listItemContentStyle = css({
 
 const listItemNameStyle = css({
   flex: "[1]",
+  minWidth: "[0]",
   fontSize: "sm",
   fontWeight: "medium",
   lineHeight: "snug",
@@ -125,6 +119,13 @@ const listItemNameStyle = css({
   overflow: "hidden",
   textOverflow: "ellipsis",
   whiteSpace: "nowrap",
+  /* renderItem may nest its own lines (e.g. a name with a subtitle); each
+     line truncates the same way plain-text items do. */
+  "& *": {
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+  },
 });
 
 const LIST_ITEM_ICON_SIZE = 12;

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/components/arc.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/components/arc.tsx
@@ -248,7 +248,6 @@ function getCustomArcPath({
   targetPosition: Position;
 }): [path: string, labelX: number, labelY: number] {
   const dx = targetX - sourceX;
-  const dy = targetY - sourceY;
 
   // Control point offset scales with horizontal distance, with a minimum
   const offset = Math.max(Math.abs(dx) * 0.7, 80);
@@ -260,9 +259,9 @@ function getCustomArcPath({
 
   const path = `M ${sourceX},${sourceY} C ${cp1x},${cp1y} ${cp2x},${cp2y} ${targetX},${targetY}`;
 
-  // Label at the midpoint of the cubic bezier (t=0.5)
-  const labelX = sourceX + dx / 2;
-  const labelY = sourceY + dy / 2;
+  // Label at the midpoint of the cubic bezier: B(0.5) = (P0 + 3·CP1 + 3·CP2 + P3) / 8
+  const labelX = (sourceX + 3 * cp1x + 3 * cp2x + targetX) / 8;
+  const labelY = (sourceY + 3 * cp1y + 3 * cp2y + targetY) / 8;
 
   return [path, labelX, labelY];
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Left-sidebar list items cropped inconsistently. Rows with a row menu always reserved space for the hidden "More options" button (it was revealed by animating opacity, which keeps its layout size), so those lists wrapped labels ~20px early — while lists without menus used the full width. And items rendering a name with a subtitle (e.g. parameters) escaped the row's ellipsis and clipped hard, while plain-text items showed "…".

Labels now take the full row width with a consistent ellipsis, and only shrink while the row is hovered (or its menu is open), when the button actually appears.

**Before** — space reserved for the hidden button, and name/subtitle lines hard-clip without an ellipsis:

<img width="415" height="1350" alt="image" src="https://github.com/user-attachments/assets/cfb1faf7-6df6-47f8-b930-606fe5778fbd" />

**After** — full-width labels, consistent "…" truncation (same net, same 200px sidebar):

<img width="415" height="1350" alt="image" src="https://github.com/user-attachments/assets/62238c2d-6a11-4be4-bff1-8d50e88094b9" />

## 🔗 Related links

- [FE-1515](https://linear.app/hash/issue/FE-1515/give-sidebar-list-labels-the-full-row-width-until-the-row-menu-shows)

## 🚫 Blocked by

- [ ] #9354 — stacked on `claude/fe-1512-adaptive-bezier-label-midpoint`; only the last commit belongs to this PR until the stack below merges.

## 🔍 What does this change?

- `filterable-list-sub-view.tsx` hides `[data-row-action]` with `display: none` instead of `opacity: 0`, revealing it on row hover or while its menu is open — the hidden button no longer occupies layout.
- `listItemNameStyle` applies its truncation (nowrap, hidden overflow, ellipsis) to nested item lines as well, so name + subtitle renderers truncate like plain-text ones.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] modifies an **npm**-publishable library and **I have added a changeset file(s)**

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

The user guide does not describe row-menu reveal behaviour.

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

- The 150ms fade/slide reveal animation is gone — `display` cannot transition, so the button appears instantly. A `@starting-style` fade can be added later if the pop feels abrupt.
- While hidden, the button is no longer in the tab order (`display: none`). Previously it was tab-focusable but invisible, which was not meaningfully more accessible.

## 🛡 What tests cover this?

- None — CSS-only. Verified in the running app: button computes `display: none` by default and the label content spans the full row (244px of a 256px row); forcing the menu-open state (the same rule as `:hover`) shows the 20px button and shrinks the content to 224px; nested name and `<pre>` subtitle lines compute `nowrap` / `ellipsis` / `hidden`.

## ❓ How to test this?

1. `yarn workspace @hashintel/petrinaut dev`, open a story with parameters (e.g. `Handle Spike With Sir`), narrow the left sidebar.
2. Long labels truncate with "…" and reach the row's right edge; name and subtitle lines truncate alike.
3. Hover a row: the "⋯" button appears and the label shortens; unhover with the menu open: the button stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
