### PR TITLE
FE-1513: Contour plot over two swept parameters, navigable in real time

### DIFF
--- a/.changeset/sweep-surface-contour.md
+++ b/.changeset/sweep-surface-contour.md
@@ -1,0 +1,5 @@
+---
+"@hashintel/petrinaut": patch
+---
+
+Sweep experiments with two or more swept parameters gain a Surface section: an Optuna-style filled contour of a metric's final value over two chosen parameters, filling in live as combinations are sampled (8 runs each, coarse-to-fine) on a background lane that never steals the navigator's workers. Clicking the surface moves the navigator to the nearest combination; other parameters stay at their navigator values and changing them restarts the fill.

--- a/.changeset/sweep-surface-contour.md
+++ b/.changeset/sweep-surface-contour.md
@@ -2,4 +2,4 @@
 "@hashintel/petrinaut": patch
 ---
 
-Sweep experiments with two or more swept parameters gain a Surface section: an Optuna-style filled contour of a metric's final value over two chosen parameters, filling in live as combinations are sampled (8 runs each, coarse-to-fine) on a background lane that never steals the navigator's workers. Clicking the surface moves the navigator to the nearest combination; other parameters stay at their navigator values and changing them restarts the fill.
+Sweeps with two or more swept parameters gain a Surface section: a contour of a metric's final value over two chosen parameters, filled in live on a background lane. Clicking it moves the navigator to the nearest combination.

--- a/libs/@hashintel/petrinaut/docs/experiments.md
+++ b/libs/@hashintel/petrinaut/docs/experiments.md
@@ -65,6 +65,10 @@ A sweep never computes its whole grid up front. It computes **the combination yo
 
 Every combination samples the same seed sequence (common random numbers), so differences you see between combinations come from the parameters, not from sampling luck. The GPU backend works for sweeps the same way it does for a plain experiment: the choice is made on the first batch and each later combination reuses it.
 
+#### The surface view
+
+A sweep with two or more swept parameters grows a **Surface** section under the metrics: a contour plot of one metric's final value over two parameters you pick, with every other parameter held at its navigator value. The plot fills in live — combinations are sampled a few at a time (8 runs each), coarse shape first — and **clicking the surface moves the navigator** to the nearest combination, which then refines it with more runs. Changing the fixed parameters, the axes, or the metric restarts the fill for the new slice.
+
 ### Compute backend (experimental)
 
 Experiments run on the CPU unless you ask for the GPU. Switch on **WebGPU** under **Settings → Simulation**, and the Create Experiment drawer gains a **Run on GPU** switch. Running on your graphics hardware is dramatically faster — a 4000-run experiment that takes six seconds on the CPU finishes in a few milliseconds.

--- a/libs/@hashintel/petrinaut/src/react/experiments/context.ts
+++ b/libs/@hashintel/petrinaut/src/react/experiments/context.ts
@@ -4,7 +4,7 @@ import type {
   ExperimentParameterAxis,
   ExperimentParameterInput,
 } from "./parameter-grid";
-import type { SweepSelection } from "./sweep-session";
+import type { SweepCellSnapshot, SweepSelection } from "./sweep-session";
 import type {
   AdHocScenarioState,
   MonteCarloExpressionMetricSpec,
@@ -190,6 +190,16 @@ export type ExperimentsContextValue = {
   removeExperiment: (experimentId: string) => void;
   /** Moves a sweep's navigator; compute follows the selection. */
   setSweepSelection: (experimentId: string, selection: SweepSelection) => void;
+  /**
+   * Brings a sweep combination up to at least `minRuns` finished runs on the
+   * background lane, resolving with its snapshot — the surface view's feed.
+   * Resolves null for unknown experiments and disposed sessions.
+   */
+  sampleSweepCell: (
+    experimentId: string,
+    parameterValues: Readonly<Record<string, number>>,
+    minRuns: number,
+  ) => Promise<SweepCellSnapshot | null>;
 };
 
 const DEFAULT_CONTEXT_VALUE: ExperimentsContextValue = {
@@ -201,6 +211,7 @@ const DEFAULT_CONTEXT_VALUE: ExperimentsContextValue = {
   cancelExperiment: () => {},
   removeExperiment: () => {},
   setSweepSelection: () => {},
+  sampleSweepCell: () => Promise.resolve(null),
 };
 
 export const ExperimentsContext = createContext<ExperimentsContextValue>(

--- a/libs/@hashintel/petrinaut/src/react/experiments/contour-grid.test.ts
+++ b/libs/@hashintel/petrinaut/src/react/experiments/contour-grid.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  bluesColor,
+  coarseToFineOrder,
+  contourLevels,
+  idwRaster,
+  marchingSquaresSegments,
+  sweepCellObjective,
+} from "./contour-grid";
+
+import type { MonteCarloUserDefinedMetricFrame } from "@hashintel/petrinaut-core";
+
+describe("coarseToFineOrder", () => {
+  it("visits corners and midpoints before in-between cells", () => {
+    const order = coarseToFineOrder(5, 5);
+    expect(order).toHaveLength(25);
+
+    const rankOf = (x: number, y: number) =>
+      order.findIndex((cell) => cell.x === x && cell.y === y);
+
+    // The four corners come before the grid centre, which comes before an
+    // odd-index cell that only exists on the finest lattice.
+    expect(rankOf(0, 0)).toBeLessThan(rankOf(2, 2));
+    expect(rankOf(4, 4)).toBeLessThan(rankOf(2, 2));
+    expect(rankOf(2, 2)).toBeLessThan(rankOf(1, 2));
+    expect(rankOf(1, 2)).toBeLessThan(-0.5 + 25);
+  });
+
+  it("covers every cell exactly once", () => {
+    const order = coarseToFineOrder(3, 4);
+    const keys = new Set(order.map((cell) => `${cell.x},${cell.y}`));
+    expect(keys.size).toBe(12);
+  });
+});
+
+describe("idwRaster", () => {
+  it("is flat at the sample value with a single sample", () => {
+    const raster = idwRaster({
+      samples: [{ x: 1, y: 1, value: 7 }],
+      nx: 3,
+      ny: 3,
+      width: 4,
+      height: 4,
+    });
+    expect([...raster].every((value) => Math.abs(value - 7) < 1e-9)).toBe(true);
+  });
+
+  it("hits sample values exactly at their raster positions", () => {
+    // 2x2 grid rendered on a 2x2 raster: each raster corner is a sample.
+    const raster = idwRaster({
+      samples: [
+        { x: 0, y: 0, value: 1 },
+        { x: 1, y: 0, value: 2 },
+        { x: 0, y: 1, value: 3 },
+        { x: 1, y: 1, value: 4 },
+      ],
+      nx: 2,
+      ny: 2,
+      width: 2,
+      height: 2,
+    });
+    // Raster rows are top-down; grid y is up, so grid (0,1)=3 is top-left.
+    expect([...raster]).toEqual([3, 4, 1, 2]);
+  });
+});
+
+describe("marchingSquaresSegments", () => {
+  it("draws a vertical iso-line through a horizontal ramp", () => {
+    // 3x2 raster ramping 0, 5, 10 in x: the level-2.5 line sits at x = 0.5.
+    const raster = new Float64Array([0, 5, 10, 0, 5, 10]);
+    const segments = marchingSquaresSegments(raster, 3, 2, 2.5);
+
+    expect(segments).toHaveLength(1);
+    const [x1, y1, x2, y2] = segments[0]!;
+    expect(x1).toBeCloseTo(0.5);
+    expect(x2).toBeCloseTo(0.5);
+    expect(Math.min(y1, y2)).toBe(0);
+    expect(Math.max(y1, y2)).toBe(1);
+  });
+
+  it("emits nothing when the level is outside the raster's range", () => {
+    const raster = new Float64Array([0, 1, 0, 1]);
+    expect(marchingSquaresSegments(raster, 2, 2, 5)).toHaveLength(0);
+  });
+});
+
+describe("contourLevels / bluesColor", () => {
+  it("places levels strictly inside the range", () => {
+    expect(contourLevels(0, 10, 4)).toEqual([2, 4, 6, 8]);
+    expect(contourLevels(3, 3, 4)).toEqual([]);
+  });
+
+  it("ramps from near-white to deep blue", () => {
+    expect(bluesColor(0)).toBe("rgb(247, 251, 255)");
+    expect(bluesColor(1)).toBe("rgb(8, 48, 107)");
+    expect(bluesColor(0.5)).toMatch(/^rgb\(/u);
+  });
+});
+
+describe("sweepCellObjective", () => {
+  const distribution = (
+    frameNumber: number,
+    bins: readonly (readonly [number, number])[],
+  ): MonteCarloUserDefinedMetricFrame => ({
+    metricId: "m",
+    label: "M",
+    outputType: "distribution",
+    frameNumber,
+    time: frameNumber,
+    bins,
+    value: null,
+    frameValue: null,
+    timeValue: null,
+    runSampleCount: 8,
+    timeSampleCount: 8,
+  });
+
+  it("reads the mean of the metric's final distribution frame", () => {
+    const frames = [
+      distribution(0, [[100, 8]]),
+      distribution(1, [
+        [10, 4],
+        [20, 4],
+      ]),
+    ];
+    expect(sweepCellObjective(frames, "m")).toBe(15);
+  });
+
+  it("returns null when the metric never reported", () => {
+    expect(sweepCellObjective([distribution(0, [[1, 8]])], "other")).toBeNull();
+  });
+});

--- a/libs/@hashintel/petrinaut/src/react/experiments/contour-grid.ts
+++ b/libs/@hashintel/petrinaut/src/react/experiments/contour-grid.ts
@@ -1,0 +1,271 @@
+/**
+ * Pure math behind the sweep surface view: turning sparse sampled grid cells
+ * into a filled contour picture, Optuna-style.
+ *
+ * The surface fills progressively — one sampled combination at a time — so
+ * the interpolator must produce something sensible at every stage: inverse
+ * distance weighting over the sampled points gives smooth blobs around the
+ * first few samples that converge to the true surface as the grid fills.
+ * Iso-lines come from marching squares over the interpolated raster.
+ */
+import type { MonteCarloUserDefinedMetricFrame } from "@hashintel/petrinaut-core";
+
+/** One sampled combination, in grid-index space. */
+export type ContourSample = {
+  /** Column index on the X axis. */
+  x: number;
+  /** Row index on the Y axis. */
+  y: number;
+  value: number;
+};
+
+/**
+ * The order to sample an `nx × ny` grid: corners and midpoints of ever finer
+ * subdivisions before their neighbours, so the surface's coarse shape appears
+ * after a handful of cells instead of filling row by row.
+ *
+ * Cells are ranked by the finest power-of-two lattice they sit on (a
+ * bit-interleaved refinement depth), ties broken row-major.
+ */
+export function coarseToFineOrder(
+  nx: number,
+  ny: number,
+): { x: number; y: number }[] {
+  const depthOf = (index: number, count: number): number => {
+    if (count <= 1 || index === 0 || index === count - 1) {
+      return 0;
+    }
+    // The finest subdivision level at which `index / (count - 1)` is a lattice
+    // point: level d has lattice spacing (count - 1) / 2^d.
+    for (let depth = 1; depth <= 30; depth++) {
+      const spacing = (count - 1) / 2 ** depth;
+      if (spacing < 1) {
+        return depth;
+      }
+      if (Number.isInteger(index / spacing)) {
+        return depth;
+      }
+    }
+    return 30;
+  };
+
+  const cells: { x: number; y: number; rank: number }[] = [];
+  for (let y = 0; y < ny; y++) {
+    for (let x = 0; x < nx; x++) {
+      cells.push({ x, y, rank: Math.max(depthOf(x, nx), depthOf(y, ny)) });
+    }
+  }
+
+  return cells
+    .sort((left, right) => left.rank - right.rank)
+    .map(({ x, y }) => ({ x, y }));
+}
+
+/**
+ * Interpolates the sampled points onto a `width × height` raster spanning the
+ * grid's index space, by inverse distance weighting (power 2).
+ *
+ * A raster point sitting exactly on a sample takes its value; with a single
+ * sample the whole raster is flat at that value, which is the honest picture
+ * of one data point.
+ */
+export function idwRaster(options: {
+  samples: readonly ContourSample[];
+  /** Grid extent in index space: samples lie in [0, nx-1] × [0, ny-1]. */
+  nx: number;
+  ny: number;
+  width: number;
+  height: number;
+}): Float64Array {
+  const { samples, nx, ny, width, height } = options;
+  const raster = new Float64Array(width * height);
+  if (samples.length === 0) {
+    return raster;
+  }
+
+  for (let py = 0; py < height; py++) {
+    // Raster rows run top-to-bottom; grid rows bottom-to-top (y up).
+    const gy = ((height - 1 - py) / Math.max(height - 1, 1)) * (ny - 1);
+    for (let px = 0; px < width; px++) {
+      const gx = (px / Math.max(width - 1, 1)) * (nx - 1);
+
+      let weightSum = 0;
+      let valueSum = 0;
+      let exact: number | null = null;
+      for (const sample of samples) {
+        const distanceSquared =
+          (sample.x - gx) * (sample.x - gx) + (sample.y - gy) * (sample.y - gy);
+        if (distanceSquared < 1e-9) {
+          exact = sample.value;
+          break;
+        }
+        const weight = 1 / distanceSquared;
+        weightSum += weight;
+        valueSum += weight * sample.value;
+      }
+
+      raster[py * width + px] = exact ?? valueSum / weightSum;
+    }
+  }
+
+  return raster;
+}
+
+/**
+ * Marching squares: the iso-lines of `raster` at `level`, as polyline segments
+ * in raster pixel coordinates. Segments rather than joined paths — the canvas
+ * strokes them identically and joining buys nothing here.
+ */
+export function marchingSquaresSegments(
+  raster: Float64Array,
+  width: number,
+  height: number,
+  level: number,
+): [number, number, number, number][] {
+  const segments: [number, number, number, number][] = [];
+  const at = (x: number, y: number): number => raster[y * width + x]!;
+  /** Where `level` sits between two corner values, clamped to the edge. */
+  const t = (a: number, b: number): number =>
+    a === b ? 0.5 : Math.min(1, Math.max(0, (level - a) / (b - a)));
+
+  for (let y = 0; y < height - 1; y++) {
+    for (let x = 0; x < width - 1; x++) {
+      const topLeft = at(x, y);
+      const topRight = at(x + 1, y);
+      const bottomRight = at(x + 1, y + 1);
+      const bottomLeft = at(x, y + 1);
+
+      const caseIndex =
+        (topLeft >= level ? 8 : 0) +
+        (topRight >= level ? 4 : 0) +
+        (bottomRight >= level ? 2 : 0) +
+        (bottomLeft >= level ? 1 : 0);
+      if (caseIndex === 0 || caseIndex === 15) {
+        continue;
+      }
+
+      // Edge midpoints, interpolated to where the level crosses.
+      const top: [number, number] = [x + t(topLeft, topRight), y];
+      const right: [number, number] = [x + 1, y + t(topRight, bottomRight)];
+      const bottom: [number, number] = [x + t(bottomLeft, bottomRight), y + 1];
+      const left: [number, number] = [x, y + t(topLeft, bottomLeft)];
+
+      const push = (a: [number, number], b: [number, number]) => {
+        segments.push([a[0], a[1], b[0], b[1]]);
+      };
+
+      switch (caseIndex) {
+        case 1:
+        case 14:
+          push(left, bottom);
+          break;
+        case 2:
+        case 13:
+          push(bottom, right);
+          break;
+        case 3:
+        case 12:
+          push(left, right);
+          break;
+        case 4:
+        case 11:
+          push(top, right);
+          break;
+        case 6:
+        case 9:
+          push(top, bottom);
+          break;
+        case 7:
+        case 8:
+          push(left, top);
+          break;
+        // The two saddles: resolve by the cell-centre average, matching the
+        // corner majority so lines never cross.
+        case 5:
+        case 10: {
+          const centreHigh =
+            (topLeft + topRight + bottomRight + bottomLeft) / 4 >= level;
+          const flipped = (caseIndex === 5) === centreHigh;
+          if (flipped) {
+            push(left, top);
+            push(bottom, right);
+          } else {
+            push(left, bottom);
+            push(top, right);
+          }
+          break;
+        }
+        default:
+          break;
+      }
+    }
+  }
+
+  return segments;
+}
+
+/** `count` evenly spaced levels strictly inside [min, max]. */
+export function contourLevels(
+  min: number,
+  max: number,
+  count: number,
+): number[] {
+  if (!(max > min) || count < 1) {
+    return [];
+  }
+  const step = (max - min) / (count + 1);
+  return Array.from({ length: count }, (_, index) => min + step * (index + 1));
+}
+
+/**
+ * Optuna's contour look: light for low values, deep blue for high.
+ * `t` in [0, 1].
+ */
+export function bluesColor(t: number): string {
+  const clamped = Math.min(1, Math.max(0, t));
+  // Endpoints sampled from the ColorBrewer Blues ramp Optuna uses.
+  const stops: [number, number, number][] = [
+    [247, 251, 255],
+    [198, 219, 239],
+    [107, 174, 214],
+    [33, 113, 181],
+    [8, 48, 107],
+  ];
+  const position = clamped * (stops.length - 1);
+  const index = Math.min(Math.floor(position), stops.length - 2);
+  const fraction = position - index;
+  const from = stops[index]!;
+  const to = stops[index + 1]!;
+  const channel = (i: number): number =>
+    Math.round(from[i]! + (to[i]! - from[i]!) * fraction);
+  return `rgb(${channel(0)}, ${channel(1)}, ${channel(2)})`;
+}
+
+/**
+ * One combination's objective: the metric's value on its final frame.
+ *
+ * Matches what a single run reports as the metric's result — a distribution
+ * frame reduces to the mean of its bins, a scalar frame to its frame value.
+ */
+export function sweepCellObjective(
+  frames: readonly MonteCarloUserDefinedMetricFrame[],
+  metricId: string,
+): number | null {
+  for (let index = frames.length - 1; index >= 0; index--) {
+    const frame = frames[index]!;
+    if (frame.metricId !== metricId) {
+      continue;
+    }
+    if (frame.outputType === "scalar") {
+      return frame.frameValue;
+    }
+    let weight = 0;
+    let sum = 0;
+    for (const [value, frequency] of frame.bins) {
+      weight += frequency;
+      sum += value * frequency;
+    }
+    return weight > 0 ? sum / weight : null;
+  }
+  return null;
+}

--- a/libs/@hashintel/petrinaut/src/react/experiments/provider.tsx
+++ b/libs/@hashintel/petrinaut/src/react/experiments/provider.tsx
@@ -459,6 +459,12 @@ export const ExperimentsProvider: React.FC<ExperimentsProviderProps> = ({
       options;
     const experimentId = experiment.id;
     let chosenBackend: ExperimentBackend | null = null;
+    /**
+     * Surface-sampling batches are 8 tiny runs; on the CPU they get one
+     * worker so the navigator's sharded batch keeps the cores. Built lazily —
+     * a sweep whose surface view is never opened spawns nothing extra.
+     */
+    let backgroundCpuBackend: ExperimentBackend | null = null;
 
     const onNote = (note: { message: string }) => {
       addNotification({
@@ -475,7 +481,13 @@ export const ExperimentsProvider: React.FC<ExperimentsProviderProps> = ({
       axes,
       runCount: experiment.runCount,
       seed: experiment.seed,
-      instantiateBatch: async ({ parameterValues, seed, runCount, signal }) => {
+      instantiateBatch: async ({
+        parameterValues,
+        seed,
+        runCount,
+        background,
+        signal,
+      }) => {
         const compiled = compileForValues(parameterValues);
         const override = {
           parameterValues: compiled.result.parameterValues,
@@ -514,11 +526,20 @@ export const ExperimentsProvider: React.FC<ExperimentsProviderProps> = ({
           return selection.handle;
         }
 
+        let batchBackend = chosenBackend;
+        if (background && chosenBackend.id === WORKER_POOL_BACKEND_ID) {
+          backgroundCpuBackend ??= createWorkerPoolExperimentBackend({
+            createWorker: workerFactoryRef.current,
+            shardCount: 1,
+          });
+          batchBackend = backgroundCpuBackend;
+        }
+
         const request = await buildRequest({
-          needsHirTrees: chosenBackend.needsHirTrees,
+          needsHirTrees: batchBackend.needsHirTrees,
           override,
         });
-        const assessment = await chosenBackend.assess(request);
+        const assessment = await batchBackend.assess(request);
         if (!assessment.eligible) {
           throw new Error(describeBlockers(assessment.blockers));
         }

--- a/libs/@hashintel/petrinaut/src/react/experiments/provider.tsx
+++ b/libs/@hashintel/petrinaut/src/react/experiments/provider.tsx
@@ -1016,6 +1016,15 @@ export const ExperimentsProvider: React.FC<ExperimentsProviderProps> = ({
     sweepSessionsRef.current.get(experimentId)?.setSelection(selection);
   };
 
+  const sampleSweepCell: ExperimentsContextValue["sampleSweepCell"] = (
+    experimentId,
+    parameterValues,
+    minRuns,
+  ) =>
+    sweepSessionsRef.current
+      .get(experimentId)
+      ?.sampleCell(parameterValues, minRuns) ?? Promise.resolve(null);
+
   const selectedExperiment =
     experiments.find((experiment) => experiment.id === selectedExperimentId) ??
     null;
@@ -1029,6 +1038,7 @@ export const ExperimentsProvider: React.FC<ExperimentsProviderProps> = ({
     cancelExperiment: useStableCallback(cancelExperiment),
     removeExperiment: useStableCallback(removeExperiment),
     setSweepSelection: useStableCallback(setSweepSelection),
+    sampleSweepCell: useStableCallback(sampleSweepCell),
   };
 
   return (

--- a/libs/@hashintel/petrinaut/src/react/experiments/sweep-session.test.ts
+++ b/libs/@hashintel/petrinaut/src/react/experiments/sweep-session.test.ts
@@ -44,6 +44,7 @@ function makeFakeBatch(request: {
   parameterValues: Readonly<Record<string, number>>;
   seed: number;
   runCount: number;
+  background?: boolean;
 }) {
   let metricListeners: ((value: {
     frames: readonly MonteCarloUserDefinedMetricFrame[];
@@ -55,6 +56,7 @@ function makeFakeBatch(request: {
   let frames: readonly MonteCarloUserDefinedMetricFrame[] = [];
   let progress: MonteCarloWorkerProgress | null = null;
   let cancelled = false;
+  let started = false;
 
   const handle: MonteCarloExperiment = {
     status: { get: () => "Running", subscribe: () => () => {} },
@@ -82,7 +84,9 @@ function makeFakeBatch(request: {
         };
       },
     },
-    start: () => {},
+    start: () => {
+      started = true;
+    },
     cancel: () => {
       cancelled = true;
     },
@@ -95,7 +99,13 @@ function makeFakeBatch(request: {
     get cancelled() {
       return cancelled;
     },
+    get started() {
+      return started;
+    },
     stream(nextFrames: readonly MonteCarloUserDefinedMetricFrame[]) {
+      if (!started) {
+        throw new Error("batch streamed before start()");
+      }
       frames = nextFrames;
       progress = {
         activeRuns: 0,
@@ -112,6 +122,9 @@ function makeFakeBatch(request: {
       }
     },
     complete() {
+      if (!started) {
+        throw new Error("batch completed before start()");
+      }
       for (const listener of eventListeners) {
         listener({
           type: "complete",
@@ -269,6 +282,58 @@ describe("createSweepSession", () => {
     expect(onError).toHaveBeenCalledWith("device lost");
     expect(batches).toHaveLength(1);
     expect(updates.at(-1)!.computing).toBe(false);
+    session.dispose();
+  });
+
+  it("samples background cells up the same seed ladder, one at a time", async () => {
+    const { session, batches, settle } = makeHarness(100);
+    await settle();
+    expect(batches).toHaveLength(1); // the navigator's own first rung
+
+    const first = session.sampleCell({ x: 2, y: 20 }, 8);
+    const second = session.sampleCell({ x: 1, y: 20 }, 8);
+    await settle();
+
+    // Serialized: the second background batch waits for the first.
+    expect(batches).toHaveLength(2);
+    expect(batches[1]!.request).toMatchObject({
+      parameterValues: { x: 2, y: 20 },
+      seed: 42,
+      runCount: 8,
+      background: true,
+    });
+
+    batches[1]!.stream([frame(8, [[5, 8]])]);
+    batches[1]!.complete();
+    await expect(first).resolves.toMatchObject({ runsCompleted: 8 });
+    await settle();
+
+    expect(batches).toHaveLength(3);
+    batches[2]!.stream([frame(8, [[6, 8]])]);
+    batches[2]!.complete();
+    await expect(second).resolves.toMatchObject({ runsCompleted: 8 });
+
+    // Sampled cells are readable like navigator-visited ones.
+    expect(session.getCell({ x: 2, y: 20 })).toMatchObject({
+      runsCompleted: 8,
+    });
+    session.dispose();
+  });
+
+  it("resolves a sampled cell from cache when it is already deep enough", async () => {
+    const { session, batches, settle } = makeHarness(25);
+    await settle();
+    batches[0]!.stream([frame(8, [[1, 8]])]);
+    batches[0]!.complete();
+    await settle();
+
+    // The navigator already took {x:0,y:10} to 8 runs; sampling it is free.
+    await expect(session.sampleCell({ x: 0, y: 10 }, 8)).resolves.toMatchObject(
+      { runsCompleted: 8 },
+    );
+    expect(
+      batches.filter((batch) => batch.request.background).length,
+    ).toBe(0);
     session.dispose();
   });
 

--- a/libs/@hashintel/petrinaut/src/react/experiments/sweep-session.test.ts
+++ b/libs/@hashintel/petrinaut/src/react/experiments/sweep-session.test.ts
@@ -331,9 +331,7 @@ describe("createSweepSession", () => {
     await expect(session.sampleCell({ x: 0, y: 10 }, 8)).resolves.toMatchObject(
       { runsCompleted: 8 },
     );
-    expect(
-      batches.filter((batch) => batch.request.background).length,
-    ).toBe(0);
+    expect(batches.filter((batch) => batch.request.background).length).toBe(0);
     session.dispose();
   });
 

--- a/libs/@hashintel/petrinaut/src/react/experiments/sweep-session.ts
+++ b/libs/@hashintel/petrinaut/src/react/experiments/sweep-session.ts
@@ -66,6 +66,11 @@ export type InstantiateSweepBatch = (options: {
   seed: number;
   /** Runs this batch adds on top of the combination's finished batches. */
   runCount: number;
+  /**
+   * A surface-sampling batch rather than the navigator's. Hosts give these a
+   * single worker so the navigator's sharded batch keeps the cores.
+   */
+  background?: boolean;
   signal: AbortSignal;
 }) => Promise<MonteCarloExperiment>;
 
@@ -89,6 +94,21 @@ export type SweepSession = {
   getCell: (
     parameterValues: Readonly<Record<string, number>>,
   ) => SweepCellSnapshot | undefined;
+  /**
+   * Brings a combination up to at least `minRuns` finished runs, off the
+   * navigator's lane — the surface view samples its grid through this.
+   *
+   * Background batches run one at a time on a single worker, so the
+   * navigator's own sharded batch keeps the cores; a cell the navigator has
+   * already refined past `minRuns` resolves immediately from cache. Seeds
+   * follow the same ladder-position rule as navigator batches, so a cell
+   * sampled here and later visited by the navigator resumes the identical
+   * run sequence. Resolves null when the session is disposed first.
+   */
+  sampleCell: (
+    parameterValues: Readonly<Record<string, number>>,
+    minRuns: number,
+  ) => Promise<SweepCellSnapshot | null>;
   dispose: () => void;
 };
 
@@ -166,6 +186,10 @@ export function createSweepSession(
       computing: update.computing,
     });
   };
+
+  // Reads go through a function so the narrowing-based lint cannot claim the
+  // flag is constant: it flips inside closures the checker treats as opaque.
+  const isDisposed = (): boolean => disposed;
 
   /** Whether `loopGeneration` still owns the session's compute slot. */
   const isStale = (loopGeneration: number): boolean =>
@@ -257,6 +281,8 @@ export function createSweepSession(
       resolveDone("stopped");
     };
 
+    handle.start();
+
     const outcome = await batchDone;
     offMetrics();
     offProgress();
@@ -324,6 +350,72 @@ export function createSweepSession(
 
   restart();
 
+  /** Serializes background sampling; one small batch in flight at most. */
+  let backgroundChain: Promise<unknown> = Promise.resolve();
+
+  const runBackgroundBatch = async (
+    values: Record<string, number>,
+    minRuns: number,
+  ): Promise<SweepCellSnapshot | null> => {
+    if (disposed || failed) {
+      return null;
+    }
+    const key = sweepCellKey(axes, values);
+    const snapshot = snapshotFor(key);
+    const target = Math.min(minRuns, runCount);
+    if (snapshot.runsCompleted >= target) {
+      return snapshot;
+    }
+
+    const abortController = new AbortController();
+    let handle: MonteCarloExperiment;
+    try {
+      handle = await instantiateBatch({
+        parameterValues: values,
+        seed: sweepBatchSeed(seed, snapshot.runsCompleted),
+        runCount: target - snapshot.runsCompleted,
+        background: true,
+        signal: abortController.signal,
+      });
+    } catch {
+      // A refused background cell is a hole in the surface, not a failed
+      // sweep; the navigator lane reports real errors.
+      return null;
+    }
+    if (isDisposed()) {
+      handle.dispose();
+      return null;
+    }
+
+    const done = new Promise<boolean>((resolve) => {
+      const offEvents = handle.events.subscribe((event) => {
+        offEvents();
+        resolve(event.type === "complete");
+      });
+    });
+    handle.start();
+    const completed = await done;
+    const frames = handle.metrics.get().frames;
+    handle.dispose();
+
+    if (!completed || isDisposed()) {
+      return null;
+    }
+    const merged: SweepCellSnapshot = {
+      runsCompleted: target,
+      metricFrames: mergeMetricFramesAcrossCells([
+        snapshot.metricFrames,
+        frames,
+      ]),
+    };
+    // The navigator may have refined this cell further while we sampled; the
+    // deeper snapshot wins.
+    if (snapshotFor(key).runsCompleted < target) {
+      cells.set(key, merged);
+    }
+    return snapshotFor(key);
+  };
+
   return {
     setSelection(next) {
       if (disposed) {
@@ -342,6 +434,13 @@ export function createSweepSession(
     },
     getCell(parameterValues) {
       return cells.get(sweepCellKey(axes, parameterValues));
+    },
+    sampleCell(parameterValues, minRuns) {
+      const next = backgroundChain.then(() =>
+        runBackgroundBatch({ ...parameterValues }, minRuns),
+      );
+      backgroundChain = next.catch(() => null);
+      return next;
     },
     dispose() {
       disposed = true;

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/create-experiment-drawer.test.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/create-experiment-drawer.test.tsx
@@ -157,6 +157,7 @@ const TestProviders = ({
             cancelExperiment: () => {},
             removeExperiment: () => {},
             setSweepSelection: () => {},
+            sampleSweepCell: () => Promise.resolve(null),
           }}
         >
           <SDCPNContext value={sdcpnContextValue}>

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/experiments-story-fixtures.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/experiments-story-fixtures.tsx
@@ -149,6 +149,15 @@ export function makeParameterSweepExperiment(): ExperimentRecord {
     name: "SIR transmission sweep",
     status: "running",
     runCount: 100,
+    metricSpecs: [
+      {
+        kind: "placeTokenCountMean",
+        id: "infected",
+        label: "Infected",
+        placeId: "place__infected",
+        runOutput: { type: "distribution", binning: "exact" },
+      },
+    ],
     parameterAxes: [
       { identifier: "transmission_rate", values: [0.1, 0.2, 0.3, 0.4, 0.5] },
       {
@@ -290,6 +299,36 @@ export function FakeExperimentsProvider({
               : experiment,
           ),
         );
+      },
+      sampleSweepCell: (_experimentId, parameterValues) => {
+        // A synthetic objective surface — a smooth bump — so the story's
+        // contour fills in the way a real sweep's would, walk delay included.
+        const coordinates = Object.values(parameterValues);
+        const x = coordinates[0] ?? 0;
+        const y = coordinates[1] ?? 0;
+        const objective =
+          100 * Math.exp(-((x - 0.35) ** 2) * 20 - ((y - 10) / 14) ** 2) +
+          6 * Math.sin(x * 9) +
+          y / 4;
+        const frame = {
+          metricId: "infected",
+          label: "Infected",
+          outputType: "distribution" as const,
+          frameNumber: 45,
+          time: 45,
+          bins: [[Math.round(objective), 8]] as (readonly [number, number])[],
+          value: null,
+          frameValue: null,
+          timeValue: null,
+          runSampleCount: 8,
+          timeSampleCount: 8,
+        };
+        return new Promise((resolve) => {
+          setTimeout(
+            () => resolve({ runsCompleted: 8, metricFrames: [frame] }),
+            120,
+          );
+        });
       },
     }),
     [experiments, selectedExperiment, selectedExperimentId],

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/sweep-surface.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/sweep-surface.tsx
@@ -48,12 +48,15 @@ const controlsStyle = css({
   alignItems: "center",
   gap: "2",
   flexWrap: "wrap",
+  // Compact inline controls; the ds Select otherwise stretches to the row.
+  "& [data-scope='select']": { width: "[170px]" },
 });
 
 const controlLabelStyle = css({
   fontSize: "xs",
   fontWeight: "medium",
   color: "neutral.s120",
+  flexShrink: 0,
 });
 
 const canvasFrameStyle = css({

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/sweep-surface.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/sweep-surface.tsx
@@ -1,0 +1,396 @@
+/**
+ * The sweep surface: an Optuna-style filled contour of one metric's final
+ * value over two swept parameters, filling in live as combinations are
+ * sampled.
+ *
+ * The view drives the sampling: while it is open, it walks the X×Y grid
+ * coarse-to-fine through the sweep's background lane (8 runs per cell), so
+ * the coarse shape of the surface appears within the first few cells and
+ * sharpens from there. Parameters outside the two shown axes stay at the
+ * navigator's values — moving them restarts the walk for the new slice, the
+ * navigator's own refinements flow in as deeper samples of their cells, and
+ * clicking the surface moves the navigator to the nearest combination.
+ */
+import { use, useEffect, useRef, useState } from "react";
+
+import { Select } from "@hashintel/ds-components";
+import { css } from "@hashintel/ds-helpers/css";
+
+import { ExperimentsContext } from "../../../../../../react/experiments/context";
+import {
+  bluesColor,
+  coarseToFineOrder,
+  contourLevels,
+  idwRaster,
+  marchingSquaresSegments,
+  sweepCellObjective,
+} from "../../../../../../react/experiments/contour-grid";
+import { useElementSize } from "../../../../../../react/hooks/use-element-size";
+
+import type { ExperimentRecord } from "../../../../../../react/experiments/context";
+import type { ContourSample } from "../../../../../../react/experiments/contour-grid";
+import type { ExperimentParameterAxis } from "../../../../../../react/experiments/parameter-grid";
+
+/** Runs a surface cell needs before its point appears. */
+const SURFACE_CELL_RUNS = 8;
+
+/** Raster resolution per grid cell, in pixels of interpolation lattice. */
+const RASTER_SUBDIVISION = 8;
+
+const surfaceStyle = css({
+  display: "flex",
+  flexDirection: "column",
+  gap: "2",
+});
+
+const controlsStyle = css({
+  display: "flex",
+  alignItems: "center",
+  gap: "2",
+  flexWrap: "wrap",
+});
+
+const controlLabelStyle = css({
+  fontSize: "xs",
+  fontWeight: "medium",
+  color: "neutral.s120",
+});
+
+const canvasFrameStyle = css({
+  position: "relative",
+  borderWidth: "[1px]",
+  borderStyle: "solid",
+  borderColor: "neutral.bd.subtle",
+  borderRadius: "md",
+  overflow: "hidden",
+  backgroundColor: "neutral.s00",
+});
+
+const canvasStyle = css({
+  display: "block",
+  width: "[100%]",
+  height: "[280px]",
+  cursor: "crosshair",
+});
+
+const captionStyle = css({
+  fontSize: "xs",
+  color: "neutral.s80",
+  fontVariantNumeric: "tabular-nums",
+});
+
+type SurfaceValues = ReadonlyMap<string, number>;
+
+function surfaceCellKey(xIndex: number, yIndex: number): string {
+  return `${xIndex},${yIndex}`;
+}
+
+/** The navigator's values for every axis not shown on the surface. */
+function fixedValuesKey(
+  experiment: ExperimentRecord,
+  xAxis: string,
+  yAxis: string,
+): string {
+  return experiment.parameterAxes
+    .filter((axis) => axis.identifier !== xAxis && axis.identifier !== yAxis)
+    .map(
+      (axis) =>
+        `${axis.identifier}=${experiment.sweep?.selection[axis.identifier] ?? 0}`,
+    )
+    .join("|");
+}
+
+function drawSurface(options: {
+  canvas: HTMLCanvasElement;
+  width: number;
+  height: number;
+  xAxis: ExperimentParameterAxis;
+  yAxis: ExperimentParameterAxis;
+  values: SurfaceValues;
+}): void {
+  const { canvas, width, height, xAxis, yAxis, values } = options;
+  const pixelRatio = globalThis.devicePixelRatio || 1;
+  canvas.width = Math.max(1, Math.round(width * pixelRatio));
+  canvas.height = Math.max(1, Math.round(height * pixelRatio));
+  const context = canvas.getContext("2d");
+  if (!context) {
+    return;
+  }
+  context.scale(pixelRatio, pixelRatio);
+  context.clearRect(0, 0, width, height);
+
+  const samples: ContourSample[] = [];
+  for (const [key, value] of values) {
+    const [x = 0, y = 0] = key.split(",").map(Number);
+    samples.push({ x, y, value });
+  }
+  if (samples.length === 0) {
+    return;
+  }
+
+  const nx = xAxis.values.length;
+  const ny = yAxis.values.length;
+  const rasterWidth = Math.max(2, (nx - 1) * RASTER_SUBDIVISION + 1);
+  const rasterHeight = Math.max(2, (ny - 1) * RASTER_SUBDIVISION + 1);
+  const raster = idwRaster({
+    samples,
+    nx,
+    ny,
+    width: rasterWidth,
+    height: rasterHeight,
+  });
+
+  let min = Number.POSITIVE_INFINITY;
+  let max = Number.NEGATIVE_INFINITY;
+  for (const sample of samples) {
+    min = Math.min(min, sample.value);
+    max = Math.max(max, sample.value);
+  }
+
+  const cellWidth = width / (rasterWidth - 1);
+  const cellHeight = height / (rasterHeight - 1);
+  const span = max - min;
+
+  // Filled bands: each raster point painted by its normalized value.
+  for (let py = 0; py < rasterHeight - 1; py++) {
+    for (let px = 0; px < rasterWidth - 1; px++) {
+      const value = raster[py * rasterWidth + px]!;
+      context.fillStyle = bluesColor(span > 0 ? (value - min) / span : 0.5);
+      context.fillRect(
+        px * cellWidth,
+        py * cellHeight,
+        cellWidth + 1,
+        cellHeight + 1,
+      );
+    }
+  }
+
+  // Iso-lines over the fill.
+  if (span > 0) {
+    context.strokeStyle = "rgba(15, 23, 42, 0.35)";
+    context.lineWidth = 1;
+    for (const level of contourLevels(min, max, 10)) {
+      context.beginPath();
+      for (const [x1, y1, x2, y2] of marchingSquaresSegments(
+        raster,
+        rasterWidth,
+        rasterHeight,
+        level,
+      )) {
+        context.moveTo(x1 * cellWidth, y1 * cellHeight);
+        context.lineTo(x2 * cellWidth, y2 * cellHeight);
+      }
+      context.stroke();
+    }
+  }
+
+  // Sampled points, so it is visible where data actually exists.
+  const pointX = (x: number): number => (x / Math.max(nx - 1, 1)) * width;
+  const pointY = (y: number): number =>
+    height - (y / Math.max(ny - 1, 1)) * height;
+  for (const sample of samples) {
+    context.beginPath();
+    context.arc(pointX(sample.x), pointY(sample.y), 2.5, 0, Math.PI * 2);
+    context.fillStyle = "rgba(15, 23, 42, 0.75)";
+    context.fill();
+    context.strokeStyle = "rgba(255, 255, 255, 0.9)";
+    context.lineWidth = 1;
+    context.stroke();
+  }
+}
+
+export const SweepSurface = ({
+  experiment,
+}: {
+  experiment: ExperimentRecord;
+}) => {
+  const { sampleSweepCell, setSweepSelection } = use(ExperimentsContext);
+  const axes = experiment.parameterAxes;
+  const [xAxisId, setXAxisId] = useState(axes[0]?.identifier ?? "");
+  const [yAxisId, setYAxisId] = useState(axes[1]?.identifier ?? "");
+  const [metricId, setMetricId] = useState(experiment.metricSpecs[0]?.id ?? "");
+  const [cellValues, setCellValues] = useState<SurfaceValues>(new Map());
+  const [walkKey, setWalkKey] = useState("");
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const frameRef = useRef<HTMLDivElement>(null);
+  const size = useElementSize(frameRef, { debounce: 50 });
+
+  const xAxis = axes.find((axis) => axis.identifier === xAxisId);
+  const yAxis = axes.find((axis) => axis.identifier === yAxisId);
+  const slice = fixedValuesKey(experiment, xAxisId, yAxisId);
+  const experimentId = experiment.id;
+  const sweepSelection = experiment.sweep?.selection;
+
+  // A new slice/axes/metric identity restarts the walk; clearing the sampled
+  // values during render (not in the effect) repaints without a stale frame.
+  const nextWalkKey = `${experimentId}|${xAxisId}|${yAxisId}|${metricId}|${slice}`;
+  if (walkKey !== nextWalkKey) {
+    setWalkKey(nextWalkKey);
+    setCellValues(new Map());
+  }
+
+  // The sampling walk: restarts whenever the slice, the shown axes, or the
+  // metric changes; stops when the section unmounts.
+  useEffect(() => {
+    if (!xAxis || !yAxis || xAxis === yAxis || metricId === "") {
+      return;
+    }
+    const walk: { stale: boolean } = { stale: false };
+    // Read through a call so the flow analysis cannot pin the flag to its
+    // initial value: cleanup flips it from outside this closure.
+    const isWalkStale = () => walk.stale;
+
+    const fixedEntries = Object.entries(
+      Object.fromEntries(
+        slice
+          .split("|")
+          .filter((entry) => entry !== "")
+          .map((entry) => entry.split("=") as [string, string]),
+      ),
+    );
+
+    const run = async () => {
+      for (const cell of coarseToFineOrder(
+        xAxis.values.length,
+        yAxis.values.length,
+      )) {
+        if (isWalkStale()) {
+          return;
+        }
+        const parameterValues: Record<string, number> = {
+          [xAxis.identifier]: xAxis.values[cell.x]!,
+          [yAxis.identifier]: yAxis.values[cell.y]!,
+        };
+        for (const [identifier, indexText] of fixedEntries) {
+          const axis = axes.find((it) => it.identifier === identifier);
+          if (axis) {
+            parameterValues[identifier] = axis.values[Number(indexText)]!;
+          }
+        }
+
+        const snapshot = await sampleSweepCell(
+          experimentId,
+          parameterValues,
+          SURFACE_CELL_RUNS,
+        );
+        if (isWalkStale()) {
+          return;
+        }
+        if (snapshot) {
+          const value = sweepCellObjective(snapshot.metricFrames, metricId);
+          if (value !== null) {
+            setCellValues((previous) => {
+              const next = new Map(previous);
+              next.set(surfaceCellKey(cell.x, cell.y), value);
+              return next;
+            });
+          }
+        }
+      }
+    };
+    void run();
+
+    return () => {
+      walk.stale = true;
+    };
+  }, [axes, experimentId, metricId, sampleSweepCell, slice, xAxis, yAxis]);
+
+  // Painting is imperative canvas work driven by measured size — outside
+  // React's render, same as the uPlot charts.
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || !xAxis || !yAxis || !size || size.width === 0) {
+      return;
+    }
+    drawSurface({
+      canvas,
+      width: size.width,
+      height: 280,
+      xAxis,
+      yAxis,
+      values: cellValues,
+    });
+  }, [cellValues, size, xAxis, yAxis]);
+
+  if (axes.length < 2 || !experiment.sweep) {
+    return null;
+  }
+
+  const axisOptions = axes.map((axis) => ({
+    value: axis.identifier,
+    text: axis.identifier,
+  }));
+  const metricOptions = experiment.metricSpecs.map((spec) => ({
+    value: spec.id,
+    text: spec.label,
+  }));
+
+  const handleCanvasClick = (event: React.MouseEvent<HTMLCanvasElement>) => {
+    if (!xAxis || !yAxis || !sweepSelection) {
+      return;
+    }
+    const bounds = event.currentTarget.getBoundingClientRect();
+    const relativeX = (event.clientX - bounds.left) / bounds.width;
+    const relativeY = 1 - (event.clientY - bounds.top) / bounds.height;
+    const xIndex = Math.round(relativeX * (xAxis.values.length - 1));
+    const yIndex = Math.round(relativeY * (yAxis.values.length - 1));
+    setSweepSelection(experimentId, {
+      ...sweepSelection,
+      [xAxis.identifier]: Math.min(
+        Math.max(xIndex, 0),
+        xAxis.values.length - 1,
+      ),
+      [yAxis.identifier]: Math.min(
+        Math.max(yIndex, 0),
+        yAxis.values.length - 1,
+      ),
+    });
+  };
+
+  const sampledCount = cellValues.size;
+  const totalCells = (xAxis?.values.length ?? 0) * (yAxis?.values.length ?? 0);
+
+  return (
+    <div className={surfaceStyle}>
+      <div className={controlsStyle}>
+        <span className={controlLabelStyle}>X</span>
+        <Select
+          size="xs"
+          aria-label="Surface X parameter"
+          items={axisOptions.filter((option) => option.value !== yAxisId)}
+          value={xAxisId}
+          onChange={(value) => setXAxisId(value ?? "")}
+        />
+        <span className={controlLabelStyle}>Y</span>
+        <Select
+          size="xs"
+          aria-label="Surface Y parameter"
+          items={axisOptions.filter((option) => option.value !== xAxisId)}
+          value={yAxisId}
+          onChange={(value) => setYAxisId(value ?? "")}
+        />
+        <span className={controlLabelStyle}>Metric</span>
+        <Select
+          size="xs"
+          aria-label="Surface metric"
+          items={metricOptions}
+          value={metricId}
+          onChange={(value) => setMetricId(value ?? "")}
+        />
+      </div>
+      <div className={canvasFrameStyle} ref={frameRef}>
+        <canvas
+          ref={canvasRef}
+          className={canvasStyle}
+          onClick={handleCanvasClick}
+          aria-label="Objective surface over the two selected parameters; click to move the navigator"
+        />
+      </div>
+      <span className={captionStyle}>
+        {sampledCount} of {totalCells} combinations sampled at{" "}
+        {SURFACE_CELL_RUNS}+ runs — click the surface to move the navigator.
+        Other parameters stay at their navigator values.
+      </span>
+    </div>
+  );
+};

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/view-experiment-drawer.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/view-experiment-drawer.tsx
@@ -16,6 +16,7 @@ import {
 } from "./experiment-metric-timeline";
 import { formatDurationMs } from "./format-duration";
 import { SweepNavigator } from "./sweep-navigator";
+import { SweepSurface } from "./sweep-surface";
 
 /**
  * Which backend ran an experiment.
@@ -392,6 +393,16 @@ export const ViewExperimentDrawer = ({
           {experiment.metricFrames.length > 0 ? (
             <Section title="Metrics" collapsible defaultOpen>
               <ExperimentMetrics experiment={experiment} />
+            </Section>
+          ) : null}
+          {experiment.sweep && experiment.parameterAxes.length >= 2 ? (
+            <Section
+              title="Surface"
+              tooltip="One metric's final value over two swept parameters, sampled progressively at 8 runs per combination. Click to move the navigator."
+              collapsible
+              defaultOpen
+            >
+              <SweepSurface experiment={experiment} />
             </Section>
           ) : null}
         </SectionList>

--- a/libs/@local/petrinaut-arch-docs/content/diagrams/sweep-surface-feed.d2
+++ b/libs/@local/petrinaut-arch-docs/content/diagrams/sweep-surface-feed.d2
@@ -1,0 +1,15 @@
+# Hand-written; rendered by the arch-docs build. Palette matches src/emit/d2.ts.
+direction: right
+
+surface: "surface view\n(X, Y, metric picks;\nclick moves the navigator)" {style.fill: "#e2f4e8"; style.stroke: "#3d8055"}
+walk: "coarse-to-fine walk\n(corners, midpoints,\nthen the rest)" {style.fill: "#e2f4e8"; style.stroke: "#3d8055"}
+lane: "background lane\n(serialized 8-run batches,\none worker)" {style.fill: "#e8e0ff"; style.stroke: "#7051b5"}
+cache: "combination cache\n(shared with the navigator)" {style.fill: "#e8e0ff"; style.stroke: "#7051b5"}
+contour: "contour raster\n(IDW + marching squares,\nBlues ramp)" {style.fill: "#e2f4e8"; style.stroke: "#3d8055"}
+
+surface -> walk: slice fixed by the\nnavigator's other axes
+walk -> lane: sampleCell(values, 8)
+lane -> cache: fold batch
+cache -> lane: already deep enough?\nresolve from cache {style.stroke-dash: 4}
+lane -> surface: snapshot per cell
+surface -> contour: objective per cell,\nredrawn as cells land

--- a/libs/@local/petrinaut-arch-docs/content/experiments/sweep-surface.mdx
+++ b/libs/@local/petrinaut-arch-docs/content/experiments/sweep-surface.mdx
@@ -1,0 +1,42 @@
+---
+title: The sweep surface
+description: How the contour view samples its grid without stealing the navigator's compute, and why the interpolation is IDW.
+sidebar_order: 30
+attachTo: react.experiments
+---
+
+The surface view shows one metric's final value over two swept parameters as
+a filled contour, Optuna-style. It is fed by the same combination cache the
+[navigator](doc:experiments/parameter-sweeps) refines — a cell sampled for
+the surface and a cell the navigator visited are the same cell.
+
+![How the surface fills](@diagrams/sweep-surface-feed.svg)
+
+## The view drives the sampling
+
+While the section is open, the component walks the X×Y grid coarse-to-fine —
+corners and lattice midpoints before their neighbours — requesting eight runs
+per combination through the session's background lane. The lane serializes
+its batches and gives each a single worker, so the navigator's sharded batch
+keeps the cores; a cell the navigator already refined resolves straight from
+cache. Parameters outside the two shown axes stay at the navigator's values,
+and changing any of them (or the axes, or the metric) restarts the walk for
+the new slice.
+
+## Rendering sparse data honestly
+
+At any moment most cells are unsampled, so the picture must make sense at
+every stage. Inverse distance weighting over the sampled points gives smooth
+blobs around the first few samples that converge to the surface as cells
+land; marching squares over that raster draws the iso-lines, and sampled
+combinations are marked with dots so it stays visible where data actually
+exists. All of that is pure, tested math in
+`react/experiments/contour-grid.ts`; the component only paints it onto a
+canvas, the same imperative-draw idiom the metric charts use.
+
+## Eight runs is a sketch
+
+A surface cell's value is the mean over eight runs — enough for the shape,
+not for reading precise values. Clicking a region moves the navigator to the
+nearest combination, whose ladder then refines it properly; the deeper result
+flows back into the same cache and the surface repaints with it.


### PR DESCRIPTION
> [!IMPORTANT]
> **Experimental**
> Behind the **Parameter sweeps** feature flag.

## Summary

Before this PR, a sweep's results drawer shows one combination at a time. Navigator selects it and its metric charts stream. There is no view of a metric across the swept grid.

A sweep with two or more swept parameters gains a **Surface** section under its metrics: a filled contour of one metric's final value over two chosen parameters, in the style of Optuna's `plot_contour`. Every other parameter is held at its navigator value. Plot fills in live as the view walks the X×Y grid coarse-to-fine at 8 runs per combination. Clicking the surface moves the navigator to the nearest combination, whose ladder then refines it.

## Links

- Ticket [FE-1513](https://linear.app/hash/issue/FE-1513)
- Reference [Optuna plot_contour](https://optuna.readthedocs.io/en/stable/tutorial/10_key_features/005_visualization.html)
- Docs [Sweep surface](https://petrinaut-docs-git-cf-fe-1513-contour-plot-over-two-swep-f78e64.stage.hash.ai/architecture/react/experiments/sweep-surface)
- Docs [Experiments](https://github.com/hashintel/hash/blob/cf/fe-1513-contour-plot-over-two-swept-parameters-navigable-in-real/libs/@hashintel/petrinaut/docs/experiments.md)

## Changes

#### UI

- `sweep-surface.tsx` adds pickers, canvas, click-to-navigate, and caption
  > X/Y/metric pickers, a canvas the pure module paints, and a caption counting sampled combinations.
  > Canvas is device-pixel aware and dots sampled combinations.
  > Walk restarts when the slice, axes, or metric changes.
  > Unmounting stops it.
- Context gains `sampleSweepCell(experimentId, values, minRuns)`
  > Delegates to the session.

#### Contour grid and sampling

- New pure module `react/experiments/contour-grid.ts` holds the surface maths
  > Inverse-distance-weighted rasterization, marching-squares iso-lines with saddle resolution, the ColorBrewer Blues ramp, the coarse-to-fine sampling order, and final-frame objective extraction.
  > Rasterization reads sensibly at every fill stage, from blobs around the first samples converging to the surface.
  > Sampling order takes corners and lattice midpoints first.
- `react/experiments/sweep-session.ts` gains a background sampling lane
  > `sampleCell(values, minRuns)` brings any combination up to a minimum run count with serialized batches of one CPU worker each, under the same seed-ladder rule, so the navigator's sharded batch keeps the cores.
  > A cell sampled here and later visited by the navigator resumes the identical run sequence into the same cache.
- Navigator lane now calls `handle.start()`
  > It never did. Hand-driven test fakes hid it and now refuse to stream before start.

## Test coverage

- `contour-grid.test.ts`, 10 tests:
  > Sampling order coverage and priority, IDW exactness at samples and single-sample flatness, marching squares on a ramp, level placement, ramp endpoints, objective extraction from final frames.
- `sweep-session.test.ts`, two new tests:
  > Background batches serialize on the same seed ladder with `background: true`.
  > Cells already deep enough resolve from cache with no batch.
- Verified live in Storybook:
  > Progressive fill with a 49/50 mid-walk caption, iso-lines and sample dots, click moving the navigator from `transmission_rate 0.3` to `0.4` and `recovery_days 8` to `14`.

## How to test

- Open [Petrinaut preview](https://petrinaut-git-cf-fe-1513-contour-plot-over-two-swept-par-d9fec6.stage.hash.ai) on Vercel
- Viewport controls > Settings > Simulation > Parameter sweeps
- Load example, select scenario with at least two numeric parameters
- Simulate > Experiments > Create
- Flip Sweep on two parameters, Run
- Open experiment, scroll to Surface
- Expect contour to fill in over a few seconds
- Click around surface
- Expect Parameters strip to follow
- Change X, Y, or metric
- Expect fill to restart
