### PR TITLE
H-6763: Add the voice interview experience

### DIFF
--- a/.changeset/stable-composer-controls.md
+++ b/.changeset/stable-composer-controls.md
@@ -6,4 +6,6 @@ Add generic host-rendered AI composer controls and a persistent interview stage 
 detached placements, protected active conversations, keyboard fallback, and one-answer buffering
 while the normal chat stream settles. Include stable finalized-text submission, conversation
 identity, stop handling, schema-validated interactive-tool text mapping, explicit separate-message
-targeting for corrections, and a queue-aware voice submission path.
+targeting for corrections, and a queue-aware voice submission path. Add the Chat / Interview mode
+switch and export `PetrinautAiInteractionMode`, with the selected interaction mode and mode-change
+callback available to host-rendered interview stages.

--- a/.changeset/stable-composer-controls.md
+++ b/.changeset/stable-composer-controls.md
@@ -8,7 +8,10 @@ while the normal chat stream settles. Include stable finalized-text submission, 
 identity, stop handling, schema-validated interactive-tool text mapping, explicit separate-message
 targeting for corrections, and a queue-aware voice submission path. Add the Chat / Interview mode
 switch and export `PetrinautAiInteractionMode`, with the selected interaction mode and mode-change
-callback available to host-rendered interview stages.
+callback available to host-rendered interview stages. `renderComposerControl` remains a supported
+public seam for hosts that only need their own control beside the message box, independently of the
+interview stage.
 
-Simplify Interview mode with a circular microphone waveform, compact recording/sent transcript
-states, phase-specific icon controls, and focused reconnect recovery.
+Simplify Interview mode with a circular microphone waveform, compact transcript states that
+distinguish recording, sending, sent, and undelivered answers, phase-specific icon controls, and
+recovery that names the kind of failure before offering reconnect.

--- a/.changeset/stable-composer-controls.md
+++ b/.changeset/stable-composer-controls.md
@@ -2,7 +2,8 @@
 "@hashintel/petrinaut": patch
 ---
 
-Add a generic host-rendered AI composer control with stable finalized-text submission,
-conversation identity, stop handling, schema-validated interactive-tool text mapping, and an
-explicit separate-message target for corrections. Add a queue-aware voice submission path so a
-finalized spoken turn is retained while another response settles.
+Add generic host-rendered AI composer controls and a persistent interview stage with docked and
+detached placements, protected active conversations, keyboard fallback, and one-answer buffering
+while the normal chat stream settles. Include stable finalized-text submission, conversation
+identity, stop handling, schema-validated interactive-tool text mapping, explicit separate-message
+targeting for corrections, and a queue-aware voice submission path.

--- a/.changeset/stable-composer-controls.md
+++ b/.changeset/stable-composer-controls.md
@@ -9,3 +9,6 @@ identity, stop handling, schema-validated interactive-tool text mapping, explici
 targeting for corrections, and a queue-aware voice submission path. Add the Chat / Interview mode
 switch and export `PetrinautAiInteractionMode`, with the selected interaction mode and mode-change
 callback available to host-rendered interview stages.
+
+Simplify Interview mode with a circular microphone waveform, compact recording/sent transcript
+states, phase-specific icon controls, and focused reconnect recovery.

--- a/apps/petrinaut-website/README.md
+++ b/apps/petrinaut-website/README.md
@@ -84,7 +84,6 @@ the server initializes an OpenAI transcription-only Realtime session and keeps
 the provider key, model, language, and vocabulary policy private. The session
 uses `gpt-live-transcribe`'s default server VAD because OpenAI's unified call
 currently times out when explicit turn detection is included during setup.
-Partial transcript updates do not close the microphone.
 
 Only finalized transcripts enter the existing Petrinaut composer and Brunch AI
 SDK transport. Partial transcripts remain display-only. The preview derives a

--- a/apps/petrinaut-website/README.md
+++ b/apps/petrinaut-website/README.md
@@ -84,6 +84,7 @@ the server initializes an OpenAI transcription-only Realtime session and keeps
 the provider key, model, language, and vocabulary policy private. The session
 uses `gpt-live-transcribe`'s default server VAD because OpenAI's unified call
 currently times out when explicit turn detection is included during setup.
+Partial transcript updates do not close the microphone.
 
 Only finalized transcripts enter the existing Petrinaut composer and Brunch AI
 SDK transport. Partial transcripts remain display-only. The preview derives a

--- a/apps/petrinaut-website/src/main/app/brunch-sweep-output.ts
+++ b/apps/petrinaut-website/src/main/app/brunch-sweep-output.ts
@@ -1,0 +1,69 @@
+import { z } from "zod";
+
+const completionFailureSchema = z.object({
+  diagnostic: z.string(),
+  nodeId: z.string().optional(),
+  kind: z.string().optional(),
+  slot: z.string().optional(),
+  requirement: z.string(),
+  actual: z.string(),
+  message: z.string(),
+  captureIds: z.array(z.string()),
+});
+
+const completionReportSchema = z.object({
+  complete: z.boolean(),
+  pluginVersion: z.string(),
+  revision: z.string(),
+  failures: z.array(completionFailureSchema),
+  sliceNodeIds: z.array(z.string()),
+  outsideSlice: z.array(
+    z.object({
+      nodeId: z.string(),
+      kind: z.string(),
+      open: z.array(completionFailureSchema),
+    }),
+  ),
+});
+
+const captureSchema = z.object({
+  id: z.string(),
+  status: z.enum(["active", "superseded", "retracted"]),
+  epistemicStatus: z.string(),
+  confidence: z.string(),
+  content: z.union([
+    z.object({ value: z.unknown() }),
+    z.object({ absence: z.string() }),
+  ]),
+  evidence: z.array(z.object({ excerpt: z.string() })).optional(),
+  basis: z
+    .object({
+      type: z.string(),
+      description: z.string(),
+    })
+    .optional(),
+  alternativeGroup: z.string().optional(),
+  supersedes: z.string().optional(),
+});
+
+/** Shape of the Brunch sweep client tool's output, as read by the app. */
+export const sweepOutputSchema = z.discriminatedUnion("status", [
+  z.object({ status: z.literal("no-settled-range") }),
+  z.object({
+    status: z.literal("refused"),
+    refusal: z.object({
+      code: z.string(),
+      message: z.string(),
+    }),
+  }),
+  z.object({
+    status: z.literal("applied"),
+    appliedCaptureIds: z.array(z.string()),
+    captures: z.array(captureSchema),
+    completion: completionReportSchema.optional(),
+  }),
+]);
+
+export type SweepCompletionFailure = z.infer<typeof completionFailureSchema>;
+export type SweepCompletionReport = z.infer<typeof completionReportSchema>;
+export type SweepCapture = z.infer<typeof captureSchema>;

--- a/apps/petrinaut-website/src/main/app/local-storage-demo/brunch-panel-transport.ts
+++ b/apps/petrinaut-website/src/main/app/local-storage-demo/brunch-panel-transport.ts
@@ -1,78 +1,16 @@
-import { z } from "zod";
-
 import { SWEEP_TOOL_NAME } from "@hashintel/brunch-agent-transport-aisdk/client-tools";
 
+import { sweepOutputSchema } from "../brunch-sweep-output";
+
+import type {
+  SweepCapture,
+  SweepCompletionFailure,
+  SweepCompletionReport,
+} from "../brunch-sweep-output";
 import type { PetrinautAiChatTransport } from "@hashintel/petrinaut/ui";
 import type { UIMessageChunk } from "ai";
 
-const completionFailureSchema = z.object({
-  diagnostic: z.string(),
-  nodeId: z.string().optional(),
-  kind: z.string().optional(),
-  slot: z.string().optional(),
-  requirement: z.string(),
-  actual: z.string(),
-  message: z.string(),
-  captureIds: z.array(z.string()),
-});
-
-const completionReportSchema = z.object({
-  complete: z.boolean(),
-  pluginVersion: z.string(),
-  revision: z.string(),
-  failures: z.array(completionFailureSchema),
-  sliceNodeIds: z.array(z.string()),
-  outsideSlice: z.array(
-    z.object({
-      nodeId: z.string(),
-      kind: z.string(),
-      open: z.array(completionFailureSchema),
-    }),
-  ),
-});
-
-const captureSchema = z.object({
-  id: z.string(),
-  status: z.enum(["active", "superseded", "retracted"]),
-  epistemicStatus: z.string(),
-  confidence: z.string(),
-  content: z.union([
-    z.object({ value: z.unknown() }),
-    z.object({ absence: z.string() }),
-  ]),
-  evidence: z.array(z.object({ excerpt: z.string() })).optional(),
-  basis: z
-    .object({
-      type: z.string(),
-      description: z.string(),
-    })
-    .optional(),
-  alternativeGroup: z.string().optional(),
-  supersedes: z.string().optional(),
-});
-
-export const sweepOutputSchema = z.discriminatedUnion("status", [
-  z.object({ status: z.literal("no-settled-range") }),
-  z.object({
-    status: z.literal("refused"),
-    refusal: z.object({
-      code: z.string(),
-      message: z.string(),
-    }),
-  }),
-  z.object({
-    status: z.literal("applied"),
-    appliedCaptureIds: z.array(z.string()),
-    captures: z.array(captureSchema),
-    completion: completionReportSchema.optional(),
-  }),
-]);
-
-type CompletionFailure = z.infer<typeof completionFailureSchema>;
-type CompletionReport = z.infer<typeof completionReportSchema>;
-type VisibleCapture = z.infer<typeof captureSchema>;
-
-const formatFailure = (failure: CompletionFailure): string => {
+const formatFailure = (failure: SweepCompletionFailure): string => {
   const location =
     failure.nodeId === undefined
       ? ""
@@ -84,7 +22,7 @@ const formatFailure = (failure: CompletionFailure): string => {
   return `Completion gap [${failure.diagnostic}]${location}: needs ${failure.requirement}; actual ${failure.actual}. ${failure.message}${captures}`;
 };
 
-const formatCapture = (capture: VisibleCapture): string => {
+const formatCapture = (capture: SweepCapture): string => {
   const content =
     "value" in capture.content
       ? JSON.stringify(capture.content.value)
@@ -106,7 +44,7 @@ const formatCapture = (capture: VisibleCapture): string => {
   return `Capture ${capture.id} (${capture.status}; ${capture.epistemicStatus}; confidence ${capture.confidence}): ${content} — ${provenance}${history.length === 0 ? "" : `; ${history.join("; ")}`}`;
 };
 
-const formatCompletion = (report: CompletionReport): string[] => [
+const formatCompletion = (report: SweepCompletionReport): string[] => [
   `Completion: ${report.complete ? "complete" : "incomplete"} · plugin ${report.pluginVersion} · revision ${report.revision}`,
   `Completion slice: ${report.sliceNodeIds.join(", ") || "none"}`,
   ...report.failures.map(formatFailure),

--- a/apps/petrinaut-website/src/main/app/local-storage-demo/brunch-panel-transport.ts
+++ b/apps/petrinaut-website/src/main/app/local-storage-demo/brunch-panel-transport.ts
@@ -1,4 +1,192 @@
+import { z } from "zod";
+
+import { SWEEP_TOOL_NAME } from "@hashintel/brunch-agent-transport-aisdk/client-tools";
+
 import type { PetrinautAiChatTransport } from "@hashintel/petrinaut/ui";
+import type { UIMessageChunk } from "ai";
+
+const completionFailureSchema = z.object({
+  diagnostic: z.string(),
+  nodeId: z.string().optional(),
+  kind: z.string().optional(),
+  slot: z.string().optional(),
+  requirement: z.string(),
+  actual: z.string(),
+  message: z.string(),
+  captureIds: z.array(z.string()),
+});
+
+const completionReportSchema = z.object({
+  complete: z.boolean(),
+  pluginVersion: z.string(),
+  revision: z.string(),
+  failures: z.array(completionFailureSchema),
+  sliceNodeIds: z.array(z.string()),
+  outsideSlice: z.array(
+    z.object({
+      nodeId: z.string(),
+      kind: z.string(),
+      open: z.array(completionFailureSchema),
+    }),
+  ),
+});
+
+const captureSchema = z.object({
+  id: z.string(),
+  status: z.enum(["active", "superseded", "retracted"]),
+  epistemicStatus: z.string(),
+  confidence: z.string(),
+  content: z.union([
+    z.object({ value: z.unknown() }),
+    z.object({ absence: z.string() }),
+  ]),
+  evidence: z.array(z.object({ excerpt: z.string() })).optional(),
+  basis: z
+    .object({
+      type: z.string(),
+      description: z.string(),
+    })
+    .optional(),
+  alternativeGroup: z.string().optional(),
+  supersedes: z.string().optional(),
+});
+
+export const sweepOutputSchema = z.discriminatedUnion("status", [
+  z.object({ status: z.literal("no-settled-range") }),
+  z.object({
+    status: z.literal("refused"),
+    refusal: z.object({
+      code: z.string(),
+      message: z.string(),
+    }),
+  }),
+  z.object({
+    status: z.literal("applied"),
+    appliedCaptureIds: z.array(z.string()),
+    captures: z.array(captureSchema),
+    completion: completionReportSchema.optional(),
+  }),
+]);
+
+type CompletionFailure = z.infer<typeof completionFailureSchema>;
+type CompletionReport = z.infer<typeof completionReportSchema>;
+type VisibleCapture = z.infer<typeof captureSchema>;
+
+const formatFailure = (failure: CompletionFailure): string => {
+  const location =
+    failure.nodeId === undefined
+      ? ""
+      : ` at ${failure.nodeId}${failure.slot === undefined ? "" : `.${failure.slot}`}`;
+  const captures =
+    failure.captureIds.length === 0
+      ? ""
+      : ` Captures: ${failure.captureIds.join(", ")}`;
+  return `Completion gap [${failure.diagnostic}]${location}: needs ${failure.requirement}; actual ${failure.actual}. ${failure.message}${captures}`;
+};
+
+const formatCapture = (capture: VisibleCapture): string => {
+  const content =
+    "value" in capture.content
+      ? JSON.stringify(capture.content.value)
+      : `absence: ${capture.content.absence}`;
+  const provenance =
+    capture.evidence !== undefined
+      ? capture.evidence.map((evidence) => `“${evidence.excerpt}”`).join("; ")
+      : capture.basis === undefined
+        ? "no provenance"
+        : `${capture.basis.type}: ${capture.basis.description}`;
+  const history = [
+    capture.alternativeGroup === undefined
+      ? undefined
+      : `alternative group ${capture.alternativeGroup}`,
+    capture.supersedes === undefined
+      ? undefined
+      : `supersedes ${capture.supersedes}`,
+  ].filter((fact) => fact !== undefined);
+  return `Capture ${capture.id} (${capture.status}; ${capture.epistemicStatus}; confidence ${capture.confidence}): ${content} — ${provenance}${history.length === 0 ? "" : `; ${history.join("; ")}`}`;
+};
+
+const formatCompletion = (report: CompletionReport): string[] => [
+  `Completion: ${report.complete ? "complete" : "incomplete"} · plugin ${report.pluginVersion} · revision ${report.revision}`,
+  `Completion slice: ${report.sliceNodeIds.join(", ") || "none"}`,
+  ...report.failures.map(formatFailure),
+  ...report.outsideSlice.flatMap((node) => [
+    `Outside completion slice: ${node.nodeId} (${node.kind}); ${node.open.length} open requirement${node.open.length === 1 ? "" : "s"}`,
+    ...node.open.map((failure) => `Outside-slice ${formatFailure(failure)}`),
+  ]),
+];
+
+const summarizeSweepOutput = (
+  output: unknown,
+):
+  | {
+      readonly title: string;
+      readonly detail: string;
+      readonly items?: readonly string[];
+    }
+  | undefined => {
+  const parsed = sweepOutputSchema.safeParse(output);
+  if (!parsed.success) return undefined;
+
+  const sweep = parsed.data;
+  switch (sweep.status) {
+    case "no-settled-range":
+      return {
+        title: "No settled range to sweep",
+        detail: "The conversation has no settled user entries.",
+      };
+    case "refused":
+      return {
+        title: "Sweep refused",
+        detail: sweep.refusal.message,
+        items: [`Refusal: ${sweep.refusal.code}`],
+      };
+    case "applied":
+      return {
+        title: "Sweep applied",
+        detail: `${sweep.appliedCaptureIds.length} new capture${sweep.appliedCaptureIds.length === 1 ? "" : "s"} · ${sweep.captures.length} total · ${sweep.completion?.complete === true ? "complete" : "incomplete"}`,
+        items: [
+          ...sweep.captures.map(formatCapture),
+          ...(sweep.completion === undefined
+            ? []
+            : formatCompletion(sweep.completion)),
+        ],
+      };
+  }
+};
+
+const decorateBrunchStream = (
+  stream: ReadableStream<UIMessageChunk>,
+): ReadableStream<UIMessageChunk> => {
+  const toolNamesByCallId = new Map<string, string>();
+  return stream.pipeThrough(
+    new TransformStream({
+      transform(chunk, controller) {
+        if (chunk.type === "tool-input-available") {
+          toolNamesByCallId.set(chunk.toolCallId, chunk.toolName);
+        }
+        if (
+          chunk.type === "tool-output-available" &&
+          toolNamesByCallId.get(chunk.toolCallId) === SWEEP_TOOL_NAME
+        ) {
+          const summary = summarizeSweepOutput(chunk.output);
+          if (
+            summary !== undefined &&
+            typeof chunk.output === "object" &&
+            chunk.output !== null
+          ) {
+            controller.enqueue({
+              ...chunk,
+              output: { ...chunk.output, ...summary },
+            });
+            return;
+          }
+        }
+        controller.enqueue(chunk);
+      },
+    }),
+  );
+};
 
 /**
  * Pin Petrinaut's stock transport to one stable conversation id so reload,
@@ -8,8 +196,18 @@ export const createBrunchPanelTransport = (
   transport: PetrinautAiChatTransport,
   conversationId: string,
 ): PetrinautAiChatTransport => ({
-  reconnectToStream: (options) =>
-    transport.reconnectToStream({ ...options, chatId: conversationId }),
-  sendMessages: (options) =>
-    transport.sendMessages({ ...options, chatId: conversationId }),
+  reconnectToStream: async (options) => {
+    const stream = await transport.reconnectToStream({
+      ...options,
+      chatId: conversationId,
+    });
+    return stream === null ? null : decorateBrunchStream(stream);
+  },
+  sendMessages: async (options) =>
+    decorateBrunchStream(
+      await transport.sendMessages({
+        ...options,
+        chatId: conversationId,
+      }),
+    ),
 });

--- a/apps/petrinaut-website/src/main/app/local-storage-demo/local-storage-demo-app.test.tsx
+++ b/apps/petrinaut-website/src/main/app/local-storage-demo/local-storage-demo-app.test.tsx
@@ -5,7 +5,7 @@ import { isValidElement, type ReactNode } from "react";
 import { describe, expect, test, vi } from "vitest";
 
 import { VoiceInterviewControl } from "../voice-interview/voice-interview-control";
-import { getBrunchVoiceComposerControl } from "./local-storage-demo-app";
+import { getBrunchVoiceInterviewStage } from "./local-storage-demo-app";
 
 const defaultTransportOptions = vi.hoisted(() => ({
   current: null as unknown,
@@ -28,16 +28,25 @@ vi.mock("@hashintel/petrinaut/ui", () => ({
 
 describe("local storage demo Brunch voice integration", () => {
   test("does not install voice on the generic local chat fallback", () => {
-    expect(getBrunchVoiceComposerControl(false)).toBeUndefined();
+    expect(getBrunchVoiceInterviewStage(false)).toBeUndefined();
   });
 
   test("installs the app-owned voice control for a configured Brunch transport", () => {
-    const renderControl = getBrunchVoiceComposerControl(true);
+    const renderControl = getBrunchVoiceInterviewStage(true);
     const control = renderControl?.({
+      canAcceptInterviewAnswer: true,
       conversationId: "petrinaut-preview:net-1",
+      focusComposer: vi.fn(),
       messages: [],
+      openSidebar: vi.fn(),
+      placement: "sidebar",
+      setActive: vi.fn(),
       status: "ready",
       stop: vi.fn(async () => undefined),
+      submitInterviewAnswer: vi.fn(async () => ({
+        kind: "message" as const,
+        messageId: "message-1",
+      })),
       submitText: vi.fn(async () => ({
         kind: "message" as const,
         messageId: "message-1",

--- a/apps/petrinaut-website/src/main/app/local-storage-demo/local-storage-demo-app.test.tsx
+++ b/apps/petrinaut-website/src/main/app/local-storage-demo/local-storage-demo-app.test.tsx
@@ -28,19 +28,22 @@ vi.mock("@hashintel/petrinaut/ui", () => ({
 
 describe("local storage demo Brunch voice integration", () => {
   test("does not install voice on the generic local chat fallback", () => {
-    expect(getBrunchVoiceInterviewStage(false)).toBeUndefined();
+    expect(getBrunchVoiceInterviewStage(null)).toBeUndefined();
   });
 
   test("installs the app-owned voice control for a configured Brunch transport", () => {
-    const renderControl = getBrunchVoiceInterviewStage(true);
-    const control = renderControl?.({
+    const config = { available: true as const, connectionTimeoutMs: 15_000 };
+    const stage = getBrunchVoiceInterviewStage(config);
+    const control = stage?.({
       canAcceptInterviewAnswer: true,
       conversationId: "petrinaut-preview:net-1",
       focusComposer: vi.fn(),
+      interactionMode: "chat",
       messages: [],
       openSidebar: vi.fn(),
       placement: "sidebar",
       setActive: vi.fn(),
+      setInteractionMode: vi.fn(),
       status: "ready",
       stop: vi.fn(async () => undefined),
       submitInterviewAnswer: vi.fn(async () => ({
@@ -61,7 +64,10 @@ describe("local storage demo Brunch voice integration", () => {
     if (!isValidElement(control)) {
       throw new Error("Expected the configured composer control to render.");
     }
-    expect(control.type).toBe(VoiceInterviewControl);
+    expect(control).toMatchObject({
+      props: { config },
+      type: VoiceInterviewControl,
+    });
   });
 
   test("correlates the existing Brunch transport request", () => {

--- a/apps/petrinaut-website/src/main/app/local-storage-demo/local-storage-demo-app.tsx
+++ b/apps/petrinaut-website/src/main/app/local-storage-demo/local-storage-demo-app.tsx
@@ -25,7 +25,11 @@ import {
 
 import { VOICE_REQUEST_ID_HEADER } from "../../../voice-diagnostics";
 import { useSentryFeedbackAction } from "../sentry-feedback-button";
-import { VoiceInterviewControl } from "../voice-interview/voice-interview-control";
+import {
+  loadOpenAIVoiceConfig,
+  type OpenAIVoiceConfig,
+  VoiceInterviewControl,
+} from "../voice-interview/voice-interview-control";
 import { brunchAskInteractiveTool } from "./brunch-ask-interactive-tool";
 import { getOrCreateBrunchConversationId } from "./brunch-conversation-id";
 import { createBrunchPanelTransport } from "./brunch-panel-transport";
@@ -91,18 +95,14 @@ const brunchPreviewConfig = resolveBrunchPreviewConfig(
   import.meta.env.VITE_BRUNCH_CHAT_ENDPOINT,
 );
 
-const renderBrunchVoiceInterviewStage = (
-  context: PetrinautAiInterviewStageContext,
-) => <VoiceInterviewControl {...context} />;
-
 export const getBrunchVoiceInterviewStage = (
-  isBrunchConfigured: boolean,
+  config: OpenAIVoiceConfig | null | undefined,
 ): PetrinautAiInterviewStage | undefined =>
-  isBrunchConfigured ? renderBrunchVoiceInterviewStage : undefined;
-
-const brunchVoiceInterviewStage = getBrunchVoiceInterviewStage(
-  brunchPreviewConfig.isBrunchConfigured,
-);
+  config
+    ? (context: PetrinautAiInterviewStageContext) => (
+        <VoiceInterviewControl {...context} config={config} />
+      )
+    : undefined;
 
 const createHandle = (net: SDCPNInLocalStorage): PetrinautDocHandle =>
   createJsonDocHandle({
@@ -154,10 +154,37 @@ const createActiveHandle = (net: SDCPNInLocalStorage): ActiveHandle => ({
  */
 export const LocalStorageDemoApp = () => {
   const sentryFeedbackAction = useSentryFeedbackAction();
+  const [openAIVoiceConfig, setOpenAIVoiceConfig] =
+    useState<OpenAIVoiceConfig | null>();
   const { aiMessagesByNetId, setAiMessagesByNetId } =
     useLocalStorageAiMessages();
   const { storedSDCPNs, setStoredSDCPNs } = useLocalStorageSDCPNs();
   const storedSDCPNsForDisplay = getStoredSDCPNsForDisplay(storedSDCPNs);
+
+  useEffect(() => {
+    if (!brunchPreviewConfig.isBrunchConfigured) {
+      // eslint-disable-next-line react-hooks-js/set-state-in-effect -- Resolve the loading sentinel when voice is not configured.
+      setOpenAIVoiceConfig(null);
+      return;
+    }
+
+    const abortController = new AbortController();
+    void loadOpenAIVoiceConfig(
+      globalThis.fetch.bind(globalThis),
+      abortController.signal,
+    ).then((config) => {
+      if (!abortController.signal.aborted) {
+        setOpenAIVoiceConfig(config);
+      }
+    });
+
+    return () => abortController.abort();
+  }, []);
+
+  const brunchVoiceInterviewStage = useMemo(
+    () => getBrunchVoiceInterviewStage(openAIVoiceConfig),
+    [openAIVoiceConfig],
+  );
 
   // Pick the most recently modified net
   const mostRecentlyModifiedNet =
@@ -342,6 +369,7 @@ export const LocalStorageDemoApp = () => {
     }),
     [
       aiMessagesByNetId,
+      brunchVoiceInterviewStage,
       conversationId,
       currentNetId,
       flueHistory.messages,

--- a/apps/petrinaut-website/src/main/app/local-storage-demo/local-storage-demo-app.tsx
+++ b/apps/petrinaut-website/src/main/app/local-storage-demo/local-storage-demo-app.tsx
@@ -17,8 +17,8 @@ import {
 import {
   DefaultChatTransport,
   Petrinaut,
-  type PetrinautAiComposerControl,
-  type PetrinautAiComposerControlContext,
+  type PetrinautAiInterviewStage,
+  type PetrinautAiInterviewStageContext,
   type PetrinautAiMessage,
   WalkthroughProvider,
 } from "@hashintel/petrinaut/ui";
@@ -91,16 +91,16 @@ const brunchPreviewConfig = resolveBrunchPreviewConfig(
   import.meta.env.VITE_BRUNCH_CHAT_ENDPOINT,
 );
 
-const renderBrunchVoiceComposerControl = (
-  context: PetrinautAiComposerControlContext,
+const renderBrunchVoiceInterviewStage = (
+  context: PetrinautAiInterviewStageContext,
 ) => <VoiceInterviewControl {...context} />;
 
-export const getBrunchVoiceComposerControl = (
+export const getBrunchVoiceInterviewStage = (
   isBrunchConfigured: boolean,
-): PetrinautAiComposerControl | undefined =>
-  isBrunchConfigured ? renderBrunchVoiceComposerControl : undefined;
+): PetrinautAiInterviewStage | undefined =>
+  isBrunchConfigured ? renderBrunchVoiceInterviewStage : undefined;
 
-const brunchVoiceComposerControl = getBrunchVoiceComposerControl(
+const brunchVoiceInterviewStage = getBrunchVoiceInterviewStage(
   brunchPreviewConfig.isBrunchConfigured,
 );
 
@@ -334,9 +334,9 @@ export const LocalStorageDemoApp = () => {
           return next;
         });
       },
-      ...(brunchVoiceComposerControl
+      ...(brunchVoiceInterviewStage
         ? {
-            renderComposerControl: brunchVoiceComposerControl,
+            renderInterviewStage: brunchVoiceInterviewStage,
           }
         : {}),
     }),

--- a/apps/petrinaut-website/src/main/app/voice-interview/interview-coverage.test.ts
+++ b/apps/petrinaut-website/src/main/app/voice-interview/interview-coverage.test.ts
@@ -87,6 +87,39 @@ describe("interview coverage", () => {
     });
   });
 
+  test("names each covered topic once when node identifiers share a label", () => {
+    const messages = [
+      {
+        id: "assistant-sweep",
+        role: "assistant",
+        parts: [
+          {
+            type: "dynamic-tool",
+            toolCallId: "sweep-2",
+            toolName: SWEEP_TOOL_NAME,
+            state: "output-available",
+            input: {},
+            output: {
+              status: "applied",
+              appliedCaptureIds: [],
+              captures: [],
+              completion: {
+                complete: true,
+                pluginVersion: "sdcpn/1",
+                revision: "revision-2",
+                failures: [],
+                sliceNodeIds: ["activity:approval", "object:approval"],
+                outsideSlice: [],
+              },
+            },
+          },
+        ],
+      },
+    ] as unknown as PetrinautAiMessage[];
+
+    expect(selectInterviewCoverage(messages)?.covered).toEqual(["approval"]);
+  });
+
   test("omits coverage when no validated completion report exists", () => {
     expect(selectInterviewCoverage([])).toBeNull();
   });

--- a/apps/petrinaut-website/src/main/app/voice-interview/interview-coverage.test.ts
+++ b/apps/petrinaut-website/src/main/app/voice-interview/interview-coverage.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "vitest";
+
+import { SWEEP_TOOL_NAME } from "@hashintel/brunch-agent-transport-aisdk/client-tools";
+
+import { selectInterviewCoverage } from "./interview-coverage";
+
+import type { PetrinautAiMessage } from "@hashintel/petrinaut/ui";
+
+describe("interview coverage", () => {
+  test("uses only authoritative completion results for covered and open topics", () => {
+    const messages = [
+      {
+        id: "assistant-sweep",
+        role: "assistant",
+        parts: [
+          {
+            type: "dynamic-tool",
+            toolCallId: "sweep-1",
+            toolName: SWEEP_TOOL_NAME,
+            state: "output-available",
+            input: {},
+            output: {
+              status: "applied",
+              appliedCaptureIds: ["capture-owner"],
+              captures: [
+                {
+                  id: "capture-owner",
+                  status: "active",
+                  epistemicStatus: "explicit",
+                  confidence: "high",
+                  content: {
+                    value: {
+                      type: "slot-asserted",
+                      kind: "activity",
+                      node: "approval",
+                      slot: "who performs it",
+                      precision: "named",
+                      assertion: { value: "shift lead" },
+                    },
+                  },
+                },
+                {
+                  id: "capture-old",
+                  status: "superseded",
+                  epistemicStatus: "explicit",
+                  confidence: "high",
+                  content: {
+                    value: {
+                      type: "slot-asserted",
+                      kind: "activity",
+                      node: "approval",
+                      slot: "how long it takes",
+                      assertion: { value: "one hour" },
+                    },
+                  },
+                },
+              ],
+              completion: {
+                complete: false,
+                pluginVersion: "sdcpn/1",
+                revision: "revision-1",
+                failures: [
+                  {
+                    diagnostic: "unaddressed",
+                    nodeId: "activity:approval",
+                    kind: "activity",
+                    slot: "how long it takes",
+                    requirement: "spread",
+                    actual: "not mentioned",
+                    message: "Duration is still unknown.",
+                    captureIds: [],
+                  },
+                ],
+                sliceNodeIds: ["activity:approval", "activity:dispatch"],
+                outsideSlice: [],
+              },
+            },
+          },
+        ],
+      },
+    ] as unknown as PetrinautAiMessage[];
+
+    expect(selectInterviewCoverage(messages)).toEqual({
+      complete: false,
+      covered: ["dispatch"],
+      stillExploring: ["approval — how long it takes"],
+    });
+  });
+
+  test("omits coverage when no validated completion report exists", () => {
+    expect(selectInterviewCoverage([])).toBeNull();
+  });
+});

--- a/apps/petrinaut-website/src/main/app/voice-interview/interview-coverage.ts
+++ b/apps/petrinaut-website/src/main/app/voice-interview/interview-coverage.ts
@@ -1,0 +1,66 @@
+import { SWEEP_TOOL_NAME } from "@hashintel/brunch-agent-transport-aisdk/client-tools";
+
+import { sweepOutputSchema } from "../local-storage-demo/brunch-panel-transport";
+
+import type { PetrinautAiMessage } from "@hashintel/petrinaut/ui";
+
+export interface InterviewCoverage {
+  readonly complete: boolean;
+  readonly covered: readonly string[];
+  readonly stillExploring: readonly string[];
+}
+
+const unique = (items: string[]): string[] => [...new Set(items)];
+
+const nodeLabel = (nodeId: string): string => {
+  const separator = nodeId.indexOf(":");
+  return separator === -1 ? nodeId : nodeId.slice(separator + 1);
+};
+
+export const selectInterviewCoverage = (
+  messages: PetrinautAiMessage[],
+): InterviewCoverage | null => {
+  for (const message of messages.toReversed()) {
+    for (const part of message.parts.toReversed()) {
+      if (
+        part.type !== "dynamic-tool" ||
+        part.toolName !== SWEEP_TOOL_NAME ||
+        part.state !== "output-available"
+      ) {
+        continue;
+      }
+      const parsed = sweepOutputSchema.safeParse(part.output);
+      if (
+        !parsed.success ||
+        parsed.data.status !== "applied" ||
+        parsed.data.completion === undefined
+      ) {
+        continue;
+      }
+
+      const { completion } = parsed.data;
+      const nodesWithFailures = new Set(
+        completion.failures.flatMap((failure) =>
+          failure.nodeId === undefined ? [] : [failure.nodeId],
+        ),
+      );
+      const covered = completion.sliceNodeIds
+        .filter((nodeId) => !nodesWithFailures.has(nodeId))
+        .map(nodeLabel);
+      const stillExploring = unique(
+        completion.failures.map((failure) =>
+          failure.nodeId === undefined
+            ? failure.message
+            : `${nodeLabel(failure.nodeId)} — ${failure.slot ?? failure.message}`,
+        ),
+      );
+
+      return {
+        complete: completion.complete,
+        covered,
+        stillExploring,
+      };
+    }
+  }
+  return null;
+};

--- a/apps/petrinaut-website/src/main/app/voice-interview/interview-coverage.ts
+++ b/apps/petrinaut-website/src/main/app/voice-interview/interview-coverage.ts
@@ -44,9 +44,11 @@ export const selectInterviewCoverage = (
           failure.nodeId === undefined ? [] : [failure.nodeId],
         ),
       );
-      const covered = completion.sliceNodeIds
-        .filter((nodeId) => !nodesWithFailures.has(nodeId))
-        .map(nodeLabel);
+      const covered = unique(
+        completion.sliceNodeIds
+          .filter((nodeId) => !nodesWithFailures.has(nodeId))
+          .map(nodeLabel),
+      );
       const stillExploring = unique(
         completion.failures.map((failure) =>
           failure.nodeId === undefined

--- a/apps/petrinaut-website/src/main/app/voice-interview/interview-coverage.ts
+++ b/apps/petrinaut-website/src/main/app/voice-interview/interview-coverage.ts
@@ -1,6 +1,6 @@
 import { SWEEP_TOOL_NAME } from "@hashintel/brunch-agent-transport-aisdk/client-tools";
 
-import { sweepOutputSchema } from "../local-storage-demo/brunch-panel-transport";
+import { sweepOutputSchema } from "../brunch-sweep-output";
 
 import type { PetrinautAiMessage } from "@hashintel/petrinaut/ui";
 

--- a/apps/petrinaut-website/src/main/app/voice-interview/openai-realtime-session.test.ts
+++ b/apps/petrinaut-website/src/main/app/voice-interview/openai-realtime-session.test.ts
@@ -37,10 +37,18 @@ const createHarness = (connectionTimeoutMs = 15_000) => {
     }),
   };
   const mediaSource = { connect: vi.fn() };
+  const tracks: Array<{ enabled: boolean; stop: ReturnType<typeof vi.fn> }> =
+    [];
+  const trackEnabledWhenMeterConnected: boolean[] = [];
   const audioContext = {
     close: vi.fn(async () => undefined),
     createAnalyser: vi.fn(() => analyser),
-    createMediaStreamSource: vi.fn(() => mediaSource),
+    createMediaStreamSource: vi.fn(() => {
+      trackEnabledWhenMeterConnected.push(tracks.at(-1)?.enabled ?? true);
+      return mediaSource;
+    }),
+    resume: vi.fn(async () => undefined),
+    state: "suspended" as AudioContextState,
   };
   const cancelAnimationFrame = vi.fn();
   const channels: FakeDataChannel[] = [];
@@ -54,9 +62,6 @@ const createHarness = (connectionTimeoutMs = 15_000) => {
     setLocalDescription: ReturnType<typeof vi.fn>;
     setRemoteDescription: ReturnType<typeof vi.fn<() => Promise<void>>>;
   }> = [];
-  const tracks: Array<{ enabled: boolean; stop: ReturnType<typeof vi.fn> }> =
-    [];
-  const trackEnabledWhenMeterCreated: boolean[] = [];
   const fetch = vi.fn<typeof globalThis.fetch>(
     async () =>
       new Response("v=0\r\no=OpenAI answer", {
@@ -126,7 +131,7 @@ const createHarness = (connectionTimeoutMs = 15_000) => {
     peers,
     reportDiagnostic,
     session,
-    trackEnabledWhenMeterCreated,
+    trackEnabledWhenMeterConnected,
     tracks,
   };
 };
@@ -149,7 +154,7 @@ describe("OpenAIRealtimeSession", () => {
       },
     });
     expect(harness.tracks[0]!.enabled).toBe(false);
-    expect(harness.trackEnabledWhenMeterCreated).toEqual([false]);
+    expect(harness.trackEnabledWhenMeterConnected).toEqual([false]);
     expect(harness.fetch).toHaveBeenCalledWith(
       "/api/voice/realtime-call",
       expect.objectContaining({
@@ -203,6 +208,36 @@ describe("OpenAIRealtimeSession", () => {
       level: 0,
       type: "microphone-level",
     });
+  });
+
+  test("resumes a suspended input meter before waiting for microphone access", async () => {
+    const harness = createHarness();
+    const track = { enabled: true, stop: vi.fn() };
+    const stream = {
+      getAudioTracks: () => [track],
+      getTracks: () => [track],
+    } as unknown as MediaStream;
+    let resolveMedia: ((mediaStream: MediaStream) => void) | undefined;
+    harness.getUserMedia.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveMedia = resolve;
+        }),
+    );
+
+    const connection = harness.session.connect();
+    const resumeCallsBeforeMedia =
+      harness.audioContext.resume.mock.calls.length;
+    const sourceCallsBeforeMedia =
+      harness.audioContext.createMediaStreamSource.mock.calls.length;
+    resolveMedia?.(stream);
+    await connection;
+
+    expect(resumeCallsBeforeMedia).toBe(1);
+    expect(sourceCallsBeforeMedia).toBe(0);
+    expect(harness.audioContext.createMediaStreamSource).toHaveBeenCalledWith(
+      stream,
+    );
   });
 
   test("emits only strict input transcription events with stable source identity", async () => {
@@ -329,19 +364,6 @@ describe("OpenAIRealtimeSession", () => {
     expect(harness.events).toEqual([
       { connectionEpoch: 1, itemId: "item-a", type: "input-committed" },
     ]);
-  });
-
-  test("closes capture before explicitly committing buffered input", async () => {
-    const harness = createHarness();
-    await harness.session.connect();
-    harness.session.setMicrophoneEnabled(true);
-
-    harness.session.commitInput();
-
-    expect(harness.tracks[0]!.enabled).toBe(false);
-    expect(harness.channels[0]!.send).toHaveBeenCalledWith(
-      JSON.stringify({ type: "input_audio_buffer.commit" }),
-    );
   });
 
   test("disposes all WebRTC resources and rejects stale events after reconnect", async () => {

--- a/apps/petrinaut-website/src/main/app/voice-interview/openai-realtime-session.test.ts
+++ b/apps/petrinaut-website/src/main/app/voice-interview/openai-realtime-session.test.ts
@@ -11,6 +11,7 @@ class FakeDataChannel extends EventTarget {
   public readonly close = vi.fn(() => {
     this.readyState = "closed";
   });
+  public readonly send = vi.fn();
 
   public open() {
     this.readyState = "open";
@@ -28,6 +29,20 @@ class FakeDataChannel extends EventTarget {
 
 const createHarness = (connectionTimeoutMs = 15_000) => {
   let requestNumber = 0;
+  const animationFrames: FrameRequestCallback[] = [];
+  const analyser = {
+    fftSize: 0,
+    getByteTimeDomainData: vi.fn((data: Uint8Array) => {
+      data.fill(160);
+    }),
+  };
+  const mediaSource = { connect: vi.fn() };
+  const audioContext = {
+    close: vi.fn(async () => undefined),
+    createAnalyser: vi.fn(() => analyser),
+    createMediaStreamSource: vi.fn(() => mediaSource),
+  };
+  const cancelAnimationFrame = vi.fn();
   const channels: FakeDataChannel[] = [];
   const peers: Array<{
     addTrack: ReturnType<typeof vi.fn>;
@@ -41,6 +56,7 @@ const createHarness = (connectionTimeoutMs = 15_000) => {
   }> = [];
   const tracks: Array<{ enabled: boolean; stop: ReturnType<typeof vi.fn> }> =
     [];
+  const trackEnabledWhenMeterCreated: boolean[] = [];
   const fetch = vi.fn<typeof globalThis.fetch>(
     async () =>
       new Response("v=0\r\no=OpenAI answer", {
@@ -78,18 +94,31 @@ const createHarness = (connectionTimeoutMs = 15_000) => {
     return peer as unknown as RTCPeerConnection;
   };
   const session = new OpenAIRealtimeSession({
+    cancelAnimationFrame,
     connectionTimeoutMs,
+    createAudioContext: () => {
+      trackEnabledWhenMeterCreated.push(tracks.at(-1)?.enabled ?? true);
+      return audioContext as unknown as AudioContext;
+    },
     createRequestId: () => `voice-request-${++requestNumber}`,
     createPeerConnection,
     fetch,
     getUserMedia,
     now: () => 100,
     reportDiagnostic,
+    requestAnimationFrame: (callback) => {
+      animationFrames.push(callback);
+      return animationFrames.length;
+    },
   });
   const events: OpenAIRealtimeSessionEvent[] = [];
   session.subscribe((event) => events.push(event));
 
   return {
+    analyser,
+    animationFrames,
+    audioContext,
+    cancelAnimationFrame,
     channels,
     events,
     fetch,
@@ -97,6 +126,7 @@ const createHarness = (connectionTimeoutMs = 15_000) => {
     peers,
     reportDiagnostic,
     session,
+    trackEnabledWhenMeterCreated,
     tracks,
   };
 };
@@ -119,6 +149,7 @@ describe("OpenAIRealtimeSession", () => {
       },
     });
     expect(harness.tracks[0]!.enabled).toBe(false);
+    expect(harness.trackEnabledWhenMeterCreated).toEqual([false]);
     expect(harness.fetch).toHaveBeenCalledWith(
       "/api/voice/realtime-call",
       expect.objectContaining({
@@ -146,6 +177,31 @@ describe("OpenAIRealtimeSession", () => {
       outcome: "success",
       requestId: "voice-request-1",
       stage: "browser",
+    });
+  });
+
+  test("reports real input level only while the microphone track is enabled", async () => {
+    const harness = createHarness();
+    await harness.session.connect();
+
+    expect(harness.animationFrames).toHaveLength(0);
+    harness.session.setMicrophoneEnabled(true);
+    expect(harness.animationFrames).toHaveLength(1);
+    harness.animationFrames.shift()?.(0);
+
+    expect(harness.events.at(-1)).toMatchObject({
+      type: "microphone-level",
+    });
+    expect((harness.events.at(-1) as { level: number }).level).toBeGreaterThan(
+      0,
+    );
+
+    harness.session.setMicrophoneEnabled(false);
+    expect(harness.tracks[0]!.enabled).toBe(false);
+    expect(harness.cancelAnimationFrame).toHaveBeenCalled();
+    expect(harness.events.at(-1)).toEqual({
+      level: 0,
+      type: "microphone-level",
     });
   });
 
@@ -273,6 +329,19 @@ describe("OpenAIRealtimeSession", () => {
     expect(harness.events).toEqual([
       { connectionEpoch: 1, itemId: "item-a", type: "input-committed" },
     ]);
+  });
+
+  test("closes capture before explicitly committing buffered input", async () => {
+    const harness = createHarness();
+    await harness.session.connect();
+    harness.session.setMicrophoneEnabled(true);
+
+    harness.session.commitInput();
+
+    expect(harness.tracks[0]!.enabled).toBe(false);
+    expect(harness.channels[0]!.send).toHaveBeenCalledWith(
+      JSON.stringify({ type: "input_audio_buffer.commit" }),
+    );
   });
 
   test("disposes all WebRTC resources and rejects stale events after reconnect", async () => {

--- a/apps/petrinaut-website/src/main/app/voice-interview/openai-realtime-session.test.ts
+++ b/apps/petrinaut-website/src/main/app/voice-interview/openai-realtime-session.test.ts
@@ -214,6 +214,37 @@ describe("OpenAIRealtimeSession", () => {
     });
   });
 
+  test("quantizes input levels and skips unchanged meter frames", async () => {
+    const harness = createHarness();
+    harness.analyser.getByteTimeDomainData.mockImplementation(
+      (data: Uint8Array) => {
+        data.fill(200);
+      },
+    );
+    await harness.session.connect();
+    harness.session.setMicrophoneEnabled(true);
+
+    const levels = () =>
+      harness.events
+        .filter((event) => event.type === "microphone-level")
+        .map((event) => (event as { level: number }).level);
+
+    harness.animationFrames.shift()?.(0);
+    harness.animationFrames.shift()?.(0);
+    harness.animationFrames.shift()?.(0);
+
+    expect(levels()).toEqual([0.56]);
+
+    harness.analyser.getByteTimeDomainData.mockImplementation(
+      (data: Uint8Array) => {
+        data.fill(160);
+      },
+    );
+    harness.animationFrames.shift()?.(0);
+
+    expect(levels()).toEqual([0.56, 0.25]);
+  });
+
   test("resumes a suspended input meter before waiting for microphone access", async () => {
     const harness = createHarness();
     const track = { enabled: true, stop: vi.fn() };

--- a/apps/petrinaut-website/src/main/app/voice-interview/openai-realtime-session.test.ts
+++ b/apps/petrinaut-website/src/main/app/voice-interview/openai-realtime-session.test.ts
@@ -27,7 +27,13 @@ class FakeDataChannel extends EventTarget {
   }
 }
 
-const createHarness = (connectionTimeoutMs = 15_000) => {
+const createHarness = ({
+  connectionTimeoutMs = 15_000,
+  createAudioContext,
+}: {
+  readonly connectionTimeoutMs?: number;
+  readonly createAudioContext?: () => AudioContext;
+} = {}) => {
   let requestNumber = 0;
   const animationFrames: FrameRequestCallback[] = [];
   const analyser = {
@@ -101,10 +107,8 @@ const createHarness = (connectionTimeoutMs = 15_000) => {
   const session = new OpenAIRealtimeSession({
     cancelAnimationFrame,
     connectionTimeoutMs,
-    createAudioContext: () => {
-      trackEnabledWhenMeterCreated.push(tracks.at(-1)?.enabled ?? true);
-      return audioContext as unknown as AudioContext;
-    },
+    createAudioContext:
+      createAudioContext ?? (() => audioContext as unknown as AudioContext),
     createRequestId: () => `voice-request-${++requestNumber}`,
     createPeerConnection,
     fetch,
@@ -238,6 +242,40 @@ describe("OpenAIRealtimeSession", () => {
     expect(harness.audioContext.createMediaStreamSource).toHaveBeenCalledWith(
       stream,
     );
+  });
+
+  test("connects without metering when audio context construction throws", async () => {
+    const harness = createHarness({
+      createAudioContext: () => {
+        throw new Error("AudioContext unavailable");
+      },
+    });
+
+    await expect(harness.session.connect()).resolves.toBe(1);
+    harness.session.setMicrophoneEnabled(true);
+
+    expect(harness.fetch).toHaveBeenCalledOnce();
+    expect(harness.peers[0]!.addTrack).toHaveBeenCalledOnce();
+    expect(harness.tracks[0]!.enabled).toBe(true);
+    expect(harness.animationFrames).toHaveLength(0);
+    expect(harness.events).toEqual([]);
+  });
+
+  test("connects without metering when meter initialization throws", async () => {
+    const harness = createHarness();
+    harness.audioContext.createMediaStreamSource.mockImplementationOnce(() => {
+      throw new Error("Media stream source unavailable");
+    });
+
+    await expect(harness.session.connect()).resolves.toBe(1);
+    harness.session.setMicrophoneEnabled(true);
+
+    expect(harness.fetch).toHaveBeenCalledOnce();
+    expect(harness.peers[0]!.addTrack).toHaveBeenCalledOnce();
+    expect(harness.tracks[0]!.enabled).toBe(true);
+    expect(harness.audioContext.close).toHaveBeenCalledOnce();
+    expect(harness.animationFrames).toHaveLength(0);
+    expect(harness.events).toEqual([]);
   });
 
   test("emits only strict input transcription events with stable source identity", async () => {
@@ -579,7 +617,7 @@ describe("OpenAIRealtimeSession", () => {
   });
 
   test("rejects a data channel already closed after negotiation", async () => {
-    const harness = createHarness(1_000);
+    const harness = createHarness({ connectionTimeoutMs: 1_000 });
     let resolveFetch: ((response: Response) => void) | undefined;
     harness.fetch.mockImplementationOnce(
       () =>

--- a/apps/petrinaut-website/src/main/app/voice-interview/openai-realtime-session.ts
+++ b/apps/petrinaut-website/src/main/app/voice-interview/openai-realtime-session.ts
@@ -156,6 +156,12 @@ export class OpenAIRealtimeSession {
     }, this.#dependencies.connectionTimeoutMs);
 
     try {
+      const audioContext = this.#dependencies.createAudioContext();
+      this.#audioContext = audioContext;
+      if (audioContext.state === "suspended") {
+        void audioContext.resume().catch(() => undefined);
+      }
+
       let mediaStream: MediaStream;
       try {
         const mediaStreamPromise = this.#dependencies.getUserMedia({
@@ -218,7 +224,7 @@ export class OpenAIRealtimeSession {
       }
       microphoneTrack.enabled = false;
       this.#microphoneTrack = microphoneTrack;
-      this.#initializeMeter(mediaStream);
+      this.#initializeMeter(audioContext, mediaStream);
 
       const peerConnection = this.#dependencies.createPeerConnection();
       this.#peerConnection = peerConnection;
@@ -369,25 +375,6 @@ export class OpenAIRealtimeSession {
     }
   }
 
-  public commitInput(): void {
-    this.setMicrophoneEnabled(false);
-    if (
-      !this.#connected ||
-      !this.#dataChannel ||
-      this.#dataChannel.readyState !== "open"
-    ) {
-      this.#handleConnectionFailure("network", "transcription");
-      return;
-    }
-    try {
-      this.#dataChannel.send(
-        JSON.stringify({ type: "input_audio_buffer.commit" }),
-      );
-    } catch {
-      this.#handleConnectionFailure("network", "transcription");
-    }
-  }
-
   public async disconnect(): Promise<void> {
     this.#releaseResources();
   }
@@ -451,12 +438,10 @@ export class OpenAIRealtimeSession {
     });
   }
 
-  #initializeMeter(mediaStream: MediaStream): void {
-    const audioContext = this.#dependencies.createAudioContext();
+  #initializeMeter(audioContext: AudioContext, mediaStream: MediaStream): void {
     const analyser = audioContext.createAnalyser();
     analyser.fftSize = 256;
     audioContext.createMediaStreamSource(mediaStream).connect(analyser);
-    this.#audioContext = audioContext;
     this.#analyser = analyser;
     this.#meterSamples = new Uint8Array(analyser.fftSize);
   }

--- a/apps/petrinaut-website/src/main/app/voice-interview/openai-realtime-session.ts
+++ b/apps/petrinaut-website/src/main/app/voice-interview/openai-realtime-session.ts
@@ -28,6 +28,7 @@ export type OpenAIRealtimeSessionEvent =
       readonly text: string;
       readonly type: "partial" | "completed";
     }
+  | { readonly level: number; readonly type: "microphone-level" }
   | {
       readonly code: VoiceErrorCode;
       readonly message: string;
@@ -36,7 +37,9 @@ export type OpenAIRealtimeSessionEvent =
     };
 
 interface OpenAIRealtimeSessionDependencies {
+  readonly cancelAnimationFrame: (handle: number) => void;
   readonly connectionTimeoutMs: number;
+  readonly createAudioContext: () => AudioContext;
   readonly createRequestId?: () => string;
   readonly createPeerConnection: () => RTCPeerConnection;
   readonly fetch: typeof globalThis.fetch;
@@ -45,6 +48,7 @@ interface OpenAIRealtimeSessionDependencies {
   ) => Promise<MediaStream>;
   readonly now?: () => number;
   readonly reportDiagnostic?: VoiceDiagnosticReporter;
+  readonly requestAnimationFrame: (callback: FrameRequestCallback) => number;
 }
 
 type SessionListener = (event: OpenAIRealtimeSessionEvent) => void;
@@ -104,6 +108,8 @@ const waitForAbort = <Value>(
 export class OpenAIRealtimeSession {
   readonly #dependencies: OpenAIRealtimeSessionDependencies;
   readonly #listeners = new Set<SessionListener>();
+  #analyser: AnalyserNode | null = null;
+  #audioContext: AudioContext | null = null;
   #abortController: AbortController | null = null;
   #activeEpoch: number | null = null;
   #connected = false;
@@ -112,6 +118,9 @@ export class OpenAIRealtimeSession {
   #dataChannel: RTCDataChannel | null = null;
   #epoch = 0;
   #mediaStream: MediaStream | null = null;
+  #meterFrame: number | null = null;
+  #meterHasSample = false;
+  #meterSamples: Uint8Array<ArrayBuffer> | null = null;
   #messageListener: ((event: MessageEvent<unknown>) => void) | null = null;
   #microphoneTrack: MediaStreamTrack | null = null;
   #peerConnection: RTCPeerConnection | null = null;
@@ -209,6 +218,7 @@ export class OpenAIRealtimeSession {
       }
       microphoneTrack.enabled = false;
       this.#microphoneTrack = microphoneTrack;
+      this.#initializeMeter(mediaStream);
 
       const peerConnection = this.#dependencies.createPeerConnection();
       this.#peerConnection = peerConnection;
@@ -349,7 +359,32 @@ export class OpenAIRealtimeSession {
 
   public setMicrophoneEnabled(enabled: boolean): void {
     if (this.#microphoneTrack) {
-      this.#microphoneTrack.enabled = enabled && this.#connected;
+      const isEnabled = enabled && this.#connected;
+      this.#microphoneTrack.enabled = isEnabled;
+      if (isEnabled) {
+        this.#startMeter();
+      } else {
+        this.#stopMeter();
+      }
+    }
+  }
+
+  public commitInput(): void {
+    this.setMicrophoneEnabled(false);
+    if (
+      !this.#connected ||
+      !this.#dataChannel ||
+      this.#dataChannel.readyState !== "open"
+    ) {
+      this.#handleConnectionFailure("network", "transcription");
+      return;
+    }
+    try {
+      this.#dataChannel.send(
+        JSON.stringify({ type: "input_audio_buffer.commit" }),
+      );
+    } catch {
+      this.#handleConnectionFailure("network", "transcription");
     }
   }
 
@@ -414,6 +449,59 @@ export class OpenAIRealtimeSession {
       requestId,
       type: "error",
     });
+  }
+
+  #initializeMeter(mediaStream: MediaStream): void {
+    const audioContext = this.#dependencies.createAudioContext();
+    const analyser = audioContext.createAnalyser();
+    analyser.fftSize = 256;
+    audioContext.createMediaStreamSource(mediaStream).connect(analyser);
+    this.#audioContext = audioContext;
+    this.#analyser = analyser;
+    this.#meterSamples = new Uint8Array(analyser.fftSize);
+  }
+
+  #startMeter(): void {
+    if (this.#meterFrame !== null || !this.#analyser || !this.#meterSamples) {
+      return;
+    }
+
+    const sample = () => {
+      if (
+        !this.#microphoneTrack?.enabled ||
+        !this.#analyser ||
+        !this.#meterSamples
+      ) {
+        this.#stopMeter();
+        return;
+      }
+      this.#analyser.getByteTimeDomainData(this.#meterSamples);
+      let squaredTotal = 0;
+      for (const value of this.#meterSamples) {
+        const normalized = (value - 128) / 128;
+        squaredTotal += normalized * normalized;
+      }
+      this.#emit({
+        level: Math.min(1, Math.sqrt(squaredTotal / this.#meterSamples.length)),
+        type: "microphone-level",
+      });
+      this.#meterHasSample = true;
+      this.#meterFrame = this.#dependencies.requestAnimationFrame(sample);
+    };
+
+    this.#meterFrame = this.#dependencies.requestAnimationFrame(sample);
+  }
+
+  #stopMeter(): void {
+    if (this.#meterFrame === null) {
+      return;
+    }
+    this.#dependencies.cancelAnimationFrame(this.#meterFrame);
+    this.#meterFrame = null;
+    if (this.#meterHasSample) {
+      this.#emit({ level: 0, type: "microphone-level" });
+      this.#meterHasSample = false;
+    }
   }
 
   #handleMessage(event: MessageEvent<unknown>, connectionEpoch: number): void {
@@ -545,6 +633,7 @@ export class OpenAIRealtimeSession {
     this.#connectionRequestId = null;
     this.#abortController?.abort();
     this.#abortController = null;
+    this.#stopMeter();
 
     if (this.#dataChannel && this.#messageListener) {
       this.#dataChannel.removeEventListener("message", this.#messageListener);
@@ -577,6 +666,12 @@ export class OpenAIRealtimeSession {
       this.#mediaStream = null;
     }
     this.#microphoneTrack = null;
+    this.#analyser = null;
+    this.#meterSamples = null;
+    if (this.#audioContext) {
+      void this.#audioContext.close();
+      this.#audioContext = null;
+    }
   }
 
   #waitForDataChannelOpen(

--- a/apps/petrinaut-website/src/main/app/voice-interview/openai-realtime-session.ts
+++ b/apps/petrinaut-website/src/main/app/voice-interview/openai-realtime-session.ts
@@ -120,6 +120,7 @@ export class OpenAIRealtimeSession {
   #mediaStream: MediaStream | null = null;
   #meterFrame: number | null = null;
   #meterHasSample = false;
+  #meterLevel = 0;
   #meterSamples: Uint8Array<ArrayBuffer> | null = null;
   #messageListener: ((event: MessageEvent<unknown>) => void) | null = null;
   #microphoneTrack: MediaStreamTrack | null = null;
@@ -481,10 +482,18 @@ export class OpenAIRealtimeSession {
         const normalized = (value - 128) / 128;
         squaredTotal += normalized * normalized;
       }
-      this.#emit({
-        level: Math.min(1, Math.sqrt(squaredTotal / this.#meterSamples.length)),
-        type: "microphone-level",
-      });
+      // The meter only drives a five-bar waveform, so two decimals is all the
+      // resolution a listener can use. Quantizing and skipping repeats keeps
+      // an every-animation-frame sample from re-rendering the interview.
+      const level =
+        Math.round(
+          Math.min(1, Math.sqrt(squaredTotal / this.#meterSamples.length)) *
+            100,
+        ) / 100;
+      if (level !== this.#meterLevel) {
+        this.#meterLevel = level;
+        this.#emit({ level, type: "microphone-level" });
+      }
       this.#meterHasSample = true;
       this.#meterFrame = this.#dependencies.requestAnimationFrame(sample);
     };
@@ -498,6 +507,7 @@ export class OpenAIRealtimeSession {
     }
     this.#dependencies.cancelAnimationFrame(this.#meterFrame);
     this.#meterFrame = null;
+    this.#meterLevel = 0;
     if (this.#meterHasSample) {
       this.#emit({ level: 0, type: "microphone-level" });
       this.#meterHasSample = false;

--- a/apps/petrinaut-website/src/main/app/voice-interview/openai-realtime-session.ts
+++ b/apps/petrinaut-website/src/main/app/voice-interview/openai-realtime-session.ts
@@ -156,10 +156,19 @@ export class OpenAIRealtimeSession {
     }, this.#dependencies.connectionTimeoutMs);
 
     try {
-      const audioContext = this.#dependencies.createAudioContext();
-      this.#audioContext = audioContext;
-      if (audioContext.state === "suspended") {
-        void audioContext.resume().catch(() => undefined);
+      let audioContext: AudioContext | null = null;
+      try {
+        audioContext = this.#dependencies.createAudioContext();
+        this.#audioContext = audioContext;
+        if (audioContext.state === "suspended") {
+          try {
+            void audioContext.resume().catch(() => undefined);
+          } catch {
+            // Input metering is optional and must not block voice connection.
+          }
+        }
+      } catch {
+        // Input metering is optional and must not block voice connection.
       }
 
       let mediaStream: MediaStream;
@@ -224,7 +233,13 @@ export class OpenAIRealtimeSession {
       }
       microphoneTrack.enabled = false;
       this.#microphoneTrack = microphoneTrack;
-      this.#initializeMeter(audioContext, mediaStream);
+      if (audioContext) {
+        try {
+          this.#initializeMeter(audioContext, mediaStream);
+        } catch {
+          this.#releaseMeterResources();
+        }
+      }
 
       const peerConnection = this.#dependencies.createPeerConnection();
       this.#peerConnection = peerConnection;
@@ -489,6 +504,21 @@ export class OpenAIRealtimeSession {
     }
   }
 
+  #releaseMeterResources(): void {
+    this.#stopMeter();
+    this.#analyser = null;
+    this.#meterSamples = null;
+    const audioContext = this.#audioContext;
+    this.#audioContext = null;
+    if (audioContext) {
+      try {
+        void audioContext.close().catch(() => undefined);
+      } catch {
+        // Input metering cleanup is best-effort.
+      }
+    }
+  }
+
   #handleMessage(event: MessageEvent<unknown>, connectionEpoch: number): void {
     const parsed = parseRealtimeEvent(event.data);
     if (!parsed || typeof parsed.type !== "string") {
@@ -618,7 +648,7 @@ export class OpenAIRealtimeSession {
     this.#connectionRequestId = null;
     this.#abortController?.abort();
     this.#abortController = null;
-    this.#stopMeter();
+    this.#releaseMeterResources();
 
     if (this.#dataChannel && this.#messageListener) {
       this.#dataChannel.removeEventListener("message", this.#messageListener);
@@ -651,12 +681,6 @@ export class OpenAIRealtimeSession {
       this.#mediaStream = null;
     }
     this.#microphoneTrack = null;
-    this.#analyser = null;
-    this.#meterSamples = null;
-    if (this.#audioContext) {
-      void this.#audioContext.close();
-      this.#audioContext = null;
-    }
   }
 
   #waitForDataChannelOpen(

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.test.tsx
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.test.tsx
@@ -1,8 +1,8 @@
 /**
  * @vitest-environment jsdom
  */
-import { act, StrictMode } from "react";
-import { createRoot } from "react-dom/client";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { StrictMode, useState } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { afterEach, describe, expect, test, vi } from "vitest";
 
@@ -10,28 +10,112 @@ import {
   loadOpenAIVoiceConfig,
   VoiceInterviewControl,
   VoiceInterviewControlView,
+  type VoiceInterviewControlViewProps,
 } from "./voice-interview-control";
 
-describe("voice interview control", () => {
-  afterEach(() => {
-    vi.unstubAllGlobals();
-  });
+import type { PetrinautAiInterviewStageContext } from "@hashintel/petrinaut/ui";
 
-  test("loads only a schema-valid, available server configuration", async () => {
+const snapshot = {
+  currentQuestion: "What happens after approval?",
+  errorCode: null,
+  errorMessage: "",
+  errorRequestId: "",
+  lastCommittedText: "",
+  microphoneEnabled: true,
+  microphoneLevel: 0.24,
+  partialText: "The request goes to",
+  phase: "listening" as const,
+};
+
+const viewProps = (
+  overrides: Partial<VoiceInterviewControlViewProps> = {},
+): VoiceInterviewControlViewProps => ({
+  consented: true,
+  correction: "",
+  coverage: null,
+  editing: false,
+  microphoneCheck: "",
+  onCheckMicrophone: vi.fn(),
+  onConsentChange: vi.fn(),
+  onCorrectionChange: vi.fn(),
+  onDoneSpeaking: vi.fn(),
+  onEdit: vi.fn(),
+  onEnd: vi.fn(),
+  onExpand: vi.fn(),
+  onInterrupt: vi.fn(),
+  onMinimize: vi.fn(),
+  onPause: vi.fn(),
+  onReconnect: vi.fn(),
+  onRedo: vi.fn(),
+  onResume: vi.fn(),
+  onShowStart: vi.fn(),
+  onStart: vi.fn(),
+  onSubmitCorrection: vi.fn(),
+  onTypeInstead: vi.fn(),
+  placement: "sidebar",
+  presentation: "full",
+  snapshot,
+  ...overrides,
+});
+
+const StatefulVoiceInterviewHarness = ({
+  onOpenSidebar,
+}: {
+  onOpenSidebar: () => void;
+}) => {
+  "use no memo";
+
+  const [active, setActive] = useState(false);
+  const [sidebarOpenRequests, setSidebarOpenRequests] = useState(0);
+  const context: PetrinautAiInterviewStageContext = {
+    canAcceptInterviewAnswer: true,
+    conversationId: "interview-test",
+    focusComposer: vi.fn(),
+    messages: [],
+    openSidebar: () => {
+      onOpenSidebar();
+      setSidebarOpenRequests((requests) => requests + 1);
+    },
+    placement: "sidebar",
+    setActive,
+    status: "ready",
+    stop: vi.fn(async () => undefined),
+    submitInterviewAnswer: vi.fn(async () => ({
+      kind: "message" as const,
+      messageId: "voice-answer",
+    })),
+    submitText: vi.fn(async () => ({
+      kind: "message" as const,
+      messageId: "typed-answer",
+    })),
+  };
+
+  return (
+    <>
+      <output>{active ? "Interview active" : "Interview inactive"}</output>
+      <output>{sidebarOpenRequests} sidebar open requests</output>
+      <VoiceInterviewControl {...context} />
+    </>
+  );
+};
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("voice interview stage", () => {
+  test("loads only a schema-valid available server configuration", async () => {
     const fetch = vi.fn<typeof globalThis.fetch>(async () =>
       Response.json({ available: true, connectionTimeoutMs: 15_000 }),
     );
-
     await expect(loadOpenAIVoiceConfig(fetch)).resolves.toEqual({
       available: true,
       connectionTimeoutMs: 15_000,
     });
     const [url, request] = fetch.mock.calls[0]!;
     expect(url).toBe("/api/voice/config");
-    expect(request).toMatchObject({
-      cache: "no-store",
-      method: "GET",
-    });
+    expect(request).toMatchObject({ cache: "no-store", method: "GET" });
     expect(request?.signal).toBeInstanceOf(AbortSignal);
 
     fetch.mockResolvedValueOnce(
@@ -44,183 +128,188 @@ describe("voice interview control", () => {
     await expect(loadOpenAIVoiceConfig(fetch)).resolves.toBeNull();
   });
 
-  test("renders an accessible idle voice action and live status", () => {
+  test("shows disclosure and requires consent before starting", () => {
     const html = renderToStaticMarkup(
       <VoiceInterviewControlView
-        correction=""
-        onCorrectionChange={vi.fn()}
-        onEnd={vi.fn()}
-        onReconnect={vi.fn()}
-        onStart={vi.fn()}
-        onSubmitCorrection={vi.fn()}
-        snapshot={{
-          errorCode: null,
-          errorMessage: "",
-          errorRequestId: "",
-          lastCommittedText: "",
-          partialText: "",
-          phase: "idle",
-        }}
+        {...viewProps({ consented: false, presentation: "start" })}
       />,
     );
 
-    expect(html).toContain("Start voice input");
-    expect(html).toContain('aria-live="polite"');
-    expect(html).toContain("Voice input is off.");
+    expect(html).toContain("sent to OpenAI for transcription");
+    expect(html).toContain("does not retain the audio");
+    expect(html).toMatch(/<button[^>]*disabled[^>]*>Start interview/u);
+    expect(html).toContain("Use text instead");
+    expect(html).toContain("Check microphone");
+    expect(html).toContain("pos_absolute");
+    expect(html).not.toContain("pos_fixed");
   });
 
-  test("labels the half-duplex listening state and keeps partial text visibly provisional", () => {
+  test("keeps diagnostic recovery details visible without reopening the microphone", () => {
     const html = renderToStaticMarkup(
       <VoiceInterviewControlView
-        correction="The incident manager closes it."
-        onCorrectionChange={vi.fn()}
-        onEnd={vi.fn()}
-        onReconnect={vi.fn()}
-        onStart={vi.fn()}
-        onSubmitCorrection={vi.fn()}
-        snapshot={{
-          errorCode: null,
-          errorMessage: "",
-          errorRequestId: "",
-          lastCommittedText: "The support lead closes it.",
-          partialText: "The next activity",
-          phase: "listening",
-        }}
-      />,
-    );
-
-    expect(html).toContain("Microphone on. Listening.");
-    expect(html).toContain("Live transcript (not sent)");
-    expect(html).toContain("The next activity");
-    expect(html).toContain(
-      "Microphone on. Listening. Live transcript (not sent): The next activity",
-    );
-    expect(html).toContain("End voice input");
-    expect(html).toContain("Correct last voice answer");
-    expect(html).toContain("Send correction");
-  });
-
-  test("offers reconnection without reopening the microphone after failure", () => {
-    const html = renderToStaticMarkup(
-      <VoiceInterviewControlView
-        correction=""
-        onCorrectionChange={vi.fn()}
-        onEnd={vi.fn()}
-        onReconnect={vi.fn()}
-        onStart={vi.fn()}
-        onSubmitCorrection={vi.fn()}
-        snapshot={{
-          errorCode: "microphone-permission",
-          errorMessage:
-            "Allow microphone access in your browser settings, then reconnect voice input.",
-          errorRequestId: "voice-request-permission",
-          lastCommittedText: "",
-          partialText: "",
-          phase: "recoverable-error",
-        }}
+        {...viewProps({
+          snapshot: {
+            ...snapshot,
+            errorCode: "microphone-permission",
+            errorMessage:
+              "Allow microphone access in your browser settings, then reconnect voice input.",
+            errorRequestId: "voice-request-permission",
+            microphoneEnabled: false,
+            microphoneLevel: 0,
+            partialText: "",
+            phase: "recoverable-error",
+          },
+        })}
       />,
     );
 
     expect(html).toContain(
-      "Microphone off. Allow microphone access in your browser settings, then reconnect voice input.",
+      "Microphone off · Allow microphone access in your browser settings, then reconnect voice input.",
     );
     expect(html).toContain("Error code: microphone-permission.");
     expect(html).toContain("Diagnostic reference: voice-request-permission.");
-    expect(html).toContain("Reconnect voice input");
+    expect(html).toContain(">Reconnect<");
   });
 
-  test("remains interactive after Strict Mode replays its effects", async () => {
-    const fetch = vi.fn<typeof globalThis.fetch>(async () =>
-      Response.json({ available: true, connectionTimeoutMs: 15_000 }),
-    );
+  test("starts in the full stage and keeps recovery visible under Strict Mode", async () => {
     const getUserMedia = vi.fn(async () => {
       throw new DOMException("Permission denied", "NotAllowedError");
     });
-    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
-    vi.stubGlobal("fetch", fetch);
-    vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
+    const openSidebar = vi.fn();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof globalThis.fetch>(async () =>
+        Response.json({ available: true, connectionTimeoutMs: 15_000 }),
+      ),
+    );
+    vi.stubGlobal("navigator", {
+      mediaDevices: { getUserMedia },
+    });
 
-    const container = document.createElement("div");
-    document.body.append(container);
-    const root = createRoot(container);
+    render(
+      <StrictMode>
+        <StatefulVoiceInterviewHarness onOpenSidebar={openSidebar} />
+      </StrictMode>,
+    );
 
-    try {
-      await act(async () => {
-        root.render(
-          <StrictMode>
-            <VoiceInterviewControl
-              conversationId="petrinaut-preview:net-1"
-              messages={[]}
-              status="ready"
-              stop={vi.fn(async () => undefined)}
-              submitText={vi.fn(async () => ({
-                kind: "message" as const,
-                messageId: "message-1",
-              }))}
-              submitVoiceInput={vi.fn(async () => ({
-                kind: "message" as const,
-                messageId: "voice-message-1",
-              }))}
-            />
-          </StrictMode>,
-        );
-      });
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Start voice interview" }),
+    );
+    fireEvent.click(screen.getByRole("checkbox"));
+    fireEvent.click(screen.getByRole("button", { name: "Start interview" }));
 
-      const startButton = container.querySelector<HTMLButtonElement>(
-        'button[aria-label="Start voice input"]',
-      );
-      expect(startButton).not.toBeNull();
+    expect(
+      await screen.findByRole("region", { name: "Voice interview stage" }),
+    ).not.toBeNull();
+    expect(
+      await screen.findAllByText(
+        /Microphone off · Allow microphone access in your browser settings, then reconnect voice input\. Error code: microphone-permission\./u,
+      ),
+    ).toHaveLength(2);
+    expect(screen.getByRole("button", { name: "Reconnect" })).not.toBeNull();
+    expect(screen.getByText("Interview active")).not.toBeNull();
+    expect(screen.getByText("1 sidebar open requests")).not.toBeNull();
+    expect(openSidebar).toHaveBeenCalledOnce();
+  });
 
-      await act(async () => {
-        startButton!.click();
-      });
+  test("keeps the question visible, distinguishes provisional text, and names microphone level", () => {
+    const html = renderToStaticMarkup(
+      <VoiceInterviewControlView {...viewProps()} />,
+    );
 
-      expect(getUserMedia).toHaveBeenCalledOnce();
-      expect(container.textContent).toContain(
-        "Allow microphone access in your browser settings, then reconnect voice input.",
-      );
-      expect(
-        container.querySelector('button[aria-label="Reconnect voice input"]'),
-      ).not.toBeNull();
-    } finally {
-      await act(async () => root.unmount());
-      container.remove();
+    expect(html).toContain("What happens after approval?");
+    expect(html).toContain("What we’re hearing · Not sent yet");
+    expect(html).toContain("Microphone on · Listening");
+    expect(html).toContain("Microphone input level: Medium");
+    expect(html).toContain("Done speaking");
+    expect(html).toContain("motionReduce:vis_hidden");
+    expect(html).toContain("pos_relative");
+    expect(html).not.toContain("pos_fixed");
+    expect(html).toContain('aria-live="polite"');
+  });
+
+  test("renders committed repair actions separately from pause, minimize, and end", () => {
+    const html = renderToStaticMarkup(
+      <VoiceInterviewControlView
+        {...viewProps({
+          snapshot: {
+            ...snapshot,
+            lastCommittedText: "The shift lead approves it.",
+            microphoneEnabled: false,
+            microphoneLevel: 0,
+            partialText: "",
+            phase: "waiting",
+          },
+        })}
+      />,
+    );
+
+    for (const name of [
+      "Minimize",
+      "End interview",
+      "Redo answer",
+      "Edit text",
+      "Type instead",
+    ]) {
+      expect(html).toContain(name);
     }
   });
 
-  test("announces synthesis, playback, and the AI-generated voice disclosure", () => {
-    const renderPhase = (phase: "synthesizing" | "playing") =>
-      renderToStaticMarkup(
-        <VoiceInterviewControlView
-          correction=""
-          onCorrectionChange={vi.fn()}
-          onEnd={vi.fn()}
-          onReconnect={vi.fn()}
-          onStart={vi.fn()}
-          onSubmitCorrection={vi.fn()}
-          snapshot={{
-            errorCode: null,
-            errorMessage: "",
-            errorRequestId: "",
-            lastCommittedText: "",
+  test("offers deterministic interrupt instead of listening during playback", () => {
+    const html = renderToStaticMarkup(
+      <VoiceInterviewControlView
+        {...viewProps({
+          snapshot: {
+            ...snapshot,
+            microphoneEnabled: false,
+            microphoneLevel: 0,
             partialText: "",
-            phase,
-          }}
-        />,
-      );
-
-    const synthesizing = renderPhase("synthesizing");
-    expect(synthesizing).toContain(
-      "Microphone off. Creating AI-generated speech.",
-    );
-    expect(synthesizing).toContain(
-      "Spoken responses use an AI-generated OpenAI voice.",
+            phase: "playing",
+          },
+        })}
+      />,
     );
 
-    const playing = renderPhase("playing");
-    expect(playing).toContain("Microphone off. Playing AI-generated speech.");
-    expect(playing).toContain(
-      "Spoken responses use an AI-generated OpenAI voice.",
+    expect(html).toContain("Microphone off · Interviewer speaking");
+    expect(html).toContain("Interrupt and speak");
+    expect(html).not.toContain(">Pause<");
+  });
+
+  test("uses a detached bottom mini bar with independent expand, type, pause, and end controls", () => {
+    const html = renderToStaticMarkup(
+      <VoiceInterviewControlView
+        {...viewProps({ placement: "detached", presentation: "mini" })}
+      />,
     );
+
+    expect(html).toContain('aria-label="Voice interview mini bar"');
+    expect(html).toContain(
+      'aria-label="Expand voice interview. Microphone on · Listening"',
+    );
+    expect(html).toContain("Microphone on · Listening");
+    expect(html).toContain("--voice-interview-right");
+    expect(html).toContain("[@media_(min-width:_768px)]");
+    expect(html).not.toContain("md:right_4");
+    expect(html).toContain('aria-label="Type an interview answer"');
+    expect(html).toContain(">Pause<");
+    expect(html).toContain('aria-label="End interview"');
+  });
+
+  test("shows authoritative covered and still-exploring facts without a question count", () => {
+    const html = renderToStaticMarkup(
+      <VoiceInterviewControlView
+        {...viewProps({
+          coverage: {
+            complete: false,
+            covered: ["dispatch"],
+            stillExploring: ["approval — how long it takes"],
+          },
+        })}
+      />,
+    );
+
+    expect(html).toContain("Covered");
+    expect(html).toContain("Still exploring");
+    expect(html).not.toMatch(/\d+ of \d+/u);
   });
 });

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.test.tsx
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.test.tsx
@@ -7,7 +7,10 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { afterEach, describe, expect, test, vi } from "vitest";
 
 import {
+  acknowledgeVoiceInterviewDisclosure,
+  isVoiceInterviewDisclosureAcknowledged,
   loadOpenAIVoiceConfig,
+  VOICE_INTERVIEW_DISCLOSURE_STORAGE_KEY,
   VoiceInterviewControl,
   VoiceInterviewControlView,
   type VoiceInterviewControlViewProps,
@@ -100,12 +103,70 @@ const StatefulVoiceInterviewHarness = ({
   );
 };
 
+const stubUnavailableMicrophone = () => {
+  const getUserMedia = vi.fn(async () => {
+    throw new DOMException("Permission denied", "NotAllowedError");
+  });
+  vi.stubGlobal(
+    "fetch",
+    vi.fn<typeof globalThis.fetch>(async () =>
+      Response.json({ available: true, connectionTimeoutMs: 15_000 }),
+    ),
+  );
+  vi.stubGlobal(
+    "AudioContext",
+    class {
+      public readonly state = "suspended";
+      public readonly close = vi.fn(async () => undefined);
+      public readonly resume = vi.fn(async () => undefined);
+    },
+  );
+  vi.stubGlobal("navigator", {
+    mediaDevices: { getUserMedia },
+  });
+  return getUserMedia;
+};
+
 afterEach(() => {
   cleanup();
   vi.unstubAllGlobals();
+  window.localStorage.clear();
 });
 
 describe("voice interview stage", () => {
+  test("stores and reads the current disclosure acknowledgement", () => {
+    const values = new Map<string, string>();
+    const storage = {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => values.set(key, value),
+    };
+
+    expect(isVoiceInterviewDisclosureAcknowledged(storage)).toBe(false);
+    acknowledgeVoiceInterviewDisclosure(storage);
+    expect(values.get(VOICE_INTERVIEW_DISCLOSURE_STORAGE_KEY)).toBe(
+      "acknowledged",
+    );
+    expect(isVoiceInterviewDisclosureAcknowledged(storage)).toBe(true);
+  });
+
+  test("fails safe when disclosure storage is unavailable", () => {
+    const unavailableStorage = {
+      getItem: () => {
+        throw new DOMException("Blocked", "SecurityError");
+      },
+      setItem: () => {
+        throw new DOMException("Blocked", "SecurityError");
+      },
+    };
+
+    expect(isVoiceInterviewDisclosureAcknowledged(unavailableStorage)).toBe(
+      false,
+    );
+    expect(() =>
+      acknowledgeVoiceInterviewDisclosure(unavailableStorage),
+    ).not.toThrow();
+  });
+
   test("loads only a schema-valid available server configuration", async () => {
     const fetch = vi.fn<typeof globalThis.fetch>(async () =>
       Response.json({ available: true, connectionTimeoutMs: 15_000 }),
@@ -219,6 +280,50 @@ describe("voice interview stage", () => {
     expect(screen.getByText("Interview active")).not.toBeNull();
     expect(screen.getByText("1 sidebar open requests")).not.toBeNull();
     expect(openSidebar).toHaveBeenCalledOnce();
+  });
+
+  test("records acknowledgement only when the interview starts", async () => {
+    window.localStorage.clear();
+    stubUnavailableMicrophone();
+    render(
+      <StatefulVoiceInterviewHarness onOpenSidebar={vi.fn()} />,
+    );
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Start voice interview" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Check microphone" }));
+    expect(
+      window.localStorage.getItem(VOICE_INTERVIEW_DISCLOSURE_STORAGE_KEY),
+    ).toBeNull();
+
+    fireEvent.click(screen.getByRole("checkbox"));
+    fireEvent.click(screen.getByRole("button", { name: "Start interview" }));
+    expect(
+      window.localStorage.getItem(VOICE_INTERVIEW_DISCLOSURE_STORAGE_KEY),
+    ).toBe("acknowledged");
+  });
+
+  test("skips the disclosure after it has been acknowledged", async () => {
+    stubUnavailableMicrophone();
+    window.localStorage.setItem(
+      VOICE_INTERVIEW_DISCLOSURE_STORAGE_KEY,
+      "acknowledged",
+    );
+    render(
+      <StatefulVoiceInterviewHarness onOpenSidebar={vi.fn()} />,
+    );
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Start voice interview" }),
+    );
+
+    expect(
+      screen.queryByRole("region", { name: "Start voice interview" }),
+    ).toBeNull();
+    expect(
+      await screen.findByRole("region", { name: "Voice interview stage" }),
+    ).not.toBeNull();
   });
 
   test("keeps the question visible, distinguishes provisional text, and names microphone level", () => {

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.test.tsx
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.test.tsx
@@ -717,6 +717,7 @@ describe("voice interview stage", () => {
     expect(
       screen.getByText("We couldn’t reconnect the microphone"),
     ).not.toBeNull();
+    expect(screen.getByText("Microphone unavailable")).not.toBeNull();
     expect(
       screen.getByText(
         "Connect or select a microphone, then reconnect voice input.",
@@ -730,6 +731,7 @@ describe("voice interview stage", () => {
       ),
     );
     expect(screen.getByText("We lost the voice connection")).not.toBeNull();
+    expect(screen.getByText("Connection paused")).not.toBeNull();
 
     rendered.rerender(
       recovery(
@@ -738,6 +740,7 @@ describe("voice interview stage", () => {
       ),
     );
     expect(screen.getByText("The interview couldn’t continue")).not.toBeNull();
+    expect(screen.getByText("Interview paused")).not.toBeNull();
 
     rendered.rerender(
       recovery(
@@ -746,6 +749,7 @@ describe("voice interview stage", () => {
       ),
     );
     expect(screen.getByText("The interview couldn’t continue")).not.toBeNull();
+    expect(screen.getByText("Interview paused")).not.toBeNull();
     expect(
       screen.queryByText("We couldn’t reconnect the microphone"),
     ).toBeNull();

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.test.tsx
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.test.tsx
@@ -708,34 +708,102 @@ describe("voice interview stage", () => {
   });
 
   test("uses a detached bottom mini bar with independent expand, type, pause, and end controls", () => {
-    const html = renderToStaticMarkup(
-      <VoiceInterviewControlView
-        {...viewProps({ placement: "detached", presentation: "mini" })}
-      />,
-    );
-
-    expect(html).toContain('aria-label="Voice interview mini bar"');
-    expect(html).toContain(
-      'aria-label="Expand voice interview. Microphone on · Listening. Question: What happens after approval?"',
-    );
-    expect(html).toContain("Microphone on · Listening");
-    expect(html).toContain("What happens after approval?");
-    expect(html).toContain("--voice-interview-right");
-    expect(html).toContain("[@media_(min-width:_768px)]");
-    expect(html).not.toContain("md:right_4");
-    expect(html).toContain('aria-label="Use text instead"');
-    expect(html).toContain(">Pause<");
-    expect(html).toContain('aria-label="End interview"');
-
     render(
       <VoiceInterviewControlView
         {...viewProps({ placement: "detached", presentation: "mini" })}
       />,
     );
-    const endButton = screen.getByRole("button", { name: "End interview" });
-    expect(endButton.querySelector("svg")).not.toBeNull();
-    expect(endButton.parentElement?.getAttribute("data-part")).toBe("trigger");
-    expect(endButton.parentElement?.getAttribute("data-scope")).toBe("tooltip");
+
+    expect(
+      screen.getByRole("region", { name: "Voice interview mini bar" }),
+    ).not.toBeNull();
+    expect(
+      screen.getByRole("button", {
+        name: "Expand voice interview. Microphone on · Listening. Question: What happens after approval?",
+      }),
+    ).not.toBeNull();
+    expect(screen.getByText("Listening")).not.toBeNull();
+    expect(screen.queryByText("Microphone on · Listening")).toBeNull();
+    expect(screen.getByText("What happens after approval?")).not.toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Done speaking" }),
+    ).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Pause" })).not.toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Use text instead" }),
+    ).not.toBeNull();
+    expect(
+      screen.getByRole("button", { name: "End interview" }),
+    ).not.toBeNull();
+
+    for (const name of [
+      "Done speaking",
+      "Pause",
+      "Use text instead",
+      "End interview",
+    ]) {
+      const button = screen.getByRole("button", { name });
+      expect(button.querySelector("svg")).not.toBeNull();
+      expect(button.parentElement?.getAttribute("data-scope")).toBe("tooltip");
+    }
+
+    const html = renderToStaticMarkup(
+      <VoiceInterviewControlView
+        {...viewProps({ placement: "detached", presentation: "mini" })}
+      />,
+    );
+    expect(html).toContain("--voice-interview-right");
+    expect(html).toContain("[@media_(min-width:_768px)]");
+    expect(html).not.toContain("md:right_4");
+  });
+
+  test("shows only the valid compact phase action", () => {
+    const rendered = render(
+      <VoiceInterviewControlView
+        {...viewProps({
+          snapshot: { ...snapshot, microphoneEnabled: false, phase: "paused" },
+          presentation: "mini",
+        })}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Resume listening" }),
+    ).not.toBeNull();
+    expect(screen.queryByRole("button", { name: "Done speaking" })).toBeNull();
+    expect(
+      screen
+        .getByRole("button", { name: "Resume listening" })
+        .querySelector("svg"),
+    ).not.toBeNull();
+    expect(
+      screen
+        .getByRole("button", { name: "Resume listening" })
+        .parentElement?.getAttribute("data-scope"),
+    ).toBe("tooltip");
+
+    rendered.rerender(
+      <VoiceInterviewControlView
+        {...viewProps({
+          snapshot: { ...snapshot, microphoneEnabled: false, phase: "playing" },
+          presentation: "mini",
+        })}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: "Interrupt and speak" }),
+    ).not.toBeNull();
+    expect(screen.queryByRole("button", { name: "Pause" })).toBeNull();
+    expect(
+      screen
+        .getByRole("button", { name: "Interrupt and speak" })
+        .querySelector("svg"),
+    ).not.toBeNull();
+    expect(
+      screen
+        .getByRole("button", { name: "Interrupt and speak" })
+        .parentElement?.getAttribute("data-scope"),
+    ).toBe("tooltip");
   });
 
   test("announces compact question and provisional transcript context", () => {

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.test.tsx
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.test.tsx
@@ -22,6 +22,8 @@ import {
   type VoiceInterviewControlViewProps,
 } from "./voice-interview-control";
 
+import type { VoiceTurnSnapshot } from "./voice-turn-controller";
+
 import type { PetrinautAiInterviewStageContext } from "@hashintel/petrinaut/ui";
 
 const snapshot = {
@@ -588,6 +590,74 @@ describe("voice interview stage", () => {
     ).toBe("");
   });
 
+  test("orders the full listening actions as keyboard, done speaking, then pause", () => {
+    const html = renderToStaticMarkup(
+      <VoiceInterviewControlView {...viewProps()} />,
+    );
+
+    expect(html.indexOf('aria-label="Use text instead"')).toBeLessThan(
+      html.indexOf('aria-label="Done speaking"'),
+    );
+    expect(html.indexOf('aria-label="Done speaking"')).toBeLessThan(
+      html.indexOf('aria-label="Pause"'),
+    );
+  });
+
+  test("offers only resume and keyboard actions while paused", () => {
+    render(
+      <VoiceInterviewControlView
+        {...viewProps({
+          snapshot: {
+            ...snapshot,
+            microphoneEnabled: false,
+            microphoneLevel: 0,
+            partialText: "",
+            phase: "paused",
+          },
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Paused")).not.toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Resume listening" }),
+    ).not.toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Use text instead" }),
+    ).not.toBeNull();
+    expect(screen.queryByRole("button", { name: "Done speaking" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Pause" })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Interrupt and speak" }),
+    ).toBeNull();
+  });
+
+  test("shows the waveform only while the microphone is listening", () => {
+    const rendered = render(<VoiceInterviewControlView {...viewProps()} />);
+
+    expect(screen.getByTestId("voice-waveform")).not.toBeNull();
+
+    for (const phase of ["paused", "playing", "waiting"] as const) {
+      rendered.rerender(
+        <VoiceInterviewControlView
+          {...viewProps({
+            snapshot: {
+              ...snapshot,
+              microphoneEnabled: false,
+              microphoneLevel: 0,
+              partialText: "",
+              phase,
+            },
+          })}
+        />,
+      );
+      expect(screen.queryByTestId("voice-waveform")).toBeNull();
+      expect(
+        screen.queryByText(/Microphone input level:/u),
+      ).toBeNull();
+    }
+  });
+
   test("keeps reconnect visible and makes secondary recovery icon-only", () => {
     render(
       <VoiceInterviewControlView
@@ -619,6 +689,69 @@ describe("voice interview stage", () => {
         .querySelector("svg"),
     ).not.toBeNull();
     expect(screen.getByText("Technical details")).not.toBeNull();
+  });
+
+  test("names the recovery problem for each error family", () => {
+    const recovery = (
+      errorCode: VoiceTurnSnapshot["errorCode"],
+      errorMessage: string,
+    ) => (
+      <VoiceInterviewControlView
+        {...viewProps({
+          snapshot: {
+            ...snapshot,
+            errorCode,
+            errorMessage,
+            microphoneEnabled: false,
+            microphoneLevel: 0,
+            partialText: "",
+            phase: "recoverable-error",
+          },
+        })}
+      />
+    );
+
+    const rendered = render(
+      recovery(
+        "microphone-device",
+        "Connect or select a microphone, then reconnect voice input.",
+      ),
+    );
+    expect(
+      screen.getByText("We couldn’t reconnect the microphone"),
+    ).not.toBeNull();
+    expect(
+      screen.getByText(
+        "Connect or select a microphone, then reconnect voice input.",
+      ),
+    ).not.toBeNull();
+
+    rendered.rerender(
+      recovery(
+        "timeout",
+        "The voice connection timed out. Check your connection, then reconnect voice input.",
+      ),
+    );
+    expect(screen.getByText("We lost the voice connection")).not.toBeNull();
+
+    rendered.rerender(
+      recovery(
+        "invalid-response",
+        "The interview could not accept that answer. Use the composer to retry.",
+      ),
+    );
+    expect(screen.getByText("The interview couldn’t continue")).not.toBeNull();
+
+    rendered.rerender(
+      recovery(
+        null,
+        "The interview could not accept that answer. Use the composer to retry.",
+      ),
+    );
+    expect(screen.getByText("The interview couldn’t continue")).not.toBeNull();
+    expect(
+      screen.queryByText("We couldn’t reconnect the microphone"),
+    ).toBeNull();
   });
 
   test("renders icons for the listening controls", () => {
@@ -888,5 +1021,21 @@ describe("voice interview stage", () => {
     expect(html).toContain("Covered");
     expect(html).toContain("Still exploring");
     expect(html).not.toMatch(/\d+ of \d+/u);
+  });
+
+  test("keeps interview coverage as a low-emphasis details row", () => {
+    const html = renderToStaticMarkup(
+      <VoiceInterviewControlView
+        {...viewProps({
+          coverage: {
+            complete: false,
+            covered: ["dispatch"],
+            stillExploring: ["approval — how long it takes"],
+          },
+        })}
+      />,
+    );
+
+    expect(html).toMatch(/<details class="[^"]*fs_xs/u);
   });
 });

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.test.tsx
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.test.tsx
@@ -403,6 +403,35 @@ describe("voice interview stage", () => {
     expect(focusComposer).toHaveBeenCalledOnce();
   });
 
+  test("uses text from an active interview without ending the session", async () => {
+    window.localStorage.setItem(
+      VOICE_INTERVIEW_DISCLOSURE_STORAGE_KEY,
+      "acknowledged",
+    );
+    const focusComposer = vi.fn();
+    stubUnavailableMicrophone();
+    render(
+      <StatefulVoiceInterviewHarness
+        onFocusComposer={focusComposer}
+        onOpenSidebar={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Select Interview" }));
+    expect(
+      await screen.findByRole("region", { name: "Voice interview stage" }),
+    ).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Use text instead" }));
+
+    expect(screen.getByText("Chat mode")).not.toBeNull();
+    expect(screen.getByText("Interview active")).not.toBeNull();
+    expect(
+      screen.getByRole("region", { name: "Voice interview mini bar" }),
+    ).not.toBeNull();
+    expect(focusComposer).toHaveBeenCalledOnce();
+  });
+
   test("skips the disclosure after it has been acknowledged", async () => {
     stubUnavailableMicrophone();
     window.localStorage.setItem(

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.test.tsx
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.test.tsx
@@ -23,7 +23,6 @@ import {
 } from "./voice-interview-control";
 
 import type { VoiceTurnSnapshot } from "./voice-turn-controller";
-
 import type { PetrinautAiInterviewStageContext } from "@hashintel/petrinaut/ui";
 
 const snapshot = {
@@ -652,9 +651,7 @@ describe("voice interview stage", () => {
         />,
       );
       expect(screen.queryByTestId("voice-waveform")).toBeNull();
-      expect(
-        screen.queryByText(/Microphone input level:/u),
-      ).toBeNull();
+      expect(screen.queryByText(/Microphone input level:/u)).toBeNull();
     }
   });
 

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.test.tsx
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.test.tsx
@@ -405,9 +405,17 @@ describe("voice interview stage", () => {
     fireEvent.click(screen.getByRole("button", { name: "Select Interview" }));
     await screen.findByText("Listening");
     fireEvent.click(screen.getByRole("button", { name: "End interview" }));
+
+    expect(screen.getByText("Chat mode")).not.toBeNull();
+    expect(screen.getByText("Interview inactive")).not.toBeNull();
+    expect(
+      screen.queryByRole("region", { name: "Voice interview mini bar" }),
+    ).toBeNull();
+
     fireEvent.click(screen.getByRole("button", { name: "Select Interview" }));
 
     expect(connect).toHaveBeenCalledOnce();
+    expect(screen.getByText("Interview inactive")).not.toBeNull();
     finishDisconnect?.();
 
     await waitFor(() => expect(connect).toHaveBeenCalledTimes(2));

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.test.tsx
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.test.tsx
@@ -1,7 +1,13 @@
 /**
  * @vitest-environment jsdom
  */
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { StrictMode, useState } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { afterEach, describe, expect, test, vi } from "vitest";
@@ -31,6 +37,8 @@ const snapshot = {
   phase: "listening" as const,
 };
 
+const config = { available: true as const, connectionTimeoutMs: 15_000 };
+
 const viewProps = (
   overrides: Partial<VoiceInterviewControlViewProps> = {},
 ): VoiceInterviewControlViewProps => ({
@@ -52,7 +60,6 @@ const viewProps = (
   onReconnect: vi.fn(),
   onRedo: vi.fn(),
   onResume: vi.fn(),
-  onShowStart: vi.fn(),
   onStart: vi.fn(),
   onSubmitCorrection: vi.fn(),
   onTypeInstead: vi.fn(),
@@ -63,18 +70,23 @@ const viewProps = (
 });
 
 const StatefulVoiceInterviewHarness = ({
+  onFocusComposer = vi.fn(),
   onOpenSidebar,
 }: {
+  onFocusComposer?: () => void;
   onOpenSidebar: () => void;
 }) => {
   "use no memo";
 
   const [active, setActive] = useState(false);
+  const [interactionMode, setInteractionMode] =
+    useState<PetrinautAiInterviewStageContext["interactionMode"]>("chat");
   const [sidebarOpenRequests, setSidebarOpenRequests] = useState(0);
   const context: PetrinautAiInterviewStageContext = {
     canAcceptInterviewAnswer: true,
     conversationId: "interview-test",
-    focusComposer: vi.fn(),
+    focusComposer: onFocusComposer,
+    interactionMode,
     messages: [],
     openSidebar: () => {
       onOpenSidebar();
@@ -82,6 +94,7 @@ const StatefulVoiceInterviewHarness = ({
     },
     placement: "sidebar",
     setActive,
+    setInteractionMode,
     status: "ready",
     stop: vi.fn(async () => undefined),
     submitInterviewAnswer: vi.fn(async () => ({
@@ -96,9 +109,18 @@ const StatefulVoiceInterviewHarness = ({
 
   return (
     <>
+      <button type="button" onClick={() => setInteractionMode("chat")}>
+        Select Chat
+      </button>
+      <button type="button" onClick={() => setInteractionMode("interview")}>
+        Select Interview
+      </button>
       <output>{active ? "Interview active" : "Interview inactive"}</output>
+      <output>
+        {interactionMode === "chat" ? "Chat mode" : "Interview mode"}
+      </output>
       <output>{sidebarOpenRequests} sidebar open requests</output>
-      <VoiceInterviewControl {...context} />
+      <VoiceInterviewControl {...context} config={config} />
     </>
   );
 };
@@ -206,7 +228,7 @@ describe("voice interview stage", () => {
       html.indexOf("Check microphone"),
     );
     expect(html).toMatch(/<button[^>]*disabled[^>]*>Start interview/u);
-    expect(html).toContain("Use text");
+    expect(html).toContain(">Use text instead<");
     expect(html).toContain("Check microphone");
     expect(html).toContain("pos_absolute");
     expect(html).not.toContain("pos_fixed");
@@ -244,27 +266,8 @@ describe("voice interview stage", () => {
   });
 
   test("starts in the full stage and keeps recovery visible under Strict Mode", async () => {
-    const getUserMedia = vi.fn(async () => {
-      throw new DOMException("Permission denied", "NotAllowedError");
-    });
+    const getUserMedia = stubUnavailableMicrophone();
     const openSidebar = vi.fn();
-    vi.stubGlobal(
-      "fetch",
-      vi.fn<typeof globalThis.fetch>(async () =>
-        Response.json({ available: true, connectionTimeoutMs: 15_000 }),
-      ),
-    );
-    vi.stubGlobal(
-      "AudioContext",
-      class {
-        public readonly state = "suspended";
-        public readonly close = vi.fn(async () => undefined);
-        public readonly resume = vi.fn(async () => undefined);
-      },
-    );
-    vi.stubGlobal("navigator", {
-      mediaDevices: { getUserMedia },
-    });
 
     render(
       <StrictMode>
@@ -272,9 +275,7 @@ describe("voice interview stage", () => {
       </StrictMode>,
     );
 
-    fireEvent.click(
-      await screen.findByRole("button", { name: "Start voice interview" }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: "Select Interview" }));
     fireEvent.click(screen.getByRole("checkbox"));
     fireEvent.click(screen.getByRole("button", { name: "Start interview" }));
 
@@ -288,8 +289,75 @@ describe("voice interview stage", () => {
     ).toHaveLength(2);
     expect(screen.getByRole("button", { name: "Reconnect" })).not.toBeNull();
     expect(screen.getByText("Interview active")).not.toBeNull();
+    expect(screen.getByText("Interview mode")).not.toBeNull();
     expect(screen.getByText("1 sidebar open requests")).not.toBeNull();
     expect(openSidebar).toHaveBeenCalledOnce();
+    expect(getUserMedia).toHaveBeenCalledOnce();
+
+    fireEvent.click(screen.getByRole("button", { name: "Select Chat" }));
+    expect(
+      screen.getByRole("region", { name: "Voice interview mini bar" }),
+    ).not.toBeNull();
+    expect(screen.getByText("Chat mode")).not.toBeNull();
+    expect(openSidebar).toHaveBeenCalledOnce();
+  });
+
+  test("uses full Interview and compact Chat presentations without ending", async () => {
+    window.localStorage.setItem(
+      VOICE_INTERVIEW_DISCLOSURE_STORAGE_KEY,
+      "acknowledged",
+    );
+    const getUserMedia = stubUnavailableMicrophone();
+    render(<StatefulVoiceInterviewHarness onOpenSidebar={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Select Interview" }));
+    expect(
+      await screen.findByRole("region", { name: "Voice interview stage" }),
+    ).not.toBeNull();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Minimize voice interview" }),
+    );
+    expect(
+      screen.getByRole("region", { name: "Voice interview mini bar" }),
+    ).not.toBeNull();
+    expect(screen.getByText("Interview active")).not.toBeNull();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Expand voice interview/u }),
+    );
+    expect(
+      screen.getByRole("region", { name: "Voice interview stage" }),
+    ).not.toBeNull();
+    expect(screen.getByText("Interview mode")).not.toBeNull();
+    expect(getUserMedia).toHaveBeenCalledOnce();
+  });
+
+  test("ends the interview and returns to Chat", async () => {
+    window.localStorage.setItem(
+      VOICE_INTERVIEW_DISCLOSURE_STORAGE_KEY,
+      "acknowledged",
+    );
+    stubUnavailableMicrophone();
+    render(<StatefulVoiceInterviewHarness onOpenSidebar={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Select Interview" }));
+    expect(
+      await screen.findByRole("region", { name: "Voice interview stage" }),
+    ).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "End interview" }));
+
+    expect(screen.getByText("Chat mode")).not.toBeNull();
+    expect(screen.getByText("Interview inactive")).not.toBeNull();
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("region", { name: "Voice interview stage" }),
+      ).toBeNull();
+      expect(
+        screen.queryByRole("region", { name: "Voice interview mini bar" }),
+      ).toBeNull();
+    });
   });
 
   test("records acknowledgement only when the interview starts", async () => {
@@ -297,9 +365,7 @@ describe("voice interview stage", () => {
     stubUnavailableMicrophone();
     render(<StatefulVoiceInterviewHarness onOpenSidebar={vi.fn()} />);
 
-    fireEvent.click(
-      await screen.findByRole("button", { name: "Start voice interview" }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: "Select Interview" }));
     fireEvent.click(screen.getByRole("button", { name: "Check microphone" }));
     expect(
       window.localStorage.getItem(VOICE_INTERVIEW_DISCLOSURE_STORAGE_KEY),
@@ -314,21 +380,27 @@ describe("voice interview stage", () => {
 
   test("does not record acknowledgement when choosing text instead", async () => {
     window.localStorage.clear();
+    const focusComposer = vi.fn();
     vi.stubGlobal(
       "fetch",
       vi.fn<typeof globalThis.fetch>(async () =>
         Response.json({ available: true, connectionTimeoutMs: 15_000 }),
       ),
     );
-    render(<StatefulVoiceInterviewHarness onOpenSidebar={vi.fn()} />);
-
-    fireEvent.click(
-      await screen.findByRole("button", { name: "Start voice interview" }),
+    render(
+      <StatefulVoiceInterviewHarness
+        onFocusComposer={focusComposer}
+        onOpenSidebar={vi.fn()}
+      />,
     );
-    fireEvent.click(screen.getByRole("button", { name: "Use text" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Select Interview" }));
+    fireEvent.click(screen.getByRole("button", { name: "Use text instead" }));
     expect(
       window.localStorage.getItem(VOICE_INTERVIEW_DISCLOSURE_STORAGE_KEY),
     ).toBeNull();
+    expect(screen.getByText("Chat mode")).not.toBeNull();
+    expect(focusComposer).toHaveBeenCalledOnce();
   });
 
   test("skips the disclosure after it has been acknowledged", async () => {
@@ -339,9 +411,7 @@ describe("voice interview stage", () => {
     );
     render(<StatefulVoiceInterviewHarness onOpenSidebar={vi.fn()} />);
 
-    fireEvent.click(
-      await screen.findByRole("button", { name: "Start voice interview" }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: "Select Interview" }));
 
     expect(
       screen.queryByRole("region", { name: "Start voice interview" }),
@@ -423,7 +493,7 @@ describe("voice interview stage", () => {
       "End interview",
       "Redo answer",
       "Edit text",
-      "Type instead",
+      "Use text instead",
     ]) {
       expect(html).toContain(name);
     }
@@ -518,7 +588,7 @@ describe("voice interview stage", () => {
     expect(html).toContain("--voice-interview-right");
     expect(html).toContain("[@media_(min-width:_768px)]");
     expect(html).not.toContain("md:right_4");
-    expect(html).toContain('aria-label="Type an interview answer"');
+    expect(html).toContain('aria-label="Use text instead"');
     expect(html).toContain(">Pause<");
     expect(html).toContain('aria-label="End interview"');
 

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.test.tsx
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.test.tsx
@@ -30,6 +30,7 @@ const snapshot = {
   errorCode: null,
   errorMessage: "",
   errorRequestId: "",
+  lastAnswerDelivery: "none" as const,
   lastCommittedText: "",
   microphoneEnabled: true,
   microphoneLevel: 0.24,
@@ -507,6 +508,7 @@ describe("voice interview stage", () => {
         {...viewProps({
           snapshot: {
             ...snapshot,
+            lastAnswerDelivery: "delivered",
             lastCommittedText: "The shift lead assigns an owner.",
             microphoneEnabled: false,
             microphoneLevel: 0,
@@ -519,6 +521,53 @@ describe("voice interview stage", () => {
 
     expect(screen.getByText("Your answer")).not.toBeNull();
     expect(screen.getByText("Sent")).not.toBeNull();
+    expect(screen.getByText("The shift lead assigns an owner.")).not.toBeNull();
+  });
+
+  test("shows a sending status while the answer is still being delivered", () => {
+    render(
+      <VoiceInterviewControlView
+        {...viewProps({
+          snapshot: {
+            ...snapshot,
+            lastAnswerDelivery: "pending",
+            lastCommittedText: "The shift lead assigns an owner.",
+            microphoneEnabled: false,
+            microphoneLevel: 0,
+            partialText: "",
+            phase: "delivering",
+          },
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Your answer")).not.toBeNull();
+    expect(screen.getByText("Sending")).not.toBeNull();
+    expect(screen.queryByText("Sent")).toBeNull();
+  });
+
+  test("shows a not-sent status when delivery failed", () => {
+    render(
+      <VoiceInterviewControlView
+        {...viewProps({
+          snapshot: {
+            ...snapshot,
+            errorCode: null,
+            errorMessage:
+              "The interview could not accept that answer. Use the composer to retry.",
+            lastAnswerDelivery: "failed",
+            lastCommittedText: "The shift lead assigns an owner.",
+            microphoneEnabled: false,
+            microphoneLevel: 0,
+            partialText: "",
+            phase: "recoverable-error",
+          },
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Not sent")).not.toBeNull();
+    expect(screen.queryByText("Sent")).toBeNull();
     expect(screen.getByText("The shift lead assigns an owner.")).not.toBeNull();
   });
 

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.test.tsx
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.test.tsx
@@ -304,6 +304,27 @@ describe("voice interview stage", () => {
     ).toBe("acknowledged");
   });
 
+  test("does not record acknowledgement when choosing text instead", async () => {
+    window.localStorage.clear();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof globalThis.fetch>(async () =>
+        Response.json({ available: true, connectionTimeoutMs: 15_000 }),
+      ),
+    );
+    render(
+      <StatefulVoiceInterviewHarness onOpenSidebar={vi.fn()} />,
+    );
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Start voice interview" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Use text instead" }));
+    expect(
+      window.localStorage.getItem(VOICE_INTERVIEW_DISCLOSURE_STORAGE_KEY),
+    ).toBeNull();
+  });
+
   test("skips the disclosure after it has been acknowledged", async () => {
     stubUnavailableMicrophone();
     window.localStorage.setItem(

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.test.tsx
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.test.tsx
@@ -239,6 +239,8 @@ describe("voice interview stage", () => {
     expect(html).toContain("microphone-permission");
     expect(html).toContain("voice-request-permission");
     expect(html).toContain(">Reconnect<");
+    expect(html).toContain(">Use text instead<");
+    expect(html).not.toContain(">Type instead<");
   });
 
   test("starts in the full stage and keeps recovery visible under Strict Mode", async () => {
@@ -509,7 +511,7 @@ describe("voice interview stage", () => {
 
     expect(html).toContain('aria-label="Voice interview mini bar"');
     expect(html).toContain(
-      'aria-label="Expand voice interview. Microphone on · Listening"',
+      'aria-label="Expand voice interview. Microphone on · Listening. Question: What happens after approval?"',
     );
     expect(html).toContain("Microphone on · Listening");
     expect(html).toContain("What happens after approval?");
@@ -529,6 +531,23 @@ describe("voice interview stage", () => {
     expect(endButton.querySelector("svg")).not.toBeNull();
     expect(endButton.parentElement?.getAttribute("data-part")).toBe("trigger");
     expect(endButton.parentElement?.getAttribute("data-scope")).toBe("tooltip");
+  });
+
+  test("announces compact question and provisional transcript context", () => {
+    render(
+      <VoiceInterviewControlView
+        {...viewProps({ placement: "detached", presentation: "mini" })}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", {
+        name: "Expand voice interview. Microphone on · Listening. Question: What happens after approval?",
+      }),
+    ).not.toBeNull();
+    expect(screen.getByRole("status").textContent).toBe(
+      "Microphone on · Listening. Question: What happens after approval? Not sent yet: The request goes to",
+    );
   });
 
   test("shows authoritative covered and still-exploring facts without a question count", () => {

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.test.tsx
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.test.tsx
@@ -16,6 +16,7 @@ import {
 import type { PetrinautAiInterviewStageContext } from "@hashintel/petrinaut/ui";
 
 const snapshot = {
+  canReviseLastAnswer: false,
   currentQuestion: "What happens after approval?",
   errorCode: null,
   errorMessage: "",
@@ -182,6 +183,14 @@ describe("voice interview stage", () => {
         Response.json({ available: true, connectionTimeoutMs: 15_000 }),
       ),
     );
+    vi.stubGlobal(
+      "AudioContext",
+      class {
+        public readonly state = "suspended";
+        public readonly close = vi.fn(async () => undefined);
+        public readonly resume = vi.fn(async () => undefined);
+      },
+    );
     vi.stubGlobal("navigator", {
       mediaDevices: { getUserMedia },
     });
@@ -253,6 +262,59 @@ describe("voice interview stage", () => {
     ]) {
       expect(html).toContain(name);
     }
+  });
+
+  test("enables repair actions only while the last answer can be revised", () => {
+    const rendered = render(
+      <VoiceInterviewControlView
+        {...viewProps({
+          snapshot: {
+            ...snapshot,
+            canReviseLastAnswer: false,
+            lastCommittedText: "The shift lead approves it.",
+            microphoneEnabled: false,
+            microphoneLevel: 0,
+            partialText: "",
+            phase: "waiting",
+          },
+        })}
+      />,
+    );
+
+    expect(
+      screen
+        .getByRole("button", { name: "Redo answer" })
+        .hasAttribute("disabled"),
+    ).toBe(true);
+    expect(
+      screen
+        .getByRole("button", { name: "Edit text" })
+        .hasAttribute("disabled"),
+    ).toBe(true);
+
+    rendered.rerender(
+      <VoiceInterviewControlView
+        {...viewProps({
+          snapshot: {
+            ...snapshot,
+            canReviseLastAnswer: true,
+            lastCommittedText: "The shift lead approves it.",
+            partialText: "",
+          },
+        })}
+      />,
+    );
+
+    expect(
+      screen
+        .getByRole("button", { name: "Redo answer" })
+        .hasAttribute("disabled"),
+    ).toBe(false);
+    expect(
+      screen
+        .getByRole("button", { name: "Edit text" })
+        .hasAttribute("disabled"),
+    ).toBe(false);
   });
 
   test("offers deterministic interrupt instead of listening during playback", () => {

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.test.tsx
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.test.tsx
@@ -108,6 +108,10 @@ const StatefulVoiceInterviewHarness = ({
       kind: "message" as const,
       messageId: "typed-answer",
     })),
+    submitVoiceInput: vi.fn(async () => ({
+      kind: "message" as const,
+      messageId: "voice-answer",
+    })),
   };
 
   return (

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.test.tsx
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.test.tsx
@@ -293,9 +293,7 @@ describe("voice interview stage", () => {
   test("records acknowledgement only when the interview starts", async () => {
     window.localStorage.clear();
     stubUnavailableMicrophone();
-    render(
-      <StatefulVoiceInterviewHarness onOpenSidebar={vi.fn()} />,
-    );
+    render(<StatefulVoiceInterviewHarness onOpenSidebar={vi.fn()} />);
 
     fireEvent.click(
       await screen.findByRole("button", { name: "Start voice interview" }),
@@ -320,9 +318,7 @@ describe("voice interview stage", () => {
         Response.json({ available: true, connectionTimeoutMs: 15_000 }),
       ),
     );
-    render(
-      <StatefulVoiceInterviewHarness onOpenSidebar={vi.fn()} />,
-    );
+    render(<StatefulVoiceInterviewHarness onOpenSidebar={vi.fn()} />);
 
     fireEvent.click(
       await screen.findByRole("button", { name: "Start voice interview" }),
@@ -339,9 +335,7 @@ describe("voice interview stage", () => {
       VOICE_INTERVIEW_DISCLOSURE_STORAGE_KEY,
       "acknowledged",
     );
-    render(
-      <StatefulVoiceInterviewHarness onOpenSidebar={vi.fn()} />,
-    );
+    render(<StatefulVoiceInterviewHarness onOpenSidebar={vi.fn()} />);
 
     fireEvent.click(
       await screen.findByRole("button", { name: "Start voice interview" }),

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.test.tsx
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.test.tsx
@@ -12,6 +12,7 @@ import { StrictMode, useState } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { afterEach, describe, expect, test, vi } from "vitest";
 
+import { OpenAIRealtimeSession } from "./openai-realtime-session";
 import {
   acknowledgeVoiceInterviewDisclosure,
   isVoiceInterviewDisclosureAcknowledged,
@@ -372,6 +373,42 @@ describe("voice interview stage", () => {
         screen.queryByRole("region", { name: "Voice interview mini bar" }),
       ).toBeNull();
     });
+  });
+
+  test("restarts when Interview is reselected before teardown completes", async () => {
+    window.localStorage.setItem(
+      VOICE_INTERVIEW_DISCLOSURE_STORAGE_KEY,
+      "acknowledged",
+    );
+    const connect = vi
+      .spyOn(OpenAIRealtimeSession.prototype, "connect")
+      .mockResolvedValue(1);
+    let finishDisconnect: (() => void) | undefined;
+    vi.spyOn(OpenAIRealtimeSession.prototype, "disconnect")
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            finishDisconnect = resolve;
+          }),
+      )
+      .mockResolvedValue(undefined);
+    vi.spyOn(
+      OpenAIRealtimeSession.prototype,
+      "setMicrophoneEnabled",
+    ).mockImplementation(() => {});
+    render(<StatefulVoiceInterviewHarness onOpenSidebar={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Select Interview" }));
+    await screen.findByText("Listening");
+    fireEvent.click(screen.getByRole("button", { name: "End interview" }));
+    fireEvent.click(screen.getByRole("button", { name: "Select Interview" }));
+
+    expect(connect).toHaveBeenCalledOnce();
+    finishDisconnect?.();
+
+    await waitFor(() => expect(connect).toHaveBeenCalledTimes(2));
+    expect(screen.getByText("Interview active")).not.toBeNull();
+    expect(screen.getByText("Listening")).not.toBeNull();
   });
 
   test("records acknowledgement only when the interview starts", async () => {

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.test.tsx
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.test.tsx
@@ -228,7 +228,7 @@ describe("voice interview stage", () => {
       html.indexOf("Check microphone"),
     );
     expect(html).toMatch(/<button[^>]*disabled[^>]*>Start interview/u);
-    expect(html).toContain(">Use text instead<");
+    expect(html).toContain('aria-label="Use text instead"');
     expect(html).toContain("Check microphone");
     expect(html).toContain("pos_absolute");
     expect(html).not.toContain("pos_fixed");
@@ -253,7 +253,7 @@ describe("voice interview stage", () => {
       />,
     );
 
-    expect(html).toContain("We couldn’t connect");
+    expect(html).toContain("We couldn’t reconnect the microphone");
     expect(html).toContain(
       "Allow microphone access in your browser settings, then reconnect voice input.",
     );
@@ -261,7 +261,7 @@ describe("voice interview stage", () => {
     expect(html).toContain("microphone-permission");
     expect(html).toContain("voice-request-permission");
     expect(html).toContain(">Reconnect<");
-    expect(html).toContain(">Use text instead<");
+    expect(html).toContain('aria-label="Use text instead"');
     expect(html).not.toContain(">Type instead<");
   });
 
@@ -283,10 +283,10 @@ describe("voice interview stage", () => {
       await screen.findByRole("region", { name: "Voice interview stage" }),
     ).not.toBeNull();
     expect(
-      await screen.findAllByText(
+      await screen.findByText(
         /Microphone off · Allow microphone access in your browser settings, then reconnect voice input\./u,
       ),
-    ).toHaveLength(2);
+    ).not.toBeNull();
     expect(screen.getByRole("button", { name: "Reconnect" })).not.toBeNull();
     expect(screen.getByText("Interview active")).not.toBeNull();
     expect(screen.getByText("Interview mode")).not.toBeNull();
@@ -450,20 +450,112 @@ describe("voice interview stage", () => {
     ).not.toBeNull();
   });
 
-  test("keeps the question visible, distinguishes provisional text, and names microphone level", () => {
+  test("keeps the question visible and names microphone level", () => {
     const html = renderToStaticMarkup(
       <VoiceInterviewControlView {...viewProps()} />,
     );
 
     expect(html).toContain("What happens after approval?");
-    expect(html).toContain("What we’re hearing · Not sent yet");
-    expect(html).toContain("Microphone on · Listening");
+    expect(html).toContain("Live transcript");
+    expect(html).toContain("Listening");
     expect(html).toContain("Microphone input level: Medium");
-    expect(html).toContain("Done speaking");
+    expect(html).toContain('aria-label="Done speaking"');
     expect(html).toContain("motionReduce:vis_hidden");
     expect(html).toContain("pos_relative");
     expect(html).not.toContain("pos_fixed");
     expect(html).toContain('aria-live="polite"');
+  });
+
+  test("centers a circular microphone and waveform without visible level copy", () => {
+    render(<VoiceInterviewControlView {...viewProps()} />);
+
+    expect(screen.getByTestId("voice-microphone-focal")).not.toBeNull();
+    expect(screen.getByTestId("voice-waveform")).not.toBeNull();
+    expect(screen.getByText("Listening")).not.toBeNull();
+
+    const accessibleLevel = screen.getByText(
+      "Microphone input level: Medium",
+    );
+    expect(accessibleLevel.className).toContain("pos_absolute");
+    expect(
+      screen.queryByText("Microphone on · Listening", {
+        selector: ":not([role='status'])",
+      }),
+    ).toBeNull();
+  });
+
+  test("shows compact recording and sent transcript statuses", () => {
+    const rendered = render(<VoiceInterviewControlView {...viewProps()} />);
+
+    expect(screen.getByText("Live transcript")).not.toBeNull();
+    expect(screen.getByText("Recording")).not.toBeNull();
+    expect(screen.queryByText("What we’re hearing · Not sent yet")).toBeNull();
+    expect(screen.getByRole("status").textContent).toContain("Not sent yet");
+
+    rendered.rerender(
+      <VoiceInterviewControlView
+        {...viewProps({
+          snapshot: {
+            ...snapshot,
+            lastCommittedText: "The shift lead assigns an owner.",
+            microphoneEnabled: false,
+            microphoneLevel: 0,
+            partialText: "",
+            phase: "waiting",
+          },
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Your answer")).not.toBeNull();
+    expect(screen.getByText("Sent")).not.toBeNull();
+    expect(screen.getByText("The shift lead assigns an owner.")).not.toBeNull();
+  });
+
+  test("uses voice-app icon controls while listening", () => {
+    render(<VoiceInterviewControlView {...viewProps()} />);
+
+    for (const name of ["Use text instead", "Done speaking", "Pause"]) {
+      const button = screen.getByRole("button", { name });
+      expect(button.querySelector("svg")).not.toBeNull();
+      expect(button.parentElement?.getAttribute("data-scope")).toBe("tooltip");
+    }
+
+    expect(
+      screen
+        .getByRole("button", { name: "Done speaking" })
+        .textContent.replaceAll("\u200B", "")
+        .trim(),
+    ).toBe("");
+  });
+
+  test("keeps reconnect visible and makes secondary recovery icon-only", () => {
+    render(
+      <VoiceInterviewControlView
+        {...viewProps({
+          snapshot: {
+            ...snapshot,
+            errorCode: "microphone-permission",
+            errorMessage:
+              "Allow microphone access in your browser settings, then reconnect voice input.",
+            errorRequestId: "voice-request-permission",
+            microphoneEnabled: false,
+            microphoneLevel: 0,
+            partialText: "",
+            phase: "recoverable-error",
+          },
+        })}
+      />,
+    );
+
+    expect(screen.getByText("We couldn’t reconnect the microphone")).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Reconnect" }).textContent).toContain(
+      "Reconnect",
+    );
+    expect(
+      screen.getByRole("button", { name: "Use text instead" }).querySelector("svg"),
+    ).not.toBeNull();
+    expect(screen.getByText("Technical details")).not.toBeNull();
   });
 
   test("renders icons for the listening controls", () => {
@@ -597,7 +689,7 @@ describe("voice interview stage", () => {
     );
 
     expect(html).toContain("Microphone off · Interviewer speaking");
-    expect(html).toContain("Interrupt and speak");
+    expect(html).toContain('aria-label="Interrupt and speak"');
     expect(html).not.toContain(">Pause<");
   });
 

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.test.tsx
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.test.tsx
@@ -218,6 +218,11 @@ describe("voice interview stage", () => {
         {...viewProps({ consented: false, presentation: "start" })}
       />,
     );
+    render(
+      <VoiceInterviewControlView
+        {...viewProps({ consented: false, presentation: "start" })}
+      />,
+    );
 
     expect(html).toContain("Voice interview");
     expect(html).toContain("Talk through your process with AI");
@@ -232,6 +237,13 @@ describe("voice interview stage", () => {
     expect(html).toContain("Check microphone");
     expect(html).toContain("pos_absolute");
     expect(html).not.toContain("pos_fixed");
+
+    const textButton = screen.getByRole("button", { name: "Use text instead" });
+    expect(textButton.querySelector("svg")).not.toBeNull();
+    expect(textButton.parentElement?.getAttribute("data-scope")).toBe(
+      "tooltip",
+    );
+    expect(textButton.textContent.replaceAll("\u200B", "").trim()).toBe("");
   });
 
   test("keeps diagnostic recovery details visible without reopening the microphone", () => {

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.test.tsx
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.test.tsx
@@ -525,6 +525,16 @@ describe("voice interview stage", () => {
     expect(html).toContain('aria-label="Type an interview answer"');
     expect(html).toContain(">Pause<");
     expect(html).toContain('aria-label="End interview"');
+
+    render(
+      <VoiceInterviewControlView
+        {...viewProps({ placement: "detached", presentation: "mini" })}
+      />,
+    );
+    const endButton = screen.getByRole("button", { name: "End interview" });
+    expect(endButton.querySelector("svg")).not.toBeNull();
+    expect(endButton.parentElement?.getAttribute("data-part")).toBe("trigger");
+    expect(endButton.parentElement?.getAttribute("data-scope")).toBe("tooltip");
   });
 
   test("shows authoritative covered and still-exploring facts without a question count", () => {

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.test.tsx
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.test.tsx
@@ -473,9 +473,7 @@ describe("voice interview stage", () => {
     expect(screen.getByTestId("voice-waveform")).not.toBeNull();
     expect(screen.getByText("Listening")).not.toBeNull();
 
-    const accessibleLevel = screen.getByText(
-      "Microphone input level: Medium",
-    );
+    const accessibleLevel = screen.getByText("Microphone input level: Medium");
     expect(accessibleLevel.className).toContain("pos_absolute");
     expect(
       screen.queryByText("Microphone on · Listening", {
@@ -548,12 +546,16 @@ describe("voice interview stage", () => {
       />,
     );
 
-    expect(screen.getByText("We couldn’t reconnect the microphone")).not.toBeNull();
-    expect(screen.getByRole("button", { name: "Reconnect" }).textContent).toContain(
-      "Reconnect",
-    );
     expect(
-      screen.getByRole("button", { name: "Use text instead" }).querySelector("svg"),
+      screen.getByText("We couldn’t reconnect the microphone"),
+    ).not.toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Reconnect" }).textContent,
+    ).toContain("Reconnect");
+    expect(
+      screen
+        .getByRole("button", { name: "Use text instead" })
+        .querySelector("svg"),
     ).not.toBeNull();
     expect(screen.getByText("Technical details")).not.toBeNull();
   });

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.test.tsx
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.test.tsx
@@ -197,10 +197,16 @@ describe("voice interview stage", () => {
       />,
     );
 
-    expect(html).toContain("sent to OpenAI for transcription");
-    expect(html).toContain("does not retain the audio");
+    expect(html).toContain("Voice interview");
+    expect(html).toContain("Talk through your process with AI");
+    expect(html).toContain("transcribed by OpenAI");
+    expect(html).toContain("keeps finalized answers");
+    expect(html).toContain("not the audio");
+    expect(html.indexOf("Start interview")).toBeLessThan(
+      html.indexOf("Check microphone"),
+    );
     expect(html).toMatch(/<button[^>]*disabled[^>]*>Start interview/u);
-    expect(html).toContain("Use text instead");
+    expect(html).toContain("Use text");
     expect(html).toContain("Check microphone");
     expect(html).toContain("pos_absolute");
     expect(html).not.toContain("pos_fixed");
@@ -225,11 +231,13 @@ describe("voice interview stage", () => {
       />,
     );
 
+    expect(html).toContain("We couldn’t connect");
     expect(html).toContain(
-      "Microphone off · Allow microphone access in your browser settings, then reconnect voice input.",
+      "Allow microphone access in your browser settings, then reconnect voice input.",
     );
-    expect(html).toContain("Error code: microphone-permission.");
-    expect(html).toContain("Diagnostic reference: voice-request-permission.");
+    expect(html).toContain("<summary>Technical details</summary>");
+    expect(html).toContain("microphone-permission");
+    expect(html).toContain("voice-request-permission");
     expect(html).toContain(">Reconnect<");
   });
 
@@ -273,7 +281,7 @@ describe("voice interview stage", () => {
     ).not.toBeNull();
     expect(
       await screen.findAllByText(
-        /Microphone off · Allow microphone access in your browser settings, then reconnect voice input\. Error code: microphone-permission\./u,
+        /Microphone off · Allow microphone access in your browser settings, then reconnect voice input\./u,
       ),
     ).toHaveLength(2);
     expect(screen.getByRole("button", { name: "Reconnect" })).not.toBeNull();
@@ -319,7 +327,7 @@ describe("voice interview stage", () => {
     fireEvent.click(
       await screen.findByRole("button", { name: "Start voice interview" }),
     );
-    fireEvent.click(screen.getByRole("button", { name: "Use text instead" }));
+    fireEvent.click(screen.getByRole("button", { name: "Use text" }));
     expect(
       window.localStorage.getItem(VOICE_INTERVIEW_DISCLOSURE_STORAGE_KEY),
     ).toBeNull();
@@ -363,6 +371,41 @@ describe("voice interview stage", () => {
     expect(html).toContain('aria-live="polite"');
   });
 
+  test("renders icons for the listening controls", () => {
+    render(<VoiceInterviewControlView {...viewProps()} />);
+
+    for (const name of [
+      "Minimize voice interview",
+      "End interview",
+      "Done speaking",
+      "Pause",
+    ]) {
+      expect(
+        screen.getByRole("button", { name }).querySelector("svg"),
+      ).not.toBeNull();
+    }
+  });
+
+  test("does not describe an unavailable meter while the microphone is off", () => {
+    const waitingHtml = renderToStaticMarkup(
+      <VoiceInterviewControlView
+        {...viewProps({
+          snapshot: {
+            ...snapshot,
+            microphoneEnabled: false,
+            microphoneLevel: 0,
+            partialText: "",
+            phase: "waiting",
+          },
+        })}
+      />,
+    );
+
+    expect(waitingHtml).not.toContain(
+      "Microphone input level unavailable while microphone is off",
+    );
+  });
+
   test("renders committed repair actions separately from pause, minimize, and end", () => {
     const html = renderToStaticMarkup(
       <VoiceInterviewControlView
@@ -380,7 +423,7 @@ describe("voice interview stage", () => {
     );
 
     for (const name of [
-      "Minimize",
+      "Minimize voice interview",
       "End interview",
       "Redo answer",
       "Edit text",
@@ -475,6 +518,7 @@ describe("voice interview stage", () => {
       'aria-label="Expand voice interview. Microphone on · Listening"',
     );
     expect(html).toContain("Microphone on · Listening");
+    expect(html).toContain("What happens after approval?");
     expect(html).toContain("--voice-interview-right");
     expect(html).toContain("[@media_(min-width:_768px)]");
     expect(html).not.toContain("md:right_4");

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.tsx
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.tsx
@@ -1301,13 +1301,6 @@ const AvailableVoiceInterviewControl = ({
     [context.messages],
   );
 
-  if (previousPlacement !== context.placement) {
-    setPreviousPlacement(context.placement);
-    if (context.placement === "detached" && snapshot.phase !== "idle") {
-      setPresentation("mini");
-    }
-  }
-
   useLayoutEffect(() => {
     store.controller.updateChat({
       canAcceptInterviewAnswer: context.canAcceptInterviewAnswer,

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.tsx
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.tsx
@@ -87,7 +87,7 @@ export const acknowledgeVoiceInterviewDisclosure = (
   }
 };
 
-type Presentation = "trigger" | "start" | "full" | "mini";
+type Presentation = "start" | "full" | "mini";
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;
@@ -129,11 +129,6 @@ const rootStyle = cva({
   },
   variants: {
     presentation: {
-      trigger: {
-        position: "absolute",
-        right: "[44px]",
-        bottom: "[-44px]",
-      },
       start: {
         position: "absolute",
         right: "0",
@@ -485,7 +480,6 @@ export interface VoiceInterviewControlViewProps {
   readonly onReconnect: () => void;
   readonly onRedo: () => void;
   readonly onResume: () => void;
-  readonly onShowStart: () => void;
   readonly onStart: () => void;
   readonly onSubmitCorrection: () => void;
   readonly onTypeInstead: () => void;
@@ -513,7 +507,6 @@ export const VoiceInterviewControlView = ({
   onReconnect,
   onRedo,
   onResume,
-  onShowStart,
   onStart,
   onSubmitCorrection,
   onTypeInstead,
@@ -521,23 +514,6 @@ export const VoiceInterviewControlView = ({
   presentation,
   snapshot,
 }: VoiceInterviewControlViewProps) => {
-  if (presentation === "trigger") {
-    return placement === "sidebar" ? (
-      <div className={rootStyle({ presentation: "trigger" })}>
-        <Button
-          aria-label="Start voice interview"
-          prefix={<FaMicrophone aria-hidden="true" />}
-          shape="round"
-          size="sm"
-          tooltip="Start voice interview"
-          type="button"
-          variant="subtle"
-          onClick={onShowStart}
-        />
-      </div>
-    ) : null;
-  }
-
   if (presentation === "start") {
     if (placement === "detached") return null;
     return (
@@ -559,7 +535,7 @@ export const VoiceInterviewControlView = ({
               variant="ghost"
               onClick={onTypeInstead}
             >
-              Use text
+              Use text instead
             </Button>
           </header>
           <p className={statusStyle}>
@@ -649,11 +625,11 @@ export const VoiceInterviewControlView = ({
             </Button>
           )}
           <Button
-            aria-label="Type an interview answer"
+            aria-label="Use text instead"
             prefix={<FaKeyboard aria-hidden="true" />}
             shape="round"
             size="xs"
-            tooltip="Type an interview answer"
+            tooltip="Use text instead"
             type="button"
             variant="ghost"
             onClick={onTypeInstead}
@@ -845,9 +821,7 @@ export const VoiceInterviewControlView = ({
             </>
           )}
           <Button type="button" variant="ghost" onClick={onTypeInstead}>
-            {snapshot.phase === "recoverable-error"
-              ? "Use text instead"
-              : "Type instead"}
+            Use text instead
           </Button>
         </div>
 
@@ -920,14 +894,15 @@ const AvailableVoiceInterviewControl = ({
     store.getSnapshot,
     store.getSnapshot,
   );
-  const [presentation, setPresentation] = useState<Presentation>("trigger");
-  const [previousPlacement, setPreviousPlacement] = useState(context.placement);
+  const [presentation, setPresentation] = useState<Presentation>("full");
   const [consented, setConsented] = useState(false);
   const [microphoneCheck, setMicrophoneCheck] = useState("");
   const [correction, setCorrection] = useState("");
   const [editing, setEditing] = useState(false);
-  const { openSidebar, setActive } = context;
+  const { interactionMode, openSidebar, setActive, setInteractionMode } =
+    context;
   const openSidebarRef = useRef(openSidebar);
+  const handledInterviewSelectionRef = useRef(false);
   const coverage = selectInterviewCoverage(context.messages);
 
   if (previousPlacement !== context.placement) {
@@ -961,10 +936,32 @@ const AvailableVoiceInterviewControl = ({
   }, [openSidebar]);
 
   useEffect(() => {
+    if (interactionMode === "chat") {
+      handledInterviewSelectionRef.current = false;
+      return;
+    }
+    if (handledInterviewSelectionRef.current || active) {
+      handledInterviewSelectionRef.current = true;
+      return;
+    }
+
+    handledInterviewSelectionRef.current = true;
+    if (isVoiceInterviewDisclosureAcknowledged()) {
+      // eslint-disable-next-line react-hooks-js/set-state-in-effect -- Mode selection intentionally drives the host presentation.
+      setPresentation("full");
+      setActive(true);
+      void store.controller.start();
+    } else {
+      setPresentation("start");
+    }
+  }, [active, interactionMode, setActive, store]);
+
+  useEffect(() => {
     if (snapshot.phase === "recoverable-error") {
+      setInteractionMode("interview");
       openSidebarRef.current();
     }
-  }, [snapshot.phase]);
+  }, [setInteractionMode, snapshot.phase]);
 
   useEffect(
     () => () => {
@@ -974,10 +971,22 @@ const AvailableVoiceInterviewControl = ({
   );
 
   const end = () => {
-    setPresentation("trigger");
     setEditing(false);
     context.setActive(false);
+    context.setInteractionMode("chat");
     void store.controller.end();
+  };
+
+  const minimize = () => context.setInteractionMode("chat");
+
+  const expand = () => {
+    context.openSidebar();
+    context.setInteractionMode("interview");
+  };
+
+  const useTextInstead = () => {
+    context.setInteractionMode("chat");
+    context.focusComposer();
   };
 
   const startInterview = () => {
@@ -985,6 +994,25 @@ const AvailableVoiceInterviewControl = ({
     context.setActive(true);
     void store.controller.start();
   };
+
+  const visiblePresentation =
+    snapshot.phase === "recoverable-error"
+      ? context.interactionMode === "chat"
+        ? "mini"
+        : "full"
+      : context.placement === "detached"
+        ? active
+          ? "mini"
+          : null
+        : context.interactionMode === "chat"
+          ? active
+            ? "mini"
+            : null
+          : presentation;
+
+  if (visiblePresentation === null) {
+    return null;
+  }
 
   return (
     <VoiceInterviewControlView
@@ -1008,12 +1036,9 @@ const AvailableVoiceInterviewControl = ({
       onDoneSpeaking={() => store.controller.doneSpeaking()}
       onEdit={() => setEditing(true)}
       onEnd={end}
-      onExpand={() => {
-        context.openSidebar();
-        setPresentation("full");
-      }}
+      onExpand={expand}
       onInterrupt={() => store.controller.interruptAndSpeak()}
-      onMinimize={() => setPresentation("mini")}
+      onMinimize={minimize}
       onPause={() => store.controller.pause()}
       onReconnect={() => {
         setPresentation("full");
@@ -1021,13 +1046,6 @@ const AvailableVoiceInterviewControl = ({
       }}
       onRedo={() => store.controller.redoAnswer()}
       onResume={() => store.controller.resume()}
-      onShowStart={() => {
-        if (isVoiceInterviewDisclosureAcknowledged()) {
-          startInterview();
-        } else {
-          setPresentation("start");
-        }
-      }}
       onStart={() => {
         acknowledgeVoiceInterviewDisclosure();
         startInterview();
@@ -1041,41 +1059,25 @@ const AvailableVoiceInterviewControl = ({
           }
         });
       }}
-      onTypeInstead={() => {
-        if (snapshot.phase === "idle") setPresentation("trigger");
-        context.focusComposer();
-      }}
+      onTypeInstead={useTextInstead}
       placement={context.placement}
-      presentation={
-        snapshot.phase === "recoverable-error" ? "full" : presentation
-      }
+      presentation={visiblePresentation}
       snapshot={snapshot}
     />
   );
 };
 
-export const VoiceInterviewControl = (
-  context: PetrinautAiInterviewStageContext,
-) => {
-  const [config, setConfig] = useState<OpenAIVoiceConfig | null>();
-
-  useEffect(() => {
-    const abortController = new AbortController();
-    void loadOpenAIVoiceConfig(
-      globalThis.fetch.bind(globalThis),
-      abortController.signal,
-    ).then((loadedConfig) => {
-      if (!abortController.signal.aborted) setConfig(loadedConfig);
-    });
-    return () => abortController.abort();
-  }, []);
-
-  if (!config || !context.conversationId) return null;
+export const VoiceInterviewControl = ({
+  config,
+  ...context
+}: PetrinautAiInterviewStageContext & {
+  readonly config: OpenAIVoiceConfig;
+}) => {
   return (
     <AvailableVoiceInterviewControl
       key={context.conversationId}
       config={config}
-      context={{ ...context, conversationId: context.conversationId }}
+      context={context}
     />
   );
 };

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.tsx
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.tsx
@@ -39,6 +39,7 @@ import { SpeechPlaybackController } from "./speech-playback-controller";
 import {
   VoiceTurnController,
   type VoiceLatencyEvent,
+  type VoiceTurnPhase,
   type VoiceTurnSnapshot,
 } from "./voice-turn-controller";
 
@@ -418,7 +419,7 @@ const recoveryStyle = css({
   fontSize: "sm",
 });
 
-const technicalDetailsStyle = css({
+const secondaryDetailsStyle = css({
   color: "neutral.s80",
   fontSize: "xs",
   _open: { color: "neutral.s90" },
@@ -577,30 +578,44 @@ const Meter = ({ snapshot }: { snapshot: VoiceTurnSnapshot }) => {
   );
 };
 
+const focalIcon = (phase: VoiceTurnPhase): ReactNode => {
+  switch (phase) {
+    case "listening":
+      return <FaMicrophone aria-hidden="true" />;
+    case "paused":
+      return <FaMicrophoneSlash aria-hidden="true" />;
+    case "playing":
+      return <FaVolumeHigh aria-hidden="true" />;
+    case "delivering":
+      return <FaCircleCheck aria-hidden="true" />;
+    case "recoverable-error":
+      return <FaTriangleExclamation aria-hidden="true" />;
+    case "idle":
+    case "connecting":
+    case "transcribing":
+    case "waiting":
+    case "synthesizing":
+      return <FaCircleNotch aria-hidden="true" />;
+  }
+};
+
+const focalTone = (phase: VoiceTurnPhase) => {
+  switch (phase) {
+    case "recoverable-error":
+      return "error";
+    case "delivering":
+      return "success";
+    case "listening":
+      return "active";
+    default:
+      return "idle";
+  }
+};
+
 const VoiceFocal = ({ snapshot }: { snapshot: VoiceTurnSnapshot }) => {
   const active = snapshot.phase === "listening";
-  const tone =
-    snapshot.phase === "recoverable-error"
-      ? "error"
-      : snapshot.phase === "delivering"
-        ? "success"
-        : active
-          ? "active"
-          : "idle";
-  const icon =
-    snapshot.phase === "listening" ? (
-      <FaMicrophone aria-hidden="true" />
-    ) : snapshot.phase === "paused" ? (
-      <FaMicrophoneSlash aria-hidden="true" />
-    ) : snapshot.phase === "playing" ? (
-      <FaVolumeHigh aria-hidden="true" />
-    ) : snapshot.phase === "delivering" ? (
-      <FaCircleCheck aria-hidden="true" />
-    ) : snapshot.phase === "recoverable-error" ? (
-      <FaTriangleExclamation aria-hidden="true" />
-    ) : (
-      <FaCircleNotch aria-hidden="true" />
-    );
+  const tone = focalTone(snapshot.phase);
+  const icon = focalIcon(snapshot.phase);
 
   return (
     <div className={focalAreaStyle}>
@@ -617,6 +632,25 @@ const VoiceFocal = ({ snapshot }: { snapshot: VoiceTurnSnapshot }) => {
       </span>
     </div>
   );
+};
+
+/**
+ * Recoverable errors cover far more than microphone access, so the heading
+ * names the family the error code belongs to rather than always blaming the
+ * microphone. The message below it stays the actionable guidance.
+ */
+const recoveryHeading = (errorCode: VoiceTurnSnapshot["errorCode"]): string => {
+  switch (errorCode) {
+    case "microphone-permission":
+    case "microphone-device":
+      return "We couldn’t reconnect the microphone";
+    case "network":
+    case "timeout":
+    case "request-aborted":
+      return "We lost the voice connection";
+    default:
+      return "The interview couldn’t continue";
+  }
 };
 
 const deliveryStatus = (
@@ -711,7 +745,7 @@ const TranscriptStrip = ({
 const Coverage = ({ coverage }: { coverage: InterviewCoverage | null }) => {
   if (!coverage) return null;
   return (
-    <details>
+    <details className={secondaryDetailsStyle}>
       <summary className={labelStyle}>
         {coverage.complete ? "Coverage complete" : "Interview coverage"}
       </summary>
@@ -1017,10 +1051,10 @@ export const VoiceInterviewControlView = ({
 
         {snapshot.phase === "recoverable-error" && (
           <div className={recoveryStyle}>
-            <strong>We couldn’t reconnect the microphone</strong>
+            <strong>{recoveryHeading(snapshot.errorCode)}</strong>
             <span>{snapshot.errorMessage}</span>
             {(snapshot.errorCode || snapshot.errorRequestId) && (
-              <details className={technicalDetailsStyle}>
+              <details className={secondaryDetailsStyle}>
                 <summary>Technical details</summary>
                 {snapshot.errorCode && (
                   <div>Error code: {snapshot.errorCode}</div>
@@ -1060,6 +1094,26 @@ export const VoiceInterviewControlView = ({
         )}
 
         <div className={actionsStyle}>
+          {snapshot.phase === "recoverable-error" && (
+            <Button
+              aria-label="Reconnect"
+              prefix={<FaRotate aria-hidden="true" />}
+              type="button"
+              onClick={onReconnect}
+            >
+              Reconnect
+            </Button>
+          )}
+          <Button
+            aria-label="Use text instead"
+            prefix={<FaKeyboard aria-hidden="true" />}
+            shape="round"
+            size="sm"
+            tooltip="Use text instead"
+            type="button"
+            variant="ghost"
+            onClick={onTypeInstead}
+          />
           {isSpeaking && (
             <Button
               aria-label="Interrupt and speak"
@@ -1105,26 +1159,6 @@ export const VoiceInterviewControlView = ({
               onClick={onResume}
             />
           )}
-          {snapshot.phase === "recoverable-error" && (
-            <Button
-              aria-label="Reconnect"
-              prefix={<FaRotate aria-hidden="true" />}
-              type="button"
-              onClick={onReconnect}
-            >
-              Reconnect
-            </Button>
-          )}
-          <Button
-            aria-label="Use text instead"
-            prefix={<FaKeyboard aria-hidden="true" />}
-            shape="round"
-            size="sm"
-            tooltip="Use text instead"
-            type="button"
-            variant="ghost"
-            onClick={onTypeInstead}
-          />
         </div>
 
         <Coverage coverage={coverage} />
@@ -1140,6 +1174,33 @@ export const VoiceInterviewControlView = ({
       </span>
     </section>
   );
+};
+
+/**
+ * Recovery always stays visible, a detached or Chat-mode host only keeps an
+ * active session as the compact bar, and Interview mode shows whichever stage
+ * the user last chose.
+ */
+const selectVisiblePresentation = ({
+  active,
+  interactionMode,
+  phase,
+  placement,
+  presentation,
+}: {
+  readonly active: boolean;
+  readonly interactionMode: PetrinautAiInterviewStageContext["interactionMode"];
+  readonly phase: VoiceTurnPhase;
+  readonly placement: PetrinautAiInterviewStageContext["placement"];
+  readonly presentation: Presentation;
+}): Presentation | null => {
+  if (phase === "recoverable-error") {
+    return interactionMode === "chat" ? "mini" : "full";
+  }
+  if (placement === "detached" || interactionMode === "chat") {
+    return active ? "mini" : null;
+  }
+  return presentation;
 };
 
 const recordLatency = (event: VoiceLatencyEvent): void => {
@@ -1301,20 +1362,13 @@ const AvailableVoiceInterviewControl = ({
     void store.controller.start();
   };
 
-  const visiblePresentation =
-    snapshot.phase === "recoverable-error"
-      ? context.interactionMode === "chat"
-        ? "mini"
-        : "full"
-      : context.placement === "detached"
-        ? active
-          ? "mini"
-          : null
-        : context.interactionMode === "chat"
-          ? active
-            ? "mini"
-            : null
-          : presentation;
+  const visiblePresentation = selectVisiblePresentation({
+    active,
+    interactionMode: context.interactionMode,
+    phase: snapshot.phase,
+    placement: context.placement,
+    presentation,
+  });
 
   if (visiblePresentation === null) {
     return null;

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.tsx
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.tsx
@@ -2,29 +2,37 @@ import {
   type FormEvent,
   useEffect,
   useLayoutEffect,
+  useRef,
   useState,
   useSyncExternalStore,
 } from "react";
-import { FaMicrophone, FaMicrophoneSlash } from "react-icons/fa6";
+import { FaKeyboard, FaMicrophone, FaMicrophoneSlash } from "react-icons/fa6";
 
 import { Button } from "@hashintel/ds-components";
-import { css } from "@hashintel/ds-helpers/css";
+import { css, cva } from "@hashintel/ds-helpers/css";
 
 import { reportVoiceDiagnostic } from "../../../voice-diagnostics";
 import { selectCanonicalSpeechSegments } from "./canonical-speech";
+import {
+  type InterviewCoverage,
+  selectInterviewCoverage,
+} from "./interview-coverage";
 import { OpenAIRealtimeSession } from "./openai-realtime-session";
 import { SpeechPlaybackController } from "./speech-playback-controller";
 import {
   VoiceTurnController,
+  type VoiceLatencyEvent,
   type VoiceTurnSnapshot,
 } from "./voice-turn-controller";
 
-import type { PetrinautAiComposerControlContext } from "@hashintel/petrinaut/ui";
+import type { PetrinautAiInterviewStageContext } from "@hashintel/petrinaut/ui";
 
 export interface OpenAIVoiceConfig {
   readonly available: true;
   readonly connectionTimeoutMs: number;
 }
+
+type Presentation = "trigger" | "start" | "full" | "mini";
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;
@@ -39,10 +47,7 @@ export const loadOpenAIVoiceConfig = async (
       method: "GET",
       signal,
     });
-    if (!response.ok) {
-      return null;
-    }
-
+    if (!response.ok) return null;
     const body: unknown = await response.json();
     if (
       !isRecord(body) ||
@@ -62,77 +67,164 @@ export const loadOpenAIVoiceConfig = async (
   }
 };
 
-const controlStyle = css({
-  position: "relative",
-  flexShrink: "0",
+const rootStyle = cva({
+  base: {
+    zIndex: "overlay",
+    pointerEvents: "auto",
+  },
+  variants: {
+    presentation: {
+      trigger: {
+        position: "absolute",
+        right: "[44px]",
+        bottom: "[-44px]",
+      },
+      start: {
+        position: "absolute",
+        right: "0",
+        bottom: "[-2px]",
+        width: "full",
+      },
+      full: {
+        position: "relative",
+        width: "full",
+      },
+      mini: {
+        position: "relative",
+        width: "full",
+      },
+      detached: {
+        position: "fixed",
+        "--voice-interview-right": "0px",
+        "--voice-interview-bottom": "0px",
+        "--voice-interview-left": "0px",
+        "--voice-interview-width": "100%",
+        right: "[var(--voice-interview-right)]",
+        bottom: "[var(--voice-interview-bottom)]",
+        left: "[var(--voice-interview-left)]",
+        width: "[var(--voice-interview-width)]",
+        "@media (min-width: 768px)": {
+          "--voice-interview-right": "var(--spacing-4)",
+          "--voice-interview-bottom": "var(--spacing-4)",
+          "--voice-interview-left": "auto",
+          "--voice-interview-width": "440px",
+        },
+      },
+    },
+  },
 });
 
-const panelStyle = css({
-  position: "absolute",
-  right: "0",
-  bottom: "[calc(100% + 8px)]",
-  zIndex: "overlay",
+const cardStyle = css({
   display: "flex",
-  width: "[280px]",
   flexDirection: "column",
-  gap: "2",
-  padding: "3",
+  gap: "3",
+  padding: "4",
   borderWidth: "thin",
   borderStyle: "solid",
   borderColor: "neutral.a20",
-  borderRadius: "lg",
+  borderTopLeftRadius: "xl",
+  borderTopRightRadius: "xl",
+  borderBottomRightRadius: "xl",
+  borderBottomLeftRadius: "xl",
   backgroundColor: "neutral.s00",
-  boxShadow: "lg",
+  boxShadow: "xl",
+});
+
+const stageStyle = css({
+  display: "flex",
+  maxHeight: "[72vh]",
+  flexDirection: "column",
+  gap: "3",
+  padding: "3",
+  overflowY: "auto",
+  borderTopWidth: "thin",
+  borderBottomWidth: "thin",
+  borderStyle: "solid",
+  borderColor: "neutral.a20",
+  backgroundColor: "neutral.s00",
+  boxShadow: "[0 -8px 24px rgba(0,0,0,0.06)]",
+  borderRadius: "lg",
+});
+
+const headerStyle = css({
+  display: "flex",
+  alignItems: "center",
+  gap: "2",
+});
+
+const titleStyle = css({
+  flex: "1",
+  color: "neutral.s100",
+  fontSize: "sm",
+  fontWeight: "semibold",
+});
+
+const questionStyle = css({
+  color: "neutral.s110",
+  fontSize: "lg",
+  fontWeight: "semibold",
+  lineHeight: "snug",
+});
+
+const listeningStyle = css({
+  display: "flex",
+  minHeight: "[84px]",
+  flexDirection: "column",
+  alignItems: "center",
+  justifyContent: "center",
+  gap: "2",
+  borderRadius: "lg",
+  backgroundColor: "blue.a10",
+});
+
+const meterStyle = css({
+  display: "flex",
+  height: "[34px]",
+  alignItems: "center",
+  gap: "1",
+  _motionReduce: { visibility: "hidden" },
+});
+
+const meterBarStyle = css({
+  width: "[5px]",
+  minHeight: "[4px]",
+  borderRadius: "full",
+  backgroundColor: "blue.s70",
+  transition: "[height 80ms linear]",
+  _motionReduce: { transition: "[none]" },
 });
 
 const statusStyle = css({
   color: "neutral.s90",
-  fontSize: "xs",
+  fontSize: "sm",
   fontWeight: "medium",
-  lineHeight: "relaxed",
 });
 
-const disclosureStyle = css({
-  color: "neutral.s70",
-  fontSize: "xs",
-  lineHeight: "relaxed",
-});
-
-const liveRegionStyle = css({
-  position: "absolute",
-  width: "[1px]",
-  height: "[1px]",
-  padding: "0",
-  margin: "[-1px]",
-  overflow: "hidden",
-  clip: "[rect(0, 0, 0, 0)]",
-  whiteSpace: "nowrap",
-  borderWidth: "0",
-});
-
-const partialStyle = css({
+const transcriptStyle = css({
   display: "flex",
   flexDirection: "column",
   gap: "1",
-  padding: "2",
-  borderRadius: "md",
+  padding: "2.5",
+  borderRadius: "lg",
   backgroundColor: "neutral.s10",
   color: "neutral.s100",
   fontSize: "sm",
 });
 
-const partialLabelStyle = css({
+const labelStyle = css({
   color: "neutral.s80",
   fontSize: "xs",
+  fontWeight: "semibold",
 });
 
-const correctionFormStyle = css({
+const actionsStyle = css({
   display: "flex",
-  flexDirection: "column",
+  flexWrap: "wrap",
+  alignItems: "center",
   gap: "2",
 });
 
-const correctionInputStyle = css({
+const inputStyle = css({
   width: "full",
   paddingX: "2",
   paddingY: "1.5",
@@ -144,37 +236,76 @@ const correctionInputStyle = css({
   color: "neutral.s100",
   fontSize: "sm",
   _focusVisible: {
-    borderColor: "blue.a70",
     outline: "2px solid",
-    outlineColor: "blue.a30",
+    outlineColor: "blue.a40",
     outlineOffset: "[1px]",
   },
 });
 
-const panelActionsStyle = css({
+const miniStyle = css({
   display: "flex",
-  justifyContent: "flex-end",
+  minHeight: "[60px]",
+  alignItems: "center",
   gap: "2",
+  padding: "2",
+  borderWidth: "thin",
+  borderStyle: "solid",
+  borderColor: "neutral.a20",
+  borderTopLeftRadius: "lg",
+  borderTopRightRadius: "lg",
+  borderBottomRightRadius: "lg",
+  borderBottomLeftRadius: "lg",
+  backgroundColor: "neutral.s00",
+  boxShadow: "lg",
+});
+
+const miniExpandStyle = css({
+  display: "flex",
+  minWidth: "0",
+  flex: "1",
+  alignItems: "center",
+  gap: "2",
+  padding: "2",
+  color: "neutral.s100",
+  textAlign: "left",
+  background: "[transparent]",
+  border: "none",
+  cursor: "pointer",
+  _focusVisible: { outline: "2px solid", outlineColor: "blue.a50" },
+});
+
+const liveRegionStyle = css({
+  position: "absolute",
+  width: "[1px]",
+  height: "[1px]",
+  padding: "0",
+  margin: "[-1px]",
+  overflow: "hidden",
+  clip: "[rect(0,0,0,0)]",
+  whiteSpace: "nowrap",
+  borderWidth: "0",
 });
 
 const statusText = (snapshot: VoiceTurnSnapshot): string => {
   switch (snapshot.phase) {
     case "idle":
-      return "Voice input is off.";
+      return "Microphone off · Interview not started";
     case "connecting":
-      return "Microphone off. Connecting voice input.";
+      return "Microphone off · Joining the interview";
     case "listening":
-      return "Microphone on. Listening.";
+      return "Microphone on · Listening";
+    case "paused":
+      return "Microphone off · Paused";
     case "transcribing":
-      return "Microphone off. Finalizing the transcript.";
+      return "Microphone off · Finishing your answer";
     case "delivering":
-      return "Microphone off. Sending the finalized transcript to Brunch.";
+      return "Microphone off · Answer recorded";
     case "waiting":
-      return "Microphone off. Waiting for Brunch.";
+      return "Microphone off · Writing that down";
     case "synthesizing":
-      return "Microphone off. Creating AI-generated speech.";
+      return "Microphone off · Preparing the next question";
     case "playing":
-      return "Microphone off. Playing AI-generated speech.";
+      return "Microphone off · Interviewer speaking";
     case "recoverable-error": {
       const diagnostic =
         snapshot.errorCode === null
@@ -184,35 +315,262 @@ const statusText = (snapshot: VoiceTurnSnapshot): string => {
                 ? ` Diagnostic reference: ${snapshot.errorRequestId}.`
                 : ""
             }`;
-      return `Microphone off. ${snapshot.errorMessage}${diagnostic}`;
+      return `Microphone off · ${snapshot.errorMessage}${diagnostic}`;
     }
   }
 };
 
-interface VoiceInterviewControlViewProps {
+const inputLevelText = (level: number): string =>
+  level >= 0.35
+    ? "High"
+    : level >= 0.12
+      ? "Medium"
+      : level > 0
+        ? "Low"
+        : "Quiet";
+
+const Meter = ({ snapshot }: { snapshot: VoiceTurnSnapshot }) => {
+  const level = snapshot.microphoneEnabled ? snapshot.microphoneLevel : 0;
+  return (
+    <>
+      <div className={meterStyle} aria-hidden="true">
+        {[0.7, 1, 0.8, 1.15, 0.65].map((factor) => (
+          <span
+            className={meterBarStyle}
+            key={factor}
+            style={{ height: `${4 + Math.round(level * factor * 26)}px` }}
+          />
+        ))}
+      </div>
+      <span className={labelStyle}>
+        {snapshot.microphoneEnabled
+          ? `Microphone input level: ${inputLevelText(level)}`
+          : "Microphone input level unavailable while microphone is off"}
+      </span>
+    </>
+  );
+};
+
+const Coverage = ({ coverage }: { coverage: InterviewCoverage | null }) => {
+  if (!coverage) return null;
+  return (
+    <details>
+      <summary className={labelStyle}>
+        {coverage.complete ? "Coverage complete" : "Interview coverage"}
+      </summary>
+      {coverage.covered.length > 0 && (
+        <div>
+          <strong className={labelStyle}>Covered</strong>
+          <ul>
+            {coverage.covered.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {coverage.stillExploring.length > 0 && (
+        <div>
+          <strong className={labelStyle}>Still exploring</strong>
+          <ul>
+            {coverage.stillExploring.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </details>
+  );
+};
+
+export interface VoiceInterviewControlViewProps {
+  readonly consented: boolean;
   readonly correction: string;
+  readonly coverage: InterviewCoverage | null;
+  readonly editing: boolean;
+  readonly microphoneCheck: string;
+  readonly onCheckMicrophone: () => void;
+  readonly onConsentChange: (consented: boolean) => void;
   readonly onCorrectionChange: (value: string) => void;
+  readonly onDoneSpeaking: () => void;
+  readonly onEdit: () => void;
   readonly onEnd: () => void;
+  readonly onExpand: () => void;
+  readonly onInterrupt: () => void;
+  readonly onMinimize: () => void;
+  readonly onPause: () => void;
   readonly onReconnect: () => void;
+  readonly onRedo: () => void;
+  readonly onResume: () => void;
+  readonly onShowStart: () => void;
   readonly onStart: () => void;
   readonly onSubmitCorrection: () => void;
+  readonly onTypeInstead: () => void;
+  readonly placement: "sidebar" | "detached";
+  readonly presentation: Presentation;
   readonly snapshot: VoiceTurnSnapshot;
 }
 
 export const VoiceInterviewControlView = ({
+  consented,
   correction,
+  coverage,
+  editing,
+  microphoneCheck,
+  onCheckMicrophone,
+  onConsentChange,
   onCorrectionChange,
+  onDoneSpeaking,
+  onEdit,
   onEnd,
+  onExpand,
+  onInterrupt,
+  onMinimize,
+  onPause,
   onReconnect,
+  onRedo,
+  onResume,
+  onShowStart,
   onStart,
   onSubmitCorrection,
+  onTypeInstead,
+  placement,
+  presentation,
   snapshot,
 }: VoiceInterviewControlViewProps) => {
-  const isIdle = snapshot.phase === "idle";
-  const isConnecting = snapshot.phase === "connecting";
-  const hasError = snapshot.phase === "recoverable-error";
-  const canCorrect =
-    snapshot.phase === "listening" && snapshot.lastCommittedText.length > 0;
+  if (presentation === "trigger") {
+    return placement === "sidebar" ? (
+      <div className={rootStyle({ presentation: "trigger" })}>
+        <Button
+          aria-label="Start voice interview"
+          prefix={<FaMicrophone aria-hidden="true" />}
+          shape="round"
+          size="sm"
+          tooltip="Start voice interview"
+          type="button"
+          variant="subtle"
+          onClick={onShowStart}
+        />
+      </div>
+    ) : null;
+  }
+
+  if (presentation === "start") {
+    if (placement === "detached") return null;
+    return (
+      <section
+        aria-label="Start voice interview"
+        className={rootStyle({ presentation: "start" })}
+      >
+        <div className={cardStyle}>
+          <h2 className={questionStyle}>Talk with the AI interviewer</h2>
+          <p className={statusStyle}>
+            Your speech is sent to OpenAI for transcription. Petrinaut keeps
+            finalized answers in this conversation; this app does not retain the
+            audio.
+          </p>
+          <p className={statusStyle}>
+            Questions are spoken by an AI-generated OpenAI voice. You can pause,
+            type, correct an answer, or end the interview at any time.
+          </p>
+          <label className={statusStyle}>
+            <input
+              checked={consented}
+              type="checkbox"
+              onChange={(event) => onConsentChange(event.currentTarget.checked)}
+            />{" "}
+            I understand how speech and transcripts are handled.
+          </label>
+          {microphoneCheck && <p className={labelStyle}>{microphoneCheck}</p>}
+          <div className={actionsStyle}>
+            <Button type="button" variant="subtle" onClick={onCheckMicrophone}>
+              Check microphone
+            </Button>
+            <Button disabled={!consented} type="button" onClick={onStart}>
+              Start interview
+            </Button>
+            <Button type="button" variant="ghost" onClick={onTypeInstead}>
+              Use text instead
+            </Button>
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  const effectivePresentation =
+    placement === "detached" ? "detached" : presentation;
+  const status = statusText(snapshot);
+  const isSpeaking =
+    snapshot.phase === "playing" || snapshot.phase === "synthesizing";
+
+  if (
+    effectivePresentation === "mini" ||
+    effectivePresentation === "detached"
+  ) {
+    return (
+      <section
+        aria-label="Voice interview mini bar"
+        className={rootStyle({ presentation: effectivePresentation })}
+      >
+        <div className={miniStyle}>
+          <button
+            aria-label={`Expand voice interview. ${status}`}
+            className={miniExpandStyle}
+            type="button"
+            onClick={onExpand}
+          >
+            {snapshot.microphoneEnabled ? (
+              <FaMicrophone aria-hidden="true" />
+            ) : (
+              <FaMicrophoneSlash aria-hidden="true" />
+            )}
+            <span>{status}</span>
+          </button>
+          {isSpeaking ? (
+            <Button size="xs" type="button" onClick={onInterrupt}>
+              Interrupt and speak
+            </Button>
+          ) : snapshot.phase === "paused" ? (
+            <Button size="xs" type="button" onClick={onResume}>
+              Resume
+            </Button>
+          ) : (
+            <Button
+              disabled={!snapshot.microphoneEnabled}
+              size="xs"
+              type="button"
+              variant="subtle"
+              onClick={onPause}
+            >
+              Pause
+            </Button>
+          )}
+          <Button
+            aria-label="Type an interview answer"
+            prefix={<FaKeyboard aria-hidden="true" />}
+            shape="round"
+            size="xs"
+            tooltip="Type an interview answer"
+            type="button"
+            variant="ghost"
+            onClick={onTypeInstead}
+          />
+          <Button
+            aria-label="End interview"
+            size="xs"
+            type="button"
+            variant="ghost"
+            onClick={onEnd}
+          >
+            End
+          </Button>
+        </div>
+        <span className={liveRegionStyle} role="status" aria-live="polite">
+          {status}
+        </span>
+      </section>
+    );
+  }
 
   const submitCorrection = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -220,105 +578,131 @@ export const VoiceInterviewControlView = ({
   };
 
   return (
-    <div className={controlStyle}>
-      {isIdle ? (
-        <Button
-          aria-label="Start voice input"
-          prefix={<FaMicrophone aria-hidden="true" />}
-          shape="round"
-          size="sm"
-          tooltip="Start voice input"
-          type="button"
-          variant="subtle"
-          onClick={onStart}
-        />
-      ) : (
-        <Button
-          aria-label={hasError ? "Reconnect voice input" : "End voice input"}
-          disabled={isConnecting}
-          prefix={<FaMicrophoneSlash aria-hidden="true" />}
-          shape="round"
-          size="sm"
-          tooltip={hasError ? "Reconnect voice input" : "End voice input"}
-          type="button"
-          variant="subtle"
-          onClick={hasError ? onReconnect : onEnd}
-        />
-      )}
+    <section
+      aria-label="Voice interview stage"
+      className={rootStyle({ presentation: "full" })}
+    >
+      <div className={stageStyle}>
+        <header className={headerStyle}>
+          <span className={titleStyle}>AI · Voice interview</span>
+          <Button size="xs" type="button" variant="ghost" onClick={onMinimize}>
+            Minimize
+          </Button>
+          <Button size="xs" type="button" variant="ghost" onClick={onEnd}>
+            End interview
+          </Button>
+        </header>
 
+        <p className={questionStyle}>
+          {snapshot.currentQuestion || "The next question will appear here."}
+        </p>
+
+        <div className={listeningStyle}>
+          {snapshot.microphoneEnabled ? (
+            <FaMicrophone aria-hidden="true" />
+          ) : (
+            <FaMicrophoneSlash aria-hidden="true" />
+          )}
+          <Meter snapshot={snapshot} />
+          <span className={statusStyle}>{status}</span>
+        </div>
+
+        {snapshot.partialText && (
+          <div className={transcriptStyle}>
+            <span className={labelStyle}>
+              What we’re hearing · Not sent yet
+            </span>
+            <span>{snapshot.partialText}</span>
+          </div>
+        )}
+        {!snapshot.partialText && snapshot.lastCommittedText && (
+          <div className={transcriptStyle}>
+            <span className={labelStyle}>Answer recorded</span>
+            <span>{snapshot.lastCommittedText}</span>
+          </div>
+        )}
+
+        {editing && (
+          <form className={actionsStyle} onSubmit={submitCorrection}>
+            <label className={labelStyle} htmlFor="voice-answer-correction">
+              Correct the recorded answer
+            </label>
+            <input
+              className={inputStyle}
+              id="voice-answer-correction"
+              value={correction}
+              onChange={(event) =>
+                onCorrectionChange(event.currentTarget.value)
+              }
+            />
+            <Button disabled={!correction.trim()} size="xs" type="submit">
+              Send correction
+            </Button>
+          </form>
+        )}
+
+        <div className={actionsStyle}>
+          {isSpeaking && (
+            <Button type="button" onClick={onInterrupt}>
+              Interrupt and speak
+            </Button>
+          )}
+          {snapshot.phase === "listening" && (
+            <>
+              <Button type="button" onClick={onDoneSpeaking}>
+                Done speaking
+              </Button>
+              <Button type="button" variant="subtle" onClick={onPause}>
+                Pause
+              </Button>
+            </>
+          )}
+          {snapshot.phase === "paused" && (
+            <Button type="button" onClick={onResume}>
+              Resume listening
+            </Button>
+          )}
+          {snapshot.phase === "recoverable-error" && (
+            <Button type="button" onClick={onReconnect}>
+              Reconnect
+            </Button>
+          )}
+          {snapshot.lastCommittedText && !snapshot.partialText && (
+            <>
+              <Button type="button" variant="subtle" onClick={onRedo}>
+                Redo answer
+              </Button>
+              <Button type="button" variant="ghost" onClick={onEdit}>
+                Edit text
+              </Button>
+            </>
+          )}
+          <Button type="button" variant="ghost" onClick={onTypeInstead}>
+            Type instead
+          </Button>
+        </div>
+
+        <Coverage coverage={coverage} />
+      </div>
       <span
         className={liveRegionStyle}
         role="status"
-        aria-atomic="true"
         aria-live="polite"
+        aria-atomic="true"
       >
-        {statusText(snapshot)}
-        {snapshot.partialText &&
-          ` Live transcript (not sent): ${snapshot.partialText}`}
+        {status}
+        {snapshot.partialText && ` Not sent yet: ${snapshot.partialText}`}
       </span>
-
-      {!isIdle && (
-        <section className={panelStyle} aria-label="Voice input status">
-          <p className={statusStyle}>{statusText(snapshot)}</p>
-          <p className={disclosureStyle}>
-            Spoken responses use an AI-generated OpenAI voice.
-          </p>
-          {snapshot.partialText && (
-            <p className={partialStyle}>
-              <span className={partialLabelStyle}>
-                Live transcript (not sent)
-              </span>
-              {snapshot.partialText}
-            </p>
-          )}
-          {canCorrect && (
-            <form className={correctionFormStyle} onSubmit={submitCorrection}>
-              <label className={partialLabelStyle} htmlFor="voice-correction">
-                Correct last voice answer
-              </label>
-              <input
-                className={correctionInputStyle}
-                id="voice-correction"
-                onChange={(event) => onCorrectionChange(event.target.value)}
-                placeholder="Enter the corrected answer"
-                value={correction}
-              />
-              <Button
-                disabled={!correction.trim()}
-                size="xs"
-                type="submit"
-                variant="subtle"
-              >
-                Send correction
-              </Button>
-            </form>
-          )}
-          <div className={panelActionsStyle}>
-            {hasError ? (
-              <Button
-                size="xs"
-                type="button"
-                variant="subtle"
-                onClick={onReconnect}
-              >
-                Reconnect voice input
-              </Button>
-            ) : (
-              <Button
-                disabled={isConnecting}
-                size="xs"
-                type="button"
-                variant="subtle"
-                onClick={onEnd}
-              >
-                End voice input
-              </Button>
-            )}
-          </div>
-        </section>
-      )}
-    </div>
+    </section>
   );
+};
+
+const recordLatency = (event: VoiceLatencyEvent): void => {
+  performance.measure(`voice-interview:${event.name}`, {
+    detail: { questionId: event.questionId },
+    duration: event.elapsedMs,
+    start: 0,
+  });
 };
 
 const AvailableVoiceInterviewControl = ({
@@ -326,16 +710,20 @@ const AvailableVoiceInterviewControl = ({
   context,
 }: {
   config: OpenAIVoiceConfig;
-  context: PetrinautAiComposerControlContext & { conversationId: string };
+  context: PetrinautAiInterviewStageContext & { conversationId: string };
 }) => {
   const [store] = useState(() => {
     const session = new OpenAIRealtimeSession({
+      cancelAnimationFrame: (handle) => globalThis.cancelAnimationFrame(handle),
       connectionTimeoutMs: config.connectionTimeoutMs,
+      createAudioContext: () => new AudioContext(),
       createPeerConnection: () => new RTCPeerConnection(),
       fetch: globalThis.fetch.bind(globalThis),
       getUserMedia: (constraints) =>
         navigator.mediaDevices.getUserMedia(constraints),
       reportDiagnostic: reportVoiceDiagnostic,
+      requestAnimationFrame: (callback) =>
+        globalThis.requestAnimationFrame(callback),
     });
     const playback = new SpeechPlaybackController({
       createAudio: (source) => new Audio(source),
@@ -346,9 +734,10 @@ const AvailableVoiceInterviewControl = ({
     });
     const controller = new VoiceTurnController({
       conversationId: context.conversationId,
+      onLatencyEvent: recordLatency,
       playback,
       session,
-      submitText: context.submitVoiceInput,
+      submitText: context.submitInterviewAnswer,
     });
     return {
       controller,
@@ -362,14 +751,51 @@ const AvailableVoiceInterviewControl = ({
     store.getSnapshot,
     store.getSnapshot,
   );
+  const [presentation, setPresentation] = useState<Presentation>("trigger");
+  const [previousPlacement, setPreviousPlacement] = useState(context.placement);
+  const [consented, setConsented] = useState(false);
+  const [microphoneCheck, setMicrophoneCheck] = useState("");
   const [correction, setCorrection] = useState("");
+  const [editing, setEditing] = useState(false);
+  const { openSidebar, setActive } = context;
+  const openSidebarRef = useRef(openSidebar);
+  const coverage = selectInterviewCoverage(context.messages);
+
+  if (previousPlacement !== context.placement) {
+    setPreviousPlacement(context.placement);
+    if (context.placement === "detached" && snapshot.phase !== "idle") {
+      setPresentation("mini");
+    }
+  }
 
   useLayoutEffect(() => {
     store.controller.updateChat({
+      canAcceptInterviewAnswer: context.canAcceptInterviewAnswer,
       canonicalSegments: selectCanonicalSpeechSegments(context.messages),
       status: context.status,
     });
-  }, [context.messages, context.status, store]);
+  }, [
+    context.canAcceptInterviewAnswer,
+    context.messages,
+    context.status,
+    store,
+  ]);
+
+  const active = snapshot.phase !== "idle";
+
+  useEffect(() => {
+    setActive(active);
+  }, [active, setActive]);
+
+  useEffect(() => {
+    openSidebarRef.current = openSidebar;
+  }, [openSidebar]);
+
+  useEffect(() => {
+    if (snapshot.phase === "recoverable-error") {
+      openSidebarRef.current();
+    }
+  }, [snapshot.phase]);
 
   useEffect(
     () => () => {
@@ -378,25 +804,75 @@ const AvailableVoiceInterviewControl = ({
     [store],
   );
 
+  const end = () => {
+    setPresentation("trigger");
+    setEditing(false);
+    context.setActive(false);
+    void store.controller.end();
+  };
+
   return (
     <VoiceInterviewControlView
+      consented={consented}
       correction={correction}
+      coverage={coverage}
+      editing={editing}
+      microphoneCheck={microphoneCheck}
+      onCheckMicrophone={() => {
+        setMicrophoneCheck("Checking microphone…");
+        void navigator.mediaDevices.getUserMedia({ audio: true }).then(
+          (stream) => {
+            for (const track of stream.getTracks()) track.stop();
+            setMicrophoneCheck("Microphone ready.");
+          },
+          () => setMicrophoneCheck("Microphone access was not available."),
+        );
+      }}
+      onConsentChange={setConsented}
       onCorrectionChange={setCorrection}
-      onEnd={() => void store.controller.end()}
-      onReconnect={() => void store.controller.reconnect()}
-      onStart={() => void store.controller.start()}
+      onDoneSpeaking={() => store.controller.doneSpeaking()}
+      onEdit={() => setEditing(true)}
+      onEnd={end}
+      onExpand={() => {
+        context.openSidebar();
+        setPresentation("full");
+      }}
+      onInterrupt={() => store.controller.interruptAndSpeak()}
+      onMinimize={() => setPresentation("mini")}
+      onPause={() => store.controller.pause()}
+      onReconnect={() => {
+        setPresentation("full");
+        void store.controller.reconnect();
+      }}
+      onRedo={() => store.controller.redoAnswer()}
+      onResume={() => store.controller.resume()}
+      onShowStart={() => setPresentation("start")}
+      onStart={() => {
+        setPresentation("full");
+        context.setActive(true);
+        void store.controller.start();
+      }}
       onSubmitCorrection={() => {
         const value = correction;
         setCorrection("");
+        setEditing(false);
         void store.controller.submitCorrection(value);
       }}
+      onTypeInstead={() => {
+        if (snapshot.phase === "idle") setPresentation("trigger");
+        context.focusComposer();
+      }}
+      placement={context.placement}
+      presentation={
+        snapshot.phase === "recoverable-error" ? "full" : presentation
+      }
       snapshot={snapshot}
     />
   );
 };
 
 export const VoiceInterviewControl = (
-  context: PetrinautAiComposerControlContext,
+  context: PetrinautAiInterviewStageContext,
 ) => {
   const [config, setConfig] = useState<OpenAIVoiceConfig | null>();
 
@@ -406,17 +882,12 @@ export const VoiceInterviewControl = (
       globalThis.fetch.bind(globalThis),
       abortController.signal,
     ).then((loadedConfig) => {
-      if (!abortController.signal.aborted) {
-        setConfig(loadedConfig);
-      }
+      if (!abortController.signal.aborted) setConfig(loadedConfig);
     });
     return () => abortController.abort();
   }, []);
 
-  if (!config || !context.conversationId) {
-    return null;
-  }
-
+  if (!config || !context.conversationId) return null;
   return (
     <AvailableVoiceInterviewControl
       key={context.conversationId}

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.tsx
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.tsx
@@ -848,31 +848,69 @@ export const VoiceInterviewControlView = ({
               <FaMicrophoneSlash aria-hidden="true" />
             )}
             <span className={miniTextStyle}>
-              <span>{status}</span>
+              <span>{shortStatusText(snapshot)}</span>
               {snapshot.currentQuestion && (
                 <span className={contextStyle}>{snapshot.currentQuestion}</span>
               )}
             </span>
           </button>
-          {isSpeaking ? (
-            <Button size="xs" type="button" onClick={onInterrupt}>
-              Interrupt and speak
-            </Button>
-          ) : snapshot.phase === "paused" ? (
-            <Button size="xs" type="button" onClick={onResume}>
-              Resume
-            </Button>
-          ) : (
+          {snapshot.phase === "listening" && (
+            <>
+              <Button
+                aria-label="Done speaking"
+                prefix={<FaCheck aria-hidden="true" />}
+                shape="round"
+                size="xs"
+                tooltip="Done speaking"
+                type="button"
+                onClick={onDoneSpeaking}
+              />
+              <Button
+                aria-label="Pause"
+                disabled={!snapshot.microphoneEnabled}
+                prefix={<FaPause aria-hidden="true" />}
+                shape="round"
+                size="xs"
+                tooltip="Pause"
+                type="button"
+                variant="subtle"
+                onClick={onPause}
+              />
+            </>
+          )}
+          {snapshot.phase === "paused" && (
             <Button
-              disabled={!snapshot.microphoneEnabled}
-              prefix={<FaPause aria-hidden="true" />}
+              aria-label="Resume listening"
+              prefix={<FaPlay aria-hidden="true" />}
+              shape="round"
               size="xs"
+              tooltip="Resume listening"
               type="button"
-              variant="subtle"
-              onClick={onPause}
-            >
-              Pause
-            </Button>
+              onClick={onResume}
+            />
+          )}
+          {(snapshot.phase === "synthesizing" ||
+            snapshot.phase === "playing") && (
+            <Button
+              aria-label="Interrupt and speak"
+              prefix={<FaMicrophone aria-hidden="true" />}
+              shape="round"
+              size="xs"
+              tooltip="Interrupt and speak"
+              type="button"
+              onClick={onInterrupt}
+            />
+          )}
+          {snapshot.phase === "recoverable-error" && (
+            <Button
+              aria-label="Reconnect"
+              prefix={<FaRotate aria-hidden="true" />}
+              shape="round"
+              size="xs"
+              tooltip="Reconnect"
+              type="button"
+              onClick={onReconnect}
+            />
           )}
           <Button
             aria-label="Use text instead"

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.tsx
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.tsx
@@ -629,13 +629,18 @@ export const VoiceInterviewControlView = ({
             </label>
             <input
               className={inputStyle}
+              disabled={!snapshot.canReviseLastAnswer}
               id="voice-answer-correction"
               value={correction}
               onChange={(event) =>
                 onCorrectionChange(event.currentTarget.value)
               }
             />
-            <Button disabled={!correction.trim()} size="xs" type="submit">
+            <Button
+              disabled={!snapshot.canReviseLastAnswer || !correction.trim()}
+              size="xs"
+              type="submit"
+            >
               Send correction
             </Button>
           </form>
@@ -669,10 +674,20 @@ export const VoiceInterviewControlView = ({
           )}
           {snapshot.lastCommittedText && !snapshot.partialText && (
             <>
-              <Button type="button" variant="subtle" onClick={onRedo}>
+              <Button
+                disabled={!snapshot.canReviseLastAnswer}
+                type="button"
+                variant="subtle"
+                onClick={onRedo}
+              >
                 Redo answer
               </Button>
-              <Button type="button" variant="ghost" onClick={onEdit}>
+              <Button
+                disabled={!snapshot.canReviseLastAnswer}
+                type="button"
+                variant="ghost"
+                onClick={onEdit}
+              >
                 Edit text
               </Button>
             </>
@@ -854,9 +869,12 @@ const AvailableVoiceInterviewControl = ({
       }}
       onSubmitCorrection={() => {
         const value = correction;
-        setCorrection("");
-        setEditing(false);
-        void store.controller.submitCorrection(value);
+        void store.controller.submitCorrection(value).then((accepted) => {
+          if (accepted) {
+            setCorrection("");
+            setEditing(false);
+          }
+        });
       }}
       onTypeInstead={() => {
         if (snapshot.phase === "idle") setPresentation("trigger");

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.tsx
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.tsx
@@ -7,12 +7,20 @@ import {
   useSyncExternalStore,
 } from "react";
 import {
+  FaArrowRotateLeft,
   FaCheck,
+  FaCircleCheck,
+  FaCircleNotch,
   FaKeyboard,
   FaMicrophone,
   FaMicrophoneSlash,
   FaMinus,
   FaPause,
+  FaPen,
+  FaPlay,
+  FaRotate,
+  FaTriangleExclamation,
+  FaVolumeHigh,
   FaXmark,
 } from "react-icons/fa6";
 
@@ -198,6 +206,7 @@ const stageStyle = css({
 const headerStyle = css({
   display: "flex",
   alignItems: "center",
+  justifyContent: "flex-end",
   gap: "2",
 });
 
@@ -243,15 +252,116 @@ const miniTextStyle = css({
   flexDirection: "column",
 });
 
-const listeningStyle = css({
+const focalAreaStyle = css({
   display: "flex",
-  minHeight: "[84px]",
+  minHeight: "[150px]",
   flexDirection: "column",
   alignItems: "center",
   justifyContent: "center",
+  gap: "3",
+});
+
+const focalCircleStyle = cva({
+  base: {
+    position: "relative",
+    display: "flex",
+    width: "[108px]",
+    height: "[108px]",
+    flexDirection: "column",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: "2",
+    borderWidth: "thin",
+    borderStyle: "solid",
+    borderRadius: "full",
+    _before: {
+      content: '""',
+      position: "absolute",
+      inset: "[-10px]",
+      borderWidth: "thin",
+      borderStyle: "solid",
+      borderColor: "blue.a20",
+      borderRadius: "full",
+    },
+  },
+  variants: {
+    tone: {
+      active: {
+        borderColor: "blue.a30",
+        backgroundColor: "blue.a10",
+        color: "blue.s90",
+        boxShadow: "[0 14px 30px rgba(35,125,181,0.14)]",
+      },
+      idle: {
+        borderColor: "neutral.a20",
+        backgroundColor: "neutral.s20",
+        color: "neutral.s80",
+      },
+      success: {
+        borderColor: "green.a30",
+        backgroundColor: "green.a10",
+        color: "green.s90",
+      },
+      error: {
+        borderColor: "red.a30",
+        backgroundColor: "red.a10",
+        color: "red.s90",
+      },
+    },
+  },
+});
+
+const shortStateStyle = css({
+  display: "flex",
+  alignItems: "center",
   gap: "2",
-  borderRadius: "lg",
-  backgroundColor: "blue.a10",
+  color: "neutral.s90",
+  fontSize: "xs",
+  fontWeight: "semibold",
+});
+
+const recordingDotStyle = css({
+  width: "[7px]",
+  height: "[7px]",
+  borderRadius: "full",
+  backgroundColor: "green.s70",
+  boxShadow: "[0 0 0 4px rgba(24,168,120,0.10)]",
+});
+
+const transcriptHeaderStyle = css({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  gap: "2",
+});
+
+const recordingTranscriptDotStyle = css({
+  width: "[7px]",
+  height: "[7px]",
+  borderRadius: "full",
+  backgroundColor: "red.s70",
+});
+
+const transcriptActionsStyle = css({
+  display: "flex",
+  justifyContent: "flex-end",
+  gap: "1",
+});
+
+const transcriptStateStyle = cva({
+  base: {
+    display: "flex",
+    alignItems: "center",
+    gap: "1",
+    fontSize: "xs",
+    fontWeight: "semibold",
+  },
+  variants: {
+    state: {
+      recording: { color: "red.s80" },
+      sent: { color: "green.s90" },
+    },
+  },
 });
 
 const meterStyle = css({
@@ -294,10 +404,15 @@ const labelStyle = css({
   fontWeight: "semibold",
 });
 
-const phaseStyle = css({
-  color: "blue.s80",
-  fontSize: "xs",
-  fontWeight: "semibold",
+const recoveryStyle = css({
+  display: "flex",
+  flexDirection: "column",
+  gap: "1",
+  padding: "2.5",
+  borderRadius: "lg",
+  backgroundColor: "red.a10",
+  color: "neutral.s100",
+  fontSize: "sm",
 });
 
 const technicalDetailsStyle = css({
@@ -401,6 +516,31 @@ const statusText = (snapshot: VoiceTurnSnapshot): string => {
   }
 };
 
+const shortStatusText = (snapshot: VoiceTurnSnapshot): string => {
+  switch (snapshot.phase) {
+    case "idle":
+      return "Ready";
+    case "connecting":
+      return "Connecting";
+    case "listening":
+      return "Listening";
+    case "paused":
+      return "Paused";
+    case "transcribing":
+      return "Finishing answer";
+    case "delivering":
+      return "Answer recorded";
+    case "waiting":
+      return "Writing that down";
+    case "synthesizing":
+      return "Preparing next question";
+    case "playing":
+      return "Interviewer speaking";
+    case "recoverable-error":
+      return "Connection paused";
+  }
+};
+
 const inputLevelText = (level: number): string =>
   level >= 0.35
     ? "High"
@@ -414,7 +554,11 @@ const Meter = ({ snapshot }: { snapshot: VoiceTurnSnapshot }) => {
   const level = snapshot.microphoneLevel;
   return (
     <>
-      <div className={meterStyle} aria-hidden="true">
+      <div
+        aria-hidden="true"
+        className={meterStyle}
+        data-testid="voice-waveform"
+      >
         {[0.7, 1, 0.8, 1.15, 0.65].map((factor) => (
           <span
             className={meterBarStyle}
@@ -423,10 +567,114 @@ const Meter = ({ snapshot }: { snapshot: VoiceTurnSnapshot }) => {
           />
         ))}
       </div>
-      <span className={labelStyle}>
+      <span className={liveRegionStyle}>
         {`Microphone input level: ${inputLevelText(level)}`}
       </span>
     </>
+  );
+};
+
+const VoiceFocal = ({ snapshot }: { snapshot: VoiceTurnSnapshot }) => {
+  const active = snapshot.phase === "listening";
+  const tone =
+    snapshot.phase === "recoverable-error"
+      ? "error"
+      : snapshot.phase === "delivering"
+        ? "success"
+        : active
+          ? "active"
+          : "idle";
+  const icon =
+    snapshot.phase === "listening" ? (
+      <FaMicrophone aria-hidden="true" />
+    ) : snapshot.phase === "paused" ? (
+      <FaMicrophoneSlash aria-hidden="true" />
+    ) : snapshot.phase === "playing" ? (
+      <FaVolumeHigh aria-hidden="true" />
+    ) : snapshot.phase === "delivering" ? (
+      <FaCircleCheck aria-hidden="true" />
+    ) : snapshot.phase === "recoverable-error" ? (
+      <FaTriangleExclamation aria-hidden="true" />
+    ) : (
+      <FaCircleNotch aria-hidden="true" />
+    );
+
+  return (
+    <div className={focalAreaStyle}>
+      <div
+        className={focalCircleStyle({ tone })}
+        data-testid="voice-microphone-focal"
+      >
+        {icon}
+        {active && <Meter snapshot={snapshot} />}
+      </div>
+      <span className={shortStateStyle}>
+        {active && <span className={recordingDotStyle} />}
+        {shortStatusText(snapshot)}
+      </span>
+    </div>
+  );
+};
+
+const TranscriptStrip = ({
+  onEdit,
+  onRedo,
+  snapshot,
+}: {
+  onEdit: () => void;
+  onRedo: () => void;
+  snapshot: VoiceTurnSnapshot;
+}) => {
+  const recording = Boolean(snapshot.partialText);
+  const text = snapshot.partialText || snapshot.lastCommittedText;
+  if (!text) return null;
+
+  return (
+    <div className={transcriptStyle}>
+      <div className={transcriptHeaderStyle}>
+        <span className={labelStyle}>
+          {recording ? "Live transcript" : "Your answer"}
+        </span>
+        {recording ? (
+          <span className={transcriptStateStyle({ state: "recording" })}>
+            <span className={recordingTranscriptDotStyle} />
+            Recording
+          </span>
+        ) : (
+          <span className={transcriptStateStyle({ state: "sent" })}>
+            <FaCircleCheck aria-hidden="true" />
+            Sent
+          </span>
+        )}
+      </div>
+      <span>{text}</span>
+      {!recording && (
+        <div className={transcriptActionsStyle}>
+          <Button
+            aria-label="Redo answer"
+            disabled={!snapshot.canReviseLastAnswer}
+            prefix={<FaArrowRotateLeft aria-hidden="true" />}
+            shape="round"
+            size="xs"
+            tooltip="Redo answer"
+            type="button"
+            variant="ghost"
+            onClick={onRedo}
+          />
+          <Button
+            aria-label="Edit text"
+            disabled={!snapshot.canReviseLastAnswer}
+            prefix={<FaPen aria-hidden="true" />}
+            shape="round"
+            size="xs"
+            tooltip="Edit text"
+            type="button"
+            variant="ghost"
+            onClick={onEdit}
+          />
+        </div>
+      )}
+    </div>
   );
 };
 
@@ -530,13 +778,15 @@ export const VoiceInterviewControlView = ({
               </span>
             </div>
             <Button
+              aria-label="Use text instead"
+              prefix={<FaKeyboard aria-hidden="true" />}
+              shape="round"
               size="xs"
+              tooltip="Use text instead"
               type="button"
               variant="ghost"
               onClick={onTypeInstead}
-            >
-              Use text instead
-            </Button>
+            />
           </header>
           <p className={statusStyle}>
             Your speech is transcribed by OpenAI. Petrinaut keeps finalized
@@ -669,7 +919,6 @@ export const VoiceInterviewControlView = ({
     >
       <div className={stageStyle}>
         <header className={headerStyle}>
-          <span className={titleStyle}>Voice interview</span>
           <Button
             aria-label="Minimize voice interview"
             prefix={<FaMinus aria-hidden="true" />}
@@ -696,19 +945,11 @@ export const VoiceInterviewControlView = ({
           {snapshot.currentQuestion || "The next question will appear here."}
         </p>
 
-        <div className={listeningStyle}>
-          {snapshot.microphoneEnabled ? (
-            <FaMicrophone aria-hidden="true" />
-          ) : (
-            <FaMicrophoneSlash aria-hidden="true" />
-          )}
-          {snapshot.microphoneEnabled && <Meter snapshot={snapshot} />}
-          <span className={phaseStyle}>{status}</span>
-        </div>
+        <VoiceFocal snapshot={snapshot} />
 
         {snapshot.phase === "recoverable-error" && (
-          <div className={transcriptStyle}>
-            <strong>We couldn’t connect</strong>
+          <div className={recoveryStyle}>
+            <strong>We couldn’t reconnect the microphone</strong>
             <span>{snapshot.errorMessage}</span>
             {(snapshot.errorCode || snapshot.errorRequestId) && (
               <details className={technicalDetailsStyle}>
@@ -724,20 +965,11 @@ export const VoiceInterviewControlView = ({
           </div>
         )}
 
-        {snapshot.partialText && (
-          <div className={transcriptStyle}>
-            <span className={labelStyle}>
-              What we’re hearing · Not sent yet
-            </span>
-            <span>{snapshot.partialText}</span>
-          </div>
-        )}
-        {!snapshot.partialText && snapshot.lastCommittedText && (
-          <div className={transcriptStyle}>
-            <span className={labelStyle}>Answer recorded</span>
-            <span>{snapshot.lastCommittedText}</span>
-          </div>
-        )}
+        <TranscriptStrip
+          onEdit={onEdit}
+          onRedo={onRedo}
+          snapshot={snapshot}
+        />
 
         {editing && (
           <form className={actionsStyle} onSubmit={submitCorrection}>
@@ -765,64 +997,70 @@ export const VoiceInterviewControlView = ({
 
         <div className={actionsStyle}>
           {isSpeaking && (
-            <Button type="button" onClick={onInterrupt}>
-              Interrupt and speak
-            </Button>
+            <Button
+              aria-label="Interrupt and speak"
+              prefix={<FaMicrophone aria-hidden="true" />}
+              shape="round"
+              size="md"
+              tooltip="Interrupt and speak"
+              type="button"
+              onClick={onInterrupt}
+            />
           )}
           {snapshot.phase === "listening" && (
             <>
               <Button
                 aria-label="Done speaking"
                 prefix={<FaCheck aria-hidden="true" />}
+                shape="round"
+                size="md"
+                tooltip="Done speaking"
                 type="button"
                 onClick={onDoneSpeaking}
-              >
-                Done speaking
-              </Button>
+              />
               <Button
                 aria-label="Pause"
                 prefix={<FaPause aria-hidden="true" />}
+                shape="round"
+                size="sm"
+                tooltip="Pause"
                 type="button"
                 variant="subtle"
                 onClick={onPause}
-              >
-                Pause
-              </Button>
+              />
             </>
           )}
           {snapshot.phase === "paused" && (
-            <Button type="button" onClick={onResume}>
-              Resume listening
-            </Button>
+            <Button
+              aria-label="Resume listening"
+              prefix={<FaPlay aria-hidden="true" />}
+              shape="round"
+              size="md"
+              tooltip="Resume listening"
+              type="button"
+              onClick={onResume}
+            />
           )}
           {snapshot.phase === "recoverable-error" && (
-            <Button type="button" onClick={onReconnect}>
+            <Button
+              aria-label="Reconnect"
+              prefix={<FaRotate aria-hidden="true" />}
+              type="button"
+              onClick={onReconnect}
+            >
               Reconnect
             </Button>
           )}
-          {snapshot.lastCommittedText && !snapshot.partialText && (
-            <>
-              <Button
-                disabled={!snapshot.canReviseLastAnswer}
-                type="button"
-                variant="subtle"
-                onClick={onRedo}
-              >
-                Redo answer
-              </Button>
-              <Button
-                disabled={!snapshot.canReviseLastAnswer}
-                type="button"
-                variant="ghost"
-                onClick={onEdit}
-              >
-                Edit text
-              </Button>
-            </>
-          )}
-          <Button type="button" variant="ghost" onClick={onTypeInstead}>
-            Use text instead
-          </Button>
+          <Button
+            aria-label="Use text instead"
+            prefix={<FaKeyboard aria-hidden="true" />}
+            shape="round"
+            size="sm"
+            tooltip="Use text instead"
+            type="button"
+            variant="ghost"
+            onClick={onTypeInstead}
+          />
         </div>
 
         <Coverage coverage={coverage} />

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.tsx
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.tsx
@@ -32,6 +32,49 @@ export interface OpenAIVoiceConfig {
   readonly connectionTimeoutMs: number;
 }
 
+export const VOICE_INTERVIEW_DISCLOSURE_STORAGE_KEY =
+  "petrinaut:voice-interview-disclosure:v1";
+const VOICE_INTERVIEW_DISCLOSURE_ACKNOWLEDGED = "acknowledged";
+
+const getVoiceInterviewDisclosureStorage = (): Storage | null => {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+};
+
+export const isVoiceInterviewDisclosureAcknowledged = (
+  storage: Pick<Storage, "getItem"> | null =
+    getVoiceInterviewDisclosureStorage(),
+): boolean => {
+  try {
+    return (
+      storage?.getItem(VOICE_INTERVIEW_DISCLOSURE_STORAGE_KEY) ===
+      VOICE_INTERVIEW_DISCLOSURE_ACKNOWLEDGED
+    );
+  } catch {
+    return false;
+  }
+};
+
+export const acknowledgeVoiceInterviewDisclosure = (
+  storage: Pick<Storage, "setItem"> | null =
+    getVoiceInterviewDisclosureStorage(),
+): void => {
+  try {
+    storage?.setItem(
+      VOICE_INTERVIEW_DISCLOSURE_STORAGE_KEY,
+      VOICE_INTERVIEW_DISCLOSURE_ACKNOWLEDGED,
+    );
+  } catch {
+    // Storage is optional; the disclosure will appear again next time.
+  }
+};
+
 type Presentation = "trigger" | "start" | "full" | "mini";
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -826,6 +869,12 @@ const AvailableVoiceInterviewControl = ({
     void store.controller.end();
   };
 
+  const startInterview = () => {
+    setPresentation("full");
+    context.setActive(true);
+    void store.controller.start();
+  };
+
   return (
     <VoiceInterviewControlView
       consented={consented}
@@ -861,11 +910,16 @@ const AvailableVoiceInterviewControl = ({
       }}
       onRedo={() => store.controller.redoAnswer()}
       onResume={() => store.controller.resume()}
-      onShowStart={() => setPresentation("start")}
+      onShowStart={() => {
+        if (isVoiceInterviewDisclosureAcknowledged()) {
+          startInterview();
+        } else {
+          setPresentation("start");
+        }
+      }}
       onStart={() => {
-        setPresentation("full");
-        context.setActive(true);
-        void store.controller.start();
+        acknowledgeVoiceInterviewDisclosure();
+        startInterview();
       }}
       onSubmitCorrection={() => {
         const value = correction;

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.tsx
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.tsx
@@ -1336,8 +1336,7 @@ const AvailableVoiceInterviewControl = ({
       handledInterviewSelectionRef.current = false;
       return;
     }
-    if (handledInterviewSelectionRef.current || active) {
-      handledInterviewSelectionRef.current = true;
+    if (active || handledInterviewSelectionRef.current) {
       return;
     }
 

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.tsx
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.tsx
@@ -841,11 +841,15 @@ export const VoiceInterviewControlView = ({
 };
 
 const recordLatency = (event: VoiceLatencyEvent): void => {
-  performance.measure(`voice-interview:${event.name}`, {
-    detail: { questionId: event.questionId },
-    duration: event.elapsedMs,
-    start: 0,
-  });
+  try {
+    performance.measure(`voice-interview:${event.name}`, {
+      detail: { questionId: event.questionId },
+      duration: event.elapsedMs,
+      start: 0,
+    });
+  } catch {
+    // Performance measurement is optional and must not interrupt the interview.
+  }
 };
 
 const AvailableVoiceInterviewControl = ({
@@ -894,7 +898,7 @@ const AvailableVoiceInterviewControl = ({
     store.getSnapshot,
     store.getSnapshot,
   );
-  const [presentation, setPresentation] = useState<Presentation>("full");
+  const [presentation, setPresentation] = useState<Presentation>("start");
   const [consented, setConsented] = useState(false);
   const [microphoneCheck, setMicrophoneCheck] = useState("");
   const [correction, setCorrection] = useState("");

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.tsx
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.tsx
@@ -1290,6 +1290,7 @@ const AvailableVoiceInterviewControl = ({
   const [microphoneCheck, setMicrophoneCheck] = useState("");
   const [correction, setCorrection] = useState("");
   const [editing, setEditing] = useState(false);
+  const [endRequested, setEndRequested] = useState(false);
   const { interactionMode, openSidebar, setActive, setInteractionMode } =
     context;
   const openSidebarRef = useRef(openSidebar);
@@ -1314,7 +1315,7 @@ const AvailableVoiceInterviewControl = ({
     store,
   ]);
 
-  const active = snapshot.phase !== "idle";
+  const active = !endRequested && snapshot.phase !== "idle";
 
   useEffect(() => {
     setActive(active);
@@ -1329,7 +1330,11 @@ const AvailableVoiceInterviewControl = ({
       handledInterviewSelectionRef.current = false;
       return;
     }
-    if (active || handledInterviewSelectionRef.current) {
+    if (
+      active ||
+      endRequested ||
+      handledInterviewSelectionRef.current
+    ) {
       return;
     }
 
@@ -1342,7 +1347,7 @@ const AvailableVoiceInterviewControl = ({
     } else {
       setPresentation("start");
     }
-  }, [active, interactionMode, setActive, store]);
+  }, [active, endRequested, interactionMode, setActive, store]);
 
   useEffect(() => {
     if (snapshot.phase === "recoverable-error") {
@@ -1367,11 +1372,15 @@ const AvailableVoiceInterviewControl = ({
   );
 
   const end = () => {
+    setEndRequested(true);
     setCorrection("");
     setEditing(false);
     context.setActive(false);
     context.setInteractionMode("chat");
-    void store.controller.end();
+    void store.controller.end().then(
+      () => setEndRequested(false),
+      () => setEndRequested(false),
+    );
   };
 
   const minimize = () => context.setInteractionMode("chat");

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.tsx
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.tsx
@@ -1359,6 +1359,14 @@ const AvailableVoiceInterviewControl = ({
     }
   }, [setInteractionMode, snapshot.phase]);
 
+  useEffect(() => {
+    if (!snapshot.lastCommittedText) {
+      // eslint-disable-next-line react-hooks-js/set-state-in-effect -- A new question invalidates any correction for the previous answer.
+      setCorrection("");
+      setEditing(false);
+    }
+  }, [snapshot.lastCommittedText]);
+
   useEffect(
     () => () => {
       void store.controller.end();
@@ -1367,6 +1375,7 @@ const AvailableVoiceInterviewControl = ({
   );
 
   const end = () => {
+    setCorrection("");
     setEditing(false);
     context.setActive(false);
     context.setInteractionMode("chat");

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.tsx
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.tsx
@@ -593,6 +593,12 @@ export const VoiceInterviewControlView = ({
   const status = statusText(snapshot);
   const isSpeaking =
     snapshot.phase === "playing" || snapshot.phase === "synthesizing";
+  const compactQuestionContext = snapshot.currentQuestion
+    ? ` Question: ${snapshot.currentQuestion}`
+    : "";
+  const compactLiveOutput = `${status}.${compactQuestionContext}${
+    snapshot.partialText ? ` Not sent yet: ${snapshot.partialText}` : ""
+  }`;
 
   if (
     effectivePresentation === "mini" ||
@@ -605,7 +611,7 @@ export const VoiceInterviewControlView = ({
       >
         <div className={miniStyle}>
           <button
-            aria-label={`Expand voice interview. ${status}`}
+            aria-label={`Expand voice interview. ${status}.${compactQuestionContext}`}
             className={miniExpandStyle}
             type="button"
             onClick={onExpand}
@@ -663,8 +669,13 @@ export const VoiceInterviewControlView = ({
             onClick={onEnd}
           />
         </div>
-        <span className={liveRegionStyle} role="status" aria-live="polite">
-          {status}
+        <span
+          className={liveRegionStyle}
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+        >
+          {compactLiveOutput}
         </span>
       </section>
     );
@@ -834,7 +845,9 @@ export const VoiceInterviewControlView = ({
             </>
           )}
           <Button type="button" variant="ghost" onClick={onTypeInstead}>
-            Type instead
+            {snapshot.phase === "recoverable-error"
+              ? "Use text instead"
+              : "Type instead"}
           </Button>
         </div>
 

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.tsx
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.tsx
@@ -965,11 +965,7 @@ export const VoiceInterviewControlView = ({
           </div>
         )}
 
-        <TranscriptStrip
-          onEdit={onEdit}
-          onRedo={onRedo}
-          snapshot={snapshot}
-        />
+        <TranscriptStrip onEdit={onEdit} onRedo={onRedo} snapshot={snapshot} />
 
         {editing && (
           <form className={actionsStyle} onSubmit={submitCorrection}>

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.tsx
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.tsx
@@ -521,6 +521,24 @@ const statusText = (snapshot: VoiceTurnSnapshot): string => {
   }
 };
 
+type RecoveryErrorFamily = "connection" | "interview" | "microphone";
+
+const recoveryErrorFamily = (
+  errorCode: VoiceTurnSnapshot["errorCode"],
+): RecoveryErrorFamily => {
+  switch (errorCode) {
+    case "microphone-permission":
+    case "microphone-device":
+      return "microphone";
+    case "network":
+    case "timeout":
+    case "request-aborted":
+      return "connection";
+    default:
+      return "interview";
+  }
+};
+
 const shortStatusText = (snapshot: VoiceTurnSnapshot): string => {
   switch (snapshot.phase) {
     case "idle":
@@ -541,8 +559,16 @@ const shortStatusText = (snapshot: VoiceTurnSnapshot): string => {
       return "Preparing next question";
     case "playing":
       return "Interviewer speaking";
-    case "recoverable-error":
-      return "Connection paused";
+    case "recoverable-error": {
+      switch (recoveryErrorFamily(snapshot.errorCode)) {
+        case "microphone":
+          return "Microphone unavailable";
+        case "connection":
+          return "Connection paused";
+        case "interview":
+          return "Interview paused";
+      }
+    }
   }
 };
 
@@ -641,15 +667,12 @@ const VoiceFocal = ({ snapshot }: { snapshot: VoiceTurnSnapshot }) => {
  * microphone. The message below it stays the actionable guidance.
  */
 const recoveryHeading = (errorCode: VoiceTurnSnapshot["errorCode"]): string => {
-  switch (errorCode) {
-    case "microphone-permission":
-    case "microphone-device":
+  switch (recoveryErrorFamily(errorCode)) {
+    case "microphone":
       return "We couldn’t reconnect the microphone";
-    case "network":
-    case "timeout":
-    case "request-aborted":
+    case "connection":
       return "We lost the voice connection";
-    default:
+    case "interview":
       return "The interview couldn’t continue";
   }
 };

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.tsx
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.tsx
@@ -1330,11 +1330,7 @@ const AvailableVoiceInterviewControl = ({
       handledInterviewSelectionRef.current = false;
       return;
     }
-    if (
-      active ||
-      endRequested ||
-      handledInterviewSelectionRef.current
-    ) {
+    if (active || endRequested || handledInterviewSelectionRef.current) {
       return;
     }
 

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.tsx
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.tsx
@@ -56,8 +56,10 @@ const getVoiceInterviewDisclosureStorage = (): Storage | null => {
 };
 
 export const isVoiceInterviewDisclosureAcknowledged = (
-  storage: Pick<Storage, "getItem"> | null =
-    getVoiceInterviewDisclosureStorage(),
+  storage: Pick<
+    Storage,
+    "getItem"
+  > | null = getVoiceInterviewDisclosureStorage(),
 ): boolean => {
   try {
     return (
@@ -70,8 +72,10 @@ export const isVoiceInterviewDisclosureAcknowledged = (
 };
 
 export const acknowledgeVoiceInterviewDisclosure = (
-  storage: Pick<Storage, "setItem"> | null =
-    getVoiceInterviewDisclosureStorage(),
+  storage: Pick<
+    Storage,
+    "setItem"
+  > | null = getVoiceInterviewDisclosureStorage(),
 ): void => {
   try {
     storage?.setItem(
@@ -549,7 +553,12 @@ export const VoiceInterviewControlView = ({
                 Talk through your process with AI
               </span>
             </div>
-            <Button size="xs" type="button" variant="ghost" onClick={onTypeInstead}>
+            <Button
+              size="xs"
+              type="button"
+              variant="ghost"
+              onClick={onTypeInstead}
+            >
               Use text
             </Button>
           </header>

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.tsx
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.tsx
@@ -645,13 +645,14 @@ export const VoiceInterviewControlView = ({
           />
           <Button
             aria-label="End interview"
+            prefix={<FaXmark aria-hidden="true" />}
+            shape="round"
             size="xs"
+            tooltip="End interview"
             type="button"
             variant="ghost"
             onClick={onEnd}
-          >
-            End
-          </Button>
+          />
         </div>
         <span className={liveRegionStyle} role="status" aria-live="polite">
           {status}

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.tsx
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.tsx
@@ -1,5 +1,6 @@
 import {
   type FormEvent,
+  type ReactNode,
   useEffect,
   useLayoutEffect,
   useRef,
@@ -359,7 +360,9 @@ const transcriptStateStyle = cva({
   variants: {
     state: {
       recording: { color: "red.s80" },
+      sending: { color: "neutral.s80" },
       sent: { color: "green.s90" },
+      unsent: { color: "red.s90" },
     },
   },
 });
@@ -616,6 +619,31 @@ const VoiceFocal = ({ snapshot }: { snapshot: VoiceTurnSnapshot }) => {
   );
 };
 
+const deliveryStatus = (
+  delivery: VoiceTurnSnapshot["lastAnswerDelivery"],
+): { icon: ReactNode; label: string; state: "sending" | "sent" | "unsent" } => {
+  switch (delivery) {
+    case "delivered":
+      return {
+        icon: <FaCircleCheck aria-hidden="true" />,
+        label: "Sent",
+        state: "sent",
+      };
+    case "pending":
+      return {
+        icon: <FaCircleNotch aria-hidden="true" />,
+        label: "Sending",
+        state: "sending",
+      };
+    default:
+      return {
+        icon: <FaTriangleExclamation aria-hidden="true" />,
+        label: "Not sent",
+        state: "unsent",
+      };
+  }
+};
+
 const TranscriptStrip = ({
   onEdit,
   onRedo,
@@ -629,6 +657,8 @@ const TranscriptStrip = ({
   const text = snapshot.partialText || snapshot.lastCommittedText;
   if (!text) return null;
 
+  const delivery = deliveryStatus(snapshot.lastAnswerDelivery);
+
   return (
     <div className={transcriptStyle}>
       <div className={transcriptHeaderStyle}>
@@ -641,9 +671,9 @@ const TranscriptStrip = ({
             Recording
           </span>
         ) : (
-          <span className={transcriptStateStyle({ state: "sent" })}>
-            <FaCircleCheck aria-hidden="true" />
-            Sent
+          <span className={transcriptStateStyle({ state: delivery.state })}>
+            {delivery.icon}
+            {delivery.label}
           </span>
         )}
       </div>

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.tsx
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.tsx
@@ -6,7 +6,15 @@ import {
   useState,
   useSyncExternalStore,
 } from "react";
-import { FaKeyboard, FaMicrophone, FaMicrophoneSlash } from "react-icons/fa6";
+import {
+  FaCheck,
+  FaKeyboard,
+  FaMicrophone,
+  FaMicrophoneSlash,
+  FaMinus,
+  FaPause,
+  FaXmark,
+} from "react-icons/fa6";
 
 import { Button } from "@hashintel/ds-components";
 import { css, cva } from "@hashintel/ds-helpers/css";
@@ -180,8 +188,7 @@ const stageStyle = css({
   gap: "3",
   padding: "3",
   overflowY: "auto",
-  borderTopWidth: "thin",
-  borderBottomWidth: "thin",
+  borderWidth: "thin",
   borderStyle: "solid",
   borderColor: "neutral.a20",
   backgroundColor: "neutral.s00",
@@ -195,6 +202,12 @@ const headerStyle = css({
   gap: "2",
 });
 
+const startHeaderStyle = css({
+  display: "flex",
+  alignItems: "center",
+  gap: "2",
+});
+
 const titleStyle = css({
   flex: "1",
   color: "neutral.s100",
@@ -202,11 +215,33 @@ const titleStyle = css({
   fontWeight: "semibold",
 });
 
+const subtitleStyle = css({
+  color: "neutral.s80",
+  fontSize: "xs",
+  lineHeight: "snug",
+});
+
 const questionStyle = css({
   color: "neutral.s110",
   fontSize: "lg",
   fontWeight: "semibold",
   lineHeight: "snug",
+});
+
+const contextStyle = css({
+  display: "block",
+  overflow: "hidden",
+  color: "neutral.s80",
+  fontSize: "xs",
+  lineHeight: "snug",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+});
+
+const miniTextStyle = css({
+  display: "flex",
+  minWidth: "0",
+  flexDirection: "column",
 });
 
 const listeningStyle = css({
@@ -258,6 +293,18 @@ const labelStyle = css({
   color: "neutral.s80",
   fontSize: "xs",
   fontWeight: "semibold",
+});
+
+const phaseStyle = css({
+  color: "blue.s80",
+  fontSize: "xs",
+  fontWeight: "semibold",
+});
+
+const technicalDetailsStyle = css({
+  color: "neutral.s80",
+  fontSize: "xs",
+  _open: { color: "neutral.s90" },
 });
 
 const actionsStyle = css({
@@ -350,15 +397,7 @@ const statusText = (snapshot: VoiceTurnSnapshot): string => {
     case "playing":
       return "Microphone off · Interviewer speaking";
     case "recoverable-error": {
-      const diagnostic =
-        snapshot.errorCode === null
-          ? ""
-          : ` Error code: ${snapshot.errorCode}.${
-              snapshot.errorRequestId
-                ? ` Diagnostic reference: ${snapshot.errorRequestId}.`
-                : ""
-            }`;
-      return `Microphone off · ${snapshot.errorMessage}${diagnostic}`;
+      return `Microphone off · ${snapshot.errorMessage}`;
     }
   }
 };
@@ -373,7 +412,7 @@ const inputLevelText = (level: number): string =>
         : "Quiet";
 
 const Meter = ({ snapshot }: { snapshot: VoiceTurnSnapshot }) => {
-  const level = snapshot.microphoneEnabled ? snapshot.microphoneLevel : 0;
+  const level = snapshot.microphoneLevel;
   return (
     <>
       <div className={meterStyle} aria-hidden="true">
@@ -386,9 +425,7 @@ const Meter = ({ snapshot }: { snapshot: VoiceTurnSnapshot }) => {
         ))}
       </div>
       <span className={labelStyle}>
-        {snapshot.microphoneEnabled
-          ? `Microphone input level: ${inputLevelText(level)}`
-          : "Microphone input level unavailable while microphone is off"}
+        {`Microphone input level: ${inputLevelText(level)}`}
       </span>
     </>
   );
@@ -505,15 +542,20 @@ export const VoiceInterviewControlView = ({
         className={rootStyle({ presentation: "start" })}
       >
         <div className={cardStyle}>
-          <h2 className={questionStyle}>Talk with the AI interviewer</h2>
+          <header className={startHeaderStyle}>
+            <div className={titleStyle}>
+              <strong>Voice interview</strong>
+              <span className={subtitleStyle}>
+                Talk through your process with AI
+              </span>
+            </div>
+            <Button size="xs" type="button" variant="ghost" onClick={onTypeInstead}>
+              Use text
+            </Button>
+          </header>
           <p className={statusStyle}>
-            Your speech is sent to OpenAI for transcription. Petrinaut keeps
-            finalized answers in this conversation; this app does not retain the
-            audio.
-          </p>
-          <p className={statusStyle}>
-            Questions are spoken by an AI-generated OpenAI voice. You can pause,
-            type, correct an answer, or end the interview at any time.
+            Your speech is transcribed by OpenAI. Petrinaut keeps finalized
+            answers in this conversation, not the audio.
           </p>
           <label className={statusStyle}>
             <input
@@ -525,14 +567,11 @@ export const VoiceInterviewControlView = ({
           </label>
           {microphoneCheck && <p className={labelStyle}>{microphoneCheck}</p>}
           <div className={actionsStyle}>
-            <Button type="button" variant="subtle" onClick={onCheckMicrophone}>
-              Check microphone
-            </Button>
             <Button disabled={!consented} type="button" onClick={onStart}>
               Start interview
             </Button>
-            <Button type="button" variant="ghost" onClick={onTypeInstead}>
-              Use text instead
+            <Button type="button" variant="subtle" onClick={onCheckMicrophone}>
+              Check microphone
             </Button>
           </div>
         </div>
@@ -567,7 +606,12 @@ export const VoiceInterviewControlView = ({
             ) : (
               <FaMicrophoneSlash aria-hidden="true" />
             )}
-            <span>{status}</span>
+            <span className={miniTextStyle}>
+              <span>{status}</span>
+              {snapshot.currentQuestion && (
+                <span className={contextStyle}>{snapshot.currentQuestion}</span>
+              )}
+            </span>
           </button>
           {isSpeaking ? (
             <Button size="xs" type="button" onClick={onInterrupt}>
@@ -580,6 +624,7 @@ export const VoiceInterviewControlView = ({
           ) : (
             <Button
               disabled={!snapshot.microphoneEnabled}
+              prefix={<FaPause aria-hidden="true" />}
               size="xs"
               type="button"
               variant="subtle"
@@ -627,13 +672,27 @@ export const VoiceInterviewControlView = ({
     >
       <div className={stageStyle}>
         <header className={headerStyle}>
-          <span className={titleStyle}>AI · Voice interview</span>
-          <Button size="xs" type="button" variant="ghost" onClick={onMinimize}>
-            Minimize
-          </Button>
-          <Button size="xs" type="button" variant="ghost" onClick={onEnd}>
-            End interview
-          </Button>
+          <span className={titleStyle}>Voice interview</span>
+          <Button
+            aria-label="Minimize voice interview"
+            prefix={<FaMinus aria-hidden="true" />}
+            shape="round"
+            size="xs"
+            tooltip="Minimize"
+            type="button"
+            variant="ghost"
+            onClick={onMinimize}
+          />
+          <Button
+            aria-label="End interview"
+            prefix={<FaXmark aria-hidden="true" />}
+            shape="round"
+            size="xs"
+            tooltip="End interview"
+            type="button"
+            variant="ghost"
+            onClick={onEnd}
+          />
         </header>
 
         <p className={questionStyle}>
@@ -646,9 +705,27 @@ export const VoiceInterviewControlView = ({
           ) : (
             <FaMicrophoneSlash aria-hidden="true" />
           )}
-          <Meter snapshot={snapshot} />
-          <span className={statusStyle}>{status}</span>
+          {snapshot.microphoneEnabled && <Meter snapshot={snapshot} />}
+          <span className={phaseStyle}>{status}</span>
         </div>
+
+        {snapshot.phase === "recoverable-error" && (
+          <div className={transcriptStyle}>
+            <strong>We couldn’t connect</strong>
+            <span>{snapshot.errorMessage}</span>
+            {(snapshot.errorCode || snapshot.errorRequestId) && (
+              <details className={technicalDetailsStyle}>
+                <summary>Technical details</summary>
+                {snapshot.errorCode && (
+                  <div>Error code: {snapshot.errorCode}</div>
+                )}
+                {snapshot.errorRequestId && (
+                  <div>Diagnostic reference: {snapshot.errorRequestId}</div>
+                )}
+              </details>
+            )}
+          </div>
+        )}
 
         {snapshot.partialText && (
           <div className={transcriptStyle}>
@@ -697,10 +774,21 @@ export const VoiceInterviewControlView = ({
           )}
           {snapshot.phase === "listening" && (
             <>
-              <Button type="button" onClick={onDoneSpeaking}>
+              <Button
+                aria-label="Done speaking"
+                prefix={<FaCheck aria-hidden="true" />}
+                type="button"
+                onClick={onDoneSpeaking}
+              >
                 Done speaking
               </Button>
-              <Button type="button" variant="subtle" onClick={onPause}>
+              <Button
+                aria-label="Pause"
+                prefix={<FaPause aria-hidden="true" />}
+                type="button"
+                variant="subtle"
+                onClick={onPause}
+              >
                 Pause
               </Button>
             </>

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.tsx
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-interview-control.tsx
@@ -3,6 +3,7 @@ import {
   type ReactNode,
   useEffect,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState,
   useSyncExternalStore,
@@ -1270,7 +1271,12 @@ const AvailableVoiceInterviewControl = ({
     context;
   const openSidebarRef = useRef(openSidebar);
   const handledInterviewSelectionRef = useRef(false);
-  const coverage = selectInterviewCoverage(context.messages);
+  // Microphone level updates re-render this component many times per answer;
+  // the coverage scan only changes when the conversation does.
+  const coverage = useMemo(
+    () => selectInterviewCoverage(context.messages),
+    [context.messages],
+  );
 
   if (previousPlacement !== context.placement) {
     setPreviousPlacement(context.placement);

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-preview.integration.test.ts
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-preview.integration.test.ts
@@ -161,14 +161,25 @@ describe("controlled voice preview", () => {
     };
     let requestNumber = 0;
     const createRequestId = () => requestIds[requestNumber++]!;
+    const audioContext = {
+      close: vi.fn(async () => undefined),
+      createAnalyser: vi.fn(() => ({
+        fftSize: 0,
+        getByteTimeDomainData: vi.fn(),
+      })),
+      createMediaStreamSource: vi.fn(() => ({ connect: vi.fn() })),
+    };
     const session = new OpenAIRealtimeSession({
+      cancelAnimationFrame: vi.fn(),
       connectionTimeoutMs: 15_000,
+      createAudioContext: () => audioContext as unknown as AudioContext,
       createPeerConnection: () => peer as unknown as RTCPeerConnection,
       createRequestId,
       fetch: browserFetch,
       getUserMedia: async () => mediaStream,
       now: clock,
       reportDiagnostic,
+      requestAnimationFrame: vi.fn(() => 1),
     });
     const audio = createAudioHarness();
     const revokeObjectURL = vi.fn();

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-turn-controller.test.ts
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-turn-controller.test.ts
@@ -1049,6 +1049,45 @@ describe("VoiceTurnController", () => {
     expect(harness.session.connect).toHaveBeenCalledTimes(2);
   });
 
+  test("does not replay an answered question after reconnecting", async () => {
+    const harness = createHarness();
+    const question = {
+      ...canonicalSegment(
+        "ask-answered-reconnect",
+        "What happens after approval?",
+      ),
+      source: "brunch-ask" as const,
+    };
+    harness.controller.updateChat({
+      canAcceptInterviewAnswer: true,
+      canonicalSegments: [question],
+      status: "streaming",
+    });
+    await harness.controller.start();
+    await vi.waitFor(() =>
+      expect(harness.controller.getSnapshot().phase).toBe("listening"),
+    );
+    harness.emit({
+      key: key(1, "answered-item"),
+      text: "The request is assigned to the shift lead.",
+      type: "completed",
+    });
+    await vi.waitFor(() => expect(harness.submitText).toHaveBeenCalledOnce());
+    updateChatStatus(harness.controller, "streaming");
+    updateChatStatus(harness.controller, "ready");
+
+    harness.emit({
+      code: "network",
+      message: "The voice connection failed. Try reconnecting.",
+      requestId: "voice-request-answered-reconnect",
+      type: "error",
+    });
+    await harness.controller.reconnect();
+
+    expect(harness.playback.play).toHaveBeenCalledOnce();
+    expect(harness.session.connect).toHaveBeenCalledTimes(2);
+  });
+
   test("replays a pending question after ending and restarting", async () => {
     const harness = createHarness();
     const question = {

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-turn-controller.test.ts
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-turn-controller.test.ts
@@ -184,6 +184,42 @@ describe("VoiceTurnController", () => {
     });
   });
 
+  test("keeps capture closed while an answer transcript settles", async () => {
+    const harness = createHarness();
+    const question = {
+      ...canonicalSegment("ask-transcribing", "Who approves it?"),
+      source: "brunch-ask" as const,
+    };
+    harness.controller.updateChat({
+      canAcceptInterviewAnswer: true,
+      canonicalSegments: [question],
+      status: "streaming",
+    });
+    await harness.controller.start();
+    await vi.waitFor(() =>
+      expect(harness.controller.getSnapshot().phase).toBe("listening"),
+    );
+
+    harness.emit({
+      connectionEpoch: 1,
+      itemId: "answer-transcribing",
+      type: "input-committed",
+    });
+    harness.controller.updateChat({
+      canAcceptInterviewAnswer: true,
+      canonicalSegments: [question],
+      status: "streaming",
+    });
+
+    expect(harness.controller.getSnapshot()).toMatchObject({
+      microphoneEnabled: false,
+      phase: "transcribing",
+    });
+    expect(harness.session.setMicrophoneEnabled).toHaveBeenLastCalledWith(
+      false,
+    );
+  });
+
   test("records answer-to-question visibility and speech latency", async () => {
     const harness = createHarness();
     await harness.controller.start();
@@ -1072,6 +1108,8 @@ describe("VoiceTurnController", () => {
       text: "The request is assigned to the shift lead.",
       type: "completed",
     });
+    expect(harness.submitText).not.toHaveBeenCalled();
+    updateChatStatus(harness.controller, "ready");
     await vi.waitFor(() => expect(harness.submitText).toHaveBeenCalledOnce());
     updateChatStatus(harness.controller, "streaming");
     updateChatStatus(harness.controller, "ready");

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-turn-controller.test.ts
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-turn-controller.test.ts
@@ -13,7 +13,6 @@ const createHarness = () => {
   let epoch = 0;
   let listener: ((event: OpenAIRealtimeSessionEvent) => void) | undefined;
   const session = {
-    commitInput: vi.fn(),
     connect: vi.fn(async () => ++epoch),
     disconnect: vi.fn(async () => undefined),
     setMicrophoneEnabled: vi.fn(),
@@ -167,19 +166,18 @@ describe("VoiceTurnController", () => {
     });
   });
 
-  test("closes the microphone before committing when the expert is done speaking", async () => {
+  test("relies on server VAD after the expert is done speaking", async () => {
     const order: string[] = [];
     const harness = createHarness();
     harness.session.setMicrophoneEnabled.mockImplementation((enabled) => {
       if (!enabled) order.push("microphone-off");
     });
-    harness.session.commitInput.mockImplementation(() => order.push("commit"));
     await harness.controller.start();
     order.length = 0;
 
     harness.controller.doneSpeaking();
 
-    expect(order).toEqual(["microphone-off", "commit"]);
+    expect(order).toEqual(["microphone-off"]);
     expect(harness.controller.getSnapshot()).toMatchObject({
       microphoneEnabled: false,
       phase: "transcribing",
@@ -968,7 +966,8 @@ describe("VoiceTurnController", () => {
       expect.objectContaining({ text: "Accepted final" }),
     );
     expect(harness.controller.getSnapshot()).toMatchObject({
-      lastCommittedText: "Accepted final",
+      canReviseLastAnswer: false,
+      lastCommittedText: "",
       phase: "idle",
     });
   });
@@ -1119,6 +1118,29 @@ describe("VoiceTurnController", () => {
     );
   });
 
+  test("reports a rejected correction so the caller can preserve its draft", async () => {
+    const harness = createHarness();
+    await harness.controller.start();
+    harness.emit({
+      key: key(1, "item-a"),
+      text: "The support lead closes it.",
+      type: "completed",
+    });
+    await vi.waitFor(() => expect(harness.submitText).toHaveBeenCalledOnce());
+    updateChatStatus(harness.controller, "streaming");
+    updateChatStatus(harness.controller, "ready");
+    harness.submitText.mockRejectedValueOnce(
+      new Error("A queued answer already exists"),
+    );
+
+    const accepted = await harness.controller.submitCorrection(
+      "The incident manager closes it.",
+    );
+
+    expect(accepted).toBe(false);
+    expect(harness.controller.getSnapshot().phase).toBe("recoverable-error");
+  });
+
   test("ignores a typed correction while the previous answer is still pending", async () => {
     const harness = createHarness();
     let finishDelivery: (() => void) | undefined;
@@ -1137,12 +1159,16 @@ describe("VoiceTurnController", () => {
       type: "completed",
     });
     await vi.waitFor(() => expect(harness.submitText).toHaveBeenCalledOnce());
-    expect(harness.controller.getSnapshot().phase).toBe("delivering");
+    expect(harness.controller.getSnapshot()).toMatchObject({
+      canReviseLastAnswer: false,
+      phase: "delivering",
+    });
 
-    await harness.controller.submitCorrection(
+    const accepted = await harness.controller.submitCorrection(
       "The incident manager closes it.",
     );
 
+    expect(accepted).toBe(false);
     expect(harness.submitText).toHaveBeenCalledOnce();
     expect(harness.controller.getSnapshot().phase).toBe("delivering");
     finishDelivery?.();

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-turn-controller.test.ts
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-turn-controller.test.ts
@@ -1280,6 +1280,65 @@ describe("VoiceTurnController", () => {
     expect(harness.controller.getSnapshot().phase).toBe("recoverable-error");
   });
 
+  test("keeps the current question after a failed correction and reconnect", async () => {
+    const harness = createHarness();
+    const question = {
+      ...canonicalSegment(
+        "ask-failed-correction",
+        "What happens after approval?",
+      ),
+      source: "brunch-ask" as const,
+    };
+    const chat = (status: "ready" | "streaming") =>
+      harness.controller.updateChat({
+        canAcceptInterviewAnswer: true,
+        canonicalSegments: [question],
+        status,
+      });
+    chat("ready");
+    await harness.controller.start();
+    await vi.waitFor(() =>
+      expect(harness.controller.getSnapshot().phase).toBe("listening"),
+    );
+
+    harness.emit({
+      key: key(1, "answer-before-correction"),
+      text: "The support lead closes it.",
+      type: "completed",
+    });
+    await vi.waitFor(() => expect(harness.submitText).toHaveBeenCalledOnce());
+    chat("streaming");
+    chat("ready");
+
+    // Redo reopens the ask, so the typed correction below is the only
+    // delivery that can settle it.
+    harness.controller.redoAnswer();
+    expect(harness.controller.getSnapshot()).toMatchObject({
+      canReviseLastAnswer: true,
+      phase: "listening",
+    });
+    harness.submitText.mockRejectedValueOnce(
+      new Error("A queued answer already exists"),
+    );
+
+    const accepted = await harness.controller.submitCorrection(
+      "The incident manager closes it.",
+    );
+
+    expect(accepted).toBe(false);
+    expect(harness.controller.getSnapshot().phase).toBe("recoverable-error");
+
+    await harness.controller.reconnect();
+
+    await vi.waitFor(() =>
+      expect(harness.controller.getSnapshot()).toMatchObject({
+        currentQuestion: "What happens after approval?",
+        microphoneEnabled: true,
+        phase: "listening",
+      }),
+    );
+  });
+
   test("ignores a typed correction while the previous answer is still pending", async () => {
     const harness = createHarness();
     let finishDelivery: (() => void) | undefined;

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-turn-controller.test.ts
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-turn-controller.test.ts
@@ -546,7 +546,7 @@ describe("VoiceTurnController", () => {
     });
     expect(harness.controller.getSnapshot()).toMatchObject({
       partialText: "The support",
-      phase: "transcribing",
+      phase: "listening",
     });
     expect(harness.submitText).not.toHaveBeenCalled();
 
@@ -674,7 +674,7 @@ describe("VoiceTurnController", () => {
     );
   });
 
-  test("closes the microphone when a partial transcript arrives", async () => {
+  test("keeps listening when a partial transcript arrives", async () => {
     const harness = createHarness();
     await harness.controller.start();
 
@@ -685,9 +685,13 @@ describe("VoiceTurnController", () => {
     });
 
     expect(harness.session.setMicrophoneEnabled).toHaveBeenLastCalledWith(
-      false,
+      true,
     );
-    expect(harness.controller.getSnapshot().phase).toBe("transcribing");
+    expect(harness.controller.getSnapshot()).toMatchObject({
+      microphoneEnabled: true,
+      partialText: "The support",
+      phase: "listening",
+    });
   });
 
   test("ignores duplicate, stale, and out-of-order completed items", async () => {

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-turn-controller.test.ts
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-turn-controller.test.ts
@@ -545,9 +545,11 @@ describe("VoiceTurnController", () => {
       type: "partial",
     });
     expect(harness.controller.getSnapshot()).toMatchObject({
+      microphoneEnabled: true,
       partialText: "The support",
       phase: "listening",
     });
+    expect(harness.session.setMicrophoneEnabled).toHaveBeenLastCalledWith(true);
     expect(harness.submitText).not.toHaveBeenCalled();
 
     harness.emit({
@@ -672,26 +674,6 @@ describe("VoiceTurnController", () => {
     expect(harness.submitText).toHaveBeenLastCalledWith(
       expect.objectContaining({ text: "The incident manager owns it." }),
     );
-  });
-
-  test("keeps listening when a partial transcript arrives", async () => {
-    const harness = createHarness();
-    await harness.controller.start();
-
-    harness.emit({
-      key: key(1, "item-a"),
-      text: "The support",
-      type: "partial",
-    });
-
-    expect(harness.session.setMicrophoneEnabled).toHaveBeenLastCalledWith(
-      true,
-    );
-    expect(harness.controller.getSnapshot()).toMatchObject({
-      microphoneEnabled: true,
-      partialText: "The support",
-      phase: "listening",
-    });
   });
 
   test("ignores duplicate, stale, and out-of-order completed items", async () => {

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-turn-controller.test.ts
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-turn-controller.test.ts
@@ -1622,11 +1622,137 @@ describe("VoiceTurnController", () => {
     expect(harness.controller.getSnapshot()).toMatchObject({
       errorCode: "network",
       errorRequestId: "voice-request-in-flight-speech",
+      lastAnswerDelivery: "failed",
       phase: "recoverable-error",
     });
     expect(harness.session.setMicrophoneEnabled).toHaveBeenLastCalledWith(
       false,
     );
+  });
+
+  test("marks the last answer delivered only once the composer accepts it", async () => {
+    const harness = createHarness();
+    let finishDelivery: (() => void) | undefined;
+    harness.submitText.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishDelivery = () => resolve({ kind: "message" as const });
+        }),
+    );
+    await harness.controller.start();
+
+    harness.emit({
+      key: key(1, "item-a"),
+      text: "The support lead triages it.",
+      type: "completed",
+    });
+    await vi.waitFor(() => expect(harness.submitText).toHaveBeenCalledOnce());
+
+    expect(harness.controller.getSnapshot()).toMatchObject({
+      lastAnswerDelivery: "pending",
+      lastCommittedText: "The support lead triages it.",
+      phase: "delivering",
+    });
+
+    finishDelivery?.();
+    await vi.waitFor(() =>
+      expect(harness.controller.getSnapshot().lastAnswerDelivery).toBe(
+        "delivered",
+      ),
+    );
+  });
+
+  test("records a failed delivery instead of a delivered answer", async () => {
+    const harness = createHarness();
+    harness.submitText.mockRejectedValueOnce(new Error("Delivery rejected"));
+    await harness.controller.start();
+
+    harness.emit({
+      key: key(1, "item-b"),
+      text: "The support lead triages it.",
+      type: "completed",
+    });
+
+    await vi.waitFor(() =>
+      expect(harness.controller.getSnapshot()).toMatchObject({
+        lastAnswerDelivery: "failed",
+        lastCommittedText: "The support lead triages it.",
+        phase: "recoverable-error",
+      }),
+    );
+  });
+
+  test("clears delivery state when the next question arrives", async () => {
+    const harness = createHarness();
+    await harness.controller.start();
+    harness.emit({
+      key: key(1, "item-c"),
+      text: "The support lead triages it.",
+      type: "completed",
+    });
+    await vi.waitFor(() =>
+      expect(harness.controller.getSnapshot().lastAnswerDelivery).toBe(
+        "delivered",
+      ),
+    );
+
+    harness.controller.updateChat({
+      canAcceptInterviewAnswer: true,
+      canonicalSegments: [
+        {
+          ...canonicalSegment("ask-after-delivery"),
+          source: "brunch-ask" as const,
+        },
+      ],
+      status: "ready",
+    });
+
+    expect(harness.controller.getSnapshot()).toMatchObject({
+      lastAnswerDelivery: "none",
+      lastCommittedText: "",
+    });
+  });
+
+  test("does not let a stale delivery result overwrite the next answer", async () => {
+    const harness = createHarness();
+    let finishStaleDelivery: (() => void) | undefined;
+    harness.submitText.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishStaleDelivery = () => resolve({ kind: "message" as const });
+        }),
+    );
+    await harness.controller.start();
+    harness.emit({
+      key: key(1, "item-stale"),
+      text: "The first answer.",
+      type: "completed",
+    });
+    await vi.waitFor(() => expect(harness.submitText).toHaveBeenCalledOnce());
+
+    harness.emit({
+      code: "network",
+      message: "The voice connection failed. Try reconnecting.",
+      requestId: "voice-request-stale-delivery",
+      type: "error",
+    });
+    await harness.controller.reconnect();
+    harness.submitText.mockRejectedValueOnce(new Error("Delivery rejected"));
+    harness.emit({
+      key: key(2, "item-current"),
+      text: "The second answer.",
+      type: "completed",
+    });
+    await vi.waitFor(() =>
+      expect(harness.controller.getSnapshot().lastAnswerDelivery).toBe(
+        "failed",
+      ),
+    );
+
+    finishStaleDelivery?.();
+    await Promise.resolve();
+
+    expect(harness.controller.getSnapshot().lastAnswerDelivery).toBe("failed");
   });
 
   test("cancels speech synchronously and rejects stale playback events when voice ends", async () => {

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-turn-controller.test.ts
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-turn-controller.test.ts
@@ -448,6 +448,38 @@ describe("VoiceTurnController", () => {
     expect(harness.controller.getSnapshot().phase).toBe("listening");
   });
 
+  test("waits for answer capacity before opening the microphone after connection", async () => {
+    const harness = createHarness();
+    harness.controller.updateChat({
+      canAcceptInterviewAnswer: false,
+      canonicalSegments: [],
+      status: "ready",
+    });
+
+    await harness.controller.start();
+
+    expect(harness.session.connect).toHaveBeenCalledOnce();
+    expect(harness.session.setMicrophoneEnabled).toHaveBeenLastCalledWith(
+      false,
+    );
+    expect(harness.controller.getSnapshot()).toMatchObject({
+      microphoneEnabled: false,
+      phase: "waiting",
+    });
+
+    harness.controller.updateChat({
+      canAcceptInterviewAnswer: true,
+      canonicalSegments: [],
+      status: "ready",
+    });
+
+    expect(harness.session.setMicrophoneEnabled).toHaveBeenLastCalledWith(true);
+    expect(harness.controller.getSnapshot()).toMatchObject({
+      microphoneEnabled: true,
+      phase: "listening",
+    });
+  });
+
   test("preserves a Brunch error that occurs while voice is connecting", async () => {
     const harness = createHarness();
     let finishConnection: (() => void) | undefined;
@@ -1174,7 +1206,7 @@ describe("VoiceTurnController", () => {
     finishDelivery?.();
   });
 
-  test("ignores a typed correction while answer capacity is unavailable", async () => {
+  test("closes capture and ignores correction while answer capacity is unavailable", async () => {
     const harness = createHarness();
     await harness.controller.start();
     harness.emit({
@@ -1190,14 +1222,34 @@ describe("VoiceTurnController", () => {
       canonicalSegments: [],
       status: "ready",
     });
-    expect(harness.controller.getSnapshot().phase).toBe("listening");
+    expect(harness.session.setMicrophoneEnabled).toHaveBeenLastCalledWith(
+      false,
+    );
+    expect(harness.controller.getSnapshot()).toMatchObject({
+      microphoneEnabled: false,
+      phase: "waiting",
+    });
 
     await harness.controller.submitCorrection(
       "The incident manager closes it.",
     );
 
     expect(harness.submitText).toHaveBeenCalledOnce();
-    expect(harness.controller.getSnapshot().phase).toBe("listening");
+    expect(harness.controller.getSnapshot()).toMatchObject({
+      microphoneEnabled: false,
+      phase: "waiting",
+    });
+
+    harness.controller.updateChat({
+      canAcceptInterviewAnswer: true,
+      canonicalSegments: [],
+      status: "ready",
+    });
+    expect(harness.session.setMicrophoneEnabled).toHaveBeenLastCalledWith(true);
+    expect(harness.controller.getSnapshot()).toMatchObject({
+      microphoneEnabled: true,
+      phase: "listening",
+    });
   });
 
   test("seeds finalized history without replaying it when voice starts or reconnects", async () => {

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-turn-controller.test.ts
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-turn-controller.test.ts
@@ -13,6 +13,7 @@ const createHarness = () => {
   let epoch = 0;
   let listener: ((event: OpenAIRealtimeSessionEvent) => void) | undefined;
   const session = {
+    commitInput: vi.fn(),
     connect: vi.fn(async () => ++epoch),
     disconnect: vi.fn(async () => undefined),
     setMicrophoneEnabled: vi.fn(),
@@ -24,6 +25,11 @@ const createHarness = () => {
     }),
   };
   const submitText = vi.fn(async () => ({ kind: "message" as const }));
+  const latencyEvents: Array<{
+    elapsedMs: number;
+    name: string;
+    questionId: string;
+  }> = [];
   const playback = {
     cancel: vi.fn(),
     play: vi.fn(
@@ -37,6 +43,14 @@ const createHarness = () => {
   };
   const controller = new VoiceTurnController({
     conversationId: "preview/net 1",
+    now: (() => {
+      let now = 1_000;
+      return () => {
+        now += 100;
+        return now;
+      };
+    })(),
+    onLatencyEvent: (event) => latencyEvents.push(event),
     playback,
     session,
     submitText,
@@ -45,6 +59,7 @@ const createHarness = () => {
   return {
     controller,
     emit: (event: OpenAIRealtimeSessionEvent) => listener?.(event),
+    latencyEvents,
     playback,
     session,
     submitText,
@@ -75,6 +90,176 @@ const updateChatStatus = (
 ) => controller.updateChat({ canonicalSegments: [], status });
 
 describe("VoiceTurnController", () => {
+  test("speaks a pending interview question and opens capture before generic chat settlement", async () => {
+    const harness = createHarness();
+    let finishPlayback: (() => void) | undefined;
+    harness.playback.play.mockImplementationOnce(
+      async (_segment, events = {}) => {
+        events.onPlaying?.();
+        await new Promise<void>((resolve) => {
+          finishPlayback = resolve;
+        });
+      },
+    );
+    const question = {
+      ...canonicalSegment("ask-1", "What happens after approval?"),
+      source: "brunch-ask" as const,
+    };
+
+    harness.controller.updateChat({
+      canAcceptInterviewAnswer: true,
+      canonicalSegments: [question],
+      status: "streaming",
+    });
+    await harness.controller.start();
+
+    expect(harness.playback.play).toHaveBeenCalledWith(
+      question,
+      expect.any(Object),
+    );
+    expect(harness.controller.getSnapshot()).toMatchObject({
+      currentQuestion: "What happens after approval?",
+      microphoneEnabled: false,
+      phase: "playing",
+    });
+
+    finishPlayback?.();
+    await vi.waitFor(() =>
+      expect(harness.controller.getSnapshot()).toMatchObject({
+        microphoneEnabled: true,
+        phase: "listening",
+      }),
+    );
+    expect(harness.session.setMicrophoneEnabled).toHaveBeenLastCalledWith(true);
+  });
+
+  test("cancels playback completely before enabling the microphone to interrupt", async () => {
+    const order: string[] = [];
+    const harness = createHarness();
+    harness.playback.cancel.mockImplementation(() => order.push("cancel"));
+    harness.session.setMicrophoneEnabled.mockImplementation((enabled) => {
+      if (enabled) order.push("microphone-on");
+    });
+    harness.playback.play.mockImplementationOnce(
+      async (_segment, events = {}) => {
+        events.onPlaying?.();
+        await new Promise(() => undefined);
+      },
+    );
+    harness.controller.updateChat({
+      canAcceptInterviewAnswer: true,
+      canonicalSegments: [
+        {
+          ...canonicalSegment("ask-1"),
+          source: "brunch-ask" as const,
+        },
+      ],
+      status: "streaming",
+    });
+    await harness.controller.start();
+
+    harness.controller.interruptAndSpeak();
+
+    expect(order.slice(-2)).toEqual(["cancel", "microphone-on"]);
+    expect(harness.controller.getSnapshot()).toMatchObject({
+      microphoneEnabled: true,
+      phase: "listening",
+    });
+  });
+
+  test("closes the microphone before committing when the expert is done speaking", async () => {
+    const order: string[] = [];
+    const harness = createHarness();
+    harness.session.setMicrophoneEnabled.mockImplementation((enabled) => {
+      if (!enabled) order.push("microphone-off");
+    });
+    harness.session.commitInput.mockImplementation(() => order.push("commit"));
+    await harness.controller.start();
+    order.length = 0;
+
+    harness.controller.doneSpeaking();
+
+    expect(order).toEqual(["microphone-off", "commit"]);
+    expect(harness.controller.getSnapshot()).toMatchObject({
+      microphoneEnabled: false,
+      phase: "transcribing",
+    });
+  });
+
+  test("records answer-to-question visibility and speech latency", async () => {
+    const harness = createHarness();
+    await harness.controller.start();
+    harness.emit({
+      key: key(1, "answer-1"),
+      text: "Approval sends it to dispatch.",
+      type: "completed",
+    });
+    harness.controller.updateChat({
+      canAcceptInterviewAnswer: true,
+      canonicalSegments: [
+        {
+          ...canonicalSegment("ask-next"),
+          source: "brunch-ask" as const,
+        },
+      ],
+      status: "streaming",
+    });
+
+    await vi.waitFor(() =>
+      expect(harness.latencyEvents.map(({ name }) => name)).toEqual([
+        "question-visible",
+        "question-spoken-started",
+        "question-spoken",
+        "answer-ready",
+      ]),
+    );
+    expect(harness.latencyEvents.every(({ elapsedMs }) => elapsedMs >= 0)).toBe(
+      true,
+    );
+  });
+
+  test("pauses without ending the connection and redoes an answer as an explicit correction", async () => {
+    const harness = createHarness();
+    harness.controller.updateChat({
+      canAcceptInterviewAnswer: true,
+      canonicalSegments: [
+        {
+          ...canonicalSegment("ask-1"),
+          source: "brunch-ask" as const,
+        },
+      ],
+      status: "ready",
+    });
+    await harness.controller.start();
+
+    harness.controller.pause();
+    expect(harness.controller.getSnapshot()).toMatchObject({
+      microphoneEnabled: false,
+      phase: "paused",
+    });
+    expect(harness.session.disconnect).not.toHaveBeenCalled();
+
+    harness.controller.resume();
+    harness.emit({
+      key: key(1, "answer-1"),
+      text: "The operator approves it.",
+      type: "completed",
+    });
+    await vi.waitFor(() => expect(harness.submitText).toHaveBeenCalledOnce());
+    harness.controller.redoAnswer();
+    expect(harness.controller.getSnapshot().phase).toBe("listening");
+    harness.emit({
+      key: key(1, "answer-2"),
+      text: "The shift lead approves it.",
+      type: "completed",
+    });
+    await vi.waitFor(() => expect(harness.submitText).toHaveBeenCalledTimes(2));
+    expect(harness.submitText).toHaveBeenLastCalledWith({
+      target: "message",
+      text: 'Correction to my previous voice answer "The operator approves it.": The shift lead approves it.',
+    });
+  });
+
   test("does not surface an unrelated Brunch error before voice starts", async () => {
     const harness = createHarness();
 
@@ -88,7 +273,7 @@ describe("VoiceTurnController", () => {
 
     await harness.controller.start();
     expect(harness.controller.getSnapshot()).toMatchObject({
-      errorMessage: "Wait for Brunch to finish before starting voice input.",
+      errorMessage: "Wait for the current response to finish before starting.",
       phase: "recoverable-error",
     });
   });
@@ -104,7 +289,7 @@ describe("VoiceTurnController", () => {
       false,
     );
     expect(harness.controller.getSnapshot()).toMatchObject({
-      errorMessage: "Wait for Brunch to finish before starting voice input.",
+      errorMessage: "Wait for the current response to finish before starting.",
       phase: "recoverable-error",
     });
   });
@@ -146,7 +331,7 @@ describe("VoiceTurnController", () => {
     expect(harness.session.disconnect).toHaveBeenCalledOnce();
     expect(harness.controller.getSnapshot()).toMatchObject({
       errorMessage:
-        "Brunch could not complete the current turn. Use the composer to retry.",
+        "The interview could not complete that turn. Use the composer to retry.",
       phase: "recoverable-error",
     });
   });
@@ -673,6 +858,41 @@ describe("VoiceTurnController", () => {
     expect(harness.session.setMicrophoneEnabled).toHaveBeenLastCalledWith(
       false,
     );
+  });
+
+  test("reconnects to a pending question without waiting for generic chat settlement", async () => {
+    const harness = createHarness();
+    const question = {
+      ...canonicalSegment("ask-reconnect", "What happens after approval?"),
+      source: "brunch-ask" as const,
+    };
+    harness.controller.updateChat({
+      canAcceptInterviewAnswer: true,
+      canonicalSegments: [question],
+      status: "streaming",
+    });
+    await harness.controller.start();
+    await vi.waitFor(() =>
+      expect(harness.controller.getSnapshot().phase).toBe("listening"),
+    );
+    harness.emit({
+      code: "network",
+      message: "The voice connection failed. Try reconnecting.",
+      requestId: "voice-request-reconnect",
+      type: "error",
+    });
+
+    await harness.controller.reconnect();
+
+    await vi.waitFor(() =>
+      expect(harness.controller.getSnapshot()).toMatchObject({
+        currentQuestion: "What happens after approval?",
+        microphoneEnabled: true,
+        phase: "listening",
+      }),
+    );
+    expect(harness.playback.play).toHaveBeenCalledTimes(2);
+    expect(harness.session.connect).toHaveBeenCalledTimes(2);
   });
 
   test("does not let a late delivery overwrite a connection failure", async () => {

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-turn-controller.test.ts
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-turn-controller.test.ts
@@ -246,6 +246,8 @@ describe("VoiceTurnController", () => {
       type: "completed",
     });
     await vi.waitFor(() => expect(harness.submitText).toHaveBeenCalledOnce());
+    updateChatStatus(harness.controller, "streaming");
+    updateChatStatus(harness.controller, "ready");
     harness.controller.redoAnswer();
     expect(harness.controller.getSnapshot().phase).toBe("listening");
     harness.emit({
@@ -257,6 +259,141 @@ describe("VoiceTurnController", () => {
     expect(harness.submitText).toHaveBeenLastCalledWith({
       target: "message",
       text: 'Correction to my previous voice answer "The operator approves it.": The shift lead approves it.',
+    });
+  });
+
+  test("keeps redo disabled while the previous answer is pending", async () => {
+    const harness = createHarness();
+    let finishDelivery: (() => void) | undefined;
+    harness.submitText.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishDelivery = () => resolve({ kind: "message" as const });
+        }),
+    );
+    harness.controller.updateChat({
+      canAcceptInterviewAnswer: true,
+      canonicalSegments: [
+        {
+          ...canonicalSegment("ask-pending-redo"),
+          source: "brunch-ask" as const,
+        },
+      ],
+      status: "ready",
+    });
+    await harness.controller.start();
+    harness.emit({
+      key: key(1, "answer-pending-redo"),
+      text: "The operator approves it.",
+      type: "completed",
+    });
+    await vi.waitFor(() => expect(harness.submitText).toHaveBeenCalledOnce());
+
+    harness.controller.redoAnswer();
+
+    expect(harness.controller.getSnapshot()).toMatchObject({
+      microphoneEnabled: false,
+      phase: "delivering",
+    });
+    finishDelivery?.();
+  });
+
+  test("holds queued question speech while paused and starts it on resume", async () => {
+    const harness = createHarness();
+    let finishPlayback: (() => void) | undefined;
+    harness.playback.play.mockImplementationOnce(
+      async (_segment, events = {}) => {
+        events.onPlaying?.();
+        await new Promise<void>((resolve) => {
+          finishPlayback = resolve;
+        });
+      },
+    );
+    await harness.controller.start();
+    harness.controller.pause();
+    const question = {
+      ...canonicalSegment("ask-paused"),
+      source: "brunch-ask" as const,
+    };
+
+    harness.controller.updateChat({
+      canAcceptInterviewAnswer: true,
+      canonicalSegments: [question],
+      status: "streaming",
+    });
+
+    expect(harness.playback.play).not.toHaveBeenCalled();
+    expect(harness.controller.getSnapshot()).toMatchObject({
+      microphoneEnabled: false,
+      phase: "paused",
+    });
+
+    harness.controller.resume();
+    await vi.waitFor(() =>
+      expect(harness.controller.getSnapshot().phase).toBe("playing"),
+    );
+    expect(harness.playback.play).toHaveBeenCalledWith(
+      question,
+      expect.any(Object),
+    );
+
+    finishPlayback?.();
+    await vi.waitFor(() =>
+      expect(harness.controller.getSnapshot()).toMatchObject({
+        microphoneEnabled: true,
+        phase: "listening",
+      }),
+    );
+  });
+
+  test("answers a new question normally after redo was armed", async () => {
+    const harness = createHarness();
+    const firstQuestion = {
+      ...canonicalSegment("ask-first"),
+      source: "brunch-ask" as const,
+    };
+    harness.controller.updateChat({
+      canAcceptInterviewAnswer: true,
+      canonicalSegments: [firstQuestion],
+      status: "ready",
+    });
+    await harness.controller.start();
+    harness.emit({
+      key: key(1, "answer-first"),
+      text: "The operator approves it.",
+      type: "completed",
+    });
+    await vi.waitFor(() => expect(harness.submitText).toHaveBeenCalledOnce());
+    updateChatStatus(harness.controller, "streaming");
+    updateChatStatus(harness.controller, "ready");
+    harness.controller.redoAnswer();
+
+    const nextQuestion = {
+      ...canonicalSegment("ask-next"),
+      source: "brunch-ask" as const,
+    };
+    harness.controller.updateChat({
+      canAcceptInterviewAnswer: true,
+      canonicalSegments: [firstQuestion, nextQuestion],
+      status: "ready",
+    });
+    await vi.waitFor(() =>
+      expect(harness.controller.getSnapshot()).toMatchObject({
+        currentQuestion: nextQuestion.text,
+        phase: "listening",
+      }),
+    );
+    const nextAnswerKey = key(1, "answer-next");
+    harness.emit({
+      key: nextAnswerKey,
+      text: "The supervisor dispatches it.",
+      type: "completed",
+    });
+
+    await vi.waitFor(() => expect(harness.submitText).toHaveBeenCalledTimes(2));
+    expect(harness.submitText).toHaveBeenLastCalledWith({
+      id: createVoiceMessageId("preview/net 1", nextAnswerKey),
+      text: "The supervisor dispatches it.",
     });
   });
 
@@ -895,6 +1032,35 @@ describe("VoiceTurnController", () => {
     expect(harness.session.connect).toHaveBeenCalledTimes(2);
   });
 
+  test("replays a pending question after ending and restarting", async () => {
+    const harness = createHarness();
+    const question = {
+      ...canonicalSegment("ask-restart", "What happens after approval?"),
+      source: "brunch-ask" as const,
+    };
+    harness.controller.updateChat({
+      canAcceptInterviewAnswer: true,
+      canonicalSegments: [question],
+      status: "ready",
+    });
+    await harness.controller.start();
+    await vi.waitFor(() =>
+      expect(harness.controller.getSnapshot().phase).toBe("listening"),
+    );
+
+    await harness.controller.end();
+    await harness.controller.start();
+
+    await vi.waitFor(() =>
+      expect(harness.controller.getSnapshot()).toMatchObject({
+        currentQuestion: "What happens after approval?",
+        microphoneEnabled: true,
+        phase: "listening",
+      }),
+    );
+    expect(harness.playback.play).toHaveBeenCalledTimes(2);
+  });
+
   test("does not let a late delivery overwrite a connection failure", async () => {
     const harness = createHarness();
     let finishDelivery: (() => void) | undefined;
@@ -951,6 +1117,61 @@ describe("VoiceTurnController", () => {
     expect(harness.session.setMicrophoneEnabled).toHaveBeenLastCalledWith(
       false,
     );
+  });
+
+  test("ignores a typed correction while the previous answer is still pending", async () => {
+    const harness = createHarness();
+    let finishDelivery: (() => void) | undefined;
+    harness.submitText
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            finishDelivery = () => resolve({ kind: "message" as const });
+          }),
+      )
+      .mockRejectedValueOnce(new Error("A queued answer already exists"));
+    await harness.controller.start();
+    harness.emit({
+      key: key(1, "answer-pending"),
+      text: "The support lead closes it.",
+      type: "completed",
+    });
+    await vi.waitFor(() => expect(harness.submitText).toHaveBeenCalledOnce());
+    expect(harness.controller.getSnapshot().phase).toBe("delivering");
+
+    await harness.controller.submitCorrection(
+      "The incident manager closes it.",
+    );
+
+    expect(harness.submitText).toHaveBeenCalledOnce();
+    expect(harness.controller.getSnapshot().phase).toBe("delivering");
+    finishDelivery?.();
+  });
+
+  test("ignores a typed correction while answer capacity is unavailable", async () => {
+    const harness = createHarness();
+    await harness.controller.start();
+    harness.emit({
+      key: key(1, "answer-before-capacity-closes"),
+      text: "The support lead closes it.",
+      type: "completed",
+    });
+    await vi.waitFor(() => expect(harness.submitText).toHaveBeenCalledOnce());
+    updateChatStatus(harness.controller, "streaming");
+    updateChatStatus(harness.controller, "ready");
+    harness.controller.updateChat({
+      canAcceptInterviewAnswer: false,
+      canonicalSegments: [],
+      status: "ready",
+    });
+    expect(harness.controller.getSnapshot().phase).toBe("listening");
+
+    await harness.controller.submitCorrection(
+      "The incident manager closes it.",
+    );
+
+    expect(harness.submitText).toHaveBeenCalledOnce();
+    expect(harness.controller.getSnapshot().phase).toBe("listening");
   });
 
   test("seeds finalized history without replaying it when voice starts or reconnects", async () => {

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-turn-controller.test.ts
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-turn-controller.test.ts
@@ -1085,6 +1085,50 @@ describe("VoiceTurnController", () => {
     expect(harness.session.connect).toHaveBeenCalledTimes(2);
   });
 
+  test("keeps the current question after failed answer delivery and reconnect", async () => {
+    const harness = createHarness();
+    const question = {
+      ...canonicalSegment(
+        "ask-failed-delivery",
+        "What happens after approval?",
+      ),
+      source: "brunch-ask" as const,
+    };
+    harness.controller.updateChat({
+      canAcceptInterviewAnswer: true,
+      canonicalSegments: [question],
+      status: "ready",
+    });
+    await harness.controller.start();
+    await vi.waitFor(() =>
+      expect(harness.controller.getSnapshot().phase).toBe("listening"),
+    );
+    harness.submitText.mockRejectedValueOnce(
+      new Error("Concurrent Brunch turn"),
+    );
+
+    harness.emit({
+      key: key(1, "failed-answer"),
+      text: "The shift lead approves it.",
+      type: "completed",
+    });
+    await vi.waitFor(() =>
+      expect(harness.controller.getSnapshot().phase).toBe("recoverable-error"),
+    );
+
+    await harness.controller.reconnect();
+
+    await vi.waitFor(() =>
+      expect(harness.controller.getSnapshot()).toMatchObject({
+        currentQuestion: "What happens after approval?",
+        microphoneEnabled: true,
+        phase: "listening",
+      }),
+    );
+    expect(harness.playback.play).toHaveBeenCalledTimes(2);
+    expect(harness.session.connect).toHaveBeenCalledTimes(2);
+  });
+
   test("does not replay an answered question after reconnecting", async () => {
     const harness = createHarness();
     const question = {

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-turn-controller.ts
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-turn-controller.ts
@@ -556,10 +556,8 @@ export class VoiceTurnController {
     this.#activeKey = key;
 
     if (event.type === "partial") {
-      this.#setMicrophoneEnabled(false);
       this.#update({
         partialText: `${this.#snapshot.partialText}${event.text}`,
-        phase: "transcribing",
       });
       return;
     }

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-turn-controller.ts
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-turn-controller.ts
@@ -750,12 +750,14 @@ export class VoiceTurnController {
       return;
     }
 
+    if (this.#snapshot.phase === "transcribing") {
+      this.#setMicrophoneEnabled(false);
+      return;
+    }
+
     if (!this.#canAcceptInterviewAnswer) {
       this.#setMicrophoneEnabled(false);
-      if (
-        this.#snapshot.phase !== "transcribing" &&
-        this.#snapshot.phase !== "delivering"
-      ) {
+      if (this.#snapshot.phase !== "delivering") {
         this.#update({ phase: "waiting" });
       }
       return;
@@ -770,11 +772,6 @@ export class VoiceTurnController {
         this.#answerReadyQuestionId = this.#activeQuestionId();
         this.#recordLatency("answer-ready", this.#activeQuestionId());
       }
-      return;
-    }
-
-    if (this.#snapshot.phase === "transcribing") {
-      this.#session.setMicrophoneEnabled(false);
       return;
     }
 

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-turn-controller.ts
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-turn-controller.ts
@@ -10,6 +10,7 @@ export type VoiceTurnPhase =
   | "idle"
   | "connecting"
   | "listening"
+  | "paused"
   | "transcribing"
   | "delivering"
   | "waiting"
@@ -18,17 +19,31 @@ export type VoiceTurnPhase =
   | "recoverable-error";
 
 export interface VoiceTurnSnapshot {
+  readonly currentQuestion: string;
   readonly errorCode: VoiceErrorCode | null;
   readonly errorMessage: string;
   readonly errorRequestId: string;
   readonly lastCommittedText: string;
+  readonly microphoneEnabled: boolean;
+  readonly microphoneLevel: number;
   readonly partialText: string;
   readonly phase: VoiceTurnPhase;
+}
+
+export interface VoiceLatencyEvent {
+  readonly elapsedMs: number;
+  readonly name:
+    | "question-visible"
+    | "question-spoken-started"
+    | "question-spoken"
+    | "answer-ready";
+  readonly questionId: string;
 }
 
 type ChatStatus = "ready" | "submitted" | "streaming" | "error";
 
 interface RealtimeSession {
+  commitInput(): void;
   connect(): Promise<number>;
   disconnect(): Promise<void>;
   setMicrophoneEnabled(enabled: boolean): void;
@@ -51,12 +66,15 @@ interface SpeechPlayback {
 
 interface VoiceTurnControllerDependencies {
   readonly conversationId: string;
+  readonly now?: () => number;
+  readonly onLatencyEvent?: (event: VoiceLatencyEvent) => void;
   readonly playback: SpeechPlayback;
   readonly session: RealtimeSession;
   readonly submitText: (input: SubmitTextInput) => Promise<unknown>;
 }
 
 interface ChatUpdate {
+  readonly canAcceptInterviewAnswer?: boolean;
   readonly canonicalSegments: CanonicalSpeechSegment[];
   readonly status: ChatStatus;
 }
@@ -79,10 +97,13 @@ export const createVoiceMessageId = (
   ].join(":");
 
 const initialSnapshot: VoiceTurnSnapshot = {
+  currentQuestion: "",
   errorCode: null,
   errorMessage: "",
   errorRequestId: "",
   lastCommittedText: "",
+  microphoneEnabled: false,
+  microphoneLevel: 0,
   partialText: "",
   phase: "idle",
 };
@@ -90,31 +111,46 @@ const initialSnapshot: VoiceTurnSnapshot = {
 export class VoiceTurnController {
   readonly #conversationId: string;
   readonly #listeners = new Set<SnapshotListener>();
+  readonly #now: () => number;
+  readonly #onLatencyEvent: ((event: VoiceLatencyEvent) => void) | undefined;
   readonly #playback: SpeechPlayback;
   readonly #session: RealtimeSession;
   readonly #submitText: (input: SubmitTextInput) => Promise<unknown>;
   readonly #completedKeys = new Set<string>();
   readonly #seenSpeechSegmentIds = new Set<string>();
   readonly #speechQueue: CanonicalSpeechSegment[] = [];
+  #answerFinalizedAt: number | null = null;
+  #answerReadyQuestionId: string | null = null;
   #activeEpoch: number | null = null;
   #activeItemId: string | null = null;
   #activeKey: string | null = null;
   #activeSpeechSegmentId: string | null = null;
   #awaitingChatCycle = false;
+  #availableSegments: CanonicalSpeechSegment[] = [];
+  #canAcceptInterviewAnswer = true;
   #chatStatus: ChatStatus = "ready";
+  #currentQuestionId: string | null = null;
   #generation = 0;
   #pendingDelivery: SubmitTextInput | null = null;
+  #paused = false;
+  #questionAnswered = false;
+  #questionPlaybackComplete = false;
+  #redoing = false;
   #sawBusyChatStatus = false;
   #snapshot = initialSnapshot;
   #speechLoopGeneration: number | null = null;
 
   public constructor({
     conversationId,
+    now = () => performance.now(),
+    onLatencyEvent,
     playback,
     session,
     submitText,
   }: VoiceTurnControllerDependencies) {
     this.#conversationId = conversationId;
+    this.#now = now;
+    this.#onLatencyEvent = onLatencyEvent;
     this.#playback = playback;
     this.#session = session;
     this.#submitText = submitText;
@@ -134,10 +170,12 @@ export class VoiceTurnController {
     if (this.#snapshot.phase !== "idle") {
       return;
     }
-    if (!this.#isChatReady()) {
-      this.#session.setMicrophoneEnabled(false);
+    this.#queueAvailableSegments();
+    if (!this.#isChatReady() && !this.#hasPendingQuestion()) {
+      this.#setMicrophoneEnabled(false);
       this.#update({
-        errorMessage: "Wait for Brunch to finish before starting voice input.",
+        errorMessage:
+          "Wait for the current response to finish before starting.",
         phase: "recoverable-error",
       });
       return;
@@ -154,8 +192,12 @@ export class VoiceTurnController {
       this.#activeItemId = null;
       this.#activeKey = null;
       this.#completedKeys.clear();
-      const canListen = this.#isChatReady() && this.#speechQueue.length === 0;
-      this.#session.setMicrophoneEnabled(canListen);
+      this.#paused = false;
+      const canListen =
+        this.#isChatReady() &&
+        this.#speechQueue.length === 0 &&
+        !this.#hasAnswerableQuestion();
+      this.#setMicrophoneEnabled(canListen);
       this.#update({
         partialText: "",
         phase: canListen ? "listening" : "waiting",
@@ -169,7 +211,7 @@ export class VoiceTurnController {
         error instanceof VoiceError
           ? error
           : new VoiceError("connection", "invalid-response", "");
-      this.#session.setMicrophoneEnabled(false);
+      this.#setMicrophoneEnabled(false);
       this.#update({
         errorCode: voiceError.code,
         errorMessage: voiceError.message,
@@ -187,21 +229,40 @@ export class VoiceTurnController {
     this.#activeSpeechSegmentId = null;
     this.#awaitingChatCycle = false;
     this.#pendingDelivery = null;
+    this.#answerFinalizedAt = null;
+    this.#answerReadyQuestionId = null;
+    this.#currentQuestionId = null;
+    this.#paused = false;
+    this.#questionAnswered = false;
+    this.#questionPlaybackComplete = false;
+    this.#redoing = false;
     this.#sawBusyChatStatus = false;
     this.#speechLoopGeneration = null;
     this.#speechQueue.length = 0;
     this.#playback.cancel();
-    this.#session.setMicrophoneEnabled(false);
+    this.#setMicrophoneEnabled(false);
     await this.#session.disconnect();
     this.#update({
       errorMessage: "",
+      currentQuestion: "",
+      microphoneLevel: 0,
       partialText: "",
       phase: "idle",
     });
   }
 
   public async reconnect(): Promise<void> {
+    const pendingQuestionId = this.#currentQuestionId;
     await this.end();
+    if (
+      pendingQuestionId !== null &&
+      this.#availableSegments.some(
+        (segment) =>
+          segment.id === pendingQuestionId && segment.source === "brunch-ask",
+      )
+    ) {
+      this.#seenSpeechSegmentIds.delete(pendingQuestionId);
+    }
     await this.start();
   }
 
@@ -211,12 +272,14 @@ export class VoiceTurnController {
     if (
       !correctedText ||
       !previousText ||
-      this.#snapshot.phase !== "listening"
+      this.#activeEpoch === null ||
+      this.#speechLoopGeneration !== null
     ) {
       return;
     }
 
-    this.#session.setMicrophoneEnabled(false);
+    this.#questionAnswered = true;
+    this.#setMicrophoneEnabled(false);
     this.#update({ errorMessage: "", phase: "delivering" });
     await this.#deliver({
       target: "message",
@@ -224,7 +287,73 @@ export class VoiceTurnController {
     });
   }
 
-  public updateChat({ canonicalSegments, status }: ChatUpdate): void {
+  public interruptAndSpeak(): void {
+    if (
+      this.#activeEpoch === null ||
+      (this.#snapshot.phase !== "playing" &&
+        this.#snapshot.phase !== "synthesizing")
+    ) {
+      return;
+    }
+
+    ++this.#generation;
+    this.#speechLoopGeneration = null;
+    this.#activeSpeechSegmentId = null;
+    this.#speechQueue.length = 0;
+    this.#playback.cancel();
+    this.#questionPlaybackComplete = Boolean(this.#snapshot.currentQuestion);
+    this.#paused = false;
+    this.#settleListeningIfReady();
+  }
+
+  public doneSpeaking(): void {
+    if (this.#activeEpoch === null || this.#snapshot.phase !== "listening") {
+      return;
+    }
+    this.#setMicrophoneEnabled(false);
+    this.#update({ phase: "transcribing" });
+    this.#session.commitInput();
+  }
+
+  public pause(): void {
+    if (this.#activeEpoch === null || this.#snapshot.phase !== "listening") {
+      return;
+    }
+    this.#paused = true;
+    this.#setMicrophoneEnabled(false);
+    this.#update({ phase: "paused" });
+  }
+
+  public resume(): void {
+    if (this.#snapshot.phase !== "paused") {
+      return;
+    }
+    this.#paused = false;
+    this.#settleListeningIfReady();
+  }
+
+  public redoAnswer(): void {
+    if (
+      this.#activeEpoch === null ||
+      !this.#snapshot.lastCommittedText ||
+      this.#speechLoopGeneration !== null ||
+      !this.#canAcceptInterviewAnswer
+    ) {
+      return;
+    }
+    this.#redoing = true;
+    this.#questionAnswered = false;
+    this.#paused = false;
+    this.#settleListeningIfReady();
+  }
+
+  public updateChat({
+    canAcceptInterviewAnswer = true,
+    canonicalSegments,
+    status,
+  }: ChatUpdate): void {
+    this.#availableSegments = canonicalSegments;
+    this.#canAcceptInterviewAnswer = canAcceptInterviewAnswer;
     this.#chatStatus = status;
     const canQueueSpeech =
       status !== "error" &&
@@ -234,9 +363,10 @@ export class VoiceTurnController {
       if (this.#seenSpeechSegmentIds.has(segment.id)) {
         continue;
       }
-      this.#seenSpeechSegmentIds.add(segment.id);
       if (canQueueSpeech) {
-        this.#speechQueue.push(segment);
+        this.#queueSpeechSegment(segment);
+      } else if (segment.source === "assistant-text") {
+        this.#seenSpeechSegmentIds.add(segment.id);
       }
     }
 
@@ -262,8 +392,8 @@ export class VoiceTurnController {
         return;
       }
       const errorMessage = this.#awaitingChatCycle
-        ? "Brunch could not accept the voice turn. Use the composer to retry."
-        : "Brunch could not complete the current turn. Use the composer to retry.";
+        ? "The interview could not accept that answer. Use the composer to retry."
+        : "The interview could not complete that turn. Use the composer to retry.";
       ++this.#generation;
       this.#activeEpoch = null;
       this.#activeItemId = null;
@@ -274,7 +404,7 @@ export class VoiceTurnController {
       this.#activeSpeechSegmentId = null;
       this.#speechLoopGeneration = null;
       this.#playback.cancel();
-      this.#session.setMicrophoneEnabled(false);
+      this.#setMicrophoneEnabled(false);
       void this.#session.disconnect();
       this.#update({ errorMessage, phase: "recoverable-error" });
       return;
@@ -285,7 +415,11 @@ export class VoiceTurnController {
       if (this.#awaitingChatCycle) {
         this.#sawBusyChatStatus = true;
       }
-      this.#session.setMicrophoneEnabled(false);
+      if (this.#hasAnswerableQuestion() && !this.#paused) {
+        this.#settleListeningIfReady();
+        return;
+      }
+      this.#setMicrophoneEnabled(false);
       if (
         this.#speechLoopGeneration === null &&
         (this.#snapshot.phase === "listening" ||
@@ -337,10 +471,10 @@ export class VoiceTurnController {
         return;
       }
       this.#awaitingChatCycle = false;
-      this.#session.setMicrophoneEnabled(false);
+      this.#setMicrophoneEnabled(false);
       this.#update({
         errorMessage:
-          "Brunch could not accept the voice turn. Use the composer to retry.",
+          "The interview could not accept that answer. Use the composer to retry.",
         phase: "recoverable-error",
       });
     }
@@ -355,6 +489,12 @@ export class VoiceTurnController {
   }
 
   #handleSessionEvent(event: OpenAIRealtimeSessionEvent): void {
+    if (event.type === "microphone-level") {
+      if (this.#snapshot.microphoneEnabled) {
+        this.#update({ microphoneLevel: event.level });
+      }
+      return;
+    }
     if (event.type === "error") {
       ++this.#generation;
       this.#activeEpoch = null;
@@ -367,7 +507,7 @@ export class VoiceTurnController {
       this.#speechLoopGeneration = null;
       this.#speechQueue.length = 0;
       this.#playback.cancel();
-      this.#session.setMicrophoneEnabled(false);
+      this.#setMicrophoneEnabled(false);
       this.#update({
         errorCode: event.code,
         errorMessage: event.message,
@@ -390,7 +530,7 @@ export class VoiceTurnController {
         return;
       }
       this.#activeItemId = event.itemId;
-      this.#session.setMicrophoneEnabled(false);
+      this.#setMicrophoneEnabled(false);
       this.#update({ phase: "transcribing" });
       return;
     }
@@ -418,7 +558,7 @@ export class VoiceTurnController {
     this.#activeKey = key;
 
     if (event.type === "partial") {
-      this.#session.setMicrophoneEnabled(false);
+      this.#setMicrophoneEnabled(false);
       this.#update({
         partialText: `${this.#snapshot.partialText}${event.text}`,
         phase: "transcribing",
@@ -439,11 +579,21 @@ export class VoiceTurnController {
       return;
     }
 
-    this.#session.setMicrophoneEnabled(false);
-    const input = {
-      id: createVoiceMessageId(this.#conversationId, event.key),
-      text: finalText,
-    };
+    this.#setMicrophoneEnabled(false);
+    const previousText = this.#snapshot.lastCommittedText;
+    const redoing = this.#redoing;
+    this.#redoing = false;
+    this.#questionAnswered = true;
+    this.#answerFinalizedAt = this.#now();
+    const input = redoing
+      ? {
+          target: "message" as const,
+          text: `Correction to my previous voice answer "${previousText}": ${finalText}`,
+        }
+      : {
+          id: createVoiceMessageId(this.#conversationId, event.key),
+          text: finalText,
+        };
     const canDeliver = this.#isChatReady();
     this.#update({
       errorMessage: "",
@@ -470,7 +620,7 @@ export class VoiceTurnController {
 
     const generation = this.#generation;
     this.#speechLoopGeneration = generation;
-    this.#session.setMicrophoneEnabled(false);
+    this.#setMicrophoneEnabled(false);
     this.#update({ errorMessage: "", phase: "synthesizing" });
     void this.#drainSpeechQueue(generation);
   }
@@ -487,7 +637,7 @@ export class VoiceTurnController {
       }
 
       this.#activeSpeechSegmentId = segment.id;
-      this.#session.setMicrophoneEnabled(false);
+      this.#setMicrophoneEnabled(false);
       this.#update({ errorMessage: "", phase: "synthesizing" });
       try {
         await this.#playback.play(segment, {
@@ -498,6 +648,9 @@ export class VoiceTurnController {
               this.#activeSpeechSegmentId === segment.id
             ) {
               this.#update({ phase: "playing" });
+              if (segment.source === "brunch-ask") {
+                this.#recordLatency("question-spoken-started", segment.id);
+              }
             }
           },
         });
@@ -515,7 +668,7 @@ export class VoiceTurnController {
         this.#activeSpeechSegmentId = null;
         this.#speechLoopGeneration = null;
         this.#speechQueue.length = 0;
-        this.#session.setMicrophoneEnabled(false);
+        this.#setMicrophoneEnabled(false);
         this.#update({
           errorCode: voiceError.code,
           errorMessage: voiceError.message,
@@ -532,6 +685,10 @@ export class VoiceTurnController {
         return;
       }
       this.#activeSpeechSegmentId = null;
+      if (segment.source === "brunch-ask") {
+        this.#questionPlaybackComplete = true;
+        this.#recordLatency("question-spoken", segment.id);
+      }
     }
 
     if (
@@ -549,8 +706,24 @@ export class VoiceTurnController {
     if (
       this.#activeEpoch === null ||
       this.#snapshot.phase === "recoverable-error" ||
+      this.#paused ||
       this.#speechLoopGeneration !== null
     ) {
+      if (this.#paused) {
+        this.#setMicrophoneEnabled(false);
+      }
+      return;
+    }
+
+    if (this.#hasAnswerableQuestion()) {
+      this.#awaitingChatCycle = false;
+      this.#sawBusyChatStatus = false;
+      this.#setMicrophoneEnabled(true);
+      this.#update({ errorMessage: "", phase: "listening" });
+      if (this.#answerReadyQuestionId !== this.#activeQuestionId()) {
+        this.#answerReadyQuestionId = this.#activeQuestionId();
+        this.#recordLatency("answer-ready", this.#activeQuestionId());
+      }
       return;
     }
 
@@ -566,7 +739,7 @@ export class VoiceTurnController {
 
     if (this.#awaitingChatCycle) {
       if (!this.#sawBusyChatStatus || this.#chatStatus !== "ready") {
-        this.#session.setMicrophoneEnabled(false);
+        this.#setMicrophoneEnabled(false);
         if (this.#snapshot.phase !== "waiting") {
           this.#update({ phase: "waiting" });
         }
@@ -577,15 +750,84 @@ export class VoiceTurnController {
     }
 
     if (!this.#isChatReady()) {
-      this.#session.setMicrophoneEnabled(false);
+      this.#setMicrophoneEnabled(false);
       if (this.#snapshot.phase !== "delivering") {
         this.#update({ phase: "waiting" });
       }
       return;
     }
 
-    this.#session.setMicrophoneEnabled(true);
+    this.#setMicrophoneEnabled(true);
     this.#update({ errorMessage: "", phase: "listening" });
+  }
+
+  #activeQuestionId(): string {
+    return this.#currentQuestionId ?? this.#snapshot.currentQuestion;
+  }
+
+  #hasPendingQuestion(): boolean {
+    return (
+      Boolean(this.#snapshot.currentQuestion) && this.#canAcceptInterviewAnswer
+    );
+  }
+
+  #hasAnswerableQuestion(): boolean {
+    return (
+      Boolean(this.#snapshot.currentQuestion) &&
+      this.#questionPlaybackComplete &&
+      !this.#questionAnswered &&
+      this.#canAcceptInterviewAnswer
+    );
+  }
+
+  #queueAvailableSegments(): void {
+    for (const segment of this.#availableSegments) {
+      if (!this.#seenSpeechSegmentIds.has(segment.id)) {
+        this.#queueSpeechSegment(segment);
+      }
+    }
+  }
+
+  #queueSpeechSegment(segment: CanonicalSpeechSegment): void {
+    this.#seenSpeechSegmentIds.add(segment.id);
+    this.#speechQueue.push(segment);
+    if (segment.source === "brunch-ask") {
+      this.#currentQuestionId = segment.id;
+      this.#questionPlaybackComplete = false;
+      this.#questionAnswered = false;
+      this.#answerReadyQuestionId = null;
+      this.#awaitingChatCycle = false;
+      this.#sawBusyChatStatus = false;
+      this.#update({
+        currentQuestion: segment.text,
+        lastCommittedText: "",
+      });
+      this.#recordLatency("question-visible", segment.id);
+    }
+  }
+
+  #recordLatency(name: VoiceLatencyEvent["name"], questionId: string): void {
+    if (this.#answerFinalizedAt === null) {
+      return;
+    }
+    this.#onLatencyEvent?.({
+      elapsedMs: Math.max(0, this.#now() - this.#answerFinalizedAt),
+      name,
+      questionId,
+    });
+  }
+
+  #setMicrophoneEnabled(enabled: boolean): void {
+    this.#session.setMicrophoneEnabled(enabled);
+    if (
+      this.#snapshot.microphoneEnabled !== enabled ||
+      (!enabled && this.#snapshot.microphoneLevel !== 0)
+    ) {
+      this.#update({
+        microphoneEnabled: enabled,
+        ...(enabled ? {} : { microphoneLevel: 0 }),
+      });
+    }
   }
 
   #update(update: Partial<VoiceTurnSnapshot>): void {

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-turn-controller.ts
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-turn-controller.ts
@@ -292,7 +292,9 @@ export class VoiceTurnController {
       return false;
     }
 
-    this.#questionAnswered = true;
+    // `#deliver` latches `#questionAnswered` once the interview accepts the
+    // text. Latching it here would mark the ask settled even when delivery
+    // fails, so `reconnect` would drop the still-unanswered question.
     this.#setMicrophoneEnabled(false);
     this.#update({
       errorMessage: "",

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-turn-controller.ts
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-turn-controller.ts
@@ -18,12 +18,20 @@ export type VoiceTurnPhase =
   | "playing"
   | "recoverable-error";
 
+/**
+ * Whether the committed answer reached the interview. `pending` covers an
+ * in-flight submission, so a failed or unfinished delivery is never mistaken
+ * for a successful one.
+ */
+export type VoiceAnswerDelivery = "none" | "pending" | "delivered" | "failed";
+
 export interface VoiceTurnSnapshot {
   readonly canReviseLastAnswer: boolean;
   readonly currentQuestion: string;
   readonly errorCode: VoiceErrorCode | null;
   readonly errorMessage: string;
   readonly errorRequestId: string;
+  readonly lastAnswerDelivery: VoiceAnswerDelivery;
   readonly lastCommittedText: string;
   readonly microphoneEnabled: boolean;
   readonly microphoneLevel: number;
@@ -102,6 +110,7 @@ const initialSnapshot: VoiceTurnSnapshot = {
   errorCode: null,
   errorMessage: "",
   errorRequestId: "",
+  lastAnswerDelivery: "none",
   lastCommittedText: "",
   microphoneEnabled: false,
   microphoneLevel: 0,
@@ -131,6 +140,7 @@ export class VoiceTurnController {
   #canAcceptInterviewAnswer = true;
   #chatStatus: ChatStatus = "ready";
   #currentQuestionId: string | null = null;
+  #deliverySequence = 0;
   #generation = 0;
   #pendingDelivery: SubmitTextInput | null = null;
   #paused = false;
@@ -250,6 +260,7 @@ export class VoiceTurnController {
     this.#update({
       errorMessage: "",
       currentQuestion: "",
+      lastAnswerDelivery: "none",
       lastCommittedText: "",
       microphoneLevel: 0,
       partialText: "",
@@ -281,7 +292,11 @@ export class VoiceTurnController {
 
     this.#questionAnswered = true;
     this.#setMicrophoneEnabled(false);
-    this.#update({ errorMessage: "", phase: "delivering" });
+    this.#update({
+      errorMessage: "",
+      lastAnswerDelivery: "pending",
+      phase: "delivering",
+    });
     return this.#deliver({
       target: "message",
       text: `Correction to my previous voice answer "${previousText}": ${correctedText}`,
@@ -438,10 +453,12 @@ export class VoiceTurnController {
     }
 
     const generation = this.#generation;
+    const delivery = ++this.#deliverySequence;
     this.#awaitingChatCycle = true;
     this.#sawBusyChatStatus = false;
     try {
       await this.#submitText(input);
+      this.#recordDeliveryOutcome(delivery, "delivered");
       if (
         generation !== this.#generation ||
         !this.#isAwaitingCurrentChatCycle()
@@ -454,6 +471,7 @@ export class VoiceTurnController {
       this.#settleListeningIfReady();
       return true;
     } catch {
+      this.#recordDeliveryOutcome(delivery, "failed");
       if (
         generation !== this.#generation ||
         this.#snapshot.phase === "recoverable-error"
@@ -476,6 +494,23 @@ export class VoiceTurnController {
       });
       return false;
     }
+  }
+
+  /**
+   * Applies a delivery result only while it still describes the answer the
+   * snapshot is waiting on, so a late result cannot relabel a newer answer.
+   */
+  #recordDeliveryOutcome(
+    delivery: number,
+    outcome: "delivered" | "failed",
+  ): void {
+    if (
+      delivery !== this.#deliverySequence ||
+      this.#snapshot.lastAnswerDelivery !== "pending"
+    ) {
+      return;
+    }
+    this.#update({ lastAnswerDelivery: outcome });
   }
 
   #isAwaitingCurrentChatCycle(): boolean {
@@ -593,6 +628,7 @@ export class VoiceTurnController {
     const canDeliver = this.#isChatReady();
     this.#update({
       errorMessage: "",
+      lastAnswerDelivery: "pending",
       lastCommittedText: finalText,
       partialText: "",
       phase: canDeliver ? "delivering" : "waiting",
@@ -820,6 +856,7 @@ export class VoiceTurnController {
       this.#sawBusyChatStatus = false;
       this.#update({
         currentQuestion: segment.text,
+        lastAnswerDelivery: "none",
         lastCommittedText: "",
       });
       this.#recordLatency("question-visible", segment.id);

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-turn-controller.ts
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-turn-controller.ts
@@ -269,7 +269,9 @@ export class VoiceTurnController {
   }
 
   public async reconnect(): Promise<void> {
-    const pendingQuestionId = this.#currentQuestionId;
+    const pendingQuestionId = this.#questionAnswered
+      ? null
+      : this.#currentQuestionId;
     await this.end();
     if (
       pendingQuestionId !== null &&

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-turn-controller.ts
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-turn-controller.ts
@@ -222,6 +222,9 @@ export class VoiceTurnController {
   }
 
   public async end(): Promise<void> {
+    if (!this.#questionAnswered && this.#currentQuestionId !== null) {
+      this.#seenSpeechSegmentIds.delete(this.#currentQuestionId);
+    }
     ++this.#generation;
     this.#activeEpoch = null;
     this.#activeItemId = null;
@@ -273,6 +276,9 @@ export class VoiceTurnController {
       !correctedText ||
       !previousText ||
       this.#activeEpoch === null ||
+      this.#snapshot.phase !== "listening" ||
+      this.#awaitingChatCycle ||
+      !this.#canAcceptInterviewAnswer ||
       this.#speechLoopGeneration !== null
     ) {
       return;
@@ -329,6 +335,7 @@ export class VoiceTurnController {
       return;
     }
     this.#paused = false;
+    this.#startSpeechQueueIfNeeded();
     this.#settleListeningIfReady();
   }
 
@@ -336,6 +343,8 @@ export class VoiceTurnController {
     if (
       this.#activeEpoch === null ||
       !this.#snapshot.lastCommittedText ||
+      this.#snapshot.phase !== "listening" ||
+      this.#awaitingChatCycle ||
       this.#speechLoopGeneration !== null ||
       !this.#canAcceptInterviewAnswer
     ) {
@@ -613,7 +622,8 @@ export class VoiceTurnController {
       this.#speechLoopGeneration !== null ||
       this.#speechQueue.length === 0 ||
       this.#activeEpoch === null ||
-      this.#snapshot.phase === "transcribing"
+      this.#snapshot.phase === "transcribing" ||
+      this.#paused
     ) {
       return;
     }
@@ -795,6 +805,7 @@ export class VoiceTurnController {
       this.#currentQuestionId = segment.id;
       this.#questionPlaybackComplete = false;
       this.#questionAnswered = false;
+      this.#redoing = false;
       this.#answerReadyQuestionId = null;
       this.#awaitingChatCycle = false;
       this.#sawBusyChatStatus = false;

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-turn-controller.ts
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-turn-controller.ts
@@ -19,6 +19,7 @@ export type VoiceTurnPhase =
   | "recoverable-error";
 
 export interface VoiceTurnSnapshot {
+  readonly canReviseLastAnswer: boolean;
   readonly currentQuestion: string;
   readonly errorCode: VoiceErrorCode | null;
   readonly errorMessage: string;
@@ -43,7 +44,6 @@ export interface VoiceLatencyEvent {
 type ChatStatus = "ready" | "submitted" | "streaming" | "error";
 
 interface RealtimeSession {
-  commitInput(): void;
   connect(): Promise<number>;
   disconnect(): Promise<void>;
   setMicrophoneEnabled(enabled: boolean): void;
@@ -97,6 +97,7 @@ export const createVoiceMessageId = (
   ].join(":");
 
 const initialSnapshot: VoiceTurnSnapshot = {
+  canReviseLastAnswer: false,
   currentQuestion: "",
   errorCode: null,
   errorMessage: "",
@@ -248,6 +249,7 @@ export class VoiceTurnController {
     this.#update({
       errorMessage: "",
       currentQuestion: "",
+      lastCommittedText: "",
       microphoneLevel: 0,
       partialText: "",
       phase: "idle",
@@ -269,25 +271,17 @@ export class VoiceTurnController {
     await this.start();
   }
 
-  public async submitCorrection(correction: string): Promise<void> {
+  public async submitCorrection(correction: string): Promise<boolean> {
     const correctedText = correction.trim();
     const previousText = this.#snapshot.lastCommittedText;
-    if (
-      !correctedText ||
-      !previousText ||
-      this.#activeEpoch === null ||
-      this.#snapshot.phase !== "listening" ||
-      this.#awaitingChatCycle ||
-      !this.#canAcceptInterviewAnswer ||
-      this.#speechLoopGeneration !== null
-    ) {
-      return;
+    if (!correctedText || !this.#canReviseLastAnswer()) {
+      return false;
     }
 
     this.#questionAnswered = true;
     this.#setMicrophoneEnabled(false);
     this.#update({ errorMessage: "", phase: "delivering" });
-    await this.#deliver({
+    return this.#deliver({
       target: "message",
       text: `Correction to my previous voice answer "${previousText}": ${correctedText}`,
     });
@@ -318,7 +312,6 @@ export class VoiceTurnController {
     }
     this.#setMicrophoneEnabled(false);
     this.#update({ phase: "transcribing" });
-    this.#session.commitInput();
   }
 
   public pause(): void {
@@ -340,14 +333,7 @@ export class VoiceTurnController {
   }
 
   public redoAnswer(): void {
-    if (
-      this.#activeEpoch === null ||
-      !this.#snapshot.lastCommittedText ||
-      this.#snapshot.phase !== "listening" ||
-      this.#awaitingChatCycle ||
-      this.#speechLoopGeneration !== null ||
-      !this.#canAcceptInterviewAnswer
-    ) {
+    if (!this.#canReviseLastAnswer()) {
       return;
     }
     this.#redoing = true;
@@ -442,12 +428,12 @@ export class VoiceTurnController {
     this.#settleListeningIfReady();
   }
 
-  async #deliver(input: SubmitTextInput): Promise<void> {
+  async #deliver(input: SubmitTextInput): Promise<boolean> {
     if (!this.#isChatReady()) {
       this.#pendingDelivery = input;
-      this.#session.setMicrophoneEnabled(false);
+      this.#setMicrophoneEnabled(false);
       this.#update({ phase: "waiting" });
-      return;
+      return false;
     }
 
     const generation = this.#generation;
@@ -459,25 +445,26 @@ export class VoiceTurnController {
         generation !== this.#generation ||
         !this.#isAwaitingCurrentChatCycle()
       ) {
-        return;
+        return false;
       }
       if (this.#snapshot.phase === "delivering") {
         this.#update({ phase: "waiting" });
       }
       this.#settleListeningIfReady();
+      return true;
     } catch {
       if (
         generation !== this.#generation ||
         this.#snapshot.phase === "recoverable-error"
       ) {
-        return;
+        return false;
       }
       if (!this.#isChatReady()) {
         this.#pendingDelivery = input;
         this.#awaitingChatCycle = false;
-        this.#session.setMicrophoneEnabled(false);
+        this.#setMicrophoneEnabled(false);
         this.#update({ phase: "waiting" });
-        return;
+        return false;
       }
       this.#awaitingChatCycle = false;
       this.#setMicrophoneEnabled(false);
@@ -486,6 +473,7 @@ export class VoiceTurnController {
           "The interview could not accept that answer. Use the composer to retry.",
         phase: "recoverable-error",
       });
+      return false;
     }
   }
 
@@ -790,6 +778,17 @@ export class VoiceTurnController {
     );
   }
 
+  #canReviseLastAnswer(snapshot = this.#snapshot): boolean {
+    return (
+      Boolean(snapshot.lastCommittedText) &&
+      this.#activeEpoch !== null &&
+      snapshot.phase === "listening" &&
+      !this.#awaitingChatCycle &&
+      this.#speechLoopGeneration === null &&
+      this.#canAcceptInterviewAnswer
+    );
+  }
+
   #queueAvailableSegments(): void {
     for (const segment of this.#availableSegments) {
       if (!this.#seenSpeechSegmentIds.has(segment.id)) {
@@ -846,7 +845,11 @@ export class VoiceTurnController {
       update.errorMessage !== undefined && !("errorCode" in update)
         ? { errorCode: null, errorRequestId: "" }
         : {};
-    this.#snapshot = { ...this.#snapshot, ...clearedError, ...update };
+    const snapshot = { ...this.#snapshot, ...clearedError, ...update };
+    this.#snapshot = {
+      ...snapshot,
+      canReviseLastAnswer: this.#canReviseLastAnswer(snapshot),
+    };
     for (const listener of this.#listeners) {
       listener(this.#snapshot);
     }

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-turn-controller.ts
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-turn-controller.ts
@@ -195,6 +195,7 @@ export class VoiceTurnController {
       this.#completedKeys.clear();
       this.#paused = false;
       const canListen =
+        this.#canAcceptInterviewAnswer &&
         this.#isChatReady() &&
         this.#speechQueue.length === 0 &&
         !this.#hasAnswerableQuestion();
@@ -713,6 +714,17 @@ export class VoiceTurnController {
       return;
     }
 
+    if (!this.#canAcceptInterviewAnswer) {
+      this.#setMicrophoneEnabled(false);
+      if (
+        this.#snapshot.phase !== "transcribing" &&
+        this.#snapshot.phase !== "delivering"
+      ) {
+        this.#update({ phase: "waiting" });
+      }
+      return;
+    }
+
     if (this.#hasAnswerableQuestion()) {
       this.#awaitingChatCycle = false;
       this.#sawBusyChatStatus = false;
@@ -828,14 +840,15 @@ export class VoiceTurnController {
   }
 
   #setMicrophoneEnabled(enabled: boolean): void {
-    this.#session.setMicrophoneEnabled(enabled);
+    const microphoneEnabled = enabled && this.#canAcceptInterviewAnswer;
+    this.#session.setMicrophoneEnabled(microphoneEnabled);
     if (
-      this.#snapshot.microphoneEnabled !== enabled ||
-      (!enabled && this.#snapshot.microphoneLevel !== 0)
+      this.#snapshot.microphoneEnabled !== microphoneEnabled ||
+      (!microphoneEnabled && this.#snapshot.microphoneLevel !== 0)
     ) {
       this.#update({
-        microphoneEnabled: enabled,
-        ...(enabled ? {} : { microphoneLevel: 0 }),
+        microphoneEnabled,
+        ...(microphoneEnabled ? {} : { microphoneLevel: 0 }),
       });
     }
   }

--- a/apps/petrinaut-website/src/main/app/voice-interview/voice-turn-controller.ts
+++ b/apps/petrinaut-website/src/main/app/voice-interview/voice-turn-controller.ts
@@ -467,6 +467,7 @@ export class VoiceTurnController {
       ) {
         return false;
       }
+      this.#questionAnswered = true;
       if (this.#snapshot.phase === "delivering") {
         this.#update({ phase: "waiting" });
       }
@@ -616,7 +617,6 @@ export class VoiceTurnController {
     const previousText = this.#snapshot.lastCommittedText;
     const redoing = this.#redoing;
     this.#redoing = false;
-    this.#questionAnswered = true;
     this.#answerFinalizedAt = this.#now();
     const input = redoing
       ? {

--- a/docs/superpowers/specs/2026-08-27-chat-interview-mode-switch-design.md
+++ b/docs/superpowers/specs/2026-08-27-chat-interview-mode-switch-design.md
@@ -1,0 +1,105 @@
+# Chat and Interview Mode Switch
+
+## Goal
+
+Make text chat and voice interview feel like two uniform ways to work with the same Petrinaut AI assistant. Move voice discovery out of the composer, expose it beside Chat at the top of the relevant surfaces, and preserve clear microphone/session awareness when switching modes.
+
+## Scope
+
+- Replace the composer microphone trigger with a labeled `Chat` / `Interview` mode switch.
+- Show the same switch in:
+  - the empty-canvas “Describe the process you want to create” card; and
+  - the AI assistant panel header.
+- Change the empty-conversation composer placeholder from “Get creating...” to “Describe the process you want to create”.
+- Reuse the existing disclosure, voice session, compact bar, recovery, and local-storage behavior.
+- Keep Chat and Interview in one conversation. This is an input-mode change, not a separate assistant or thread.
+
+## Interaction Design
+
+### Shared mode tabs
+
+A reusable Petrinaut component renders two labeled tabs:
+
+- `Chat`, with the existing AI assistant icon.
+- `Interview`, with a microphone icon.
+
+The tabs use Petrinaut’s current neutral/blue styling, visible selected state, keyboard-accessible buttons, and accessible selected-state semantics. They remain labeled rather than becoming icon-only so their meaning does not depend on tooltips.
+
+When no host interview stage is configured, Petrinaut renders the current chat-only UI and no mode switch.
+
+### Empty canvas
+
+Chat is selected by default and retains the current title, example input, and submit action.
+
+Selecting Interview changes the card body to a microphone-led introduction:
+
+- “Talk through your process with AI”
+- a short explanation that guided questions will help create the model
+- `Start interview`
+
+Selecting `Start interview` opens the AI panel in Interview mode. On first use, the existing disclosure is shown there; after acknowledgement, the existing behavior starts the session directly. The main card does not duplicate consent or own a voice connection.
+
+### AI assistant panel
+
+The panel header replaces the static `AI` label with the same `Chat` / `Interview` tabs. Clear and close controls remain on the right.
+
+Chat mode shows the existing conversation, prompt chips, and composer. For an empty conversation, the composer placeholder is “Describe the process you want to create”.
+
+Interview mode shows the same conversation plus the full existing interview stage, and hides the generic composer and prompt chips to keep one primary input surface. Existing interview actions such as `Use text instead` switch to Chat and focus the composer.
+
+### Active-session switching
+
+Switching from Interview to Chat does not pause or end an active session. The full stage becomes the existing compact status bar above the composer, preserving visible microphone/session state and a route back to Interview.
+
+The following actions also align with the mode switch:
+
+- Expand/open interview: select Interview.
+- Minimize or `Use text instead`: select Chat.
+- End interview: end the voice session and return to Chat.
+- Close the AI panel: retain the existing detached compact bar behavior.
+
+## Architecture
+
+Petrinaut owns the provider-neutral mode selection because both entry points and the surrounding layout belong to Petrinaut. The host-owned voice implementation continues to own disclosure, microphone, realtime connection, transcripts, and interview lifecycle.
+
+Add a provider-neutral interaction mode type (`"chat" | "interview"`) and expose the selected mode plus a mode-change callback in `PetrinautAiInterviewStageContext`.
+
+`EditorView` carries the empty-card mode request into `AiAssistantPanel` when opening it. `AiAssistantPanel` owns the live mode for that mounted conversation and passes it to both the panel contents and the host interview stage. The stage remains mounted while modes change so an active voice session is not accidentally destroyed.
+
+`VoiceInterviewControl` derives its visible presentation from both its existing lifecycle and Petrinaut’s selected mode:
+
+- inactive + Chat: no voice trigger;
+- inactive + Interview: existing start/disclosure presentation;
+- active + Interview: full stage;
+- active + Chat: compact bar;
+- closed sidebar + active session: detached compact bar.
+
+## Error Handling
+
+Existing microphone, connection, and service recovery states remain in the interview stage. Switching to Chat during an error keeps any active session represented by the compact bar. `Use text instead` remains the reliable escape path and selects Chat.
+
+If interview configuration is unavailable, the mode tabs are omitted rather than exposing an Interview mode that cannot start.
+
+## Accessibility
+
+- The shared switch exposes a tablist with two named tabs and the selected tab.
+- Both tabs have visible text and decorative icons hidden from assistive technology.
+- Selecting Chat focuses the composer when initiated from an interview fallback action.
+- An active interview remains visible and announced in compact form after switching to Chat.
+- Existing live transcript announcements and icon-button labels remain unchanged.
+
+## Testing
+
+Add or update tests for:
+
+- shared tabs, labels, selected state, and disabled-feature fallback;
+- empty-card Chat and Interview content and actions;
+- carrying an Interview selection from the empty card into the panel;
+- the new empty-conversation composer placeholder;
+- hiding the generic composer in Interview mode;
+- preserving the mounted interview stage when modes change;
+- full-to-compact and compact-to-full transitions;
+- `Use text instead`, minimize, expand, end, and panel-close mode behavior;
+- existing disclosure persistence and voice-session tests.
+
+Update the Petrinaut AI assistant user guide to describe Chat / Interview mode selection and the compact active-session behavior.

--- a/docs/superpowers/specs/2026-08-27-minimal-voice-interview-ui-design.md
+++ b/docs/superpowers/specs/2026-08-27-minimal-voice-interview-ui-design.md
@@ -1,0 +1,191 @@
+# Minimal Voice Interview UI
+
+## Goal
+
+Make Interview mode feel like a focused voice application: one clear question, one circular microphone-and-waveform focal element, compact transcript feedback, and only the controls needed for the current state.
+
+This is a visual and interaction refinement of the existing voice interview. It does not change transcription policy, answer submission, disclosure persistence, microphone gating, conversation identity, or Chat / Interview mode ownership.
+
+## Visual Hierarchy
+
+The AI panel header continues to show the `Chat` / `Interview` mode switch. The interview stage removes its duplicate “Voice interview” title.
+
+The full stage is ordered as:
+
+1. short state indicator;
+2. current question;
+3. circular microphone state with waveform;
+4. transcript strip, only when text exists;
+5. state-specific icon controls;
+6. optional collapsed secondary details.
+
+The current question remains clear, but the circular microphone element is the strongest visual element.
+
+## Circular Microphone and Waveform
+
+The focal element is a soft blue circular surface with a subtle outer ring.
+
+While listening:
+
+- a microphone icon sits in the centre;
+- live waveform bars respond to the existing microphone-level value;
+- a small green indicator and the short label `Listening` show that capture is active.
+
+The visible `Microphone input level: Quiet/Low/Medium/High` label is removed. The equivalent microphone-level description remains available to assistive technology.
+
+Other phases reuse the same circle:
+
+- connecting or finishing: `FaCircleNotch`;
+- paused: muted-microphone icon and `Paused`;
+- interviewer speaking: speaker icon and `Interviewer speaking`;
+- answer recorded: success/check icon and `Answer recorded`;
+- recoverable error: warning icon and a neutral error state.
+
+Reduced-motion behavior keeps the state understandable without waveform animation.
+
+## Icon Set and Tooltips
+
+Use the application’s existing `react-icons/fa6` dependency. Do not add custom SVGs, emoji icons, or another icon package.
+
+Use these existing Font Awesome components:
+
+- listening and interrupt: `FaMicrophone`;
+- microphone off or paused: `FaMicrophoneSlash`;
+- Done speaking: `FaCheck`;
+- Pause: `FaPause`;
+- switch to Chat: `FaKeyboard`;
+- Resume listening: `FaPlay`;
+- interviewer playback: `FaVolumeHigh`;
+- connecting and finishing: `FaCircleNotch`;
+- Reconnect: `FaRotate`;
+- recorded or sent: `FaCircleCheck`;
+- recoverable error: `FaTriangleExclamation`;
+- Minimize: `FaMinus`;
+- End interview: `FaXmark`;
+- Redo answer: `FaArrowRotateLeft`;
+- Edit text: `FaPen`.
+
+Icon-only controls use circular Petrinaut buttons, concise `aria-label` values, and DS tooltips. Tooltips provide the full action title on hover and keyboard focus.
+
+## Controls
+
+Only actions valid for the current phase are shown.
+
+Listening shows:
+
+- keyboard icon — switch to Chat and focus the composer;
+- primary check icon — Done speaking;
+- pause icon — Pause.
+
+Paused shows:
+
+- keyboard icon — switch to Chat;
+- primary microphone or play icon — Resume listening.
+
+Interviewer playback shows:
+
+- keyboard icon — switch to Chat;
+- primary microphone icon — Interrupt and speak.
+
+After an answer is recorded, Redo and Edit remain available as compact icon actions associated with the transcript rather than as full-width buttons. They stay disabled while the answer cannot be revised.
+
+Minimize and End remain icon-only controls in the top-right of the stage. The duplicate stage title is removed.
+
+The compact bar uses the same icon language. While it is actively listening, it exposes Done speaking as well as Pause, keyboard, and End so the user does not have to expand merely to finish an answer.
+
+## Transcript Feedback
+
+The transcript becomes one compact strip and appears only when partial or committed text exists.
+
+For partial text:
+
+- label: `Live transcript`;
+- trailing status: recording dot and `Recording`;
+- transcript text below or beside the label.
+
+For committed text:
+
+- label: `Your answer`;
+- trailing status: success icon and `Sent`;
+- transcript text;
+- compact Redo/Edit actions when applicable.
+
+The visible phrase `What we’re hearing · Not sent yet` is removed. The live region continues to announce that partial text has not been sent, preserving the distinction for assistive technology.
+
+## Initial Entry and Disclosure
+
+The empty-canvas Interview entry remains:
+
+1. select `Interview`;
+2. select `Start interview`.
+
+If the current disclosure version has already been acknowledged, the panel opens in Interview mode and capture starts automatically without an intermediate trigger or start card.
+
+On first use, the one-time disclosure still appears before microphone capture. It keeps the required transcription and retention explanation, consent checkbox, Start interview action, optional microphone check, and a keyboard icon for returning to Chat. Disclosure persistence remains versioned in local storage.
+
+## Recovery
+
+Recovery uses the same circular focal layout without a waveform:
+
+- warning or muted-microphone icon in the circle;
+- concise heading;
+- one actionable sentence;
+- primary `Reconnect` action with the existing rotate/reconnect icon and visible label;
+- keyboard icon to switch to Chat;
+- collapsed `Technical details` for error code and diagnostic reference.
+
+Permission, device, network, timeout, and invalid-response guidance remains accurate. Reconnecting never implies that capture is active until the microphone has actually reopened.
+
+## Secondary Information
+
+Interview coverage remains available but does not compete with the voice controls. When present, it stays collapsed in a low-emphasis progress/details row below the primary interaction.
+
+Correction input remains visible only while the user is actively editing a committed answer.
+
+## Compact and Detached Presentations
+
+The compact bar keeps:
+
+- microphone or state icon;
+- short current state;
+- one-line current question;
+- state-valid icon actions with tooltips.
+
+Closing the panel keeps the same session in the detached compact bar. Neither compacting nor detaching reconnects, pauses, or ends the session.
+
+## Accessibility
+
+- The waveform is decorative and hidden from assistive technology.
+- A screen-reader-only description retains the microphone input level.
+- State changes and partial transcript text continue through the existing polite live region.
+- Every icon-only action has an exact accessible name and tooltip.
+- Color is never the only state signal; every recording, sent, paused, and error state also has text or an icon.
+- Disabled correction actions remain programmatically disabled.
+
+## Architecture
+
+Keep the existing separation:
+
+- `VoiceInterviewControl` owns lifecycle-to-presentation mapping and handlers.
+- `VoiceInterviewControlView` owns the visual state rendering.
+- `VoiceTurnController` and `OpenAIRealtimeSession` remain unchanged unless a test proves the visual refactor requires a behavioral correction.
+- Petrinaut continues to own Chat / Interview mode and composer focus.
+
+Extract small view helpers only when they make the state-specific rendering clearer, such as a microphone focal component, transcript strip, and icon action row. Do not introduce a new state store or icon abstraction layer.
+
+## Testing and Documentation
+
+Update focused tests to verify:
+
+- no visible microphone-level text while an accessible level description remains;
+- circular microphone and waveform in listening state;
+- exact icons, accessible names, and tooltips for each phase;
+- icon-only keyboard action selects Chat;
+- Done speaking appears in full and compact listening presentations;
+- partial transcript shows `Recording` and committed text shows `Sent`;
+- first-use disclosure remains gated and returning users start directly;
+- paused, playback, answer-recorded, compact, detached, and recovery states expose only valid actions;
+- reconnect guidance and technical details remain available;
+- existing microphone/session lifecycle tests remain green.
+
+Update the Petrinaut AI assistant user guide and changeset to describe the simplified visual states and icon controls. No user-guide screenshots currently cover this surface.

--- a/libs/@hashintel/brunch-agent/docs/adr/0009-openai-voice-ui-turn-shell.md
+++ b/libs/@hashintel/brunch-agent/docs/adr/0009-openai-voice-ui-turn-shell.md
@@ -36,9 +36,9 @@ recovery or public availability.
    transcription policy and calls OpenAI's unified WebRTC initialization endpoint. The fixed
    model is `gpt-live-transcribe`. Turn detection uses that model's default server VAD because the
    unified endpoint currently times out when either VAD mode is configured during initialization;
-   semantic VAD remains a tunable evaluation setting once initialization supports it. Provider
-   keys, prompts, vocabulary, language policy, and model selection remain server-side. Realtime
-   never generates assistant responses.
+   semantic VAD remains a tunable evaluation setting once initialization supports it. Partial
+   transcription events do not disable capture. Provider keys, prompts, vocabulary, language
+   policy, and model selection remain server-side. Realtime never generates assistant responses.
 4. **Completed provider items are the only admitted audio input.** Partials are display-only.
    Completed items are keyed by connection epoch, provider item ID, and content index, then enter
    the existing Petrinaut composer and AI SDK transport once. A pending `brunch_ask` uses its

--- a/libs/@hashintel/brunch-agent/docs/adr/0009-openai-voice-ui-turn-shell.md
+++ b/libs/@hashintel/brunch-agent/docs/adr/0009-openai-voice-ui-turn-shell.md
@@ -27,8 +27,13 @@ recovery or public availability.
 
 1. **The host application owns voice.** `apps/petrinaut-website` owns OpenAI policy, WebRTC,
    transcript event parsing, half-duplex state, playback, feature UI, and server routes.
-   `@hashintel/petrinaut` exposes only a generic composer control and finalized-text submission
-   seam. Brunch packages contain no provider code.
+   `@hashintel/petrinaut` exposes provider-neutral seams only: a generic composer control
+   (`renderComposerControl`) and a persistent host-rendered interview stage
+   (`renderInterviewStage`) whose `PetrinautAiInterviewStageContext` supplies finalized-text
+   submission, conversation identity, sidebar placement and focus, active-conversation
+   protection, and the Chat / Interview interaction mode. Petrinaut owns the mode switch and
+   composer focus; it knows nothing about OpenAI, audio, or transcription. Brunch packages
+   contain no provider code.
 2. **OpenAI is the only runtime voice provider.** Do not add a provider abstraction, selector,
    compatibility layer, or ElevenLabs dependency, configuration, route, script, test, or
    diagnostic.
@@ -45,9 +50,12 @@ recovery or public availability.
    existing correlated tool-output path; otherwise the final becomes a stable-ID user message.
    A user-initiated correction is a new explicit message and opts out of pending-tool mapping
    rather than being silently inferred from its wording.
-5. **The interaction is half-duplex.** The microphone is closed while Brunch is handling a turn
-   and while speech is synthesized or playing. Barge-in and simultaneous listening and playback
-   are out of scope.
+5. **The interaction is half-duplex.** The microphone is closed while speech is synthesized or
+   playing, and while a turn the interview cannot yet absorb is outstanding. Petrinaut may
+   retain exactly one finalized answer while the normal chat stream settles, so a pending
+   `brunch_ask` keeps capture open for that one answer instead of waiting for generic chat
+   settlement; the buffered answer still enters the conversation through the canonical composer
+   path. Barge-in and simultaneous listening and playback are out of scope.
 6. **Speech receives canonical Brunch text exactly.** A dedicated OpenAI Speech request receives
    only finalized assistant text or the validated `brunch_ask.input.question` selected from the
    AI SDK message structure. The application does not scrape rendered DOM, ask Realtime to "say
@@ -64,7 +72,9 @@ recovery or public availability.
   status, and the effective host-supplied or generated conversation identity. Interactive tools may
   opt into a schema-validated text-to-output mapper. Keyboard and alternate finalized text therefore
   cannot bypass ask correlation by default; the host may explicitly target a separate message for
-  a correction.
+  a correction. It also gains the interview-stage seam and `PetrinautAiInteractionMode`, which keep
+  Chat / Interview ownership, docked and detached placement, and one-answer buffering inside
+  Petrinaut rather than in provider code.
 - OpenAI implementation names and policy stay in `apps/petrinaut-website`. The existing
   `transport-aisdk` package remains the sole browser-to-Brunch conversation transport.
 - Preview PRs may demonstrate transcription and exact canonical speech before production
@@ -118,7 +128,8 @@ recovery or public availability.
 ## Revisit condition
 
 Revisit if the unified OpenAI WebRTC initialization API cannot enforce server-owned transcription
-policy; if the generic composer seam cannot preserve the existing AI SDK and `brunch_ask` paths;
+policy; if the generic composer and interview-stage seams cannot preserve the existing AI SDK and
+`brunch_ask` paths;
 or if production authentication, replay, telemetry, or projection contracts require a boundary
 change rather than an application adapter. Do not address any of these by making browser or
 provider history authoritative.

--- a/libs/@hashintel/petrinaut/CHANGELOG.md
+++ b/libs/@hashintel/petrinaut/CHANGELOG.md
@@ -6,7 +6,15 @@
 
 - Add generic host-rendered AI composer controls and a persistent interview stage with docked and
   detached placements, protected active conversations, keyboard fallback, and one-answer buffering
-  while the normal chat stream settles.
+  while the normal chat stream settles. Add the Chat / Interview mode switch and export
+  `PetrinautAiInteractionMode`, with the selected interaction mode and mode-change callback
+  available to host-rendered interview stages. `renderComposerControl` remains a supported public
+  seam for hosts that only need their own control beside the message box, independently of the
+  interview stage.
+
+- Simplify Interview mode with a circular microphone waveform, compact transcript states that
+  distinguish recording, sending, sent, and undelivered answers, phase-specific icon controls, and
+  recovery that names the kind of failure before offering reconnect.
 
 ## 0.0.19
 

--- a/libs/@hashintel/petrinaut/CHANGELOG.md
+++ b/libs/@hashintel/petrinaut/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### Patch Changes
 
-- Add a generic host-rendered AI composer control with stable finalized-text submission,
-  conversation identity, stop handling, schema-validated interactive-tool text mapping, and an
-  explicit separate-message target for corrections.
+- Add generic host-rendered AI composer controls and a persistent interview stage with docked and
+  detached placements, protected active conversations, keyboard fallback, and one-answer buffering
+  while the normal chat stream settles.
 
 ## 0.0.19
 

--- a/libs/@hashintel/petrinaut/docs/ai-assistant.md
+++ b/libs/@hashintel/petrinaut/docs/ai-assistant.md
@@ -29,21 +29,26 @@ If the host offers voice input, a finalized spoken turn is held while an existin
 finishes and is submitted when the conversation is ready.
 
 When the Brunch voice preview is enabled by the host, select **Start voice interview** beside the
-composer. Review the transcription, retention, and AI-voice disclosure, optionally check your
-microphone, confirm that you understand it, then select **Start interview**. The full interview
-stage opens above the composer. It keeps the current question visible, labels live words **Not sent
-yet**, and shows **Answer recorded** only after finalization. The words shown as the question are
-also the exact words spoken by the AI-generated OpenAI voice.
+composer. The first time, review the transcription, retention, and AI-voice disclosure, optionally
+check your microphone, confirm that you understand it, then select **Start interview**. Petrinaut
+remembers that acknowledgement in this browser for the current disclosure version, so later
+sessions start directly. If browser storage is unavailable or the disclosure changes, Petrinaut asks
+again.
+
+The full interview stage opens above the composer. It keeps the current question visible, labels
+live words **Not sent yet**, and shows **Answer recorded** only after finalization. The words shown
+as the question are also the exact words spoken by the AI-generated OpenAI voice.
 
 The stage names the microphone state and shows input activity only while the microphone is really
 on. During interviewer playback, **Interrupt and speak** first stops playback and then opens the
 microphone; it does not listen and play at the same time. While listening, choose **Done speaking**
-to close the microphone and let voice detection finish the answer, or **Pause** to turn the
-microphone off temporarily. **Pause**, **Minimize**, **End interview**, and **Interrupt and speak**
-are separate actions. After an answer is recorded and the interviewer is ready, use **Redo answer**
-to say an explicit correction or **Edit text** to type one. These correction controls remain
-unavailable while the previous answer is still being written down. The normal message composer
-remains available as a keyboard fallback.
+or **Pause** — each keeps a visible label with a supporting icon — to close the microphone and let
+voice detection finish the answer, or to turn the microphone off temporarily. **Pause**,
+**Minimize**, **End interview**, and **Interrupt and speak** are separate actions. The header uses
+icon-only controls with tooltips **Minimize** and **End interview**. After an answer is recorded
+and the interviewer is ready, use **Redo answer** to say an explicit correction or **Edit text** to
+type one. These correction controls remain unavailable while the previous answer is still being
+written down. The normal message composer remains available as a keyboard fallback.
 
 Minimizing produces a compact bar above the composer. Closing the AI sidebar during an active
 interview moves that same session to a bottom bar over the canvas; reopening the sidebar docks it
@@ -59,9 +64,10 @@ Petrinaut canvas remains the model surface.
 If voice cannot continue, the status panel identifies the kind of problem. For microphone
 permission or device errors, allow access or connect/select a microphone before reconnecting. For
 an interrupted request, network error, or timeout, check the connection and choose **Reconnect**.
-If the preview is unavailable, continue with the text composer. An invalid service response
-includes a diagnostic reference you can give to an operator; that reference and its diagnostic
-record do not contain your transcript or the response being spoken.
+If the preview is unavailable, continue with the text composer. Error codes and diagnostic
+references sit under collapsed **Technical details** so you can share them with an operator without
+them dominating the interview; that reference and its diagnostic record do not contain your
+transcript or the response being spoken.
 
 When no interview is active, **Clear AI chat** via the delete button in the top right of the panel
 wipes the conversation, stops any in-flight stream, and tells the host app to forget the messages

--- a/libs/@hashintel/petrinaut/docs/ai-assistant.md
+++ b/libs/@hashintel/petrinaut/docs/ai-assistant.md
@@ -28,21 +28,42 @@ other follow-up that must not answer the pending question.
 If the host offers voice input, a finalized spoken turn is held while an existing response
 finishes and is submitted when the conversation is ready.
 
-When the Brunch voice preview is enabled by the host, the additional control can accept finalized
-microphone transcripts and speak finalized assistant responses. Live transcript fragments are
-labelled **not sent** and do not enter the conversation. The microphone is off while Brunch is
-working or a response is playing. Spoken responses use an AI-generated OpenAI voice, as disclosed
-in the voice status panel. If speech fails, the response remains visible to read and the voice
-control offers recovery instead of changing or regenerating the text.
+When the Brunch voice preview is enabled by the host, select **Start voice interview** beside the
+composer. Review the transcription, retention, and AI-voice disclosure, optionally check your
+microphone, confirm that you understand it, then select **Start interview**. The full interview
+stage opens above the composer. It keeps the current question visible, labels live words **Not sent
+yet**, and shows **Answer recorded** only after finalization. The words shown as the question are
+also the exact words spoken by the AI-generated OpenAI voice.
+
+The stage names the microphone state and shows input activity only while the microphone is really
+on. During interviewer playback, **Interrupt and speak** first stops playback and then opens the
+microphone; it does not listen and play at the same time. While listening, choose **Done speaking**
+to finalize immediately or **Pause** to turn the microphone off temporarily. **Pause**,
+**Minimize**, **End interview**, and **Interrupt and speak** are separate actions. After an answer
+is recorded, use **Redo answer** to say an explicit correction or **Edit text** to type one. The
+normal message composer remains available as a keyboard fallback.
+
+Minimizing produces a compact bar above the composer. Closing the AI sidebar during an active
+interview moves that same session to a bottom bar over the canvas; reopening the sidebar docks it
+again. These presentation changes do not reconnect or end the voice session. On narrow screens the
+full stage is a bottom sheet and the compact presentation is a bottom bar. If the session fails,
+the sidebar reopens to the full recovery view. **Clear AI chat** is unavailable while an interview
+is active.
+
+When Brunch has produced authoritative completion information, the stage can expand **Covered** and
+**Still exploring** topics. It does not show a question count or a speculative model preview; the
+Petrinaut canvas remains the model surface.
 
 If voice cannot continue, the status panel identifies the kind of problem. For microphone
 permission or device errors, allow access or connect/select a microphone before reconnecting. For
-an interrupted request, network error, or timeout, check the connection and choose **Reconnect
-voice input**. If the preview is unavailable, continue with the text composer. An invalid service
-response includes a diagnostic reference you can give to an operator; that reference and its
-diagnostic record do not contain your transcript or the response being spoken.
+an interrupted request, network error, or timeout, check the connection and choose **Reconnect**.
+If the preview is unavailable, continue with the text composer. An invalid service response
+includes a diagnostic reference you can give to an operator; that reference and its diagnostic
+record do not contain your transcript or the response being spoken.
 
-**Clear AI chat** via the delete button in the top right of the panel: wipes the conversation, stops any in-flight stream, and tells the host app to forget the messages (if the host persists them).
+When no interview is active, **Clear AI chat** via the delete button in the top right of the panel
+wipes the conversation, stops any in-flight stream, and tells the host app to forget the messages
+(if the host persists them).
 
 ## What the assistant can do
 
@@ -79,7 +100,7 @@ When the assistant edits code surfaces (lambdas, kernels, dynamics, visualizers,
 
 ## Host configuration
 
-Whether the assistant is available, which additional composer controls appear, where the
+Whether the assistant is available, which additional composer controls or interview stages appear, where the
 conversation is stored (in-memory, in your host app's database, or anywhere else), and the model
 behind it are all controlled by the host application that embeds Petrinaut. Read-only documents
 and the simulate-mode restrictions described above always apply when applicable.

--- a/libs/@hashintel/petrinaut/docs/ai-assistant.md
+++ b/libs/@hashintel/petrinaut/docs/ai-assistant.md
@@ -28,16 +28,21 @@ other follow-up that must not answer the pending question.
 If the host offers voice input, a finalized spoken turn is held while an existing response
 finishes and is submitted when the conversation is ready.
 
-When the Brunch voice preview is enabled by the host, select **Start voice interview** beside the
-composer. The first time, review the disclosure that OpenAI transcribes your speech and Petrinaut
-keeps finalized answers in the conversation rather than the audio, optionally check your microphone,
-confirm that you understand it, then select **Start interview**. Petrinaut remembers that
-acknowledgement in this browser for the current disclosure version, so later sessions start directly.
-If browser storage is unavailable or the disclosure changes, Petrinaut asks again.
+When the Brunch voice preview is enabled and available, **Chat** and **Interview** tabs appear on
+the first-run card and in the assistant panel header. If voice is unavailable, **Interview** is not
+shown. On the first-run card, select **Interview** and then **Start interview** to open the panel at
+the existing one-time disclosure. Review that OpenAI transcribes your speech and Petrinaut keeps
+finalized answers in the conversation rather than the audio, optionally check your microphone,
+confirm that you understand it, then select **Start interview** in the disclosure. Petrinaut
+remembers that acknowledgement in this browser for the current disclosure version, so later
+selections of **Interview** start directly. If browser storage is unavailable or the disclosure
+changes, Petrinaut asks again.
 
-The full interview stage opens above the composer. It keeps the current question visible, labels
-live words **Not sent yet**, and shows **Answer recorded** only after finalization. The words shown
-as the question are also the exact words spoken by the AI-generated OpenAI voice.
+While **Interview** is selected, the full interview stage replaces the generic message composer. It
+keeps the current question visible, labels live words **Not sent yet**, and shows **Answer
+recorded** only after finalization. The words shown as the question are also the exact words spoken
+by the AI-generated OpenAI voice. Choose **Use text instead** to select **Chat** and return focus to
+the composer.
 
 The stage names the microphone state and shows input activity only while the microphone is really
 on. During interviewer playback, **Interrupt and speak** first stops playback and then opens the
@@ -48,13 +53,16 @@ voice detection finish the answer, or to turn the microphone off temporarily. **
 icon-only controls with tooltips **Minimize** and **End interview**. After an answer is recorded
 and the interviewer is ready, use **Redo answer** to say an explicit correction or **Edit text** to
 type one. These correction controls remain unavailable while the previous answer is still being
-written down. The normal message composer remains available as a keyboard fallback.
+written down. Choose **Use text instead** to switch to the generic message composer as a keyboard
+fallback.
 
-Minimizing produces a compact bar above the composer. Closing the AI sidebar during an active
-interview moves that same session to a bottom bar over the canvas; reopening the sidebar docks it
-again. These presentation changes do not reconnect or end the voice session. On narrow screens the
-compact presentation remains a bottom bar. If the session fails, the sidebar reopens to the full
-recovery view. **Clear AI chat** is unavailable while an interview is active.
+Selecting **Chat** or **Minimize** hides the full stage. If the interview is active, the same session
+continues in a compact bar above the composer; expanding the bar reopens the sidebar and selects
+**Interview**. Closing the AI sidebar during an active interview moves the compact bar over the
+canvas; reopening the sidebar docks it again. These presentation changes do not reconnect or end
+the voice session. On narrow screens the compact presentation remains a bottom bar. If the session
+fails, the sidebar reopens to the full recovery view once; selecting **Chat** after that keeps the
+recovery controls compact. **Clear AI chat** is unavailable while an interview is active.
 
 When Brunch has produced authoritative completion information, the stage can expand **Covered** and
 **Still exploring** topics. It does not show a question count or a speculative model preview; the

--- a/libs/@hashintel/petrinaut/docs/ai-assistant.md
+++ b/libs/@hashintel/petrinaut/docs/ai-assistant.md
@@ -48,7 +48,8 @@ The stage names the microphone state and shows input activity only while the mic
 on. During interviewer playback, **Interrupt and speak** first stops playback and then opens the
 microphone; it does not listen and play at the same time. While listening, choose **Done speaking**
 or **Pause** — each keeps a visible label with a supporting icon — to close the microphone and let
-voice detection finish the answer, or to turn the microphone off temporarily. **Pause**,
+voice detection finish the answer, or to turn the microphone off temporarily. Provisional
+transcript updates do not turn off the microphone. **Pause**,
 **Minimize**, **End interview**, and **Interrupt and speak** are separate actions. The header uses
 icon-only controls with tooltips **Minimize** and **End interview**. After an answer is recorded
 and the interviewer is ready, use **Redo answer** to say an explicit correction or **Edit text** to

--- a/libs/@hashintel/petrinaut/docs/ai-assistant.md
+++ b/libs/@hashintel/petrinaut/docs/ai-assistant.md
@@ -38,10 +38,12 @@ also the exact words spoken by the AI-generated OpenAI voice.
 The stage names the microphone state and shows input activity only while the microphone is really
 on. During interviewer playback, **Interrupt and speak** first stops playback and then opens the
 microphone; it does not listen and play at the same time. While listening, choose **Done speaking**
-to finalize immediately or **Pause** to turn the microphone off temporarily. **Pause**,
-**Minimize**, **End interview**, and **Interrupt and speak** are separate actions. After an answer
-is recorded, use **Redo answer** to say an explicit correction or **Edit text** to type one. The
-normal message composer remains available as a keyboard fallback.
+to close the microphone and let voice detection finish the answer, or **Pause** to turn the
+microphone off temporarily. **Pause**, **Minimize**, **End interview**, and **Interrupt and speak**
+are separate actions. After an answer is recorded and the interviewer is ready, use **Redo answer**
+to say an explicit correction or **Edit text** to type one. These correction controls remain
+unavailable while the previous answer is still being written down. The normal message composer
+remains available as a keyboard fallback.
 
 Minimizing produces a compact bar above the composer. Closing the AI sidebar during an active
 interview moves that same session to a bottom bar over the canvas; reopening the sidebar docks it

--- a/libs/@hashintel/petrinaut/docs/ai-assistant.md
+++ b/libs/@hashintel/petrinaut/docs/ai-assistant.md
@@ -46,10 +46,10 @@ the composer.
 
 The stage names the microphone state and shows input activity only while the microphone is really
 on. During interviewer playback, **Interrupt and speak** first stops playback and then opens the
-microphone; it does not listen and play at the same time. While listening, choose **Done speaking**
-or **Pause** — each keeps a visible label with a supporting icon — to close the microphone and let
-voice detection finish the answer, or to turn the microphone off temporarily. Provisional
-transcript updates do not turn off the microphone. **Pause**,
+microphone; it does not listen and play at the same time. While listening, a natural pause lets
+voice detection finish the answer automatically. Choose **Done speaking** to close capture so it
+can finish sooner, or **Pause** to turn the microphone off temporarily without submitting.
+Provisional transcript updates do not turn off the microphone. **Pause**,
 **Minimize**, **End interview**, and **Interrupt and speak** are separate actions. The header uses
 icon-only controls with tooltips **Minimize** and **End interview**. After an answer is recorded
 and the interviewer is ready, use **Redo answer** to say an explicit correction or **Edit text** to

--- a/libs/@hashintel/petrinaut/docs/ai-assistant.md
+++ b/libs/@hashintel/petrinaut/docs/ai-assistant.md
@@ -29,11 +29,11 @@ If the host offers voice input, a finalized spoken turn is held while an existin
 finishes and is submitted when the conversation is ready.
 
 When the Brunch voice preview is enabled by the host, select **Start voice interview** beside the
-composer. The first time, review the transcription, retention, and AI-voice disclosure, optionally
-check your microphone, confirm that you understand it, then select **Start interview**. Petrinaut
-remembers that acknowledgement in this browser for the current disclosure version, so later
-sessions start directly. If browser storage is unavailable or the disclosure changes, Petrinaut asks
-again.
+composer. The first time, review the disclosure that OpenAI transcribes your speech and Petrinaut
+keeps finalized answers in the conversation rather than the audio, optionally check your microphone,
+confirm that you understand it, then select **Start interview**. Petrinaut remembers that
+acknowledgement in this browser for the current disclosure version, so later sessions start directly.
+If browser storage is unavailable or the disclosure changes, Petrinaut asks again.
 
 The full interview stage opens above the composer. It keeps the current question visible, labels
 live words **Not sent yet**, and shows **Answer recorded** only after finalization. The words shown
@@ -53,9 +53,8 @@ written down. The normal message composer remains available as a keyboard fallba
 Minimizing produces a compact bar above the composer. Closing the AI sidebar during an active
 interview moves that same session to a bottom bar over the canvas; reopening the sidebar docks it
 again. These presentation changes do not reconnect or end the voice session. On narrow screens the
-full stage is a bottom sheet and the compact presentation is a bottom bar. If the session fails,
-the sidebar reopens to the full recovery view. **Clear AI chat** is unavailable while an interview
-is active.
+compact presentation remains a bottom bar. If the session fails, the sidebar reopens to the full
+recovery view. **Clear AI chat** is unavailable while an interview is active.
 
 When Brunch has produced authoritative completion information, the stage can expand **Covered** and
 **Still exploring** topics. It does not show a question count or a speculative model preview; the

--- a/libs/@hashintel/petrinaut/docs/ai-assistant.md
+++ b/libs/@hashintel/petrinaut/docs/ai-assistant.md
@@ -38,11 +38,15 @@ remembers that acknowledgement in this browser for the current disclosure versio
 selections of **Interview** start directly. If browser storage is unavailable or the disclosure
 changes, Petrinaut asks again.
 
-While **Interview** is selected, the full interview stage replaces the generic message composer. It
-keeps the current question visible, labels live words **Not sent yet**, and shows **Answer
-recorded** only after finalization. The words shown as the question are also the exact words spoken
-by the AI-generated OpenAI voice. Choose **Use text instead** to select **Chat** and return focus to
-the composer.
+The full Interview stage keeps the current question above a circular microphone control. While
+Petrinaut is listening, waveform bars respond to your microphone and a short **Listening** status
+confirms capture. The technical input-level name remains available to screen readers without adding
+visible meter text.
+
+Partial words appear in a compact **Live transcript** strip with a **Recording** status. After
+finalization, the strip changes to **Your answer** with **Sent**. Icon controls provide **Done
+speaking**, **Pause**, **Use text instead**, and the actions valid for the current phase; hover or
+focus an icon to see its title.
 
 The stage names the microphone state and shows input activity only while the microphone is really
 on. During interviewer playback, **Interrupt and speak** first stops playback and then opens the
@@ -69,14 +73,14 @@ When Brunch has produced authoritative completion information, the stage can exp
 **Still exploring** topics. It does not show a question count or a speculative model preview; the
 Petrinaut canvas remains the model surface.
 
-If voice cannot continue, the status panel identifies the kind of problem. For microphone
-permission or device errors, allow access or connect/select a microphone before reconnecting. For
-an interrupted request, network error, or timeout, check the connection and choose **Reconnect**.
-If the preview is unavailable, continue with the text composer. An invalid service response
-includes a diagnostic reference you can give to an operator; error codes and that reference sit
-under collapsed **Technical details** so you can share them without them dominating the interview.
-That reference and its diagnostic record do not contain your transcript or the response being
-spoken.
+If voice cannot continue, the status panel identifies the kind of problem with a warning circle and
+a visible **Reconnect** action. For microphone permission or device errors, allow access or
+connect/select a microphone before reconnecting. For an interrupted request, network error, or
+timeout, check the connection and choose **Reconnect**. If the preview is unavailable, continue
+with the text composer. An invalid service response includes a diagnostic reference you can give to
+an operator; error codes and that reference sit under collapsed **Technical details** so you can share
+them without them dominating the interview. That reference and its diagnostic record do not contain
+your transcript or the response being spoken.
 
 When no interview is active, **Clear AI chat** via the delete button in the top right of the panel
 wipes the conversation, stops any in-flight stream, and tells the host app to forget the messages

--- a/libs/@hashintel/petrinaut/docs/ai-assistant.md
+++ b/libs/@hashintel/petrinaut/docs/ai-assistant.md
@@ -44,9 +44,11 @@ confirms capture. The technical input-level name remains available to screen rea
 visible meter text.
 
 Partial words appear in a compact **Live transcript** strip with a **Recording** status. After
-finalization, the strip changes to **Your answer** with **Sent**. Icon controls provide **Done
-speaking**, **Pause**, **Use text instead**, and the actions valid for the current phase; hover or
-focus an icon to see its title.
+finalization, the strip changes to **Your answer**. It reads **Sending** while the answer is on its
+way to the interview and **Sent** once the interview has accepted it; if delivery fails, it reads
+**Not sent** so you know to retry rather than assuming the answer arrived. Icon controls provide
+**Use text instead**, **Done speaking**, **Pause**, and the other actions valid for the current
+phase; hover or focus an icon to see its title.
 
 The stage names the microphone state and shows input activity only while the microphone is really
 on. During interviewer playback, **Interrupt and speak** first stops playback and then opens the
@@ -74,7 +76,10 @@ When Brunch has produced authoritative completion information, the stage can exp
 Petrinaut canvas remains the model surface.
 
 If voice cannot continue, the status panel identifies the kind of problem with a warning circle and
-a visible **Reconnect** action. For microphone permission or device errors, allow access or
+a visible **Reconnect** action. The heading names that kind: microphone wording for permission and
+device problems, connection wording for network, timeout, and interrupted requests, and neutral
+interview wording when the interview itself could not continue. For microphone permission or device
+errors, allow access or
 connect/select a microphone before reconnecting. For an interrupted request, network error, or
 timeout, check the connection and choose **Reconnect**. If the preview is unavailable, continue
 with the text composer. An invalid service response includes a diagnostic reference you can give to

--- a/libs/@hashintel/petrinaut/docs/ai-assistant.md
+++ b/libs/@hashintel/petrinaut/docs/ai-assistant.md
@@ -64,10 +64,11 @@ Petrinaut canvas remains the model surface.
 If voice cannot continue, the status panel identifies the kind of problem. For microphone
 permission or device errors, allow access or connect/select a microphone before reconnecting. For
 an interrupted request, network error, or timeout, check the connection and choose **Reconnect**.
-If the preview is unavailable, continue with the text composer. Error codes and diagnostic
-references sit under collapsed **Technical details** so you can share them with an operator without
-them dominating the interview; that reference and its diagnostic record do not contain your
-transcript or the response being spoken.
+If the preview is unavailable, continue with the text composer. An invalid service response
+includes a diagnostic reference you can give to an operator; error codes and that reference sit
+under collapsed **Technical details** so you can share them without them dominating the interview.
+That reference and its diagnostic record do not contain your transcript or the response being
+spoken.
 
 When no interview is active, **Clear AI chat** via the delete button in the top right of the panel
 wipes the conversation, stops any in-flight stream, and tells the host app to forget the messages

--- a/libs/@hashintel/petrinaut/src/ui/index.ts
+++ b/libs/@hashintel/petrinaut/src/ui/index.ts
@@ -21,6 +21,7 @@ export type {
   PetrinautAiComposerControlContext,
   PetrinautAiComposerStatus,
   PetrinautAiComposerSubmitTextResult,
+  PetrinautAiInteractionMode,
   PetrinautAiInterviewStage,
   PetrinautAiInterviewStageContext,
   PetrinautAiInterviewStagePlacement,

--- a/libs/@hashintel/petrinaut/src/ui/index.ts
+++ b/libs/@hashintel/petrinaut/src/ui/index.ts
@@ -21,6 +21,9 @@ export type {
   PetrinautAiComposerControlContext,
   PetrinautAiComposerStatus,
   PetrinautAiComposerSubmitTextResult,
+  PetrinautAiInterviewStage,
+  PetrinautAiInterviewStageContext,
+  PetrinautAiInterviewStagePlacement,
 } from "./types/ai-assistant-composer-control";
 export type {
   PetrinautNavigationAction,

--- a/libs/@hashintel/petrinaut/src/ui/petrinaut.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/petrinaut.tsx
@@ -33,7 +33,10 @@ const editorRootStyle = css({
   backgroundColor: "neutral.s25",
 });
 
-import type { PetrinautAiComposerControl } from "./types/ai-assistant-composer-control";
+import type {
+  PetrinautAiComposerControl,
+  PetrinautAiInterviewStage,
+} from "./types/ai-assistant-composer-control";
 import type { PetrinautAiInteractiveTool } from "./types/ai-interactive-tool";
 import type {
   PetrinautAiMessage,
@@ -52,6 +55,8 @@ export type PetrinautAiAssistant = {
   onMessages?: (messages: PetrinautAiMessage[]) => void;
   /** Render a host-owned control inside the assistant composer. */
   renderComposerControl?: PetrinautAiComposerControl;
+  /** Render one persistent, provider-neutral interview stage. */
+  renderInterviewStage?: PetrinautAiInterviewStage;
   transport: PetrinautAiTransport;
 };
 

--- a/libs/@hashintel/petrinaut/src/ui/types/ai-assistant-composer-control.ts
+++ b/libs/@hashintel/petrinaut/src/ui/types/ai-assistant-composer-control.ts
@@ -41,3 +41,31 @@ export type PetrinautAiComposerControlContext = {
 export type PetrinautAiComposerControl = (
   context: PetrinautAiComposerControlContext,
 ) => ReactNode;
+
+/** Provider-neutral placement for one persistent host-owned interview stage. */
+export type PetrinautAiInterviewStagePlacement = "sidebar" | "detached";
+
+/** Stable controls and placement supplied to a host-owned interview stage. */
+export type PetrinautAiInterviewStageContext =
+  PetrinautAiComposerControlContext & {
+    /** True when Petrinaut can retain one next answer, even while chat settles. */
+    canAcceptInterviewAnswer: boolean;
+    /** Bring back the sidebar and place keyboard focus in its composer. */
+    focusComposer: () => void;
+    /** Open the AI sidebar without changing the interview session. */
+    openSidebar: () => void;
+    placement: PetrinautAiInterviewStagePlacement;
+    /** Tell Petrinaut to protect the active conversation from accidental clearing. */
+    setActive: (active: boolean) => void;
+    /**
+     * Accept one finalized answer immediately. If generic chat is still busy,
+     * Petrinaut retains it and submits it through the canonical composer path
+     * as soon as that path is ready.
+     */
+    submitInterviewAnswer: PetrinautAiComposerControlContext["submitText"];
+  };
+
+/** Render callback for a persistent host-owned stage above the composer. */
+export type PetrinautAiInterviewStage = (
+  context: PetrinautAiInterviewStageContext,
+) => ReactNode;

--- a/libs/@hashintel/petrinaut/src/ui/types/ai-assistant-composer-control.ts
+++ b/libs/@hashintel/petrinaut/src/ui/types/ai-assistant-composer-control.ts
@@ -1,6 +1,9 @@
 import type { PetrinautAiMessage } from "../views/Editor/panels/ai-assistant-panel/types";
 import type { ReactNode } from "react";
 
+/** The active way a user is providing input to the AI assistant. */
+export type PetrinautAiInteractionMode = "chat" | "interview";
+
 /** Current lifecycle state of Petrinaut's AI SDK conversation. */
 export type PetrinautAiComposerStatus =
   | "submitted"
@@ -52,11 +55,13 @@ export type PetrinautAiInterviewStageContext =
     canAcceptInterviewAnswer: boolean;
     /** Bring back the sidebar and place keyboard focus in its composer. */
     focusComposer: () => void;
+    interactionMode: PetrinautAiInteractionMode;
     /** Open the AI sidebar without changing the interview session. */
     openSidebar: () => void;
     placement: PetrinautAiInterviewStagePlacement;
     /** Tell Petrinaut to protect the active conversation from accidental clearing. */
     setActive: (active: boolean) => void;
+    setInteractionMode: (mode: PetrinautAiInteractionMode) => void;
     /**
      * Accept one finalized answer immediately. If generic chat is still busy,
      * Petrinaut retains it and submits it through the canonical composer path

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/components/ai-cta-modal.test.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/components/ai-cta-modal.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { AiCtaModal } from "./ai-cta-modal";
+
+afterEach(cleanup);
+
+describe("AiCtaModal", () => {
+  test("switches from Chat creation to the Interview entry point", () => {
+    const onStartInterview = vi.fn();
+    render(
+      <AiCtaModal
+        bottomClearance={0}
+        interviewAvailable={true}
+        onDismiss={vi.fn()}
+        onStartInterview={onStartInterview}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", {
+        name: "Describe the process you want to create",
+      }),
+    ).not.toBeNull();
+    fireEvent.click(screen.getByRole("tab", { name: "Interview" }));
+    expect(
+      screen.getByRole("heading", {
+        name: "Talk through your process with AI",
+      }),
+    ).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Start interview" }));
+    expect(onStartInterview).toHaveBeenCalledOnce();
+  });
+
+  test("keeps the current chat-only card when interview is unavailable", () => {
+    render(
+      <AiCtaModal
+        bottomClearance={0}
+        interviewAvailable={false}
+        onDismiss={vi.fn()}
+        onStartInterview={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole("tablist")).toBeNull();
+    expect(
+      screen.getByLabelText("Describe the process you want to create"),
+    ).not.toBeNull();
+  });
+});

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/components/ai-cta-modal.test.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/components/ai-cta-modal.test.tsx
@@ -53,4 +53,40 @@ describe("AiCtaModal", () => {
       screen.getByLabelText("Describe the process you want to create"),
     ).not.toBeNull();
   });
+
+  test("returns to Chat when Interview becomes unavailable", () => {
+    const { rerender } = render(
+      <AiCtaModal
+        bottomClearance={0}
+        interviewAvailable={true}
+        onDismiss={vi.fn()}
+        onStartInterview={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("tab", { name: "Interview" }));
+    expect(
+      screen.getByRole("heading", {
+        name: "Talk through your process with AI",
+      }),
+    ).not.toBeNull();
+
+    rerender(
+      <AiCtaModal
+        bottomClearance={0}
+        interviewAvailable={false}
+        onDismiss={vi.fn()}
+        onStartInterview={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole("tablist")).toBeNull();
+    expect(
+      screen.getByRole("heading", {
+        name: "Describe the process you want to create",
+      }),
+    ).not.toBeNull();
+  });
 });

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/components/ai-cta-modal.test.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/components/ai-cta-modal.test.tsx
@@ -26,7 +26,7 @@ describe("AiCtaModal", () => {
         name: "Describe the process you want to create",
       }),
     ).not.toBeNull();
-    fireEvent.click(screen.getByRole("tab", { name: "Interview" }));
+    fireEvent.click(screen.getByRole("button", { name: "Interview" }));
     expect(
       screen.getByRole("heading", {
         name: "Talk through your process with AI",
@@ -48,7 +48,9 @@ describe("AiCtaModal", () => {
       />,
     );
 
-    expect(screen.queryByRole("tablist")).toBeNull();
+    expect(
+      screen.queryByRole("group", { name: "AI interaction mode" }),
+    ).toBeNull();
     expect(
       screen.getByLabelText("Describe the process you want to create"),
     ).not.toBeNull();
@@ -65,7 +67,7 @@ describe("AiCtaModal", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("tab", { name: "Interview" }));
+    fireEvent.click(screen.getByRole("button", { name: "Interview" }));
     expect(
       screen.getByRole("heading", {
         name: "Talk through your process with AI",
@@ -82,7 +84,9 @@ describe("AiCtaModal", () => {
       />,
     );
 
-    expect(screen.queryByRole("tablist")).toBeNull();
+    expect(
+      screen.queryByRole("group", { name: "AI interaction mode" }),
+    ).toBeNull();
     expect(
       screen.getByRole("heading", {
         name: "Describe the process you want to create",

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/components/ai-cta-modal.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/components/ai-cta-modal.tsx
@@ -4,6 +4,12 @@ import { Button, TextInput } from "@hashintel/ds-components";
 import { css } from "@hashintel/ds-helpers/css";
 
 import { AiAssistantIcon } from "../../../components/ai-assistant-icon";
+import {
+  AiInteractionModeTabs,
+  AiMicrophoneIcon,
+} from "./ai-interaction-mode-tabs";
+
+import type { PetrinautAiInteractionMode } from "../../../types/ai-assistant-composer-control";
 
 const aiCtaModalLayerStyle = css({
   position: "absolute",
@@ -73,14 +79,20 @@ const aiCtaModalTitleStyle = css({
 
 export const AiCtaModal = ({
   bottomClearance,
+  interviewAvailable,
   onDismiss,
+  onStartInterview,
   onSubmit,
 }: {
   bottomClearance: number;
+  interviewAvailable: boolean;
   onDismiss: () => void;
+  onStartInterview: () => void;
   onSubmit: (message: string) => void;
 }) => {
   const [promptInput, setPromptInput] = useState("");
+  const [interactionMode, setInteractionMode] =
+    useState<PetrinautAiInteractionMode>("chat");
 
   const canSubmit = promptInput.trim().length > 0;
   const inputRef = useRef<HTMLInputElement | null>(null);
@@ -141,38 +153,70 @@ export const AiCtaModal = ({
           aria-label="Dismiss"
           iconName="close"
         />
-        <div className={aiCtaModalIconStyle}>
-          <AiAssistantIcon size={32} />
-        </div>
-        <div className={aiCtaModalCopyStyle}>
-          <h2 className={aiCtaModalTitleStyle}>
-            Describe the process you want to create
-          </h2>
-        </div>
-        <TextInput
-          inputRef={inputRef}
-          value={promptInput}
-          onChange={setPromptInput}
-          placeholder="e.g. Model an SIR outbreak with recovery"
-          aria-label="Describe the process you want to create"
-          size="lg"
-          suffix={{
-            variant: "subtle",
-            content: (
-              <Button
-                type="submit"
-                size="lg"
-                variant="solid"
-                tone="brand"
-                disabled={!canSubmit}
-                aria-label="Send first AI assistant message"
-                iconName="arrowUp"
-                tooltip="Send first AI assistant message"
-                className={css({ margin: "2" })}
-              />
-            ),
-          }}
-        />
+        {interviewAvailable && (
+          <AiInteractionModeTabs
+            mode={interactionMode}
+            onModeChange={setInteractionMode}
+          />
+        )}
+        {interactionMode === "chat" ? (
+          <>
+            <div className={aiCtaModalIconStyle}>
+              <AiAssistantIcon size={32} />
+            </div>
+            <h2 className={aiCtaModalTitleStyle}>
+              Describe the process you want to create
+            </h2>
+            <TextInput
+              inputRef={inputRef}
+              value={promptInput}
+              onChange={setPromptInput}
+              placeholder="e.g. Model an SIR outbreak with recovery"
+              aria-label="Describe the process you want to create"
+              size="lg"
+              suffix={{
+                variant: "subtle",
+                content: (
+                  <Button
+                    type="submit"
+                    size="lg"
+                    variant="solid"
+                    tone="brand"
+                    disabled={!canSubmit}
+                    aria-label="Send first AI assistant message"
+                    iconName="arrowUp"
+                    tooltip="Send first AI assistant message"
+                    className={css({ margin: "2" })}
+                  />
+                ),
+              }}
+            />
+          </>
+        ) : (
+          <>
+            <div className={aiCtaModalIconStyle} aria-hidden="true">
+              <AiMicrophoneIcon />
+            </div>
+            <div className={aiCtaModalCopyStyle}>
+              <h2 className={aiCtaModalTitleStyle}>
+                Talk through your process with AI
+              </h2>
+              <p>
+                Answer a few guided questions and Petrinaut will create the
+                model.
+              </p>
+            </div>
+            <Button
+              type="button"
+              size="md"
+              variant="solid"
+              tone="brand"
+              onClick={onStartInterview}
+            >
+              Start interview
+            </Button>
+          </>
+        )}
       </form>
     </div>
   );

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/components/ai-cta-modal.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/components/ai-cta-modal.tsx
@@ -68,6 +68,12 @@ const aiCtaModalCopyStyle = css({
   maxWidth: "[420px]",
 });
 
+const aiCtaModalDescriptionStyle = css({
+  margin: "0",
+  color: "neutral.s80",
+  textStyle: "sm",
+});
+
 const aiCtaModalTitleStyle = css({
   margin: "0",
   color: "neutral.s110",
@@ -129,6 +135,8 @@ export const AiCtaModal = ({
     };
   }, [onDismiss]);
 
+  const effectiveInteractionMode = interviewAvailable ? interactionMode : "chat";
+
   return (
     <div className={aiCtaModalLayerStyle} style={{ bottom: bottomClearance }}>
       <form
@@ -159,7 +167,7 @@ export const AiCtaModal = ({
             onModeChange={setInteractionMode}
           />
         )}
-        {interactionMode === "chat" ? (
+        {effectiveInteractionMode === "chat" ? (
           <>
             <div className={aiCtaModalIconStyle}>
               <AiAssistantIcon size={32} />
@@ -201,7 +209,7 @@ export const AiCtaModal = ({
               <h2 className={aiCtaModalTitleStyle}>
                 Talk through your process with AI
               </h2>
-              <p>
+              <p className={aiCtaModalDescriptionStyle}>
                 Answer a few guided questions and Petrinaut will create the
                 model.
               </p>

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/components/ai-cta-modal.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/components/ai-cta-modal.tsx
@@ -135,7 +135,9 @@ export const AiCtaModal = ({
     };
   }, [onDismiss]);
 
-  const effectiveInteractionMode = interviewAvailable ? interactionMode : "chat";
+  const effectiveInteractionMode = interviewAvailable
+    ? interactionMode
+    : "chat";
 
   return (
     <div className={aiCtaModalLayerStyle} style={{ bottom: bottomClearance }}>
@@ -172,9 +174,11 @@ export const AiCtaModal = ({
             <div className={aiCtaModalIconStyle}>
               <AiAssistantIcon size={32} />
             </div>
-            <h2 className={aiCtaModalTitleStyle}>
-              Describe the process you want to create
-            </h2>
+            <div className={aiCtaModalCopyStyle}>
+              <h2 className={aiCtaModalTitleStyle}>
+                Describe the process you want to create
+              </h2>
+            </div>
             <TextInput
               inputRef={inputRef}
               value={promptInput}

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/components/ai-interaction-mode-tabs.test.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/components/ai-interaction-mode-tabs.test.tsx
@@ -9,22 +9,42 @@ import { AiInteractionModeTabs } from "./ai-interaction-mode-tabs";
 afterEach(cleanup);
 
 describe("AiInteractionModeTabs", () => {
-  test("shows Chat and Interview as labeled tabs", () => {
+  test("shows Chat selected in a labeled button group", () => {
     const onModeChange = vi.fn();
-    render(
-      <AiInteractionModeTabs mode="chat" onModeChange={onModeChange} />,
-    );
+    render(<AiInteractionModeTabs mode="chat" onModeChange={onModeChange} />);
 
     expect(
-      screen.getByRole("tab", { name: "Chat" }).getAttribute("aria-selected"),
+      screen.getByRole("group", { name: "AI interaction mode" }),
+    ).not.toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Chat" }).getAttribute("aria-pressed"),
     ).toBe("true");
     expect(
       screen
-        .getByRole("tab", { name: "Interview" })
-        .getAttribute("aria-selected"),
+        .getByRole("button", { name: "Interview" })
+        .getAttribute("aria-pressed"),
     ).toBe("false");
 
-    fireEvent.click(screen.getByRole("tab", { name: "Interview" }));
+    fireEvent.click(screen.getByRole("button", { name: "Interview" }));
     expect(onModeChange).toHaveBeenCalledWith("interview");
+  });
+
+  test("shows Interview selected and returns to Chat", () => {
+    const onModeChange = vi.fn();
+    render(
+      <AiInteractionModeTabs mode="interview" onModeChange={onModeChange} />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Chat" }).getAttribute("aria-pressed"),
+    ).toBe("false");
+    expect(
+      screen
+        .getByRole("button", { name: "Interview" })
+        .getAttribute("aria-pressed"),
+    ).toBe("true");
+
+    fireEvent.click(screen.getByRole("button", { name: "Chat" }));
+    expect(onModeChange).toHaveBeenCalledWith("chat");
   });
 });

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/components/ai-interaction-mode-tabs.test.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/components/ai-interaction-mode-tabs.test.tsx
@@ -1,0 +1,30 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { AiInteractionModeTabs } from "./ai-interaction-mode-tabs";
+
+afterEach(cleanup);
+
+describe("AiInteractionModeTabs", () => {
+  test("shows Chat and Interview as labeled tabs", () => {
+    const onModeChange = vi.fn();
+    render(
+      <AiInteractionModeTabs mode="chat" onModeChange={onModeChange} />,
+    );
+
+    expect(
+      screen.getByRole("tab", { name: "Chat" }).getAttribute("aria-selected"),
+    ).toBe("true");
+    expect(
+      screen
+        .getByRole("tab", { name: "Interview" })
+        .getAttribute("aria-selected"),
+    ).toBe("false");
+
+    fireEvent.click(screen.getByRole("tab", { name: "Interview" }));
+    expect(onModeChange).toHaveBeenCalledWith("interview");
+  });
+});

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/components/ai-interaction-mode-tabs.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/components/ai-interaction-mode-tabs.tsx
@@ -4,7 +4,7 @@ import { AiAssistantIcon } from "../../../components/ai-assistant-icon";
 
 import type { PetrinautAiInteractionMode } from "../../../types/ai-assistant-composer-control";
 
-const tabListStyle = css({
+const modeGroupStyle = css({
   display: "flex",
   alignItems: "center",
   gap: "1",
@@ -68,11 +68,10 @@ export const AiInteractionModeTabs = ({
   mode: PetrinautAiInteractionMode;
   onModeChange: (mode: PetrinautAiInteractionMode) => void;
 }) => (
-  <div aria-label="AI interaction mode" className={tabListStyle} role="tablist">
+  <div aria-label="AI interaction mode" className={modeGroupStyle} role="group">
     <button
-      aria-selected={mode === "chat"}
+      aria-pressed={mode === "chat"}
       className={tabStyle({ selected: mode === "chat" })}
-      role="tab"
       type="button"
       onClick={() => onModeChange("chat")}
     >
@@ -80,9 +79,8 @@ export const AiInteractionModeTabs = ({
       Chat
     </button>
     <button
-      aria-selected={mode === "interview"}
+      aria-pressed={mode === "interview"}
       className={tabStyle({ selected: mode === "interview" })}
-      role="tab"
       type="button"
       onClick={() => onModeChange("interview")}
     >

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/components/ai-interaction-mode-tabs.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/components/ai-interaction-mode-tabs.tsx
@@ -1,0 +1,93 @@
+import { css, cva } from "@hashintel/ds-helpers/css";
+
+import { AiAssistantIcon } from "../../../components/ai-assistant-icon";
+
+import type { PetrinautAiInteractionMode } from "../../../types/ai-assistant-composer-control";
+
+const tabListStyle = css({
+  display: "flex",
+  alignItems: "center",
+  gap: "1",
+  padding: "1",
+  borderRadius: "lg",
+  backgroundColor: "neutral.s20",
+});
+
+const tabStyle = cva({
+  base: {
+    display: "flex",
+    alignItems: "center",
+    gap: "1",
+    height: "[28px]",
+    paddingX: "2",
+    border: "none",
+    borderRadius: "md",
+    backgroundColor: "[transparent]",
+    color: "neutral.s90",
+    cursor: "pointer",
+    fontSize: "xs",
+    fontWeight: "medium",
+    _focusVisible: {
+      outline: "[2px solid token(colors.blue.s70)]",
+      outlineOffset: "[2px]",
+    },
+  },
+  variants: {
+    selected: {
+      true: {
+        backgroundColor: "neutral.s00",
+        boxShadow: "xs",
+        color: "blue.s90",
+      },
+    },
+  },
+});
+
+export const AiMicrophoneIcon = () => (
+  <svg
+    aria-hidden="true"
+    fill="none"
+    height="15"
+    viewBox="0 0 16 16"
+    width="15"
+  >
+    <path
+      d="M5.5 4a2.5 2.5 0 0 1 5 0v4a2.5 2.5 0 0 1-5 0V4Zm-2 3.5V8a4.5 4.5 0 0 0 9 0v-.5M8 12.5V15m-2 0h4"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.4"
+    />
+  </svg>
+);
+
+export const AiInteractionModeTabs = ({
+  mode,
+  onModeChange,
+}: {
+  mode: PetrinautAiInteractionMode;
+  onModeChange: (mode: PetrinautAiInteractionMode) => void;
+}) => (
+  <div aria-label="AI interaction mode" className={tabListStyle} role="tablist">
+    <button
+      aria-selected={mode === "chat"}
+      className={tabStyle({ selected: mode === "chat" })}
+      role="tab"
+      type="button"
+      onClick={() => onModeChange("chat")}
+    >
+      <AiAssistantIcon size={15} />
+      Chat
+    </button>
+    <button
+      aria-selected={mode === "interview"}
+      className={tabStyle({ selected: mode === "interview" })}
+      role="tab"
+      type="button"
+      onClick={() => onModeChange("interview")}
+    >
+      <AiMicrophoneIcon />
+      Interview
+    </button>
+  </div>
+);

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/editor-view.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/editor-view.tsx
@@ -54,6 +54,7 @@ import { SimulateView } from "./panels/SimulateView/simulate-view";
 import { SimulationCreationDrawer } from "./simulation-creation-drawer";
 
 import type { PetrinautAiAssistant } from "../../petrinaut";
+import type { PetrinautAiInteractionMode } from "../../types/ai-assistant-composer-control";
 import type { PetrinautSlots } from "../../types/petrinaut-slots";
 import type { ViewportAction } from "../../types/viewport-action";
 
@@ -159,6 +160,8 @@ export const EditorView = ({
   const [pendingAiAssistantMessage, setPendingAiAssistantMessage] = useState<
     string | null
   >(null);
+  const [pendingAiInteractionMode, setPendingAiInteractionMode] =
+    useState<PetrinautAiInteractionMode | null>(null);
   const [isAiCtaDismissed, setIsAiCtaDismissed] = useState(false);
 
   const {
@@ -487,9 +490,15 @@ export const EditorView = ({
             {showEmptyAiHero && (
               <AiCtaModal
                 bottomClearance={isBottomPanelOpen ? bottomPanelHeight : 0}
+                interviewAvailable={aiAssistant.renderInterviewStage !== undefined}
                 onDismiss={() => setIsAiCtaDismissed(true)}
+                onStartInterview={() => {
+                  setPendingAiInteractionMode("interview");
+                  setAiAssistantOpen(true);
+                }}
                 onSubmit={(message) => {
                   setPendingAiAssistantMessage(message);
+                  setPendingAiInteractionMode("chat");
                   setAiAssistantOpen(true);
                 }}
               />
@@ -513,8 +522,12 @@ export const EditorView = ({
                 key={petriNetId ?? "no-net"}
                 aiAssistant={aiAssistant}
                 initialMessage={pendingAiAssistantMessage}
+                initialInteractionMode={pendingAiInteractionMode}
                 onInitialMessageConsumed={() =>
                   setPendingAiAssistantMessage(null)
+                }
+                onInitialInteractionModeConsumed={() =>
+                  setPendingAiInteractionMode(null)
                 }
               />
             )}

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/editor-view.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/editor-view.tsx
@@ -490,7 +490,9 @@ export const EditorView = ({
             {showEmptyAiHero && (
               <AiCtaModal
                 bottomClearance={isBottomPanelOpen ? bottomPanelHeight : 0}
-                interviewAvailable={aiAssistant.renderInterviewStage !== undefined}
+                interviewAvailable={
+                  aiAssistant.renderInterviewStage !== undefined
+                }
                 onDismiss={() => setIsAiCtaDismissed(true)}
                 onStartInterview={() => {
                   setPendingAiInteractionMode("interview");

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel.test.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel.test.tsx
@@ -252,6 +252,44 @@ describe("AiAssistantPanel composer submissions", () => {
     expect(interviewStageUnmounts).toBe(0);
   });
 
+  test("switches modes without unmounting the interview stage", () => {
+    interviewStageMounts = 0;
+    interviewStageUnmounts = 0;
+    const Stage = (context: PetrinautAiInterviewStageContext) => {
+      useEffect(() => {
+        interviewStageMounts += 1;
+        return () => {
+          interviewStageUnmounts += 1;
+        };
+      }, []);
+      return (
+        <button
+          type="button"
+          onClick={() => context.setInteractionMode("chat")}
+        >
+          {`Stage ${context.interactionMode}`}
+        </button>
+      );
+    };
+    const aiAssistant: PetrinautAiAssistant = {
+      renderInterviewStage: (context) => <Stage {...context} />,
+      transport: {
+        reconnectToStream: () => Promise.resolve(null),
+        sendMessages: vi.fn(),
+      },
+    };
+
+    renderTestPanel({ aiAssistant });
+
+    fireEvent.click(screen.getByRole("tab", { name: "Interview" }));
+    expect(screen.getByText("Stage interview")).not.toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Stage interview" }));
+
+    expect(screen.getByPlaceholderText("Describe the process you want to create")).not.toBeNull();
+    expect(interviewStageMounts).toBe(1);
+    expect(interviewStageUnmounts).toBe(0);
+  });
+
   test("accepts one interview answer while generic chat is streaming and submits it after settlement", async () => {
     let firstStreamController:
       | ReadableStreamDefaultController<UIMessageChunk>

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel.test.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel.test.tsx
@@ -356,6 +356,68 @@ describe("AiAssistantPanel composer submissions", () => {
     expect(requests).toHaveLength(3);
   });
 
+  test("reopens the interview answer buffer when the conversation changes", async () => {
+    let streamController:
+      | ReadableStreamDefaultController<UIMessageChunk>
+      | undefined;
+    const transport: PetrinautAiTransport = {
+      reconnectToStream: () => Promise.resolve(null),
+      sendMessages: vi.fn(() =>
+        Promise.resolve(
+          new ReadableStream({
+            start(controller) {
+              streamController = controller;
+              for (const chunk of textChunks("question", "Question ready")) {
+                controller.enqueue(chunk);
+              }
+            },
+          }),
+        ),
+      ),
+    };
+    let latestStageContext: PetrinautAiInterviewStageContext | undefined;
+    const createAiAssistant = (
+      conversationId: string,
+    ): PetrinautAiAssistant => ({
+      conversationId,
+      renderInterviewStage: (context) => {
+        latestStageContext = context;
+        return null;
+      },
+      transport,
+    });
+    const rendered = renderTestPanel({
+      aiAssistant: createAiAssistant("conversation-1"),
+    });
+    let initialSubmission: Promise<unknown> | undefined;
+    act(() => {
+      initialSubmission = latestStageContext?.submitText({ text: "Begin" });
+    });
+    void initialSubmission?.catch(() => undefined);
+    await waitFor(() => expect(latestStageContext?.status).toBe("streaming"));
+    let queuedAnswer: Promise<unknown> | undefined;
+    act(() => {
+      queuedAnswer = latestStageContext?.submitInterviewAnswer({
+        target: "message",
+        text: "Queued interview answer",
+      });
+    });
+    const queuedAnswerRejection = expect(queuedAnswer).rejects.toThrow(
+      "The interview conversation changed.",
+    );
+    await waitFor(() =>
+      expect(latestStageContext?.canAcceptInterviewAnswer).toBe(false),
+    );
+
+    rendered.rerenderPanel(createAiAssistant("conversation-2"));
+
+    await queuedAnswerRejection;
+    await waitFor(() =>
+      expect(latestStageContext?.canAcceptInterviewAnswer).toBe(true),
+    );
+    await act(async () => streamController?.close());
+  });
+
   test("exposes the generated useChat conversation identity to host controls", async () => {
     const chatIds: string[] = [];
     const observedConversationIds = new Set<string>();

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel.test.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel.test.tsx
@@ -288,11 +288,13 @@ describe("AiAssistantPanel composer submissions", () => {
 
     renderTestPanel({ aiAssistant });
 
-    fireEvent.click(screen.getByRole("tab", { name: "Interview" }));
+    fireEvent.click(screen.getByRole("button", { name: "Interview" }));
     expect(screen.getByText("Stage interview")).not.toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "Stage interview" }));
 
-    expect(screen.getByPlaceholderText("Describe the process you want to create")).not.toBeNull();
+    expect(
+      screen.getByPlaceholderText("Describe the process you want to create"),
+    ).not.toBeNull();
     expect(interviewStageMounts).toBe(1);
     expect(interviewStageUnmounts).toBe(0);
   });

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel.test.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel.test.tsx
@@ -2,6 +2,7 @@
  * @vitest-environment jsdom
  */
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -32,12 +33,18 @@ import { definePetrinautAiInteractiveTool } from "../../../types/ai-interactive-
 import { AiAssistantPanel } from "./ai-assistant-panel";
 
 import type { PetrinautAiAssistant } from "../../../petrinaut";
-import type { PetrinautAiComposerControlContext } from "../../../types/ai-assistant-composer-control";
+import type {
+  PetrinautAiComposerControlContext,
+  PetrinautAiInterviewStageContext,
+} from "../../../types/ai-assistant-composer-control";
 import type {
   PetrinautAiMessage,
   PetrinautAiTransport,
 } from "./ai-assistant-panel/types";
 import type { UIMessageChunk } from "ai";
+
+let interviewStageMounts = 0;
+let interviewStageUnmounts = 0;
 
 const emptySDCPN: SDCPN = {
   places: [],
@@ -149,10 +156,12 @@ const testInstances: ReturnType<typeof createPetrinaut>[] = [];
 
 const renderTestPanel = ({
   aiAssistant,
+  editorContext = editorContextValue,
   initialMessage,
   petriNetDefinition = emptySDCPN,
 }: {
   aiAssistant: PetrinautAiAssistant;
+  editorContext?: EditorContextValue;
   initialMessage?: string;
   petriNetDefinition?: SDCPN;
 }) => {
@@ -175,9 +184,12 @@ const renderTestPanel = ({
     getItemType: () => null,
   };
 
-  const renderPanel = (nextAiAssistant: PetrinautAiAssistant) => (
+  const renderPanel = (
+    nextAiAssistant: PetrinautAiAssistant,
+    nextEditorContext: EditorContextValue,
+  ) => (
     <PetrinautInstanceContext.Provider value={instance}>
-      <EditorContext.Provider value={editorContextValue}>
+      <EditorContext.Provider value={nextEditorContext}>
         <SDCPNContext.Provider value={sdcpnContext}>
           <AiAssistantPanel
             aiAssistant={nextAiAssistant}
@@ -187,12 +199,14 @@ const renderTestPanel = ({
       </EditorContext.Provider>
     </PetrinautInstanceContext.Provider>
   );
-  const rendered = render(renderPanel(aiAssistant));
+  const rendered = render(renderPanel(aiAssistant, editorContext));
 
   return {
     ...rendered,
-    rerenderPanel: (nextAiAssistant: PetrinautAiAssistant) =>
-      rendered.rerender(renderPanel(nextAiAssistant)),
+    rerenderPanel: (
+      nextAiAssistant: PetrinautAiAssistant,
+      nextEditorContext = editorContext,
+    ) => rendered.rerender(renderPanel(nextAiAssistant, nextEditorContext)),
   };
 };
 
@@ -204,6 +218,144 @@ afterEach(() => {
 });
 
 describe("AiAssistantPanel composer submissions", () => {
+  test("redocks one mounted interview stage when the sidebar closes and reopens", () => {
+    interviewStageMounts = 0;
+    interviewStageUnmounts = 0;
+    const Stage = ({ placement }: { placement: string }) => {
+      useEffect(() => {
+        interviewStageMounts += 1;
+        return () => {
+          interviewStageUnmounts += 1;
+        };
+      }, []);
+      return <div>{`Stage ${placement}`}</div>;
+    };
+    const aiAssistant: PetrinautAiAssistant = {
+      renderInterviewStage: ({ placement }) => <Stage placement={placement} />,
+      transport: {
+        reconnectToStream: () => Promise.resolve(null),
+        sendMessages: vi.fn(),
+      },
+    };
+    const rendered = renderTestPanel({ aiAssistant });
+
+    expect(screen.getByText("Stage sidebar")).not.toBeNull();
+    rendered.rerenderPanel(aiAssistant, {
+      ...editorContextValue,
+      isAiAssistantOpen: false,
+    });
+    expect(screen.getByText("Stage detached")).not.toBeNull();
+    rendered.rerenderPanel(aiAssistant, editorContextValue);
+
+    expect(screen.getByText("Stage sidebar")).not.toBeNull();
+    expect(interviewStageMounts).toBe(1);
+    expect(interviewStageUnmounts).toBe(0);
+  });
+
+  test("accepts one interview answer while generic chat is streaming and submits it after settlement", async () => {
+    let firstStreamController:
+      | ReadableStreamDefaultController<UIMessageChunk>
+      | undefined;
+    let secondStreamController:
+      | ReadableStreamDefaultController<UIMessageChunk>
+      | undefined;
+    const requests: PetrinautAiMessage[][] = [];
+    const transport: PetrinautAiTransport = {
+      reconnectToStream: () => Promise.resolve(null),
+      sendMessages: vi.fn(({ messages }) => {
+        requests.push(structuredClone(messages));
+        if (requests.length === 1) {
+          return Promise.resolve(
+            new ReadableStream({
+              start(controller) {
+                firstStreamController = controller;
+                for (const chunk of textChunks("question", "Question ready")) {
+                  controller.enqueue(chunk);
+                }
+              },
+            }),
+          );
+        }
+        if (requests.length === 2) {
+          return Promise.resolve(
+            new ReadableStream({
+              start(controller) {
+                secondStreamController = controller;
+                for (const chunk of textChunks(
+                  "acknowledgement",
+                  "Answer accepted",
+                )) {
+                  controller.enqueue(chunk);
+                }
+              },
+            }),
+          );
+        }
+        return Promise.resolve(
+          streamChunks(textChunks("next-answer", "Next answer accepted")),
+        );
+      }),
+    };
+    let latestStageContext: PetrinautAiInterviewStageContext | undefined;
+
+    renderTestPanel({
+      aiAssistant: {
+        renderInterviewStage: (context) => {
+          latestStageContext = context;
+          return (
+            <button
+              type="button"
+              onClick={() => {
+                void (context.status === "ready"
+                  ? context.submitText({ text: "Begin" })
+                  : context.submitInterviewAnswer({
+                      target: "message",
+                      text: "Queued interview answer",
+                    }));
+              }}
+            >
+              {context.status === "ready" ? "Begin" : "Answer now"}
+            </button>
+          );
+        },
+        transport,
+      },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Begin" }));
+    await screen.findByRole("button", { name: "Answer now" });
+    expect(latestStageContext?.canAcceptInterviewAnswer).toBe(true);
+    fireEvent.click(screen.getByRole("button", { name: "Answer now" }));
+    await waitFor(() =>
+      expect(latestStageContext?.canAcceptInterviewAnswer).toBe(false),
+    );
+    expect(requests).toHaveLength(1);
+
+    await act(async () => firstStreamController?.close());
+    await screen.findByText("Answer accepted");
+
+    expect(requests).toHaveLength(2);
+    expect(latestStageContext?.status).toBe("streaming");
+    expect(latestStageContext?.canAcceptInterviewAnswer).toBe(true);
+    expect(requests[1]?.at(-1)).toMatchObject({
+      role: "user",
+      parts: [{ type: "text", text: "Queued interview answer" }],
+    });
+
+    void latestStageContext?.submitInterviewAnswer({
+      target: "message",
+      text: "Next interview answer",
+    });
+    await waitFor(() =>
+      expect(latestStageContext?.canAcceptInterviewAnswer).toBe(false),
+    );
+    expect(requests).toHaveLength(2);
+
+    await act(async () => secondStreamController?.close());
+    await screen.findByText("Next answer accepted");
+    expect(requests).toHaveLength(3);
+  });
+
   test("exposes the generated useChat conversation identity to host controls", async () => {
     const chatIds: string[] = [];
     const observedConversationIds = new Set<string>();

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel.test.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel.test.tsx
@@ -299,6 +299,53 @@ describe("AiAssistantPanel composer submissions", () => {
     expect(interviewStageUnmounts).toBe(0);
   });
 
+  test("moves focus to the composer only when the interview stage requests it", () => {
+    const Stage = (context: PetrinautAiInterviewStageContext) => (
+      <>
+        <button
+          type="button"
+          onClick={() => context.setInteractionMode("chat")}
+        >
+          Minimize interview
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            context.setInteractionMode("chat");
+            context.focusComposer();
+          }}
+        >
+          Use text instead
+        </button>
+      </>
+    );
+    const aiAssistant: PetrinautAiAssistant = {
+      renderInterviewStage: (context) => <Stage {...context} />,
+      transport: {
+        reconnectToStream: () => Promise.resolve(null),
+        sendMessages: vi.fn(),
+      },
+    };
+
+    renderTestPanel({ aiAssistant });
+    fireEvent.click(screen.getByRole("button", { name: "Interview" }));
+
+    const minimizeButton = screen.getByRole("button", {
+      name: "Minimize interview",
+    });
+    minimizeButton.focus();
+    fireEvent.click(minimizeButton);
+
+    expect(document.activeElement).toBe(minimizeButton);
+
+    fireEvent.click(screen.getByRole("button", { name: "Interview" }));
+    fireEvent.click(screen.getByRole("button", { name: "Use text instead" }));
+
+    expect(document.activeElement).toBe(
+      screen.getByPlaceholderText("Describe the process you want to create"),
+    );
+  });
+
   test("defers and consumes an initial Interview mode once, then falls back to Chat", () => {
     let latestInteractionMode = "chat";
     const onInitialInteractionModeConsumed = vi.fn();

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel.test.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel.test.tsx
@@ -35,6 +35,7 @@ import { AiAssistantPanel } from "./ai-assistant-panel";
 import type { PetrinautAiAssistant } from "../../../petrinaut";
 import type {
   PetrinautAiComposerControlContext,
+  PetrinautAiInteractionMode,
   PetrinautAiInterviewStageContext,
 } from "../../../types/ai-assistant-composer-control";
 import type {
@@ -157,12 +158,16 @@ const testInstances: ReturnType<typeof createPetrinaut>[] = [];
 const renderTestPanel = ({
   aiAssistant,
   editorContext = editorContextValue,
+  initialInteractionMode,
   initialMessage,
+  onInitialInteractionModeConsumed,
   petriNetDefinition = emptySDCPN,
 }: {
   aiAssistant: PetrinautAiAssistant;
   editorContext?: EditorContextValue;
+  initialInteractionMode?: PetrinautAiInteractionMode;
   initialMessage?: string;
+  onInitialInteractionModeConsumed?: () => void;
   petriNetDefinition?: SDCPN;
 }) => {
   const handle = createJsonDocHandle({
@@ -193,7 +198,9 @@ const renderTestPanel = ({
         <SDCPNContext.Provider value={sdcpnContext}>
           <AiAssistantPanel
             aiAssistant={nextAiAssistant}
+            initialInteractionMode={initialInteractionMode}
             initialMessage={initialMessage}
+            onInitialInteractionModeConsumed={onInitialInteractionModeConsumed}
           />
         </SDCPNContext.Provider>
       </EditorContext.Provider>
@@ -288,6 +295,50 @@ describe("AiAssistantPanel composer submissions", () => {
     expect(screen.getByPlaceholderText("Describe the process you want to create")).not.toBeNull();
     expect(interviewStageMounts).toBe(1);
     expect(interviewStageUnmounts).toBe(0);
+  });
+
+  test("defers and consumes an initial Interview mode once, then falls back to Chat", () => {
+    let latestInteractionMode = "chat";
+    const onInitialInteractionModeConsumed = vi.fn();
+    const aiAssistant: PetrinautAiAssistant = {
+      renderInterviewStage: (context) => {
+        latestInteractionMode = context.interactionMode;
+        return <div>Interview stage</div>;
+      },
+      transport: {
+        reconnectToStream: () => Promise.resolve(null),
+        sendMessages: vi.fn(),
+      },
+    };
+    const closedEditorContext = {
+      ...editorContextValue,
+      isAiAssistantOpen: false,
+    };
+    const rendered = renderTestPanel({
+      aiAssistant,
+      editorContext: closedEditorContext,
+      initialInteractionMode: "interview",
+      onInitialInteractionModeConsumed,
+    });
+
+    expect(latestInteractionMode).toBe("chat");
+    expect(onInitialInteractionModeConsumed).not.toHaveBeenCalled();
+
+    rendered.rerenderPanel(aiAssistant, editorContextValue);
+
+    expect(latestInteractionMode).toBe("interview");
+    expect(onInitialInteractionModeConsumed).toHaveBeenCalledOnce();
+
+    const unavailableAssistant: PetrinautAiAssistant = {
+      transport: aiAssistant.transport,
+    };
+    rendered.rerenderPanel(unavailableAssistant, editorContextValue);
+
+    expect(screen.queryByText("Interview stage")).toBeNull();
+    expect(
+      screen.getByPlaceholderText("Describe the process you want to create"),
+    ).not.toBeNull();
+    expect(onInitialInteractionModeConsumed).toHaveBeenCalledOnce();
   });
 
   test("accepts one interview answer while generic chat is streaming and submits it after settlement", async () => {

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel.tsx
@@ -862,6 +862,7 @@ export const AiAssistantPanel = ({
         new Error("The interview conversation changed."),
       );
       queuedInterviewAnswerRef.current = null;
+      setInterviewAnswerQueued(false);
     },
     [conversationId],
   );

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel.tsx
@@ -258,9 +258,6 @@ export const AiAssistantPanel = ({
   const selectInteractionMode = useCallback(
     (nextMode: PetrinautAiInteractionMode) => {
       setInteractionMode(nextMode);
-      if (nextMode === "chat") {
-        setComposerFocusRequest((request) => request + 1);
-      }
     },
     [],
   );
@@ -1011,6 +1008,7 @@ export const AiAssistantPanel = ({
     focusComposer: () => {
       selectInteractionMode("chat");
       setAiAssistantOpen(true);
+      setComposerFocusRequest((request) => request + 1);
     },
     interactionMode,
     openSidebar: () => setAiAssistantOpen(true),

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel.tsx
@@ -936,7 +936,11 @@ export const AiAssistantPanel = ({
     ) {
       selectInteractionMode("chat");
     }
-  }, [aiAssistant.renderInterviewStage, interactionMode, selectInteractionMode]);
+  }, [
+    aiAssistant.renderInterviewStage,
+    interactionMode,
+    selectInteractionMode,
+  ]);
 
   useEffect(() => {
     const trimmedInitialMessage = initialMessage?.trim();

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel.tsx
@@ -211,11 +211,15 @@ const applyPetrinautAiCommand = async ({
 
 export const AiAssistantPanel = ({
   aiAssistant,
+  initialInteractionMode,
   initialMessage,
+  onInitialInteractionModeConsumed,
   onInitialMessageConsumed,
 }: {
   aiAssistant: PetrinautAiAssistant;
+  initialInteractionMode?: PetrinautAiInteractionMode | null;
   initialMessage?: string | null;
+  onInitialInteractionModeConsumed?: () => void;
   onInitialMessageConsumed?: () => void;
 }) => {
   // The wrapped AI transport closes over several refs (diagnostics version,
@@ -251,6 +255,15 @@ export const AiAssistantPanel = ({
   const [interviewAnswerQueued, setInterviewAnswerQueued] = useState(false);
   const [interactionMode, setInteractionMode] =
     useState<PetrinautAiInteractionMode>("chat");
+  const selectInteractionMode = useCallback(
+    (nextMode: PetrinautAiInteractionMode) => {
+      setInteractionMode(nextMode);
+      if (nextMode === "chat") {
+        setComposerFocusRequest((request) => request + 1);
+      }
+    },
+    [],
+  );
   const queuedInterviewAnswerRef = useRef<QueuedInterviewAnswer | null>(null);
   const submittedInitialMessageRef = useRef<string | null>(null);
 
@@ -883,6 +896,39 @@ export const AiAssistantPanel = ({
   }, [stopStateRef]);
 
   useEffect(() => {
+    if (
+      !isAiAssistantOpen ||
+      initialInteractionMode === undefined ||
+      initialInteractionMode === null
+    ) {
+      return;
+    }
+
+    selectInteractionMode(
+      initialInteractionMode === "interview" &&
+        aiAssistant.renderInterviewStage === undefined
+        ? "chat"
+        : initialInteractionMode,
+    );
+    onInitialInteractionModeConsumed?.();
+  }, [
+    aiAssistant.renderInterviewStage,
+    initialInteractionMode,
+    isAiAssistantOpen,
+    onInitialInteractionModeConsumed,
+    selectInteractionMode,
+  ]);
+
+  useEffect(() => {
+    if (
+      interactionMode === "interview" &&
+      aiAssistant.renderInterviewStage === undefined
+    ) {
+      selectInteractionMode("chat");
+    }
+  }, [aiAssistant.renderInterviewStage, interactionMode, selectInteractionMode]);
+
+  useEffect(() => {
     const trimmedInitialMessage = initialMessage?.trim();
     if (!trimmedInitialMessage) {
       submittedInitialMessageRef.current = null;
@@ -949,14 +995,14 @@ export const AiAssistantPanel = ({
     ...composerControlContext,
     canAcceptInterviewAnswer: !interviewAnswerQueued,
     focusComposer: () => {
+      selectInteractionMode("chat");
       setAiAssistantOpen(true);
-      setComposerFocusRequest((request) => request + 1);
     },
     interactionMode,
     openSidebar: () => setAiAssistantOpen(true),
     placement: isAiAssistantOpen ? "sidebar" : "detached",
     setActive: setInterviewActive,
-    setInteractionMode,
+    setInteractionMode: selectInteractionMode,
     submitInterviewAnswer,
   });
   /* eslint-enable react-hooks-js/refs */
@@ -968,6 +1014,8 @@ export const AiAssistantPanel = ({
       composerFocusRequest={composerFocusRequest}
       error={streamError ?? error}
       input={input}
+      interactionMode={interactionMode}
+      interviewAvailable={aiAssistant.renderInterviewStage !== undefined}
       interviewStage={interviewStage}
       interactiveTools={aiAssistant.interactiveTools}
       isOpen={isAiAssistantOpen}
@@ -990,6 +1038,7 @@ export const AiAssistantPanel = ({
       }}
       onClose={() => setAiAssistantOpen(false)}
       onInputChange={setInput}
+      onInteractionModeChange={selectInteractionMode}
       onInteractiveToolSubmit={({ toolCallId, toolName, output }) => {
         if (!isPetrinautAiCommandToolName(toolName)) {
           if (

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel.tsx
@@ -90,6 +90,14 @@ const selectTarget = (
   });
 };
 
+type QueuedInterviewAnswer = {
+  readonly input: Parameters<
+    PetrinautAiComposerControlContext["submitText"]
+  >[0];
+  readonly reject: (reason?: unknown) => void;
+  readonly resolve: (result: PetrinautAiComposerSubmitTextResult) => void;
+};
+
 const isPetrinautAiMutationToolName = (
   toolName: string,
 ): toolName is PetrinautAiMutationToolName =>
@@ -237,6 +245,10 @@ export const AiAssistantPanel = ({
   const { petriNetDefinition, setTitle, title } = use(SDCPNContext);
 
   const [input, setInput] = useState("");
+  const [composerFocusRequest, setComposerFocusRequest] = useState(0);
+  const [interviewActive, setInterviewActive] = useState(false);
+  const [interviewAnswerQueued, setInterviewAnswerQueued] = useState(false);
+  const queuedInterviewAnswerRef = useRef<QueuedInterviewAnswer | null>(null);
   const submittedInitialMessageRef = useRef<string | null>(null);
 
   const titleRef = useRef(title);
@@ -790,6 +802,70 @@ export const AiAssistantPanel = ({
 
   const stopStateRef = useLatest({ status, stop });
 
+  const submitInterviewAnswer = useCallback<
+    PetrinautAiComposerControlContext["submitText"]
+  >(
+    (answer) => {
+      if (queuedInterviewAnswerRef.current) {
+        return Promise.reject(
+          new Error("The previous interview answer is still being submitted."),
+        );
+      }
+      const currentStatus = composerSubmissionStateRef.current.status;
+      if (currentStatus === "error") {
+        return Promise.reject(
+          new Error("The interview is not ready to accept an answer."),
+        );
+      }
+      if (currentStatus === "ready") {
+        return submitText(answer);
+      }
+
+      setInterviewAnswerQueued(true);
+      return new Promise((resolve, reject) => {
+        queuedInterviewAnswerRef.current = {
+          input: answer,
+          reject,
+          resolve,
+        };
+      });
+    },
+    [composerSubmissionStateRef, submitText],
+  );
+
+  useEffect(() => {
+    const queued = queuedInterviewAnswerRef.current;
+    if (!queued) {
+      return;
+    }
+    if (status === "error") {
+      queuedInterviewAnswerRef.current = null;
+      setInterviewAnswerQueued(false);
+      queued.reject(new Error("The interview could not accept that answer."));
+      return;
+    }
+    if (status !== "ready") {
+      return;
+    }
+
+    queuedInterviewAnswerRef.current = null;
+    setInterviewAnswerQueued(false);
+    void submitText(queued.input).then(
+      (result) => queued.resolve(result),
+      (caught: unknown) => queued.reject(caught),
+    );
+  }, [status, submitText]);
+
+  useEffect(
+    () => () => {
+      queuedInterviewAnswerRef.current?.reject(
+        new Error("The interview conversation changed."),
+      );
+      queuedInterviewAnswerRef.current = null;
+    },
+    [conversationId],
+  );
+
   // Like submitText, stop is exposed to host controls and must stay stable.
   const stopComposer = useCallback(async () => {
     const { status: currentStatus, stop: stopCurrentResponse } =
@@ -833,7 +909,7 @@ export const AiAssistantPanel = ({
     sendMessage,
   ]);
 
-  if (!isAiAssistantOpen || !instance) {
+  if (!instance) {
     return null;
   }
 
@@ -865,14 +941,30 @@ export const AiAssistantPanel = ({
   const composerControl = aiAssistant.renderComposerControl?.(
     composerControlContext,
   );
+  const interviewStage = aiAssistant.renderInterviewStage?.({
+    ...composerControlContext,
+    canAcceptInterviewAnswer: !interviewAnswerQueued,
+    focusComposer: () => {
+      setAiAssistantOpen(true);
+      setComposerFocusRequest((request) => request + 1);
+    },
+    openSidebar: () => setAiAssistantOpen(true),
+    placement: isAiAssistantOpen ? "sidebar" : "detached",
+    setActive: setInterviewActive,
+    submitInterviewAnswer,
+  });
   /* eslint-enable react-hooks-js/refs */
 
   return (
     <AiAssistantContents
+      clearMessagesDisabled={interviewActive}
       composerControl={composerControl}
+      composerFocusRequest={composerFocusRequest}
       error={streamError ?? error}
       input={input}
+      interviewStage={interviewStage}
       interactiveTools={aiAssistant.interactiveTools}
+      isOpen={isAiAssistantOpen}
       messages={messages}
       onClearMessages={() => {
         // Clearing aborts any in-flight response too, which fires `onFinish`

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel.tsx
@@ -59,6 +59,7 @@ import type {
   PetrinautAiComposerControlContext,
   PetrinautAiComposerSubmitText,
   PetrinautAiComposerSubmitTextResult,
+  PetrinautAiInteractionMode,
 } from "../../../types/ai-assistant-composer-control";
 import type { PetrinautAiMessage } from "./ai-assistant-panel/types";
 
@@ -248,6 +249,8 @@ export const AiAssistantPanel = ({
   const [composerFocusRequest, setComposerFocusRequest] = useState(0);
   const [interviewActive, setInterviewActive] = useState(false);
   const [interviewAnswerQueued, setInterviewAnswerQueued] = useState(false);
+  const [interactionMode, setInteractionMode] =
+    useState<PetrinautAiInteractionMode>("chat");
   const queuedInterviewAnswerRef = useRef<QueuedInterviewAnswer | null>(null);
   const submittedInitialMessageRef = useRef<string | null>(null);
 
@@ -949,9 +952,11 @@ export const AiAssistantPanel = ({
       setAiAssistantOpen(true);
       setComposerFocusRequest((request) => request + 1);
     },
+    interactionMode,
     openSidebar: () => setAiAssistantOpen(true),
     placement: isAiAssistantOpen ? "sidebar" : "detached",
     setActive: setInterviewActive,
+    setInteractionMode,
     submitInterviewAnswer,
   });
   /* eslint-enable react-hooks-js/refs */

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel.tsx
@@ -265,6 +265,8 @@ export const AiAssistantPanel = ({
     [],
   );
   const queuedInterviewAnswerRef = useRef<QueuedInterviewAnswer | null>(null);
+  const consumedInitialInteractionModeRef =
+    useRef<PetrinautAiInteractionMode | null>(null);
   const submittedInitialMessageRef = useRef<string | null>(null);
 
   const titleRef = useRef(title);
@@ -897,9 +899,16 @@ export const AiAssistantPanel = ({
 
   useEffect(() => {
     if (
-      !isAiAssistantOpen ||
       initialInteractionMode === undefined ||
       initialInteractionMode === null
+    ) {
+      consumedInitialInteractionModeRef.current = null;
+      return;
+    }
+
+    if (
+      !isAiAssistantOpen ||
+      consumedInitialInteractionModeRef.current === initialInteractionMode
     ) {
       return;
     }
@@ -910,6 +919,7 @@ export const AiAssistantPanel = ({
         ? "chat"
         : initialInteractionMode,
     );
+    consumedInitialInteractionModeRef.current = initialInteractionMode;
     onInitialInteractionModeConsumed?.();
   }, [
     aiAssistant.renderInterviewStage,

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel/ai-assistant-contents.test.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel/ai-assistant-contents.test.tsx
@@ -79,8 +79,34 @@ describe("AiAssistantContents", () => {
     expect(screen.getByTestId("ai-interview-stage").dataset.placement).toBe(
       "detached",
     );
+    expect(
+      screen
+        .getByRole("complementary", { name: "AI assistant" })
+        .getAttribute("aria-hidden"),
+    ).toBeNull();
     expect(interviewStageMounts).toBe(1);
     expect(interviewStageUnmounts).toBe(0);
+  });
+
+  test("hides a closed chat-only panel from the accessibility tree", () => {
+    const { container } = render(
+      <AiAssistantContents
+        input=""
+        isOpen={false}
+        messages={[]}
+        onClose={noop}
+        onInputChange={noop}
+        onStop={noop}
+        onSubmit={noop}
+        status="ready"
+      />,
+    );
+
+    expect(
+      container
+        .querySelector('aside[aria-label="AI assistant"]')
+        ?.getAttribute("aria-hidden"),
+    ).toBe("true");
   });
 
   test("keeps keyboard drafting available and protects clear-chat during an active interview", () => {
@@ -141,7 +167,7 @@ describe("AiAssistantContents", () => {
     expect(
       screen.getByPlaceholderText("Describe the process you want to create"),
     ).not.toBeNull();
-    fireEvent.click(screen.getByRole("tab", { name: "Interview" }));
+    fireEvent.click(screen.getByRole("button", { name: "Interview" }));
     expect(onInteractionModeChange).toHaveBeenCalledWith("interview");
 
     rendered.rerender(

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel/ai-assistant-contents.test.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel/ai-assistant-contents.test.tsx
@@ -9,7 +9,7 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
-import { createElement } from "react";
+import { createElement, useEffect } from "react";
 import { afterEach, describe, expect, test, vi } from "vitest";
 
 import { DEFAULT_PETRINAUT_EXTENSIONS } from "@hashintel/petrinaut-core";
@@ -20,6 +20,8 @@ import { AiAssistantContents } from "./ai-assistant-contents";
 import type { PetrinautAiMessage } from "./types";
 
 const renderMarkdown = vi.hoisted(() => vi.fn());
+let interviewStageMounts = 0;
+let interviewStageUnmounts = 0;
 
 vi.mock("react-markdown", async (importOriginal) => {
   const actual = await importOriginal<typeof import("react-markdown")>();
@@ -42,6 +44,83 @@ afterEach(() => {
 });
 
 describe("AiAssistantContents", () => {
+  test("keeps one provider-neutral interview stage mounted while it moves between docked and detached presentation", () => {
+    interviewStageMounts = 0;
+    interviewStageUnmounts = 0;
+    const Stage = () => {
+      useEffect(() => {
+        interviewStageMounts += 1;
+        return () => {
+          interviewStageUnmounts += 1;
+        };
+      }, []);
+      return <div>Interview stage</div>;
+    };
+    const props = {
+      input: "",
+      interviewStage: <Stage />,
+      messages: [] as PetrinautAiMessage[],
+      onClose: noop,
+      onInputChange: noop,
+      onStop: noop,
+      onSubmit: noop,
+      status: "ready" as const,
+    };
+    const { rerender } = render(
+      <AiAssistantContents {...props} isOpen={true} />,
+    );
+
+    expect(screen.getByText("Interview stage")).not.toBeNull();
+    expect(screen.getByTestId("ai-interview-stage").dataset.placement).toBe(
+      "sidebar",
+    );
+    rerender(<AiAssistantContents {...props} isOpen={false} />);
+
+    expect(screen.getByTestId("ai-interview-stage").dataset.placement).toBe(
+      "detached",
+    );
+    expect(interviewStageMounts).toBe(1);
+    expect(interviewStageUnmounts).toBe(0);
+  });
+
+  test("keeps keyboard drafting available and protects clear-chat during an active interview", () => {
+    render(
+      <AiAssistantContents
+        clearMessagesDisabled={true}
+        input="Draft answer"
+        interviewStage={<div>Active interview</div>}
+        isOpen={true}
+        messages={[
+          {
+            id: "assistant-1",
+            role: "assistant",
+            parts: [{ type: "text", text: "Question" }],
+          },
+        ]}
+        onClearMessages={vi.fn()}
+        onClose={noop}
+        onInputChange={noop}
+        onStop={noop}
+        onSubmit={noop}
+        status="streaming"
+      />,
+    );
+
+    expect(
+      screen.getByRole<HTMLTextAreaElement>("textbox", {
+        name: "Message AI assistant",
+      }).disabled,
+    ).toBe(false);
+    expect(
+      screen.getByRole("complementary", { name: "AI assistant" }).className,
+    ).toContain("z_[calc(var(--z-index-sticky)_+_2)]");
+    expect(
+      screen.getByRole<HTMLButtonElement>("button", {
+        name: "Clear AI chat",
+      }).disabled,
+    ).toBe(true);
+  });
+
   test("keeps completed messages memoized when interactive tools are omitted", () => {
     const messages: PetrinautAiMessage[] = [
       {

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel/ai-assistant-contents.test.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel/ai-assistant-contents.test.tsx
@@ -121,6 +121,38 @@ describe("AiAssistantContents", () => {
     ).toBe(true);
   });
 
+  test("switches the panel between Chat composer and Interview stage", () => {
+    const onInteractionModeChange = vi.fn();
+    const props = {
+      input: "",
+      interactionMode: "chat" as const,
+      interviewAvailable: true,
+      interviewStage: <div>Interview stage</div>,
+      messages: [] as PetrinautAiMessage[],
+      onClose: noop,
+      onInputChange: noop,
+      onInteractionModeChange,
+      onStop: noop,
+      onSubmit: noop,
+      status: "ready" as const,
+    };
+    const rendered = render(<AiAssistantContents {...props} />);
+
+    expect(
+      screen.getByPlaceholderText("Describe the process you want to create"),
+    ).not.toBeNull();
+    fireEvent.click(screen.getByRole("tab", { name: "Interview" }));
+    expect(onInteractionModeChange).toHaveBeenCalledWith("interview");
+
+    rendered.rerender(
+      <AiAssistantContents {...props} interactionMode="interview" />,
+    );
+    expect(
+      screen.queryByRole("textbox", { name: "Message AI assistant" }),
+    ).toBeNull();
+    expect(screen.getByText("Interview stage")).not.toBeNull();
+  });
+
   test("keeps completed messages memoized when interactive tools are omitted", () => {
     const messages: PetrinautAiMessage[] = [
       {

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel/ai-assistant-contents.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel/ai-assistant-contents.tsx
@@ -13,6 +13,7 @@ import { css, cva } from "@hashintel/ds-helpers/css";
 
 import { AiAssistantIcon } from "../../../../components/ai-assistant-icon";
 import { ResizeHandle } from "../../../../resize/resize-handle";
+import { AiInteractionModeTabs } from "../../components/ai-interaction-mode-tabs";
 import { getMessageRenderItems } from "./ai-assistant-contents/get-message-render-items";
 import {
   PromptChips,
@@ -26,6 +27,7 @@ import {
 } from "./ai-assistant-contents/tool-list";
 
 import type { PetrinautAiInteractiveTool } from "../../../../types/ai-interactive-tool";
+import type { PetrinautAiInteractionMode } from "../../../../types/ai-assistant-composer-control";
 import type { AiToolTarget } from "./tool-summaries";
 import type { PetrinautAiMessage } from "./types";
 
@@ -39,6 +41,8 @@ export type AiAssistantContentsProps = {
   composerFocusRequest?: number;
   error?: Error;
   input: string;
+  interactionMode?: PetrinautAiInteractionMode;
+  interviewAvailable?: boolean;
   interviewStage?: ReactNode;
   interactiveTools?: readonly PetrinautAiInteractiveTool[];
   isOpen?: boolean;
@@ -46,6 +50,7 @@ export type AiAssistantContentsProps = {
   onClearMessages?: () => void;
   onClose: () => void;
   onInputChange: (value: string) => void;
+  onInteractionModeChange?: (mode: PetrinautAiInteractionMode) => void;
   onInteractiveToolSubmit?: OnInteractiveToolSubmit;
   onSelectToolTarget?: (target: AiToolTarget) => void;
   onSendPrompt?: (prompt: string) => void;
@@ -443,6 +448,8 @@ export const AiAssistantContents = ({
   composerFocusRequest = 0,
   error,
   input,
+  interactionMode = "chat",
+  interviewAvailable = false,
   interviewStage,
   interactiveTools = EMPTY_INTERACTIVE_TOOLS,
   isOpen = true,
@@ -450,6 +457,7 @@ export const AiAssistantContents = ({
   onClearMessages,
   onClose,
   onInputChange,
+  onInteractionModeChange,
   onInteractiveToolSubmit,
   onSelectToolTarget,
   onSendPrompt,
@@ -560,7 +568,14 @@ export const AiAssistantContents = ({
         <div
           className={`${headerStyle} ${panelContentStyle({ visible: isOpen })}`}
         >
-          <div className={tabStyle({ active: true })}>AI</div>
+          {interviewAvailable ? (
+            <AiInteractionModeTabs
+              mode={interactionMode}
+              onModeChange={onInteractionModeChange ?? (() => {})}
+            />
+          ) : (
+            <div className={tabStyle({ active: true })}>AI</div>
+          )}
           <div style={{ flex: 1 }} />
           <Button
             size="xs"
@@ -621,9 +636,10 @@ export const AiAssistantContents = ({
           </div>
         )}
 
-        <div
-          className={`${composerWrapStyle} ${panelContentStyle({ visible: isOpen })}`}
-        >
+        {interactionMode === "chat" && (
+          <div
+            className={`${composerWrapStyle} ${panelContentStyle({ visible: isOpen })}`}
+          >
           {showChips && (
             <PromptChips
               chips={promptChips}
@@ -669,7 +685,7 @@ export const AiAssistantContents = ({
                 }}
                 placeholder={
                   messages.length === 0
-                    ? "Get creating..."
+                    ? "Describe the process you want to create"
                     : "Continue iterating..."
                 }
                 aria-label="Message AI assistant"
@@ -693,7 +709,8 @@ export const AiAssistantContents = ({
               />
             </div>
           </form>
-        </div>
+          </div>
+        )}
       </div>
     </aside>
   );

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel/ai-assistant-contents.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel/ai-assistant-contents.tsx
@@ -34,10 +34,14 @@ type AiAssistantStatus = "submitted" | "streaming" | "ready" | "error";
 const EMPTY_INTERACTIVE_TOOLS: readonly PetrinautAiInteractiveTool[] = [];
 
 export type AiAssistantContentsProps = {
+  clearMessagesDisabled?: boolean;
   composerControl?: ReactNode;
+  composerFocusRequest?: number;
   error?: Error;
   input: string;
+  interviewStage?: ReactNode;
   interactiveTools?: readonly PetrinautAiInteractiveTool[];
+  isOpen?: boolean;
   messages: PetrinautAiMessage[];
   onClearMessages?: () => void;
   onClose: () => void;
@@ -55,26 +59,41 @@ export type AiAssistantContentsProps = {
 
 const defaultAssistantWidth = 500;
 
-const shellStyle = css({
-  position: "absolute",
-  top: "0",
-  right: "0",
-  bottom: "0",
-  width: `[${defaultAssistantWidth}px]`,
-  maxWidth: "[calc(100vw - 32px)]",
-  zIndex: "sticky",
-  padding: "2",
-  pointerEvents: "auto",
-  transition: "[right 150ms ease-in-out]",
-  _before: {
-    content: '""',
+const shellStyle = cva({
+  base: {
     position: "absolute",
-    inset: "2",
-    borderRadius: "[14px]",
-    background:
-      "[radial-gradient(circle at 78% 28%, rgba(52,160,250,0.22), rgba(190,230,255,0.04) 54%, transparent 80%)]",
-    filter: "[blur(4px)]",
-    pointerEvents: "none",
+    right: "0",
+    zIndex: "[calc(var(--z-index-sticky) + 2)]",
+    pointerEvents: "auto",
+    transition: "[right 150ms ease-in-out]",
+  },
+  variants: {
+    open: {
+      true: {
+        top: "0",
+        bottom: "0",
+        width: `[${defaultAssistantWidth}px]`,
+        maxWidth: "[calc(100vw - 32px)]",
+        padding: "2",
+        _before: {
+          content: '""',
+          position: "absolute",
+          inset: "2",
+          borderRadius: "[14px]",
+          background:
+            "[radial-gradient(circle at 78% 28%, rgba(52,160,250,0.22), rgba(190,230,255,0.04) 54%, transparent 80%)]",
+          filter: "[blur(4px)]",
+          pointerEvents: "none",
+        },
+      },
+      false: {
+        bottom: "0",
+        width: "[0px]",
+        height: "[0px]",
+        overflow: "visible",
+        pointerEvents: "none",
+      },
+    },
   },
 });
 
@@ -88,16 +107,46 @@ const resizeAnchorStyle = css({
   width: "[0]",
 });
 
-const cardStyle = css({
+const cardStyle = cva({
+  base: {
+    position: "relative",
+    display: "flex",
+    flexDirection: "column",
+  },
+  variants: {
+    open: {
+      true: {
+        height: "full",
+        overflow: "hidden",
+        backgroundColor: "neutral.s10",
+        borderRadius: "[12px]",
+        boxShadow:
+          "[0px 0px 0px 1px rgba(0,0,0,0.06), 0px 1px 1px -0.5px rgba(0,0,0,0.04), 0px 12px 12px -6px rgba(0,0,0,0.02), 0px 4px 4px -12px rgba(0,0,0,0.02)]",
+      },
+      false: {
+        width: "[0px]",
+        height: "[0px]",
+        overflow: "visible",
+        pointerEvents: "none",
+      },
+    },
+  },
+});
+
+const panelContentStyle = cva({
+  variants: {
+    visible: {
+      false: { display: "none" },
+    },
+  },
+});
+
+const interviewStageStyle = css({
   position: "relative",
-  display: "flex",
-  flexDirection: "column",
-  height: "full",
-  overflow: "hidden",
-  backgroundColor: "neutral.s10",
-  borderRadius: "[12px]",
-  boxShadow:
-    "[0px 0px 0px 1px rgba(0,0,0,0.06), 0px 1px 1px -0.5px rgba(0,0,0,0.04), 0px 12px 12px -6px rgba(0,0,0,0.02), 0px 4px 4px -12px rgba(0,0,0,0.02)]",
+  zIndex: "[2]",
+  flexShrink: "0",
+  overflow: "visible",
+  pointerEvents: "auto",
 });
 
 const headerStyle = css({
@@ -389,10 +438,14 @@ const AiAssistantMessage = memo(
 AiAssistantMessage.displayName = "AiAssistantMessage";
 
 export const AiAssistantContents = ({
+  clearMessagesDisabled = false,
   composerControl,
+  composerFocusRequest = 0,
   error,
   input,
+  interviewStage,
   interactiveTools = EMPTY_INTERACTIVE_TOOLS,
+  isOpen = true,
   messages,
   onClearMessages,
   onClose,
@@ -439,8 +492,10 @@ export const AiAssistantContents = ({
   });
 
   useEffect(() => {
-    inputRef.current?.focus();
-  }, []);
+    if (isOpen) {
+      inputRef.current?.focus();
+    }
+  }, [composerFocusRequest, isOpen]);
 
   // Auto-grow the composer to fit its content (up to `composerMaxHeight`,
   // after which it scrolls internally). Resetting to `auto` before measuring
@@ -478,14 +533,19 @@ export const AiAssistantContents = ({
 
   return (
     <aside
-      className={shellStyle}
-      style={{ right: rightOffset, width: assistantWidth }}
+      className={shellStyle({ open: isOpen })}
+      style={{
+        right: isOpen ? rightOffset : 0,
+        ...(isOpen ? { width: assistantWidth } : {}),
+      }}
       aria-label="AI assistant"
     >
       {/* Zero-width anchor on the card's left edge: the handle must straddle
           the visible card border, but the card clips overflow and the shell's
           padding pushes the shell edge away from it. */}
-      <div className={resizeAnchorStyle}>
+      <div
+        className={`${resizeAnchorStyle} ${panelContentStyle({ visible: isOpen })}`}
+      >
         <ResizeHandle
           edge="left"
           appearance="line"
@@ -496,8 +556,10 @@ export const AiAssistantContents = ({
           label="Resize AI assistant"
         />
       </div>
-      <div className={cardStyle}>
-        <div className={headerStyle}>
+      <div className={cardStyle({ open: isOpen })}>
+        <div
+          className={`${headerStyle} ${panelContentStyle({ visible: isOpen })}`}
+        >
           <div className={tabStyle({ active: true })}>AI</div>
           <div style={{ flex: 1 }} />
           <Button
@@ -506,7 +568,7 @@ export const AiAssistantContents = ({
             tone="error"
             className={headerButtonStyle}
             aria-label="Clear AI chat"
-            disabled={messages.length === 0}
+            disabled={clearMessagesDisabled || messages.length === 0}
             onClick={onClearMessages}
             iconName="trash"
             tooltip="Clear AI chat"
@@ -522,7 +584,9 @@ export const AiAssistantContents = ({
           />
         </div>
 
-        <div className={messagesStyle}>
+        <div
+          className={`${messagesStyle} ${panelContentStyle({ visible: isOpen })}`}
+        >
           {messages.length === 0 && (
             <div className={emptyStyle}>
               <AiAssistantIcon size={28} />
@@ -547,7 +611,19 @@ export const AiAssistantContents = ({
           <div ref={messagesEndRef} />
         </div>
 
-        <div className={composerWrapStyle}>
+        {interviewStage && (
+          <div
+            className={interviewStageStyle}
+            data-placement={isOpen ? "sidebar" : "detached"}
+            data-testid="ai-interview-stage"
+          >
+            {interviewStage}
+          </div>
+        )}
+
+        <div
+          className={`${composerWrapStyle} ${panelContentStyle({ visible: isOpen })}`}
+        >
           {showChips && (
             <PromptChips
               chips={promptChips}
@@ -574,7 +650,6 @@ export const AiAssistantContents = ({
                 className={composerTextareaStyle}
                 rows={1}
                 value={input}
-                disabled={isBusy}
                 onChange={(event) => onInputChange(event.currentTarget.value)}
                 onKeyDown={(event) => {
                   // Enter sends; Shift+Enter inserts a newline (the textarea's
@@ -593,11 +668,9 @@ export const AiAssistantContents = ({
                   }
                 }}
                 placeholder={
-                  isBusy
-                    ? "Waiting for response..."
-                    : messages.length === 0
-                      ? "Get creating..."
-                      : "Continue iterating..."
+                  messages.length === 0
+                    ? "Get creating..."
+                    : "Continue iterating..."
                 }
                 aria-label="Message AI assistant"
               />

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel/ai-assistant-contents.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel/ai-assistant-contents.tsx
@@ -568,10 +568,10 @@ export const AiAssistantContents = ({
         <div
           className={`${headerStyle} ${panelContentStyle({ visible: isOpen })}`}
         >
-          {interviewAvailable ? (
+          {interviewAvailable && onInteractionModeChange ? (
             <AiInteractionModeTabs
               mode={interactionMode}
-              onModeChange={onInteractionModeChange ?? (() => {})}
+              onModeChange={onInteractionModeChange}
             />
           ) : (
             <div className={tabStyle({ active: true })}>AI</div>
@@ -640,75 +640,75 @@ export const AiAssistantContents = ({
           <div
             className={`${composerWrapStyle} ${panelContentStyle({ visible: isOpen })}`}
           >
-          {showChips && (
-            <PromptChips
-              chips={promptChips}
-              disabled={isBusy}
-              onDismiss={() => setChipsDismissed(true)}
-              onSelect={(prompt) => onSendPrompt(prompt)}
-            />
-          )}
-          <form
-            onSubmit={(event) => {
-              event.preventDefault();
-              const submitter = (event.nativeEvent as SubmitEvent).submitter;
-              if (
-                canSubmit &&
-                submitter?.hasAttribute("data-ai-assistant-submit")
-              ) {
-                onSubmit();
-              }
-            }}
-          >
-            <div className={composerStyle}>
-              <textarea
-                ref={inputRef}
-                className={composerTextareaStyle}
-                rows={1}
-                value={input}
-                onChange={(event) => onInputChange(event.currentTarget.value)}
-                onKeyDown={(event) => {
-                  // Enter sends; Shift+Enter inserts a newline (the textarea's
-                  // native behaviour, so we just let it through). The
-                  // `isComposing` guard stops an IME confirmation keystroke
-                  // from sending a half-finished message.
-                  if (
-                    event.key === "Enter" &&
-                    !event.shiftKey &&
-                    !event.nativeEvent.isComposing
-                  ) {
-                    event.preventDefault();
-                    if (canSubmit) {
-                      onSubmit();
-                    }
-                  }
-                }}
-                placeholder={
-                  messages.length === 0
-                    ? "Describe the process you want to create"
-                    : "Continue iterating..."
+            {showChips && (
+              <PromptChips
+                chips={promptChips}
+                disabled={isBusy}
+                onDismiss={() => setChipsDismissed(true)}
+                onSelect={(prompt) => onSendPrompt(prompt)}
+              />
+            )}
+            <form
+              onSubmit={(event) => {
+                event.preventDefault();
+                const submitter = (event.nativeEvent as SubmitEvent).submitter;
+                if (
+                  canSubmit &&
+                  submitter?.hasAttribute("data-ai-assistant-submit")
+                ) {
+                  onSubmit();
                 }
-                aria-label="Message AI assistant"
-              />
-              {composerControl}
-              <Button
-                data-ai-assistant-submit
-                type={isBusy ? "button" : "submit"}
-                size="sm"
-                variant={isBusy ? "subtle" : "solid"}
-                tone={isBusy ? "neutral" : "brand"}
-                disabled={!isBusy && !canSubmit}
-                aria-label={isBusy ? "Stop AI response" : "Send message"}
-                onClick={() => {
-                  if (isBusy) {
-                    onStop();
+              }}
+            >
+              <div className={composerStyle}>
+                <textarea
+                  ref={inputRef}
+                  className={composerTextareaStyle}
+                  rows={1}
+                  value={input}
+                  onChange={(event) => onInputChange(event.currentTarget.value)}
+                  onKeyDown={(event) => {
+                    // Enter sends; Shift+Enter inserts a newline (the textarea's
+                    // native behaviour, so we just let it through). The
+                    // `isComposing` guard stops an IME confirmation keystroke
+                    // from sending a half-finished message.
+                    if (
+                      event.key === "Enter" &&
+                      !event.shiftKey &&
+                      !event.nativeEvent.isComposing
+                    ) {
+                      event.preventDefault();
+                      if (canSubmit) {
+                        onSubmit();
+                      }
+                    }
+                  }}
+                  placeholder={
+                    messages.length === 0
+                      ? "Describe the process you want to create"
+                      : "Continue iterating..."
                   }
-                }}
-                iconName={isBusy ? "stopFilled" : "arrowUp"}
-                tooltip={isBusy ? "Stop AI response" : "Send message"}
-              />
-            </div>
-          </form>
+                  aria-label="Message AI assistant"
+                />
+                {composerControl}
+                <Button
+                  data-ai-assistant-submit
+                  type={isBusy ? "button" : "submit"}
+                  size="sm"
+                  variant={isBusy ? "subtle" : "solid"}
+                  tone={isBusy ? "neutral" : "brand"}
+                  disabled={!isBusy && !canSubmit}
+                  aria-label={isBusy ? "Stop AI response" : "Send message"}
+                  onClick={() => {
+                    if (isBusy) {
+                      onStop();
+                    }
+                  }}
+                  iconName={isBusy ? "stopFilled" : "arrowUp"}
+                  tooltip={isBusy ? "Stop AI response" : "Send message"}
+                />
+              </div>
+            </form>
           </div>
         )}
       </div>

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel/ai-assistant-contents.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel/ai-assistant-contents.tsx
@@ -26,8 +26,8 @@ import {
   type OnInteractiveToolSubmit,
 } from "./ai-assistant-contents/tool-list";
 
-import type { PetrinautAiInteractiveTool } from "../../../../types/ai-interactive-tool";
 import type { PetrinautAiInteractionMode } from "../../../../types/ai-assistant-composer-control";
+import type { PetrinautAiInteractiveTool } from "../../../../types/ai-interactive-tool";
 import type { AiToolTarget } from "./tool-summaries";
 import type { PetrinautAiMessage } from "./types";
 
@@ -541,12 +541,13 @@ export const AiAssistantContents = ({
 
   return (
     <aside
+      aria-hidden={!isOpen && !interviewStage ? true : undefined}
+      aria-label="AI assistant"
       className={shellStyle({ open: isOpen })}
       style={{
         right: isOpen ? rightOffset : 0,
         ...(isOpen ? { width: assistantWidth } : {}),
       }}
-      aria-label="AI assistant"
     >
       {/* Zero-width anchor on the card's left edge: the handle must straddle
           the visible card border, but the card clips overflow and the shell's


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR turns the H-6763 composer microphone into a persistent, half-duplex interview experience. Domain experts can hear canonical Brunch questions, answer by voice, review finalized transcripts, correct an answer, pause or interrupt playback, fall back to typing, and end the interview without losing the surrounding conversation.

It is stacked on #9378 and keeps provider-specific OpenAI transport, transcription, and synthesis in the Petrinaut website host while exposing a provider-neutral interview stage through Petrinaut. The remaining upstream ask-emission contract and credentialed end-to-end witness are called out below rather than hidden behind the UI.

## 🔗 Related links

- [H-6763: Support for realtime audio interviewing of domain experts](https://linear.app/hash/issue/H-6763/support-for-realtime-audio-interviewing-of-domain-experts) _(internal)_
- [#9378: Improve voice preview reliability diagnostics](https://github.com/hashintel/hash/pull/9378) — required parent PR
- [ADR-0009: OpenAI voice UI turn shell](https://github.com/hashintel/hash/blob/kostandin/h-6763-voice-interview-ux/libs/%40hashintel/brunch-agent/docs/adr/0009-openai-voice-ui-turn-shell.md)
- [Condition-5 turn-latency assessment](https://github.com/hashintel/hash/blob/kostandin/h-6763-voice-interview-ux/libs/%40hashintel/brunch-agent/docs/evidence/evaluations/process-model-elicitation/baseline/condition-5-turn-latency.md)

## 🚫 Blocked by

- [ ] [#9378](https://github.com/hashintel/hash/pull/9378)
- [ ] An accepted Brunch/Flue contract that emits the terminal `brunch_ask` before background sweep/settlement. The controller consumes an emitted ask immediately, but current upstream ordering can still delay emission; the UI deliberately does not claim answer readiness before a canonical ask exists.

## 🔍 What does this change?

- Adds a provider-neutral interview-stage API to Petrinaut and an OpenAI-backed implementation in `@apps/petrinaut-website`.
- Keeps one controller and WebRTC session alive across full sidebar, compact sidebar, and detached bottom-bar presentations. Placement changes do not reconnect or reopen the microphone; recoverable errors reopen the full stage.
- Separates interview-answer capacity from generic chat readiness, speaks emitted `brunch_ask` text before settlement completes, and records finalized-answer → question-visible/spoken/answer-ready latency.
- Implements explicit half-duplex turn taking: playback completes before capture opens, **Interrupt and speak** cancels playback first, and **Done speaking** closes capture while provider VAD remains the single commit authority.
- Adds a real RMS microphone meter whose audio context is resumed from the start action, plus reduced-motion and text equivalents.
- Distinguishes provisional and committed transcripts, gates redo/edit controls on actual correction capacity, preserves rejected correction drafts, and clears prior-answer state when an interview ends.
- Keeps the current question and keyboard composer visible, protects active interviews from Clear Chat, and presents authoritative covered/still-exploring topics without speculative projection or question counts.
- Adds disclosure and consent, accessible responsive controls, Petrinaut user documentation, and the required Petrinaut changeset.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] modifies an **npm**-publishable library and **I have added a changeset file(s)**

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] require changes to docs which **are made** as part of this PR

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

- The accepted upstream ask-before-settlement contract described in **Blocked by** is not yet available, so upstream work can still delay when the next question is emitted.
- The authoritative projection contract is not available. This PR therefore leaves Petrinaut's main canvas as the model surface instead of rendering a speculative preview.
- No credentialed OpenAI + Brunch browser witness was available. Browser review covered start, responsive layout, microphone-error recovery, keyboard fallback, Clear Chat protection, and accessibility, but not real synthesis quality or end-to-end turn latency.

## 🐾 Next steps

- Establish terminal-ask emission before background settlement and capture the requested answer-to-next-question latency witness.
- Run a credentialed expert witness covering interruption, vocabulary rendering, microphone feedback, correction flows, and presentation transitions.
- Connect the emerging model to Petrinaut's main canvas when the authoritative projection contract is available.

## 🛡 What tests cover this?

- `yarn workspace @apps/petrinaut-website test:unit` — 18 files and 130 tests covering the realtime session, turn controller, speech playback, responsive interview controls, diagnostics, and mocked integration boundary.
- `yarn workspace @hashintel/petrinaut test:unit` — 28 files and 220 tests covering the host API, conversation lifecycle, answer queue, Clear Chat protection, and panel integration.
- Brunch transport and app unit suites cover interview-answer routing and terminal ask behavior.
- Website and Petrinaut TypeScript/ESLint checks cover the affected packages; formatting and Markdown lint pass for the changed files and user guide.
- Browser checks cover desktop and 390 px layouts, recovery behavior, and the affected sidebar's WCAG A/AA axe audit.

## ❓ How to test this?

1. Configure the Petrinaut website with the OpenAI voice preview enabled, a valid OpenAI API key, and a Brunch chat endpoint.
2. Open the AI sidebar and select **Start voice interview**. Confirm disclosure and consent appear before microphone access, then start the interview.
3. Confirm the canonical question is visible and spoken before the microphone opens, and that the microphone meter responds only while capture is active.
4. Exercise **Done speaking**, pause/resume, minimize/expand, sidebar close/reopen, **Interrupt and speak**, redo, typed correction, and keyboard fallback. Confirm presentation changes alone do not reconnect or change microphone state.
5. While an interview is active, confirm Clear Chat is disabled. Trigger a recoverable microphone or network error and confirm the sidebar reopens to the full recovery stage.
6. Confirm correction controls remain disabled while an answer is being written down, rejected correction text remains editable, and ending/restarting does not expose the prior answer.
7. At a 390 px viewport, confirm the full stage stays above the composer and the detached compact presentation becomes a bottom bar.

## 📹 Demo
https://www.loom.com/share/4592af568cf144cd9f58c0b579da6492