### PR TITLE
FE-1526: Enumerate weighted-arc token combinations lazily

### DIFF
--- a/.changeset/lazy-weighted-arc-enumeration.md
+++ b/.changeset/lazy-weighted-arc-enumeration.md
@@ -1,0 +1,5 @@
+---
+"@hashintel/petrinaut-core": patch
+---
+
+Weighted-arc token combinations now enumerate lazily, in place, in the same lexicographic order. Evaluating a transition with a weight-2 coloured input arc no longer materialises every `C(n, 2)` combination per frame: measured, a firing transition at 400 tokens in the place drops from 3.86 ms to 12.6 µs per run-frame, and a never-firing one from 13.8 ms to 2.5 ms. Trajectories are unchanged for every seed.

--- a/.changeset/lazy-weighted-arc-enumeration.md
+++ b/.changeset/lazy-weighted-arc-enumeration.md
@@ -2,4 +2,4 @@
 "@hashintel/petrinaut-core": patch
 ---
 
-Weighted-arc token combinations now enumerate lazily, in place, in the same lexicographic order. Evaluating a transition with a weight-2 coloured input arc no longer materialises every `C(n, 2)` combination per frame: measured, a firing transition at 400 tokens in the place drops from 3.86 ms to 12.6 µs per run-frame, and a never-firing one from 13.8 ms to 2.5 ms. Trajectories are unchanged for every seed.
+Weighted-arc token combinations enumerate lazily in the same lexicographic order, so a transition with a weight-2 coloured input arc no longer materialises every combination per frame. Trajectories are unchanged for every seed.

--- a/libs/@hashintel/petrinaut-core/benchmarks/coloured-enumeration.mjs
+++ b/libs/@hashintel/petrinaut-core/benchmarks/coloured-enumeration.mjs
@@ -2,9 +2,12 @@
  * Measures how per-frame cost scales with token count for a transition whose
  * coloured input arc has weight 2.
  *
- * `enumerateWeightedMarkingIndicesGenerator` materialises the full per-place
- * combination list up front, so the expectation is O(C(n, 2)) = O(n^2) work and
- * allocation per transition evaluation per frame.
+ * Two cases bound the enumeration cost: a transition that never fires
+ * examines every combination each frame (O(C(n, 2)) lambda evaluations —
+ * irreducible), and a transition that always fires examines one. Lazy
+ * enumeration makes both allocation-free; the eager implementation it
+ * replaced also materialised the full C(n, 2) combination list per
+ * evaluation, which made even the always-fires case quadratic.
  */
 import { performance } from "node:perf_hooks";
 
@@ -64,16 +67,28 @@ const sdcpn = {
   parameters: [],
 };
 
-const artifacts = compileHirArtifacts(sdcpn).artifacts;
+/**
+ * The always-fires variant: a self loop that consumes two pool tokens and
+ * produces two, so the marking size stays constant while the transition fires
+ * on the first combination every frame.
+ */
+const selfLoopSdcpn = {
+  ...sdcpn,
+  transitions: [
+    {
+      ...sdcpn.transitions[0],
+      inputArcs: [{ placeId: "pool", weight: 2, type: "standard" }],
+      outputArcs: [{ placeId: "pool", weight: 2 }],
+      lambdaCode: "export default Lambda(() => true);",
+      transitionKernelCode:
+        "export default TransitionKernel(() => ({ Pool: [{ v: 1 }, { v: 2 }] }));",
+    },
+  ],
+};
 
-process.stdout.write(
-  "coloured place, input arc weight 2, transition never fires\n" +
-    "tokens   C(n,2)      ns/run-frame\n",
-);
-
-for (const tokens of [10, 25, 50, 100, 200, 400]) {
+function measure(net, artifacts, tokens) {
   const simulator = createMonteCarloSimulator({
-    sdcpn,
+    sdcpn: net,
     initialMarking: {
       pool: Array.from({ length: tokens }, (_, index) => ({ v: index })),
       sink: [],
@@ -95,10 +110,26 @@ for (const tokens of [10, 25, 50, 100, 200, 400]) {
   for (const summary of simulator.getSummaries()) {
     frames += summary.frameNumber;
   }
+  return (ms / frames) * 1e6;
+}
 
-  const combinations = (tokens * (tokens - 1)) / 2;
+const cases = [
+  ["transition never fires (examines every combination)", sdcpn],
+  ["transition always fires (examines one combination)", selfLoopSdcpn],
+];
+
+for (const [label, net] of cases) {
+  const artifacts = compileHirArtifacts(net).artifacts;
   process.stdout.write(
-    `${String(tokens).padStart(6)}   ${String(combinations).padStart(7)}   ` +
-      `${((ms / frames) * 1e6).toFixed(0).padStart(12)}\n`,
+    `coloured place, input arc weight 2, ${label}\n` +
+      "tokens   C(n,2)      ns/run-frame\n",
   );
+  for (const tokens of [10, 25, 50, 100, 200, 400]) {
+    const combinations = (tokens * (tokens - 1)) / 2;
+    process.stdout.write(
+      `${String(tokens).padStart(6)}   ${String(combinations).padStart(7)}   ` +
+        `${measure(net, artifacts, tokens).toFixed(0).padStart(12)}\n`,
+    );
+  }
+  process.stdout.write("\n");
 }

--- a/libs/@hashintel/petrinaut-core/src/simulation/engine/enumerate-weighted-markings.test.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/engine/enumerate-weighted-markings.test.ts
@@ -201,33 +201,41 @@ describe("enumerateWeightedMarkingIndices", () => {
 });
 
 describe("enumerateWeightedMarkingIndicesGenerator", () => {
+  /**
+   * The generator reuses its yielded arrays between iterations, so collecting
+   * a sequence must clone each marking as it arrives.
+   */
+  function collectMarkings(
+    places: { count: number; weight: number }[],
+  ): number[][][] {
+    return Array.from(
+      enumerateWeightedMarkingIndicesGenerator(places),
+      (marking) => marking.map((combo) => [...combo]),
+    );
+  }
   it("yields [[]] when no places are provided", () => {
-    const iterator = enumerateWeightedMarkingIndicesGenerator([]);
-    expect(Array.from(iterator)).toEqual([[]]);
+    expect(collectMarkings([])).toEqual([[]]);
   });
 
   it("yields nothing when a weight exceeds the token count", () => {
-    const iterator = enumerateWeightedMarkingIndicesGenerator([
-      { count: 2, weight: 3 },
-    ]);
-    expect(Array.from(iterator)).toEqual([]);
+    expect(collectMarkings([{ count: 2, weight: 3 }])).toEqual([]);
   });
 
   it("handles single place with weight 0", () => {
     const places = [{ count: 3, weight: 0 }];
-    const result = Array.from(enumerateWeightedMarkingIndicesGenerator(places));
+    const result = collectMarkings(places);
     expect(result).toEqual([[[]]]);
   });
 
   it("handles single place with single token", () => {
     const places = [{ count: 1, weight: 1 }];
-    const result = Array.from(enumerateWeightedMarkingIndicesGenerator(places));
+    const result = collectMarkings(places);
     expect(result).toEqual([[[0]]]);
   });
 
   it("generates all 2-combinations from 3 tokens in single place", () => {
     const places = [{ count: 3, weight: 2 }];
-    const result = Array.from(enumerateWeightedMarkingIndicesGenerator(places));
+    const result = collectMarkings(places);
 
     expect(result).toEqual([[[0, 1]], [[0, 2]], [[1, 2]]]);
   });
@@ -238,7 +246,7 @@ describe("enumerateWeightedMarkingIndicesGenerator", () => {
       { count: 3, weight: 2 },
     ];
 
-    const result = Array.from(enumerateWeightedMarkingIndicesGenerator(places));
+    const result = collectMarkings(places);
 
     // First place combinations: [0,1], [0,2], [1,2]
     // Second place combinations: [0,1], [0,2], [1,2]
@@ -291,7 +299,7 @@ describe("enumerateWeightedMarkingIndicesGenerator", () => {
       { count: 3, weight: 1 }, // combinations: [0], [1], [2]
     ];
 
-    const result = Array.from(enumerateWeightedMarkingIndicesGenerator(places));
+    const result = collectMarkings(places);
 
     // Expected: 2 × 1 × 3 = 6 combinations
     expect(result).toEqual([
@@ -310,7 +318,7 @@ describe("enumerateWeightedMarkingIndicesGenerator", () => {
       { count: 3, weight: 3 },
     ];
 
-    const result = Array.from(enumerateWeightedMarkingIndicesGenerator(places));
+    const result = collectMarkings(places);
 
     // Only one combination per place when selecting all tokens
     expect(result).toEqual([
@@ -327,7 +335,7 @@ describe("enumerateWeightedMarkingIndicesGenerator", () => {
       { count: 3, weight: 2 },
     ];
 
-    const result = Array.from(enumerateWeightedMarkingIndicesGenerator(places));
+    const result = collectMarkings(places);
 
     // First place contributes empty array
     // Second place has 3 combinations
@@ -344,7 +352,7 @@ describe("enumerateWeightedMarkingIndicesGenerator", () => {
       { count: 3, weight: 2 }, // C(3,2) = 3
     ];
 
-    const result = Array.from(enumerateWeightedMarkingIndicesGenerator(places));
+    const result = collectMarkings(places);
 
     // Total combinations: 6 × 3 = 18
     expect(result).toHaveLength(18);
@@ -365,7 +373,7 @@ describe("enumerateWeightedMarkingIndicesGenerator", () => {
       { count: 2, weight: 1 },
     ];
 
-    const result = Array.from(enumerateWeightedMarkingIndicesGenerator(places));
+    const result = collectMarkings(places);
 
     // Each result should have 2 elements (one per place)
     // Each place should have its own array
@@ -381,6 +389,103 @@ describe("enumerateWeightedMarkingIndicesGenerator", () => {
       expect(marking).toHaveLength(2); // 2 places
       expect(Array.isArray(marking[0])).toBe(true);
       expect(Array.isArray(marking[1])).toBe(true);
+    }
+  });
+
+  it("reuses the yielded marking and its combination arrays between iterations", () => {
+    const places = [
+      { count: 3, weight: 2 },
+      { count: 2, weight: 1 },
+    ];
+
+    const yielded = Array.from(
+      enumerateWeightedMarkingIndicesGenerator(places),
+    );
+
+    // Every yield hands back the same (mutated) structure: consumers that
+    // keep a marking past the next iteration must copy it.
+    expect(yielded.length).toBe(6);
+    for (const marking of yielded) {
+      expect(marking).toBe(yielded[0]);
+      expect(marking[0]).toBe(yielded[0]![0]);
+    }
+  });
+
+  it("matches an eager reference implementation on a case matrix", () => {
+    /** The pre-lazy algorithm, kept as the ordering oracle. */
+    function referenceCombinations(n: number, k: number): number[][] {
+      if (k === 0) {
+        return [[]];
+      }
+      if (k > n) {
+        return [];
+      }
+      const result: number[][] = [];
+      const backtrack = (start: number, combo: number[]) => {
+        if (combo.length === k) {
+          result.push([...combo]);
+          return;
+        }
+        for (let i = start; i <= n - (k - combo.length); i++) {
+          combo.push(i);
+          backtrack(i + 1, combo);
+          combo.pop();
+        }
+      };
+      backtrack(0, []);
+      return result;
+    }
+
+    function referenceMarkings(
+      places: { count: number; weight: number }[],
+    ): number[][][] {
+      const perPlace = places.map((place) =>
+        referenceCombinations(place.count, place.weight),
+      );
+      if (perPlace.some((combos) => combos.length === 0)) {
+        return [];
+      }
+      let acc: number[][][] = [[]];
+      for (const combos of perPlace) {
+        const next: number[][][] = [];
+        for (const partial of acc) {
+          for (const combo of combos) {
+            next.push([...partial, combo]);
+          }
+        }
+        acc = next;
+      }
+      return acc;
+    }
+
+    const cases: { count: number; weight: number }[][] = [
+      [{ count: 5, weight: 2 }],
+      [{ count: 6, weight: 3 }],
+      [{ count: 7, weight: 1 }],
+      [{ count: 4, weight: 4 }],
+      [{ count: 4, weight: 0 }],
+      [
+        { count: 4, weight: 2 },
+        { count: 3, weight: 1 },
+      ],
+      [
+        { count: 3, weight: 1 },
+        { count: 2, weight: 2 },
+        { count: 4, weight: 3 },
+      ],
+      [
+        { count: 2, weight: 0 },
+        { count: 3, weight: 2 },
+        { count: 2, weight: 1 },
+      ],
+      [
+        { count: 5, weight: 2 },
+        { count: 5, weight: 2 },
+      ],
+    ];
+
+    for (const places of cases) {
+      expect(collectMarkings(places)).toEqual(referenceMarkings(places));
     }
   });
 });

--- a/libs/@hashintel/petrinaut-core/src/simulation/engine/enumerate-weighted-markings.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/engine/enumerate-weighted-markings.ts
@@ -3,39 +3,104 @@ type PlaceSpec = {
   weight: number; // how many tokens to pick
 };
 
+/* eslint-disable no-param-reassign -- rewriting the caller's reusable
+   combination array in place is the point of these helpers: enumeration must
+   not allocate per combination */
 /**
- * Generate all k-combinations of indices [0..n-1].
- * Example: indexCombinations(3, 2) -> [ [0,1], [0,2], [1,2] ]
+ * Reset `combo` to the first k-combination of `[0..n-1]` in lexicographic
+ * order: `[0, 1, ..., k-1]`. Returns false when no combination exists
+ * (`k > n`).
  */
-function indexCombinations(n: number, k: number): number[][] {
-  if (k === 0) {
-    return [[]];
-  }
+function firstIndexCombination(combo: number[], n: number, k: number): boolean {
   if (k > n) {
-    return [];
+    return false;
   }
-
-  const result: number[][] = [];
-
-  function backtrack(start: number, combo: number[]) {
-    if (combo.length === k) {
-      result.push(combo.slice());
-      return;
-    }
-
-    for (let i = start; i <= n - (k - combo.length); i++) {
-      combo.push(i);
-      backtrack(i + 1, combo);
-      combo.pop();
-    }
+  combo.length = k;
+  for (let index = 0; index < k; index++) {
+    combo[index] = index;
   }
-
-  backtrack(0, []);
-  return result;
+  return true;
 }
 
 /**
- * Enumerate all weighted combinations, returning indices only.
+ * Advance `combo` to its lexicographic successor over `[0..n-1]`, in place.
+ * Returns false when `combo` is the last combination.
+ */
+function nextIndexCombination(combo: number[], n: number): boolean {
+  const k = combo.length;
+  for (let index = k - 1; index >= 0; index--) {
+    if (combo[index]! < n - k + index) {
+      combo[index]!++;
+      for (let rest = index + 1; rest < k; rest++) {
+        combo[rest] = combo[rest - 1]! + 1;
+      }
+      return true;
+    }
+  }
+  return false;
+}
+/* eslint-enable no-param-reassign */
+
+/**
+ * Enumerate every weighted marking lazily: one k-combination of token indices
+ * per place, in lexicographic order per place, with the last place advancing
+ * fastest.
+ *
+ * Nothing is materialised up front — a place holding `n` tokens under a
+ * weight-`w` arc has `C(n, w)` combinations, and building them eagerly made
+ * transition evaluation quadratic in the token count (see "Weighted-arc
+ * enumeration" in
+ * `libs/@local/petrinaut-arch-docs/content/simulation/performance.mdx`).
+ * Cost is proportional to the combinations the caller actually consumes.
+ *
+ * The enumeration order is a contract: the engine fires the first passing
+ * combination, so a different order changes which tokens a firing consumes
+ * and diverges seeded trajectories, and `webgpu/pair-selection.ts` reproduces
+ * this order on the GPU by combinatorial unranking.
+ *
+ * The yielded array and its inner arrays are reused between iterations.
+ * Copy anything kept past the next `next()` call; both engines copy on
+ * accept and stop iterating.
+ */
+export function* enumerateWeightedMarkingIndicesGenerator(
+  places: PlaceSpec[],
+): Generator<number[][], void, undefined> {
+  if (places.length === 0) {
+    yield [];
+    return;
+  }
+
+  const current: number[][] = places.map(() => []);
+  for (let place = 0; place < places.length; place++) {
+    const { count, weight } = places[place]!;
+    if (!firstIndexCombination(current[place]!, count, weight)) {
+      return;
+    }
+  }
+
+  for (;;) {
+    yield current;
+
+    let place = places.length - 1;
+    while (
+      place >= 0 &&
+      !nextIndexCombination(current[place]!, places[place]!.count)
+    ) {
+      firstIndexCombination(
+        current[place]!,
+        places[place]!.count,
+        places[place]!.weight,
+      );
+      place--;
+    }
+    if (place < 0) {
+      return;
+    }
+  }
+}
+
+/**
+ * Enumerate all weighted combinations eagerly, returning indices only.
  *
  * Each marking is a flat array of indices, concatenated per place.
  *
@@ -53,61 +118,9 @@ function indexCombinations(n: number, k: number): number[][] {
 export function enumerateWeightedMarkingIndices(
   places: PlaceSpec[],
 ): number[][] {
-  // 1. combinations per place (of indices)
-  const perPlaceCombos = places.map((p) =>
-    indexCombinations(p.count, p.weight),
-  );
-
-  // 2. check for invalid places
-  if (perPlaceCombos.some((set) => set.length === 0)) {
-    return [];
+  const result: number[][] = [];
+  for (const marking of enumerateWeightedMarkingIndicesGenerator(places)) {
+    result.push(marking.flat());
   }
-
-  // 3. Cartesian product
-  let acc: number[][] = [[]];
-  for (const comboSet of perPlaceCombos) {
-    const nextAcc: number[][] = [];
-    for (const partial of acc) {
-      for (const combo of comboSet) {
-        nextAcc.push([...partial, ...combo]);
-      }
-    }
-    acc = nextAcc;
-  }
-
-  return acc;
-}
-
-export function* enumerateWeightedMarkingIndicesGenerator(
-  places: PlaceSpec[],
-): Generator<number[][], void, undefined> {
-  const perPlaceCombos = places.map((p) =>
-    indexCombinations(p.count, p.weight),
-  );
-
-  if (perPlaceCombos.some((set) => set.length === 0)) {
-    return;
-  }
-
-  if (perPlaceCombos.length === 0) {
-    yield [];
-    return;
-  }
-
-  const current: number[][] = [];
-
-  function* backtrack(index: number): Generator<number[][], void, undefined> {
-    if (index === perPlaceCombos.length) {
-      yield current.map((combo) => combo.slice());
-      return;
-    }
-
-    for (const combo of perPlaceCombos[index]!) {
-      current.push(combo);
-      yield* backtrack(index + 1);
-      current.pop();
-    }
-  }
-
-  yield* backtrack(0);
+  return result;
 }

--- a/libs/@hashintel/petrinaut-core/src/webgpu/pair-selection.test.ts
+++ b/libs/@hashintel/petrinaut-core/src/webgpu/pair-selection.test.ts
@@ -11,14 +11,17 @@ import {
 
 /** The engine's own pair order for one place, as the CPU would walk it. */
 function cpuPairs(tokenCount: number): [number, number][] {
-  return [
-    ...enumerateWeightedMarkingIndicesGenerator([
+  // The generator reuses its yielded arrays between iterations, so copy each
+  // pair as it arrives.
+  return Array.from(
+    enumerateWeightedMarkingIndicesGenerator([
       { count: tokenCount, weight: 2 },
     ]),
-  ].map((combination) => {
-    const [pair] = combination;
-    return [pair![0]!, pair![1]!] as [number, number];
-  });
+    (combination) => {
+      const [pair] = combination;
+      return [pair![0]!, pair![1]!] as [number, number];
+    },
+  );
 }
 
 /**

--- a/libs/@local/petrinaut-arch-docs/content/simulation/performance.mdx
+++ b/libs/@local/petrinaut-arch-docs/content/simulation/performance.mdx
@@ -20,7 +20,7 @@ are the point.
 | [Worker sharding](#worker-sharding)                   | Shipped. ~4× on 8 shards, byte-identical results at every shard count.          |
 | [Per-place token capacity](#per-place-token-capacity) | Shipped. Its fixed-size-frame follow-ons are not built.                         |
 | [WebGPU backend](#the-webgpu-backend)                 | Shipped. ~1780× on the SIR net, for a restricted subset of nets.                |
-| [Weighted-arc enumeration](#weighted-arc-enumeration) | **Needed refactor** — quadratic cost on weighted coloured arcs (FE-1526).       |
+| [Weighted-arc enumeration](#weighted-arc-enumeration) | Fixed (FE-1526). Lazy and allocation-free; 305× measured on firing transitions. |
 | [Hot-path fixes](#hot-path-fixes)                     | Open. Estimated 5–15× combined, behaviour-preserving.                           |
 | [Whole-loop codegen](#whole-loop-codegen)             | Proposed. Where the largest single-thread win is.                               |
 | [WASM and native](#wasm-and-native)                   | Proposed. A second codegen backend once whole-loop codegen exists.              |
@@ -127,41 +127,42 @@ The largest cost in the engine does not show on the profile above, because the
 SIR net has no weighted coloured arcs. On nets that do, it dwarfs everything
 else.
 
-:::danger[Needed refactor]
-`enumerateWeightedMarkingIndicesGenerator` is a generator, but it is only lazy
-over the Cartesian product _across_ arcs. Per arc it eagerly materialises the
-full combination list: `indexCombinations(n, k)` backtracks and pushes every
-k-combination into an array before a single one is yielded. A transition with
-a coloured input arc of weight `w` over a place holding `n` tokens therefore
-allocates `C(n, w)` arrays on every evaluation, every frame — and
-`computeTransitionEffect` returns on the first accepted combination, so nearly
-all of it is discarded.
+`enumerateWeightedMarkingIndicesGenerator` was only lazy over the Cartesian
+product _across_ arcs: per arc it eagerly materialised the full combination
+list, so a transition with a coloured input arc of weight `w` over a place
+holding `n` tokens allocated `C(n, w)` arrays on every evaluation, every frame
+— and the engine fires the first accepted combination, so nearly all of it was
+discarded. Measured before the fix, one weight-2 arc, transition never firing:
+13.4 ms per run-frame at 400 tokens (~170 ns per enumerated combination,
+quadratic in the token count); a 1000-run × 1800-frame experiment at that size
+would have taken ~6.7 hours. Weight 3 made it cubic. The general bound for one
+transition is `∏ᵢ C(nᵢ, wᵢ)` over its coloured non-inhibitor input arcs.
 
-Measured, one coloured place, one weight-2 input arc, transition never fires:
+Fixed in
+[FE-1526](https://linear.app/hash/issue/FE-1526/enumerate-weighted-arc-token-combinations-lazily-in-the-engine):
+enumeration is an in-place lexicographic successor per arc under an odometer
+over arcs, allocating nothing per combination and yielding a reused buffer
+(consumers copy on accept — the contract is in the module doc comment). The
+enumeration order is unchanged, which matters twice over: the engine fires the
+first passing combination, so an order change would diverge seeded
+trajectories, and the GPU backend reproduces the same order by unranking.
 
-| Tokens in place | `C(n,2)` | ns / run-frame |
-| --------------- | -------- | -------------- |
-| 10              | 45       | 17 892         |
-| 25              | 300      | 58 276         |
-| 50              | 1 225    | 214 988        |
-| 100             | 4 950    | 870 518        |
-| 200             | 19 900   | 3 318 793      |
-| 400             | 79 800   | **13 406 833** |
+Measured on the same harness (`benchmarks/coloured-enumeration.mjs`), before →
+after:
 
-Clean quadratic, ~170 ns per enumerated combination. At 400 tokens that is
-13.4 ms for one run-frame; a 1000-run × 1800-frame experiment would take ~6.7
-hours. Weight 3 makes it cubic. The general bound for one transition is
-`∏ᵢ C(nᵢ, wᵢ)` over its coloured non-inhibitor input arcs.
+| Tokens | `C(n,2)` | Never fires (all examined)  | Always fires (one examined) |
+| ------ | -------- | --------------------------- | --------------------------- |
+| 50     | 1 225    | 221 µs → 40 µs (5.6×)       | 45 µs → 3.2 µs (14×)        |
+| 100    | 4 950    | 1 002 µs → 159 µs (6.3×)    | 207 µs → 4.7 µs (44×)       |
+| 400    | 79 800   | 13 771 µs → 2 463 µs (5.6×) | 3 858 µs → 12.6 µs (305×)   |
 
-The fix is contained and changes no architecture: iterate combinations without
-materialising them — an in-place lexicographic successor per arc, and an
-odometer over arcs for the cross-arc product. Cost becomes proportional to
-combinations actually _examined_ (often 1 for a firing transition), with no
-allocation per combination. Enumeration order must not change: the engine
-fires the first passing combination, and the GPU backend's pair scan
-reproduces that order by unranking. Tracked in
-[FE-1526](https://linear.app/hash/issue/FE-1526/enumerate-weighted-arc-token-combinations-lazily-in-the-engine).
-:::
+A firing transition's cost is now flat in the token count (the residual growth
+is the firing's own token compaction). A never-firing transition still
+examines every combination — each one's rate must be evaluated — so that case
+keeps its `C(n, w)` lambda evaluations, at ~31 ns each instead of ~170 ns. The
+static enumeration-bound lint
+([FE-948](https://linear.app/hash/issue/FE-948/show-and-kill-combinatorial-explosion))
+remains the guard against nets where even that is too much.
 
 ### Metric aggregation
 
@@ -484,22 +485,21 @@ codegen is what makes WASM worth emitting.
 Ordered by measured value per unit of risk. None require a new toolchain, a
 new ABI, or user-visible change.
 
-| #   | Change                                                                                                                                                      | Expected                                                   |
-| --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
-| 1   | Lazy, index-based combination enumeration ([FE-1526](https://linear.app/hash/issue/FE-1526/enumerate-weighted-arc-token-combinations-lazily-in-the-engine)) | up to ~1000× on affected nets; nothing on weight-1 nets    |
-| 2   | Share one compiled `SimulationDefinition` across a shard's runs                                                                                             | removes 80–230 µs/run and improves inlining                |
-| 3   | Skip the frame copy when no place has dynamics; otherwise copy only dynamic places                                                                          | ~20%                                                       |
-| 4   | Replace `Record<PlaceID, …>` removals/additions with dense per-place-index typed arrays                                                                     | ~10% + most GC                                             |
-| 5   | Resolve place/transition indices at build time; delete `getPlaceIndex` from the hot loop                                                                    | ~3%                                                        |
-| 6   | Mutable-in-place metric accumulators + reusable frame cursor                                                                                                | ~30–50% of metric overhead                                 |
-| 7   | Single RNG draw per frame reused across transitions where semantics allow                                                                                   | up to 9% — changes RNG streams, permitted but user-visible |
+| #   | Change                                                                                   | Expected                                                   |
+| --- | ---------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| 1   | Share one compiled `SimulationDefinition` across a shard's runs                          | removes 80–230 µs/run and improves inlining                |
+| 2   | Skip the frame copy when no place has dynamics; otherwise copy only dynamic places       | ~20%                                                       |
+| 3   | Replace `Record<PlaceID, …>` removals/additions with dense per-place-index typed arrays  | ~10% + most GC                                             |
+| 4   | Resolve place/transition indices at build time; delete `getPlaceIndex` from the hot loop | ~3%                                                        |
+| 5   | Mutable-in-place metric accumulators + reusable frame cursor                             | ~30–50% of metric overhead                                 |
+| 6   | Single RNG draw per frame reused across transitions where semantics allow                | up to 9% — changes RNG streams, permitted but user-visible |
 
-Items 1–6 are behaviour-preserving. Item 7 changes RNG streams — the
+Items 1–5 are behaviour-preserving. Item 6 changes RNG streams — the
 reproducibility decision below permits that across engine versions, but
 existing seeds would produce different (equally valid) trajectories, which is
-a product-visible change. Estimated for items 1–6 combined on a typical
-coloured net: **5–15×** before any threading, **20–60×** combined with
-sharding on 8 cores.
+a product-visible change. Estimated for items 1–5 plus the landed enumeration
+fix, on a typical coloured net: **5–15×** before any threading, **20–60×**
+combined with sharding on 8 cores.
 
 ### Whole-loop codegen
 


### PR DESCRIPTION
## Summary

Before this PR, `indexCombinations` materialised every k-combination of an input arc's tokens before the first one was used. A transition with a weight-`w` coloured input arc over `n` tokens therefore allocated `C(n, w)` arrays per evaluation per frame. Measured cost was 13.4 ms per run-frame at 400 tokens for a never-firing weight-2 arc.

Generator now enumerates lazily with no per-combination allocation. Order is unchanged, so every seeded trajectory is identical. Measured on `benchmarks/coloured-enumeration.mjs`, extended with an always-fires self-loop case, at 400 tokens:

| Case | Before | After |
| --- | --- | --- |
| Never fires (examines all 79 800 combinations) | 13 771 µs | 2 463 µs (5.6×) |
| Always fires (examines one) | 3 858 µs | 12.6 µs (305×) |

A firing transition's cost is now flat in the token count. Never-firing case keeps its `C(n, w)` lambda evaluations, since each combination's rate must be computed, at ~31 ns per combination instead of ~170 ns.

## Links

- Ticket [FE-1526](https://linear.app/hash/issue/FE-1526)
- Docs [Simulation performance](https://petrinaut-docs-git-cf-fe-1526-enumerate-weighted-arc-tok-148020.stage.hash.ai/architecture/core/simulation/performance)

## Changes

- `enumerate-weighted-markings.ts` enumerates lazily with an in-place successor per arc
  > Odometer over arcs advances a lexicographic successor in place; nothing is allocated per combination.
  > Yielded marking is a reused buffer.
  > Module doc comment states the contract and both engines already copy on accept.
- Eager `enumerateWeightedMarkingIndices` is reimplemented over the lazy generator
  > One source of truth for the order.
- Enumeration order is unchanged
  > Engine fires the first passing combination, so an order change would diverge every seeded trajectory.
  > `webgpu/pair-selection.ts` reproduces the same order by unranking.

## Test coverage

- `enumerate-weighted-markings.test.ts`:
  > New test pins the sequence against the previous algorithm across a case matrix, keeping that algorithm in the test as the ordering oracle. Another test pins the buffer-reuse contract.
- `webgpu/pair-selection.test.ts`:
  > GPU pair-order tests pass unchanged. Their collection helper now copies per yield, as the contract requires.

## How to test

- `turbo run build test:unit --filter '@hashintel/petrinaut-core'`
- `node libs/@hashintel/petrinaut-core/benchmarks/coloured-enumeration.mjs`
- Compare never-fires and always-fires rows at 400 tokens with table above
- Run any seeded simulation with weighted coloured input arc on this branch and its base
- Expect identical trajectories
