### PR TITLE
FE-1536: Contour surface for optimization studies with local recompute

### DIFF
--- a/.changeset/ds-slider-change-end.md
+++ b/.changeset/ds-slider-change-end.md
@@ -1,0 +1,5 @@
+---
+"@hashintel/ds-components": patch
+---
+
+`Slider` accepts `step` and `onChangeEnd`.

--- a/.changeset/ds-slider-change-end.md
+++ b/.changeset/ds-slider-change-end.md
@@ -1,5 +1,0 @@
----
-"@hashintel/ds-components": patch
----
-
-`Slider` accepts `step` and `onChangeEnd`.

--- a/.changeset/optimization-surface.md
+++ b/.changeset/optimization-surface.md
@@ -1,0 +1,5 @@
+---
+"@hashintel/petrinaut": patch
+---
+
+Optimization studies with two or more optimized numeric parameters gain a Surface section: an Optuna-style contour of the objective over two chosen parameters, filled by points computed locally against the study's frozen model snapshot, with the study's trials drawn as markers. Sliders navigate the space, the selected point refines with escalating batches while the readout streams the objective's mean and median, and clicking the plot moves the selection.

--- a/.changeset/optimization-surface.md
+++ b/.changeset/optimization-surface.md
@@ -1,5 +1,6 @@
 ---
 "@hashintel/petrinaut": patch
+"@hashintel/ds-components": patch
 ---
 
-Optimization studies with two or more optimized numeric parameters gain a Surface section: an Optuna-style contour of the objective over two chosen parameters, filled by points computed locally against the study's frozen model snapshot, with the study's trials drawn as markers. Sliders navigate the space, the selected point refines with escalating batches while the readout streams the objective's mean and median, and clicking the plot moves the selection.
+Optimization studies with two or more optimized numeric parameters gain a Surface section: a contour of the objective over two chosen parameters, computed locally against the study's frozen model, with the study's trials as markers. Sliders and clicks move the selected point, which refines with escalating batches. `Slider` accepts `step` and `onChangeEnd`.

--- a/libs/@hashintel/ds-components/src/components/Slider/slider.tsx
+++ b/libs/@hashintel/ds-components/src/components/Slider/slider.tsx
@@ -23,11 +23,14 @@ export interface SliderProps {
   style?: React.CSSProperties;
   min?: number;
   max?: number;
+  step?: number;
   value?: number;
   defaultValue?: number;
   label?: string;
   showValueText?: boolean;
   onChange?: (value: number) => void;
+  /** Fires once when a drag or keyboard interaction settles. */
+  onChangeEnd?: (value: number) => void;
 }
 
 export const Slider: React.FC<SliderProps> = ({
@@ -35,15 +38,18 @@ export const Slider: React.FC<SliderProps> = ({
   style,
   min,
   max,
+  step,
   value,
   defaultValue,
   label,
   showValueText = false,
   onChange,
+  onChangeEnd,
 }) => {
   return (
     <BaseSlider.Root
       min={min}
+      step={step}
       className={cx(
         css({
           position: "relative",
@@ -62,6 +68,12 @@ export const Slider: React.FC<SliderProps> = ({
         // For now this component only supports single value sliders
         if (newValue !== undefined) {
           onChange?.(newValue);
+        }
+      }}
+      onValueChangeEnd={(details) => {
+        const newValue = details.value[0];
+        if (newValue !== undefined) {
+          onChangeEnd?.(newValue);
         }
       }}
     >

--- a/libs/@hashintel/petrinaut/docs/optimization.md
+++ b/libs/@hashintel/petrinaut/docs/optimization.md
@@ -88,6 +88,25 @@ connection reports how many of the requested trials had completed and includes
 a diagnostic identifier for support. Trials received before the failure are
 kept, and a **Retry** action starts a fresh run with the same settings.
 
+## The surface view
+
+A study with two or more optimized numeric parameters grows a **Surface**
+section at the bottom of its drawer: an Optuna-style contour of the objective
+over two parameters you pick. The study's own trials appear as rings (the best
+trial highlighted), and the filled contour comes from points **computed
+locally on your machine** — the study's model snapshot runs on a background
+worker, a few runs per point, and the plot fills in coarse shape first.
+
+One slider per optimized parameter navigates the space; parameters not shown
+on the plot hold at their slider position, which starts at the best trial's
+value. Move a slider or **click the plot** and the selected point recomputes
+with escalating batches while the readout streams the objective's mean and
+median. Points you have visited are cached, so returning to them is instant.
+
+Log-scale domains slide in log space, and integer domains snap to their step.
+Local points always reflect the model as it was when the study launched, even
+if you have edited the net since.
+
 ## Connection drops and reloads
 
 An optimization runs on the server, not in your browser tab. If the connection

--- a/libs/@hashintel/petrinaut/src/react/experiments/context.ts
+++ b/libs/@hashintel/petrinaut/src/react/experiments/context.ts
@@ -7,6 +7,7 @@ import type {
 import type { SweepCellSnapshot, SweepSelection } from "./sweep-session";
 import type {
   AdHocScenarioState,
+  SDCPN,
   MonteCarloExpressionMetricSpec,
   MonteCarloMetricSpec,
   MonteCarloUserDefinedMetricFrame,
@@ -201,9 +202,37 @@ export type ExperimentsContextValue = {
    */
   sampleSweepCell: (
     experimentId: string,
-    parameterValues: Readonly<Record<string, number>>,
+    position: Readonly<Record<string, number>>,
     minRuns: number,
   ) => Promise<SweepCellSnapshot | null>;
+  /**
+   * Computes one metric sample against an arbitrary net snapshot, on the
+   * background single-worker lane — the optimization surface's local compute
+   * path, which must run a study's frozen model rather than the live editor
+   * net. Batches are serialized; compilation is cached per `cacheKey`.
+   * Resolves null when the batch is refused or fails (a hole in the surface,
+   * not an error).
+   */
+  sampleDetachedObjective: (
+    request: DetachedObjectiveRequest,
+  ) => Promise<SweepCellSnapshot | null>;
+};
+
+/** One local compute batch for an optimization study's objective. */
+export type DetachedObjectiveRequest = {
+  /** Compile-cache identity; one study keeps one compiled snapshot. */
+  cacheKey: string;
+  /** The frozen model snapshot to run (not the live editor net). */
+  definition: SDCPN;
+  scenarioId: string;
+  /** Parsed values for every scenario parameter (bindings plus navigation). */
+  scenarioParameterValues: Readonly<Record<string, number | boolean>>;
+  /** The study's objective metric, evaluated as an expression metric. */
+  metric: { id: string; label: string; code: string };
+  seed: number;
+  runCount: number;
+  dt: number;
+  maxTime: number;
 };
 
 const DEFAULT_CONTEXT_VALUE: ExperimentsContextValue = {
@@ -216,6 +245,7 @@ const DEFAULT_CONTEXT_VALUE: ExperimentsContextValue = {
   removeExperiment: () => {},
   setSweepSelection: () => {},
   sampleSweepCell: () => Promise.resolve(null),
+  sampleDetachedObjective: () => Promise.resolve(null),
 };
 
 export const ExperimentsContext = createContext<ExperimentsContextValue>(

--- a/libs/@hashintel/petrinaut/src/react/experiments/provider.tsx
+++ b/libs/@hashintel/petrinaut/src/react/experiments/provider.tsx
@@ -16,6 +16,7 @@ import {
   type MonteCarloExperimentState,
   getDefaultMonteCarloShardCount,
   type WorkerFactory,
+  DEFAULT_PETRINAUT_EXTENSIONS,
   type Scenario,
   type ScenarioParameter,
 } from "@hashintel/petrinaut-core";
@@ -48,6 +49,7 @@ import {
   type ExperimentsContextValue,
   isExperimentActive,
   isTerminalExperimentStatus,
+  type DetachedObjectiveRequest,
 } from "./context";
 import {
   buildParameterAxis,
@@ -58,6 +60,7 @@ import {
 import {
   createSweepSession,
   type SweepSession,
+  type SweepCellSnapshot,
   type SweepSessionUpdate,
 } from "./sweep-session";
 
@@ -259,6 +262,24 @@ export const ExperimentsProvider: React.FC<ExperimentsProviderProps> = ({
     new Map<string, PendingExperimentRegistration>(),
   );
   const sweepSessionsRef = useRef(new Map<string, SweepSession>());
+  /** Serializes detached objective batches on one background worker. */
+  const detachedChainRef = useRef<Promise<unknown>>(Promise.resolve());
+  const detachedCpuBackendRef = useRef<ExperimentBackend | null>(null);
+  const detachedCompileCacheRef = useRef(
+    new Map<
+      string,
+      Promise<{
+        scenario: Scenario;
+        scenarioHir: Awaited<ReturnType<typeof requestScenarioHir>>;
+        artifacts: Awaited<ReturnType<typeof requestHirArtifacts>>["artifacts"];
+        metricArtifact: NonNullable<
+          Awaited<
+            ReturnType<typeof requestHirArtifacts>
+          >["artifacts"]["metrics"][string]
+        >;
+      }>
+    >(),
+  );
   const [experiments, setExperiments] = useState<ExperimentRecord[]>([]);
   const selectedExperimentId =
     navigation.state.simulateResource?.type === "experiment"
@@ -1019,6 +1040,145 @@ export const ExperimentsProvider: React.FC<ExperimentsProviderProps> = ({
       .get(experimentId)
       ?.sampleCell(parameterValues, minRuns) ?? Promise.resolve(null);
 
+  const runDetachedObjectiveBatch = async (
+    request: DetachedObjectiveRequest,
+  ): Promise<SweepCellSnapshot | null> => {
+    try {
+      // One compiled snapshot per study: the frozen definition, its scenario
+      // HIR, and its HIR artifacts never change for a given cacheKey.
+      let compiled = detachedCompileCacheRef.current.get(request.cacheKey);
+      if (!compiled) {
+        compiled = (async () => {
+          const scenario = (request.definition.scenarios ?? []).find(
+            (candidate: Scenario) => candidate.id === request.scenarioId,
+          );
+          if (!scenario) {
+            throw new Error(
+              `Scenario ${request.scenarioId} is not in the model snapshot`,
+            );
+          }
+          // The snapshot runs under default extensions, as it does on the
+          // optimizer service — the live editor's toggles do not apply to a
+          // frozen study.
+          const { artifacts, failures } = await requestHirArtifacts(
+            request.definition,
+            DEFAULT_PETRINAUT_EXTENSIONS,
+            { includeHir: false },
+          );
+          const metricArtifact = getOwn(artifacts.metrics, request.metric.id);
+          if (!metricArtifact) {
+            throw new Error(
+              failures
+                .map((failure) => failure.diagnostics[0]?.message)
+                .filter(Boolean)
+                .join("; ") || "The objective metric did not compile",
+            );
+          }
+          const scenarioHir = await requestScenarioHir(scenario);
+          return { scenario, scenarioHir, artifacts, metricArtifact };
+        })();
+        detachedCompileCacheRef.current.set(request.cacheKey, compiled);
+        compiled.catch(() => {
+          // A failed compile is retried on the next sample rather than cached.
+          detachedCompileCacheRef.current.delete(request.cacheKey);
+        });
+      }
+      const { scenario, scenarioHir, artifacts, metricArtifact } =
+        await compiled;
+
+      const compiledScenario = compileScenario(
+        scenario,
+        scenarioHir,
+        request.definition.parameters,
+        request.definition.places,
+        request.definition.types,
+        {
+          // Scenario compilation is numeric; boolean bindings arrive as their
+          // 0/1 encoding, matching how the engine stores boolean parameters.
+          scenarioParameterValues: Object.fromEntries(
+            Object.entries(request.scenarioParameterValues).map(
+              ([identifier, value]) => [
+                identifier,
+                typeof value === "boolean" ? (value ? 1 : 0) : value,
+              ],
+            ),
+          ),
+        },
+      );
+      if (!compiledScenario.ok) {
+        return null;
+      }
+
+      detachedCpuBackendRef.current ??= createWorkerPoolExperimentBackend({
+        createWorker: workerFactoryRef.current,
+        shardCount: 1,
+      });
+      const backend = detachedCpuBackendRef.current;
+
+      const abortController = new AbortController();
+      const assessment = await backend.assess({
+        sdcpn: request.definition,
+        extensions: DEFAULT_PETRINAUT_EXTENSIONS,
+        initialMarking: compiledScenario.result.initialState,
+        parameterValues: compiledScenario.result.parameterValues,
+        seed: request.seed,
+        dt: request.dt,
+        maxTime: request.maxTime,
+        runCount: request.runCount,
+        metricSpecs: [
+          {
+            kind: "expression",
+            id: request.metric.id,
+            label: request.metric.label,
+            code: request.metric.code,
+            sampleRuns: "all",
+            runOutput: { type: "distribution" },
+            artifact: metricArtifact,
+          },
+        ],
+        hirArtifacts: artifacts,
+      });
+      if (!assessment.eligible) {
+        return null;
+      }
+      const instantiated = await assessment.instantiate({
+        signal: abortController.signal,
+      });
+      if (!instantiated.ok) {
+        return null;
+      }
+      const handle = instantiated.handle;
+
+      const done = new Promise<boolean>((resolve) => {
+        const offEvents = handle.events.subscribe((event) => {
+          offEvents();
+          resolve(event.type === "complete");
+        });
+      });
+      handle.start();
+      const completed = await done;
+      const frames = handle.metrics.get().frames;
+      handle.dispose();
+      if (!completed) {
+        return null;
+      }
+      return { runsCompleted: request.runCount, metricFrames: frames };
+    } catch {
+      // A refused or failed batch is a hole in the surface, not an error the
+      // optimization view should surface.
+      return null;
+    }
+  };
+
+  const sampleDetachedObjective: ExperimentsContextValue["sampleDetachedObjective"] =
+    (request) => {
+      const next = detachedChainRef.current.then(() =>
+        runDetachedObjectiveBatch(request),
+      );
+      detachedChainRef.current = next.catch(() => null);
+      return next;
+    };
+
   const selectedExperiment =
     experiments.find((experiment) => experiment.id === selectedExperimentId) ??
     null;
@@ -1033,6 +1193,7 @@ export const ExperimentsProvider: React.FC<ExperimentsProviderProps> = ({
     removeExperiment: useStableCallback(removeExperiment),
     setSweepSelection: useStableCallback(setSweepSelection),
     sampleSweepCell: useStableCallback(sampleSweepCell),
+    sampleDetachedObjective: useStableCallback(sampleDetachedObjective),
   };
 
   return (

--- a/libs/@hashintel/petrinaut/src/react/optimizations/surface-grid.test.ts
+++ b/libs/@hashintel/petrinaut/src/react/optimizations/surface-grid.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildOptimizationSurfaceAxes,
+  OPTIMIZATION_AXIS_STEPS,
+  optimizationAxisMidpoint,
+  optimizationAxisPositionFor,
+  optimizationAxisValueAt,
+} from "./surface-grid";
+
+import type { OptimizationSurfaceAxis } from "./surface-grid";
+import type { PetrinautOptimizationInput } from "@hashintel/petrinaut-core";
+
+const inputWith = (
+  bindings: PetrinautOptimizationInput["scenario"]["parameterBindings"],
+): PetrinautOptimizationInput =>
+  ({
+    scenario: { id: "s", parameterBindings: bindings },
+  }) as PetrinautOptimizationInput;
+
+describe("buildOptimizationSurfaceAxes", () => {
+  it("keeps non-boolean optimized parameters, in binding order", () => {
+    const axes = buildOptimizationSurfaceAxes(
+      inputWith({
+        rate: {
+          kind: "optimize",
+          domain: {
+            kind: "continuous",
+            minimum: 0.1,
+            maximum: 2,
+            scale: "linear",
+          },
+        },
+        fixed: { kind: "fixed", value: 3 },
+        flag: { kind: "optimize", domain: { kind: "boolean" } },
+        batch: {
+          kind: "optimize",
+          domain: {
+            kind: "integer",
+            minimum: 10,
+            maximum: 50,
+            step: 5,
+            scale: "linear",
+          },
+        },
+      }),
+    );
+
+    expect(axes.map((axis) => axis.identifier)).toEqual(["rate", "batch"]);
+    expect(axes[0]!.stepCount).toBe(OPTIMIZATION_AXIS_STEPS);
+    // 8 domain steps of 5 between 10 and 50.
+    expect(axes[1]!.stepCount).toBe(8);
+  });
+});
+
+describe("optimizationAxisValueAt", () => {
+  it("maps linear continuous positions across the domain", () => {
+    const axis: OptimizationSurfaceAxis = {
+      identifier: "rate",
+      domain: { kind: "continuous", minimum: 0, maximum: 1, scale: "linear" },
+      stepCount: 50,
+    };
+    expect(optimizationAxisValueAt(axis, 0)).toBe(0);
+    expect(optimizationAxisValueAt(axis, 25)).toBe(0.5);
+    expect(optimizationAxisValueAt(axis, 50)).toBe(1);
+  });
+
+  it("quantizes log-scale domains in log space", () => {
+    const axis: OptimizationSurfaceAxis = {
+      identifier: "rate",
+      domain: { kind: "continuous", minimum: 0.01, maximum: 100, scale: "log" },
+      stepCount: 50,
+    };
+    expect(optimizationAxisValueAt(axis, 0)).toBe(0.01);
+    // Halfway in log space is the geometric mean.
+    expect(optimizationAxisValueAt(axis, 25)).toBeCloseTo(1, 9);
+    expect(optimizationAxisValueAt(axis, 50)).toBe(100);
+  });
+
+  it("snaps integer domains to their step", () => {
+    const axis: OptimizationSurfaceAxis = {
+      identifier: "batch",
+      domain: {
+        kind: "integer",
+        minimum: 10,
+        maximum: 50,
+        step: 5,
+        scale: "linear",
+      },
+      stepCount: 8,
+    };
+    expect(optimizationAxisValueAt(axis, 0)).toBe(10);
+    expect(optimizationAxisValueAt(axis, 3)).toBe(25);
+    expect(optimizationAxisValueAt(axis, 8)).toBe(50);
+  });
+});
+
+describe("optimizationAxisPositionFor", () => {
+  it("inverts the linear mapping, clamped to the domain", () => {
+    const axis: OptimizationSurfaceAxis = {
+      identifier: "rate",
+      domain: { kind: "continuous", minimum: 0, maximum: 1, scale: "linear" },
+      stepCount: 50,
+    };
+    expect(optimizationAxisPositionFor(axis, 0.5)).toBe(25);
+    expect(optimizationAxisPositionFor(axis, -4)).toBe(0);
+    expect(optimizationAxisPositionFor(axis, 7)).toBe(50);
+  });
+
+  it("inverts the log mapping", () => {
+    const axis: OptimizationSurfaceAxis = {
+      identifier: "rate",
+      domain: { kind: "continuous", minimum: 0.01, maximum: 100, scale: "log" },
+      stepCount: 50,
+    };
+    expect(optimizationAxisPositionFor(axis, 1)).toBe(25);
+    expect(
+      optimizationAxisPositionFor(axis, optimizationAxisValueAt(axis, 37)),
+    ).toBe(37);
+  });
+
+  it("gives the midpoint of an axis", () => {
+    const axis: OptimizationSurfaceAxis = {
+      identifier: "batch",
+      domain: {
+        kind: "integer",
+        minimum: 10,
+        maximum: 50,
+        step: 5,
+        scale: "linear",
+      },
+      stepCount: 8,
+    };
+    expect(optimizationAxisMidpoint(axis)).toBe(4);
+    expect(optimizationAxisValueAt(axis, 4)).toBe(30);
+  });
+});

--- a/libs/@hashintel/petrinaut/src/react/optimizations/surface-grid.ts
+++ b/libs/@hashintel/petrinaut/src/react/optimizations/surface-grid.ts
@@ -1,0 +1,121 @@
+/**
+ * Quantized navigation space over an optimization study's optimized
+ * parameters, mirroring the experiments' sweep axes but built from the
+ * study's parameter domains: continuous domains honour their log scale by
+ * quantizing in log space, and integer domains snap to their declared step.
+ * Boolean domains have no axis — there is nothing to slide.
+ */
+import type {
+  PetrinautOptimizationInput,
+  PetrinautOptimizationParameterBinding,
+} from "@hashintel/petrinaut-core";
+
+type OptimizeBinding = Extract<
+  PetrinautOptimizationParameterBinding,
+  { kind: "optimize" }
+>;
+type NumericDomain = Extract<
+  OptimizeBinding["domain"],
+  { kind: "continuous" } | { kind: "integer" }
+>;
+
+/** Quantization steps per axis; integer domains use one step per domain step. */
+export const OPTIMIZATION_AXIS_STEPS = 50;
+
+export type OptimizationSurfaceAxis = {
+  identifier: string;
+  domain: NumericDomain;
+  /** Positions run 0..stepCount inclusive. */
+  stepCount: number;
+};
+
+/** The navigable axes of a study: its non-boolean optimized parameters. */
+export function buildOptimizationSurfaceAxes(
+  input: PetrinautOptimizationInput,
+): OptimizationSurfaceAxis[] {
+  const axes: OptimizationSurfaceAxis[] = [];
+  for (const [identifier, binding] of Object.entries(
+    input.scenario.parameterBindings,
+  )) {
+    if (binding.kind !== "optimize" || binding.domain.kind === "boolean") {
+      continue;
+    }
+    const domain = binding.domain;
+    const stepCount =
+      domain.kind === "integer"
+        ? Math.min(
+            OPTIMIZATION_AXIS_STEPS,
+            Math.round((domain.maximum - domain.minimum) / domain.step),
+          )
+        : OPTIMIZATION_AXIS_STEPS;
+    axes.push({ identifier, domain, stepCount });
+  }
+  return axes;
+}
+
+/** Strips float artifacts (e.g. 0.30000000000000004) from mapped values. */
+function normalizeValue(value: number): number {
+  return Number(value.toPrecision(12));
+}
+
+/** The domain value at a quantized position (0..stepCount). */
+export function optimizationAxisValueAt(
+  axis: OptimizationSurfaceAxis,
+  position: number,
+): number {
+  const { domain, stepCount } = axis;
+  const fraction = Math.min(Math.max(position, 0), stepCount) / stepCount;
+
+  if (domain.kind === "integer") {
+    const totalSteps = Math.round(
+      (domain.maximum - domain.minimum) / domain.step,
+    );
+    const stepIndex =
+      domain.scale === "log"
+        ? Math.round(
+            (Math.exp(
+              Math.log(domain.minimum) +
+                (Math.log(domain.maximum) - Math.log(domain.minimum)) *
+                  fraction,
+            ) -
+              domain.minimum) /
+              domain.step,
+          )
+        : Math.round(totalSteps * fraction);
+    return domain.minimum + domain.step * Math.min(stepIndex, totalSteps);
+  }
+
+  if (domain.scale === "log") {
+    return normalizeValue(
+      Math.exp(
+        Math.log(domain.minimum) +
+          (Math.log(domain.maximum) - Math.log(domain.minimum)) * fraction,
+      ),
+    );
+  }
+  return normalizeValue(
+    domain.minimum + (domain.maximum - domain.minimum) * fraction,
+  );
+}
+
+/** The quantized position nearest to `value` (0..stepCount). */
+export function optimizationAxisPositionFor(
+  axis: OptimizationSurfaceAxis,
+  value: number,
+): number {
+  const { domain, stepCount } = axis;
+  const clamped = Math.min(Math.max(value, domain.minimum), domain.maximum);
+  const fraction =
+    domain.scale === "log"
+      ? (Math.log(clamped) - Math.log(domain.minimum)) /
+        (Math.log(domain.maximum) - Math.log(domain.minimum))
+      : (clamped - domain.minimum) / (domain.maximum - domain.minimum);
+  return Math.min(Math.max(Math.round(fraction * stepCount), 0), stepCount);
+}
+
+/** The middle of a domain, as a starting position before any trial exists. */
+export function optimizationAxisMidpoint(
+  axis: OptimizationSurfaceAxis,
+): number {
+  return Math.round(axis.stepCount / 2);
+}

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/create-experiment-drawer.test.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/create-experiment-drawer.test.tsx
@@ -158,6 +158,7 @@ const TestProviders = ({
             removeExperiment: () => {},
             setSweepSelection: () => {},
             sampleSweepCell: () => Promise.resolve(null),
+            sampleDetachedObjective: () => Promise.resolve(null),
           }}
         >
           <SDCPNContext value={sdcpnContextValue}>

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/experiments-story-fixtures.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/experiments-story-fixtures.tsx
@@ -305,6 +305,44 @@ export function FakeExperimentsProvider({
           current.filter((experiment) => experiment.id !== experimentId),
         );
       },
+      sampleDetachedObjective: (request) => {
+        // The same synthetic bump as sampleSweepCell, over the study's real
+        // parameter values, so the optimization surface story fills live.
+        const values = Object.values(request.scenarioParameterValues).filter(
+          (entry): entry is number => typeof entry === "number",
+        );
+        const x = values[0] ?? 0;
+        const y = values[1] ?? 0;
+        const objective =
+          100 * Math.exp(-((x - 0.35) ** 2) * 20 - ((y - 10) / 14) ** 2) +
+          6 * Math.sin(x * 9) +
+          y / 4;
+        const frame = {
+          metricId: request.metric.id,
+          label: request.metric.label,
+          outputType: "distribution" as const,
+          frameNumber: 45,
+          time: 45,
+          bins: [
+            [Math.round(objective * 100) / 100, request.runCount],
+          ] as (readonly [number, number])[],
+          value: null,
+          frameValue: null,
+          timeValue: null,
+          runSampleCount: request.runCount,
+          timeSampleCount: request.runCount,
+        };
+        return new Promise((resolve) => {
+          setTimeout(
+            () =>
+              resolve({
+                runsCompleted: request.runCount,
+                metricFrames: [frame],
+              }),
+            100,
+          );
+        });
+      },
       setSweepSelection: (experimentId, selection) => {
         setExperiments((current) =>
           current.map((experiment) =>

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/optimization-surface.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/optimization-surface.tsx
@@ -1,0 +1,757 @@
+/**
+ * The optimization surface: an Optuna-style filled contour of the study's
+ * objective over two optimized parameters, computed locally.
+ *
+ * The study's own trials arrive with parameter values and objective values,
+ * and are drawn as markers (projected onto the two shown axes, the way
+ * Optuna's `plot_contour` projects). The interpolated fill comes from points
+ * this view computes itself: it walks an X×Y sub-grid of the two shown
+ * parameters coarse-to-fine, running the study's frozen model snapshot with
+ * its objective metric on a background worker, holding every other optimized
+ * parameter at its slider position (initially the best trial's value). One
+ * slider per optimized parameter navigates the space; the selected point
+ * refines with escalating batches, and the readout streams the objective's
+ * mean and median as runs accumulate. Clicking the surface moves the two
+ * shown sliders to the clicked position.
+ *
+ * In a future iteration the optimizer streams its own evaluations back
+ * through the same feed; the trial markers are that feed's first form.
+ */
+import { use, useEffect, useRef, useState } from "react";
+
+import { Select, Slider } from "@hashintel/ds-components";
+import { css } from "@hashintel/ds-helpers/css";
+
+import { ExperimentsContext } from "../../../../../../react/experiments/context";
+import {
+  bluesColor,
+  coarseToFineOrder,
+  contourLevels,
+  idwRaster,
+  marchingSquaresSegments,
+  sweepCellObjective,
+} from "../../../../../../react/experiments/contour-grid";
+import {
+  EXPERIMENT_RUN_LADDER,
+  mergeMetricFramesAcrossCells,
+} from "../../../../../../react/experiments/parameter-grid";
+import { sweepBatchSeed } from "../../../../../../react/experiments/sweep-session";
+import { useElementSize } from "../../../../../../react/hooks/use-element-size";
+import {
+  buildOptimizationSurfaceAxes,
+  optimizationAxisMidpoint,
+  optimizationAxisPositionFor,
+  optimizationAxisValueAt,
+} from "../../../../../../react/optimizations/surface-grid";
+
+import type { ExperimentsContextValue } from "../../../../../../react/experiments/context";
+import type { ContourSample } from "../../../../../../react/experiments/contour-grid";
+import type { SweepCellSnapshot } from "../../../../../../react/experiments/sweep-session";
+import type { OptimizationRecord } from "../../../../../../react/optimizations/context";
+import type { OptimizationSurfaceAxis } from "../../../../../../react/optimizations/surface-grid";
+
+/** Runs a surface cell needs before its point appears. */
+const SURFACE_CELL_RUNS = 8;
+
+/** Ladder cap for the selected point's local refinement. */
+const SELECTED_POINT_MAX_RUNS = 100;
+
+/** Sampled positions per axis on the surface's sub-grid. */
+const SURFACE_GRID_POSITIONS = 11;
+
+/** Raster resolution per grid cell, in pixels of interpolation lattice. */
+const RASTER_SUBDIVISION = 8;
+
+/** Evenly spread quantized positions of `axis` shown on the surface. */
+function surfacePositions(axis: OptimizationSurfaceAxis): number[] {
+  const count = Math.min(SURFACE_GRID_POSITIONS, axis.stepCount + 1);
+  const positions = Array.from({ length: count }, (_, index) =>
+    Math.round((index * axis.stepCount) / (count - 1)),
+  );
+  return [...new Set(positions)];
+}
+
+const surfaceStyle = css({
+  display: "flex",
+  flexDirection: "column",
+  gap: "2",
+});
+
+const controlsStyle = css({
+  display: "flex",
+  alignItems: "center",
+  gap: "2",
+  flexWrap: "wrap",
+  "& [data-scope='select']": { width: "[170px]" },
+});
+
+const controlLabelStyle = css({
+  fontSize: "xs",
+  fontWeight: "medium",
+  color: "neutral.s120",
+  flexShrink: 0,
+});
+
+const sliderRowStyle = css({
+  display: "flex",
+  alignItems: "center",
+  gap: "2",
+});
+
+const sliderNameStyle = css({
+  fontSize: "xs",
+  fontWeight: "medium",
+  color: "neutral.s120",
+  width: "[140px]",
+  flexShrink: 0,
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+});
+
+const sliderControlStyle = css({
+  flex: "1",
+});
+
+const sliderValueStyle = css({
+  fontSize: "xs",
+  fontVariantNumeric: "tabular-nums",
+  color: "neutral.s100",
+  width: "[96px]",
+  flexShrink: 0,
+  textAlign: "right",
+});
+
+const canvasFrameStyle = css({
+  position: "relative",
+  borderWidth: "[1px]",
+  borderStyle: "solid",
+  borderColor: "neutral.bd.subtle",
+  borderRadius: "md",
+  overflow: "hidden",
+  backgroundColor: "neutral.s00",
+});
+
+const canvasStyle = css({
+  display: "block",
+  width: "[100%]",
+  height: "[280px]",
+  cursor: "crosshair",
+});
+
+const captionStyle = css({
+  fontSize: "xs",
+  color: "neutral.s80",
+  fontVariantNumeric: "tabular-nums",
+});
+
+const readoutStyle = css({
+  fontSize: "xs",
+  color: "neutral.s100",
+  fontVariantNumeric: "tabular-nums",
+});
+
+function formatValue(value: number): string {
+  if (Number.isInteger(value)) {
+    return String(value);
+  }
+  const abs = Math.abs(value);
+  return abs !== 0 && (abs < 0.001 || abs >= 10_000)
+    ? value.toExponential(2)
+    : String(Number(value.toPrecision(4)));
+}
+
+/** Mean and median of a distribution frame's bins. */
+function distributionStats(
+  snapshot: SweepCellSnapshot,
+  metricId: string,
+): { runs: number; mean: number; median: number } | null {
+  for (let index = snapshot.metricFrames.length - 1; index >= 0; index--) {
+    const frame = snapshot.metricFrames[index]!;
+    if (frame.metricId !== metricId || frame.outputType !== "distribution") {
+      continue;
+    }
+    let weight = 0;
+    let sum = 0;
+    for (const [value, frequency] of frame.bins) {
+      weight += frequency;
+      sum += value * frequency;
+    }
+    if (weight === 0) {
+      return null;
+    }
+    const half = weight / 2;
+    let cumulative = 0;
+    let median = frame.bins[0]?.[0] ?? 0;
+    for (const [value, frequency] of frame.bins) {
+      cumulative += frequency;
+      if (cumulative >= half) {
+        median = value;
+        break;
+      }
+    }
+    return { runs: weight, mean: sum / weight, median };
+  }
+  return null;
+}
+
+type SurfaceValues = ReadonlyMap<string, number>;
+
+/**
+ * Brings one cell up to at least `minRuns` locally computed runs, merging
+ * batches into `cache`. Everything is passed explicitly so the calling
+ * effects can declare honest dependencies.
+ */
+async function sampleStudyCell(options: {
+  sampleDetachedObjective: ExperimentsContextValue["sampleDetachedObjective"];
+  cache: Map<string, SweepCellSnapshot>;
+  optimization: OptimizationRecord;
+  axes: readonly OptimizationSurfaceAxis[];
+  xAxisId: string;
+  yAxisId: string;
+  /** Slider position per off-surface axis, plus boolean fallbacks. */
+  slice: string;
+  xPosition: number;
+  yPosition: number;
+  minRuns: number;
+}): Promise<SweepCellSnapshot | null> {
+  const {
+    sampleDetachedObjective,
+    cache,
+    optimization,
+    axes,
+    xAxisId,
+    yAxisId,
+    slice,
+    xPosition,
+    yPosition,
+    minRuns,
+  } = options;
+  const input = optimization.input;
+  const objectiveMetric = input.model.definition.metrics?.find(
+    (metric) => metric.id === input.objective.metricId,
+  );
+  if (!objectiveMetric) {
+    return null;
+  }
+
+  const sliceEntries = new Map(
+    slice
+      .split("|")
+      .filter((entry) => entry !== "")
+      .map((entry) => entry.split("=") as [string, string]),
+  );
+
+  const values: Record<string, number | boolean> = {};
+  for (const [identifier, binding] of Object.entries(
+    input.scenario.parameterBindings,
+  )) {
+    if (binding.kind === "fixed") {
+      values[identifier] = binding.value;
+    } else if (binding.domain.kind === "boolean") {
+      values[identifier] = sliceEntries.get(identifier) === "true";
+    }
+  }
+  for (const axis of axes) {
+    const position =
+      axis.identifier === xAxisId
+        ? xPosition
+        : axis.identifier === yAxisId
+          ? yPosition
+          : Number(sliceEntries.get(axis.identifier) ?? 0);
+    values[axis.identifier] = optimizationAxisValueAt(axis, position);
+  }
+
+  const key = `${slice}|x=${xPosition}|y=${yPosition}`;
+  const cached = cache.get(key);
+  if (cached && cached.runsCompleted >= minRuns) {
+    return cached;
+  }
+  const from = cached?.runsCompleted ?? 0;
+  const snapshot = await sampleDetachedObjective({
+    cacheKey: optimization.id,
+    definition: input.model.definition,
+    scenarioId: input.scenario.id,
+    scenarioParameterValues: values,
+    metric: {
+      id: objectiveMetric.id,
+      label: objectiveMetric.name,
+      code: objectiveMetric.code,
+    },
+    seed: sweepBatchSeed(input.execution.seed, from),
+    runCount: minRuns - from,
+    dt: input.execution.dt,
+    maxTime: input.execution.maxTime,
+  });
+  if (!snapshot) {
+    return cached ?? null;
+  }
+  const merged: SweepCellSnapshot = {
+    runsCompleted: minRuns,
+    metricFrames: cached
+      ? mergeMetricFramesAcrossCells([
+          cached.metricFrames,
+          snapshot.metricFrames,
+        ])
+      : snapshot.metricFrames,
+  };
+  cache.set(key, merged);
+  return merged;
+}
+
+function gridCellKey(xIndex: number, yIndex: number): string {
+  return `${xIndex},${yIndex}`;
+}
+
+function drawSurface(options: {
+  canvas: HTMLCanvasElement;
+  width: number;
+  height: number;
+  nx: number;
+  ny: number;
+  values: SurfaceValues;
+  trials: readonly { x: number; y: number; best: boolean }[];
+}): void {
+  const { canvas, width, height, nx, ny, values, trials } = options;
+  const pixelRatio = globalThis.devicePixelRatio || 1;
+  canvas.width = Math.max(1, Math.round(width * pixelRatio));
+  canvas.height = Math.max(1, Math.round(height * pixelRatio));
+  const context = canvas.getContext("2d");
+  if (!context) {
+    return;
+  }
+  context.scale(pixelRatio, pixelRatio);
+  context.clearRect(0, 0, width, height);
+
+  const samples: ContourSample[] = [];
+  for (const [key, value] of values) {
+    const [x = 0, y = 0] = key.split(",").map(Number);
+    samples.push({ x, y, value });
+  }
+
+  const pointX = (x: number): number => (x / Math.max(nx - 1, 1)) * width;
+  const pointY = (y: number): number =>
+    height - (y / Math.max(ny - 1, 1)) * height;
+
+  if (samples.length > 0) {
+    const rasterWidth = Math.max(2, (nx - 1) * RASTER_SUBDIVISION + 1);
+    const rasterHeight = Math.max(2, (ny - 1) * RASTER_SUBDIVISION + 1);
+    const raster = idwRaster({
+      samples,
+      nx,
+      ny,
+      width: rasterWidth,
+      height: rasterHeight,
+    });
+
+    let min = Number.POSITIVE_INFINITY;
+    let max = Number.NEGATIVE_INFINITY;
+    for (const sample of samples) {
+      min = Math.min(min, sample.value);
+      max = Math.max(max, sample.value);
+    }
+
+    const cellWidth = width / (rasterWidth - 1);
+    const cellHeight = height / (rasterHeight - 1);
+    const span = max - min;
+
+    for (let py = 0; py < rasterHeight - 1; py++) {
+      for (let px = 0; px < rasterWidth - 1; px++) {
+        const value = raster[py * rasterWidth + px]!;
+        context.fillStyle = bluesColor(span > 0 ? (value - min) / span : 0.5);
+        context.fillRect(
+          px * cellWidth,
+          py * cellHeight,
+          cellWidth + 1,
+          cellHeight + 1,
+        );
+      }
+    }
+
+    if (span > 0) {
+      context.strokeStyle = "rgba(15, 23, 42, 0.35)";
+      context.lineWidth = 1;
+      for (const level of contourLevels(min, max, 10)) {
+        context.beginPath();
+        for (const [x1, y1, x2, y2] of marchingSquaresSegments(
+          raster,
+          rasterWidth,
+          rasterHeight,
+          level,
+        )) {
+          context.moveTo(x1 * cellWidth, y1 * cellHeight);
+          context.lineTo(x2 * cellWidth, y2 * cellHeight);
+        }
+        context.stroke();
+      }
+    }
+
+    for (const sample of samples) {
+      context.beginPath();
+      context.arc(pointX(sample.x), pointY(sample.y), 2.5, 0, Math.PI * 2);
+      context.fillStyle = "rgba(15, 23, 42, 0.75)";
+      context.fill();
+      context.strokeStyle = "rgba(255, 255, 255, 0.9)";
+      context.lineWidth = 1;
+      context.stroke();
+    }
+  }
+
+  // Trial markers, projected onto the shown axes. Distinct from the sampled
+  // dots: hollow rings, with the best trial emphasised.
+  for (const trial of trials) {
+    context.beginPath();
+    context.arc(
+      pointX(trial.x),
+      pointY(trial.y),
+      trial.best ? 5 : 3.5,
+      0,
+      Math.PI * 2,
+    );
+    context.strokeStyle = trial.best
+      ? "rgba(217, 119, 6, 0.95)"
+      : "rgba(217, 119, 6, 0.55)";
+    context.lineWidth = trial.best ? 2 : 1.25;
+    context.stroke();
+  }
+}
+
+export const OptimizationSurface = ({
+  optimization,
+}: {
+  optimization: OptimizationRecord;
+}) => {
+  const { sampleDetachedObjective } = use(ExperimentsContext);
+  const input = optimization.input;
+  const axes = buildOptimizationSurfaceAxes(input);
+  const objectiveMetric = input.model.definition.metrics?.find(
+    (metric) => metric.id === input.objective.metricId,
+  );
+
+  const [xAxisId, setXAxisId] = useState(axes[0]?.identifier ?? "");
+  const [yAxisId, setYAxisId] = useState(axes[1]?.identifier ?? "");
+  const [positions, setPositions] = useState<Record<string, number>>({});
+  const [cellValues, setCellValues] = useState<SurfaceValues>(new Map());
+  const [selectedStats, setSelectedStats] = useState<{
+    runs: number;
+    mean: number;
+    median: number;
+  } | null>(null);
+  const [walkKey, setWalkKey] = useState("");
+  /** Finished local batches per position tuple, merged across rungs. */
+  const cellCacheRef = useRef(new Map<string, SweepCellSnapshot>());
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const frameRef = useRef<HTMLDivElement>(null);
+  const size = useElementSize(frameRef, { debounce: 50 });
+
+  const xAxis = axes.find((axis) => axis.identifier === xAxisId);
+  const yAxis = axes.find((axis) => axis.identifier === yAxisId);
+
+  /** Slider position per axis: explicit, else best trial, else midpoint. */
+  const positionOf = (axis: OptimizationSurfaceAxis): number => {
+    const explicit = positions[axis.identifier];
+    if (explicit !== undefined) {
+      return explicit;
+    }
+    const best = optimization.best?.parameters[axis.identifier];
+    return typeof best === "number"
+      ? optimizationAxisPositionFor(axis, best)
+      : optimizationAxisMidpoint(axis);
+  };
+
+  /**
+   * The off-surface coordinates: slider positions of the other axes, plus
+   * boolean bindings at the best trial's values. Part of the cache key, so a
+   * best-trial change that moves a boolean restarts the walk rather than
+   * silently mixing slices.
+   */
+  const booleanSlice = Object.entries(input.scenario.parameterBindings)
+    .filter(
+      (
+        entry,
+      ): entry is [string, { kind: "optimize"; domain: { kind: "boolean" } }] =>
+        entry[1].kind === "optimize" && entry[1].domain.kind === "boolean",
+    )
+    .map(([identifier]) => {
+      const best = optimization.best?.parameters[identifier];
+      return `${identifier}=${typeof best === "boolean" ? best : false}`;
+    });
+  const slice = [
+    ...axes
+      .filter(
+        (axis) => axis.identifier !== xAxisId && axis.identifier !== yAxisId,
+      )
+      .map((axis) => `${axis.identifier}=${positionOf(axis)}`),
+    ...booleanSlice,
+  ].join("|");
+
+  // A new slice/axes identity restarts the walk; clearing the sampled values
+  // during render (not in an effect) repaints without a stale frame.
+  const nextWalkKey = `${optimization.id}|${xAxisId}|${yAxisId}|${slice}`;
+  if (walkKey !== nextWalkKey) {
+    setWalkKey(nextWalkKey);
+    setCellValues(new Map());
+    setSelectedStats(null);
+  }
+
+  const xSelected = xAxis ? positionOf(xAxis) : 0;
+  const ySelected = yAxis ? positionOf(yAxis) : 0;
+
+  // The grid walk: samples the X×Y sub-grid coarse-to-fine on the background
+  // lane, feeding the contour. Restarts when the slice or axes change.
+  useEffect(() => {
+    const axesNow = buildOptimizationSurfaceAxes(optimization.input);
+    const walkXAxis = axesNow.find((axis) => axis.identifier === xAxisId);
+    const walkYAxis = axesNow.find((axis) => axis.identifier === yAxisId);
+    const metricId = optimization.input.objective.metricId;
+    if (!walkXAxis || !walkYAxis || walkXAxis === walkYAxis) {
+      return;
+    }
+    const walk: { stale: boolean } = { stale: false };
+    const isWalkStale = () => walk.stale;
+    const xPositions = surfacePositions(walkXAxis);
+    const yPositions = surfacePositions(walkYAxis);
+
+    const run = async () => {
+      for (const cell of coarseToFineOrder(
+        xPositions.length,
+        yPositions.length,
+      )) {
+        if (isWalkStale()) {
+          return;
+        }
+        const snapshot = await sampleStudyCell({
+          sampleDetachedObjective,
+          cache: cellCacheRef.current,
+          optimization,
+          axes: axesNow,
+          xAxisId,
+          yAxisId,
+          slice,
+          xPosition: xPositions[cell.x]!,
+          yPosition: yPositions[cell.y]!,
+          minRuns: SURFACE_CELL_RUNS,
+        });
+        if (isWalkStale()) {
+          return;
+        }
+        if (snapshot) {
+          const value = sweepCellObjective(snapshot.metricFrames, metricId);
+          if (value !== null) {
+            setCellValues((previous) => {
+              const next = new Map(previous);
+              next.set(gridCellKey(cell.x, cell.y), value);
+              return next;
+            });
+          }
+        }
+      }
+    };
+    void run();
+
+    return () => {
+      walk.stale = true;
+    };
+  }, [optimization, xAxisId, yAxisId, slice, sampleDetachedObjective]);
+
+  // The selected point's refinement: escalating batches, streaming the
+  // objective's mean/median into the readout.
+  useEffect(() => {
+    const axesNow = buildOptimizationSurfaceAxes(optimization.input);
+    const walkXAxis = axesNow.find((axis) => axis.identifier === xAxisId);
+    const walkYAxis = axesNow.find((axis) => axis.identifier === yAxisId);
+    const metricId = optimization.input.objective.metricId;
+    if (!walkXAxis || !walkYAxis || walkXAxis === walkYAxis) {
+      return;
+    }
+    const refinement: { stale: boolean } = { stale: false };
+    const isRefinementStale = () => refinement.stale;
+
+    const run = async () => {
+      for (const target of EXPERIMENT_RUN_LADDER) {
+        if (target > SELECTED_POINT_MAX_RUNS) {
+          return;
+        }
+        const snapshot = await sampleStudyCell({
+          sampleDetachedObjective,
+          cache: cellCacheRef.current,
+          optimization,
+          axes: axesNow,
+          xAxisId,
+          yAxisId,
+          slice,
+          xPosition: xSelected,
+          yPosition: ySelected,
+          minRuns: target,
+        });
+        if (isRefinementStale()) {
+          return;
+        }
+        if (!snapshot) {
+          return;
+        }
+        setSelectedStats(distributionStats(snapshot, metricId));
+        setCellValues((previous) => {
+          // The selected point is usually also a grid cell; refresh it.
+          const xPositions = surfacePositions(walkXAxis);
+          const yPositions = surfacePositions(walkYAxis);
+          const xIndex = xPositions.indexOf(xSelected);
+          const yIndex = yPositions.indexOf(ySelected);
+          if (xIndex === -1 || yIndex === -1) {
+            return previous;
+          }
+          const value = sweepCellObjective(snapshot.metricFrames, metricId);
+          if (value === null) {
+            return previous;
+          }
+          const next = new Map(previous);
+          next.set(gridCellKey(xIndex, yIndex), value);
+          return next;
+        });
+      }
+    };
+    void run();
+
+    return () => {
+      refinement.stale = true;
+    };
+  }, [
+    optimization,
+    xAxisId,
+    yAxisId,
+    slice,
+    xSelected,
+    ySelected,
+    sampleDetachedObjective,
+  ]);
+
+  // Painting is imperative canvas work driven by measured size.
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || !xAxis || !yAxis || !size || size.width === 0) {
+      return;
+    }
+    const xPositions = surfacePositions(xAxis);
+    const yPositions = surfacePositions(yAxis);
+    const trials = optimization.trials
+      .filter((trial) => trial.state === "complete" && trial.objective !== null)
+      .map((trial) => {
+        const xValue = trial.parameters[xAxis.identifier];
+        const yValue = trial.parameters[yAxis.identifier];
+        if (typeof xValue !== "number" || typeof yValue !== "number") {
+          return null;
+        }
+        return {
+          x:
+            (optimizationAxisPositionFor(xAxis, xValue) / xAxis.stepCount) *
+            (xPositions.length - 1),
+          y:
+            (optimizationAxisPositionFor(yAxis, yValue) / yAxis.stepCount) *
+            (yPositions.length - 1),
+          best: optimization.best?.trial === trial.trial,
+        };
+      })
+      .filter((trial) => trial !== null);
+    drawSurface({
+      canvas,
+      width: size.width,
+      height: 280,
+      nx: xPositions.length,
+      ny: yPositions.length,
+      values: cellValues,
+      trials,
+    });
+  }, [cellValues, size, xAxis, yAxis, optimization.trials, optimization.best]);
+
+  if (axes.length < 2 || !objectiveMetric) {
+    return null;
+  }
+
+  const axisOptions = axes.map((axis) => ({
+    value: axis.identifier,
+    text: axis.identifier,
+  }));
+
+  const handleCanvasClick = (event: React.MouseEvent<HTMLCanvasElement>) => {
+    if (!xAxis || !yAxis) {
+      return;
+    }
+    const bounds = event.currentTarget.getBoundingClientRect();
+    const clamp = (fraction: number) => Math.min(Math.max(fraction, 0), 1);
+    const relativeX = clamp((event.clientX - bounds.left) / bounds.width);
+    const relativeY = clamp(1 - (event.clientY - bounds.top) / bounds.height);
+    setPositions((previous) => ({
+      ...previous,
+      [xAxis.identifier]: Math.round(relativeX * xAxis.stepCount),
+      [yAxis.identifier]: Math.round(relativeY * yAxis.stepCount),
+    }));
+  };
+
+  const direction =
+    input.objective.direction === "maximize" ? "Maximize" : "Minimize";
+
+  return (
+    <div className={surfaceStyle}>
+      <div className={controlsStyle}>
+        <span className={controlLabelStyle}>X</span>
+        <Select
+          size="xs"
+          aria-label="Surface X parameter"
+          items={axisOptions.filter((option) => option.value !== yAxisId)}
+          value={xAxisId}
+          onChange={(value) => setXAxisId(value ?? "")}
+        />
+        <span className={controlLabelStyle}>Y</span>
+        <Select
+          size="xs"
+          aria-label="Surface Y parameter"
+          items={axisOptions.filter((option) => option.value !== xAxisId)}
+          value={yAxisId}
+          onChange={(value) => setYAxisId(value ?? "")}
+        />
+      </div>
+      {axes.map((axis) => (
+        <div className={sliderRowStyle} key={axis.identifier}>
+          <span className={sliderNameStyle} title={axis.identifier}>
+            {axis.identifier}
+          </span>
+          <Slider
+            className={sliderControlStyle}
+            min={0}
+            max={axis.stepCount}
+            step={1}
+            value={positionOf(axis)}
+            onChangeEnd={(position) =>
+              setPositions((previous) => ({
+                ...previous,
+                [axis.identifier]: position,
+              }))
+            }
+          />
+          <span className={sliderValueStyle}>
+            {formatValue(optimizationAxisValueAt(axis, positionOf(axis)))}
+          </span>
+        </div>
+      ))}
+      <div className={readoutStyle}>
+        {direction} {objectiveMetric.name} at selection:{" "}
+        {selectedStats
+          ? `${formatValue(selectedStats.mean)} mean · ${formatValue(
+              selectedStats.median,
+            )} median · ${selectedStats.runs} runs`
+          : "computing…"}
+      </div>
+      <div ref={frameRef} className={canvasFrameStyle}>
+        <canvas
+          ref={canvasRef}
+          className={canvasStyle}
+          onClick={handleCanvasClick}
+        />
+      </div>
+      <span className={captionStyle}>
+        {cellValues.size} locally computed points · rings are the study's trials
+        (best highlighted) · click to navigate
+      </span>
+    </div>
+  );
+};

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/view-optimization-drawer.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/view-optimization-drawer.tsx
@@ -10,6 +10,7 @@ import {
 } from "../../../../../../react/optimizations/context";
 import { Section, SectionList } from "../../../../../components/section";
 import { Table, type TableColumn } from "../../../../../components/table";
+import { OptimizationSurface } from "./optimization-surface";
 
 const summaryStyle = css({
   marginTop: "-1",
@@ -300,6 +301,12 @@ export const ViewOptimizationDrawer = ({
 
   const active = isOptimizationActive(optimization);
   const displayedSteps = optimization.trials.slice(-200).reverse();
+  // The surface needs two navigable (non-boolean optimized) parameters.
+  const surfaceEligible =
+    Object.values(optimization.input.scenario.parameterBindings).filter(
+      (binding) =>
+        binding.kind === "optimize" && binding.domain.kind !== "boolean",
+    ).length >= 2;
 
   return (
     <Drawer
@@ -349,6 +356,16 @@ export const ViewOptimizationDrawer = ({
                 getRowId={(trial) => String(trial.trial)}
                 rows={displayedSteps}
               />
+            </Section>
+          ) : null}
+          {surfaceEligible ? (
+            <Section
+              title="Surface"
+              tooltip="The objective over two optimized parameters, computed locally on this machine — the study's own trials appear as rings. Move the sliders or click the plot to recompute elsewhere."
+              collapsible
+              defaultOpen
+            >
+              <OptimizationSurface optimization={optimization} />
             </Section>
           ) : null}
         </SectionList>

--- a/libs/@local/petrinaut-arch-docs/content/experiments/sweep-surface.mdx
+++ b/libs/@local/petrinaut-arch-docs/content/experiments/sweep-surface.mdx
@@ -40,3 +40,19 @@ A surface cell's value is the mean over eight runs — enough for the shape,
 not for reading precise values. Clicking a region moves the navigator to the
 nearest combination, whose ladder then refines it properly; the deeper result
 flows back into the same cache and the surface repaints with it.
+
+## The optimization surface
+
+The optimization drawer mounts the same rendering and sampling shape over a
+study's optimized parameters (`optimization-surface.tsx`), with two
+differences. Axes come from the study's domains (`react/optimizations/
+surface-grid.ts`): log-scale domains quantize in log space and integer domains
+snap to their step. And samples cannot go through a sweep session — a study
+must run its **frozen model snapshot**, not the live editor net — so the
+experiments provider exposes `sampleDetachedObjective`: a serialized
+single-worker lane that compiles the snapshot once per study (cached), runs
+its objective as an expression metric, and returns the finished frames. The
+component keeps its own per-position cache and climbs the same run ladder for
+the selected point, streaming the objective's mean and median. The study's
+completed trials draw as projected markers over the locally computed fill —
+the first form of the optimizer streaming its evaluations back.


### PR DESCRIPTION
> [!IMPORTANT]
> **Experimental**
> Behind the **Optimization surface** feature flag.

## Summary

Before this PR, Optuna-style contour surface existed only in the Experiments drawer. An optimization study is where it matters most. It already declares bounded parameters and an objective. Its trials stream back with parameter and objective values.

This adds a Surface section to the optimization detail drawer. Study trials draw as markers over a contour computed locally. Sliders and clicks navigate it. Objective mean and median stream at the selected point.

## Links

- Ticket [FE-1536](https://linear.app/hash/issue/FE-1536)
- Docs [Sweep surface](https://petrinaut-docs-git-cf-fe-1536-contour-surface-for-optimi-c4c94c.stage.hash.ai/architecture/react/experiments/sweep-surface)
- Docs [Optimization](https://github.com/hashintel/hash/blob/cf/fe-1536-contour-surface-for-optimization-studies-with-local/libs/@hashintel/petrinaut/docs/optimization.md)

## Changes

#### UI

- `optimization-surface.tsx` renders in the drawer after Steps
  > Gated on two non-boolean optimized parameters. X/Y pickers and one slider per optimized parameter, initialized from the best trial, else the domain midpoint.
- Coarse-to-fine local walk feeds the contour
  > Positions are cached with ladder seeds. Common random numbers follow the sweep rule.
- Readout streams objective mean, median, and runs at the selected point
- Completed trials draw as rings, best highlighted
  > Projected the way Optuna's `plot_contour` projects.
  > Clicking the surface navigates to the clicked position.
- ds `Slider` gains `step` and `onChangeEnd` pass-throughs

#### Core

- `sampleDetachedObjective` runs local compute against any net snapshot
  > Lives on the experiments context, on a serialized single-worker lane.
  > Compilation is cached per study, HIR artifacts plus scenario HIR.
  > Objective runs as an expression metric.
  > Booleans coerce to the engine's 0/1 encoding.
- Study runs its frozen `input.model.definition`
  > Not the live editor net. Both drift the moment the user edits after launching.
- `react/optimizations/surface-grid.ts` builds quantized axes from the study's domains
  > Log-scale domains quantize in log space. Integer domains snap to their declared step.

## Known issues

Local batches queue on one serialized lane. On heavy nets the selected point's readout can wait behind walk cells. It should jump the queue. Tracked in the ticket.

## Test coverage

- `surface-grid.test.ts`:
  > Log-space quantization and integer step snapping.

## How to test

- Open [Petrinaut preview](https://petrinaut-git-cf-fe-1536-contour-surface-for-optimizatio-039c77.stage.hash.ai) on Vercel
- Viewport controls > Settings > Simulation > Optimization surface
- Optimizations tab needs a deployment with the optimizer service on the `/optimization` route
- Local fallback: `turbo run dev --filter @apps/petrinaut-website -- --with-optimizer-service`
- Load example > Supply Chain Profit
- Simulate > Optimizations > Create
- Pick scenario, Optimize two numeric parameters with a search range, choose objective, Run
- Open study drawer
- Expect Surface section with sliders at best trial values and trial rings across the plane
- Expect contour filling from local simulations of the frozen snapshot
- Expect readout streaming mean and median for the selected point
- Click surface
- Expect sliders move to the clicked position
