### PR TITLE
BE-793: Carry the authentication Report to the rejection

### DIFF
--- a/libs/@local/middleware/src/authentication/mod.rs
+++ b/libs/@local/middleware/src/authentication/mod.rs
@@ -24,39 +24,52 @@ use axum::{
     middleware::Next,
     response::Response,
 };
+use error_stack::Report;
 use type_system::principal::actor::ActorId;
 
 use self::{
     provider::{AuthenticationProvider, Caller},
-    request::{AuthenticationError, resolve_request_actor},
+    request::{AuthenticationError, log_rejection, resolve_request_actor},
     service_secret::{presents_service_secret, service_credential},
 };
 use crate::response::error_response;
 
 /// The resolved authentication of a request, stored as a request extension.
+///
+/// A rejection carries the full report. The [`Arc`] is what lets it live in an extension:
+/// [`Report`] is not [`Clone`], and an extension value has to be.
 #[derive(Clone)]
-pub(crate) struct ResolvedAuthentication(Result<Option<ActorId>, AuthenticationError>);
+pub(crate) struct ResolvedAuthentication(Result<Option<ActorId>, Arc<Report<AuthenticationError>>>);
 
 impl ResolvedAuthentication {
     #[cfg(test)]
-    pub(crate) const fn new(outcome: Result<Option<ActorId>, AuthenticationError>) -> Self {
+    pub(crate) const fn new(
+        outcome: Result<Option<ActorId>, Arc<Report<AuthenticationError>>>,
+    ) -> Self {
         Self(outcome)
     }
 
-    pub(crate) const fn outcome(&self) -> &Result<Option<ActorId>, AuthenticationError> {
+    pub(crate) const fn outcome(
+        &self,
+    ) -> &Result<Option<ActorId>, Arc<Report<AuthenticationError>>> {
         &self.0
     }
 }
 
 /// Converts an authentication failure into the response returned to the client.
 ///
-/// The response carries the client-safe message. Identifiers stay in the server-side logs. Only
-/// logs at debug level: a rejection is the caller's to repair, and where verification itself
-/// failed, [`resolve_request_actor`] has already logged the report at the level matching the
-/// fault domain.
-fn rejection(error: &AuthenticationError) -> Response {
-    tracing::debug!(%error, "request rejected");
+/// The response carries the client-safe message. Identifiers and the report's attachments stay in
+/// the server-side logs, where [`log_rejection`] has already reported them.
+fn rejection(report: &Report<AuthenticationError>) -> Response {
+    let error = report.current_context();
     error_response(error.status_code(), error.client_message().to_owned())
+}
+
+/// Reports a rejection and converts it into the response returned to the client.
+fn logged_rejection(error: AuthenticationError) -> Response {
+    let report = Report::new(error);
+    log_rejection(&report);
+    rejection(&report)
 }
 
 /// Returns the rejection for a request that does not carry the service secret, [`None`] when it
@@ -66,12 +79,13 @@ fn service_secret_rejection(headers: &http::HeaderMap, service_secret: &str) -> 
         return None;
     }
 
-    if service_credential(headers).is_some() {
-        tracing::warn!("request rejected due to a service credential mismatch");
-        return Some(rejection(&AuthenticationError::InvalidServiceSecret));
-    }
-    tracing::debug!("request rejected without a service credential");
-    Some(rejection(&AuthenticationError::MissingServiceSecret))
+    // A presented credential that does not match says the sender believed it had one, which the
+    // fault domain separates from a request carrying none at all.
+    Some(logged_rejection(if service_credential(headers).is_some() {
+        AuthenticationError::InvalidServiceSecret
+    } else {
+        AuthenticationError::MissingServiceSecret
+    }))
 }
 
 /// Rejects requests that do not carry the service secret.
@@ -106,7 +120,10 @@ pub async fn service_secret_middleware(
 
 /// Records the authenticated actor on the request span and stores the outcome as a request
 /// extension.
-fn store_outcome(request: &mut Request, outcome: Result<Option<ActorId>, AuthenticationError>) {
+fn store_outcome(
+    request: &mut Request,
+    outcome: Result<Option<ActorId>, Arc<Report<AuthenticationError>>>,
+) {
     if let Ok(Some(actor_id)) = &outcome {
         tracing::Span::current().record("actor_entity_uuid", tracing::field::display(actor_id));
     }
@@ -194,11 +211,17 @@ where
 
     let outcome = resolve_request_actor(&*provider, request.headers())
         .await
-        .map(Caller::into_actor);
+        .map(Caller::into_actor)
+        .map_err(Arc::new);
 
     match &outcome {
-        Err(AuthenticationError::MissingDelegatedActor) if bootstrap => {}
-        Err(error) => return rejection(error),
+        Err(report)
+            if bootstrap
+                && matches!(
+                    report.current_context(),
+                    AuthenticationError::MissingDelegatedActor
+                ) => {}
+        Err(report) => return rejection(report),
         Ok(_) => {}
     }
 
@@ -224,10 +247,12 @@ impl<S: Sync> FromRequestParts<S> for AuthenticatedActorId {
     ) -> impl Future<Output = Result<Self, Self::Rejection>> + Send {
         core::future::ready(match parts.extensions.get::<ResolvedAuthentication>() {
             Some(ResolvedAuthentication(Ok(Some(actor_id)))) => Ok(Self(*actor_id)),
+            // Resolution succeeded and found no actor; the rejection originates here, in the
+            // handler's requirement, so this is the site that reports it.
             Some(ResolvedAuthentication(Ok(None))) => {
-                Err(rejection(&AuthenticationError::MissingCredentials))
+                Err(logged_rejection(AuthenticationError::MissingCredentials))
             }
-            Some(ResolvedAuthentication(Err(error))) => Err(rejection(error)),
+            Some(ResolvedAuthentication(Err(report))) => Err(rejection(report)),
             None => {
                 tracing::error!(
                     "`AuthenticatedActorId` extracted on a route without authentication middleware"
@@ -255,7 +280,7 @@ impl<S: Sync> OptionalFromRequestParts<S> for AuthenticatedActorId {
     ) -> impl Future<Output = Result<Option<Self>, Self::Rejection>> + Send {
         core::future::ready(match parts.extensions.get::<ResolvedAuthentication>() {
             Some(ResolvedAuthentication(Ok(caller))) => Ok(caller.map(Self)),
-            Some(ResolvedAuthentication(Err(error))) => Err(rejection(error)),
+            Some(ResolvedAuthentication(Err(report))) => Err(rejection(report)),
             None => {
                 tracing::error!(
                     "`AuthenticatedActorId` extracted on a route without authentication middleware"

--- a/libs/@local/middleware/src/authentication/request.rs
+++ b/libs/@local/middleware/src/authentication/request.rs
@@ -222,7 +222,11 @@ where
                 // delegating, so resolving it as anonymous points at a configuration fault.
                 tracing::warn!("actor-ID header carried no recognized credential");
             }
-            C::anonymous().map_err(Report::new)
+            C::anonymous().map_err(|error| {
+                let report = Report::new(error);
+                log_rejection(&report);
+                report
+            })
         }
     }
 }
@@ -486,6 +490,30 @@ mod tests {
                 error()
             );
         }
+
+        // The uncredentialed rejection takes the `Continue` path instead of a provider's
+        // rejection, so it has its own logging site to pin. Same test: the event tests share
+        // the process-global callsite interest cache and cannot run in parallel.
+        let levels = EventLevels::default();
+        let subscriber = tracing_subscriber::registry().with(levels.clone());
+        tracing::callsite::rebuild_interest_cache();
+
+        async {
+            let _outcome: Result<ActorId, _> = resolve_request_actor(
+                &StaticAuthenticationProvider::NotRecognized,
+                &HeaderMap::new(),
+            )
+            .await;
+        }
+        .with_subscriber(subscriber)
+        .await;
+
+        let recorded = levels.0.lock().expect("the event log should lock");
+        assert_eq!(
+            recorded.as_slice(),
+            [tracing::Level::DEBUG],
+            "the missing credentials should be logged once"
+        );
     }
 
     /// What the provider recorded about the credential has to survive the resolver, or the

--- a/libs/@local/middleware/src/authentication/request.rs
+++ b/libs/@local/middleware/src/authentication/request.rs
@@ -2,6 +2,7 @@
 
 use core::{ops::ControlFlow, str::FromStr as _};
 
+use error_stack::Report;
 use http::{HeaderMap, StatusCode};
 use type_system::principal::actor::ActorEntityUuid;
 use uuid::Uuid;
@@ -10,6 +11,20 @@ use crate::authentication::provider::{AuthenticationProvider, Caller};
 
 /// Name of the header carrying an unverified actor ID.
 pub const ACTOR_ID_HEADER: &str = "X-Authenticated-User-Actor-Id";
+
+/// Whose fault a rejection is.
+///
+/// The domain decides how loudly a rejection is reported: an exhaustive set, so a new domain
+/// forces every reporting site to take a position rather than defaulting to the quietest one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FaultDomain {
+    /// The service cannot answer credential questions at all.
+    Service,
+    /// The credential is intact, but provisioning or deployment configuration is not.
+    Operator,
+    /// The caller can repair the request on its own.
+    Caller,
+}
 
 /// Errors that can occur while authenticating a request.
 #[derive(Debug, Clone, derive_more::Display)]
@@ -98,6 +113,34 @@ impl AuthenticationError {
         }
     }
 
+    /// Returns whose fault a rejection with this error is.
+    #[must_use]
+    pub const fn fault_domain(&self) -> FaultDomain {
+        match self {
+            Self::ProviderUnreachable
+            | Self::ProviderRejection
+            | Self::InvalidProviderResponse
+            | Self::StoreError => FaultDomain::Service,
+            // A verified credential pointing at a missing or non-user actor is broken
+            // provisioning, and legitimate senders of the service credential are internal
+            // services, so a mismatch points at deployment configuration.
+            Self::IdentityWithoutActor
+            | Self::NotProvisioned { .. }
+            | Self::ActorNotFound { .. }
+            | Self::NotAUser { .. }
+            | Self::InvalidServiceSecret => FaultDomain::Operator,
+            // A request arriving without the service secret says nothing about the deployment —
+            // anyone can send one, so reporting it above debug hands a caller the log volume.
+            Self::MissingCredentials
+            | Self::MalformedCredential
+            | Self::InvalidActorIdHeader
+            | Self::MissingServiceSecret
+            | Self::MissingDelegatedActor
+            | Self::InvalidSession
+            | Self::InvalidAccessToken => FaultDomain::Caller,
+        }
+    }
+
     /// Returns the message reported to the client for this error.
     ///
     /// Never carries identifiers. Those remain in the [`Display`] representation used for
@@ -129,6 +172,21 @@ impl AuthenticationError {
     }
 }
 
+/// Reports a rejection at the level its [`FaultDomain`] calls for.
+///
+/// The one place a rejection is reported, so a report reaching a response has been logged exactly
+/// once, wherever it was produced.
+pub(crate) fn log_rejection(report: &Report<AuthenticationError>) {
+    match report.current_context().fault_domain() {
+        FaultDomain::Service => tracing::error!(error = ?report, "credential verification failed"),
+        FaultDomain::Operator => tracing::warn!(
+            error = ?report,
+            "credential rejected, pointing at provisioning or deployment configuration"
+        ),
+        FaultDomain::Caller => tracing::debug!(error = ?report, "credential rejected"),
+    }
+}
+
 /// Resolves the acting principal from the request headers.
 ///
 /// The provider is the only credential path: a request whose credential is rejected fails, and a
@@ -145,7 +203,7 @@ impl AuthenticationError {
 pub async fn resolve_request_actor<P, C>(
     provider: &P,
     headers: &HeaderMap,
-) -> Result<C, AuthenticationError>
+) -> Result<C, Report<AuthenticationError>>
 where
     P: AuthenticationProvider<C>,
     C: Caller,
@@ -155,31 +213,8 @@ where
     match provider.authenticate(headers).await {
         ControlFlow::Break(Ok(caller)) => Ok(caller),
         ControlFlow::Break(Err(report)) => {
-            let error = report.current_context().clone();
-            if error.status_code().is_server_error() {
-                tracing::error!(error = ?report, "credential verification failed");
-            } else if matches!(
-                error,
-                AuthenticationError::NotProvisioned { .. }
-                    | AuthenticationError::IdentityWithoutActor
-                    | AuthenticationError::ActorNotFound { .. }
-                    | AuthenticationError::NotAUser { .. }
-            ) {
-                // A verified credential pointing at a missing or non-user actor is broken
-                // provisioning. The client cannot resolve this on its own.
-                tracing::warn!(error = ?report, "credential rejected due to broken actor provisioning");
-            } else if matches!(
-                error,
-                AuthenticationError::MissingServiceSecret
-                    | AuthenticationError::InvalidServiceSecret
-            ) {
-                // Legitimate senders of this credential are internal services, so a
-                // mismatch points at deployment configuration.
-                tracing::warn!(error = ?report, "credential rejected due to a service credential mismatch");
-            } else {
-                tracing::debug!(error = ?report, "credential rejected");
-            }
-            Err(error)
+            log_rejection(&report);
+            Err(report)
         }
         ControlFlow::Continue(()) => {
             if headers.contains_key(ACTOR_ID_HEADER) {
@@ -187,7 +222,7 @@ where
                 // delegating, so resolving it as anonymous points at a configuration fault.
                 tracing::warn!("actor-ID header carried no recognized credential");
             }
-            C::anonymous()
+            C::anonymous().map_err(Report::new)
         }
     }
 }
@@ -216,14 +251,57 @@ pub fn actor_id_from_header(headers: &HeaderMap) -> Result<ActorEntityUuid, Auth
 
 #[cfg(test)]
 mod tests {
-    use core::mem;
+    use alloc::sync::Arc;
+    use core::{assert_matches, mem, ops::ControlFlow};
+    use std::sync::Mutex;
 
+    use error_stack::Report;
     use http::HeaderMap;
+    use tracing::instrument::WithSubscriber as _;
+    use tracing_subscriber::layer::SubscriberExt as _;
     use type_system::principal::actor::{ActorEntityUuid, ActorId, UserId};
     use uuid::Uuid;
 
-    use super::{AuthenticationError, resolve_request_actor};
-    use crate::authentication::provider::StaticAuthenticationProvider;
+    use super::{AuthenticationError, FaultDomain, resolve_request_actor};
+    use crate::authentication::provider::{
+        AuthenticationProvider, Caller, StaticAuthenticationProvider,
+    };
+
+    /// The attachment the rejecting provider adds, standing in for what a real provider records
+    /// about the credential it refused.
+    const PROVIDER_DETAIL: &str = "provider response (401): session expired";
+
+    /// A provider rejecting every request with the given error, carrying an attachment.
+    struct RejectingProvider(fn() -> AuthenticationError);
+
+    impl<C: Caller> AuthenticationProvider<C> for RejectingProvider {
+        fn authenticate(
+            &self,
+            _headers: &HeaderMap,
+        ) -> impl Future<Output = ControlFlow<Result<C, Report<AuthenticationError>>>> + Send
+        {
+            core::future::ready(ControlFlow::Break(Err(
+                Report::new((self.0)()).attach(PROVIDER_DETAIL)
+            )))
+        }
+    }
+
+    /// Records the level of every event emitted under the subscriber it is layered onto.
+    #[derive(Clone, Default)]
+    struct EventLevels(Arc<Mutex<Vec<tracing::Level>>>);
+
+    impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for EventLevels {
+        fn on_event(
+            &self,
+            event: &tracing::Event<'_>,
+            _ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            self.0
+                .lock()
+                .expect("the event log should lock")
+                .push(*event.metadata().level());
+        }
+    }
 
     fn random_user() -> ActorId {
         ActorId::User(UserId::new(ActorEntityUuid::new(Uuid::new_v4())))
@@ -261,9 +339,14 @@ mod tests {
 
         let outcome: Result<ActorId, _> = resolve_request_actor(&provider, &headers).await;
 
-        assert!(
-            matches!(outcome, Err(AuthenticationError::InvalidSession)),
-            "a rejected credential should fail even when an actor-ID header is present"
+        assert_matches!(
+            outcome
+                .expect_err(
+                    "a rejected credential should fail even when an actor-ID header is present"
+                )
+                .current_context(),
+            AuthenticationError::InvalidSession,
+            "the rejection should carry the provider's reason"
         );
     }
 
@@ -274,9 +357,14 @@ mod tests {
 
         let outcome: Result<ActorId, _> = resolve_request_actor(&provider, &headers).await;
 
-        assert!(
-            matches!(outcome, Err(AuthenticationError::MissingCredentials)),
-            "the actor-ID header should not resolve without a provider recognizing it"
+        assert_matches!(
+            outcome
+                .expect_err(
+                    "the actor-ID header should not resolve without a provider recognizing it"
+                )
+                .current_context(),
+            AuthenticationError::MissingCredentials,
+            "the rejection should name the missing credentials"
         );
     }
 
@@ -286,9 +374,12 @@ mod tests {
 
         let outcome: Result<ActorId, _> = resolve_request_actor(&provider, &HeaderMap::new()).await;
 
-        assert!(
-            matches!(outcome, Err(AuthenticationError::MissingCredentials)),
-            "a request without credentials should fail authentication"
+        assert_matches!(
+            outcome
+                .expect_err("a request without credentials should fail authentication")
+                .current_context(),
+            AuthenticationError::MissingCredentials,
+            "the rejection should name the missing credentials"
         );
     }
 
@@ -330,6 +421,87 @@ mod tests {
         }
 
         errors
+    }
+
+    /// A status the service reports as its own fault is the service's fault to report.
+    ///
+    /// Cross-checks the domain against [`status_code`], which classifies the same errors
+    /// independently, so the two cannot drift apart unnoticed.
+    ///
+    /// [`status_code`]: AuthenticationError::status_code
+    #[test]
+    fn server_errors_are_the_services_fault() {
+        for error in every_error("identity-id", ActorEntityUuid::new(Uuid::new_v4())) {
+            assert_eq!(
+                error.status_code().is_server_error(),
+                error.fault_domain() == FaultDomain::Service,
+                "`{error}` should report the same fault domain as its status code"
+            );
+        }
+    }
+
+    /// The level a rejection is logged at follows its fault domain.
+    ///
+    /// Pins the mapping at the logging site: [`fault_domain`] alone says nothing about which
+    /// macro the resolver reaches for.
+    ///
+    /// [`fault_domain`]: AuthenticationError::fault_domain
+    #[tokio::test]
+    async fn rejections_log_at_their_domains_level() {
+        let cases = [
+            (
+                (|| AuthenticationError::ProviderUnreachable) as fn() -> AuthenticationError,
+                tracing::Level::ERROR,
+            ),
+            (
+                || AuthenticationError::IdentityWithoutActor,
+                tracing::Level::WARN,
+            ),
+            (
+                || AuthenticationError::InvalidSession,
+                tracing::Level::DEBUG,
+            ),
+        ];
+
+        for (error, expected) in cases {
+            let levels = EventLevels::default();
+            let subscriber = tracing_subscriber::registry().with(levels.clone());
+            let provider = RejectingProvider(error);
+            // A test that reached these call sites without a subscriber cached them as
+            // uninteresting process-wide, and a scoped subscriber does not invalidate that.
+            tracing::callsite::rebuild_interest_cache();
+
+            async {
+                let _outcome: Result<ActorId, _> =
+                    resolve_request_actor(&provider, &HeaderMap::new()).await;
+            }
+            .with_subscriber(subscriber)
+            .await;
+
+            let recorded = levels.0.lock().expect("the event log should lock");
+            assert_eq!(
+                recorded.as_slice(),
+                [expected],
+                "`{}` should be logged once, at its domain's level",
+                error()
+            );
+        }
+    }
+
+    /// What the provider recorded about the credential has to survive the resolver, or the
+    /// rejection cannot be diagnosed from the report alone.
+    #[tokio::test]
+    async fn rejection_carries_the_providers_attachment() {
+        let provider = RejectingProvider(|| AuthenticationError::InvalidSession);
+
+        let report = resolve_request_actor::<_, ActorId>(&provider, &HeaderMap::new())
+            .await
+            .expect_err("a rejected credential should fail");
+
+        assert!(
+            format!("{report:?}").contains(PROVIDER_DETAIL),
+            "the provider's attachment should survive the resolver"
+        );
     }
 
     /// Every error the client can reach reports something.

--- a/libs/@local/middleware/src/rate_limit/mod.rs
+++ b/libs/@local/middleware/src/rate_limit/mod.rs
@@ -564,7 +564,10 @@ pub async fn principal_limit_middleware(
         Err(error) => {
             // `authentication_middleware` stores an error only as `MissingDelegatedActor` on a
             // bootstrap route, and those requests present the service secret and passed above.
-            tracing::error!(%error, "authentication error reached the rate limiter unrejected");
+            // Reaching this means the middleware order broke, so the report's attachments are
+            // the only account of what the provider saw — `Display` would print the first
+            // context and drop them.
+            tracing::error!(error = ?error, "authentication error reached the rate limiter unrejected");
             return internal_error();
         }
     };

--- a/libs/@local/middleware/src/rate_limit/tests.rs
+++ b/libs/@local/middleware/src/rate_limit/tests.rs
@@ -9,6 +9,7 @@ use core::{
 use axum::{
     Router, body::Body, extract::ConnectInfo, middleware, response::Response, routing::get,
 };
+use error_stack::Report;
 use http::{Request, StatusCode};
 use tower::ServiceExt as _;
 use type_system::principal::actor::{ActorEntityUuid, ActorId, UserId};
@@ -657,9 +658,9 @@ async fn authentication_error_fails_loudly() {
     let mut request = request(IpAddr::V4(Ipv4Addr::LOCALHOST));
     request
         .extensions_mut()
-        .insert(ResolvedAuthentication::new(Err(
+        .insert(ResolvedAuthentication::new(Err(Arc::new(Report::new(
             AuthenticationError::MissingDelegatedActor,
-        )));
+        )))));
 
     assert_eq!(
         send(&router, request).await.status(),


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

`resolve_request_actor` received a `Report<AuthenticationError>` from the provider chain, logged it, and returned the bare context. Everything downstream — the request extension, the extractors, the rejection — therefore worked from a variant with no attachments and no source chain, and the log level was picked by an `if matches!` chain whose trailing `else` sent any unrecognised variant to `debug`.

The report now travels to the rejection, and every rejection is reported at the level its fault domain calls for, from one place.

## 🔗 Related links

- BE-793

## 🔍 What does this change?

- `resolve_request_actor` returns `Result<C, Report<AuthenticationError>>`; `ResolvedAuthentication` carries the report as an `Arc` (`Report` is not `Clone`, extension values must be)
- `AuthenticationError::fault_domain()` — an exhaustive match onto the new `FaultDomain { Service, Operator, Caller }`, replacing the level chain; a new variant or domain breaks the build instead of silently logging at `debug`
- `log_rejection` is the one site mapping a domain to a level, and every rejection path goes through it — including `service_secret_rejection` and the extractor's anonymous-caller arm, which previously picked their levels by hand
- `MissingServiceSecret` moves from the operator domain to the caller domain: anyone can send a request without the secret, so reporting it above `debug` hands a caller the log volume; a *mismatching* secret stays an operator concern
- The rate limiter's error log renders the report with `?` instead of `%` — `Display` for `Report` prints the first context and drops the attachments, which is exactly what this PR exists to stop losing
- New tests: the emitted level per fault domain (via an event-capturing subscriber layer), the provider's attachment surviving the resolver, and a `status_code`/`fault_domain` consistency check across all variants

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

- The `Err` arms of both extractors are only reachable through a bootstrap route whose handler takes an actor extractor, and no test constructs that combination. The arms are two lines delegating to the shared rejection path; a wrong guard in the middleware is caught by the existing bootstrap tests.

## 🐾 Next steps

- BE-755 (credential caching) restructures `resolve_request_actor`; a cache must hold the bare `AuthenticationError` and build a fresh report per request, since a stored report would replay the originating request's span trace
- BE-774 can use `FaultDomain` as the label for rejection metrics

## 🛡 What tests cover this?

- `rejections_log_at_their_domains_level` — the level actually emitted at the logging site, per domain
- `rejection_carries_the_providers_attachment` — the provider's attachment survives the resolver
- `server_errors_are_the_services_fault` — `status_code` and `fault_domain` cannot drift apart on the service boundary
- The existing middleware, extractor, and rate-limit suites (66 + 6 in `hash-middleware`)

## ❓ How to test this?

1. Checkout the branch
2. `cargo test --all-features -p hash-middleware`
3. Reject a credential against a running Graph and confirm the log line carries the full report at the domain's level, once
