### PR TITLE
FE-1523: Correct Petrinaut changeset on YAML default export

### DIFF
--- a/.changeset/yaml-import-export.md
+++ b/.changeset/yaml-import-export.md
@@ -3,4 +3,4 @@
 "@hashintel/petrinaut": patch
 ---
 
-Nets and optimization manifests can be imported as YAML as well as JSON, detected from the content. Exports default to YAML, with multi-line code fields written as block scalars; JSON export remains available. Exported documents (both formats) write `version`, `meta`, and `title` first, then the net sections in dependency order. On import, a versioned file may omit `meta`.
+Nets and optimization manifests can be imported and exported in YAML and JSON.


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The changeset from #9379 says "Exports default to YAML". The editor's Export menu offers YAML and JSON as explicit choices, so the changelog entry would misdescribe what users see. This rewords the changeset before a release consumes it.

## 🔗 Related links

- [FE-1523](https://linear.app/hash/issue/FE-1523/import-and-export-petrinaut-files-as-yaml)
- #9379, which added the changeset

## 🔍 What does this change?

- Rewords `.changeset/yaml-import-export.md` to one sentence: nets and optimization manifests can be imported and exported in YAML and JSON.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

It edits the text of an existing changeset; the release that consumes it is unchanged.

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- None; the change is changelog text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)