### PR TITLE
Mirror FE-1538: Add the worksheet keyboard-flow layer

### DIFF
--- a/libs/@hashintel/petrinaut/src/ui/worksheet/focus-flow.test.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/worksheet/focus-flow.test.tsx
@@ -1,0 +1,454 @@
+/**
+ * @vitest-environment jsdom
+ */
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { useRef } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { focusLands } from "./focus-flow";
+import { FocusRoot, FocusStack } from "./focus-stack";
+import { useFocusGrid } from "./use-focus-grid";
+import { useFocusHeader } from "./use-focus-member";
+import { useFocusStops } from "./use-focus-stops";
+
+import type { FocusStop, FocusStopTarget } from "./use-focus-stops";
+
+afterEach(cleanup);
+
+/** A uniform grid of buttons wired through `useFocusGrid`. */
+const GridHarness: React.FC<{
+  label: string;
+  rows: number;
+  columns: number;
+}> = ({ label, rows, columns }) => {
+  // Destructured, not held as one object: the React Compiler rejects
+  // `ref={grid.register(...)}` (member access into a hook result in ref
+  // position reads as a ref access during render).
+  const { register, onKeyDown, onFocusCell, tabIndexFor, attach } =
+    useFocusGrid();
+  return (
+    <div role="grid" aria-label={label} ref={attach}>
+      {Array.from({ length: rows }, (_row, row) => (
+        <div key={row} role="row">
+          {Array.from({ length: columns }, (_column, column) => (
+            <button
+              key={column}
+              type="button"
+              ref={register(row, column)}
+              tabIndex={tabIndexFor(row, column)}
+              onKeyDown={onKeyDown(row, column)}
+              onFocus={() => onFocusCell(row, column)}
+            >
+              {`${label} ${row},${column}`}
+            </button>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+const targetKey = (target: FocusStopTarget) =>
+  `${target.stopId}:${target.column}`;
+
+/** A stops table of buttons wired through `useFocusStops`. */
+const StopsHarness: React.FC<{
+  label: string;
+  stops: FocusStop[];
+  columnCount: number;
+}> = ({ label, stops, columnCount }) => {
+  const parts = useRef(new Map<string, HTMLButtonElement>());
+  const { onKeyDown, onFocusTarget, tabIndexFor, attach } = useFocusStops({
+    stops,
+    columnCount,
+    focusTarget: (target) => focusLands(parts.current.get(targetKey(target))),
+  });
+
+  const partButton = (target: FocusStopTarget, text: string) => (
+    <button
+      key={targetKey(target)}
+      type="button"
+      ref={(element) => {
+        if (element) {
+          parts.current.set(targetKey(target), element);
+        } else {
+          parts.current.delete(targetKey(target));
+        }
+      }}
+      tabIndex={tabIndexFor(target)}
+      onKeyDown={onKeyDown(target)}
+      onFocus={() => onFocusTarget(target)}
+    >
+      {text}
+    </button>
+  );
+
+  return (
+    <div role="grid" aria-label={label} ref={attach}>
+      {stops.map((stop) => (
+        <div key={stop.id} role="row">
+          {stop.kind === "row" && stop.gutter
+            ? partButton(
+                { stopId: stop.id, column: "gutter" },
+                `${label} ${stop.id} gutter`,
+              )
+            : null}
+          {stop.kind === "full"
+            ? partButton(
+                { stopId: stop.id, column: 0 },
+                `${label} ${stop.id} full`,
+              )
+            : (stop.kind === "sparse"
+                ? stop.columns
+                : Array.from({ length: columnCount }, (_, column) => column)
+              ).map((column) =>
+                partButton(
+                  { stopId: stop.id, column },
+                  `${label} ${stop.id} c${column}`,
+                ),
+              )}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+/** A single collapsible-header button wired through `useFocusHeader`. */
+const HeaderHarness: React.FC<{
+  label: string;
+  collapse?: () => void;
+  expand?: () => void;
+}> = ({ label, collapse, expand }) => {
+  const { attach, onHeaderKeyDown } = useFocusHeader({ collapse, expand });
+  return (
+    <button type="button" ref={attach} onKeyDown={onHeaderKeyDown}>
+      {label}
+    </button>
+  );
+};
+
+/** Focuses the button with the given text, asserting focus landed. */
+const focusPart = (name: string): HTMLElement => {
+  const target = screen.getByText(name);
+  act(() => {
+    target.focus();
+  });
+  expect(document.activeElement).toBe(target);
+  return target;
+};
+
+/** Presses an arrow key on whatever currently holds focus. */
+const arrow = (key: "ArrowUp" | "ArrowDown" | "ArrowLeft" | "ArrowRight") => {
+  const active = document.activeElement;
+  if (!active) {
+    throw new Error("nothing holds focus");
+  }
+  fireEvent.keyDown(active, { key });
+};
+
+const expectFocused = (name: string) => {
+  expect(document.activeElement).toBe(screen.getByText(name));
+};
+
+const VerticalChain: React.FC<{ middleRows: number }> = ({ middleRows }) => (
+  <FocusRoot>
+    <FocusStack axis="vertical">
+      <GridHarness label="A" rows={2} columns={1} />
+      <GridHarness label="B" rows={middleRows} columns={1} />
+      <GridHarness label="C" rows={2} columns={1} />
+    </FocusStack>
+  </FocusRoot>
+);
+
+const ShrinkingPair: React.FC<{ bRows: number }> = ({ bRows }) => (
+  <FocusRoot>
+    <FocusStack axis="horizontal">
+      <GridHarness label="A" rows={1} columns={1} />
+      <GridHarness label="B" rows={bRows} columns={2} />
+    </FocusStack>
+  </FocusRoot>
+);
+
+describe("worksheet focus flow", () => {
+  it("moves between grid cells with arrows and keeps focus in place on a refused edge move", () => {
+    render(
+      <FocusRoot>
+        <GridHarness label="A" rows={2} columns={2} />
+      </FocusRoot>,
+    );
+
+    focusPart("A 0,0");
+    arrow("ArrowRight");
+    expectFocused("A 0,1");
+    arrow("ArrowDown");
+    expectFocused("A 1,1");
+    arrow("ArrowLeft");
+    expectFocused("A 1,0");
+    arrow("ArrowUp");
+    expectFocused("A 0,0");
+
+    arrow("ArrowLeft");
+    expectFocused("A 0,0");
+    arrow("ArrowUp");
+    expectFocused("A 0,0");
+  });
+
+  it("carries focus between sibling columns' grids at a grid edge, and back", () => {
+    render(
+      <FocusRoot>
+        <FocusStack axis="horizontal">
+          <FocusStack axis="vertical">
+            <GridHarness label="A" rows={2} columns={2} />
+          </FocusStack>
+          <FocusStack axis="vertical">
+            <GridHarness label="B" rows={2} columns={2} />
+          </FocusStack>
+        </FocusStack>
+      </FocusRoot>,
+    );
+
+    focusPart("A 0,0");
+    arrow("ArrowRight");
+    expectFocused("A 0,1");
+
+    arrow("ArrowRight");
+    expectFocused("B 0,0");
+
+    arrow("ArrowLeft");
+    expectFocused("A 0,1");
+  });
+
+  it("re-enters a grid at its remembered cell by default", () => {
+    render(
+      <FocusRoot>
+        <FocusStack axis="horizontal">
+          <FocusStack axis="vertical">
+            <GridHarness label="A" rows={2} columns={1} />
+          </FocusStack>
+          <FocusStack axis="vertical">
+            <GridHarness label="B" rows={2} columns={2} />
+          </FocusStack>
+        </FocusStack>
+      </FocusRoot>,
+    );
+
+    focusPart("B 1,1");
+    focusPart("A 0,0");
+    arrow("ArrowRight");
+    expectFocused("B 1,1");
+  });
+
+  it('enters aligned with the source row under entry="aligned", ignoring the remembered cell', () => {
+    render(
+      <FocusRoot>
+        <FocusStack axis="horizontal" entry="aligned">
+          <GridHarness label="A" rows={3} columns={2} />
+          <GridHarness label="B" rows={3} columns={2} />
+        </FocusStack>
+      </FocusRoot>,
+    );
+
+    focusPart("B 0,0");
+    focusPart("A 2,1");
+    arrow("ArrowRight");
+    expectFocused("B 2,0");
+  });
+
+  it("applies the aligned policy at the routing stack, through plain inner stacks", () => {
+    render(
+      <FocusRoot>
+        <FocusStack axis="horizontal" entry="aligned">
+          <FocusStack axis="vertical">
+            <GridHarness label="A" rows={3} columns={2} />
+          </FocusStack>
+          <FocusStack axis="vertical">
+            <GridHarness label="B" rows={3} columns={2} />
+          </FocusStack>
+        </FocusStack>
+      </FocusRoot>,
+    );
+
+    // Only the horizontal (routing) stack opts into alignment; the plain
+    // vertical stacks pass the entry through unchanged.
+    focusPart("B 0,0");
+    focusPart("A 2,1");
+    arrow("ArrowRight");
+    expectFocused("B 2,0");
+  });
+
+  it("chains vertically into the next grid and skips a member whose enter fails", () => {
+    const view = render(<VerticalChain middleRows={2} />);
+
+    focusPart("A 1,0");
+    arrow("ArrowDown");
+    expectFocused("B 0,0");
+
+    view.rerender(<VerticalChain middleRows={0} />);
+
+    focusPart("A 1,0");
+    arrow("ArrowDown");
+    expectFocused("C 0,0");
+  });
+
+  it("never lets arrows leave a containing stack, even toward a routable sibling", () => {
+    render(
+      <FocusRoot>
+        <FocusStack axis="horizontal">
+          <FocusStack axis="horizontal" contain>
+            <GridHarness label="A" rows={2} columns={2} />
+          </FocusStack>
+          <GridHarness label="B" rows={2} columns={2} />
+        </FocusStack>
+      </FocusRoot>,
+    );
+
+    focusPart("A 0,1");
+    arrow("ArrowRight");
+    expectFocused("A 0,1");
+
+    arrow("ArrowUp");
+    expectFocused("A 0,1");
+  });
+
+  it("falls back to a mounted cell when the remembered cell unmounted", () => {
+    const view = render(<ShrinkingPair bRows={2} />);
+
+    focusPart("B 1,1");
+    view.rerender(<ShrinkingPair bRows={1} />);
+
+    focusPart("A 0,0");
+    arrow("ArrowRight");
+    expectFocused("B 0,0");
+  });
+
+  it("roves the tabindex: exactly one tabbable cell, following focus", () => {
+    const view = render(
+      <FocusRoot>
+        <GridHarness label="A" rows={2} columns={3} />
+      </FocusRoot>,
+    );
+
+    const tabbable = () =>
+      [...view.container.querySelectorAll("button")].filter(
+        (button) => button.tabIndex === 0,
+      );
+    expect(tabbable()).toEqual([screen.getByText("A 0,0")]);
+
+    focusPart("A 1,2");
+    expect(tabbable()).toEqual([screen.getByText("A 1,2")]);
+    expect(screen.getByText("A 0,0").tabIndex).toBe(-1);
+  });
+
+  it("walks stops vertically with column memory, nearest sparse column, and a gutter lane", () => {
+    render(
+      <FocusRoot>
+        <StopsHarness
+          label="T"
+          stops={[
+            { id: "r0", kind: "row", gutter: true },
+            { id: "count", kind: "full" },
+            { id: "r1", kind: "row", gutter: true },
+            { id: "shared", kind: "sparse", columns: [0, 2] },
+          ]}
+          columnCount={3}
+        />
+      </FocusRoot>,
+    );
+
+    focusPart("T r0 c1");
+    arrow("ArrowDown");
+    expectFocused("T count full");
+
+    arrow("ArrowDown");
+    expectFocused("T r1 c1");
+
+    arrow("ArrowDown");
+    expectFocused("T shared c0");
+
+    focusPart("T r0 gutter");
+    arrow("ArrowDown");
+    expectFocused("T r1 gutter");
+
+    arrow("ArrowRight");
+    expectFocused("T r1 c0");
+
+    arrow("ArrowLeft");
+    expectFocused("T r1 gutter");
+  });
+
+  it("overflows the stops table into the stack, vertically and horizontally", () => {
+    render(
+      <FocusRoot>
+        <FocusStack axis="vertical">
+          <FocusStack axis="horizontal">
+            <StopsHarness
+              label="T"
+              stops={[
+                { id: "r0", kind: "row" },
+                { id: "r1", kind: "row" },
+              ]}
+              columnCount={2}
+            />
+            <GridHarness label="R" rows={1} columns={1} />
+          </FocusStack>
+          <GridHarness label="D" rows={1} columns={1} />
+        </FocusStack>
+      </FocusRoot>,
+    );
+
+    focusPart("T r1 c0");
+    arrow("ArrowDown");
+    expectFocused("D 0,0");
+
+    focusPart("T r0 c1");
+    arrow("ArrowRight");
+    expectFocused("R 0,0");
+  });
+
+  it("drives collapse/expand from a header's Left/Right, routing horizontally without them", () => {
+    const collapse = vi.fn();
+    const expand = vi.fn();
+    const withHandlers = render(
+      <FocusRoot>
+        <FocusStack axis="horizontal">
+          <HeaderHarness label="H" collapse={collapse} expand={expand} />
+          <GridHarness label="G" rows={1} columns={1} />
+        </FocusStack>
+      </FocusRoot>,
+    );
+
+    focusPart("H");
+    arrow("ArrowLeft");
+    expect(collapse).toHaveBeenCalledTimes(1);
+    expectFocused("H");
+    arrow("ArrowRight");
+    expect(expand).toHaveBeenCalledTimes(1);
+    expectFocused("H");
+
+    withHandlers.unmount();
+
+    render(
+      <FocusRoot>
+        <FocusStack axis="horizontal">
+          <GridHarness label="L" rows={1} columns={1} />
+          <HeaderHarness label="H2" />
+          <GridHarness label="R" rows={1} columns={1} />
+        </FocusStack>
+      </FocusRoot>,
+    );
+
+    focusPart("H2");
+    arrow("ArrowLeft");
+    expectFocused("L 0,0");
+
+    focusPart("H2");
+    arrow("ArrowRight");
+    expectFocused("R 0,0");
+  });
+});

--- a/libs/@hashintel/petrinaut/src/ui/worksheet/focus-flow.ts
+++ b/libs/@hashintel/petrinaut/src/ui/worksheet/focus-flow.ts
@@ -1,0 +1,77 @@
+/**
+ * The vocabulary of the worksheet's keyboard flow: directions, entry
+ * descriptors, and the member contract every focusable unit (a grid, a
+ * header, a lone cell) fulfils toward its enclosing `FocusStack`.
+ *
+ * The model is a tree. `FocusStack` nodes give the tree its geometry
+ * (horizontal or vertical); members are its leaves. An arrow move that runs
+ * off a member's edge asks the nearest enclosing stack to carry focus to a
+ * sibling along that axis; a stack at its own edge asks its parent, unless
+ * it `contain`s the walk. A move nobody accepts leaves focus where it is —
+ * the canonical data-grid outcome.
+ */
+
+import { createContext } from "react";
+
+export type FocusAxis = "horizontal" | "vertical";
+export type FocusDirection = "up" | "down" | "left" | "right";
+
+/** The axis a direction moves along. */
+export const focusAxisOf = (direction: FocusDirection): FocusAxis =>
+  direction === "left" || direction === "right" ? "horizontal" : "vertical";
+
+/** Whether a direction moves toward later document order on its axis. */
+export const focusForward = (direction: FocusDirection): boolean =>
+  direction === "down" || direction === "right";
+
+/**
+ * How an arriving move lands inside a member: the direction it travels
+ * (entering downward means arriving at the top), and — under a stack's
+ * `entry="aligned"` policy — the position it left from, so a grid can keep
+ * the row of a horizontal move or the column of a vertical one.
+ */
+export interface FocusEntry {
+  direction: FocusDirection;
+  from?: { row: number; column: number };
+}
+
+export interface FocusMemberHandle {
+  /** The member's mounted element, for document-order sorting. */
+  element: HTMLElement;
+  /** Move focus into the member. Returns whether focus landed. */
+  enter: (entry: FocusEntry) => boolean;
+}
+
+/** What a stack offers the members (and child stacks) inside it. */
+export interface FocusGroup {
+  register: (id: string, handle: FocusMemberHandle) => void;
+  unregister: (id: string) => void;
+  /**
+   * Carry focus from the given member toward `direction`. Returns whether
+   * focus moved; false leaves focus where it is.
+   */
+  moveFrom: (
+    id: string,
+    direction: FocusDirection,
+    from?: { row: number; column: number },
+  ) => boolean;
+}
+
+/** Outside any stack: every move is refused and focus stays put. */
+export const BOUNDARY_FOCUS_GROUP: FocusGroup = {
+  register: () => {},
+  unregister: () => {},
+  moveFrom: () => false,
+};
+
+export const FocusGroupContext =
+  createContext<FocusGroup>(BOUNDARY_FOCUS_GROUP);
+
+/** Focuses an element, reporting whether focus actually landed on it. */
+export function focusLands(element: HTMLElement | null | undefined): boolean {
+  if (!element) {
+    return false;
+  }
+  element.focus();
+  return document.activeElement === element;
+}

--- a/libs/@hashintel/petrinaut/src/ui/worksheet/focus-stack.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/worksheet/focus-stack.tsx
@@ -1,0 +1,211 @@
+/**
+ * @layerRoot ui.worksheet
+ * @role Reusable keyboard flow and interaction grammar for worksheets — panels composed of spreadsheet grids and ordinary controls
+ *
+ * `FocusStack`: a nestable directional group in the worksheet's keyboard
+ * flow. It renders `display: contents`, so it adds no box and no role — the
+ * layout stays the host's — and coordinates its children: an arrow move
+ * that runs off a child's edge along the stack's axis carries focus to the
+ * neighbouring child, entering it at its remembered position (focusgroup
+ * semantics, the default) or aligned with the position the move left from
+ * (`entry="aligned"`). Cross-axis moves, and moves off the stack's own
+ * edge, forward to the enclosing stack — unless `contain` bounds the walk.
+ *
+ * Tab order is untouched throughout: every grid stays its own tab stop and
+ * plain controls keep theirs. Arrow-crossing between siblings is an
+ * enhancement over that intact order, never a replacement.
+ *
+ * `FocusRoot` bounds a flow: moves that escape the outermost stack stop
+ * there. Stacks used without a root behave the same (the default group
+ * refuses every move), so the root is documentation more than mechanism.
+ */
+
+import { use, useEffect, useId, useRef, useState } from "react";
+
+import { css } from "@hashintel/ds-helpers/css";
+
+import {
+  BOUNDARY_FOCUS_GROUP,
+  focusAxisOf,
+  FocusGroupContext,
+  focusForward,
+  type FocusAxis,
+  type FocusEntry,
+  type FocusGroup,
+  type FocusMemberHandle,
+} from "./focus-flow";
+
+import type { ReactNode } from "react";
+
+const contentsStyle = css({ display: "contents" });
+
+export interface FocusStackProps {
+  axis: FocusAxis;
+  /** Arrows never carry focus out of this stack, in any direction. */
+  contain?: boolean;
+  /**
+   * Where a move arriving from a sibling lands inside a child: the child's
+   * remembered position ("remembered", the default — focusgroup semantics),
+   * or aligned with the position the move left from ("aligned" — a
+   * horizontal move keeps its row, a vertical one its column).
+   */
+  entry?: "remembered" | "aligned";
+  children: ReactNode;
+}
+
+/**
+ * One directional group. Children register through context — grids and
+ * headers via their hooks, nested stacks automatically.
+ */
+export const FocusStack: React.FC<FocusStackProps> = ({
+  axis,
+  contain = false,
+  entry = "remembered",
+  children,
+}) => {
+  const parent = use(FocusGroupContext);
+  const id = useId();
+  const membersRef = useRef(new Map<string, FocusMemberHandle>());
+  // The child focus last landed in, restored when a move re-enters the
+  // stack. Updated from focusin (covering pointer clicks too) and read only
+  // in event handlers; invalid ids fall back to edge entry.
+  const lastChildRef = useRef<string | null>(null);
+  const [element, setElement] = useState<HTMLDivElement | null>(null);
+
+  const orderedMembers = (): { id: string; handle: FocusMemberHandle }[] =>
+    [...membersRef.current.entries()]
+      .map(([memberId, handle]) => ({ id: memberId, handle }))
+      .sort((a, b) =>
+        // eslint-disable-next-line no-bitwise -- compareDocumentPosition returns a bitmask
+        a.handle.element.compareDocumentPosition(b.handle.element) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+          ? -1
+          : 1,
+      );
+
+  /**
+   * `applyPolicy` marks the stack that routes a move: it decides between
+   * remembered and aligned entry. Stacks the entry then passes through
+   * hand it on unchanged, so one `entry="aligned"` at the routing level is
+   * enough.
+   */
+  const enterChild = (
+    memberId: string,
+    entering: FocusEntry,
+    applyPolicy: boolean,
+  ): boolean => {
+    const handle = membersRef.current.get(memberId);
+    if (!handle) {
+      return false;
+    }
+    const resolved =
+      applyPolicy && entry !== "aligned"
+        ? { direction: entering.direction }
+        : entering;
+    const landed = handle.enter(resolved);
+    if (landed) {
+      lastChildRef.current = memberId;
+    }
+    return landed;
+  };
+
+  /** Enter this stack as a whole: its remembered child, else edge-first.
+   * The routing ancestor already applied its entry policy — pass through:
+   * an aligned `from` still picks the remembered child (child choice has no
+   * geometry to align with), and aligns the position inside it. */
+  const enterStack = (entering: FocusEntry): boolean => {
+    {
+      const remembered = lastChildRef.current;
+      if (remembered && enterChild(remembered, entering, false)) {
+        return true;
+      }
+    }
+    const ordered = orderedMembers();
+    const walk = focusForward(entering.direction) ? ordered : ordered.reverse();
+    return walk.some((member) => enterChild(member.id, entering, false));
+  };
+
+  const group: FocusGroup = {
+    register: (memberId, handle) => {
+      membersRef.current.set(memberId, handle);
+    },
+    unregister: (memberId) => {
+      membersRef.current.delete(memberId);
+      if (lastChildRef.current === memberId) {
+        lastChildRef.current = null;
+      }
+    },
+    moveFrom: (memberId, direction, from) => {
+      if (focusAxisOf(direction) === axis) {
+        const ordered = orderedMembers();
+        const start = ordered.findIndex((member) => member.id === memberId);
+        if (start !== -1) {
+          const step = focusForward(direction) ? 1 : -1;
+          for (
+            let index = start + step;
+            index >= 0 && index < ordered.length;
+            index += step
+          ) {
+            if (enterChild(ordered[index]!.id, { direction, from }, true)) {
+              return true;
+            }
+          }
+        }
+      }
+      if (contain) {
+        return false;
+      }
+      return parent.moveFrom(id, direction, from);
+    },
+  };
+  // A stable identity for the context value would drop every keystroke's
+  // closure; the compiler memoizes it against its real inputs.
+
+  // Re-register every render so the parent always holds the freshest enter
+  // closure; unregister only on unmount (or a parent change), so the
+  // parent's memory of this child survives ordinary renders.
+  useEffect(() => {
+    if (element) {
+      parent.register(id, { element, enter: enterStack });
+    }
+  });
+  useEffect(() => () => parent.unregister(id), [parent, id]);
+
+  return (
+    <FocusGroupContext value={group}>
+      <div
+        ref={setElement}
+        className={contentsStyle}
+        role="presentation"
+        data-focus-stack={axis}
+        onFocus={(event) => {
+          // Track which child holds focus, so re-entry restores it. focusin
+          // bubbles through display:contents wrappers.
+          if (!(event.target instanceof Node)) {
+            return;
+          }
+          for (const [memberId, handle] of membersRef.current) {
+            if (handle.element.contains(event.target)) {
+              lastChildRef.current = memberId;
+              return;
+            }
+          }
+        }}
+      >
+        {children}
+      </div>
+    </FocusGroupContext>
+  );
+};
+
+export interface FocusRootProps {
+  children: ReactNode;
+}
+
+/**
+ * The boundary of a keyboard flow: moves escaping the outermost stack stop
+ * here, and stacks inside never route into surrounding UI.
+ */
+export const FocusRoot: React.FC<FocusRootProps> = ({ children }) => (
+  <FocusGroupContext value={BOUNDARY_FOCUS_GROUP}>{children}</FocusGroupContext>
+);

--- a/libs/@hashintel/petrinaut/src/ui/worksheet/use-focus-grid.ts
+++ b/libs/@hashintel/petrinaut/src/ui/worksheet/use-focus-grid.ts
@@ -1,0 +1,248 @@
+/**
+ * Spreadsheet-style focus movement for a uniform grid of focusable cells,
+ * as one member of the enclosing `FocusStack`. Cells register under their
+ * (row, column) position; arrow keys move focus to the nearest registered
+ * neighbour, skipping positions nothing registered. Inside a text input the
+ * horizontal arrows keep moving the caret — only the vertical ones
+ * navigate.
+ *
+ * A move past any edge asks the stack to carry focus onward, with the
+ * source position attached so an `entry="aligned"` neighbour can keep the
+ * row of a horizontal move or the column of a vertical one. A refused move
+ * leaves focus where it is.
+ *
+ * The grid is one tab stop: `tabIndexFor` roves the tabbable cell — the
+ * last-focused one, falling back to (0, 0) — and entering the grid restores
+ * that remembered cell (or the aligned/edge position of the arriving move).
+ * The memory drops when the remembered cell unregisters.
+ */
+
+import { use, useEffect, useId, useRef, useState } from "react";
+
+import {
+  FocusGroupContext,
+  focusLands,
+  type FocusDirection,
+  type FocusEntry,
+} from "./focus-flow";
+
+export interface FocusGrid {
+  register: (
+    row: number,
+    column: number,
+  ) => (element: HTMLElement | null) => void;
+  onKeyDown: (row: number, column: number) => React.KeyboardEventHandler;
+  /** Reports the cell that gained focus; wire to every cell's onFocus. */
+  onFocusCell: (row: number, column: number) => void;
+  /** 0 for the grid's one tabbable cell, -1 for the rest. */
+  tabIndexFor: (row: number, column: number) => 0 | -1;
+  /** Attach to the grid's root element; registered while mounted. */
+  attach: (element: HTMLElement | null) => void;
+}
+
+const cellKey = (row: number, column: number) => `${row}-${column}`;
+
+export function useFocusGrid(): FocusGrid {
+  const group = use(FocusGroupContext);
+  const id = useId();
+  const cells = useRef(new Map<string, HTMLElement>());
+  const bounds = useRef({ rows: 0, columns: 0 });
+  // The roving tab stop: last-focused cell, in state because it renders as
+  // tabIndex. Falls back to (0, 0) until something focuses.
+  const [tabbable, setTabbable] = useState<{ row: number; column: number }>({
+    row: 0,
+    column: 0,
+  });
+  const [element, setElement] = useState<HTMLElement | null>(null);
+
+  const register =
+    (row: number, column: number) => (target: HTMLElement | null) => {
+      const key = cellKey(row, column);
+      if (target) {
+        cells.current.set(key, target);
+        bounds.current.rows = Math.max(bounds.current.rows, row + 1);
+        bounds.current.columns = Math.max(bounds.current.columns, column + 1);
+      } else {
+        cells.current.delete(key);
+      }
+    };
+
+  const move = (
+    row: number,
+    column: number,
+    rowStep: number,
+    columnStep: number,
+  ): boolean => {
+    let r = row + rowStep;
+    let c = column + columnStep;
+    while (
+      r >= 0 &&
+      c >= 0 &&
+      r < bounds.current.rows &&
+      c < bounds.current.columns
+    ) {
+      const target = cells.current.get(cellKey(r, c));
+      if (target) {
+        target.focus();
+        return true;
+      }
+      r += rowStep;
+      c += columnStep;
+    }
+    return false;
+  };
+
+  /** The nearest registered cell to a wished position, scanning that row
+   * first and then neighbouring rows. */
+  const focusNearest = (row: number, column: number): boolean => {
+    const rows = bounds.current.rows;
+    const columns = bounds.current.columns;
+    const wishedRow = Math.min(Math.max(row, 0), Math.max(rows - 1, 0));
+    const wishedColumn = Math.min(
+      Math.max(column, 0),
+      Math.max(columns - 1, 0),
+    );
+    for (let rowOffset = 0; rowOffset < rows; rowOffset += 1) {
+      for (const r of rowOffset === 0
+        ? [wishedRow]
+        : [wishedRow - rowOffset, wishedRow + rowOffset]) {
+        if (r < 0 || r >= rows) {
+          continue;
+        }
+        for (let columnOffset = 0; columnOffset < columns; columnOffset += 1) {
+          for (const c of columnOffset === 0
+            ? [wishedColumn]
+            : [wishedColumn - columnOffset, wishedColumn + columnOffset]) {
+            if (c < 0 || c >= columns) {
+              continue;
+            }
+            if (focusLands(cells.current.get(cellKey(r, c)))) {
+              return true;
+            }
+          }
+        }
+      }
+    }
+    return false;
+  };
+
+  const enter = (entry: FocusEntry): boolean => {
+    // Aligned entry: keep the source row on a horizontal move, the source
+    // column on a vertical one; the travel direction supplies the other
+    // coordinate (arriving downward means the top row).
+    if (entry.from) {
+      const horizontal =
+        entry.direction === "left" || entry.direction === "right";
+      const row = horizontal
+        ? entry.from.row
+        : entry.direction === "down"
+          ? 0
+          : bounds.current.rows - 1;
+      const column = horizontal
+        ? entry.direction === "right"
+          ? 0
+          : bounds.current.columns - 1
+        : entry.from.column;
+      return focusNearest(row, column);
+    }
+    // Remembered entry: the roving cell, wherever it is.
+    if (focusLands(cells.current.get(cellKey(tabbable.row, tabbable.column)))) {
+      return true;
+    }
+    const fromEnd = entry.direction === "up" || entry.direction === "left";
+    return focusNearest(
+      fromEnd ? bounds.current.rows - 1 : 0,
+      fromEnd ? bounds.current.columns - 1 : 0,
+    );
+  };
+  const enterRef = useRef(enter);
+  useEffect(() => {
+    enterRef.current = enter;
+  });
+
+  // Memory needs no consumer wiring: any focus landing inside the grid —
+  // arrows, Tab, pointer clicks — updates the roving cell via focusin on
+  // the grid's root. `onFocusCell` stays for cells rendered outside it.
+  useEffect(() => {
+    if (!element) {
+      return undefined;
+    }
+    const onFocusIn = (event: FocusEvent) => {
+      if (!(event.target instanceof Node)) {
+        return;
+      }
+      for (const [key, cell] of cells.current) {
+        if (cell === event.target || cell.contains(event.target)) {
+          const [row, column] = key.split("-").map(Number);
+          setTabbable((current) =>
+            current.row === row && current.column === column
+              ? current
+              : { row: row!, column: column! },
+          );
+          return;
+        }
+      }
+    };
+    element.addEventListener("focusin", onFocusIn);
+    return () => element.removeEventListener("focusin", onFocusIn);
+  }, [element]);
+
+  useEffect(() => {
+    if (element) {
+      group.register(id, {
+        element,
+        enter: (entry) => enterRef.current(entry),
+      });
+    }
+  });
+  useEffect(() => () => group.unregister(id), [group, id]);
+
+  const onKeyDown =
+    (row: number, column: number): React.KeyboardEventHandler =>
+    (event) => {
+      const target = event.target as HTMLElement;
+      const inTextField =
+        target.tagName === "INPUT" || target.tagName === "TEXTAREA";
+      const direction: FocusDirection | null =
+        event.key === "ArrowDown"
+          ? "down"
+          : event.key === "ArrowUp"
+            ? "up"
+            : event.key === "ArrowRight" && !inTextField
+              ? "right"
+              : event.key === "ArrowLeft" && !inTextField
+                ? "left"
+                : null;
+      if (direction === null) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      const moved =
+        direction === "down"
+          ? move(row, column, 1, 0)
+          : direction === "up"
+            ? move(row, column, -1, 0)
+            : direction === "right"
+              ? move(row, column, 0, 1)
+              : move(row, column, 0, -1);
+      if (!moved) {
+        group.moveFrom(id, direction, { row, column });
+      }
+    };
+
+  return {
+    register,
+    onKeyDown,
+    onFocusCell: (row, column) => {
+      setTabbable((current) =>
+        current.row === row && current.column === column
+          ? current
+          : { row, column },
+      );
+    },
+    tabIndexFor: (row, column) =>
+      tabbable.row === row && tabbable.column === column ? 0 : -1,
+    attach: setElement,
+  };
+}

--- a/libs/@hashintel/petrinaut/src/ui/worksheet/use-focus-member.ts
+++ b/libs/@hashintel/petrinaut/src/ui/worksheet/use-focus-member.ts
@@ -1,0 +1,96 @@
+/**
+ * Membership in the enclosing `FocusStack`, for units that are not grids: a
+ * single focusable element (a collapsible header, a lone cell) or a custom
+ * navigator that owns its internal movement and only delegates edge moves.
+ */
+
+import { use, useEffect, useId, useState } from "react";
+
+import {
+  FocusGroupContext,
+  focusLands,
+  type FocusDirection,
+  type FocusEntry,
+} from "./focus-flow";
+
+export interface FocusMember {
+  /** Attach to the member's root element; registered while mounted. */
+  attach: (element: HTMLElement | null) => void;
+  /** Carry focus out of this member. Returns whether focus moved. */
+  moveFrom: (
+    direction: FocusDirection,
+    from?: { row: number; column: number },
+  ) => boolean;
+}
+
+/** Registers one member entered through `enter`. */
+export function useFocusMember(
+  enter: (entry: FocusEntry) => boolean,
+): FocusMember {
+  const group = use(FocusGroupContext);
+  const id = useId();
+  const [element, setElement] = useState<HTMLElement | null>(null);
+
+  // Re-register every render for a fresh `enter` closure; unregister only
+  // on unmount or a group change, so the group's memory of this member
+  // survives ordinary renders.
+  useEffect(() => {
+    if (element) {
+      group.register(id, { element, enter });
+    }
+  });
+  useEffect(() => () => group.unregister(id), [group, id]);
+
+  return {
+    attach: setElement,
+    moveFrom: (direction, from) => group.moveFrom(id, direction, from),
+  };
+}
+
+export interface FocusHeader {
+  /** Attach to the header's focusable trigger. */
+  attach: (element: HTMLButtonElement | null) => void;
+  /**
+   * Arrow handling for the trigger: vertical moves leave to the
+   * neighbouring member; Left/Right collapse/expand when handlers are
+   * given, and otherwise leave horizontally.
+   */
+  onHeaderKeyDown: React.KeyboardEventHandler;
+}
+
+/**
+ * A single-element member for a section or place header. Left/Right drive
+ * its collapse state when handlers are given — a header that owns
+ * horizontal keys never emits horizontal moves.
+ */
+export function useFocusHeader(options: {
+  collapse?: () => void;
+  expand?: () => void;
+}): FocusHeader {
+  const [element, setElement] = useState<HTMLButtonElement | null>(null);
+  const member = useFocusMember(() => focusLands(element));
+
+  const onHeaderKeyDown: React.KeyboardEventHandler = (event) => {
+    const handled = (action: () => unknown) => {
+      event.preventDefault();
+      event.stopPropagation();
+      action();
+    };
+    if (event.key === "ArrowUp") {
+      handled(() => member.moveFrom("up"));
+    } else if (event.key === "ArrowDown") {
+      handled(() => member.moveFrom("down"));
+    } else if (event.key === "ArrowLeft") {
+      handled(options.collapse ?? (() => member.moveFrom("left")));
+    } else if (event.key === "ArrowRight") {
+      handled(options.expand ?? (() => member.moveFrom("right")));
+    }
+  };
+
+  const attach = (target: HTMLButtonElement | null) => {
+    setElement(target);
+    member.attach(target);
+  };
+
+  return { attach, onHeaderKeyDown };
+}

--- a/libs/@hashintel/petrinaut/src/ui/worksheet/use-focus-stops.ts
+++ b/libs/@hashintel/petrinaut/src/ui/worksheet/use-focus-stops.ts
@@ -1,0 +1,289 @@
+/**
+ * Focus movement for tables whose lines are not a uniform grid, as one
+ * member of the enclosing `FocusStack`. The owner declares an ordered list
+ * of stops, top to bottom:
+ *
+ * - `row` — a full line of cells, columns 0..columnCount-1, optionally
+ *   with a gutter lane on its left;
+ * - `full` — one full-width target (a dynamic row's count strip);
+ * - `sparse` — a line with targets in some columns only (a shared-values
+ *   line), entered at the nearest declared column.
+ *
+ * Vertical arrows walk the stops, carrying the column across full-width
+ * stops (column memory); horizontal arrows walk a line's own parts. The
+ * gutter is its own lane: vertical moves stay gutter-to-gutter over `row`
+ * stops, ArrowRight enters the line's cells at column 0, and ArrowLeft
+ * from column 0 returns to it. Moves past any edge ask the stack to carry
+ * focus onward; a refused move leaves focus where it is.
+ *
+ * Focusing stays the owner's: `focusTarget` receives the wished position
+ * and reports whether an element took focus, so ref bookkeeping and
+ * nearest-column policies live with the table that owns them.
+ */
+
+import { use, useEffect, useId, useRef, useState } from "react";
+
+import {
+  FocusGroupContext,
+  type FocusDirection,
+  type FocusEntry,
+} from "./focus-flow";
+
+export type FocusStop =
+  | { id: string; kind: "row"; gutter?: boolean }
+  | { id: string; kind: "full" }
+  | { id: string; kind: "sparse"; columns: number[] };
+
+/** A wished position; `column: "gutter"` targets a row stop's gutter lane. */
+export interface FocusStopTarget {
+  stopId: string;
+  column: number | "gutter";
+}
+
+export interface FocusStopsOptions {
+  /** Ordered stops, top to bottom; rebuilt every render by the owner. */
+  stops: FocusStop[];
+  columnCount: number;
+  /** Focus the target; returns whether an element took focus. */
+  focusTarget: (target: FocusStopTarget) => boolean;
+}
+
+export interface FocusStops {
+  /** Arrow handling for the element at the given position. */
+  onKeyDown: (position: FocusStopTarget) => React.KeyboardEventHandler;
+  /** Reports the position that gained focus; wire to every part's onFocus. */
+  onFocusTarget: (position: FocusStopTarget) => void;
+  /** 0 for the table's one tabbable position, -1 for the rest. */
+  tabIndexFor: (position: FocusStopTarget) => 0 | -1;
+  /** Attach to the table's root element; registered while mounted. */
+  attach: (element: HTMLElement | null) => void;
+  /** Carry focus out of the table. Returns whether focus moved. */
+  moveFrom: (
+    direction: FocusDirection,
+    from?: { row: number; column: number },
+  ) => boolean;
+}
+
+const samePosition = (a: FocusStopTarget, b: FocusStopTarget): boolean =>
+  a.stopId === b.stopId && a.column === b.column;
+
+export function useFocusStops(options: FocusStopsOptions): FocusStops {
+  const { stops, columnCount, focusTarget } = options;
+  const group = use(FocusGroupContext);
+  const id = useId();
+  // The column vertical moves aim at, persisted across full-width stops.
+  const lastColumnRef = useRef(0);
+  // The roving tab stop, in state because it renders as tabIndex.
+  const [tabbable, setTabbable] = useState<FocusStopTarget | null>(null);
+  const [element, setElement] = useState<HTMLElement | null>(null);
+
+  const stopIndexOf = (stopId: string): number =>
+    stops.findIndex((stop) => stop.id === stopId);
+
+  const entryColumn = (stop: FocusStop, column: number): number | "gutter" => {
+    if (stop.kind === "full") {
+      return 0;
+    }
+    if (stop.kind === "sparse") {
+      if (stop.columns.length === 0) {
+        return 0;
+      }
+      return stop.columns.reduce((best, candidate) =>
+        Math.abs(candidate - column) < Math.abs(best - column)
+          ? candidate
+          : best,
+      );
+    }
+    return column;
+  };
+
+  /** Focus a stop by index at the wished column; skips unfocusable stops. */
+  const focusStopAt = (
+    index: number,
+    column: number,
+    step: 1 | -1,
+  ): boolean => {
+    for (let at = index; at >= 0 && at < stops.length; at += step) {
+      const stop = stops[at]!;
+      if (focusTarget({ stopId: stop.id, column: entryColumn(stop, column) })) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  const moveVertically = (fromIndex: number, step: 1 | -1): boolean => {
+    const next = fromIndex + step;
+    if (next < 0 || next >= stops.length) {
+      return false;
+    }
+    return focusStopAt(next, lastColumnRef.current, step);
+  };
+
+  const gutterRows = (): number[] =>
+    stops.flatMap((stop, index) =>
+      stop.kind === "row" && stop.gutter ? [index] : [],
+    );
+
+  const enter = (entry: FocusEntry): boolean => {
+    if (entry.from) {
+      const horizontal =
+        entry.direction === "left" || entry.direction === "right";
+      if (horizontal) {
+        const index = Math.min(Math.max(entry.from.row, 0), stops.length - 1);
+        const column = entry.direction === "right" ? 0 : columnCount - 1;
+        return focusStopAt(index, column, 1) || focusStopAt(index, column, -1);
+      }
+      const fromEnd = entry.direction === "up";
+      return focusStopAt(
+        fromEnd ? stops.length - 1 : 0,
+        entry.from.column,
+        fromEnd ? -1 : 1,
+      );
+    }
+    if (tabbable && focusTarget(tabbable)) {
+      return true;
+    }
+    const fromEnd = entry.direction === "up" || entry.direction === "left";
+    return focusStopAt(
+      fromEnd ? stops.length - 1 : 0,
+      lastColumnRef.current,
+      fromEnd ? -1 : 1,
+    );
+  };
+  const enterRef = useRef(enter);
+  useEffect(() => {
+    enterRef.current = enter;
+  });
+
+  useEffect(() => {
+    if (element) {
+      group.register(id, {
+        element,
+        enter: (entry) => enterRef.current(entry),
+      });
+    }
+  });
+  useEffect(() => () => group.unregister(id), [group, id]);
+
+  const moveFrom = (
+    direction: FocusDirection,
+    from?: { row: number; column: number },
+  ): boolean => group.moveFrom(id, direction, from);
+
+  const onKeyDown =
+    (position: FocusStopTarget): React.KeyboardEventHandler =>
+    (event) => {
+      const target = event.target as HTMLElement;
+      const inTextField =
+        target.tagName === "INPUT" || target.tagName === "TEXTAREA";
+      const direction: FocusDirection | null =
+        event.key === "ArrowDown"
+          ? "down"
+          : event.key === "ArrowUp"
+            ? "up"
+            : event.key === "ArrowRight" && !inTextField
+              ? "right"
+              : event.key === "ArrowLeft" && !inTextField
+                ? "left"
+                : null;
+      if (direction === null) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+
+      const index = stopIndexOf(position.stopId);
+      if (index === -1) {
+        return;
+      }
+      const stop = stops[index]!;
+      if (position.column !== "gutter") {
+        lastColumnRef.current =
+          stop.kind === "full" ? lastColumnRef.current : position.column;
+      }
+      const overflowFrom = {
+        row: index,
+        column:
+          position.column === "gutter"
+            ? 0
+            : stop.kind === "full"
+              ? lastColumnRef.current
+              : position.column,
+      };
+
+      // The gutter lane: vertical moves stay gutter-to-gutter over row
+      // stops; ArrowRight enters the line's cells at column 0.
+      if (position.column === "gutter") {
+        if (direction === "right") {
+          focusTarget({ stopId: position.stopId, column: 0 });
+          return;
+        }
+        if (direction === "left") {
+          moveFrom("left", overflowFrom);
+          return;
+        }
+        const lane = gutterRows();
+        const at = lane.indexOf(index);
+        const next = lane[at + (direction === "down" ? 1 : -1)];
+        if (next !== undefined) {
+          focusTarget({ stopId: stops[next]!.id, column: "gutter" });
+        } else {
+          moveFrom(direction, overflowFrom);
+        }
+        return;
+      }
+
+      if (direction === "up" || direction === "down") {
+        if (!moveVertically(index, direction === "down" ? 1 : -1)) {
+          moveFrom(direction, overflowFrom);
+        }
+        return;
+      }
+
+      // Horizontal, within the line.
+      if (stop.kind === "full") {
+        moveFrom(direction, overflowFrom);
+        return;
+      }
+      const lineColumns =
+        stop.kind === "sparse"
+          ? stop.columns
+          : Array.from({ length: columnCount }, (_, column) => column);
+      const at = lineColumns.indexOf(position.column);
+      const next = lineColumns[at + (direction === "right" ? 1 : -1)];
+      if (next !== undefined) {
+        focusTarget({ stopId: stop.id, column: next });
+        return;
+      }
+      if (direction === "left" && stop.kind === "row" && stop.gutter) {
+        focusTarget({ stopId: stop.id, column: "gutter" });
+        return;
+      }
+      moveFrom(direction, overflowFrom);
+    };
+
+  return {
+    onKeyDown,
+    onFocusTarget: (position) => {
+      // A full-width stop has no column of its own: recording its nominal
+      // column 0 would drop the column memory it is meant to carry across.
+      const stop = stops.find((candidate) => candidate.id === position.stopId);
+      if (position.column !== "gutter" && stop?.kind !== "full") {
+        lastColumnRef.current = position.column;
+      }
+      setTabbable((current) =>
+        current && samePosition(current, position) ? current : position,
+      );
+    },
+    tabIndexFor: (position) => {
+      const current = tabbable ?? {
+        stopId: stops[0]?.id ?? "",
+        column: stops[0]?.kind === "row" && stops[0].gutter ? "gutter" : 0,
+      };
+      return samePosition(current, position) ? 0 : -1;
+    },
+    attach: setElement,
+    moveFrom,
+  };
+}

--- a/libs/@hashintel/petrinaut/src/ui/worksheet/use-row-selection.ts
+++ b/libs/@hashintel/petrinaut/src/ui/worksheet/use-row-selection.ts
@@ -1,0 +1,34 @@
+/**
+ * The row-selection model every gutter table shares: focusing any gutter
+ * selects its whole row, and a row whose gutter menu is open stays selected
+ * while the menu holds focus. One menu is open at a time per table.
+ */
+
+import { useState } from "react";
+
+export interface RowSelection {
+  /** The row rendered as selected: the focused row, or the menu's row. */
+  selectedRow: number | null;
+  /** The open gutter menu, if any. */
+  menu: { row: number; anchor: HTMLButtonElement } | null;
+  openMenu: (row: number, anchor: HTMLButtonElement) => void;
+  closeMenu: () => void;
+  /** Reports gutter focus (`null` on blur). */
+  setFocusedRow: (row: number | null) => void;
+}
+
+export function useRowSelection(): RowSelection {
+  const [focusedRow, setFocusedRow] = useState<number | null>(null);
+  const [menu, setMenu] = useState<{
+    row: number;
+    anchor: HTMLButtonElement;
+  } | null>(null);
+
+  return {
+    selectedRow: menu?.row ?? focusedRow,
+    menu,
+    openMenu: (row, anchor) => setMenu({ row, anchor }),
+    closeMenu: () => setMenu(null),
+    setFocusedRow,
+  };
+}

--- a/libs/@hashintel/petrinaut/src/ui/worksheet/use-select-first.ts
+++ b/libs/@hashintel/petrinaut/src/ui/worksheet/use-select-first.ts
@@ -1,0 +1,35 @@
+/**
+ * The worksheet's activation grammar for a click target that is also a
+ * selectable cell: the first pointer click only selects (focuses) it, a
+ * click on an already-selected target activates, and a keyboard "click"
+ * (Enter/Space, which carries no pointer detail) always activates. The
+ * second click of a double-click lands on an already-selected target, so
+ * double-click activates without a handler of its own — important where
+ * activation is not idempotent (materializing a phantom row).
+ */
+
+import { useRef } from "react";
+
+export interface SelectFirstActivation {
+  /** Record whether the target was already selected when the press began. */
+  onPointerDown: React.PointerEventHandler<HTMLElement>;
+  /** Whether this click activates: a keyboard "click", or a click on an
+   * already-selected target. */
+  shouldActivate: (event: React.MouseEvent<HTMLElement>) => boolean;
+}
+
+/**
+ * One instance serves any number of sibling targets: only one can be
+ * focused at a time, and a target's pointerdown always precedes its click.
+ */
+export function useSelectFirstActivation(): SelectFirstActivation {
+  const wasFocusedOnPointerDownRef = useRef(false);
+  return {
+    onPointerDown: (event) => {
+      wasFocusedOnPointerDownRef.current =
+        document.activeElement === event.currentTarget;
+    },
+    shouldActivate: (event) =>
+      event.detail === 0 || wasFocusedOnPointerDownRef.current,
+  };
+}

--- a/libs/@hashintel/petrinaut/src/ui/worksheet/worksheet.stories.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/worksheet/worksheet.stories.tsx
@@ -1,0 +1,581 @@
+import { Fragment, type ReactNode, useRef, useState } from "react";
+
+import { css, cva } from "@hashintel/ds-helpers/css";
+
+import { focusLands } from "./focus-flow";
+import { FocusRoot, FocusStack } from "./focus-stack";
+import { useFocusGrid, type FocusGrid } from "./use-focus-grid";
+import { useFocusHeader } from "./use-focus-member";
+import {
+  useFocusStops,
+  type FocusStop,
+  type FocusStops,
+  type FocusStopTarget,
+} from "./use-focus-stops";
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+// -- Styles ---------------------------------------------------------------
+
+const pageStyle = css({
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "flex-start",
+  gap: "[16px]",
+});
+
+const introStyle = css({
+  maxWidth: "[560px]",
+  fontSize: "sm",
+  lineHeight: "[20px]",
+  color: "neutral.s80",
+});
+
+const columnsStyle = css({
+  display: "flex",
+  alignItems: "flex-start",
+  gap: "[24px]",
+});
+
+const columnStyle = css({
+  display: "flex",
+  flexDirection: "column",
+  gap: "[12px]",
+});
+
+const gridBoxStyle = css({
+  display: "flex",
+  flexDirection: "column",
+  gap: "[4px]",
+  padding: "[8px]",
+  borderWidth: "[1px]",
+  borderStyle: "solid",
+  borderColor: "neutral.bd.subtle",
+  borderRadius: "[6px]",
+});
+
+const gridTitleStyle = css({
+  fontSize: "xs",
+  fontWeight: "medium",
+  color: "neutral.s80",
+});
+
+const gridRowStyle = css({
+  display: "flex",
+  gap: "[4px]",
+});
+
+const containedPairStyle = css({
+  display: "flex",
+  gap: "[12px]",
+  padding: "[8px]",
+  borderWidth: "[1px]",
+  borderStyle: "dashed",
+  borderColor: "blue.s50",
+  borderRadius: "[6px]",
+});
+
+const stopsTableStyle = css({
+  display: "grid",
+  gridTemplateColumns: "[36px repeat(3, 104px)]",
+  gap: "[4px]",
+  width: "[fit-content]",
+  padding: "[8px]",
+  borderWidth: "[1px]",
+  borderStyle: "solid",
+  borderColor: "neutral.bd.subtle",
+  borderRadius: "[6px]",
+});
+
+const sparseLabelStyle = css({
+  gridColumn: "[span 2]",
+  display: "flex",
+  alignItems: "center",
+  paddingX: "[8px]",
+  fontSize: "xs",
+  color: "neutral.s80",
+});
+
+const sectionHeaderStyle = css({
+  display: "flex",
+  alignItems: "center",
+  gap: "[6px]",
+  height: "[28px]",
+  paddingX: "[8px]",
+  fontSize: "xs",
+  fontWeight: "medium",
+  textAlign: "left",
+  color: "neutral.s120",
+  backgroundColor: "neutral.s20",
+  borderWidth: "[1px]",
+  borderStyle: "solid",
+  borderColor: "neutral.bd.subtle",
+  borderRadius: "[4px]",
+  cursor: "pointer",
+  _focus: {
+    outline: "[2px solid {colors.blue.s50}]",
+    outlineOffset: "[1px]",
+  },
+});
+
+const cellStyle = cva({
+  base: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    minWidth: "[56px]",
+    height: "[28px]",
+    paddingX: "[8px]",
+    fontSize: "xs",
+    color: "neutral.s120",
+    backgroundColor: "neutral.s05",
+    borderWidth: "[1px]",
+    borderStyle: "solid",
+    borderColor: "neutral.bd.subtle",
+    borderRadius: "[4px]",
+    cursor: "pointer",
+    _focus: {
+      outline: "[2px solid {colors.blue.s50}]",
+      outlineOffset: "[1px]",
+    },
+  },
+  variants: {
+    tone: {
+      plain: {},
+      header: {
+        fontWeight: "medium",
+        backgroundColor: "neutral.s20",
+      },
+      gutter: {
+        minWidth: "[36px]",
+        paddingX: "[0px]",
+        backgroundColor: "neutral.s20",
+      },
+      strip: {
+        gridColumn: "[1 / -1]",
+        backgroundColor: "neutral.s20",
+      },
+    },
+  },
+  defaultVariants: { tone: "plain" },
+});
+
+// -- Demo building blocks -------------------------------------------------
+
+const range = (count: number): number[] =>
+  Array.from({ length: count }, (_, index) => index);
+
+const StoryFrame = ({
+  intro,
+  children,
+}: {
+  intro: string;
+  children: ReactNode;
+}) => (
+  <div className={pageStyle}>
+    <p className={introStyle}>{intro}</p>
+    {children}
+  </div>
+);
+
+const GridCell = ({
+  grid,
+  row,
+  column,
+  label,
+}: {
+  grid: FocusGrid;
+  row: number;
+  column: number;
+  label: string;
+}) => (
+  <button
+    type="button"
+    ref={grid.register(row, column)}
+    tabIndex={grid.tabIndexFor(row, column)}
+    onKeyDown={grid.onKeyDown(row, column)}
+    onFocus={() => grid.onFocusCell(row, column)}
+    className={cellStyle()}
+  >
+    {label}
+  </button>
+);
+
+/** A bordered rows-by-columns grid of buttons, one member of the flow. */
+const DemoGrid = ({
+  label,
+  rows,
+  columns,
+}: {
+  label: string;
+  rows: number;
+  columns: number;
+}) => {
+  const grid = useFocusGrid();
+  return (
+    <div
+      ref={(element) => grid.attach(element)}
+      aria-label={label}
+      className={gridBoxStyle}
+    >
+      <div className={gridTitleStyle}>{label}</div>
+      {range(rows).map((row) => (
+        <div key={row} className={gridRowStyle}>
+          {range(columns).map((column) => (
+            <GridCell
+              key={column}
+              grid={grid}
+              row={row}
+              column={column}
+              label={`${row},${column}`}
+            />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+// -- Meta -----------------------------------------------------------------
+
+const meta = {
+  title: "worksheet/FocusStack",
+  component: FocusStack,
+  parameters: {
+    layout: "padded",
+  },
+  args: {
+    axis: "horizontal",
+    children: null,
+  },
+} satisfies Meta<typeof FocusStack>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// -- Two columns ----------------------------------------------------------
+
+const TwoColumnsExample = ({ entry }: { entry?: "remembered" | "aligned" }) => (
+  <FocusRoot>
+    <div className={columnsStyle}>
+      <FocusStack axis="horizontal" entry={entry}>
+        <FocusStack axis="vertical">
+          <div className={columnStyle}>
+            <DemoGrid label="Left top grid" rows={2} columns={3} />
+            <DemoGrid label="Left bottom grid" rows={3} columns={2} />
+          </div>
+        </FocusStack>
+        <FocusStack axis="vertical">
+          <div className={columnStyle}>
+            <DemoGrid label="Right top grid" rows={3} columns={3} />
+            <DemoGrid label="Right bottom grid" rows={2} columns={2} />
+          </div>
+        </FocusStack>
+      </FocusStack>
+    </div>
+  </FocusRoot>
+);
+
+export const TwoColumns: Story = {
+  render: () => (
+    <StoryFrame
+      intro={
+        "Two columns, each a vertical stack of two grids of different sizes. " +
+        "Click any cell, then move with the arrow keys: running off a grid's " +
+        "edge crosses into the neighbouring grid or column, and every grid " +
+        "remembers the cell you last visited, so crossing back returns there " +
+        "(the default entry). Tab and Shift+Tab jump grid to grid — each " +
+        "grid is a single tab stop with a roving tabindex."
+      }
+    >
+      <TwoColumnsExample />
+    </StoryFrame>
+  ),
+};
+
+// -- Aligned entry --------------------------------------------------------
+
+export const AlignedEntry: Story = {
+  render: () => (
+    <StoryFrame
+      intro={
+        'The same layout with entry="aligned" on the horizontal stack — the ' +
+        "stack that routes a move decides the policy, and inner stacks pass " +
+        "it through. Crossing into a neighbour keeps the row of a horizontal " +
+        "move, landing on the nearest cell instead of the neighbour's " +
+        "remembered cell. Try ArrowRight from different rows of the left " +
+        "grids and watch the row carry across."
+      }
+    >
+      <TwoColumnsExample entry="aligned" />
+    </StoryFrame>
+  ),
+};
+
+// -- Contained ------------------------------------------------------------
+
+const ContainedExample = () => (
+  <FocusRoot>
+    <div className={columnStyle}>
+      <FocusStack axis="vertical">
+        <DemoGrid label="Top grid" rows={2} columns={3} />
+        <FocusStack axis="horizontal" contain>
+          <div className={containedPairStyle}>
+            <DemoGrid label="Inner left grid" rows={2} columns={2} />
+            <DemoGrid label="Inner right grid" rows={2} columns={2} />
+          </div>
+        </FocusStack>
+        <DemoGrid label="Bottom grid" rows={2} columns={3} />
+      </FocusStack>
+    </div>
+  </FocusRoot>
+);
+
+export const Contained: Story = {
+  render: () => (
+    <StoryFrame
+      intro={
+        "A vertical stack whose middle member is a horizontal stack with " +
+        "contain (the dashed border). Arrow down from the top grid to enter " +
+        "the pair, then try to leave with the arrow keys: Left and Right " +
+        "cross between the two inner grids, but no arrow escapes the pair " +
+        "— Up and Down are refused. Tab still moves freely in and out."
+      }
+    >
+      <ContainedExample />
+    </StoryFrame>
+  ),
+};
+
+// -- Stops table ----------------------------------------------------------
+
+const STOPS: FocusStop[] = [
+  { id: "header", kind: "row" },
+  { id: "strip", kind: "full" },
+  { id: "process-1", kind: "row", gutter: true },
+  { id: "process-2", kind: "row", gutter: true },
+  { id: "process-3", kind: "row", gutter: true },
+  { id: "shared", kind: "sparse", columns: [1, 2] },
+];
+
+const STOPS_COLUMN_COUNT = 3;
+
+const targetKey = (target: FocusStopTarget) =>
+  `${target.stopId}:${target.column}`;
+
+const StopCell = ({
+  table,
+  targets,
+  position,
+  label,
+  ariaLabel,
+  tone = "plain",
+  reportFocus = true,
+}: {
+  table: FocusStops;
+  targets: { current: Map<string, HTMLElement> };
+  position: FocusStopTarget;
+  label: string;
+  ariaLabel?: string;
+  tone?: "plain" | "header" | "gutter" | "strip";
+  /**
+   * A full-width stop has no column of its own; reporting its wired column
+   * (0) on focus would overwrite the column memory that vertical moves
+   * carry across it, so the strip skips the report.
+   */
+  reportFocus?: boolean;
+}) => (
+  <button
+    type="button"
+    ref={(element) => {
+      if (element) {
+        targets.current.set(targetKey(position), element);
+      } else {
+        targets.current.delete(targetKey(position));
+      }
+    }}
+    aria-label={ariaLabel}
+    tabIndex={table.tabIndexFor(position)}
+    onKeyDown={table.onKeyDown(position)}
+    onFocus={reportFocus ? () => table.onFocusTarget(position) : undefined}
+    className={cellStyle({ tone })}
+  >
+    {label}
+  </button>
+);
+
+const StopsTableExample = () => {
+  const targets = useRef(new Map<string, HTMLElement>());
+  const table = useFocusStops({
+    stops: STOPS,
+    columnCount: STOPS_COLUMN_COUNT,
+    focusTarget: (target) => focusLands(targets.current.get(targetKey(target))),
+  });
+
+  const headerLabels = ["Name", "Rate", "Unit"];
+  const processRows = [
+    { stopId: "process-1", cells: ["Mix", "0.4", "per s"] },
+    { stopId: "process-2", cells: ["Heat", "1.2", "per s"] },
+    { stopId: "process-3", cells: ["Cool", "0.7", "per s"] },
+  ];
+  const sharedCells: { column: number; label: string }[] = [
+    { column: 1, label: "1.0" },
+    { column: 2, label: "per s" },
+  ];
+
+  return (
+    <FocusRoot>
+      <div
+        ref={(element) => table.attach(element)}
+        aria-label="Process table"
+        className={stopsTableStyle}
+      >
+        <div />
+        {headerLabels.map((label, column) => (
+          <StopCell
+            key={label}
+            table={table}
+            targets={targets}
+            position={{ stopId: "header", column }}
+            label={label}
+            tone="header"
+          />
+        ))}
+        <StopCell
+          table={table}
+          targets={targets}
+          position={{ stopId: "strip", column: 0 }}
+          label="3 processes (full-width strip)"
+          tone="strip"
+          reportFocus={false}
+        />
+        {processRows.map((row) => (
+          <Fragment key={row.stopId}>
+            <StopCell
+              table={table}
+              targets={targets}
+              position={{ stopId: row.stopId, column: "gutter" }}
+              label="⋮"
+              ariaLabel={`${row.cells[0]} row gutter`}
+              tone="gutter"
+            />
+            {row.cells.map((label, column) => (
+              <StopCell
+                key={`${row.stopId}-${label}`}
+                table={table}
+                targets={targets}
+                position={{ stopId: row.stopId, column }}
+                label={label}
+              />
+            ))}
+          </Fragment>
+        ))}
+        <div className={sparseLabelStyle}>shared (cols 1–2)</div>
+        {sharedCells.map((cell) => (
+          <StopCell
+            key={cell.column}
+            table={table}
+            targets={targets}
+            position={{ stopId: "shared", column: cell.column }}
+            label={cell.label}
+          />
+        ))}
+      </div>
+    </FocusRoot>
+  );
+};
+
+export const StopsTable: Story = {
+  render: () => (
+    <StoryFrame
+      intro={
+        "A non-uniform table built with useFocusStops. The ⋮ gutter is its " +
+        "own lane: ArrowUp/Down stay gutter to gutter, ArrowRight enters " +
+        "the row's cells at column 0, and ArrowLeft from column 0 returns " +
+        "to the gutter. Vertical moves remember your column across the " +
+        "full-width strip — go down from the Rate header and you resurface " +
+        "in the Rate column — and the sparse shared line has cells only in " +
+        "its two declared columns, entered at the nearest one."
+      }
+    >
+      <StopsTableExample />
+    </StoryFrame>
+  ),
+};
+
+// -- Mixed controls -------------------------------------------------------
+
+const ActionRow = () => {
+  const grid = useFocusGrid();
+  const actions = ["Run", "Pause", "Reset"];
+  return (
+    <div
+      ref={(element) => grid.attach(element)}
+      aria-label="Action row"
+      className={gridBoxStyle}
+    >
+      <div className={gridTitleStyle}>Action row (one-row grid)</div>
+      <div className={gridRowStyle}>
+        {actions.map((label, column) => (
+          <GridCell
+            key={label}
+            grid={grid}
+            row={0}
+            column={column}
+            label={label}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+const MixedControlsExample = () => {
+  const [expanded, setExpanded] = useState(true);
+  const header = useFocusHeader({
+    collapse: () => setExpanded(false),
+    expand: () => setExpanded(true),
+  });
+  return (
+    <FocusRoot>
+      <div className={columnStyle}>
+        <FocusStack axis="vertical">
+          <button
+            type="button"
+            ref={(element) => header.attach(element)}
+            onKeyDown={(event) => header.onHeaderKeyDown(event)}
+            onClick={() => setExpanded(!expanded)}
+            aria-expanded={expanded}
+            className={sectionHeaderStyle}
+          >
+            {expanded ? "▾" : "▸"} Reaction rates
+          </button>
+          {expanded ? (
+            <DemoGrid label="Section grid" rows={2} columns={3} />
+          ) : null}
+          <ActionRow />
+        </FocusStack>
+      </div>
+    </FocusRoot>
+  );
+};
+
+export const MixedControls: Story = {
+  render: () => (
+    <StoryFrame
+      intro={
+        "A vertical stack mixing member kinds: a collapsible section " +
+        "header, its grid, and a row of plain buttons registered as a " +
+        "one-row grid (one tab stop; ArrowLeft/Right walk it). On the " +
+        "header, ArrowLeft collapses and ArrowRight expands — a header " +
+        "with collapse handlers claims the horizontal keys and never emits " +
+        "horizontal moves — while ArrowUp/Down leave to the neighbouring " +
+        "members. Collapse the section and ArrowDown lands straight on the " +
+        "action row."
+      }
+    >
+      <MixedControlsExample />
+    </StoryFrame>
+  ),
+};

--- a/libs/@local/petrinaut-arch-docs/content/ui/worksheet.mdx
+++ b/libs/@local/petrinaut-arch-docs/content/ui/worksheet.mdx
@@ -1,0 +1,76 @@
+---
+title: The worksheet keyboard flow
+description: The Focus primitives that route arrow keys through panels of grids and controls, and the contract every worksheet obeys.
+sidebar_order: 10
+attachTo: ui.worksheet
+---
+
+A worksheet is a panel composed of spreadsheet grids and ordinary controls,
+laid out in nested columns and rows. This layer gives every worksheet one
+keyboard model. It knows nothing about what the grids contain: consumers own
+their cells, refs, and state; the layer owns movement, memory, and the tab
+order. The [usage manual](doc:ui/worksheet/usage-manual) shows the wiring
+for each piece.
+
+## The pieces
+
+- `FocusStack axis="horizontal" | "vertical"`: a nestable directional
+  group. It renders `display: contents` (no box, no role): the layout stays
+  the host's. Children register through context.
+- `FocusRoot`: the boundary of a flow: moves that escape the outermost
+  stack stop there.
+- `useFocusGrid`: a uniform grid of focusable cells, one member of the
+  enclosing stack.
+- `useFocusStops`: a table whose lines are not uniform: full-width stops,
+  sparse lines, and a gutter lane, declared as an ordered stop list.
+- `useFocusHeader` / `useFocusMember`: single-element members (collapsible
+  headers, lone cells) and custom navigators.
+- `useSelectFirstActivation` and `useRowSelection`: the interaction
+  grammar shared by worksheet tables: the first click selects, the second
+  acts; a focused gutter selects its whole row.
+
+## The contract
+
+Each numbered rule is a test target; `focus-flow.test.tsx` covers them.
+
+1. Tab order is never rerouted. Each grid is one tab stop (roving
+   tabindex: `tabIndexFor` marks the remembered cell 0 and the rest -1);
+   plain controls keep their own stops. Arrow-crossing between siblings is
+   an enhancement over that intact order.
+2. Arrows move within a member; a move that runs off the member's edge
+   asks the nearest enclosing stack whose axis matches the direction to
+   carry focus to a sibling. A stack at its own edge asks its parent.
+3. A move nobody accepts leaves focus where it is, and the key is still
+   consumed. This is the canonical data-grid edge behaviour.
+4. `contain` bounds a stack: arrows never carry focus out of it, in any
+   direction.
+5. Entry restores memory by default: a stack re-enters its last-focused
+   child, a grid its last-focused cell (focusgroup semantics). Memory is
+   dropped when the remembered element unmounts; entry then falls back to
+   the edge the move arrives at.
+6. `entry="aligned"` on the stack that routes a move makes it keep its
+   position instead: a horizontal move keeps its row, a vertical one its
+   column, landing on the nearest focusable cell to the wish. Stacks the
+   entry passes through hand it on unchanged, and the remembered child
+   still picks which member receives it.
+7. Inside a text input the horizontal arrows stay with the caret; only
+   vertical arrows navigate.
+8. A header owns Left/Right when it collapses and expands; a member whose
+   entry fails (collapsed content) is skipped in the walk.
+9. In a stop table, vertical arrows walk the declared stops, carrying the
+   column across full-width stops; a sparse line is entered at the nearest
+   declared column. The gutter is its own lane: vertical moves stay
+   gutter-to-gutter over row stops, ArrowRight enters the line's cells at
+   column 0, ArrowLeft from column 0 returns to the gutter.
+10. Stacks add no ARIA. Roles belong to consumers on real elements: a data
+    table declares `role="grid"`/`row`/`gridcell` itself, and the layer
+    moves real DOM focus (never `aria-activedescendant`).
+
+## Boundaries
+
+The layer must not import form or scenario state; the dependency rule
+keeping the form layer out of its imports ships with the form. The ad-hoc scenario form is
+its first consumer; the editor's other token spreadsheet is the expected
+second. Stories in `worksheet.stories.tsx` demonstrate the configurations:
+side-by-side columns, aligned entry, contained stacks, a stop table, and
+mixed controls.

--- a/libs/@local/petrinaut-arch-docs/content/ui/worksheet/usage-manual.mdx
+++ b/libs/@local/petrinaut-arch-docs/content/ui/worksheet/usage-manual.mdx
@@ -1,0 +1,225 @@
+---
+title: Usage manual
+description: How to assemble a worksheet from the Focus primitives, with wiring examples for stacks, grids, stop tables, headers, and the selection grammar.
+sidebar_order: 20
+attachTo: ui.worksheet
+---
+
+This page shows how to build a worksheet panel from the layer's pieces. The
+[keyboard-flow contract](doc:ui/worksheet) defines the behaviour each piece
+guarantees; this page shows the wiring. The module lives at
+`libs/@hashintel/petrinaut/src/ui/worksheet/`, and every configuration below
+runs as a story in `worksheet.stories.tsx` (`yarn workspace
+@hashintel/petrinaut storybook`, under `worksheet/FocusStack`).
+
+The layer adds no ARIA and moves real DOM focus. Put roles and labels on your
+own elements: a data table declares `role="grid"`, `row`, and `gridcell`
+itself (contract rule 10).
+
+## Consuming the hooks
+
+Destructure hook results before use: `const { register, attach } =
+useFocusGrid()`. Assigning `grid.attach` straight into a `ref` makes the
+React Compiler treat the whole hook result as a ref and reject every later
+property access ("Cannot access refs during render"); destructured bindings
+compile without the diagnostic.
+
+## Lay out the flow
+
+Wrap the panel in one `FocusRoot`, then describe its geometry with nested
+`FocusStack` elements. A stack renders `display: contents`, so it adds no box
+and no role; keep layout styles on your own elements inside it.
+
+```tsx
+<FocusRoot>
+  <div className={columnsStyle}>
+    <FocusStack axis="horizontal">
+      <FocusStack axis="vertical">
+        <div className={columnStyle}>
+          <TokenGrid />
+          <VariablesGrid />
+        </div>
+      </FocusStack>
+      <FocusStack axis="vertical">
+        <div className={columnStyle}>
+          <ParametersGrid />
+        </div>
+      </FocusStack>
+    </FocusStack>
+  </div>
+</FocusRoot>
+```
+
+- `FocusRoot` bounds the flow. A move that escapes the outermost stack stops
+  there instead of routing into surrounding UI.
+- Sibling order is document order. Members and nested stacks register
+  themselves; there is nothing to list by hand.
+- `contain` on a stack refuses every arrow move out of it, in any direction.
+  Tab still moves freely.
+- `entry="aligned"` on a stack keeps the position of the moves it routes: a
+  horizontal move keeps its row, a vertical move keeps its column, landing on
+  the nearest focusable cell. The default (`entry="remembered"`) re-enters
+  each member at its last-focused position. Set the policy on the stack whose
+  axis carries the crossing; stacks the entry passes through hand it on
+  unchanged.
+
+## A uniform grid
+
+`useFocusGrid` handles a rows-by-columns block of focusable cells. Wire four
+things: `attach` on the container, and `register`, `tabIndexFor`, and
+`onKeyDown` on each cell.
+
+```tsx
+const RatesGrid = ({ rows }: { rows: string[][] }) => {
+  const { attach, register, tabIndexFor, onKeyDown } = useFocusGrid();
+  return (
+    <div ref={attach} aria-label="Rates">
+      {rows.map((cells, row) => (
+        <div key={row}>
+          {cells.map((label, column) => (
+            <button
+              key={column}
+              type="button"
+              ref={register(row, column)}
+              tabIndex={tabIndexFor(row, column)}
+              onKeyDown={onKeyDown(row, column)}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+};
+```
+
+- The grid is one tab stop: `tabIndexFor` returns `0` for the remembered cell
+  and `-1` for the rest.
+- Focus memory needs no wiring. Any focus landing inside the attached
+  container updates the remembered cell. Call `onFocusCell(row, column)` from
+  a cell's `onFocus` only when the cell renders outside the container (a
+  portal).
+- Cells register under their `(row, column)` position. Positions may have
+  holes; arrows skip positions nothing registered.
+- Inside an `<input>` or `<textarea>` the horizontal arrows keep moving the
+  caret. Only the vertical arrows navigate.
+- A toolbar is a one-row grid: register each button at row `0` and the row
+  becomes one tab stop whose buttons ArrowLeft and ArrowRight walk.
+
+## A table with irregular lines
+
+`useFocusStops` covers tables a uniform grid cannot describe: a gutter lane,
+full-width strips, and lines with cells in some columns only. Declare the
+vertical structure as an ordered list of stops, top to bottom, and keep
+ownership of focusing.
+
+```tsx
+const stops: FocusStop[] = [
+  { id: "header", kind: "row" },
+  { id: "count", kind: "full" },
+  { id: "token-1", kind: "row", gutter: true },
+  { id: "token-2", kind: "row", gutter: true },
+  { id: "shared", kind: "sparse", columns: [1, 2] },
+];
+
+const targetKey = (target: FocusStopTarget) =>
+  `${target.stopId}:${target.column}`;
+
+const TokenTable = () => {
+  const targets = useRef(new Map<string, HTMLElement>());
+  const { attach, onKeyDown, onFocusTarget, tabIndexFor } = useFocusStops({
+    stops,
+    columnCount: 3,
+    focusTarget: (target) => focusLands(targets.current.get(targetKey(target))),
+  });
+  // Each focusable part wires, for its own position: FocusStopTarget:
+  //   ref       -> store the element into targets under targetKey(position)
+  //   tabIndex  -> tabIndexFor(position)
+  //   onKeyDown -> onKeyDown(position)
+  //   onFocus   -> onFocusTarget(position)
+  // ...
+};
+```
+
+- `focusTarget` receives a wished position and reports whether an element
+  took focus. Ref bookkeeping and any nearest-column policy stay with the
+  table that owns them.
+- A `row` stop with `gutter: true` joins the gutter lane. Its gutter part
+  wires with `column: "gutter"`; the contract describes the lane's movement.
+- A `full` stop renders one full-width part wired at `column: 0`. The hook
+  keeps the column memory across it itself, so wiring `onFocusTarget` on the
+  strip is safe.
+- Rebuild the `stops` array every render; the hook reads it fresh.
+- The returned `moveFrom(direction, from?)` hands a move to the enclosing
+  stack. Use it from custom key handling at edges the stop walk does not
+  cover.
+
+## Headers and custom members
+
+`useFocusHeader` registers a section header as one member. With `collapse`
+and `expand` given, the header owns ArrowLeft and ArrowRight and never emits
+horizontal moves; omit them and the horizontal arrows leave the header
+sideways. Vertical arrows leave to the neighbouring member either way.
+
+```tsx
+const SectionHeader = () => {
+  const [expanded, setExpanded] = useState(true);
+  const { attach, onHeaderKeyDown } = useFocusHeader({
+    collapse: () => setExpanded(false),
+    expand: () => setExpanded(true),
+  });
+  return (
+    <button
+      type="button"
+      ref={attach}
+      onKeyDown={onHeaderKeyDown}
+      onClick={() => setExpanded(!expanded)}
+      aria-expanded={expanded}
+    >
+      Reaction rates
+    </button>
+  );
+};
+```
+
+A collapsed section's content fails entry, and the vertical walk skips it.
+
+`useFocusMember(enter)` registers anything else as one member. The `enter`
+callback receives the arriving `FocusEntry` and returns whether focus landed;
+the returned `moveFrom` delegates a move to the enclosing stack. A component
+with its own internal key handling registers this way and calls `moveFrom`
+when a move runs off its edge.
+
+## The selection grammar
+
+`useSelectFirstActivation` gives a click target that is also a selectable
+cell the worksheet's activation behaviour: the first pointer click only
+selects (focuses) it, a click on an already-selected target activates, and
+Enter or Space always activates.
+
+```tsx
+const { onPointerDown, shouldActivate } = useSelectFirstActivation();
+
+<button
+  type="button"
+  onPointerDown={onPointerDown}
+  onClick={(event) => {
+    if (shouldActivate(event)) {
+      activate();
+    }
+  }}
+/>;
+```
+
+- Double-click needs no handler of its own: its second click lands on an
+  already-selected target and activates. This matters where activation is
+  not idempotent, such as materializing a phantom row.
+- One instance serves any number of sibling targets.
+
+`useRowSelection` is the row-selection model gutter tables share. Its
+`selectedRow` is the row to render as selected: the row whose gutter holds
+focus, or the row whose gutter menu is open. Report gutter focus with
+`setFocusedRow(row)` and blur with `setFocusedRow(null)`; `openMenu(row,
+anchor)` and `closeMenu()` keep one menu open per table, and the menu's row
+stays selected while the menu holds focus.


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

A verbatim mirror of #9411's worksheet keyboard-flow layer, serving as the base of the Notebook view stack so that stack can build on the layer without joining #9411's own stack. It carries no changeset and no ticket of its own: the publishing changeset and the review belong to #9411. When #9411 merges, this PR collapses to an empty diff and closes.

## 🔗 Related links

- #9411 — the original, where review happens
- [FE-1538](https://linear.app/hash/issue/FE-1538/worksheet-layer-reusable-keyboard-flow-primitives-for-grids-and) _(internal)_

## 🚫 Blocked by

- [ ] #9411 merging first — this mirror must never land ahead of the original

## 🔍 What does this change?

- The `ui/worksheet` layer exactly as in #9411 (focus stacks, grids, stops, members, interaction grammar, tests, stories, arch-docs pages), minus its changeset.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing
  - deliberately no changeset: it ships with #9411

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

`focus-flow.test.tsx`, identical to #9411.

## ❓ How to test this?

Review and test on #9411; this mirror only exists to base the notebook stack on.
