### PR TITLE
FE-1500: fix StrictMode playback disposal

### DIFF
--- a/libs/@hashintel/petrinaut/src/react/playback/provider.test.tsx
+++ b/libs/@hashintel/petrinaut/src/react/playback/provider.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import { act, render, type RenderResult } from "@testing-library/react";
-import { use } from "react";
+import { StrictMode, use } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -814,6 +814,53 @@ describe("PlaybackProvider", () => {
       expect(getPlaybackValue().playbackState).toBe("Stopped");
       expect(getPlaybackValue().currentFrameIndex).toBe(0);
     });
+  });
+
+  it("advances arriving frames when StrictMode replays mount effects", async () => {
+    const initialize = vi.fn().mockResolvedValue(undefined);
+    const run = vi.fn();
+    const simulationContext = createMockSimulationContext({ initialize, run });
+    const valueHolder = { current: null as PlaybackContextValue | null };
+
+    const { rerender } = render(
+      <StrictMode>
+        <TestWrapper
+          simContext={simulationContext}
+          onContextValue={(value) => {
+            valueHolder.current = value;
+          }}
+        />
+      </StrictMode>,
+    );
+
+    await act(async () => {
+      await valueHolder.current!.play();
+    });
+
+    expect(initialize).toHaveBeenCalled();
+    expect(run).toHaveBeenCalled();
+    expect(valueHolder.current!.playbackState).toBe("Playing");
+
+    rerender(
+      <StrictMode>
+        <TestWrapper
+          simContext={createMockSimulationContext(
+            { state: "Running", initialize, run },
+            10,
+          )}
+          onContextValue={(value) => {
+            valueHolder.current = value;
+          }}
+        />
+      </StrictMode>,
+    );
+
+    act(() => {
+      rafCallbacks.shift()!(0);
+      rafCallbacks.shift()!(20);
+    });
+
+    expect(valueHolder.current!.currentFrameIndex).toBe(2);
   });
 
   describe("currentViewedFrame", () => {

--- a/libs/@hashintel/petrinaut/src/react/playback/provider.tsx
+++ b/libs/@hashintel/petrinaut/src/react/playback/provider.tsx
@@ -86,9 +86,10 @@ export const PlaybackProvider: React.FC<PlaybackProviderProps> = ({
   const [playback] = useState<Playback>(() =>
     createPlayback({ mode: playMode }),
   );
-  useEffect(() => {
-    return playback.dispose;
-  }, [playback]);
+  // Playback only owns in-memory state; its rAF and store subscriptions are
+  // cleaned up by their respective effects. Disposing this handle from an
+  // effect cleanup would permanently disable it during React StrictMode's
+  // development-only setup → cleanup → setup replay.
 
   const snapshot = useStore(playback.state);
   const { playState, frameIndex, speed, mode: requestedMode } = snapshot;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Simulation playback stalled in development builds: `PlaybackProvider` disposed its playback state machine in a `useEffect` cleanup, and React Strict Mode's setup, cleanup, setup replay left the handle permanently disposed, so `play()` and rAF ticks became no-ops while frames kept arriving. This removes the disposal effect.

## 🔗 Related links

- [FE-1500](https://linear.app/hash/issue/FE-1500/view-only-iframe-embed-of-a-petrinaut-net)

## 🔍 What does this change?

- Removes the dispose-on-cleanup effect from `PlaybackProvider`. Playback owns only in-memory state; its rAF loop and store subscriptions are cleaned up by their own effects. A comment at the site records why no disposal happens there.
- Adds a Strict Mode regression test that initializes a simulation, delivers frames across a rerender, drives two mocked animation frames, and asserts the frame index advanced.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- New: the `react/playback/provider.test.tsx` case "advances arriving frames when StrictMode replays mount effects".
- Existing: the rest of the `PlaybackProvider` suite.

## ❓ How to test this?

1. Checkout the branch and run `yarn workspace @apps/petrinaut-website dev` (the site mounts under `StrictMode`).
2. Open the local demo, switch to Simulate, and press Play.
3. Confirm the frame counter and playhead advance.
