### PR TITLE
FE-1541: Add a generic ResizeHandle and adopt it across the panels

### DIFF
--- a/libs/@hashintel/petrinaut/src/ui/components/glass-panel.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/components/glass-panel.tsx
@@ -1,26 +1,27 @@
-import { type CSSProperties, type ReactNode, useCallback, useRef } from "react";
+import { type CSSProperties, type ReactNode } from "react";
 
-import { css, cva, cx } from "@hashintel/ds-helpers/css";
+import { css, cx } from "@hashintel/ds-helpers/css";
 
-import { RESIZE_HANDLE_OFFSET, RESIZE_HANDLE_SIZE } from "../constants/ui";
-import { useResizeDrag } from "../resize/use-resize-drag";
+import { ResizeHandle, type ResizableEdge } from "../resize/resize-handle";
 
-const panelContainerStyle = cva({
-  base: {
-    position: "relative",
-    backgroundColor: "neutral.s00",
-    borderColor: "neutral.s40",
-    boxSizing: "content-box",
-    borderStyle: "solid",
+const panelContainerStyle = css({
+  position: "relative",
+  backgroundColor: "neutral.s00",
+  borderColor: "neutral.s40",
+  boxSizing: "content-box",
+  borderStyle: "solid",
+  // The dragged edge highlights while its handle reports an active resize.
+  '&:has([data-resize-edge="top"][data-resizing="true"])': {
+    borderTopColor: "blue.a70",
   },
-  variants: {
-    resizingEdge: {
-      top: { borderTopColor: "blue.a70" },
-      bottom: { borderBottomColor: "blue.a70" },
-      left: { borderLeftColor: "blue.a70" },
-      right: { borderRightColor: "blue.a70" },
-      none: {},
-    },
+  '&:has([data-resize-edge="bottom"][data-resizing="true"])': {
+    borderBottomColor: "blue.a70",
+  },
+  '&:has([data-resize-edge="left"][data-resizing="true"])': {
+    borderLeftColor: "blue.a70",
+  },
+  '&:has([data-resize-edge="right"][data-resizing="true"])': {
+    borderRightColor: "blue.a70",
   },
 });
 
@@ -29,66 +30,6 @@ const contentContainerStyle = css({
   height: "[100%]",
   width: "[100%]",
 });
-
-const resizeHandleStyle = cva({
-  base: {
-    position: "absolute",
-    backgroundColor: "[transparent]",
-    zIndex: "sticky",
-    transition: "[background-color 0.3s ease]",
-  },
-  variants: {
-    isResizing: {
-      true: {
-        backgroundColor: "blue.a40",
-      },
-      false: {
-        _hover: {
-          backgroundColor: "neutral.a30",
-        },
-      },
-    },
-    direction: {
-      vertical: { cursor: "ns-resize" },
-      horizontal: { cursor: "ew-resize" },
-    },
-  },
-});
-
-const getResizeHandlePositionStyle = (edge: ResizableEdge): CSSProperties => {
-  switch (edge) {
-    case "top":
-      return {
-        top: RESIZE_HANDLE_OFFSET,
-        left: 0,
-        right: 0,
-        height: RESIZE_HANDLE_SIZE,
-      };
-    case "bottom":
-      return {
-        bottom: RESIZE_HANDLE_OFFSET,
-        left: 0,
-        right: 0,
-        height: RESIZE_HANDLE_SIZE,
-      };
-    case "left":
-      return {
-        top: 0,
-        left: RESIZE_HANDLE_OFFSET,
-        bottom: 0,
-        width: RESIZE_HANDLE_SIZE,
-      };
-    case "right":
-      return {
-        top: 0,
-        right: RESIZE_HANDLE_OFFSET,
-        bottom: 0,
-        width: RESIZE_HANDLE_SIZE,
-      };
-  }
-};
-
-type ResizableEdge = "top" | "bottom" | "left" | "right";
 
 interface ResizeConfig {
   /** Which edge of the panel is resizable */
@@ -130,76 +71,24 @@ export const GlassPanel: React.FC<GlassPanelProps> = ({
   contentClassName,
   contentStyle,
   resizable,
-}) => {
-  const resizeStartSizeRef = useRef(0);
+}) => (
+  <div className={cx(panelContainerStyle, className)} style={style}>
+    {resizable && (
+      <ResizeHandle
+        edge={resizable.edge}
+        size={resizable.size}
+        onResize={resizable.onResize}
+        minSize={resizable.minSize ?? 100}
+        maxSize={resizable.maxSize ?? 800}
+        label={`Resize panel from ${resizable.edge}`}
+      />
+    )}
 
-  const onDrag = useCallback(
-    (delta: number) => {
-      if (!resizable) {
-        return;
-      }
-      const { edge, onResize, minSize = 100, maxSize = 800 } = resizable;
-      const effectiveDelta = edge === "top" || edge === "left" ? -delta : delta;
-      const newSize = Math.max(
-        minSize,
-        Math.min(maxSize, resizeStartSizeRef.current + effectiveDelta),
-      );
-      onResize(newSize);
-    },
-    [resizable],
-  );
-
-  const direction =
-    resizable?.edge === "left" || resizable?.edge === "right"
-      ? ("horizontal" as const)
-      : ("vertical" as const);
-
-  const { isResizing, handleMouseDown } = useResizeDrag({
-    onDrag,
-    direction,
-  });
-
-  const handleResizeStart = useCallback(
-    (event: React.MouseEvent) => {
-      if (!resizable) {
-        return;
-      }
-      resizeStartSizeRef.current = resizable.size;
-      handleMouseDown(event);
-    },
-    [resizable, handleMouseDown],
-  );
-
-  return (
     <div
-      className={cx(
-        panelContainerStyle({
-          resizingEdge: isResizing && resizable ? resizable.edge : "none",
-        }),
-        className,
-      )}
-      style={style}
+      className={cx(contentContainerStyle, contentClassName)}
+      style={contentStyle}
     >
-      {/* Resize handle */}
-      {resizable && (
-        <button
-          // Hide from tab order to prevent focus/tab traversal issues
-          tabIndex={-1}
-          type="button"
-          aria-label={`Resize panel from ${resizable.edge}`}
-          onMouseDown={handleResizeStart}
-          className={resizeHandleStyle({ isResizing, direction })}
-          style={getResizeHandlePositionStyle(resizable.edge)}
-        />
-      )}
-
-      {/* Content container */}
-      <div
-        className={cx(contentContainerStyle, contentClassName)}
-        style={contentStyle}
-      >
-        {children}
-      </div>
+      {children}
     </div>
-  );
-};
+  </div>
+);

--- a/libs/@hashintel/petrinaut/src/ui/resize/resize-handle.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/resize/resize-handle.tsx
@@ -36,10 +36,8 @@ const handleStyle = cva({
           content: '""',
           position: "absolute",
           borderRadius: "full",
-          backgroundColor: "[transparent]",
           transition: "[background-color 120ms ease-out]",
         },
-        _hover: { _before: { backgroundColor: "neutral.a40" } },
       },
     },
   },
@@ -53,6 +51,11 @@ const handleStyle = cva({
       appearance: "hidden",
       isResizing: false,
       css: { _hover: { backgroundColor: "neutral.a30" } },
+    },
+    {
+      appearance: "line",
+      isResizing: false,
+      css: { _hover: { _before: { backgroundColor: "neutral.a40" } } },
     },
     {
       appearance: "line",

--- a/libs/@hashintel/petrinaut/src/ui/resize/resize-handle.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/resize/resize-handle.tsx
@@ -1,0 +1,195 @@
+import { useRef } from "react";
+
+import { cva } from "@hashintel/ds-helpers/css";
+
+import { RESIZE_HANDLE_OFFSET, RESIZE_HANDLE_SIZE } from "../constants/ui";
+import { useResizeDrag } from "./use-resize-drag";
+
+import type { CSSProperties } from "react";
+
+export type ResizableEdge = "top" | "bottom" | "left" | "right";
+
+const handleStyle = cva({
+  base: {
+    position: "absolute",
+    backgroundColor: "[transparent]",
+    borderWidth: "[0]",
+    padding: "[0]",
+    zIndex: "sticky",
+    transition: "[background-color 0.3s ease]",
+  },
+  variants: {
+    isResizing: {
+      true: {},
+      false: {},
+    },
+    direction: {
+      vertical: { cursor: "ns-resize" },
+      horizontal: { cursor: "ew-resize" },
+    },
+    appearance: {
+      // The whole strip tints on hover and while resizing.
+      hidden: {},
+      // A centred pill line appears on hover and stays while resizing.
+      line: {
+        _before: {
+          content: '""',
+          position: "absolute",
+          borderRadius: "full",
+          backgroundColor: "[transparent]",
+          transition: "[background-color 120ms ease-out]",
+        },
+        _hover: { _before: { backgroundColor: "neutral.a40" } },
+      },
+    },
+  },
+  compoundVariants: [
+    {
+      appearance: "hidden",
+      isResizing: true,
+      css: { backgroundColor: "blue.a40" },
+    },
+    {
+      appearance: "hidden",
+      isResizing: false,
+      css: { _hover: { backgroundColor: "neutral.a30" } },
+    },
+    {
+      appearance: "line",
+      isResizing: true,
+      css: { _before: { backgroundColor: "blue.a70" } },
+    },
+    {
+      appearance: "line",
+      direction: "horizontal",
+      css: {
+        _before: {
+          top: "[12px]",
+          bottom: "[12px]",
+          left: "[50%]",
+          width: "[2px]",
+          transform: "translateX(-50%)",
+        },
+      },
+    },
+    {
+      appearance: "line",
+      direction: "vertical",
+      css: {
+        _before: {
+          left: "[12px]",
+          right: "[12px]",
+          top: "[50%]",
+          height: "[2px]",
+          transform: "translateY(-50%)",
+        },
+      },
+    },
+  ],
+});
+
+const positionStyle = (edge: ResizableEdge): CSSProperties => {
+  switch (edge) {
+    case "top":
+      return {
+        left: 0,
+        right: 0,
+        top: RESIZE_HANDLE_OFFSET,
+        height: RESIZE_HANDLE_SIZE,
+      };
+    case "bottom":
+      return {
+        left: 0,
+        right: 0,
+        bottom: RESIZE_HANDLE_OFFSET,
+        height: RESIZE_HANDLE_SIZE,
+      };
+    case "left":
+      return {
+        top: 0,
+        bottom: 0,
+        left: RESIZE_HANDLE_OFFSET,
+        width: RESIZE_HANDLE_SIZE,
+      };
+    case "right":
+      return {
+        top: 0,
+        bottom: 0,
+        right: RESIZE_HANDLE_OFFSET,
+        width: RESIZE_HANDLE_SIZE,
+      };
+  }
+};
+
+export interface ResizeHandleProps {
+  /** Which edge of the positioned parent this handle sits on. */
+  edge: ResizableEdge;
+  /** Current size along the resized axis, in pixels. */
+  size: number;
+  onResize: (size: number) => void;
+  minSize?: number;
+  maxSize?: number;
+  /** Accessible label; defaults to naming the edge. */
+  label?: string;
+  /**
+   * Visual affordance: "hidden" tints the whole strip on hover, "line"
+   * shows a centred pill. Both turn blue while resizing.
+   */
+  appearance?: "hidden" | "line";
+}
+
+/**
+ * A drag handle for resizing the nearest positioned ancestor. Dragging past
+ * the min/max bounds clamps rather than detaching, and the underlying hook
+ * lays a full-screen overlay over the page for the duration of the gesture so
+ * hover states and iframes don't swallow the pointer.
+ *
+ * The parent must be `position: relative`.
+ */
+export const ResizeHandle: React.FC<ResizeHandleProps> = ({
+  edge,
+  size,
+  onResize,
+  minSize = 100,
+  maxSize = 1200,
+  label,
+  appearance = "hidden",
+}) => {
+  const startSizeRef = useRef(0);
+
+  const onDrag = (delta: number) => {
+    // Dragging the top or left edge grows the box in the opposite direction
+    // to the pointer movement.
+    const effectiveDelta = edge === "top" || edge === "left" ? -delta : delta;
+    onResize(
+      Math.max(
+        minSize,
+        Math.min(maxSize, startSizeRef.current + effectiveDelta),
+      ),
+    );
+  };
+
+  const direction =
+    edge === "left" || edge === "right" ? "horizontal" : "vertical";
+
+  const { isResizing, handleMouseDown } = useResizeDrag({ onDrag, direction });
+
+  return (
+    <button
+      // Kept out of the tab order: the panels either side are the real targets.
+      tabIndex={-1}
+      type="button"
+      aria-label={label ?? `Resize from ${edge}`}
+      // Ancestors can style themselves against an active resize (e.g. a
+      // panel highlighting the dragged edge) via :has() on these.
+      data-resizing={isResizing}
+      data-resize-edge={edge}
+      onMouseDown={(event) => {
+        startSizeRef.current = size;
+        handleMouseDown(event);
+      }}
+      className={handleStyle({ isResizing, direction, appearance })}
+      style={positionStyle(edge)}
+    />
+  );
+};

--- a/libs/@hashintel/petrinaut/src/ui/resize/use-resize-drag.ts
+++ b/libs/@hashintel/petrinaut/src/ui/resize/use-resize-drag.ts
@@ -1,3 +1,7 @@
+/**
+ * @layerRoot ui.resize
+ * @role Drag-resize primitives — the mouse-drag hook and the edge handle built on it
+ */
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { useLatest } from "../../react/hooks/use-latest";

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel/ai-assistant-contents.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel/ai-assistant-contents.tsx
@@ -1,17 +1,11 @@
-import {
-  memo,
-  type PointerEvent as ReactPointerEvent,
-  type RefObject,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
+import { memo, type RefObject, useEffect, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 
 import { Button } from "@hashintel/ds-components";
 import { css, cva } from "@hashintel/ds-helpers/css";
 
 import { AiAssistantIcon } from "../../../../components/ai-assistant-icon";
+import { ResizeHandle } from "../../../../resize/resize-handle";
 import { getMessageRenderItems } from "./ai-assistant-contents/get-message-render-items";
 import {
   PromptChips,
@@ -76,31 +70,14 @@ const shellStyle = css({
   },
 });
 
-const resizeHandleStyle = css({
+// Tracks the card's inset within the padded shell, so the resize handle
+// straddles the card's visible left border rather than the shell edge.
+const resizeAnchorStyle = css({
   position: "absolute",
   top: "2",
   bottom: "2",
-  left: "0",
-  width: "[10px]",
-  cursor: "ew-resize",
-  zIndex: "[1]",
-  touchAction: "none",
-  _before: {
-    content: '""',
-    position: "absolute",
-    top: "[12px]",
-    bottom: "[12px]",
-    left: "[4px]",
-    width: "[2px]",
-    borderRadius: "full",
-    backgroundColor: "[transparent]",
-    transition: "[background-color 120ms ease-out]",
-  },
-  _hover: {
-    _before: {
-      backgroundColor: "neutral.a40",
-    },
-  },
+  left: "2",
+  width: "[0]",
 });
 
 const cardStyle = css({
@@ -452,30 +429,6 @@ export const AiAssistantContents = ({
     handlersRef.current = { onInteractiveToolSubmit, onSelectToolTarget };
   });
 
-  const onResizeStart = (event: ReactPointerEvent<HTMLDivElement>) => {
-    event.preventDefault();
-    const startX = event.clientX;
-    const startWidth = assistantWidth;
-    const maxWidth = Math.min(window.innerWidth - 32, 720);
-
-    const onPointerMove = (moveEvent: PointerEvent) => {
-      setAssistantWidth(
-        Math.min(
-          Math.max(startWidth + startX - moveEvent.clientX, 320),
-          maxWidth,
-        ),
-      );
-    };
-
-    const onPointerUp = () => {
-      window.removeEventListener("pointermove", onPointerMove);
-      window.removeEventListener("pointerup", onPointerUp);
-    };
-
-    window.addEventListener("pointermove", onPointerMove);
-    window.addEventListener("pointerup", onPointerUp);
-  };
-
   useEffect(() => {
     inputRef.current?.focus();
   }, []);
@@ -520,12 +473,20 @@ export const AiAssistantContents = ({
       style={{ right: rightOffset, width: assistantWidth }}
       aria-label="AI assistant"
     >
-      <div
-        aria-label="Resize AI assistant"
-        className={resizeHandleStyle}
-        onPointerDown={onResizeStart}
-        role="separator"
-      />
+      {/* Zero-width anchor on the card's left edge: the handle must straddle
+          the visible card border, but the card clips overflow and the shell's
+          padding pushes the shell edge away from it. */}
+      <div className={resizeAnchorStyle}>
+        <ResizeHandle
+          edge="left"
+          appearance="line"
+          size={assistantWidth}
+          onResize={setAssistantWidth}
+          minSize={320}
+          maxSize={720}
+          label="Resize AI assistant"
+        />
+      </div>
       <div className={cardStyle}>
         <div className={headerStyle}>
           <div className={tabStyle({ active: true })}>AI</div>


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

One shared edge-resize implementation for the package. Adds the generic `ResizeHandle` primitive (a drag handle around the existing `useResizeDrag`, with min/max clamping and two visual appearances) and moves the package's two hand-rolled copies onto it. Bottom of the Notebook view stack, but independent of it: everything here is existing-UI refactoring plus one new component.

## 🔗 Related links

- [FE-1541](https://linear.app/hash/issue/FE-1541/petrinaut-reuse-the-resizehandle-primitive-in-glasspanel) _(internal)_

## 🔍 What does this change?

- `ui/resize/resize-handle.tsx`: the primitive — edge (`top`/`bottom`/`left`/`right`), controlled `size` with min/max clamping, roving-tab-order-friendly (`tabIndex={-1}`), and an `appearance` prop: `"hidden"` tints the strip on hover, `"line"` shows a centred pill; both turn blue while resizing. It exposes `data-resizing`/`data-resize-edge` so ancestors can style themselves against an active drag with `:has()`.
- GlassPanel drops its inline handle (styles, positioning switch, drag wiring) and renders the primitive; its dragged-edge border highlight now derives from the handle's data attributes via `:has()`. The LeftSideBar, PropertiesPanel, and BottomPanel ride this unchanged.
- The AI assistant panel drops its hand-rolled pointer-drag path for the primitive with the `line` appearance, keeping its hover-pill affordance. Its shell already clamps to the viewport in CSS, so a static `maxSize` replaces the per-drag window-width computation.
- A layer declaration for `ui/resize` in the architecture docs.

Net −162 lines: three implementations become one.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing
  - behaviour-preserving refactor of unreleased-alongside code; the Notebook stack above carries the release changeset

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

No unit tests — the primitive is DOM-drag behaviour. Verified by driving the browser: all three GlassPanel-backed panels resize with the dragged-edge highlight reacting, and the AI panel resizes with exact pixel deltas through its new handle.

## ❓ How to test this?

1. `yarn workspace @hashintel/petrinaut storybook`
2. In any editor story, drag the sidebar, properties, and bottom panel edges — the panel border should highlight while dragging.
3. In the `WithAiAssistant` story, open the assistant and drag its left edge — a pill line shows on hover and while resizing.
