### PR TITLE
FE-1500: add editor presentation profiles

### DIFF
--- a/.changeset/petrinaut-presentation-profiles.md
+++ b/.changeset/petrinaut-presentation-profiles.md
@@ -1,0 +1,7 @@
+---
+"@hashintel/petrinaut": patch
+---
+
+Add a `presentationProfile` prop to `Petrinaut` (`editor` or `review`) that
+gates authoring-only controls, and extract the scenario and playback controls
+into shared components reusable outside the full editor.

--- a/apps/petrinaut-website/src/examples/embedded-example-page.tsx
+++ b/apps/petrinaut-website/src/examples/embedded-example-page.tsx
@@ -78,6 +78,7 @@ export const EmbeddedExamplePage: FunctionComponent<
           handle={handle}
           hideNetManagementControls="all"
           navigation={navigation}
+          presentationProfile="review"
           readonly
           slots={{
             topBarStart: (

--- a/apps/petrinaut-website/src/examples/full-example-page.tsx
+++ b/apps/petrinaut-website/src/examples/full-example-page.tsx
@@ -72,6 +72,7 @@ export const FullExamplePage = ({
         handle={handle}
         hideNetManagementControls="all"
         navigation={navigation}
+        presentationProfile="review"
         readonly
         slots={{
           topBarStart: (

--- a/libs/@hashintel/petrinaut/README.md
+++ b/libs/@hashintel/petrinaut/README.md
@@ -27,6 +27,28 @@ For host applications that own their Petri net data, implement a
 guide lives in the architecture docs:
 [Embedding in a host application](https://github.com/hashintel/hash/blob/main/libs/%40local/petrinaut-arch-docs/content/handle/host-integration.mdx).
 
+### Presentation profiles
+
+`presentationProfile` chooses how much editing chrome the component draws:
+
+- `editor`, the default, draws the full authoring surface.
+- `review` drops the controls whose only purpose is to change the net: the
+  add and delete actions in the sidebar lists and property panels. Source
+  code, custom visualizers, the minimap and the viewport settings stay, so a
+  reader can still inspect and simulate the model.
+
+The profile is chrome, not enforcement. A host that must not accept edits
+passes `readonly` as well, which is what disables the fields themselves:
+
+```tsx
+<Petrinaut
+  handle={handle}
+  title="My net"
+  presentationProfile="review"
+  readonly
+/>
+```
+
 ## Commands and the palette
 
 Petrinaut registers its user-invocable actions (undo, tools, search, panel

--- a/libs/@hashintel/petrinaut/src/ui/components/sub-view/deferred-sub-view.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/components/sub-view/deferred-sub-view.tsx
@@ -1,0 +1,51 @@
+import { lazy, Suspense } from "react";
+
+import type { SubView } from "./types";
+
+type DeferredSubViewOptions = Omit<
+  SubView,
+  "component" | "renderHeaderAction"
+> & {
+  load: () => Promise<SubView>;
+  hasHeaderAction?: boolean;
+};
+
+/**
+ * Keeps an optional subview behind a bundle boundary while preserving the
+ * synchronous descriptor required by the panel layout.
+ */
+export const createDeferredSubView = ({
+  load,
+  hasHeaderAction = false,
+  ...descriptor
+}: DeferredSubViewOptions): SubView => {
+  const DeferredContent = lazy(async () => {
+    const subView = await load();
+    return { default: subView.component };
+  });
+  const Content = () => (
+    <Suspense fallback={null}>
+      <DeferredContent />
+    </Suspense>
+  );
+
+  if (!hasHeaderAction) {
+    return { ...descriptor, component: Content };
+  }
+
+  const DeferredHeaderAction = lazy(async () => {
+    const subView = await load();
+    const HeaderAction = () => subView.renderHeaderAction?.() ?? null;
+    return { default: HeaderAction };
+  });
+
+  return {
+    ...descriptor,
+    component: Content,
+    renderHeaderAction: () => (
+      <Suspense fallback={null}>
+        <DeferredHeaderAction />
+      </Suspense>
+    ),
+  };
+};

--- a/libs/@hashintel/petrinaut/src/ui/components/sub-view/types.ts
+++ b/libs/@hashintel/petrinaut/src/ui/components/sub-view/types.ts
@@ -36,6 +36,16 @@ export interface SubView {
    */
   renderHeaderAction?: () => ReactNode;
   /**
+   * Whether the header action creates, deletes or clears something. A
+   * presentation that hides mutation actions hides only these.
+   *
+   * Defaults to false, because the slot also carries close buttons, view
+   * toggles and status labels, and losing those costs a reader more than a
+   * disabled Add button does. An action that is a mutation only some of the
+   * time reads the presentation itself instead of setting this.
+   */
+  headerActionMutates?: boolean;
+  /**
    * Whether this subview should grow to fill available space.
    * Only affects vertical layout. Defaults to false.
    */

--- a/libs/@hashintel/petrinaut/src/ui/components/sub-view/vertical/vertical-sub-views-container.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/components/sub-view/vertical/vertical-sub-views-container.tsx
@@ -503,9 +503,10 @@ export const VerticalSubViewsContainer: React.FC<
                   isExpanded={isExpanded}
                   onToggle={() => toggleSection(subView)}
                   renderHeaderAction={
-                    presentation.showMutationActions
-                      ? subView.renderHeaderAction
-                      : undefined
+                    subView.headerActionMutates &&
+                    !presentation.showMutationActions
+                      ? undefined
+                      : subView.renderHeaderAction
                   }
                   alwaysShowHeaderAction={subView.alwaysShowHeaderAction}
                 />

--- a/libs/@hashintel/petrinaut/src/ui/components/sub-view/vertical/vertical-sub-views-container.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/components/sub-view/vertical/vertical-sub-views-container.tsx
@@ -10,6 +10,7 @@ import { css, cva, cx } from "@hashintel/ds-helpers/css";
 
 import { UserSettingsContext } from "../../../../react/state/user-settings-context";
 import { useScrollOverflow } from "../../../hooks/use-scroll-overflow";
+import { usePetrinautPresentation } from "../../../views/shared/presentation-context";
 
 import type { SubView } from "../types";
 
@@ -422,6 +423,7 @@ interface VerticalSubViewsContainerProps {
 export const VerticalSubViewsContainer: React.FC<
   VerticalSubViewsContainerProps
 > = ({ name, subViews, defaultExpanded = true }) => {
+  const presentation = usePetrinautPresentation();
   const { showAnimations, subViewPanels, updateSubViewSection } =
     use(UserSettingsContext);
 
@@ -500,7 +502,11 @@ export const VerticalSubViewsContainer: React.FC<
                   renderTitle={subView.renderTitle}
                   isExpanded={isExpanded}
                   onToggle={() => toggleSection(subView)}
-                  renderHeaderAction={subView.renderHeaderAction}
+                  renderHeaderAction={
+                    presentation.showMutationActions
+                      ? subView.renderHeaderAction
+                      : undefined
+                  }
                   alwaysShowHeaderAction={subView.alwaysShowHeaderAction}
                 />
 

--- a/libs/@hashintel/petrinaut/src/ui/petrinaut.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/petrinaut.tsx
@@ -20,6 +20,10 @@ import { PetrinautProvider } from "../react/petrinaut-provider";
 import { Stack } from "./components/stack";
 import { MonacoProvider } from "./monaco/provider";
 import { EditorView } from "./views/Editor/editor-view";
+import {
+  PetrinautPresentationProvider,
+  type PetrinautPresentationProfile,
+} from "./views/shared/presentation-context";
 
 // `clip`, not `hidden`: a hidden-overflow box is still programmatically
 // scrollable, and focusing an element the canvas transform pushed past the
@@ -112,6 +116,12 @@ export type PetrinautProps = {
   lspWorkerFactory?: LspWorkerFactory;
   /** Optional host-controlled, router-neutral app location. */
   navigation?: PetrinautNavigationController;
+  /**
+   * Presentation policy for the full editor. `review` keeps the full editor
+   * surface while suppressing authoring actions for route-scoped read-only
+   * examples. The default remains `editor`.
+   */
+  presentationProfile?: PetrinautPresentationProfile;
 };
 
 const noop = () => {};
@@ -140,6 +150,7 @@ export const Petrinaut: FunctionComponent<PetrinautProps> = ({
   monteCarloWorkerFactory,
   lspWorkerFactory,
   navigation,
+  presentationProfile = "editor",
 }) => {
   const portalContainerRef = useRef<HTMLDivElement>(null);
   const instance = useMemo<Instance>(
@@ -167,19 +178,21 @@ export const Petrinaut: FunctionComponent<PetrinautProps> = ({
         lspWorkerFactory={lspWorkerFactory}
         navigation={navigation}
       >
-        <MonacoProvider>
-          <Stack
-            className={cx(editorRootStyle, "petrinaut-root")}
-            ref={portalContainerRef}
-          >
-            <EditorView
-              aiAssistant={aiAssistant}
-              hideNetManagementControls={hideNetManagementControls}
-              slots={slots}
-              viewportActions={viewportActions}
-            />
-          </Stack>
-        </MonacoProvider>
+        <PetrinautPresentationProvider profile={presentationProfile}>
+          <MonacoProvider>
+            <Stack
+              className={cx(editorRootStyle, "petrinaut-root")}
+              ref={portalContainerRef}
+            >
+              <EditorView
+                aiAssistant={aiAssistant}
+                hideNetManagementControls={hideNetManagementControls}
+                slots={slots}
+                viewportActions={viewportActions}
+              />
+            </Stack>
+          </MonacoProvider>
+        </PetrinautPresentationProvider>
       </PetrinautProvider>
     </PortalContainerContext>
   );

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/components/BottomBar/playback-settings-menu.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/components/BottomBar/playback-settings-menu.tsx
@@ -10,6 +10,7 @@ import {
   type PlaybackSpeed,
 } from "../../../../../react/playback/context";
 import { SimulationContext } from "../../../../../react/simulation/context";
+import { usePetrinautPresentation } from "../../../shared/presentation-context";
 import { ToolbarButton } from "./toolbar-button";
 
 const contentWidthStyle = css({
@@ -139,15 +140,27 @@ const maxTimeInputStyle = css({
   fontVariantNumeric: "tabular-nums",
 });
 
-// Split speeds into two rows of 4
-const speedRows: PlaybackSpeed[][] = [
-  PLAYBACK_SPEEDS.slice(0, 4),
-  PLAYBACK_SPEEDS.slice(4),
-];
+export type PlaybackSettingsMenuProps = {
+  allowedSpeeds?: readonly PlaybackSpeed[];
+};
 
-export const PlaybackSettingsMenu = () => {
+const toSpeedRows = (speeds: readonly PlaybackSpeed[]): PlaybackSpeed[][] => {
+  const rows: PlaybackSpeed[][] = [];
+  for (let index = 0; index < speeds.length; index += 4) {
+    rows.push(speeds.slice(index, index + 4));
+  }
+  return rows;
+};
+
+export const PlaybackSettingsMenu = ({
+  allowedSpeeds = PLAYBACK_SPEEDS,
+}: PlaybackSettingsMenuProps) => {
+  const presentation = usePetrinautPresentation();
   const triggerRef = useRef<HTMLButtonElement>(null);
   const [open, setOpen] = useState(false);
+  const playModesVisible = !presentation.compactControls;
+  const stoppingConditionsVisible = !presentation.compactControls;
+  const speedRows = toSpeedRows(allowedSpeeds);
 
   const {
     state: simulationState,
@@ -200,200 +213,264 @@ export const PlaybackSettingsMenu = () => {
           onClose={() => setOpen(false)}
         >
           <Popover.Container className={contentWidthStyle}>
-            <Popover.Header title="Playback Controls" />
-
-            {/* When pressing play section */}
-            <Popover.Body className={sectionInnerStyle}>
-              <div className={sectionLabelStyle}>When pressing play</div>
-              <Button
-                variant="ghost"
-                size="sm"
-                className={menuItemStyle({
-                  selected: playMode === "viewOnly",
-                  disabled: !isViewOnlyAvailable,
-                })}
-                onClick={() => isViewOnlyAvailable && setPlayMode("viewOnly")}
-                aria-disabled={!isViewOnlyAvailable}
-                tooltip={
-                  !isViewOnlyAvailable
-                    ? "Available when there are computed frames"
-                    : undefined
-                }
-              >
-                <Icon name="play" className={menuItemIconStyle} size="sm" />
-                <span className={menuItemTextStyle}>
-                  Play computed steps only
-                </span>
-                {playMode === "viewOnly" && (
-                  <Icon name="check" className={checkIconStyle} size="sm" />
-                )}
-              </Button>
-              <Button
-                variant="ghost"
-                size="sm"
-                className={menuItemStyle({
-                  selected: playMode === "computeBuffer",
-                  disabled: !isComputeAvailable,
-                })}
-                onClick={() =>
-                  isComputeAvailable && setPlayMode("computeBuffer")
-                }
-                aria-disabled={!isComputeAvailable}
-                tooltip={
-                  !isComputeAvailable
-                    ? "Not available when simulation is complete"
-                    : undefined
-                }
-              >
-                <Icon
-                  name="chartLine"
-                  className={menuItemIconStyle}
-                  size="sm"
-                />
-                <span className={menuItemTextStyle}>Play + compute buffer</span>
-                {playMode === "computeBuffer" && (
-                  <Icon name="check" className={checkIconStyle} size="sm" />
-                )}
-              </Button>
-              <Button
-                variant="ghost"
-                size="sm"
-                className={menuItemStyle({
-                  selected: playMode === "computeMax",
-                  disabled: !isComputeAvailable,
-                })}
-                onClick={() => isComputeAvailable && setPlayMode("computeMax")}
-                aria-disabled={!isComputeAvailable}
-                tooltip={
-                  !isComputeAvailable
-                    ? "Not available when simulation is complete"
-                    : undefined
-                }
-              >
-                <Icon
-                  name="rightToLine"
-                  className={menuItemIconStyle}
-                  size="sm"
-                />
-                <span className={menuItemTextStyle}>Play + compute max</span>
-                {playMode === "computeMax" && (
-                  <Icon name="check" className={checkIconStyle} size="sm" />
-                )}
-              </Button>
-              <div className={popoverDividerStyle} />
-            </Popover.Body>
-
-            {/* Playback speed section */}
-            <Popover.Body withPadding={false} className={sectionInnerStyle}>
-              <div className={sectionLabelStyle}>Playback speed</div>
-              {speedRows.map((row) => (
-                <div key={row[0]} className={speedGridStyle}>
-                  {row.map((speed) => (
-                    <Button
-                      key={speed}
-                      variant="ghost"
-                      size="sm"
-                      className={speedButtonStyle({
-                        selected: speed === playbackSpeed,
-                      })}
-                      onClick={() => setPlaybackSpeed(speed)}
+            {[
+              <Popover.Header key="header" title="Playback Controls" />,
+              ...(playModesVisible
+                ? [
+                    <Popover.Body
+                      key="play-modes"
+                      className={sectionInnerStyle}
                     >
-                      {formatPlaybackSpeed(speed)}
-                    </Button>
-                  ))}
-                </div>
-              ))}
-              <div className={popoverDividerStyle} />
-            </Popover.Body>
-
-            {/* Stopping conditions section */}
-            <Popover.Body withPadding={false} className={sectionInnerStyle}>
-              <div className={sectionLabelStyle}>Stopping conditions</div>
-              <Button
-                variant="ghost"
-                size="sm"
-                className={menuItemStyle({
-                  selected: stoppingCondition === "indefinitely",
-                  disabled: hasSimulation,
-                })}
-                onClick={() =>
-                  !hasSimulation &&
-                  handleStoppingConditionChange("indefinitely")
-                }
-                aria-disabled={hasSimulation}
-                tooltip={
-                  hasSimulation
-                    ? "Reset simulation to change stopping conditions"
-                    : undefined
-                }
-              >
-                <Icon name="infinity" className={menuItemIconStyle} size="sm" />
-                <span className={menuItemTextStyle}>Run indefinitely</span>
-                {stoppingCondition === "indefinitely" && (
-                  <Icon name="check" className={checkIconStyle} size="sm" />
-                )}
-              </Button>
-              <Button
-                variant="ghost"
-                size="sm"
-                className={menuItemStyle({
-                  selected: stoppingCondition === "fixed",
-                  disabled: hasSimulation,
-                })}
-                onClick={() =>
-                  !hasSimulation && handleStoppingConditionChange("fixed")
-                }
-                aria-disabled={hasSimulation}
-                tooltip={
-                  hasSimulation
-                    ? "Reset simulation to change stopping conditions"
-                    : undefined
-                }
-              >
-                <Icon name="clock" className={menuItemIconStyle} size="sm" />
-                <span className={menuItemTextStyle}>End at fixed time</span>
-                {stoppingCondition === "fixed" && (
-                  <>
-                    <NumberInput
-                      size="sm"
-                      min={0.1}
-                      step={0.1}
-                      value={maxTime ?? 10}
-                      align="right"
-                      hideStepper
-                      disabled={hasSimulation}
-                      onChange={(nextMaxTime) => {
-                        if (nextMaxTime !== null && nextMaxTime > 0) {
-                          setMaxTime(nextMaxTime);
+                      <div className={sectionLabelStyle}>
+                        When pressing play
+                      </div>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className={menuItemStyle({
+                          selected: playMode === "viewOnly",
+                          disabled: !isViewOnlyAvailable,
+                        })}
+                        onClick={() =>
+                          isViewOnlyAvailable && setPlayMode("viewOnly")
                         }
-                      }}
-                      onClick={(event) => event.stopPropagation()}
-                      className={maxTimeInputStyle}
-                      aria-label="Maximum simulation time in seconds"
-                    />
-                    <span
-                      style={{
-                        fontSize: "12px",
-                        color: "var(--colors-neutral-s100)",
-                      }}
+                        aria-disabled={!isViewOnlyAvailable}
+                        tooltip={
+                          !isViewOnlyAvailable
+                            ? "Available when there are computed frames"
+                            : undefined
+                        }
+                      >
+                        <Icon
+                          name="play"
+                          className={menuItemIconStyle}
+                          size="sm"
+                        />
+                        <span className={menuItemTextStyle}>
+                          Play computed steps only
+                        </span>
+                        {playMode === "viewOnly" && (
+                          <Icon
+                            name="check"
+                            className={checkIconStyle}
+                            size="sm"
+                          />
+                        )}
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className={menuItemStyle({
+                          selected: playMode === "computeBuffer",
+                          disabled: !isComputeAvailable,
+                        })}
+                        onClick={() =>
+                          isComputeAvailable && setPlayMode("computeBuffer")
+                        }
+                        aria-disabled={!isComputeAvailable}
+                        tooltip={
+                          !isComputeAvailable
+                            ? "Not available when simulation is complete"
+                            : undefined
+                        }
+                      >
+                        <Icon
+                          name="chartLine"
+                          className={menuItemIconStyle}
+                          size="sm"
+                        />
+                        <span className={menuItemTextStyle}>
+                          Play + compute buffer
+                        </span>
+                        {playMode === "computeBuffer" && (
+                          <Icon
+                            name="check"
+                            className={checkIconStyle}
+                            size="sm"
+                          />
+                        )}
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className={menuItemStyle({
+                          selected: playMode === "computeMax",
+                          disabled: !isComputeAvailable,
+                        })}
+                        onClick={() =>
+                          isComputeAvailable && setPlayMode("computeMax")
+                        }
+                        aria-disabled={!isComputeAvailable}
+                        tooltip={
+                          !isComputeAvailable
+                            ? "Not available when simulation is complete"
+                            : undefined
+                        }
+                      >
+                        <Icon
+                          name="rightToLine"
+                          className={menuItemIconStyle}
+                          size="sm"
+                        />
+                        <span className={menuItemTextStyle}>
+                          Play + compute max
+                        </span>
+                        {playMode === "computeMax" && (
+                          <Icon
+                            name="check"
+                            className={checkIconStyle}
+                            size="sm"
+                          />
+                        )}
+                      </Button>
+                      <div className={popoverDividerStyle} />
+                    </Popover.Body>,
+                  ]
+                : []),
+
+              <Popover.Body
+                key="playback-speed"
+                withPadding={false}
+                className={sectionInnerStyle}
+              >
+                <div className={sectionLabelStyle}>Playback speed</div>
+                {speedRows.map((row) => (
+                  <div key={row[0]} className={speedGridStyle}>
+                    {row.map((speed) => (
+                      <Button
+                        key={speed}
+                        variant="ghost"
+                        size="sm"
+                        className={speedButtonStyle({
+                          selected: speed === playbackSpeed,
+                        })}
+                        onClick={() => setPlaybackSpeed(speed)}
+                      >
+                        {formatPlaybackSpeed(speed)}
+                      </Button>
+                    ))}
+                  </div>
+                ))}
+                {stoppingConditionsVisible && (
+                  <div className={popoverDividerStyle} />
+                )}
+              </Popover.Body>,
+
+              ...(stoppingConditionsVisible
+                ? [
+                    <Popover.Body
+                      key="stopping-conditions"
+                      withPadding={false}
+                      className={sectionInnerStyle}
                     >
-                      s
-                    </span>
-                  </>
-                )}
-                {stoppingCondition !== "fixed" && (
-                  <Icon
-                    name="check"
-                    className={cx(
-                      checkIconStyle,
-                      css({ visibility: "hidden" }),
-                    )}
-                    size="sm"
-                  />
-                )}
-              </Button>
-              <div className={popoverDividerStyle} />
-            </Popover.Body>
+                      <div className={sectionLabelStyle}>
+                        Stopping conditions
+                      </div>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className={menuItemStyle({
+                          selected: stoppingCondition === "indefinitely",
+                          disabled: hasSimulation,
+                        })}
+                        onClick={() =>
+                          !hasSimulation &&
+                          handleStoppingConditionChange("indefinitely")
+                        }
+                        aria-disabled={hasSimulation}
+                        tooltip={
+                          hasSimulation
+                            ? "Reset simulation to change stopping conditions"
+                            : undefined
+                        }
+                      >
+                        <Icon
+                          name="infinity"
+                          className={menuItemIconStyle}
+                          size="sm"
+                        />
+                        <span className={menuItemTextStyle}>
+                          Run indefinitely
+                        </span>
+                        {stoppingCondition === "indefinitely" && (
+                          <Icon
+                            name="check"
+                            className={checkIconStyle}
+                            size="sm"
+                          />
+                        )}
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className={menuItemStyle({
+                          selected: stoppingCondition === "fixed",
+                          disabled: hasSimulation,
+                        })}
+                        onClick={() =>
+                          !hasSimulation &&
+                          handleStoppingConditionChange("fixed")
+                        }
+                        aria-disabled={hasSimulation}
+                        tooltip={
+                          hasSimulation
+                            ? "Reset simulation to change stopping conditions"
+                            : undefined
+                        }
+                      >
+                        <Icon
+                          name="clock"
+                          className={menuItemIconStyle}
+                          size="sm"
+                        />
+                        <span className={menuItemTextStyle}>
+                          End at fixed time
+                        </span>
+                        {stoppingCondition === "fixed" && (
+                          <>
+                            <NumberInput
+                              size="sm"
+                              min={0.1}
+                              step={0.1}
+                              value={maxTime ?? 10}
+                              align="right"
+                              hideStepper
+                              disabled={hasSimulation}
+                              onChange={(nextMaxTime) => {
+                                if (nextMaxTime !== null && nextMaxTime > 0) {
+                                  setMaxTime(nextMaxTime);
+                                }
+                              }}
+                              onClick={(event) => event.stopPropagation()}
+                              className={maxTimeInputStyle}
+                              aria-label="Maximum simulation time in seconds"
+                            />
+                            <span
+                              style={{
+                                fontSize: "12px",
+                                color: "var(--colors-neutral-s100)",
+                              }}
+                            >
+                              s
+                            </span>
+                          </>
+                        )}
+                        {stoppingCondition !== "fixed" && (
+                          <Icon
+                            name="check"
+                            className={cx(
+                              checkIconStyle,
+                              css({ visibility: "hidden" }),
+                            )}
+                            size="sm"
+                          />
+                        )}
+                      </Button>
+                      <div className={popoverDividerStyle} />
+                    </Popover.Body>,
+                  ]
+                : []),
+            ]}
           </Popover.Container>
         </Popover>
       )}

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/components/BottomBar/simulation-controls.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/components/BottomBar/simulation-controls.tsx
@@ -1,28 +1,38 @@
 import { use } from "react";
 
 import { Icon } from "@hashintel/ds-components";
-import { css } from "@hashintel/ds-helpers/css";
+import { css, cva } from "@hashintel/ds-helpers/css";
 
 import { PlaybackContext } from "../../../../../react/playback/context";
 import { SimulationContext } from "../../../../../react/simulation/context";
 import { EditorContext } from "../../../../../react/state/editor-context";
+import { usePetrinautPresentation } from "../../../shared/presentation-context";
 import { CollapsibleGroup } from "./collapsible-group";
 import { PlaybackSettingsMenu } from "./playback-settings-menu";
 import { ToolbarButton } from "./toolbar-button";
 import { ToolbarDivider } from "./toolbar-divider";
 
-const frameInfoStyle = css({
-  display: "flex",
-  flexDirection: "column",
-  alignItems: "center",
-  fontSize: "[10px]",
-  color: "neutral.s105",
-  fontWeight: "medium",
-  lineHeight: "[1]",
-  width: "[90px]",
-  fontVariantNumeric: "tabular-nums",
-  overflow: "hidden",
-  whiteSpace: "nowrap",
+import type { PlaybackSpeed } from "../../../../../react/playback/context";
+
+const frameInfoStyle = cva({
+  base: {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    fontSize: "[10px]",
+    color: "neutral.s105",
+    fontWeight: "medium",
+    lineHeight: "[1]",
+    width: "[90px]",
+    fontVariantNumeric: "tabular-nums",
+    overflow: "hidden",
+    whiteSpace: "nowrap",
+  },
+  variants: {
+    compact: {
+      true: { width: "[64px]" },
+    },
+  },
 });
 
 const elapsedTimeStyle = css({
@@ -38,45 +48,59 @@ const frameIndexStyle = css({
   marginTop: "[1px]",
 });
 
-const sliderStyle = css({
-  width: "[300px]",
-  height: "[4px]",
-  appearance: "none",
-  background: "neutral.s30",
-  borderRadius: "[2px]",
-  outline: "none",
-  cursor: "pointer",
-  "&:disabled": {
-    opacity: "[0.5]",
-    cursor: "not-allowed",
-  },
-  "&::-webkit-slider-thumb": {
+const sliderStyle = cva({
+  base: {
+    width: "[300px]",
+    height: "[4px]",
     appearance: "none",
-    width: "[12px]",
-    height: "[12px]",
-    borderRadius: "[50%]",
-    background: "blue.s90",
+    background: "neutral.s30",
+    borderRadius: "[2px]",
+    outline: "none",
     cursor: "pointer",
+    "&:disabled": {
+      opacity: "[0.5]",
+      cursor: "not-allowed",
+    },
+    "&::-webkit-slider-thumb": {
+      appearance: "none",
+      width: "[12px]",
+      height: "[12px]",
+      borderRadius: "[50%]",
+      background: "blue.s90",
+      cursor: "pointer",
+    },
+    "&::-moz-range-thumb": {
+      width: "[12px]",
+      height: "[12px]",
+      borderRadius: "[50%]",
+      background: "blue.s90",
+      cursor: "pointer",
+      border: "none",
+    },
   },
-  "&::-moz-range-thumb": {
-    width: "[12px]",
-    height: "[12px]",
-    borderRadius: "[50%]",
-    background: "blue.s90",
-    cursor: "pointer",
-    border: "none",
+  variants: {
+    compact: {
+      true: {
+        width: "[clamp(96px, 30vw, 220px)]",
+        flex: "[1 1 160px]",
+        minWidth: "[96px]",
+      },
+    },
   },
 });
 
-interface SimulationControlsProps {
+export interface SimulationControlsProps {
   disabled?: boolean;
   inSubnet?: boolean;
+  allowedPlaybackSpeeds?: readonly PlaybackSpeed[];
 }
 
 export const SimulationControls: React.FC<SimulationControlsProps> = ({
   disabled = false,
   inSubnet = false,
+  allowedPlaybackSpeeds,
 }) => {
+  const presentation = usePetrinautPresentation();
   const { dt, state: simulationState, reset } = use(SimulationContext);
 
   const {
@@ -207,8 +231,12 @@ export const SimulationControls: React.FC<SimulationControlsProps> = ({
       <CollapsibleGroup>
         {hasSimulation && (
           <>
-            <div className={frameInfoStyle}>
-              <div>Frame</div>
+            <div
+              className={frameInfoStyle({
+                compact: presentation.compactControls,
+              })}
+            >
+              {!presentation.compactControls && <div>Frame</div>}
               <div className={frameIndexStyle}>
                 {frameIndex + 1} / {totalFrames}
               </div>
@@ -224,14 +252,14 @@ export const SimulationControls: React.FC<SimulationControlsProps> = ({
               onChange={(event) =>
                 setCurrentViewedFrame(Number(event.target.value))
               }
-              className={sliderStyle}
+              className={sliderStyle({ compact: presentation.compactControls })}
             />
 
             <ToolbarDivider />
           </>
         )}
 
-        <PlaybackSettingsMenu />
+        <PlaybackSettingsMenu allowedSpeeds={allowedPlaybackSpeeds} />
       </CollapsibleGroup>
     </>
   );

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/LeftSideBar/subviews/filterable-list-sub-view.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/LeftSideBar/subviews/filterable-list-sub-view.tsx
@@ -6,6 +6,7 @@ import { css, cva } from "@hashintel/ds-helpers/css";
 import { EditorContext } from "../../../../../../react/state/editor-context";
 import { focusLands } from "../../../../../worksheet/focus-flow";
 import { useFocusStops } from "../../../../../worksheet/use-focus-stops";
+import { usePetrinautPresentation } from "../../../../shared/presentation-context";
 import { RowActionCell } from "./row-action-cell";
 
 import type {
@@ -185,6 +186,7 @@ interface FilterableListSubViewConfig<T extends FilterableListItem> {
 const FilterHeaderAction: React.FC<{
   renderExtraAction?: () => ReactNode;
 }> = ({ renderExtraAction }) => {
+  const presentation = usePetrinautPresentation();
   const { setSearchOpen } = use(EditorContext);
 
   return (
@@ -197,7 +199,9 @@ const FilterHeaderAction: React.FC<{
         iconName="search"
         onClick={() => setSearchOpen(true)}
       />
-      {renderExtraAction?.()}
+      {/* Searching a list is not a mutation, so only the extra action, which
+          is the list's Add button, answers to the presentation. */}
+      {presentation.showMutationActions && renderExtraAction?.()}
     </>
   );
 };

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/LeftSideBar/subviews/nets-list.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/LeftSideBar/subviews/nets-list.tsx
@@ -11,6 +11,7 @@ import { useIsReadOnly } from "../../../../../../react/state/use-is-read-only";
 import { UI_MESSAGES } from "../../../../../constants/ui-messages";
 import { focusLands } from "../../../../../worksheet/focus-flow";
 import { useFocusStops } from "../../../../../worksheet/use-focus-stops";
+import { usePetrinautPresentation } from "../../../../shared/presentation-context";
 import { RowActionCell } from "./row-action-cell";
 
 import type { SubView } from "../../../../../components/sub-view/types";
@@ -102,11 +103,16 @@ const renameInputStyle = css({
 });
 
 const NetsHeaderAction: React.FC = () => {
+  const presentation = usePetrinautPresentation();
   const {
     petriNetDefinition: { subnets },
   } = use(SDCPNContext);
   const { addSubnet } = usePetrinautMutations();
   const isReadOnly = useIsReadOnly();
+
+  if (!presentation.showMutationActions) {
+    return null;
+  }
 
   return (
     <Button
@@ -139,12 +145,14 @@ const targetKey = (target: FocusStopTarget): string =>
   `${target.stopId}:${target.column}`;
 
 const NetsListContent: React.FC = () => {
+  const presentation = usePetrinautPresentation();
   const {
     petriNetDefinition: { subnets },
   } = use(SDCPNContext);
   const { activeSubnetId, setActiveSubnetId } = use(ActiveNetContext);
   const { updateSubnet, removeSubnet } = usePetrinautMutations();
   const isReadOnly = useIsReadOnly();
+  const mutationActionsVisible = presentation.showMutationActions;
 
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editingName, setEditingName] = useState("");
@@ -233,7 +241,10 @@ const NetsListContent: React.FC = () => {
       if (
         (event.key === "Delete" || event.key === "Backspace") &&
         stopId !== ROOT_STOP_ID &&
-        !isReadOnly
+        !isReadOnly &&
+        // A keyboard delete is a mutation, so a presentation that hides the
+        // delete button has to refuse the shortcut too.
+        mutationActionsVisible
       ) {
         event.preventDefault();
         event.stopPropagation();
@@ -296,7 +307,11 @@ const NetsListContent: React.FC = () => {
                 setActiveSubnetId(subnet.id);
               }
             }}
-            onDoubleClick={() => startEditing(subnet.id, subnet.name)}
+            onDoubleClick={() => {
+              if (mutationActionsVisible) {
+                startEditing(subnet.id, subnet.name);
+              }
+            }}
             onKeyDown={onRowKeyDown(subnet.id, () =>
               setActiveSubnetId(subnet.id),
             )}
@@ -324,7 +339,7 @@ const NetsListContent: React.FC = () => {
             ) : (
               <span className={nameStyle}>{subnet.name}</span>
             )}
-            {editingId !== subnet.id && (
+            {mutationActionsVisible && editingId !== subnet.id && (
               <RowActionCell
                 registerButton={registerTarget(actionTarget)}
                 onArrowKeyDown={onStopsKeyDown(actionTarget)}

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/LeftSideBar/subviews/nets-list.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/LeftSideBar/subviews/nets-list.tsx
@@ -103,16 +103,11 @@ const renameInputStyle = css({
 });
 
 const NetsHeaderAction: React.FC = () => {
-  const presentation = usePetrinautPresentation();
   const {
     petriNetDefinition: { subnets },
   } = use(SDCPNContext);
   const { addSubnet } = usePetrinautMutations();
   const isReadOnly = useIsReadOnly();
-
-  if (!presentation.showMutationActions) {
-    return null;
-  }
 
   return (
     <Button
@@ -376,5 +371,6 @@ export const netsListSubView: SubView = {
     "View the root net and reusable subnets. Mark subnet places as ports, then instantiate subnets as components in the root net.",
   component: NetsListContent,
   renderHeaderAction: () => <NetsHeaderAction />,
+  headerActionMutates: true,
   defaultCollapsed: false,
 };

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/arc-properties/main.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/arc-properties/main.tsx
@@ -172,6 +172,7 @@ const arcMainContentSubView: SubView = {
   main: true,
   component: ArcMainContent,
   renderHeaderAction: () => <DeleteArcAction />,
+  headerActionMutates: true,
   alwaysShowHeaderAction: true,
 };
 

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/component-instance-properties/subviews/main.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/component-instance-properties/subviews/main.tsx
@@ -201,5 +201,6 @@ export const componentInstanceMainContentSubView: SubView = {
   renderTitle: () => <ComponentInstanceTitle />,
   component: ComponentInstanceMainContent,
   renderHeaderAction: () => <DeleteComponentInstanceAction />,
+  headerActionMutates: true,
   alwaysShowHeaderAction: true,
 };

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/differential-equation-properties/subviews/code-field.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/differential-equation-properties/subviews/code-field.tsx
@@ -1,0 +1,49 @@
+import { Form } from "@hashintel/ds-components";
+import { css } from "@hashintel/ds-helpers/css";
+
+import { useIsReadOnly } from "../../../../../../../react/state/use-is-read-only";
+import { UI_MESSAGES } from "../../../../../../constants/ui-messages";
+import { CodeEditor } from "../../../../../../monaco/code-editor";
+import { getDocumentUri } from "../../../../../../monaco/editor-paths";
+import { useDiffEqPropertiesContext } from "../context";
+
+const codeFieldStyle = css({
+  display: "flex",
+  flexDirection: "column",
+  minHeight: "0",
+});
+
+const codeEditorBoxStyle = css({
+  flex: "1",
+  minHeight: "0",
+});
+
+export const DifferentialEquationCodeField: React.FC = () => {
+  const { differentialEquation, updateDifferentialEquation } =
+    useDiffEqPropertiesContext();
+  const isReadOnly = useIsReadOnly();
+
+  return (
+    <Form.Field as="legend" label="Code" size="sm" className={codeFieldStyle}>
+      <div className={codeEditorBoxStyle}>
+        <CodeEditor
+          path={getDocumentUri(
+            "differential-equation",
+            differentialEquation.id,
+          )}
+          language="typescript"
+          value={differentialEquation.code}
+          height="100%"
+          onChange={(newCode) => {
+            updateDifferentialEquation({
+              equationId: differentialEquation.id,
+              update: { code: newCode ?? "" },
+            });
+          }}
+          options={{ readOnly: isReadOnly }}
+          tooltip={isReadOnly ? UI_MESSAGES.READ_ONLY_MODE : undefined}
+        />
+      </div>
+    </Form.Field>
+  );
+};

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/differential-equation-properties/subviews/main.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/differential-equation-properties/subviews/main.tsx
@@ -306,5 +306,6 @@ export const diffEqMainContentSubView: SubView = {
   main: true,
   component: DiffEqMainContent,
   renderHeaderAction: () => <DiffEqCodeAction />,
+  headerActionMutates: true,
   alwaysShowHeaderAction: true,
 };

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/differential-equation-properties/subviews/main.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/differential-equation-properties/subviews/main.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { lazy, Suspense, useState } from "react";
 
 import {
   Button,
@@ -20,8 +20,7 @@ import { useIsReadOnly } from "../../../../../../../react/state/use-is-read-only
 import { DraftFieldInput } from "../../../../../../components/draft-field-input";
 import { DifferentialEquationIcon } from "../../../../../../constants/entity-icons";
 import { UI_MESSAGES } from "../../../../../../constants/ui-messages";
-import { CodeEditor } from "../../../../../../monaco/code-editor";
-import { getDocumentUri } from "../../../../../../monaco/editor-paths";
+import { usePetrinautPresentation } from "../../../../../shared/presentation-context";
 import { useDiffEqPropertiesContext } from "../context";
 
 import type { SubView } from "../../../../../../components/sub-view/types";
@@ -32,18 +31,6 @@ const fieldsSectionStyle = css({
   flex: "[1]",
   minHeight: "[0]",
   gridTemplateRows: "[auto auto minmax(0, 1fr)]",
-});
-
-// the Code fieldset stretches to its grid row; hand the height to the editor
-const codeFieldStyle = css({
-  display: "flex",
-  flexDirection: "column",
-  minHeight: "[0]",
-});
-
-const codeEditorBoxStyle = css({
-  flex: "[1]",
-  minHeight: "[0]",
 });
 
 const colorDotStyle = css({
@@ -83,12 +70,18 @@ const arcStyle = css({
   alignItems: "center",
 });
 
+const DeferredDifferentialEquationCodeField = lazy(async () => {
+  const { DifferentialEquationCodeField } = await import("./code-field");
+  return { default: DifferentialEquationCodeField };
+});
+
 const DiffEqMainContent: React.FC = () => {
   const { differentialEquation, types, places, updateDifferentialEquation } =
     useDiffEqPropertiesContext();
   const [showConfirmDialog, setShowConfirmDialog] = useState(false);
   const [pendingTypeId, setPendingTypeId] = useState<string | null>(null);
   const isReadOnly = useIsReadOnly();
+  const presentation = usePetrinautPresentation();
 
   const placesUsingEquation = places.filter((place) => {
     if (!place.differentialEquationId) {
@@ -182,32 +175,11 @@ const DiffEqMainContent: React.FC = () => {
           </Tooltip>
         </Form.Field>
 
-        <Form.Field
-          as="legend"
-          label="Code"
-          size="sm"
-          className={codeFieldStyle}
-        >
-          <div className={codeEditorBoxStyle}>
-            <CodeEditor
-              path={getDocumentUri(
-                "differential-equation",
-                differentialEquation.id,
-              )}
-              language="typescript"
-              value={differentialEquation.code}
-              height="100%"
-              onChange={(newCode) => {
-                updateDifferentialEquation({
-                  equationId: differentialEquation.id,
-                  update: { code: newCode ?? "" },
-                });
-              }}
-              options={{ readOnly: isReadOnly }}
-              tooltip={isReadOnly ? UI_MESSAGES.READ_ONLY_MODE : undefined}
-            />
-          </div>
-        </Form.Field>
+        {presentation.showSourceCode && (
+          <Suspense fallback={null}>
+            <DeferredDifferentialEquationCodeField />
+          </Suspense>
+        )}
       </Form.Section>
 
       {showConfirmDialog && (

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/multi-selection-panel.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/multi-selection-panel.tsx
@@ -102,6 +102,7 @@ const multiSelectionMainSubView: SubView = {
   main: true,
   component: MultiSelectionContent,
   renderHeaderAction: () => <DeleteSelectionAction />,
+  headerActionMutates: true,
   alwaysShowHeaderAction: true,
 };
 

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/panel.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/panel.tsx
@@ -2,10 +2,7 @@ import { use } from "react";
 
 import { css, cva, cx } from "@hashintel/ds-helpers/css";
 
-import { usePetrinautMutations } from "../../../../../react";
-import { ActiveNetContext } from "../../../../../react/state/active-net-context";
 import { EditorContext } from "../../../../../react/state/editor-context";
-import { SDCPNContext } from "../../../../../react/state/sdcpn-context";
 import { usePanelTarget } from "../../../../../react/state/use-selection";
 import { UserSettingsContext } from "../../../../../react/state/user-settings-context";
 import { GlassPanel } from "../../../../components/glass-panel";
@@ -14,14 +11,7 @@ import {
   MIN_PROPERTIES_PANEL_WIDTH,
   PANEL_MARGIN,
 } from "../../../../constants/ui";
-import { ArcProperties } from "./arc-properties/main";
-import { ComponentInstanceProperties } from "./component-instance-properties/main";
-import { DifferentialEquationProperties } from "./differential-equation-properties/main";
-import { MultiSelectionPanel } from "./multi-selection-panel";
-import { ParameterProperties } from "./parameter-properties/main";
-import { PlaceProperties } from "./place-properties/main";
-import { TransitionProperties } from "./transition-properties/main";
-import { TypeProperties } from "./type-properties/main";
+import { SelectedItemProperties } from "./selected-item-properties";
 
 const glassPanelStyle = css({
   position: "absolute",
@@ -68,175 +58,9 @@ export const PropertiesPanel: React.FC = () => {
     isPanelAnimating,
   } = use(EditorContext);
 
-  const { activeNet: petriNetDefinition } = use(ActiveNetContext);
-  const { extensions, petriNetDefinition: fullSdcpn } = use(SDCPNContext);
-  const {
-    updatePlace,
-    updateTransition,
-    updateArcWeight,
-    updateArcType,
-    updateArcPlace,
-    removeArc,
-    updateType,
-    addTypeElement,
-    updateTypeElement,
-    removeTypeElement,
-    moveTypeElement,
-    updateDifferentialEquation,
-    updateParameter,
-    updateComponentInstance,
-    deleteItemsByIds,
-  } = usePetrinautMutations();
-
   const panelTarget = usePanelTarget();
 
   const isOpen = panelTarget.kind !== "none";
-
-  let content: React.ReactNode = null;
-
-  if (panelTarget.kind === "single") {
-    const { item } = panelTarget;
-
-    switch (item.type) {
-      case "place": {
-        const placeData = petriNetDefinition.places.find(
-          (place) => place.id === item.id,
-        );
-        if (placeData) {
-          content = (
-            <PlaceProperties
-              place={placeData}
-              types={extensions.colors ? petriNetDefinition.types : []}
-              updatePlace={updatePlace}
-            />
-          );
-        }
-        break;
-      }
-
-      case "transition": {
-        const transitionData = petriNetDefinition.transitions.find(
-          (transition) => transition.id === item.id,
-        );
-        if (transitionData) {
-          content = (
-            <TransitionProperties
-              transition={transitionData}
-              net={petriNetDefinition}
-              places={petriNetDefinition.places}
-              types={extensions.colors ? petriNetDefinition.types : []}
-              onArcWeightUpdate={updateArcWeight}
-              updateTransition={updateTransition}
-              updateArcPlace={updateArcPlace}
-              removeArc={removeArc}
-            />
-          );
-        }
-        break;
-      }
-
-      case "arc": {
-        content = (
-          <ArcProperties
-            arcId={item.id}
-            petriNetDefinition={petriNetDefinition}
-            fullSdcpn={fullSdcpn}
-            updateArcWeight={updateArcWeight}
-            updateArcType={updateArcType}
-            removeArc={removeArc}
-          />
-        );
-        break;
-      }
-
-      case "type": {
-        if (!extensions.colors) {
-          break;
-        }
-        const typeData = petriNetDefinition.types.find(
-          (type) => type.id === item.id,
-        );
-        if (typeData) {
-          content = (
-            <TypeProperties
-              type={typeData}
-              updateType={updateType}
-              addTypeElement={addTypeElement}
-              updateTypeElement={updateTypeElement}
-              removeTypeElement={removeTypeElement}
-              moveTypeElement={moveTypeElement}
-            />
-          );
-        }
-        break;
-      }
-
-      case "differentialEquation": {
-        if (!extensions.colors || !extensions.dynamics) {
-          break;
-        }
-        const equationData = petriNetDefinition.differentialEquations.find(
-          (equation) => equation.id === item.id,
-        );
-        if (equationData) {
-          content = (
-            <DifferentialEquationProperties
-              differentialEquation={equationData}
-              types={petriNetDefinition.types}
-              places={petriNetDefinition.places}
-              updateDifferentialEquation={updateDifferentialEquation}
-            />
-          );
-        }
-        break;
-      }
-
-      case "parameter": {
-        if (!extensions.parameters) {
-          break;
-        }
-        const parameterData = petriNetDefinition.parameters.find(
-          (parameter) => parameter.id === item.id,
-        );
-        if (parameterData) {
-          content = (
-            <ParameterProperties
-              parameter={parameterData}
-              updateParameter={updateParameter}
-            />
-          );
-        }
-        break;
-      }
-
-      case "componentInstance": {
-        const instanceData = petriNetDefinition.componentInstances.find(
-          (instance) => instance.id === item.id,
-        );
-        if (instanceData) {
-          const subnet =
-            (fullSdcpn.subnets ?? []).find(
-              (subnetCandidate) => subnetCandidate.id === instanceData.subnetId,
-            ) ?? null;
-          content = (
-            <ComponentInstanceProperties
-              instance={instanceData}
-              subnet={subnet}
-              updateComponentInstance={updateComponentInstance}
-            />
-          );
-        }
-        break;
-      }
-    }
-  } else if (panelTarget.kind === "multi") {
-    content = (
-      <MultiSelectionPanel
-        items={panelTarget.items}
-        deleteItemsByIds={deleteItemsByIds}
-      />
-    );
-  }
 
   // Calculate bottom offset based on bottom panel visibility
   // Gap between PropertiesPanel and BottomPanel matches gap between LeftSideBar and BottomPanel
@@ -268,7 +92,7 @@ export const PropertiesPanel: React.FC = () => {
         maxSize: MAX_PROPERTIES_PANEL_WIDTH,
       }}
     >
-      {content}
+      <SelectedItemProperties />
     </GlassPanel>
   );
 };

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/place-properties/main.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/place-properties/main.tsx
@@ -29,6 +29,7 @@ const baseSubViews: SubView[] = [
 
 const placeVisualizerSubView = createDeferredSubView({
   id: "place-visualizer",
+  headerActionMutates: true,
   title: "Visualizer",
   tooltip:
     "Custom visualization of tokens in this place, defined by visualizer code.",

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/place-properties/main.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/place-properties/main.tsx
@@ -4,11 +4,12 @@ import { css } from "@hashintel/ds-helpers/css";
 
 import { SDCPNContext } from "../../../../../../react/state/sdcpn-context";
 import { useIsReadOnly } from "../../../../../../react/state/use-is-read-only";
+import { createDeferredSubView } from "../../../../../components/sub-view/deferred-sub-view";
 import { VerticalSubViewsContainer } from "../../../../../components/sub-view/vertical/vertical-sub-views-container";
+import { usePetrinautPresentation } from "../../../../shared/presentation-context";
 import { PlacePropertiesProvider } from "./context";
 import { placeMainContentSubView } from "./subviews/main";
 import { placeInitialStateSubView } from "./subviews/place-initial-state/subview";
-import { placeVisualizerSubView } from "./subviews/place-visualizer/subview";
 
 import type { PetrinautMutations } from "../../../../../../react";
 import type { SubView } from "../../../../../components/sub-view/types";
@@ -26,6 +27,24 @@ const baseSubViews: SubView[] = [
   placeInitialStateSubView,
 ];
 
+const placeVisualizerSubView = createDeferredSubView({
+  id: "place-visualizer",
+  title: "Visualizer",
+  tooltip:
+    "Custom visualization of tokens in this place, defined by visualizer code.",
+  defaultCollapsed: true,
+  alwaysShowHeaderAction: true,
+  hasHeaderAction: true,
+  resizable: {
+    minHeight: 200,
+    maxHeight: 1200,
+    defaultHeight: 300,
+  },
+  load: async () =>
+    (await import("./subviews/place-visualizer/subview"))
+      .placeVisualizerSubView,
+});
+
 interface PlacePropertiesProps {
   place: Place;
   types: Color[];
@@ -38,15 +57,17 @@ export const PlaceProperties: React.FC<PlacePropertiesProps> = ({
   updatePlace,
 }) => {
   const isReadOnly = useIsReadOnly();
+  const presentation = usePetrinautPresentation();
   const { extensions } = use(SDCPNContext);
 
   const placeType =
     extensions.colors && place.colorId
       ? (types.find((tp) => tp.id === place.colorId) ?? null)
       : null;
-  const subViews = extensions.colors
-    ? [...baseSubViews, placeVisualizerSubView]
-    : baseSubViews;
+  const subViews =
+    extensions.colors && presentation.showSourceCode
+      ? [...baseSubViews, placeVisualizerSubView]
+      : baseSubViews;
 
   return (
     <div className={containerStyle}>

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/place-properties/subviews/main.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/place-properties/subviews/main.tsx
@@ -494,5 +494,6 @@ export const placeMainContentSubView: SubView = {
   main: true,
   component: PlaceMainContent,
   renderHeaderAction: () => <DeletePlaceAction />,
+  headerActionMutates: true,
   alwaysShowHeaderAction: true,
 };

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/place-properties/subviews/place-initial-state/subview.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/place-properties/subviews/place-initial-state/subview.tsx
@@ -12,6 +12,7 @@ import { css } from "@hashintel/ds-helpers/css";
 import { PlaybackContext } from "../../../../../../../../react/playback/context";
 import { SimulationContext } from "../../../../../../../../react/simulation/context";
 import { UI_MESSAGES } from "../../../../../../../constants/ui-messages";
+import { usePetrinautPresentation } from "../../../../../../shared/presentation-context";
 import { usePlacePropertiesContext } from "../../context";
 import { InitialStateEditor } from "./initial-state-editor";
 
@@ -38,6 +39,7 @@ const scenarioInfoStyle = css({
  * Only shown when not in simulation mode and there's data to clear.
  */
 const ClearStateHeaderAction: React.FC = () => {
+  const presentation = usePetrinautPresentation();
   const { place, placeType } = usePlacePropertiesContext();
   const { state, initialMarking, setInitialMarking, selectedScenarioId } =
     use(SimulationContext);
@@ -62,6 +64,13 @@ const ClearStateHeaderAction: React.FC = () => {
 
   // Hide when simulation has run or when there's no data to clear.
   if (!isSimulationNotRun || !hasData) {
+    return null;
+  }
+
+  // This slot carries a status above and a mutation here, so the sub-view
+  // cannot declare itself one or the other: only the button goes when a
+  // presentation hides mutation actions.
+  if (!presentation.showMutationActions) {
     return null;
   }
 

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/selected-item-properties.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/selected-item-properties.tsx
@@ -1,0 +1,174 @@
+import { use } from "react";
+
+import { usePetrinautMutations } from "../../../../../react";
+import { ActiveNetContext } from "../../../../../react/state/active-net-context";
+import { SDCPNContext } from "../../../../../react/state/sdcpn-context";
+import { usePanelTarget } from "../../../../../react/state/use-selection";
+import { ArcProperties } from "./arc-properties/main";
+import { ComponentInstanceProperties } from "./component-instance-properties/main";
+import { DifferentialEquationProperties } from "./differential-equation-properties/main";
+import { MultiSelectionPanel } from "./multi-selection-panel";
+import { ParameterProperties } from "./parameter-properties/main";
+import { PlaceProperties } from "./place-properties/main";
+import { TransitionProperties } from "./transition-properties/main";
+import { TypeProperties } from "./type-properties/main";
+
+/**
+ * Resolves the editor selection to the existing entity-specific property
+ * content. Layout shells (such as the resizable editor panel)
+ * intentionally share this component so their entity rendering cannot drift.
+ */
+export const SelectedItemProperties: React.FC = () => {
+  const { activeNet: petriNetDefinition } = use(ActiveNetContext);
+  const { extensions, petriNetDefinition: fullSdcpn } = use(SDCPNContext);
+  const {
+    updatePlace,
+    updateTransition,
+    updateArcWeight,
+    updateArcType,
+    updateArcPlace,
+    removeArc,
+    updateType,
+    addTypeElement,
+    updateTypeElement,
+    removeTypeElement,
+    moveTypeElement,
+    updateDifferentialEquation,
+    updateParameter,
+    updateComponentInstance,
+    deleteItemsByIds,
+  } = usePetrinautMutations();
+  const panelTarget = usePanelTarget();
+
+  if (panelTarget.kind === "single") {
+    const { item } = panelTarget;
+
+    switch (item.type) {
+      case "place": {
+        const place = petriNetDefinition.places.find(
+          (candidate) => candidate.id === item.id,
+        );
+        return place ? (
+          <PlaceProperties
+            place={place}
+            types={extensions.colors ? petriNetDefinition.types : []}
+            updatePlace={updatePlace}
+          />
+        ) : null;
+      }
+
+      case "transition": {
+        const transition = petriNetDefinition.transitions.find(
+          (candidate) => candidate.id === item.id,
+        );
+        return transition ? (
+          <TransitionProperties
+            transition={transition}
+            net={petriNetDefinition}
+            places={petriNetDefinition.places}
+            types={extensions.colors ? petriNetDefinition.types : []}
+            onArcWeightUpdate={updateArcWeight}
+            updateTransition={updateTransition}
+            updateArcPlace={updateArcPlace}
+            removeArc={removeArc}
+          />
+        ) : null;
+      }
+
+      case "arc":
+        return (
+          <ArcProperties
+            arcId={item.id}
+            petriNetDefinition={petriNetDefinition}
+            fullSdcpn={fullSdcpn}
+            updateArcWeight={updateArcWeight}
+            updateArcType={updateArcType}
+            removeArc={removeArc}
+          />
+        );
+
+      case "type": {
+        if (!extensions.colors) {
+          return null;
+        }
+        const type = petriNetDefinition.types.find(
+          (candidate) => candidate.id === item.id,
+        );
+        return type ? (
+          <TypeProperties
+            type={type}
+            updateType={updateType}
+            addTypeElement={addTypeElement}
+            updateTypeElement={updateTypeElement}
+            removeTypeElement={removeTypeElement}
+            moveTypeElement={moveTypeElement}
+          />
+        ) : null;
+      }
+
+      case "differentialEquation": {
+        if (!extensions.colors || !extensions.dynamics) {
+          return null;
+        }
+        const differentialEquation =
+          petriNetDefinition.differentialEquations.find(
+            (candidate) => candidate.id === item.id,
+          );
+        return differentialEquation ? (
+          <DifferentialEquationProperties
+            differentialEquation={differentialEquation}
+            types={petriNetDefinition.types}
+            places={petriNetDefinition.places}
+            updateDifferentialEquation={updateDifferentialEquation}
+          />
+        ) : null;
+      }
+
+      case "parameter": {
+        if (!extensions.parameters) {
+          return null;
+        }
+        const parameter = petriNetDefinition.parameters.find(
+          (candidate) => candidate.id === item.id,
+        );
+        return parameter ? (
+          <ParameterProperties
+            parameter={parameter}
+            updateParameter={updateParameter}
+          />
+        ) : null;
+      }
+
+      case "componentInstance": {
+        const instance = petriNetDefinition.componentInstances.find(
+          (candidate) => candidate.id === item.id,
+        );
+        if (!instance) {
+          return null;
+        }
+        const subnet =
+          (fullSdcpn.subnets ?? []).find(
+            (candidate) => candidate.id === instance.subnetId,
+          ) ?? null;
+        return (
+          <ComponentInstanceProperties
+            instance={instance}
+            subnet={subnet}
+            updateComponentInstance={updateComponentInstance}
+          />
+        );
+      }
+    }
+  }
+
+  if (panelTarget.kind === "multi") {
+    return (
+      <MultiSelectionPanel
+        items={panelTarget.items}
+        deleteItemsByIds={deleteItemsByIds}
+      />
+    );
+  }
+
+  return null;
+};

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/transition-properties/main.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/transition-properties/main.tsx
@@ -5,14 +5,14 @@ import { getTransitionLogicAvailability } from "@hashintel/petrinaut-core";
 
 import { SDCPNContext } from "../../../../../../react/state/sdcpn-context";
 import { useIsReadOnly } from "../../../../../../react/state/use-is-read-only";
+import { createDeferredSubView } from "../../../../../components/sub-view/deferred-sub-view";
 import { VerticalSubViewsContainer } from "../../../../../components/sub-view/vertical/vertical-sub-views-container";
+import { usePetrinautPresentation } from "../../../../shared/presentation-context";
 import {
   TransitionPropertiesProvider,
   type TransitionLogicNet,
 } from "./context";
 import { transitionMainContentSubView } from "./subviews/main";
-import { transitionFiringTimeSubView } from "./subviews/transition-firing-time/subview";
-import { transitionResultsSubView } from "./subviews/transition-results/subview";
 
 import type { PetrinautMutations } from "../../../../../../react";
 import type { SubView } from "../../../../../components/sub-view/types";
@@ -23,6 +23,40 @@ const containerStyle = css({
   flexDirection: "column",
   height: "[100%]",
   minHeight: "[0]",
+});
+
+const transitionFiringTimeSubView = createDeferredSubView({
+  id: "transition-firing-time",
+  title: "Firing Time",
+  defaultCollapsed: true,
+  tooltip:
+    "Define the rate at or conditions under which this transition will fire, optionally based on each set of input tokens' data (where input tokens have types).",
+  hasHeaderAction: true,
+  resizable: {
+    minHeight: 250,
+    maxHeight: 1200,
+    defaultHeight: 300,
+  },
+  load: async () =>
+    (await import("./subviews/transition-firing-time/subview"))
+      .transitionFiringTimeSubView,
+});
+
+const transitionResultsSubView = createDeferredSubView({
+  id: "transition-results",
+  title: "Transition Results",
+  defaultCollapsed: true,
+  tooltip:
+    "This function determines the data for output tokens, optionally based on the input token data and any global parameters defined.",
+  hasHeaderAction: true,
+  resizable: {
+    minHeight: 300,
+    maxHeight: 1200,
+    defaultHeight: 500,
+  },
+  load: async () =>
+    (await import("./subviews/transition-results/subview"))
+      .transitionResultsSubView,
 });
 
 interface TransitionPropertiesProps {
@@ -47,6 +81,7 @@ export const TransitionProperties: React.FC<TransitionPropertiesProps> = ({
   removeArc,
 }) => {
   const isReadOnly = useIsReadOnly();
+  const presentation = usePetrinautPresentation();
   const { extensions, petriNetDefinition } = use(SDCPNContext);
   const logicAvailability = getTransitionLogicAvailability(
     transition,
@@ -57,8 +92,12 @@ export const TransitionProperties: React.FC<TransitionPropertiesProps> = ({
 
   const subViews: SubView[] = [
     transitionMainContentSubView,
-    ...(logicAvailability.lambda ? [transitionFiringTimeSubView] : []),
-    ...(logicAvailability.transitionKernel ? [transitionResultsSubView] : []),
+    ...(presentation.showSourceCode && logicAvailability.lambda
+      ? [transitionFiringTimeSubView]
+      : []),
+    ...(presentation.showSourceCode && logicAvailability.transitionKernel
+      ? [transitionResultsSubView]
+      : []),
   ];
 
   return (

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/transition-properties/main.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/transition-properties/main.tsx
@@ -27,6 +27,7 @@ const containerStyle = css({
 
 const transitionFiringTimeSubView = createDeferredSubView({
   id: "transition-firing-time",
+  headerActionMutates: true,
   title: "Firing Time",
   defaultCollapsed: true,
   tooltip:
@@ -44,6 +45,7 @@ const transitionFiringTimeSubView = createDeferredSubView({
 
 const transitionResultsSubView = createDeferredSubView({
   id: "transition-results",
+  headerActionMutates: true,
   title: "Transition Results",
   defaultCollapsed: true,
   tooltip:

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/transition-properties/subviews/main.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/transition-properties/subviews/main.tsx
@@ -302,6 +302,7 @@ export const transitionMainContentSubView: SubView = {
   main: true,
   component: TransitionMainContent,
   renderHeaderAction: () => <DeleteTransitionAction />,
+  headerActionMutates: true,
   alwaysShowHeaderAction: true,
   resizable: {
     minHeight: 100,

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/type-properties/subviews/main.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/type-properties/subviews/main.tsx
@@ -21,6 +21,7 @@ import { DraftFieldInput } from "../../../../../../components/draft-field-input"
 import { SectionList } from "../../../../../../components/section";
 import { TokenTypeIcon } from "../../../../../../constants/entity-icons";
 import { UI_MESSAGES } from "../../../../../../constants/ui-messages";
+import { usePetrinautPresentation } from "../../../../../shared/presentation-context";
 import { ColorSelect } from "../color-select";
 import { useTypePropertiesContext } from "../context";
 
@@ -185,6 +186,7 @@ const TypeMainContent: React.FC = () => {
     moveTypeElement,
   } = useTypePropertiesContext();
   const isDisabled = useIsReadOnly();
+  const presentation = usePetrinautPresentation();
   const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
   const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
   const [elementNameInputs, setElementNameInputs] =
@@ -381,29 +383,33 @@ const TypeMainContent: React.FC = () => {
           disabled={isDisabled}
           labelTooltip="A type is an ordered tuple of token attributes. Real attributes can be updated by dynamics; integer and boolean attributes are discrete."
           labelActions={
-            <Button
-              onClick={handleAddElement}
-              disabled={isDisabled}
-              size="xs"
-              variant="ghost"
-              aria-label="Add dimension"
-              tooltip={
-                isDisabled ? UI_MESSAGES.READ_ONLY_MODE : "Add dimension"
-              }
-              iconName="plus"
-            />
+            presentation.showMutationActions ? (
+              <Button
+                onClick={handleAddElement}
+                disabled={isDisabled}
+                size="xs"
+                variant="ghost"
+                aria-label="Add dimension"
+                tooltip={
+                  isDisabled ? UI_MESSAGES.READ_ONLY_MODE : "Add dimension"
+                }
+                iconName="plus"
+              />
+            ) : undefined
           }
         >
           {type.elements.length === 0 ? (
             <div className={emptyDimensionsStyle}>
-              No dimensions defined. Click + to add.
+              {presentation.showMutationActions
+                ? "No dimensions defined. Click + to add."
+                : "No dimensions defined."}
             </div>
           ) : (
             <div className={dimensionsListStyle}>
               {type.elements.map((element, index) => (
                 <div
                   key={element.elementId}
-                  draggable={!isDisabled}
+                  draggable={presentation.showMutationActions && !isDisabled}
                   onDragStart={() => {
                     handleDragStart(index);
                   }}
@@ -421,11 +427,13 @@ const TypeMainContent: React.FC = () => {
                   })}
                 >
                   {/* Drag handle */}
-                  <div className={dragHandleStyle({ isDisabled })}>
-                    <div className={dragHandleLineStyle} />
-                    <div className={dragHandleLineStyle} />
-                    <div className={dragHandleLineStyle} />
-                  </div>
+                  {presentation.showMutationActions && (
+                    <div className={dragHandleStyle({ isDisabled })}>
+                      <div className={dragHandleLineStyle} />
+                      <div className={dragHandleLineStyle} />
+                      <div className={dragHandleLineStyle} />
+                    </div>
+                  )}
 
                   <div className={dimensionFieldGroupStyle}>
                     <Tooltip
@@ -472,22 +480,24 @@ const TypeMainContent: React.FC = () => {
                   </div>
 
                   {/* Delete button */}
-                  <Button
-                    onClick={() => {
-                      handleDeleteElement(element.elementId);
-                    }}
-                    disabled={isDisabled || type.elements.length === 1}
-                    size="xxs"
-                    variant="ghost"
-                    className={deleteDimensionButtonStyle}
-                    aria-label={`Delete dimension ${element.name}`}
-                    tooltip={
-                      isDisabled
-                        ? UI_MESSAGES.READ_ONLY_MODE
-                        : `Delete dimension ${element.name}`
-                    }
-                    iconName="close"
-                  />
+                  {presentation.showMutationActions && (
+                    <Button
+                      onClick={() => {
+                        handleDeleteElement(element.elementId);
+                      }}
+                      disabled={isDisabled || type.elements.length === 1}
+                      size="xxs"
+                      variant="ghost"
+                      className={deleteDimensionButtonStyle}
+                      aria-label={`Delete dimension ${element.name}`}
+                      tooltip={
+                        isDisabled
+                          ? UI_MESSAGES.READ_ONLY_MODE
+                          : `Delete dimension ${element.name}`
+                      }
+                      iconName="close"
+                    />
+                  )}
                 </div>
               ))}
             </div>

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/canvas-renderer.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/canvas-renderer.ts
@@ -25,6 +25,8 @@ export type CanvasController = {
   ) => void;
   zoomIn: () => void;
   zoomOut: () => void;
+  /** Frames the whole scene, easing the move when the renderer supports it. */
+  fitView: () => void;
   /** Client (viewport-relative screen) coordinates to scene coordinates. */
   screenToScene: (point: CanvasPoint) => CanvasPoint;
   sceneToScreen: (point: CanvasPoint) => CanvasPoint;

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/components/viewport-controls.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/components/viewport-controls.tsx
@@ -7,6 +7,7 @@ import { usePetrinautNavigation } from "../../../../react/navigation";
 import { EditorContext } from "../../../../react/state/editor-context";
 import { VIEWPORT_CONTROLS_OFFSET } from "../../../constants/ui";
 import { useCanvasInsets } from "../../../hooks/use-canvas-insets";
+import { usePetrinautPresentation } from "../../shared/presentation-context";
 import { useCanvasController } from "../canvas-renderer";
 import { ViewportSettingsDialog } from "./viewport-settings-dialog";
 
@@ -36,6 +37,7 @@ const blurredBackground = css({ backdropFilter: "[blur(10px)]" });
 export const ViewportControls: React.FC<{
   viewportActions?: ViewportAction[];
 }> = ({ viewportActions }) => {
+  const presentation = usePetrinautPresentation();
   const navigation = usePetrinautNavigation();
   const isSettingsOpen = navigation.state.overlay?.type === "viewport-settings";
   const setIsSettingsOpen = (open: boolean) => {
@@ -44,7 +46,10 @@ export const ViewportControls: React.FC<{
       { cause: "user", action: "overlay" },
     );
   };
-  const { zoomIn, zoomOut } = useCanvasController();
+  // Fit view goes through the canvas controller like the zooms: these
+  // controls sit above the renderer contract and must not reach for a
+  // renderer's own API.
+  const { fitView, zoomIn, zoomOut } = useCanvasController();
   const { collapseAllPanels, isPanelAnimating } = use(EditorContext);
 
   // Shared with the bottom toolbar, so the two keep clear of the same panels
@@ -84,39 +89,53 @@ export const ViewportControls: React.FC<{
       <Button
         size="xs"
         variant="subtle"
-        aria-label="Fullscreen"
-        tooltip="Fullscreen"
+        aria-label="Fit view"
+        tooltip="Fit view"
         tooltipOptions={{ position: "left" }}
-        iconName="expand"
+        iconName="collapse"
         className={blurredBackground}
-        onClick={collapseAllPanels}
+        onClick={fitView}
       />
-      <Button
-        size="xs"
-        variant="subtle"
-        aria-label="Lock view"
-        tooltip="Lock view"
-        tooltipOptions={{ position: "left" }}
-        iconName="lockOpen"
-        className={blurredBackground}
-        onClick={() => {
-          // Placeholder for future lock view functionality
-        }}
-      />
-      <Button
-        size="xs"
-        variant="subtle"
-        aria-label="Settings"
-        tooltip="Settings"
-        tooltipOptions={{ position: "left" }}
-        iconName="gear"
-        className={blurredBackground}
-        onClick={() => setIsSettingsOpen(true)}
-      />
-      <ViewportSettingsDialog
-        open={isSettingsOpen}
-        onOpenChange={(details) => setIsSettingsOpen(details.open)}
-      />
+      {presentation.showViewportSettings && (
+        <>
+          <Button
+            size="xs"
+            variant="subtle"
+            aria-label="Fullscreen"
+            tooltip="Fullscreen"
+            tooltipOptions={{ position: "left" }}
+            iconName="expand"
+            className={blurredBackground}
+            onClick={collapseAllPanels}
+          />
+          <Button
+            size="xs"
+            variant="subtle"
+            aria-label="Lock view"
+            tooltip="Lock view"
+            tooltipOptions={{ position: "left" }}
+            iconName="lockOpen"
+            className={blurredBackground}
+            onClick={() => {
+              // Placeholder for future lock view functionality
+            }}
+          />
+          <Button
+            size="xs"
+            variant="subtle"
+            aria-label="Settings"
+            tooltip="Settings"
+            tooltipOptions={{ position: "left" }}
+            iconName="gear"
+            className={blurredBackground}
+            onClick={() => setIsSettingsOpen(true)}
+          />
+          <ViewportSettingsDialog
+            open={isSettingsOpen}
+            onOpenChange={(details) => setIsSettingsOpen(details.open)}
+          />
+        </>
+      )}
       {viewportActions?.map((action) => (
         <Button
           key={action.key}

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas.tsx
@@ -24,6 +24,7 @@ import { EditorContext } from "../../../../../react/state/editor-context";
 import { UserSettingsContext } from "../../../../../react/state/user-settings-context";
 import { SNAP_GRID_SIZE } from "../../../../constants/ui";
 import { readDraggedNodeKind } from "../../../shared/canvas-node-drag";
+import { usePetrinautPresentation } from "../../../shared/presentation-context";
 import {
   CanvasControllerContext,
   type CanvasRenderer,
@@ -86,6 +87,7 @@ const ReactFlowCanvasInner: CanvasRenderer = ({
   containerSize,
   viewportActions,
 }) => {
+  const presentation = usePetrinautPresentation();
   const { compactNodes, showMinimap, partialSelection } =
     use(UserSettingsContext);
   const { hasCanvasSelection, globalMode } = use(EditorContext);
@@ -216,7 +218,9 @@ const ReactFlowCanvasInner: CanvasRenderer = ({
         >
           <Background gap={SNAP_GRID_SIZE} size={1} />
           {hasCanvasSelection && <div className={fadeBgStyle} />}
-          {showMinimap && <MiniMap pannable zoomable />}
+          {showMinimap && presentation.showMinimap && (
+            <MiniMap pannable zoomable />
+          )}
           {!isActualMode && (
             <ViewportControls viewportActions={viewportActions} />
           )}

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/place-state-tooltip.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/place-state-tooltip.tsx
@@ -5,13 +5,19 @@ import {
   useReactFlow,
   useViewport,
 } from "@xyflow/react";
-import { use, useRef } from "react";
+import { lazy, Suspense, use, useRef } from "react";
 
 import { css } from "@hashintel/ds-helpers/css";
 
 import { useElementSize } from "../../../../../../react/hooks/use-element-size";
 import { SDCPNContext } from "../../../../../../react/state/sdcpn-context";
-import { PlaceStateVisualization } from "../../../../shared/place-state-visualization";
+import { usePetrinautPresentation } from "../../../../shared/presentation-context";
+
+const DeferredPlaceStateVisualization = lazy(async () => {
+  const { PlaceStateVisualization } =
+    await import("../../../../shared/place-state-visualization");
+  return { default: PlaceStateVisualization };
+});
 
 // Gap between the node and the box, in screen pixels.
 const TOOLTIP_OFFSET_PX = 12;
@@ -37,6 +43,7 @@ const tooltipStyle = css({
  * Hover box surfacing a colored place's custom visualizer on the canvas.
  */
 export const PlaceStateTooltip: React.FC<{ nodeId: string }> = ({ nodeId }) => {
+  const presentation = usePetrinautPresentation();
   const { petriNetDefinition } = use(SDCPNContext);
 
   const node = useInternalNode(nodeId);
@@ -52,6 +59,7 @@ export const PlaceStateTooltip: React.FC<{ nodeId: string }> = ({ nodeId }) => {
     : null;
 
   if (
+    !presentation.showCustomVisualizers ||
     !place ||
     !placeType ||
     placeType.elements.length === 0 ||
@@ -86,7 +94,12 @@ export const PlaceStateTooltip: React.FC<{ nodeId: string }> = ({ nodeId }) => {
         // the top bar before the above/below decision settles.
         style={{ opacity: boxSize ? 1 : 0 }}
       >
-        <PlaceStateVisualization place={place} placeType={placeType} />
+        <Suspense fallback={null}>
+          <DeferredPlaceStateVisualization
+            place={place}
+            placeType={placeType}
+          />
+        </Suspense>
       </div>
     </NodeToolbar>
   );

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/use-react-flow-controller.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/use-react-flow-controller.ts
@@ -22,6 +22,10 @@ export const useReactFlowController = (): CanvasController => {
     zoomOut: () => {
       void reactFlow.zoomOut();
     },
+    fitView: () => {
+      // Padded, so the framed net does not sit against the canvas edges.
+      void reactFlow.fitView({ padding: 0.4, duration: 250 });
+    },
     screenToScene: (point) => reactFlow.screenToFlowPosition(point),
     sceneToScreen: (point) => reactFlow.flowToScreenPosition(point),
   };

--- a/libs/@hashintel/petrinaut/src/ui/views/shared/presentation-context.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/shared/presentation-context.tsx
@@ -1,0 +1,59 @@
+import { createContext, use, type PropsWithChildren } from "react";
+
+export type PetrinautPresentationProfile = "editor" | "review";
+
+export type PetrinautPresentationCapabilities = {
+  profile: PetrinautPresentationProfile;
+  /** Show controls whose only purpose is to mutate the authored net. */
+  showMutationActions: boolean;
+  /** Show authored TypeScript source in property inspectors. */
+  showSourceCode: boolean;
+  /** Compile and display user-authored visualizer code. */
+  showCustomVisualizers: boolean;
+  /** Show the full viewport settings surface and editor-only viewport actions. */
+  showViewportSettings: boolean;
+  /** Show the canvas overview minimap. */
+  showMinimap: boolean;
+  /** Prefer controls sized for a compact embed over the full editor sizing. */
+  compactControls: boolean;
+};
+
+const PRESENTATION_CAPABILITIES: Record<
+  PetrinautPresentationProfile,
+  PetrinautPresentationCapabilities
+> = {
+  editor: {
+    profile: "editor",
+    showMutationActions: true,
+    showSourceCode: true,
+    showCustomVisualizers: true,
+    showViewportSettings: true,
+    showMinimap: true,
+    compactControls: false,
+  },
+  review: {
+    profile: "review",
+    showMutationActions: false,
+    showSourceCode: true,
+    showCustomVisualizers: true,
+    showViewportSettings: true,
+    showMinimap: true,
+    compactControls: false,
+  },
+};
+
+const PetrinautPresentationContext =
+  createContext<PetrinautPresentationCapabilities>(
+    PRESENTATION_CAPABILITIES.editor,
+  );
+
+export const PetrinautPresentationProvider = ({
+  profile,
+  children,
+}: PropsWithChildren<{ profile: PetrinautPresentationProfile }>) => (
+  <PetrinautPresentationContext value={PRESENTATION_CAPABILITIES[profile]}>
+    {children}
+  </PetrinautPresentationContext>
+);
+
+export const usePetrinautPresentation = () => use(PetrinautPresentationContext);

--- a/libs/@hashintel/petrinaut/src/ui/views/shared/simulation-parameter-bounds.test.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/shared/simulation-parameter-bounds.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { clampSimulationParameterValue } from "./simulation-parameter-bounds";
+
+describe("clampSimulationParameterValue", () => {
+  const bounds = { min: 0, max: 1 };
+
+  it("leaves an unbounded value unchanged", () => {
+    expect(clampSimulationParameterValue(12)).toBe(12);
+  });
+
+  it("leaves a value inside the bounds unchanged", () => {
+    expect(clampSimulationParameterValue(0.4, bounds)).toBe(0.4);
+  });
+
+  it("clamps values to the nearest bound", () => {
+    expect(clampSimulationParameterValue(-0.1, bounds)).toBe(0);
+    expect(clampSimulationParameterValue(1.1, bounds)).toBe(1);
+  });
+});

--- a/libs/@hashintel/petrinaut/src/ui/views/shared/simulation-parameter-bounds.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/shared/simulation-parameter-bounds.ts
@@ -1,0 +1,15 @@
+export type SimulationParameterBounds = {
+  min: number;
+  max: number;
+  step?: number;
+};
+
+export type SimulationParameterBoundsByIdentifier = Readonly<
+  Record<string, SimulationParameterBounds>
+>;
+
+export const clampSimulationParameterValue = (
+  value: number,
+  bounds?: SimulationParameterBounds,
+): number =>
+  bounds ? Math.min(bounds.max, Math.max(bounds.min, value)) : value;

--- a/libs/@hashintel/petrinaut/src/ui/views/shared/simulation-scenario-controls.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/shared/simulation-scenario-controls.tsx
@@ -1,0 +1,499 @@
+import { use } from "react";
+
+import {
+  Banner,
+  Icon,
+  NumberInput,
+  Select,
+  Toggle,
+} from "@hashintel/ds-components";
+import { css, cx } from "@hashintel/ds-helpers/css";
+
+import { SimulationContext } from "../../../react/simulation/context";
+import { SDCPNContext } from "../../../react/state/sdcpn-context";
+import { Slider } from "../../components/slider";
+import { useScrollOverflow } from "../../hooks/use-scroll-overflow";
+import { clampSimulationParameterValue } from "./simulation-parameter-bounds";
+
+import type {
+  SimulationParameterBounds,
+  SimulationParameterBoundsByIdentifier,
+} from "./simulation-parameter-bounds";
+
+const NO_SCENARIO = "__none__";
+
+const rootStyle = css({
+  display: "flex",
+  flexDirection: "column",
+  gap: "5",
+  minHeight: "0",
+  height: "full",
+});
+
+const scenarioRowStyle = css({
+  display: "flex",
+  alignItems: "center",
+  gap: "2",
+  flexShrink: "0",
+  paddingRight: "2",
+});
+
+const scenarioLabelStyle = css({
+  fontSize: "[10px]",
+  fontWeight: "semibold",
+  textTransform: "uppercase",
+  color: "neutral.a100",
+  letterSpacing: "[0.5px]",
+  flexShrink: "0",
+});
+
+const scenarioSelectWrapperStyle = css({
+  flex: "1",
+  minWidth: "0",
+  "& > div > div": { minWidth: "0" },
+});
+
+const actionsStyle = css({
+  display: "flex",
+  flexShrink: "0",
+});
+
+const sectionStyle = css({
+  display: "flex",
+  flexDirection: "column",
+  gap: "1",
+  flex: "1",
+  minHeight: "0",
+});
+
+const sectionTitleStyle = css({
+  fontSize: "[10px]",
+  fontWeight: "semibold",
+  textTransform: "uppercase",
+  color: "neutral.a100",
+  letterSpacing: "[0.5px]",
+});
+
+const scrollWrapperStyle = css({
+  position: "relative",
+  flex: "1",
+  minHeight: "0",
+  display: "flex",
+  flexDirection: "column",
+});
+
+const listStyle = css({
+  display: "flex",
+  flexDirection: "column",
+  overflowY: "auto",
+  flex: "1",
+  minHeight: "0",
+  paddingBottom: "3",
+  paddingRight: "2",
+});
+
+const fadeStyle = css({
+  position: "absolute",
+  left: "0",
+  right: "0",
+  height: "[16px]",
+  pointerEvents: "none",
+  zIndex: "[1]",
+  opacity: "var(--scroll-fade-opacity)",
+  transition: "[opacity 150ms ease]",
+});
+
+const topFadeStyle = css({
+  top: "0",
+  background:
+    "[linear-gradient(to bottom, var(--colors-neutral-s00), transparent)]",
+});
+
+const bottomFadeStyle = css({
+  bottom: "0",
+  background:
+    "[linear-gradient(to top, var(--colors-neutral-s00), transparent)]",
+});
+
+const parameterRowStyle = css({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  gap: "4",
+  paddingY: "2",
+  paddingX: "1",
+  borderBottomWidth: "thin",
+  borderBottomColor: "neutral.a25",
+  "&:last-child": { borderBottomWidth: "0" },
+});
+
+const parameterNameStyle = css({
+  fontSize: "[13px]",
+  color: "neutral.fg.heading",
+});
+
+const parameterVariableStyle = css({
+  fontSize: "[11px]",
+  color: "neutral.s100",
+  fontFamily: "mono",
+});
+
+const parameterVariableOnlyStyle = css({
+  fontSize: "[12px]",
+  color: "neutral.fg.heading",
+  fontFamily: "mono",
+});
+
+const parameterInputStyle = css({ width: "[80px]" });
+const parameterSliderInputStyle = css({ width: "[65px]" });
+const ratioRowStyle = css({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "flex-end",
+  gap: "2",
+});
+const ratioSliderStyle = css({ width: "[120px]", opacity: "1" });
+
+const emptyMessageStyle = css({
+  fontSize: "xs",
+  color: "neutral.s85",
+  fontStyle: "italic",
+});
+
+const scenarioBannerStyle = css({
+  flexShrink: "0",
+  textStyle: "xs",
+  lineHeight: "[1.3]",
+  padding: "[6px 8px]",
+});
+
+const scenarioMessagesStyle = css({
+  display: "flex",
+  flexDirection: "column",
+  gap: "[4px]",
+  marginTop: "[4px !important]",
+  overflowWrap: "anywhere",
+});
+
+const ParametersScrollArea: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const { scrollRef, canScrollUp, canScrollDown, onScroll } =
+    useScrollOverflow();
+
+  return (
+    <div className={scrollWrapperStyle}>
+      <div
+        className={cx(fadeStyle, topFadeStyle)}
+        style={
+          {
+            "--scroll-fade-opacity": canScrollUp ? 1 : 0,
+          } as React.CSSProperties
+        }
+      />
+      <div ref={scrollRef} className={listStyle} onScroll={onScroll}>
+        {children}
+      </div>
+      <div
+        className={cx(fadeStyle, bottomFadeStyle)}
+        style={
+          {
+            "--scroll-fade-opacity": canScrollDown ? 1 : 0,
+          } as React.CSSProperties
+        }
+      />
+    </div>
+  );
+};
+
+type DisplayParameter = {
+  key: string;
+  name?: string;
+  variableName: string;
+  type: "real" | "integer" | "boolean" | "ratio";
+  defaultValue: string;
+};
+
+const parameterBounds = (
+  parameter: DisplayParameter,
+  boundsByIdentifier?: SimulationParameterBoundsByIdentifier,
+): SimulationParameterBounds | undefined => {
+  const declared = boundsByIdentifier?.[parameter.variableName];
+  if (declared) {
+    return declared;
+  }
+  return parameter.type === "ratio"
+    ? { min: 0, max: 1, step: 0.00001 }
+    : undefined;
+};
+
+export type SimulationScenarioControlsProps = {
+  actions?: React.ReactNode;
+  allowNoScenario?: boolean;
+  parameterBounds?: SimulationParameterBoundsByIdentifier;
+  className?: string;
+};
+
+/**
+ * Shared scenario picker and typed parameter controls, decoupled from the
+ * full editor settings panel so compact hosts can compose them too.
+ */
+export const SimulationScenarioControls: React.FC<
+  SimulationScenarioControlsProps
+> = ({
+  actions,
+  allowNoScenario = true,
+  parameterBounds: boundsByIdentifier,
+  className,
+}) => {
+  const {
+    extensions,
+    petriNetDefinition: { parameters, scenarios },
+  } = use(SDCPNContext);
+  const {
+    state: simulationState,
+    parameterValues,
+    setParameterValue,
+    selectedScenarioId: contextScenarioId,
+    setSelectedScenarioId,
+    scenarioParameterValues,
+    setScenarioParameterValue,
+    scenarioCompilationErrors,
+  } = use(SimulationContext);
+
+  const selectedScenarioId = contextScenarioId ?? NO_SCENARIO;
+  const selectedScenario = scenarios?.find(
+    (scenario) => scenario.id === selectedScenarioId,
+  );
+  const isSimulationActive =
+    simulationState === "Running" || simulationState === "Paused";
+  const globalParameters = extensions.parameters ? parameters : [];
+  const displayParameters: DisplayParameter[] = selectedScenario
+    ? selectedScenario.scenarioParameters.map((parameter) => ({
+        key: `scenario-${parameter.identifier}`,
+        variableName: parameter.identifier,
+        type: parameter.type,
+        defaultValue: String(parameter.default),
+      }))
+    : globalParameters.map((parameter) => ({
+        key: parameter.id,
+        name: parameter.name,
+        variableName: parameter.variableName,
+        type: parameter.type,
+        defaultValue: parameter.defaultValue,
+      }));
+  const scenarioOptions = [
+    ...(scenarios ?? []).map((scenario) => ({
+      value: scenario.id,
+      text: scenario.name,
+    })),
+    ...(allowNoScenario ? [{ value: NO_SCENARIO, text: "No scenario" }] : []),
+  ];
+
+  return (
+    <div className={cx(rootStyle, className)}>
+      <div className={scenarioRowStyle}>
+        <span className={scenarioLabelStyle}>Scenario</span>
+        <div className={scenarioSelectWrapperStyle}>
+          <Select
+            required
+            value={selectedScenarioId}
+            onChange={(scenarioId) =>
+              setSelectedScenarioId(
+                scenarioId === NO_SCENARIO ? null : scenarioId,
+              )
+            }
+            items={scenarioOptions}
+            size="xs"
+            disabled={isSimulationActive || scenarioOptions.length < 2}
+            renderItem={(value) => {
+              const option = scenarioOptions.find(
+                (candidate) => candidate.value === value,
+              );
+              return (
+                <span
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 6,
+                    minWidth: 0,
+                  }}
+                >
+                  {value === NO_SCENARIO && (
+                    <Icon
+                      name="dash"
+                      size="xs"
+                      className={css({ opacity: "[0.4]" })}
+                    />
+                  )}
+                  <span
+                    style={{
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    {option?.text}
+                  </span>
+                </span>
+              );
+            }}
+          />
+        </div>
+        {actions && <div className={actionsStyle}>{actions}</div>}
+      </div>
+
+      {scenarioCompilationErrors && (
+        <Banner
+          tone="error"
+          icon={false}
+          role="alert"
+          className={scenarioBannerStyle}
+        >
+          <Banner.Title as="h3">
+            Scenario failed to compile — its parameter overrides and initial
+            state are not applied.
+          </Banner.Title>
+          <Banner.Description className={scenarioMessagesStyle}>
+            {scenarioCompilationErrors.map((error) => (
+              <span key={`${error.source}:${error.itemId}:${error.message}`}>
+                {error.message}
+              </span>
+            ))}
+          </Banner.Description>
+        </Banner>
+      )}
+
+      <div className={sectionStyle}>
+        <div className={sectionTitleStyle}>Parameters</div>
+        {displayParameters.length > 0 ? (
+          <ParametersScrollArea>
+            {displayParameters.map((parameter) => {
+              const bounds = parameterBounds(parameter, boundsByIdentifier);
+              const value = selectedScenario
+                ? (scenarioParameterValues[parameter.variableName] ??
+                  parameter.defaultValue)
+                : (parameterValues[parameter.variableName] ??
+                  parameter.defaultValue);
+              const updateValue = (nextValue: string) => {
+                if (selectedScenario) {
+                  setScenarioParameterValue(parameter.variableName, nextValue);
+                } else {
+                  setParameterValue(parameter.variableName, nextValue);
+                }
+              };
+
+              return (
+                <div key={parameter.key} className={parameterRowStyle}>
+                  <div>
+                    {parameter.name === undefined ? (
+                      <div className={parameterVariableOnlyStyle}>
+                        {parameter.variableName}
+                      </div>
+                    ) : (
+                      <>
+                        <div className={parameterNameStyle}>
+                          {parameter.name}
+                        </div>
+                        <div className={parameterVariableStyle}>
+                          {parameter.variableName}
+                        </div>
+                      </>
+                    )}
+                  </div>
+                  {parameter.type === "boolean" ? (
+                    <Toggle
+                      size="xs"
+                      value={
+                        selectedScenario ? value !== "0" : value === "true"
+                      }
+                      onChange={(checked) =>
+                        updateValue(
+                          selectedScenario
+                            ? checked
+                              ? "1"
+                              : "0"
+                            : String(checked),
+                        )
+                      }
+                      disabled={isSimulationActive}
+                    />
+                  ) : parameter.type === "ratio" && selectedScenario ? (
+                    <div className={ratioRowStyle}>
+                      <Slider
+                        className={ratioSliderStyle}
+                        min={bounds?.min ?? 0}
+                        max={bounds?.max ?? 1}
+                        step={bounds?.step ?? 0.00001}
+                        value={Number(value)}
+                        onChange={(event) => updateValue(event.target.value)}
+                        disabled={isSimulationActive}
+                      />
+                      <NumberInput
+                        size="xs"
+                        min={bounds?.min}
+                        max={bounds?.max}
+                        step={bounds?.step ?? 0.00001}
+                        align="right"
+                        hideStepper
+                        value={Number(value)}
+                        onChange={(nextValue) =>
+                          updateValue(
+                            nextValue === null
+                              ? ""
+                              : String(
+                                  clampSimulationParameterValue(
+                                    nextValue,
+                                    bounds,
+                                  ),
+                                ),
+                          )
+                        }
+                        disabled={isSimulationActive}
+                        className={parameterSliderInputStyle}
+                      />
+                    </div>
+                  ) : (
+                    <NumberInput
+                      size="xs"
+                      min={bounds?.min}
+                      max={bounds?.max}
+                      align="right"
+                      step={
+                        bounds?.step ??
+                        (parameter.type === "integer" ? 1 : 0.001)
+                      }
+                      hideStepper
+                      value={Number(value)}
+                      onChange={(nextValue) =>
+                        updateValue(
+                          nextValue === null
+                            ? ""
+                            : String(
+                                clampSimulationParameterValue(
+                                  nextValue,
+                                  bounds,
+                                ),
+                              ),
+                        )
+                      }
+                      placeholder={parameter.defaultValue}
+                      disabled={isSimulationActive}
+                      className={parameterInputStyle}
+                    />
+                  )}
+                </div>
+              );
+            })}
+          </ParametersScrollArea>
+        ) : (
+          <div className={emptyMessageStyle}>
+            {selectedScenario
+              ? "No scenario parameters defined"
+              : "No parameters defined"}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/libs/@hashintel/petrinaut/src/ui/views/shared/simulation-scenario-controls.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/shared/simulation-scenario-controls.tsx
@@ -235,8 +235,10 @@ export type SimulationScenarioControlsProps = {
 };
 
 /**
- * Shared scenario picker and typed parameter controls, decoupled from the
- * full editor settings panel so compact hosts can compose them too.
+ * Shared scenario picker and typed parameter controls, decoupled from the full
+ * editor settings panel so the embedded Preview composes them too. Internal to
+ * this package: a host embeds `Petrinaut` or `PetrinautPreview`, and neither
+ * this component nor the bottom-bar controls are part of a published entry.
  */
 export const SimulationScenarioControls: React.FC<
   SimulationScenarioControlsProps


### PR DESCRIPTION
## Summary

Before this PR, every Petrinaut host got the full authoring editor. A read-only page could stop edits through the document handle, but subnet add, rename, and delete affordances, type-dimension mutation controls, and source-code fields still rendered. Scenario and playback controls lived inside the editor's bottom panel and bottom bar, so no other surface could compose them.

`Petrinaut` takes a `presentationProfile` prop, `editor` or `review`, that gates authoring-only controls. Scenario and playback controls become shared components that surfaces outside the full editor can compose. The default `editor` profile keeps every capability on, so existing hosts render as before.

## Links

- Ticket [FE-1500](https://linear.app/hash/issue/FE-1500)

## Changes

#### Presentation profiles

- `PetrinautPresentationProvider` maps a profile to capability booleans
  > `showMutationActions`, `showSourceCode`, `showCustomVisualizers`, `showViewportSettings`, `showMinimap`, `compactControls`.
  > `review` turns off mutation actions and keeps the rest on.
- Editor UI gates on those capabilities
  > Subnet add, rename, and delete affordances, type-dimension mutation controls, source-code fields in property inspectors, the custom place visualizer, viewport settings, and the minimap.
- Example pages render with the `review` profile

#### Shared components

- `SelectedItemProperties` extracted from the properties panel
- `SimulationScenarioControls` and `simulation-parameter-bounds` extracted as a scenario picker with typed parameter controls
  > Modelled on the picker and parameter list in Simulation Settings.
  > The full panel keeps its own layout, which main has since rebuilt around the ad-hoc scenario form, so the shared component serves compact hosts.
- Compact variant of the bottom-bar `SimulationControls` and `PlaybackSettingsMenu`
  > `allowedSpeeds` restricts the speed menu to an allow-list.
- `createDeferredSubView` loads optional property sub-views behind a bundle boundary
  > Transition firing time, transition results, and the place visualizer load on demand while the panel keeps a synchronous descriptor.

#### Review fixes

- Only mutating header actions answer to the presentation
  > `SubView` gained `headerActionMutates`, and the container hides an action only when it is set. Blanking the whole slot also removed Close search and the State subview's "Defined by scenario" status.
  > The filterable lists and the clear-state action read the presentation directly, because each renders a mutation and something else in the same slot.
- The deferred code menus declare themselves mutations
  > `place-visualizer`, `transition-firing-time` and `transition-results` are built through `createDeferredSubView`, which spreads the descriptor it is given, so the flag belongs on that descriptor rather than the inner sub-view.
- README documents the presentation profiles
  > What `editor` and `review` each draw, and that the profile is chrome while `readonly` is the enforcement.

## Test coverage

- `simulation-parameter-bounds.test.ts`:
  > Clamping a value into declared bounds.
- Existing `@hashintel/petrinaut` unit suite

## How to test

#### Editor unchanged

- Open [Petrinaut preview](https://petrinaut-git-claude-fe-1500-presentation.stage.hash.ai) on Vercel
  > Expect property panels, scenario controls in Simulation Settings, playback bar, viewport controls

#### Review presentation

- Open `/examples/gases-1-pn`
  > Expect no subnet add, rename or delete affordances, no type-dimension mutation controls

