### PR TITLE
FE-1528: Skip combination enumeration for token-independent lambdas

### DIFF
--- a/.changeset/lazy-weighted-arc-enumeration.md
+++ b/.changeset/lazy-weighted-arc-enumeration.md
@@ -1,0 +1,5 @@
+---
+"@hashintel/petrinaut-core": patch
+---
+
+Weighted-arc token combinations now enumerate lazily, in place, in the same lexicographic order. Evaluating a transition with a weight-2 coloured input arc no longer materialises every `C(n, 2)` combination per frame: measured, a firing transition at 400 tokens in the place drops from 3.86 ms to 12.6 µs per run-frame, and a never-firing one from 13.8 ms to 2.5 ms. Trajectories are unchanged for every seed.

--- a/.changeset/lazy-weighted-arc-enumeration.md
+++ b/.changeset/lazy-weighted-arc-enumeration.md
@@ -2,4 +2,4 @@
 "@hashintel/petrinaut-core": patch
 ---
 
-Weighted-arc token combinations now enumerate lazily, in place, in the same lexicographic order. Evaluating a transition with a weight-2 coloured input arc no longer materialises every `C(n, 2)` combination per frame: measured, a firing transition at 400 tokens in the place drops from 3.86 ms to 12.6 µs per run-frame, and a never-firing one from 13.8 ms to 2.5 ms. Trajectories are unchanged for every seed.
+Weighted-arc token combinations enumerate lazily in the same lexicographic order, so a transition with a weight-2 coloured input arc no longer materialises every combination per frame. Trajectories are unchanged for every seed.

--- a/.changeset/token-independent-lambda-fast-path.md
+++ b/.changeset/token-independent-lambda-fast-path.md
@@ -2,4 +2,4 @@
 "@hashintel/petrinaut-core": patch
 ---
 
-Transitions whose lambda reads no input tokens skip combination enumeration: the HIR analysis marks their compiled artifact, and both engines evaluate the lambda once against the first tokens in place order instead of walking every combination. Trajectories are unchanged for every seed; a never-firing weight-2 transition over 400 tokens drops from 2.5 ms to under a microsecond per run-frame.
+Transitions whose lambda reads no input tokens skip combination enumeration and evaluate the lambda once against the first tokens in place order. Trajectories are unchanged for every seed.

--- a/.changeset/token-independent-lambda-fast-path.md
+++ b/.changeset/token-independent-lambda-fast-path.md
@@ -1,0 +1,5 @@
+---
+"@hashintel/petrinaut-core": patch
+---
+
+Transitions whose lambda reads no input tokens skip combination enumeration: the HIR analysis marks their compiled artifact, and both engines evaluate the lambda once against the first tokens in place order instead of walking every combination. Trajectories are unchanged for every seed; a never-firing weight-2 transition over 400 tokens drops from 2.5 ms to under a microsecond per run-frame.

--- a/libs/@hashintel/petrinaut-core/benchmarks/coloured-enumeration.mjs
+++ b/libs/@hashintel/petrinaut-core/benchmarks/coloured-enumeration.mjs
@@ -2,9 +2,12 @@
  * Measures how per-frame cost scales with token count for a transition whose
  * coloured input arc has weight 2.
  *
- * `enumerateWeightedMarkingIndicesGenerator` materialises the full per-place
- * combination list up front, so the expectation is O(C(n, 2)) = O(n^2) work and
- * allocation per transition evaluation per frame.
+ * Two cases bound the enumeration cost: a transition that never fires
+ * examines every combination each frame (O(C(n, 2)) lambda evaluations —
+ * irreducible), and a transition that always fires examines one. Lazy
+ * enumeration makes both allocation-free; the eager implementation it
+ * replaced also materialised the full C(n, 2) combination list per
+ * evaluation, which made even the always-fires case quadratic.
  */
 import { performance } from "node:perf_hooks";
 
@@ -64,16 +67,28 @@ const sdcpn = {
   parameters: [],
 };
 
-const artifacts = compileHirArtifacts(sdcpn).artifacts;
+/**
+ * The always-fires variant: a self loop that consumes two pool tokens and
+ * produces two, so the marking size stays constant while the transition fires
+ * on the first combination every frame.
+ */
+const selfLoopSdcpn = {
+  ...sdcpn,
+  transitions: [
+    {
+      ...sdcpn.transitions[0],
+      inputArcs: [{ placeId: "pool", weight: 2, type: "standard" }],
+      outputArcs: [{ placeId: "pool", weight: 2 }],
+      lambdaCode: "export default Lambda(() => true);",
+      transitionKernelCode:
+        "export default TransitionKernel(() => ({ Pool: [{ v: 1 }, { v: 2 }] }));",
+    },
+  ],
+};
 
-process.stdout.write(
-  "coloured place, input arc weight 2, transition never fires\n" +
-    "tokens   C(n,2)      ns/run-frame\n",
-);
-
-for (const tokens of [10, 25, 50, 100, 200, 400]) {
+function measure(net, artifacts, tokens) {
   const simulator = createMonteCarloSimulator({
-    sdcpn,
+    sdcpn: net,
     initialMarking: {
       pool: Array.from({ length: tokens }, (_, index) => ({ v: index })),
       sink: [],
@@ -95,10 +110,26 @@ for (const tokens of [10, 25, 50, 100, 200, 400]) {
   for (const summary of simulator.getSummaries()) {
     frames += summary.frameNumber;
   }
+  return (ms / frames) * 1e6;
+}
 
-  const combinations = (tokens * (tokens - 1)) / 2;
+const cases = [
+  ["transition never fires (examines every combination)", sdcpn],
+  ["transition always fires (examines one combination)", selfLoopSdcpn],
+];
+
+for (const [label, net] of cases) {
+  const artifacts = compileHirArtifacts(net).artifacts;
   process.stdout.write(
-    `${String(tokens).padStart(6)}   ${String(combinations).padStart(7)}   ` +
-      `${((ms / frames) * 1e6).toFixed(0).padStart(12)}\n`,
+    `coloured place, input arc weight 2, ${label}\n` +
+      "tokens   C(n,2)      ns/run-frame\n",
   );
+  for (const tokens of [10, 25, 50, 100, 200, 400]) {
+    const combinations = (tokens * (tokens - 1)) / 2;
+    process.stdout.write(
+      `${String(tokens).padStart(6)}   ${String(combinations).padStart(7)}   ` +
+        `${measure(net, artifacts, tokens).toFixed(0).padStart(12)}\n`,
+    );
+  }
+  process.stdout.write("\n");
 }

--- a/libs/@hashintel/petrinaut-core/benchmarks/coloured-enumeration.mjs
+++ b/libs/@hashintel/petrinaut-core/benchmarks/coloured-enumeration.mjs
@@ -2,12 +2,15 @@
  * Measures how per-frame cost scales with token count for a transition whose
  * coloured input arc has weight 2.
  *
- * Two cases bound the enumeration cost: a transition that never fires
- * examines every combination each frame (O(C(n, 2)) lambda evaluations —
- * irreducible), and a transition that always fires examines one. Lazy
- * enumeration makes both allocation-free; the eager implementation it
- * replaced also materialised the full C(n, 2) combination list per
- * evaluation, which made even the always-fires case quadratic.
+ * Three cases bound the enumeration cost. With a lambda that reads token
+ * attributes: a transition that never fires examines every combination each
+ * frame (O(C(n, 2)) lambda evaluations — irreducible), and one that always
+ * fires examines one. Lazy enumeration makes both allocation-free; the eager
+ * implementation it replaced also materialised the full C(n, 2) combination
+ * list per evaluation, which made even the always-fires case quadratic.
+ * With a token-independent lambda, the artifact carries
+ * `readsNoInputTokens` and the engine tests only the first combination, so
+ * even the never-fires case is O(1) per frame.
  */
 import { performance } from "node:perf_hooks";
 
@@ -55,8 +58,10 @@ const sdcpn = {
       outputArcs: [{ placeId: "sink", weight: 1 }],
       lambdaType: "predicate",
       // Never fires, so token counts stay constant and we measure pure
-      // enablement/enumeration cost at a fixed marking size.
-      lambdaCode: "export default Lambda(() => false);",
+      // enablement/enumeration cost at a fixed marking size. Reads a token
+      // attribute so the lambda is NOT token-independent — every combination
+      // must be examined.
+      lambdaCode: "export default Lambda((input) => input.Pool[0].v < 0);",
       transitionKernelCode:
         "export default TransitionKernel(() => ({ Sink: [{ v: 1 }] }));",
       x: 50,
@@ -79,9 +84,24 @@ const selfLoopSdcpn = {
       ...sdcpn.transitions[0],
       inputArcs: [{ placeId: "pool", weight: 2, type: "standard" }],
       outputArcs: [{ placeId: "pool", weight: 2 }],
-      lambdaCode: "export default Lambda(() => true);",
+      lambdaCode: "export default Lambda((input) => input.Pool[0].v >= 0);",
       transitionKernelCode:
         "export default TransitionKernel(() => ({ Pool: [{ v: 1 }, { v: 2 }] }));",
+    },
+  ],
+};
+
+/**
+ * A token-independent never-firing lambda: the compiler flags it, and the
+ * engine tests only the first combination — O(1) per frame regardless of
+ * token count.
+ */
+const tokenIndependentSdcpn = {
+  ...sdcpn,
+  transitions: [
+    {
+      ...sdcpn.transitions[0],
+      lambdaCode: "export default Lambda(() => false);",
     },
   ],
 };
@@ -114,15 +134,21 @@ function measure(net, artifacts, tokens) {
 }
 
 const cases = [
-  ["transition never fires (examines every combination)", sdcpn],
-  ["transition always fires (examines one combination)", selfLoopSdcpn],
+  ["token-reading lambda, never fires (examines every combination)", sdcpn],
+  [
+    "token-reading lambda, always fires (examines one combination)",
+    selfLoopSdcpn,
+  ],
+  [
+    "token-independent lambda, never fires (first combination only)",
+    tokenIndependentSdcpn,
+  ],
 ];
 
 for (const [label, net] of cases) {
   const artifacts = compileHirArtifacts(net).artifacts;
   process.stdout.write(
-    `coloured place, input arc weight 2, ${label}\n` +
-      "tokens   C(n,2)      ns/run-frame\n",
+    `weight-2 coloured arc, ${label}\n` + "tokens   C(n,2)      ns/run-frame\n",
   );
   for (const tokens of [10, 25, 50, 100, 200, 400]) {
     const combinations = (tokens * (tokens - 1)) / 2;

--- a/libs/@hashintel/petrinaut-core/src/hir/artifacts.test.ts
+++ b/libs/@hashintel/petrinaut-core/src/hir/artifacts.test.ts
@@ -266,4 +266,24 @@ describe("readsNoInputTokens", () => {
       ).readsNoInputTokens,
     ).toBe(true);
   });
+
+  it("is absent for a token-free lambda that draws randomness", () => {
+    // Skipping enumeration would evaluate the draw once per frame instead of
+    // once per combination, changing how often the transition fires.
+    expect(
+      lambdaArtifactFor("export default Lambda(() => Math.random() > 0.5);")
+        .readsNoInputTokens,
+    ).toBeUndefined();
+  });
+
+  it("is absent for a lambda that reads only a token count", () => {
+    const inputPlace = sdcpn.places.find(
+      (place) => place.id === sdcpn.transitions[0]!.inputArcs[0]!.placeId,
+    )!;
+    expect(
+      lambdaArtifactFor(
+        `export default Lambda((input) => input.${inputPlace.name}.length > 1);`,
+      ).readsNoInputTokens,
+    ).toBeUndefined();
+  });
 });

--- a/libs/@hashintel/petrinaut-core/src/hir/artifacts.test.ts
+++ b/libs/@hashintel/petrinaut-core/src/hir/artifacts.test.ts
@@ -235,3 +235,35 @@ describe("compileHirArtifacts", () => {
     }
   });
 });
+
+describe("readsNoInputTokens", () => {
+  function lambdaArtifactFor(lambdaCode: string) {
+    const { artifacts, failures } = compileHirArtifacts({
+      ...sdcpn,
+      transitions: [{ ...sdcpn.transitions[0]!, lambdaCode }],
+    });
+    expect(failures).toEqual([]);
+    return artifacts.lambdas.ship!;
+  }
+
+  it("is absent when the lambda reads token attributes", () => {
+    expect(
+      lambdaArtifactFor(sdcpn.transitions[0]!.lambdaCode).readsNoInputTokens,
+    ).toBeUndefined();
+  });
+
+  it("is set for a constant lambda", () => {
+    expect(
+      lambdaArtifactFor("export default Lambda(() => true);")
+        .readsNoInputTokens,
+    ).toBe(true);
+  });
+
+  it("is set for a parameters-only lambda", () => {
+    expect(
+      lambdaArtifactFor(
+        "export default Lambda((input, parameters) => parameters.threshold > 1);",
+      ).readsNoInputTokens,
+    ).toBe(true);
+  });
+});

--- a/libs/@hashintel/petrinaut-core/src/hir/compile.ts
+++ b/libs/@hashintel/petrinaut-core/src/hir/compile.ts
@@ -22,6 +22,7 @@ import {
   type PetrinautExtensionSettings,
 } from "../extensions";
 import { createUserKeyedRecord } from "../validation/record-keys";
+import { analyzeHir } from "./analyze";
 import { fingerprintHirCompilationInput } from "./artifact-fingerprint";
 import {
   emitBufferDynamicsJs,
@@ -219,10 +220,16 @@ export function compileHirArtifacts(
               diagnostics: [notCompilableDiagnostic(item.fn)],
             });
           } else {
+            const { dependencies } = analyzeHir(item.fn);
+            const readsNoInputTokens =
+              dependencies.tokenReads.length === 0 &&
+              !dependencies.readsTokenCounts &&
+              dependencies.isDeterministic;
             artifacts.lambdas[transition.id] = {
               ...(options.includeHir ? { hir: item.fn } : {}),
               source: program.source,
               inputSlotCount: program.inputSlotCount,
+              ...(readsNoInputTokens ? { readsNoInputTokens: true } : {}),
             };
           }
         }

--- a/libs/@hashintel/petrinaut-core/src/hir/instantiate.ts
+++ b/libs/@hashintel/petrinaut-core/src/hir/instantiate.ts
@@ -90,6 +90,15 @@ export type HirLambdaArtifact = {
   /** Expected `indices.length` — engine-side sanity check. */
   inputSlotCount: number;
   /**
+   * Set when the HIR analysis proves the lambda's result cannot depend on
+   * which tokens a combination selects: it reads no token attributes or
+   * counts and is a pure function of its inputs. The engines then evaluate
+   * the first combination instead of enumerating all of them. Absent means
+   * "assume it reads tokens" — artifacts compiled before this field existed
+   * keep enumerating.
+   */
+  readsNoInputTokens?: boolean;
+  /**
    * The lowered HIR the program was emitted from.
    *
    * Carried so a second backend can compile the same code without re-running the

--- a/libs/@hashintel/petrinaut-core/src/simulation/engine/build-simulation.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/engine/build-simulation.ts
@@ -338,7 +338,7 @@ function createLambdaFn({
   artifact: HirLambdaArtifact | undefined;
   expectedSlotCount: number;
   stringPool: StringPool;
-}): HirCompiledBufferLambda {
+}): { lambdaFn: HirCompiledBufferLambda; readsNoInputTokens: boolean } {
   const availability = getTransitionLogicAvailability(
     transition,
     sdcpn,
@@ -348,7 +348,10 @@ function createLambdaFn({
 
   if (!availability.lambda || transition.lambdaCode.trim() === "") {
     // Buffer-ABI-shaped constants — the arguments are ignored.
-    return lambdaType === "stochastic" ? () => Infinity : () => true;
+    return {
+      lambdaFn: lambdaType === "stochastic" ? () => Infinity : () => true,
+      readsNoInputTokens: true,
+    };
   }
 
   if (!artifact) {
@@ -363,11 +366,14 @@ function createLambdaFn({
   }
 
   try {
-    return instantiateHirBufferLambda(
-      artifact.source,
-      parameterValues,
-      stringPool,
-    );
+    return {
+      lambdaFn: instantiateHirBufferLambda(
+        artifact.source,
+        parameterValues,
+        stringPool,
+      ),
+      readsNoInputTokens: artifact.readsNoInputTokens === true,
+    };
   } catch (error) {
     throw new SDCPNItemError(
       `Failed to instantiate the compiled Lambda for transition \`${
@@ -479,7 +485,7 @@ function createCompiledTransition({
     typesMap,
   );
   const stagingSize = computeKernelStagingSize(transition, placesMap, typesMap);
-  const lambdaFn = createLambdaFn({
+  const { lambdaFn, readsNoInputTokens } = createLambdaFn({
     transition,
     sdcpn,
     extensions,
@@ -573,6 +579,7 @@ function createCompiledTransition({
       };
     }),
     lambdaFn,
+    lambdaReadsNoInputTokens: readsNoInputTokens,
     kernelFn,
     placeBases: new Int32Array(coloredInputArcCount),
     indices: new Int32Array(expectedSlotCount),

--- a/libs/@hashintel/petrinaut-core/src/simulation/engine/compiled-transition.test-helpers.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/engine/compiled-transition.test-helpers.ts
@@ -20,6 +20,7 @@ export function makeCompiledTransition({
   places,
   types,
   lambdaFn,
+  lambdaReadsNoInputTokens = false,
   kernelFn = null,
 }: {
   transition: Transition;
@@ -27,6 +28,8 @@ export function makeCompiledTransition({
   types: Color[];
   /** Buffer-ABI mock: `(f64, u64, u8, placeBases, indices) => value`. */
   lambdaFn: HirCompiledBufferLambda;
+  /** Marks the mock lambda as token-independent (first-combination path). */
+  lambdaReadsNoInputTokens?: boolean;
   /** Buffer-ABI mock writing into the staging views, or null when the
    * transition has no colored output places. */
   kernelFn?: HirCompiledBufferKernel | null;
@@ -93,6 +96,7 @@ export function makeCompiledTransition({
     // Capacity is exercised through `buildSimulation`; these hand-built
     // transitions are unconstrained.
     capacityConstraints: [],
+    lambdaReadsNoInputTokens,
     inputPlaces,
     outputPlaces,
     lambdaFn,

--- a/libs/@hashintel/petrinaut-core/src/simulation/engine/compute-possible-transition.test.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/engine/compute-possible-transition.test.ts
@@ -112,12 +112,15 @@ function makeSimulation({
   types = [],
   lambdaFns,
   kernelFns,
+  tokenIndependentLambdas,
 }: {
   places?: Place[];
   transitions: Transition[];
   types?: Color[];
   lambdaFns: ReadonlyMap<string, HirCompiledBufferLambda>;
   kernelFns?: ReadonlyMap<string, HirCompiledBufferKernel | null>;
+  /** Transitions whose mock lambda is marked token-independent. */
+  tokenIndependentLambdas?: ReadonlySet<string>;
 }): SimulationInstance {
   const frameLayout = createEngineFrameLayout({
     places,
@@ -145,6 +148,8 @@ function makeSimulation({
             places,
             types,
             lambdaFn,
+            lambdaReadsNoInputTokens:
+              tokenIndependentLambdas?.has(transition.id) ?? false,
             kernelFn: kernelFns?.get(transition.id) ?? null,
           }),
         ];
@@ -970,5 +975,101 @@ describe("computePossibleTransition", () => {
         expect.arrayContaining([expect.stringMatching(/discrete \(string\)/)]),
       );
     });
+  });
+});
+
+describe("token-independent lambdas", () => {
+  const pool: Place = makePlace("p1", "Pool", "type1");
+  const fourTokens = {
+    p1: {
+      elements: type1.elements,
+      tokens: [{ x: 10 }, { x: 20 }, { x: 30 }, { x: 40 }],
+    },
+  };
+  const pairTransition = makeTransition({
+    id: "t1",
+    inputArcs: [{ placeId: "p1", weight: 2, type: "standard" }],
+    outputArcs: [],
+  });
+
+  function makePairSimulation(
+    lambdaFn: HirCompiledBufferLambda,
+    tokenIndependent: boolean,
+  ): SimulationInstance {
+    return makeSimulation({
+      places: [pool],
+      types: [type1],
+      transitions: [pairTransition],
+      lambdaFns: new Map([["t1", lambdaFn]]),
+      tokenIndependentLambdas: tokenIndependent
+        ? new Set(["t1"])
+        : new Set<string>(),
+    });
+  }
+
+  it("evaluates the lambda once and consumes the first tokens", () => {
+    let calls = 0;
+    const simulation = makePairSimulation(() => {
+      calls += 1;
+      return CERTAIN_FIRING_RATE;
+    }, true);
+    const frame = makeTestFrame({
+      places: fourTokens,
+      transitions: { t1: transitionState() },
+    });
+
+    const result = computePossibleTransition(frame, simulation, "t1", 42);
+
+    expect(calls).toBe(1);
+    expect(result?.remove).toEqual({ p1: new Set([0, 1]) });
+  });
+
+  it("skips the other five combinations a flagless lambda would examine", () => {
+    // Rate 0 never fires: exp(0) = 1 > U1 for every draw, so the flagless
+    // path examines all C(4,2) = 6 combinations while the flagged path
+    // examines one — with identical outcomes.
+    const runWith = (tokenIndependent: boolean) => {
+      let calls = 0;
+      const simulation = makePairSimulation(() => {
+        calls += 1;
+        return 0;
+      }, tokenIndependent);
+      const frame = makeTestFrame({
+        places: fourTokens,
+        transitions: { t1: transitionState() },
+      });
+      const { firing, newRngState } = computePossibleTransitionImpl(
+        frame,
+        { ...simulation, frameLayout: frame.layout },
+        "t1",
+        42,
+      );
+      return { calls, firing, newRngState };
+    };
+
+    const flagged = runWith(true);
+    const flagless = runWith(false);
+
+    expect(flagged.calls).toBe(1);
+    expect(flagless.calls).toBe(6);
+    expect(flagged.firing).toBeNull();
+    expect(flagless.firing).toBeNull();
+    expect(flagged.newRngState).toBe(flagless.newRngState);
+  });
+
+  it("fires identically to the enumerating path when the rate is certain", () => {
+    const runWith = (tokenIndependent: boolean) => {
+      const simulation = makePairSimulation(
+        () => CERTAIN_FIRING_RATE,
+        tokenIndependent,
+      );
+      const frame = makeTestFrame({
+        places: fourTokens,
+        transitions: { t1: transitionState() },
+      });
+      return computePossibleTransition(frame, simulation, "t1", 42);
+    };
+
+    expect(runWith(true)).toEqual(runWith(false));
   });
 });

--- a/libs/@hashintel/petrinaut-core/src/simulation/engine/compute-possible-transition.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/engine/compute-possible-transition.ts
@@ -9,7 +9,10 @@ import {
   fillTokenIndices,
 } from "./buffer-transition";
 import { hasCapacityHeadroom } from "./capacity";
-import { enumerateWeightedMarkingIndicesGenerator } from "./enumerate-weighted-markings";
+import {
+  enumerateWeightedMarkingIndicesGenerator,
+  firstWeightedMarkingIndices,
+} from "./enumerate-weighted-markings";
 import { nextRandom } from "./seeded-rng";
 import { createTokenRegionViews } from "./token-layout";
 
@@ -127,9 +130,12 @@ export function computePossibleTransition(
     (place) => place.strideBytes === 0 && place.arcType === "standard",
   );
 
-  const tokensCombinations = enumerateWeightedMarkingIndicesGenerator(
-    inputPlacesWithTokenValues,
-  );
+  // A token-independent lambda returns the same value for every combination,
+  // so either the first combination fires or none does: test only the first
+  // (structural enablement above guarantees it exists).
+  const tokensCombinations = transition.lambdaReadsNoInputTokens
+    ? [firstWeightedMarkingIndices(inputPlacesWithTokenValues)]
+    : enumerateWeightedMarkingIndicesGenerator(inputPlacesWithTokenValues);
 
   // The compiled buffer-ABI lambda reads token attributes at packed-struct
   // byte offsets straight from the shared views — no per-combination record

--- a/libs/@hashintel/petrinaut-core/src/simulation/engine/enumerate-weighted-markings.test.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/engine/enumerate-weighted-markings.test.ts
@@ -201,33 +201,41 @@ describe("enumerateWeightedMarkingIndices", () => {
 });
 
 describe("enumerateWeightedMarkingIndicesGenerator", () => {
+  /**
+   * The generator reuses its yielded arrays between iterations, so collecting
+   * a sequence must clone each marking as it arrives.
+   */
+  function collectMarkings(
+    places: { count: number; weight: number }[],
+  ): number[][][] {
+    return Array.from(
+      enumerateWeightedMarkingIndicesGenerator(places),
+      (marking) => marking.map((combo) => [...combo]),
+    );
+  }
   it("yields [[]] when no places are provided", () => {
-    const iterator = enumerateWeightedMarkingIndicesGenerator([]);
-    expect(Array.from(iterator)).toEqual([[]]);
+    expect(collectMarkings([])).toEqual([[]]);
   });
 
   it("yields nothing when a weight exceeds the token count", () => {
-    const iterator = enumerateWeightedMarkingIndicesGenerator([
-      { count: 2, weight: 3 },
-    ]);
-    expect(Array.from(iterator)).toEqual([]);
+    expect(collectMarkings([{ count: 2, weight: 3 }])).toEqual([]);
   });
 
   it("handles single place with weight 0", () => {
     const places = [{ count: 3, weight: 0 }];
-    const result = Array.from(enumerateWeightedMarkingIndicesGenerator(places));
+    const result = collectMarkings(places);
     expect(result).toEqual([[[]]]);
   });
 
   it("handles single place with single token", () => {
     const places = [{ count: 1, weight: 1 }];
-    const result = Array.from(enumerateWeightedMarkingIndicesGenerator(places));
+    const result = collectMarkings(places);
     expect(result).toEqual([[[0]]]);
   });
 
   it("generates all 2-combinations from 3 tokens in single place", () => {
     const places = [{ count: 3, weight: 2 }];
-    const result = Array.from(enumerateWeightedMarkingIndicesGenerator(places));
+    const result = collectMarkings(places);
 
     expect(result).toEqual([[[0, 1]], [[0, 2]], [[1, 2]]]);
   });
@@ -238,7 +246,7 @@ describe("enumerateWeightedMarkingIndicesGenerator", () => {
       { count: 3, weight: 2 },
     ];
 
-    const result = Array.from(enumerateWeightedMarkingIndicesGenerator(places));
+    const result = collectMarkings(places);
 
     // First place combinations: [0,1], [0,2], [1,2]
     // Second place combinations: [0,1], [0,2], [1,2]
@@ -291,7 +299,7 @@ describe("enumerateWeightedMarkingIndicesGenerator", () => {
       { count: 3, weight: 1 }, // combinations: [0], [1], [2]
     ];
 
-    const result = Array.from(enumerateWeightedMarkingIndicesGenerator(places));
+    const result = collectMarkings(places);
 
     // Expected: 2 × 1 × 3 = 6 combinations
     expect(result).toEqual([
@@ -310,7 +318,7 @@ describe("enumerateWeightedMarkingIndicesGenerator", () => {
       { count: 3, weight: 3 },
     ];
 
-    const result = Array.from(enumerateWeightedMarkingIndicesGenerator(places));
+    const result = collectMarkings(places);
 
     // Only one combination per place when selecting all tokens
     expect(result).toEqual([
@@ -327,7 +335,7 @@ describe("enumerateWeightedMarkingIndicesGenerator", () => {
       { count: 3, weight: 2 },
     ];
 
-    const result = Array.from(enumerateWeightedMarkingIndicesGenerator(places));
+    const result = collectMarkings(places);
 
     // First place contributes empty array
     // Second place has 3 combinations
@@ -344,7 +352,7 @@ describe("enumerateWeightedMarkingIndicesGenerator", () => {
       { count: 3, weight: 2 }, // C(3,2) = 3
     ];
 
-    const result = Array.from(enumerateWeightedMarkingIndicesGenerator(places));
+    const result = collectMarkings(places);
 
     // Total combinations: 6 × 3 = 18
     expect(result).toHaveLength(18);
@@ -365,7 +373,7 @@ describe("enumerateWeightedMarkingIndicesGenerator", () => {
       { count: 2, weight: 1 },
     ];
 
-    const result = Array.from(enumerateWeightedMarkingIndicesGenerator(places));
+    const result = collectMarkings(places);
 
     // Each result should have 2 elements (one per place)
     // Each place should have its own array
@@ -381,6 +389,103 @@ describe("enumerateWeightedMarkingIndicesGenerator", () => {
       expect(marking).toHaveLength(2); // 2 places
       expect(Array.isArray(marking[0])).toBe(true);
       expect(Array.isArray(marking[1])).toBe(true);
+    }
+  });
+
+  it("reuses the yielded marking and its combination arrays between iterations", () => {
+    const places = [
+      { count: 3, weight: 2 },
+      { count: 2, weight: 1 },
+    ];
+
+    const yielded = Array.from(
+      enumerateWeightedMarkingIndicesGenerator(places),
+    );
+
+    // Every yield hands back the same (mutated) structure: consumers that
+    // keep a marking past the next iteration must copy it.
+    expect(yielded.length).toBe(6);
+    for (const marking of yielded) {
+      expect(marking).toBe(yielded[0]);
+      expect(marking[0]).toBe(yielded[0]![0]);
+    }
+  });
+
+  it("matches an eager reference implementation on a case matrix", () => {
+    /** The pre-lazy algorithm, kept as the ordering oracle. */
+    function referenceCombinations(n: number, k: number): number[][] {
+      if (k === 0) {
+        return [[]];
+      }
+      if (k > n) {
+        return [];
+      }
+      const result: number[][] = [];
+      const backtrack = (start: number, combo: number[]) => {
+        if (combo.length === k) {
+          result.push([...combo]);
+          return;
+        }
+        for (let i = start; i <= n - (k - combo.length); i++) {
+          combo.push(i);
+          backtrack(i + 1, combo);
+          combo.pop();
+        }
+      };
+      backtrack(0, []);
+      return result;
+    }
+
+    function referenceMarkings(
+      places: { count: number; weight: number }[],
+    ): number[][][] {
+      const perPlace = places.map((place) =>
+        referenceCombinations(place.count, place.weight),
+      );
+      if (perPlace.some((combos) => combos.length === 0)) {
+        return [];
+      }
+      let acc: number[][][] = [[]];
+      for (const combos of perPlace) {
+        const next: number[][][] = [];
+        for (const partial of acc) {
+          for (const combo of combos) {
+            next.push([...partial, combo]);
+          }
+        }
+        acc = next;
+      }
+      return acc;
+    }
+
+    const cases: { count: number; weight: number }[][] = [
+      [{ count: 5, weight: 2 }],
+      [{ count: 6, weight: 3 }],
+      [{ count: 7, weight: 1 }],
+      [{ count: 4, weight: 4 }],
+      [{ count: 4, weight: 0 }],
+      [
+        { count: 4, weight: 2 },
+        { count: 3, weight: 1 },
+      ],
+      [
+        { count: 3, weight: 1 },
+        { count: 2, weight: 2 },
+        { count: 4, weight: 3 },
+      ],
+      [
+        { count: 2, weight: 0 },
+        { count: 3, weight: 2 },
+        { count: 2, weight: 1 },
+      ],
+      [
+        { count: 5, weight: 2 },
+        { count: 5, weight: 2 },
+      ],
+    ];
+
+    for (const places of cases) {
+      expect(collectMarkings(places)).toEqual(referenceMarkings(places));
     }
   });
 });

--- a/libs/@hashintel/petrinaut-core/src/simulation/engine/enumerate-weighted-markings.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/engine/enumerate-weighted-markings.ts
@@ -3,39 +3,104 @@ type PlaceSpec = {
   weight: number; // how many tokens to pick
 };
 
+/* eslint-disable no-param-reassign -- rewriting the caller's reusable
+   combination array in place is the point of these helpers: enumeration must
+   not allocate per combination */
 /**
- * Generate all k-combinations of indices [0..n-1].
- * Example: indexCombinations(3, 2) -> [ [0,1], [0,2], [1,2] ]
+ * Reset `combo` to the first k-combination of `[0..n-1]` in lexicographic
+ * order: `[0, 1, ..., k-1]`. Returns false when no combination exists
+ * (`k > n`).
  */
-function indexCombinations(n: number, k: number): number[][] {
-  if (k === 0) {
-    return [[]];
-  }
+function firstIndexCombination(combo: number[], n: number, k: number): boolean {
   if (k > n) {
-    return [];
+    return false;
   }
-
-  const result: number[][] = [];
-
-  function backtrack(start: number, combo: number[]) {
-    if (combo.length === k) {
-      result.push(combo.slice());
-      return;
-    }
-
-    for (let i = start; i <= n - (k - combo.length); i++) {
-      combo.push(i);
-      backtrack(i + 1, combo);
-      combo.pop();
-    }
+  combo.length = k;
+  for (let index = 0; index < k; index++) {
+    combo[index] = index;
   }
-
-  backtrack(0, []);
-  return result;
+  return true;
 }
 
 /**
- * Enumerate all weighted combinations, returning indices only.
+ * Advance `combo` to its lexicographic successor over `[0..n-1]`, in place.
+ * Returns false when `combo` is the last combination.
+ */
+function nextIndexCombination(combo: number[], n: number): boolean {
+  const k = combo.length;
+  for (let index = k - 1; index >= 0; index--) {
+    if (combo[index]! < n - k + index) {
+      combo[index]!++;
+      for (let rest = index + 1; rest < k; rest++) {
+        combo[rest] = combo[rest - 1]! + 1;
+      }
+      return true;
+    }
+  }
+  return false;
+}
+/* eslint-enable no-param-reassign */
+
+/**
+ * Enumerate every weighted marking lazily: one k-combination of token indices
+ * per place, in lexicographic order per place, with the last place advancing
+ * fastest.
+ *
+ * Nothing is materialised up front — a place holding `n` tokens under a
+ * weight-`w` arc has `C(n, w)` combinations, and building them eagerly made
+ * transition evaluation quadratic in the token count (see "Weighted-arc
+ * enumeration" in
+ * `libs/@local/petrinaut-arch-docs/content/simulation/performance.mdx`).
+ * Cost is proportional to the combinations the caller actually consumes.
+ *
+ * The enumeration order is a contract: the engine fires the first passing
+ * combination, so a different order changes which tokens a firing consumes
+ * and diverges seeded trajectories, and `webgpu/pair-selection.ts` reproduces
+ * this order on the GPU by combinatorial unranking.
+ *
+ * The yielded array and its inner arrays are reused between iterations.
+ * Copy anything kept past the next `next()` call; both engines copy on
+ * accept and stop iterating.
+ */
+export function* enumerateWeightedMarkingIndicesGenerator(
+  places: PlaceSpec[],
+): Generator<number[][], void, undefined> {
+  if (places.length === 0) {
+    yield [];
+    return;
+  }
+
+  const current: number[][] = places.map(() => []);
+  for (let place = 0; place < places.length; place++) {
+    const { count, weight } = places[place]!;
+    if (!firstIndexCombination(current[place]!, count, weight)) {
+      return;
+    }
+  }
+
+  for (;;) {
+    yield current;
+
+    let place = places.length - 1;
+    while (
+      place >= 0 &&
+      !nextIndexCombination(current[place]!, places[place]!.count)
+    ) {
+      firstIndexCombination(
+        current[place]!,
+        places[place]!.count,
+        places[place]!.weight,
+      );
+      place--;
+    }
+    if (place < 0) {
+      return;
+    }
+  }
+}
+
+/**
+ * Enumerate all weighted combinations eagerly, returning indices only.
  *
  * Each marking is a flat array of indices, concatenated per place.
  *
@@ -53,61 +118,9 @@ function indexCombinations(n: number, k: number): number[][] {
 export function enumerateWeightedMarkingIndices(
   places: PlaceSpec[],
 ): number[][] {
-  // 1. combinations per place (of indices)
-  const perPlaceCombos = places.map((p) =>
-    indexCombinations(p.count, p.weight),
-  );
-
-  // 2. check for invalid places
-  if (perPlaceCombos.some((set) => set.length === 0)) {
-    return [];
+  const result: number[][] = [];
+  for (const marking of enumerateWeightedMarkingIndicesGenerator(places)) {
+    result.push(marking.flat());
   }
-
-  // 3. Cartesian product
-  let acc: number[][] = [[]];
-  for (const comboSet of perPlaceCombos) {
-    const nextAcc: number[][] = [];
-    for (const partial of acc) {
-      for (const combo of comboSet) {
-        nextAcc.push([...partial, ...combo]);
-      }
-    }
-    acc = nextAcc;
-  }
-
-  return acc;
-}
-
-export function* enumerateWeightedMarkingIndicesGenerator(
-  places: PlaceSpec[],
-): Generator<number[][], void, undefined> {
-  const perPlaceCombos = places.map((p) =>
-    indexCombinations(p.count, p.weight),
-  );
-
-  if (perPlaceCombos.some((set) => set.length === 0)) {
-    return;
-  }
-
-  if (perPlaceCombos.length === 0) {
-    yield [];
-    return;
-  }
-
-  const current: number[][] = [];
-
-  function* backtrack(index: number): Generator<number[][], void, undefined> {
-    if (index === perPlaceCombos.length) {
-      yield current.map((combo) => combo.slice());
-      return;
-    }
-
-    for (const combo of perPlaceCombos[index]!) {
-      current.push(combo);
-      yield* backtrack(index + 1);
-      current.pop();
-    }
-  }
-
-  yield* backtrack(0);
+  return result;
 }

--- a/libs/@hashintel/petrinaut-core/src/simulation/engine/enumerate-weighted-markings.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/engine/enumerate-weighted-markings.ts
@@ -100,6 +100,21 @@ export function* enumerateWeightedMarkingIndicesGenerator(
 }
 
 /**
+ * The first weighted marking without enumeration: the lexicographically first
+ * combination per place — indices `[0..weight-1]`, the first tokens in place
+ * order. Callers must have established structural enablement
+ * (`count >= weight` per place). For a lambda whose result cannot depend on
+ * which tokens are selected, testing this marking alone is equivalent to
+ * enumerating all of them: the acceptance draw is shared across combinations,
+ * so either the first combination fires or none does.
+ */
+export function firstWeightedMarkingIndices(places: PlaceSpec[]): number[][] {
+  return places.map((place) =>
+    Array.from({ length: place.weight }, (_, index) => index),
+  );
+}
+
+/**
  * Enumerate all weighted combinations eagerly, returning indices only.
  *
  * Each marking is a flat array of indices, concatenated per place.

--- a/libs/@hashintel/petrinaut-core/src/simulation/engine/types.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/engine/types.ts
@@ -81,6 +81,14 @@ export type CompiledTransition = {
   /** Buffer-ABI lambda `(f64, u64, u8, placeBases, indices) => number |
    * boolean` (token format v2 packed structs); parameters/pool pre-bound. */
   lambdaFn: HirCompiledBufferLambda;
+  /**
+   * The lambda's result cannot depend on which tokens a combination selects —
+   * proved by the HIR analysis, or the lambda is an engine-supplied constant.
+   * Both engines then evaluate the first combination only, which is
+   * equivalent to enumerating all of them (one shared acceptance draw, first
+   * passing combination fires).
+   */
+  lambdaReadsNoInputTokens: boolean;
   /** Buffer-ABI kernel writing into `kernelStaging`, or null when the
    * transition has no colored output places. */
   kernelFn: HirCompiledBufferKernel | null;

--- a/libs/@hashintel/petrinaut-core/src/simulation/monte-carlo/token-independent-lambda.test.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/monte-carlo/token-independent-lambda.test.ts
@@ -1,0 +1,127 @@
+/**
+ * End-to-end check that the token-independent fast path changes nothing an
+ * experiment can observe: the same net, seed and artifacts produce identical
+ * runs whether the compiled artifact carries `readsNoInputTokens` (skip
+ * enumeration, take the first combination) or has it stripped (enumerate,
+ * as artifacts compiled before the flag existed do).
+ */
+import { describe, expect, it } from "vitest";
+
+import { compileHirArtifacts } from "../../hir";
+import { createMonteCarloSimulator } from "./monte-carlo-simulator";
+
+import type { HirArtifacts } from "../../hir";
+import type { SDCPN } from "../../types/sdcpn";
+
+const sdcpn: SDCPN = {
+  types: [
+    {
+      id: "item",
+      name: "Item",
+      iconSlug: "circle",
+      displayColor: "#00FF00",
+      elements: [{ elementId: "v", name: "v", type: "real" }],
+    },
+  ],
+  places: [
+    {
+      id: "pool",
+      name: "Pool",
+      colorId: "item",
+      dynamicsEnabled: false,
+      differentialEquationId: null,
+      x: 0,
+      y: 0,
+    },
+    {
+      id: "sink",
+      name: "Sink",
+      colorId: "item",
+      dynamicsEnabled: false,
+      differentialEquationId: null,
+      x: 100,
+      y: 0,
+    },
+  ],
+  transitions: [
+    {
+      id: "pair",
+      name: "Pair",
+      inputArcs: [{ placeId: "pool", weight: 2, type: "standard" }],
+      outputArcs: [{ placeId: "sink", weight: 1 }],
+      lambdaType: "stochastic",
+      // Reads a parameter but no tokens, so the compiler marks it
+      // token-independent. The mid-range rate makes runs mix firing and
+      // non-firing frames.
+      lambdaCode:
+        "export default Lambda((input, parameters) => parameters.rate);",
+      // The output token encodes which tokens were consumed, so a different
+      // combination choice would change the observable state.
+      transitionKernelCode: `export default TransitionKernel((input) => ({
+  Sink: [{ v: input.Pool[0].v * 1000 + input.Pool[1].v }],
+}));`,
+      x: 50,
+      y: 0,
+    },
+  ],
+  differentialEquations: [],
+  parameters: [
+    {
+      id: "rate",
+      name: "Rate",
+      variableName: "rate",
+      type: "real",
+      defaultValue: "2",
+    },
+  ],
+};
+
+function runToCompletion(artifacts: HirArtifacts) {
+  const simulator = createMonteCarloSimulator({
+    sdcpn,
+    initialMarking: {
+      pool: [{ v: 10 }, { v: 20 }, { v: 30 }, { v: 40 }, { v: 50 }, { v: 60 }],
+      sink: [],
+    },
+    parameterValues: { rate: "2" },
+    seed: 7,
+    dt: 0.1,
+    maxTime: 5,
+    runCount: 8,
+    hirArtifacts: artifacts,
+  });
+  simulator.runUntilComplete();
+  return {
+    summaries: simulator.getSummaries(),
+    snapshots: Array.from({ length: 8 }, (_, index) =>
+      simulator.getRunSnapshot(index),
+    ),
+  };
+}
+
+describe("token-independent lambda fast path", () => {
+  it("is marked on the compiled artifact", () => {
+    const { artifacts, failures } = compileHirArtifacts(sdcpn);
+    expect(failures).toEqual([]);
+    expect(artifacts.lambdas.pair!.readsNoInputTokens).toBe(true);
+  });
+
+  it("produces runs identical to the enumerating path", () => {
+    const { artifacts } = compileHirArtifacts(sdcpn);
+    const stripped = JSON.parse(JSON.stringify(artifacts)) as HirArtifacts;
+    delete stripped.lambdas.pair!.readsNoInputTokens;
+
+    const fast = runToCompletion(artifacts);
+    const enumerating = runToCompletion(stripped);
+
+    expect(fast.summaries).toEqual(enumerating.summaries);
+    expect(fast.snapshots).toEqual(enumerating.snapshots);
+    // The runs actually fired: an all-idle run would make the comparison
+    // vacuous.
+    expect(
+      fast.snapshots.some(
+        (snapshot) => (snapshot.placeTokenCounts.sink ?? 0) > 0,
+      ),
+    ).toBe(true);
+  });
+});

--- a/libs/@hashintel/petrinaut-core/src/simulation/monte-carlo/token-independent-lambda.test.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/monte-carlo/token-independent-lambda.test.ts
@@ -9,8 +9,11 @@ import { describe, expect, it } from "vitest";
 
 import { compileHirArtifacts } from "../../hir";
 import { createMonteCarloSimulator } from "./monte-carlo-simulator";
+import { createRunState } from "./run-state";
+import { computeTransitionEffect } from "./transition-effect";
 
 import type { HirArtifacts } from "../../hir";
+import type { HirCompiledBufferLambda } from "../../hir/instantiate";
 import type { SDCPN } from "../../types/sdcpn";
 
 const sdcpn: SDCPN = {
@@ -123,5 +126,57 @@ describe("token-independent lambda fast path", () => {
         (snapshot) => (snapshot.placeTokenCounts.sink ?? 0) > 0,
       ),
     ).toBe(true);
+  });
+
+  it("evaluates the lambda once instead of once per combination", () => {
+    // Rate 0 never fires, so the enumerating path examines every C(6, 2) = 15
+    // pair while the flagged path examines one, with the same outcome and the
+    // same RNG state afterwards.
+    const { artifacts } = compileHirArtifacts(sdcpn);
+    const runWith = (tokenIndependent: boolean) => {
+      const run = createRunState(
+        {
+          sdcpn,
+          initialMarking: {
+            pool: [{ v: 1 }, { v: 2 }, { v: 3 }, { v: 4 }, { v: 5 }, { v: 6 }],
+            sink: [],
+          },
+          parameterValues: { rate: "0" },
+          seed: 7,
+          dt: 0.1,
+          maxTime: 5,
+          runCount: 1,
+          hirArtifacts: artifacts,
+        },
+        undefined,
+        0,
+      );
+      const transition = run.simulation.compiledTransitions.get("pair")!;
+      let calls = 0;
+      const counting: HirCompiledBufferLambda = (...args) => {
+        calls += 1;
+        return transition.lambdaFn(...args);
+      };
+      const { firing, newRngState } = computeTransitionEffect(
+        run,
+        run.currentFrame,
+        {
+          ...transition,
+          lambdaFn: counting,
+          lambdaReadsNoInputTokens: tokenIndependent,
+        },
+        null,
+      );
+      return { calls, firing, newRngState };
+    };
+
+    const flagged = runWith(true);
+    const flagless = runWith(false);
+
+    expect(flagged.calls).toBe(1);
+    expect(flagless.calls).toBe(15);
+    expect(flagged.firing).toBeNull();
+    expect(flagless.firing).toBeNull();
+    expect(flagged.newRngState).toBe(flagless.newRngState);
   });
 });

--- a/libs/@hashintel/petrinaut-core/src/simulation/monte-carlo/transition-effect.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/monte-carlo/transition-effect.ts
@@ -5,7 +5,10 @@ import {
   fillTokenIndices,
 } from "../engine/buffer-transition";
 import { hasCapacityHeadroom } from "../engine/capacity";
-import { enumerateWeightedMarkingIndicesGenerator } from "../engine/enumerate-weighted-markings";
+import {
+  enumerateWeightedMarkingIndicesGenerator,
+  firstWeightedMarkingIndices,
+} from "../engine/enumerate-weighted-markings";
 import { nextRandom } from "../engine/seeded-rng";
 import { getPlaceIndex } from "./layout";
 
@@ -82,9 +85,12 @@ export function computeTransitionEffect(
     (place) => place.strideBytes === 0 && place.arcType === "standard",
   );
 
-  const tokenCombinations = enumerateWeightedMarkingIndicesGenerator(
-    inputPlacesWithValues,
-  );
+  // A token-independent lambda returns the same value for every combination,
+  // so either the first combination fires or none does: test only the first
+  // (structural enablement above guarantees it exists).
+  const tokenCombinations = transition.lambdaReadsNoInputTokens
+    ? [firstWeightedMarkingIndices(inputPlacesWithValues)]
+    : enumerateWeightedMarkingIndicesGenerator(inputPlacesWithValues);
 
   // The compiled buffer-ABI lambda/kernel read token attributes at
   // packed-struct byte offsets straight from the frame's shared views (see

--- a/libs/@hashintel/petrinaut-core/src/webgpu/pair-selection.test.ts
+++ b/libs/@hashintel/petrinaut-core/src/webgpu/pair-selection.test.ts
@@ -11,14 +11,17 @@ import {
 
 /** The engine's own pair order for one place, as the CPU would walk it. */
 function cpuPairs(tokenCount: number): [number, number][] {
-  return [
-    ...enumerateWeightedMarkingIndicesGenerator([
+  // The generator reuses its yielded arrays between iterations, so copy each
+  // pair as it arrives.
+  return Array.from(
+    enumerateWeightedMarkingIndicesGenerator([
       { count: tokenCount, weight: 2 },
     ]),
-  ].map((combination) => {
-    const [pair] = combination;
-    return [pair![0]!, pair![1]!] as [number, number];
-  });
+    (combination) => {
+      const [pair] = combination;
+      return [pair![0]!, pair![1]!] as [number, number];
+    },
+  );
 }
 
 /**

--- a/libs/@local/petrinaut-arch-docs/content/simulation/performance.mdx
+++ b/libs/@local/petrinaut-arch-docs/content/simulation/performance.mdx
@@ -15,16 +15,16 @@ are the point.
 
 ## State of play
 
-| Area                                                  | Status                                                                          |
-| ----------------------------------------------------- | ------------------------------------------------------------------------------- |
-| [Worker sharding](#worker-sharding)                   | Shipped. ~4× on 8 shards, byte-identical results at every shard count.          |
-| [Per-place token capacity](#per-place-token-capacity) | Shipped. Its fixed-size-frame follow-ons are not built.                         |
-| [WebGPU backend](#the-webgpu-backend)                 | Shipped. ~1780× on the SIR net, for a restricted subset of nets.                |
-| [Weighted-arc enumeration](#weighted-arc-enumeration) | Fixed (FE-1526). Lazy and allocation-free; 305× measured on firing transitions. |
-| [Hot-path fixes](#hot-path-fixes)                     | Open. Estimated 5–15× combined, behaviour-preserving.                           |
-| [Whole-loop codegen](#whole-loop-codegen)             | Proposed. Where the largest single-thread win is.                               |
-| [WASM and native](#wasm-and-native)                   | Proposed. A second codegen backend once whole-loop codegen exists.              |
-| [Event-driven stepping](#event-driven-stepping)       | Proposed. A semantics change; potentially a bigger lever than everything above. |
+| Area                                                  | Status                                                                                               |
+| ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| [Worker sharding](#worker-sharding)                   | Shipped. ~4× on 8 shards, byte-identical results at every shard count.                               |
+| [Per-place token capacity](#per-place-token-capacity) | Shipped. Its fixed-size-frame follow-ons are not built.                                              |
+| [WebGPU backend](#the-webgpu-backend)                 | Shipped. ~1780× on the SIR net, for a restricted subset of nets.                                     |
+| [Weighted-arc enumeration](#weighted-arc-enumeration) | Fixed (FE-1526, FE-1528). Lazy, allocation-free, and skipped outright for token-independent lambdas. |
+| [Hot-path fixes](#hot-path-fixes)                     | Open. Estimated 5–15× combined, behaviour-preserving.                                                |
+| [Whole-loop codegen](#whole-loop-codegen)             | Proposed. Where the largest single-thread win is.                                                    |
+| [WASM and native](#wasm-and-native)                   | Proposed. A second codegen backend once whole-loop codegen exists.                                   |
+| [Event-driven stepping](#event-driven-stepping)       | Proposed. A semantics change; potentially a bigger lever than everything above.                      |
 
 ## The two stepping paths
 
@@ -159,10 +159,24 @@ after:
 A firing transition's cost is now flat in the token count (the residual growth
 is the firing's own token compaction). A never-firing transition still
 examines every combination — each one's rate must be evaluated — so that case
-keeps its `C(n, w)` lambda evaluations, at ~31 ns each instead of ~170 ns. The
-static enumeration-bound lint
+keeps its `C(n, w)` lambda evaluations, at ~31 ns each instead of ~170 ns.
+
+That remaining `C(n, w)` term only applies to lambdas whose rate depends on
+which tokens are selected. When the HIR analysis proves a lambda reads no
+token attributes or counts
+([FE-1528](https://linear.app/hash/issue/FE-1528/skip-combination-enumeration-for-lambdas-that-read-no-input-tokens)),
+the compiler marks its artifact `readsNoInputTokens` and both engines test
+only the first combination — indices `0..w-1` per arc, the first tokens in
+place order. This is exact rather than approximate: the acceptance draw is
+shared across combinations, so with a combination-independent rate either the
+first combination fires or none does — same RNG stream, same consumed tokens,
+same trajectories. Engine-supplied constant lambdas (a transition with no
+lambda code) take the same path. Measured, never-firing weight-2 arc at 400
+tokens: 2 543 µs per run-frame with a token-reading lambda against **0.9 µs**
+token-independent — flat in the token count. The static enumeration-bound lint
 ([FE-948](https://linear.app/hash/issue/FE-948/show-and-kill-combinatorial-explosion))
-remains the guard against nets where even that is too much.
+remains the guard for nets whose token-reading lambdas make even lazy
+enumeration too much.
 
 ### Metric aggregation
 

--- a/libs/@local/petrinaut-arch-docs/content/simulation/performance.mdx
+++ b/libs/@local/petrinaut-arch-docs/content/simulation/performance.mdx
@@ -20,7 +20,7 @@ are the point.
 | [Worker sharding](#worker-sharding)                   | Shipped. ~4× on 8 shards, byte-identical results at every shard count.          |
 | [Per-place token capacity](#per-place-token-capacity) | Shipped. Its fixed-size-frame follow-ons are not built.                         |
 | [WebGPU backend](#the-webgpu-backend)                 | Shipped. ~1780× on the SIR net, for a restricted subset of nets.                |
-| [Weighted-arc enumeration](#weighted-arc-enumeration) | **Needed refactor** — quadratic cost on weighted coloured arcs (FE-1526).       |
+| [Weighted-arc enumeration](#weighted-arc-enumeration) | Fixed (FE-1526). Lazy and allocation-free; 305× measured on firing transitions. |
 | [Hot-path fixes](#hot-path-fixes)                     | Open. Estimated 5–15× combined, behaviour-preserving.                           |
 | [Whole-loop codegen](#whole-loop-codegen)             | Proposed. Where the largest single-thread win is.                               |
 | [WASM and native](#wasm-and-native)                   | Proposed. A second codegen backend once whole-loop codegen exists.              |
@@ -127,41 +127,42 @@ The largest cost in the engine does not show on the profile above, because the
 SIR net has no weighted coloured arcs. On nets that do, it dwarfs everything
 else.
 
-:::danger[Needed refactor]
-`enumerateWeightedMarkingIndicesGenerator` is a generator, but it is only lazy
-over the Cartesian product _across_ arcs. Per arc it eagerly materialises the
-full combination list: `indexCombinations(n, k)` backtracks and pushes every
-k-combination into an array before a single one is yielded. A transition with
-a coloured input arc of weight `w` over a place holding `n` tokens therefore
-allocates `C(n, w)` arrays on every evaluation, every frame — and
-`computeTransitionEffect` returns on the first accepted combination, so nearly
-all of it is discarded.
+`enumerateWeightedMarkingIndicesGenerator` was only lazy over the Cartesian
+product _across_ arcs: per arc it eagerly materialised the full combination
+list, so a transition with a coloured input arc of weight `w` over a place
+holding `n` tokens allocated `C(n, w)` arrays on every evaluation, every frame
+— and the engine fires the first accepted combination, so nearly all of it was
+discarded. Measured before the fix, one weight-2 arc, transition never firing:
+13.4 ms per run-frame at 400 tokens (~170 ns per enumerated combination,
+quadratic in the token count); a 1000-run × 1800-frame experiment at that size
+would have taken ~6.7 hours. Weight 3 made it cubic. The general bound for one
+transition is `∏ᵢ C(nᵢ, wᵢ)` over its coloured non-inhibitor input arcs.
 
-Measured, one coloured place, one weight-2 input arc, transition never fires:
+Fixed in
+[FE-1526](https://linear.app/hash/issue/FE-1526/enumerate-weighted-arc-token-combinations-lazily-in-the-engine):
+enumeration is an in-place lexicographic successor per arc under an odometer
+over arcs, allocating nothing per combination and yielding a reused buffer
+(consumers copy on accept — the contract is in the module doc comment). The
+enumeration order is unchanged, which matters twice over: the engine fires the
+first passing combination, so an order change would diverge seeded
+trajectories, and the GPU backend reproduces the same order by unranking.
 
-| Tokens in place | `C(n,2)` | ns / run-frame |
-| --------------- | -------- | -------------- |
-| 10              | 45       | 17 892         |
-| 25              | 300      | 58 276         |
-| 50              | 1 225    | 214 988        |
-| 100             | 4 950    | 870 518        |
-| 200             | 19 900   | 3 318 793      |
-| 400             | 79 800   | **13 406 833** |
+Measured on the same harness (`benchmarks/coloured-enumeration.mjs`), before →
+after:
 
-Clean quadratic, ~170 ns per enumerated combination. At 400 tokens that is
-13.4 ms for one run-frame; a 1000-run × 1800-frame experiment would take ~6.7
-hours. Weight 3 makes it cubic. The general bound for one transition is
-`∏ᵢ C(nᵢ, wᵢ)` over its coloured non-inhibitor input arcs.
+| Tokens | `C(n,2)` | Never fires (all examined)  | Always fires (one examined) |
+| ------ | -------- | --------------------------- | --------------------------- |
+| 50     | 1 225    | 221 µs → 40 µs (5.6×)       | 45 µs → 3.2 µs (14×)        |
+| 100    | 4 950    | 1 002 µs → 159 µs (6.3×)    | 207 µs → 4.7 µs (44×)       |
+| 400    | 79 800   | 13 771 µs → 2 463 µs (5.6×) | 3 858 µs → 12.6 µs (305×)   |
 
-The fix is contained and changes no architecture: iterate combinations without
-materialising them — an in-place lexicographic successor per arc, and an
-odometer over arcs for the cross-arc product. Cost becomes proportional to
-combinations actually _examined_ (often 1 for a firing transition), with no
-allocation per combination. Enumeration order must not change: the engine
-fires the first passing combination, and the GPU backend's pair scan
-reproduces that order by unranking. Tracked in
-[FE-1526](https://linear.app/hash/issue/FE-1526/enumerate-weighted-arc-token-combinations-lazily-in-the-engine).
-:::
+A firing transition's cost is now flat in the token count (the residual growth
+is the firing's own token compaction). A never-firing transition still
+examines every combination — each one's rate must be evaluated — so that case
+keeps its `C(n, w)` lambda evaluations, at ~31 ns each instead of ~170 ns. The
+static enumeration-bound lint
+([FE-948](https://linear.app/hash/issue/FE-948/show-and-kill-combinatorial-explosion))
+remains the guard against nets where even that is too much.
 
 ### Metric aggregation
 
@@ -484,22 +485,21 @@ codegen is what makes WASM worth emitting.
 Ordered by measured value per unit of risk. None require a new toolchain, a
 new ABI, or user-visible change.
 
-| #   | Change                                                                                                                                                      | Expected                                                   |
-| --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
-| 1   | Lazy, index-based combination enumeration ([FE-1526](https://linear.app/hash/issue/FE-1526/enumerate-weighted-arc-token-combinations-lazily-in-the-engine)) | up to ~1000× on affected nets; nothing on weight-1 nets    |
-| 2   | Share one compiled `SimulationDefinition` across a shard's runs                                                                                             | removes 80–230 µs/run and improves inlining                |
-| 3   | Skip the frame copy when no place has dynamics; otherwise copy only dynamic places                                                                          | ~20%                                                       |
-| 4   | Replace `Record<PlaceID, …>` removals/additions with dense per-place-index typed arrays                                                                     | ~10% + most GC                                             |
-| 5   | Resolve place/transition indices at build time; delete `getPlaceIndex` from the hot loop                                                                    | ~3%                                                        |
-| 6   | Mutable-in-place metric accumulators + reusable frame cursor                                                                                                | ~30–50% of metric overhead                                 |
-| 7   | Single RNG draw per frame reused across transitions where semantics allow                                                                                   | up to 9% — changes RNG streams, permitted but user-visible |
+| #   | Change                                                                                   | Expected                                                   |
+| --- | ---------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| 1   | Share one compiled `SimulationDefinition` across a shard's runs                          | removes 80–230 µs/run and improves inlining                |
+| 2   | Skip the frame copy when no place has dynamics; otherwise copy only dynamic places       | ~20%                                                       |
+| 3   | Replace `Record<PlaceID, …>` removals/additions with dense per-place-index typed arrays  | ~10% + most GC                                             |
+| 4   | Resolve place/transition indices at build time; delete `getPlaceIndex` from the hot loop | ~3%                                                        |
+| 5   | Mutable-in-place metric accumulators + reusable frame cursor                             | ~30–50% of metric overhead                                 |
+| 6   | Single RNG draw per frame reused across transitions where semantics allow                | up to 9% — changes RNG streams, permitted but user-visible |
 
-Items 1–6 are behaviour-preserving. Item 7 changes RNG streams — the
+Items 1–5 are behaviour-preserving. Item 6 changes RNG streams — the
 reproducibility decision below permits that across engine versions, but
 existing seeds would produce different (equally valid) trajectories, which is
-a product-visible change. Estimated for items 1–6 combined on a typical
-coloured net: **5–15×** before any threading, **20–60×** combined with
-sharding on 8 cores.
+a product-visible change. Estimated for items 1–5 plus the landed enumeration
+fix, on a typical coloured net: **5–15×** before any threading, **20–60×**
+combined with sharding on 8 cores.
 
 ### Whole-loop codegen
 


### PR DESCRIPTION
## Summary

Before this PR, a lambda's only per-combination input is the token attributes it reads. When it reads none, its rate is the same for every combination. Engine still enumerated every combination for such a lambda, evaluating the same rate `C(n, w)` times per frame.

Engine draws one acceptance uniform per transition per frame and fires the first passing combination, so either the first combination fires or none does. Testing only the first combination is therefore exact: same RNG stream, same consumed tokens, meaning the first `w` in place order, same trajectories for every seed. Measured on `benchmarks/coloured-enumeration.mjs` with a never-firing weight-2 arc, per run-frame:

| Case | Before (token-reading lambda, enumerates) | After (token-independent lambda) |
| --- | --- | --- |
| 50 tokens | 40 µs | 0.7 µs |
| 400 tokens | 2 543 µs | 0.9 µs (flat) |

Before the lazy enumeration of FE-1526, the eager implementation cost 13.8 ms per run-frame on the 400-token case.

## Links

- Ticket [FE-1528](https://linear.app/hash/issue/FE-1528)
- Docs [Simulation performance](https://petrinaut-docs-git-cf-fe-1528-skip-combination-enumerati-2bffa2.stage.hash.ai/architecture/core/simulation/performance)

## Changes

#### Core

- `analyzeHir` marks token-independent lambdas `readsNoInputTokens`
  > Set on the compiled artifact when the lambda reads no token attributes or counts and is deterministic; `analyzeHir` already tracks token reads.
  > Artifacts compiled before the field existed keep enumerating.
- Both engines test only the first combination when the flag is set
  > A single first-combination marking replaces the enumerator; loop bodies are untouched. Engine-supplied constant lambdas, for transitions with no lambda code, take the same path.

#### Benchmarks

- `benchmarks/coloured-enumeration.mjs` gains a token-independent case
  > Existing cases now read a token so they keep measuring enumeration.

## Next steps

WebGPU pair scan could use the same flag to skip its unranking loop.

## Test coverage

- `hir/artifacts.test.ts`:
  > `readsNoInputTokens` on compiled artifacts: set for constant and parameters-only lambdas, absent when the lambda reads token attributes or a token count, or draws randomness.
- `simulation/engine/compute-possible-transition.test.ts`:
  > One lambda call instead of `C(4,2)`, first tokens consumed, identical RNG state and outcomes against the enumerating path.
- `simulation/monte-carlo/token-independent-lambda.test.ts`:
  > End-to-end seeded run with identical results when the flag is stripped.

## How to test

- `turbo run build test:unit --filter '@hashintel/petrinaut-core'`
- `cd libs/@hashintel/petrinaut-core`
- `node benchmarks/coloured-enumeration.mjs`, imports from `../dist`
- Expect token-independent case near 1 µs per run-frame from 50 to 400 tokens
- Expect token-reading cases growing with token count
