### PR TITLE
FE-1549: Rotate sweep parameter draws by a seed-derived shift

### DIFF
--- a/.changeset/seeded-sweep-draws.md
+++ b/.changeset/seeded-sweep-draws.md
@@ -1,0 +1,5 @@
+---
+"@hashintel/petrinaut": patch
+---
+
+Range sweeps rotate each axis's low-discrepancy parameter draws by a seed-derived shift (Cranley–Patterson), so draws are unbiased over the seed and experiments with different seeds explore different value sequences — prefix stability and the selection cache are unaffected.

--- a/.changeset/seeded-sweep-draws.md
+++ b/.changeset/seeded-sweep-draws.md
@@ -2,4 +2,4 @@
 "@hashintel/petrinaut": patch
 ---
 
-Range sweeps rotate each axis's low-discrepancy parameter draws by a seed-derived shift (Cranley–Patterson), so draws are unbiased over the seed and experiments with different seeds explore different value sequences — prefix stability and the selection cache are unaffected.
+Range sweeps rotate each axis's low-discrepancy parameter draws by a seed-derived shift, so experiments with different seeds explore different value sequences.

--- a/libs/@hashintel/petrinaut/docs/experiments.md
+++ b/libs/@hashintel/petrinaut/docs/experiments.md
@@ -68,7 +68,7 @@ A sweep computes **what you have selected**. The results drawer grows a **Parame
 
 Move a slider and compute immediately restarts on the new selection, like a raytracer dropping its rays when the camera moves. Every position you have visited keeps its results: narrowing a range, collapsing to a point, or sliding back to an earlier value restores its runs and distributions instantly, and refinement resumes where it left off.
 
-Every selection uses the same seed sequence (common random numbers), and a run's parameter draw depends only on its position in the sequence, so differences you see between selections come from the parameters, not from sampling luck.
+Every selection uses the same seed sequence (common random numbers), and a run's parameter draw depends only on the experiment's seed and the run's position in the sequence, so differences you see between selections come from the parameters, not from sampling luck — while experiments with different seeds explore their own value sequences.
 
 #### The surface view
 

--- a/libs/@hashintel/petrinaut/src/react/experiments/parameter-grid.test.ts
+++ b/libs/@hashintel/petrinaut/src/react/experiments/parameter-grid.test.ts
@@ -201,30 +201,56 @@ describe("selections and regions", () => {
 describe("sweepRunFraction", () => {
   it("is prefix-stable: a run's draw never depends on how many runs exist", () => {
     const first = Array.from({ length: 8 }, (_, index) =>
-      sweepRunFraction(index, 0),
+      sweepRunFraction(7, index, 0),
     );
     const extended = Array.from({ length: 25 }, (_, index) =>
-      sweepRunFraction(index, 0),
+      sweepRunFraction(7, index, 0),
     );
     expect(extended.slice(0, 8)).toEqual(first);
   });
 
-  it("spreads early runs across the unit interval", () => {
-    const fractions = Array.from({ length: 8 }, (_, index) =>
-      sweepRunFraction(index, 0),
-    );
-    expect(Math.min(...fractions)).toBeLessThan(0.2);
-    expect(Math.max(...fractions)).toBeGreaterThan(0.8);
+  it("spreads early runs across the unit interval, whatever the seed", () => {
+    for (const seed of [0, 7, 123_456, 2 ** 31 - 1]) {
+      const fractions = Array.from({ length: 8 }, (_, index) =>
+        sweepRunFraction(seed, index, 0),
+      );
+      expect(Math.min(...fractions)).toBeLessThan(0.2);
+      expect(Math.max(...fractions)).toBeGreaterThan(0.8);
+      for (const fraction of fractions) {
+        expect(fraction).toBeGreaterThanOrEqual(0);
+        expect(fraction).toBeLessThan(1);
+      }
+    }
   });
 
   it("draws different axes from different sequences", () => {
     const xDraws = Array.from({ length: 6 }, (_, index) =>
-      sweepRunFraction(index, 0),
+      sweepRunFraction(7, index, 0),
     );
     const yDraws = Array.from({ length: 6 }, (_, index) =>
-      sweepRunFraction(index, 1),
+      sweepRunFraction(7, index, 1),
     );
     expect(xDraws).not.toEqual(yDraws);
+  });
+
+  it("reproduces exactly for the same seed", () => {
+    const first = Array.from({ length: 12 }, (_, index) =>
+      sweepRunFraction(42, index, 0),
+    );
+    const again = Array.from({ length: 12 }, (_, index) =>
+      sweepRunFraction(42, index, 0),
+    );
+    expect(again).toEqual(first);
+  });
+
+  it("draws a different value sequence per experiment seed", () => {
+    const seedA = Array.from({ length: 6 }, (_, index) =>
+      sweepRunFraction(1, index, 0),
+    );
+    const seedB = Array.from({ length: 6 }, (_, index) =>
+      sweepRunFraction(2, index, 0),
+    );
+    expect(seedA).not.toEqual(seedB);
   });
 });
 

--- a/libs/@hashintel/petrinaut/src/react/experiments/parameter-grid.ts
+++ b/libs/@hashintel/petrinaut/src/react/experiments/parameter-grid.ts
@@ -241,20 +241,43 @@ function radicalInverse(index: number, base: number): number {
 }
 
 /**
+ * A seed-derived fraction in [0, 1): each axis's Cranley–Patterson shift.
+ * `Math.imul` keeps every product in 32 bits — plain `*` would round through
+ * f64 and diverge across engines.
+ */
+/* eslint-disable no-bitwise -- a 32-bit hash is bit manipulation by definition */
+function axisShift(seed: number, axisIndex: number): number {
+  let hash =
+    (Math.imul(seed | 0, 0x9e3779b1) ^ Math.imul(axisIndex + 1, 0x85ebca6b)) >>>
+    0;
+  hash = Math.imul(hash ^ (hash >>> 15), 0x2c1b3c6d) >>> 0;
+  hash = Math.imul(hash ^ (hash >>> 13), 0x297a2d39) >>> 0;
+  hash ^= hash >>> 16;
+  return (hash >>> 0) / 4_294_967_296;
+}
+/* eslint-enable no-bitwise */
+
+/**
  * Where run `globalRunIndex` falls along ranged axis `axisIndex`, in [0, 1):
  * a per-axis low-discrepancy sequence (radical inverse in a distinct prime
- * base per axis), so any prefix of runs covers every range near-uniformly and
- * jointly. Prefix-stable in the run index — a ladder batch extends the exact
- * sequence earlier batches drew from, so cached runs never go stale.
+ * base per axis), rotated by a seed-derived shift (Cranley–Patterson). Any
+ * prefix of runs covers every range near-uniformly and jointly; the rotation
+ * makes the draws unbiased over the seed and gives every experiment seed its
+ * own value sequence. Prefix-stable — a draw depends only on the seed, the
+ * axis, and the run index — so a ladder batch extends the exact sequence
+ * earlier batches drew from, and cached runs never go stale.
  */
 export function sweepRunFraction(
+  seed: number,
   globalRunIndex: number,
   axisIndex: number,
 ): number {
-  return radicalInverse(
-    globalRunIndex + 1,
-    HALTON_BASES[axisIndex % HALTON_BASES.length]!,
-  );
+  const fraction =
+    radicalInverse(
+      globalRunIndex + 1,
+      HALTON_BASES[axisIndex % HALTON_BASES.length]!,
+    ) + axisShift(seed, axisIndex);
+  return fraction >= 1 ? fraction - 1 : fraction;
 }
 
 function mergeDistributionBins(

--- a/libs/@hashintel/petrinaut/src/react/experiments/sweep-session.ts
+++ b/libs/@hashintel/petrinaut/src/react/experiments/sweep-session.ts
@@ -212,9 +212,11 @@ export function sweepSelectionMidValues(
  * indices `[from, target)`, or undefined when every axis is a point. Each
  * ranged axis draws continuously inside its selected value interval — the
  * quantized positions bound the interval, they do not grid it — via the
- * axis's own low-discrepancy sequence, prefix-stable in the run index.
+ * axis's own seed-shifted low-discrepancy sequence, prefix-stable in the
+ * run index.
  */
 export function sweepRangeRuns(
+  seed: number,
   axes: readonly ExperimentParameterAxis[],
   selection: SweepSelection,
   from: number,
@@ -246,7 +248,8 @@ export function sweepRangeRuns(
     const globalIndex = from + localIndex;
     const parameterValues: Record<string, string> = {};
     for (const { axis, axisIndex, low, high } of ranged) {
-      const raw = low + sweepRunFraction(globalIndex, axisIndex) * (high - low);
+      const raw =
+        low + sweepRunFraction(seed, globalIndex, axisIndex) * (high - low);
       parameterValues[axis.identifier] = String(
         axis.integer ? Math.round(raw) : Number(raw.toPrecision(12)),
       );
@@ -332,6 +335,7 @@ export function createSweepSession(
     };
 
     const runs = sweepRangeRuns(
+      seed,
       axes,
       selection,
       snapshot.runsCompleted,

--- a/libs/@local/petrinaut-arch-docs/content/experiments/parameter-sweeps.mdx
+++ b/libs/@local/petrinaut-arch-docs/content/experiments/parameter-sweeps.mdx
@@ -21,8 +21,11 @@ precomputed for cameras nobody is looking through.
 A **point** selection runs the experiment at that value. A **range**
 selection runs one stochastic experiment over the ranges: each run carries
 its own drawn value per ranged parameter (`sweepRangeRuns`), low-discrepancy
-across the selected value interval and prefix-stable in the global run index
-— the quantized positions bound the interval, they do not grid it. One
+across the selected value interval, rotated by a seed-derived shift
+(Cranley–Patterson, so draws are unbiased over the seed and each experiment
+seed explores its own sequence) and prefix-stable in the seed, axis, and
+global run index — the quantized positions bound the interval, they do not
+grid it. One
 selection is one experiment: full worker-pool parallelism, and the metric
 stream is the experiment's own, so the distribution over the region streams
 from the first frames and sharpens as runs land.


### PR DESCRIPTION
> [!IMPORTANT]
> **Experimental**
> Behind the **Parameter sweeps** feature flag.

## Summary

Before this PR, range sweeps drew each run's parameter values from a bare per-axis Halton sequence. Every experiment explored the identical value sequence regardless of its seed. Deterministic low-discrepancy points are not exchangeable random samples.

Each axis's draws are now rotated by a seed-derived Cranley–Patterson shift. Draws are unbiased over the seed. They keep the low-discrepancy convergence, the even early coverage, and prefix stability.

## Links

- Ticket [FE-1549](https://linear.app/hash/issue/FE-1549)
- Docs [Parameter sweeps](https://petrinaut-docs-git-cf-fe-1549-randomize-sweep-parameter-65faa0.stage.hash.ai/architecture/react/experiments/parameter-sweeps)
- Docs [Experiments](https://github.com/hashintel/hash/blob/cf/fe-1549-randomize-sweep-parameter-draws-with-a-seed-derived-shift/libs/@hashintel/petrinaut/docs/experiments.md)

## Changes

#### Core

- `sweepRunFraction` takes the experiment seed
  > Rotates the radical-inverse fraction by a per-axis shift, modulo 1.
  > Shift is a 32-bit `Math.imul` hash of the seed and the axis index.
- `sweepRangeRuns` threads the seed through
  > Sweep session passes its experiment seed.
  > A draw depends only on the seed, the axis, and the global run index.
  > Ladder batches still extend the same sequence and the selection cache stays valid.

## Test coverage

- `parameter-grid.test.ts`:
  > Extends the `sweepRunFraction` suite: prefix stability, unit-interval spread across seeds, per-axis distinctness, exact reproduction for one seed, distinct sequences across seeds.
- Existing `sweep-session.test.ts` range-draw assertions:
  > Now exercise the seeded path.

## How to test

- Open [Petrinaut preview](https://petrinaut-git-cf-fe-1549-randomize-sweep-parameter-draws-d633cb.stage.hash.ai) on Vercel
- Viewport controls > Settings > Simulation > Parameter sweeps
- Load example > SIR
- Simulate > Experiments > Create
- Pick scenario, Sweep one numeric parameter, set min and max, Run
- Leave parameter on Range
- Expect streamed distribution covering the interval from the first rung
- Create second experiment over the same range with a different seed
- Expect different per-run draws
- Re-run with the same seed
- Expect identical draws
