### PR TITLE
FE-1532: Track a launch config for the Petrinaut dev servers

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,30 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "@hashintel/petrinaut (storybook)",
+      "runtimeExecutable": "yarn",
+      "runtimeArgs": ["workspace", "@hashintel/petrinaut", "dev"],
+      "port": 6006
+    },
+    {
+      "name": "@apps/petrinaut-website",
+      "runtimeExecutable": "yarn",
+      "runtimeArgs": ["workspace", "@apps/petrinaut-website", "dev"],
+      "port": 5173
+    },
+    {
+      "name": "@apps/petrinaut-docs",
+      "runtimeExecutable": "yarn",
+      "runtimeArgs": [
+        "exec",
+        "turbo",
+        "run",
+        "dev",
+        "--filter",
+        "@apps/petrinaut-docs"
+      ],
+      "port": 4321
+    }
+  ]
+}

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -5,13 +5,15 @@
       "name": "@hashintel/petrinaut (storybook)",
       "runtimeExecutable": "yarn",
       "runtimeArgs": ["workspace", "@hashintel/petrinaut", "dev"],
-      "port": 6006
+      "port": 6006,
+      "autoPort": true
     },
     {
       "name": "@apps/petrinaut-website",
       "runtimeExecutable": "yarn",
       "runtimeArgs": ["workspace", "@apps/petrinaut-website", "dev"],
-      "port": 5173
+      "port": 5173,
+      "autoPort": true
     },
     {
       "name": "@apps/petrinaut-docs",
@@ -24,7 +26,8 @@
         "--filter",
         "@apps/petrinaut-docs"
       ],
-      "port": 4321
+      "port": 4321,
+      "autoPort": true
     }
   ]
 }

--- a/apps/petrinaut-docs/package.json
+++ b/apps/petrinaut-docs/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "scripts": {
     "build": "astro build",
-    "dev": "astro dev",
+    "dev": "astro dev --port ${PORT:-4321}",
     "lint:tsc": "astro check --minimumSeverity error",
     "preview": "astro preview",
     "sync:bundle": "node scripts/sync-bundle.mjs"

--- a/apps/petrinaut-docs/turbo.json
+++ b/apps/petrinaut-docs/turbo.json
@@ -24,7 +24,9 @@
     "dev": {
       "cache": false,
       "persistent": true,
-      "dependsOn": ["sync:bundle"]
+      "dependsOn": ["sync:bundle"],
+      // The Claude Code preview passes the port to serve on.
+      "env": ["PORT"]
     }
   }
 }

--- a/apps/petrinaut-website/vite.config.ts
+++ b/apps/petrinaut-website/vite.config.ts
@@ -84,6 +84,8 @@ export default defineConfig(({ mode }) => {
       port: process.env.PORT ? Number(process.env.PORT) : 4173,
     },
     server: {
+      /** the Claude Code preview may provide a PORT to run on */
+      port: process.env.PORT ? Number(process.env.PORT) : 5173,
       proxy: {
         "/api/petrinaut-opt": {
           target: process.env.PETRINAUT_OPT_ORIGIN ?? "http://127.0.0.1:4004",

--- a/libs/@hashintel/petrinaut/scripts/dev.sh
+++ b/libs/@hashintel/petrinaut/scripts/dev.sh
@@ -9,4 +9,4 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 . ../../@local/petrinaut-optimizer-client/scripts/optimizer-service.sh
 optimizer_service_parse "$@"
-run_dev_server yarn storybook dev ${OPTIMIZER_FORWARDED[@]+"${OPTIMIZER_FORWARDED[@]}"}
+run_dev_server yarn storybook dev -p "${PORT:-6006}" ${OPTIMIZER_FORWARDED[@]+"${OPTIMIZER_FORWARDED[@]}"}


### PR DESCRIPTION
> [!IMPORTANT]
> Dev tooling, nothing user-facing.

## Summary

Before this PR, no launch configuration was tracked, so every agent session rediscovered the Petrinaut dev servers and their ports by hand. The docs site has to start through Turborepo, which regenerates the architecture bundle first, and running the package script alone skips that step.

Adds a launch configuration naming the three servers, and lets each of them take its port from the environment so a preview can move off a port that is already busy.

## Links

- Ticket [FE-1532](https://linear.app/hash/issue/FE-1532)

## Changes

#### Launch configuration

- Three environments, each named after its package
  > Storybook for `@hashintel/petrinaut`, the demo site for `@apps/petrinaut-website`, the documentation site for `@apps/petrinaut-docs`.
- Documentation entry starts through Turborepo
  > `sync:bundle` regenerates the architecture bundle before Astro serves it.
- Every entry sets `autoPort`
  > Preview can claim another port when the declared one is taken, which happens whenever a second Storybook already serves 6006.

#### Dev servers

- Storybook, the demo site and the documentation site read their port from `PORT`
  > None of the three did, so `autoPort` had nothing to steer and the preview waited on a port that never opened.
  > Storybook and Astro take `-p ${PORT:-<default>}`; the demo site reads `server.port` in `vite.config.ts`, matching the `preview` block already there.
- Documentation task declares `PORT` in Turborepo
  > Strict environment mode drops any variable a task does not declare.

## Next steps

- A `petrinaut-optimization` entry runs the demo site against the local optimizer service
  > Covers the whole loop, browser through to the CLI subprocess, and was verified end to end.
  > Held until the launcher forwards `--port` and `--strictPort` to Vite, tracked as FE-1529.

## Test coverage

- Manual port checks:
  > `PORT=7801`, `7802` and `7803` bind Storybook, the demo site and the documentation site on those ports.
  > Each server still falls back to its declared default when `PORT` is unset.
- Existing `@apps/petrinaut-website` and `@apps/petrinaut-docs` jobs:
  > Build and typecheck both packages.

## How to test

- `PORT=7801 yarn workspace @hashintel/petrinaut dev`
- Expect Storybook on 7801
- `yarn workspace @hashintel/petrinaut dev`
- Expect Storybook on 6006
- `PORT=7803 yarn exec turbo run dev --filter @apps/petrinaut-docs`
- Expect documentation site on 7803
