### PR TITLE
SRE-979: Split the type-system Rust crate and TypeScript package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,7 @@ blocks/**/.env
 **/build
 **/target
 **/pkg
+libs/@blockprotocol/type-system/typescript/src/generated
 
 # vscode config
 **/.vscode/settings.json

--- a/libs/@blockprotocol/type-system/rust/Cargo.toml
+++ b/libs/@blockprotocol/type-system/rust/Cargo.toml
@@ -74,9 +74,6 @@ wasm-bindgen-test = { workspace = true }
 
 
 [package.metadata.sync.turborepo]
-extra-dev-dependencies = [
-    { name = "@local/tsconfig", version = "workspace:*" },
-]
 ignore-dev-dependencies = [
     "hash-graph-test-data",
 ]

--- a/libs/@blockprotocol/type-system/rust/package.json
+++ b/libs/@blockprotocol/type-system/rust/package.json
@@ -4,32 +4,12 @@
   "private": true,
   "description": "Definitions of types within the Block Protocol Type System",
   "license": "MIT OR Apache-2.0",
-  "type": "module",
-  "typesVersions": {
-    "*": {
-      "*": [
-        "./pkg/type-system.d.ts"
-      ],
-      "types": [
-        "./types/index.snap.d.ts"
-      ],
-      "wasm": [
-        "./pkg/type-system_bg.wasm.d.ts"
-      ]
-    }
-  },
-  "exports": {
-    ".": "./pkg/type-system.js",
-    "./types": "./types/index.snap.js",
-    "./wasm": "./pkg/type-system_bg.wasm"
-  },
   "scripts": {
     "build:types": "INSTA_UPDATE=always mise exec --env dev cargo:cargo-insta -- cargo-insta test --features codegen --test codegen",
     "build:wasm": "mise exec --env prod github:wasm-bindgen/wasm-pack -- wasm-pack build --target web --out-name type-system --scope blockprotocol --release . && rm pkg/package.json",
     "doc:dependency-diagram": "cargo run -p hash-repo-chores -- dependency-diagram --output docs/dependency-diagram.mmd --root type-system --root-deps-and-dependents --link-mode non-roots --include-dev-deps --include-build-deps --logging-console-level info",
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",
-    "lint:tsc": "tsc --noEmit",
     "test:unit": "cargo hack nextest run --feature-powerset --all-targets && cargo test --all-features --doc"
   },
   "dependencies": {
@@ -38,8 +18,6 @@
     "@rust/hash-graph-temporal-versioning": "workspace:*"
   },
   "devDependencies": {
-    "@local/tsconfig": "workspace:*",
-    "@rust/hash-codegen": "workspace:*",
-    "typescript": "5.9.3"
+    "@rust/hash-codegen": "workspace:*"
   }
 }

--- a/libs/@blockprotocol/type-system/rust/tests/codegen.rs
+++ b/libs/@blockprotocol/type-system/rust/tests/codegen.rs
@@ -30,7 +30,10 @@ fn index() -> io::Result<()> {
     collection.make_branded::<knowledge::entity::id::DraftId>();
     collection.make_branded::<knowledge::entity::id::EntityEditionId>();
 
-    let settings = TypeScriptGeneratorSettings::default();
+    // Importing `Brand` from `@blockprotocol/type-system` would be circular: that package
+    // re-exports this file.
+    let settings =
+        TypeScriptGeneratorSettings::default().with_brand_module("../pkg/type-system.js");
     let mut generator = TypeScriptGenerator::new(&settings, &collection);
 
     generator.add_import_declaration("@rust/hash-codec/types", ["Real"]);

--- a/libs/@blockprotocol/type-system/rust/types/index.snap.d.ts
+++ b/libs/@blockprotocol/type-system/rust/types/index.snap.d.ts
@@ -1,7 +1,7 @@
 // This file was generated from `libs/@blockprotocol/type-system/rust/tests/codegen.rs`
 
 import type { Real } from "@rust/hash-codec/types";
-import type { Brand } from "@blockprotocol/type-system-rs";
+import type { Brand } from "../pkg/type-system.js";
 export type DraftId = Brand<string, "DraftId">;
 export type EntityEditionId = Brand<string, "EntityEditionId">;
 export type EntityUuid = Brand<string, "EntityUuid">;

--- a/libs/@blockprotocol/type-system/typescript/package.json
+++ b/libs/@blockprotocol/type-system/typescript/package.json
@@ -41,10 +41,11 @@
   "scripts": {
     "build": "yarn clean && rollup -c --bundleConfigAsCjs",
     "clean": "rimraf ./dist/",
+    "codegen": "node scripts/copy-generated.ts",
     "compressed-size": "yarn build && find dist -iname '*.js' -exec npx terser@latest --compress --mangle --output {} -- {} \\;",
     "fix:eslint": "eslint --fix .",
     "lint:eslint": "eslint --report-unused-disable-directives .",
-    "lint:tsc": "tsc --noEmit",
+    "lint:tsc": "tsc --noEmit && tsc --noEmit --project tsconfig.generated.json",
     "postpublish": "PACKAGE_DIR=$(pwd) yarn workspace @local/repo-chores exe scripts/postpublish.ts",
     "prepack": "node ../../../../scripts/check-package-payload.mjs",
     "prepublishOnly": "turbo run build && tsx scripts/prepublish.ts && yarn build",
@@ -52,6 +53,7 @@
   },
   "dependencies": {
     "@blockprotocol/type-system-rs": "workspace:^",
+    "@rust/hash-codec": "workspace:^",
     "semver": "7.7.3",
     "uuid": "14.0.0"
   },

--- a/libs/@blockprotocol/type-system/typescript/rollup.config.js
+++ b/libs/@blockprotocol/type-system/typescript/rollup.config.js
@@ -53,6 +53,18 @@ const rolls = (fmt, env) => ({
           path.resolve("../rust/pkg/type-system_bg.wasm.d.ts"),
           path.resolve("dist/wasm/type-system.wasm.d.ts"),
         );
+
+        // `src/generated` holds declaration files, which TypeScript passes over rather than
+        // emitting. Without this copy the re-exports in the emitted `main.d.ts` dangle.
+        const generatedDir = path.resolve(outdir(fmt, env), "generated");
+        fs.mkdirSync(generatedDir, { recursive: true });
+
+        for (const file of fs.readdirSync(path.resolve("src/generated"))) {
+          fs.copyFileSync(
+            path.resolve("src/generated", file),
+            path.join(generatedDir, file),
+          );
+        }
       },
     },
   ],

--- a/libs/@blockprotocol/type-system/typescript/scripts/copy-generated.ts
+++ b/libs/@blockprotocol/type-system/typescript/scripts/copy-generated.ts
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+
+/**
+ * Copies the crate's generated declarations into the package.
+ *
+ * They have to live inside the package: relative import paths are carried over into `dist`
+ * verbatim, so a path pointing outside `src` no longer resolves once it has been emitted.
+ *
+ * The two files reference each other by a path relative to the crate, which no longer holds once
+ * they sit next to each other, so those references are rewritten on the way in.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const crateRoot = path.join(packageRoot, "..", "rust");
+const targetDir = path.join(packageRoot, "src", "generated");
+
+const sources = [
+  {
+    from: path.join(crateRoot, "pkg", "type-system.d.ts"),
+    to: path.join(targetDir, "type-system.d.ts"),
+    rewrite: { "../types/index.snap.js": "./types.js" },
+  },
+  {
+    from: path.join(crateRoot, "types", "index.snap.d.ts"),
+    to: path.join(targetDir, "types.d.ts"),
+    rewrite: { "../pkg/type-system.js": "./type-system.js" },
+  },
+];
+
+fs.mkdirSync(targetDir, { recursive: true });
+
+for (const { from, to, rewrite } of sources) {
+  let content = fs.readFileSync(from, "utf8");
+
+  for (const [before, after] of Object.entries(rewrite)) {
+    content = content.replaceAll(before, after);
+  }
+
+  fs.writeFileSync(to, content, "utf8");
+
+  console.log(
+    `${path.relative(packageRoot, from)} -> ${path.relative(packageRoot, to)}`,
+  );
+}

--- a/libs/@blockprotocol/type-system/typescript/scripts/copy-generated.ts
+++ b/libs/@blockprotocol/type-system/typescript/scripts/copy-generated.ts
@@ -21,7 +21,11 @@ const packageRoot = path.resolve(
 const crateRoot = path.join(packageRoot, "..", "rust");
 const targetDir = path.join(packageRoot, "src", "generated");
 
-const sources = [
+const sources: {
+  from: string;
+  to: string;
+  rewrite: Record<string, string>;
+}[] = [
   {
     from: path.join(crateRoot, "pkg", "type-system.d.ts"),
     to: path.join(targetDir, "type-system.d.ts"),

--- a/libs/@blockprotocol/type-system/typescript/scripts/prepublish.ts
+++ b/libs/@blockprotocol/type-system/typescript/scripts/prepublish.ts
@@ -8,43 +8,6 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const packageRoot = path.resolve(__dirname, "..");
 
-const getFilesOnly = (directoryPath: string) => {
-  const files: string[] = [];
-
-  const items = fs.readdirSync(directoryPath);
-
-  for (const item of items) {
-    const fullPath = path.join(directoryPath, item);
-    const stat = fs.statSync(fullPath);
-
-    if (stat.isDirectory()) {
-      // we need different logic for src/native vs src/
-      continue;
-    }
-
-    files.push(fullPath);
-  }
-
-  return files;
-};
-
-const updateImportReferences = (
-  directoryPath: string,
-  importMappings: Record<string, string>,
-) => {
-  const files = getFilesOnly(directoryPath);
-
-  for (const file of files) {
-    let content = fs.readFileSync(file, "utf8");
-
-    for (const [oldImport, newImport] of Object.entries(importMappings)) {
-      content = content.replaceAll(oldImport, newImport);
-    }
-
-    fs.writeFileSync(file, content, "utf8");
-  }
-};
-
 const updatePackageJson = () => {
   const packageJsonPath = path.join(packageRoot, "package.json");
   const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as {
@@ -62,73 +25,32 @@ const updatePackageJson = () => {
   );
 };
 
-const vendorInUtilityTypes = (content: string) => {
-  return content.replace(
-    'import type { Real } from "@rust/hash-codec/types";',
-    "type Real = number;",
-  );
+/**
+ * `Real` is the only type the generated declarations pull from another crate. Inlining it keeps the
+ * published package free of a dependency on the unpublished `@rust/hash-codec`.
+ */
+const inlineUtilityTypes = () => {
+  const generatedDir = path.join(packageRoot, "src", "generated");
+
+  for (const file of fs.readdirSync(generatedDir)) {
+    const filePath = path.join(generatedDir, file);
+
+    fs.writeFileSync(
+      filePath,
+      fs
+        .readFileSync(filePath, "utf8")
+        .replace(
+          'import type { Real } from "@rust/hash-codec/types";',
+          "type Real = number;",
+        ),
+      "utf8",
+    );
+  }
 };
 
 const main = () => {
-  console.log(
-    "Removing @blockprotocol/type-system-rs dependency from published package...",
-  );
-
   try {
-    // 1. Create type-system-rs directory in src/native to hold vendored-in files
-    const typeSystemRsDir = path.join(
-      packageRoot,
-      "src",
-      "native",
-      "type-system-rs",
-    );
-
-    fs.mkdirSync(typeSystemRsDir, { recursive: true });
-
-    // 2. Copy @type-system.d.ts to src/native/type-system-rs/type-system.d.ts
-    const sourceTypeSystemPath = path.join(
-      packageRoot,
-      "..",
-      "rust",
-      "pkg",
-      "type-system.d.ts",
-    );
-    const targetTypeSystemPath = path.join(typeSystemRsDir, "type-system.d.ts");
-
-    const typeSystemContent = fs.readFileSync(sourceTypeSystemPath, "utf8");
-    const vendoredTypeSystemContent = vendorInUtilityTypes(typeSystemContent);
-    fs.writeFileSync(targetTypeSystemPath, vendoredTypeSystemContent, "utf8");
-
-    // 3. Copy @index.snap.d.ts to src/native/type-system-rs/types.d.ts
-    const sourceTypesPath = path.join(
-      packageRoot,
-      "..",
-      "rust",
-      "types",
-      "index.snap.d.ts",
-    );
-    const targetTypesPath = path.join(typeSystemRsDir, "types.d.ts");
-
-    const typesContent = fs.readFileSync(sourceTypesPath, "utf8");
-    const vendoredTypesContent = vendorInUtilityTypes(typesContent);
-    fs.writeFileSync(targetTypesPath, vendoredTypesContent, "utf8");
-
-    // 4. Update import references in src/native
-    updateImportReferences(path.join(packageRoot, "src", "native"), {
-      '"@blockprotocol/type-system-rs"': '"./type-system-rs/type-system.d.ts"',
-      "@blockprotocol/type-system-rs/types": "./type-system-rs/types.d.ts",
-    });
-
-    // 5. Update import references in src (but not subfolders)
-    console.log("Updating import references in src...");
-    updateImportReferences(path.join(packageRoot, "src"), {
-      '"@blockprotocol/type-system-rs"':
-        '"./native/type-system-rs/type-system.d.ts"',
-      "@blockprotocol/type-system-rs/types":
-        "./native/type-system-rs/types.d.ts",
-    });
-
-    // 6. Update package.json
+    inlineUtilityTypes();
     updatePackageJson();
 
     console.log("Prepublish script completed successfully!");

--- a/libs/@blockprotocol/type-system/typescript/src/main-slim.ts
+++ b/libs/@blockprotocol/type-system/typescript/src/main-slim.ts
@@ -1,9 +1,9 @@
 import type { EntityMetadata } from "./native/entity.js";
 
 export { atLeastOne } from "./common.js";
-export * from "./native.js";
 export type * from "./generated/type-system.js";
 export type * from "./generated/types.js";
+export * from "./native.js";
 
 /**
  * This explicit re-export is necessary as we're overwriting EntityMetadata from the crate's generated declarations,

--- a/libs/@blockprotocol/type-system/typescript/src/main-slim.ts
+++ b/libs/@blockprotocol/type-system/typescript/src/main-slim.ts
@@ -2,11 +2,11 @@ import type { EntityMetadata } from "./native/entity.js";
 
 export { atLeastOne } from "./common.js";
 export * from "./native.js";
-export type * from "@blockprotocol/type-system-rs";
-export type * from "@blockprotocol/type-system-rs/types";
+export type * from "./generated/type-system.js";
+export type * from "./generated/types.js";
 
 /**
- * This explicit re-export is necessary as we're overwriting EntityMetadata from @blockprotocol/type-system-rs,
+ * This explicit re-export is necessary as we're overwriting EntityMetadata from the crate's generated declarations,
  * and the explicit re-export removes the ambiguity of which EntityMetadata should be exported (things defined in this module take priority)
  */
 export type { EntityMetadata };

--- a/libs/@blockprotocol/type-system/typescript/src/main.ts
+++ b/libs/@blockprotocol/type-system/typescript/src/main.ts
@@ -5,9 +5,9 @@
 import type { EntityMetadata } from "./native/entity.js";
 
 export { atLeastOne, mustHaveAtLeastOne } from "./common.js";
-export * from "./native.js";
 export type * from "./generated/type-system.js";
 export type * from "./generated/types.js";
+export * from "./native.js";
 
 /**
  * This explicit re-export is necessary as we're overwriting EntityMetadata from the crate's generated declarations,

--- a/libs/@blockprotocol/type-system/typescript/src/main.ts
+++ b/libs/@blockprotocol/type-system/typescript/src/main.ts
@@ -6,11 +6,11 @@ import type { EntityMetadata } from "./native/entity.js";
 
 export { atLeastOne, mustHaveAtLeastOne } from "./common.js";
 export * from "./native.js";
-export type * from "@blockprotocol/type-system-rs";
-export type * from "@blockprotocol/type-system-rs/types";
+export type * from "./generated/type-system.js";
+export type * from "./generated/types.js";
 
 /**
- * This explicit re-export is necessary as we're overwriting EntityMetadata from @blockprotocol/type-system-rs,
+ * This explicit re-export is necessary as we're overwriting EntityMetadata from the crate's generated declarations,
  * and the explicit re-export removes the ambiguity of which EntityMetadata should be exported from here (local exports take priority)
  */
 export type { EntityMetadata };

--- a/libs/@blockprotocol/type-system/typescript/src/native/data-type.ts
+++ b/libs/@blockprotocol/type-system/typescript/src/native/data-type.ts
@@ -1,4 +1,4 @@
-import type { DataType, VersionedUrl } from "@blockprotocol/type-system-rs";
+import type { DataType, VersionedUrl } from "../generated/type-system.js";
 
 export const DATA_TYPE_META_SCHEMA: DataType["$schema"] =
   "https://blockprotocol.org/types/modules/graph/0.3/schema/data-type";

--- a/libs/@blockprotocol/type-system/typescript/src/native/entity-type.ts
+++ b/libs/@blockprotocol/type-system/typescript/src/native/entity-type.ts
@@ -1,4 +1,4 @@
-import type { EntityType, VersionedUrl } from "@blockprotocol/type-system-rs";
+import type { EntityType, VersionedUrl } from "../generated/type-system.js";
 
 export const ENTITY_TYPE_META_SCHEMA: EntityType["$schema"] =
   "https://blockprotocol.org/types/modules/graph/0.3/schema/entity-type";

--- a/libs/@blockprotocol/type-system/typescript/src/native/entity.ts
+++ b/libs/@blockprotocol/type-system/typescript/src/native/entity.ts
@@ -15,12 +15,8 @@ import type {
   PropertyValueWithMetadata,
   PropertyWithMetadata,
   VersionedUrl,
-} from "@blockprotocol/type-system-rs";
-import type {
-  DraftId,
-  EntityUuid,
-  WebId,
-} from "@blockprotocol/type-system-rs/types";
+} from "../generated/type-system.js";
+import type { DraftId, EntityUuid, WebId } from "../generated/types.js";
 
 export type TypeIdsAndPropertiesForEntity = {
   entityTypeIds: [VersionedUrl, ...VersionedUrl[]];

--- a/libs/@blockprotocol/type-system/typescript/src/native/ontology-metadata.ts
+++ b/libs/@blockprotocol/type-system/typescript/src/native/ontology-metadata.ts
@@ -2,7 +2,7 @@ import type {
   DataTypeMetadata,
   EntityTypeMetadata,
   PropertyTypeMetadata,
-} from "@blockprotocol/type-system-rs";
+} from "../generated/type-system.js";
 
 export type OntologyElementMetadata =
   | EntityTypeMetadata

--- a/libs/@blockprotocol/type-system/typescript/src/native/property-type.ts
+++ b/libs/@blockprotocol/type-system/typescript/src/native/property-type.ts
@@ -4,7 +4,7 @@ import type {
   PropertyValueArray,
   PropertyValues,
   VersionedUrl,
-} from "@blockprotocol/type-system-rs";
+} from "../generated/type-system.js";
 
 export const PROPERTY_TYPE_META_SCHEMA: PropertyType["$schema"] =
   "https://blockprotocol.org/types/modules/graph/0.3/schema/property-type";

--- a/libs/@blockprotocol/type-system/typescript/src/native/url.ts
+++ b/libs/@blockprotocol/type-system/typescript/src/native/url.ts
@@ -6,11 +6,8 @@ import type {
   ParseVersionedUrlError,
   Result,
   VersionedUrl,
-} from "@blockprotocol/type-system-rs";
-import type {
-  BaseUrl,
-  OntologyTypeVersion,
-} from "@blockprotocol/type-system-rs/types";
+} from "../generated/type-system.js";
+import type { BaseUrl, OntologyTypeVersion } from "../generated/types.js";
 import type { SemVer } from "semver";
 
 /**

--- a/libs/@blockprotocol/type-system/typescript/tsconfig.generated.json
+++ b/libs/@blockprotocol/type-system/typescript/tsconfig.generated.json
@@ -1,12 +1,10 @@
 {
   "extends": "@local/tsconfig/legacy-base-tsconfig-to-refactor.json",
-  "files": ["pkg/type-system.d.ts"],
-  "include": ["types/**/*.d.ts"],
+  "include": ["src/generated/**/*.d.ts"],
   "compilerOptions": {
     "lib": ["DOM", "ES2024"],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-    "rootDir": "types",
     "skipLibCheck": false,
     "types": []
   }

--- a/libs/@blockprotocol/type-system/typescript/turbo.json
+++ b/libs/@blockprotocol/type-system/typescript/turbo.json
@@ -2,7 +2,8 @@
   "extends": ["//"],
   "tasks": {
     "codegen": {
-      "dependsOn": ["^build:types"]
+      "dependsOn": ["^build:types"],
+      "outputs": ["src/generated/**"]
     },
     "build": {
       "outputs": ["dist/**"]

--- a/libs/@local/codegen/src/typescript.rs
+++ b/libs/@local/codegen/src/typescript.rs
@@ -17,13 +17,33 @@ use crate::{
     },
 };
 
-#[derive(Default)]
 #[non_exhaustive]
 pub struct TypeScriptGeneratorSettings {
     allocator: Allocator,
+    brand_module: String,
 }
 
-#[expect(dead_code)]
+impl Default for TypeScriptGeneratorSettings {
+    fn default() -> Self {
+        Self {
+            allocator: Allocator::default(),
+            brand_module: "@blockprotocol/type-system".to_owned(),
+        }
+    }
+}
+
+impl TypeScriptGeneratorSettings {
+    /// Sets the module that `Brand` is imported from.
+    ///
+    /// Crates that are themselves re-exported by `@blockprotocol/type-system` have to point at the
+    /// declarations directly, as importing from the package would be circular.
+    #[must_use]
+    pub fn with_brand_module(mut self, module: impl Into<String>) -> Self {
+        self.brand_module = module.into();
+        self
+    }
+}
+
 pub struct TypeScriptGenerator<'a, 'c> {
     settings: &'a TypeScriptGeneratorSettings,
     collection: &'c TypeCollection,
@@ -185,7 +205,8 @@ impl<'a, 'c> TypeScriptGenerator<'a, 'c> {
             if definition.branded {
                 if !self.has_branded_types {
                     self.has_branded_types = true;
-                    self.add_import_declaration("@blockprotocol/type-system-rs", ["Brand"]);
+                    let brand_module = self.settings.brand_module.clone();
+                    self.add_import_declaration(&brand_module, ["Brand"]);
                 }
 
                 // This extends the `UserId` type by intersecting it with the `WebId` type. We

--- a/libs/@local/graph/authorization/Cargo.toml
+++ b/libs/@local/graph/authorization/Cargo.toml
@@ -58,6 +58,9 @@ workspace = true
 
 
 [package.metadata.sync.turborepo]
+extra-dependencies = [
+    { name = "@blockprotocol/type-system", version = "workspace:*" },
+]
 extra-dev-dependencies = [
     { name = "@local/tsconfig", version = "workspace:*" },
 ]

--- a/libs/@local/graph/authorization/package.json
+++ b/libs/@local/graph/authorization/package.json
@@ -24,6 +24,7 @@
     "test:unit": "mise run test:unit @rust/hash-graph-authorization --test-strategy=powerset -- --all-targets --filterset 'not kind(test) & not kind(bench)'"
   },
   "dependencies": {
+    "@blockprotocol/type-system": "workspace:*",
     "@blockprotocol/type-system-rs": "workspace:*",
     "@rust/error-stack": "workspace:*",
     "@rust/hash-codec": "workspace:*"

--- a/libs/@local/graph/authorization/tests/codegen.rs
+++ b/libs/@local/graph/authorization/tests/codegen.rs
@@ -15,7 +15,7 @@ fn index() -> io::Result<()> {
     let mut generator = TypeScriptGenerator::new(&settings, &collection);
 
     generator.add_import_declaration(
-        "@blockprotocol/type-system-rs/types",
+        "@blockprotocol/type-system",
         [
             "ActorId",
             "ActorType",
@@ -25,9 +25,9 @@ fn index() -> io::Result<()> {
             "OntologyTypeVersion",
             "RoleId",
             "WebId",
+            "VersionedUrl",
         ],
     );
-    generator.add_import_declaration("@blockprotocol/type-system-rs", ["VersionedUrl"]);
 
     for (type_id, _, type_definition) in collection.iter() {
         if type_definition

--- a/libs/@local/graph/authorization/types/index.snap.d.ts
+++ b/libs/@local/graph/authorization/types/index.snap.d.ts
@@ -1,7 +1,6 @@
 // This file was generated from `libs/@local/graph/authorization/tests/codegen.rs`
 
-import type { ActorId, ActorType, ActorGroupId, BaseUrl, EntityUuid, OntologyTypeVersion, RoleId, WebId } from "@blockprotocol/type-system-rs/types";
-import type { VersionedUrl } from "@blockprotocol/type-system-rs";
+import type { ActorId, ActorType, ActorGroupId, BaseUrl, EntityUuid, OntologyTypeVersion, RoleId, WebId, VersionedUrl } from "@blockprotocol/type-system";
 export type Effect = "permit" | "forbid";
 export interface Policy {
 	id: PolicyId;
@@ -11,7 +10,7 @@ export interface Policy {
 	actions: ActionName[];
 	resource: (ResourceConstraint | null);
 }
-import type { Brand } from "@blockprotocol/type-system-rs";
+import type { Brand } from "@blockprotocol/type-system";
 export type PolicyId = Brand<string, "PolicyId">;
 export interface ResolvedPolicy {
 	effect: Effect;

--- a/libs/@local/graph/store/Cargo.toml
+++ b/libs/@local/graph/store/Cargo.toml
@@ -57,6 +57,9 @@ workspace = true
 
 
 [package.metadata.sync.turborepo]
+extra-dependencies = [
+    { name = "@blockprotocol/type-system", version = "workspace:*" },
+]
 extra-dev-dependencies = [
     { name = "@local/tsconfig", version = "workspace:*" },
 ]

--- a/libs/@local/graph/store/package.json
+++ b/libs/@local/graph/store/package.json
@@ -23,6 +23,7 @@
     "test:unit": "mise run test:unit @rust/hash-graph-store"
   },
   "dependencies": {
+    "@blockprotocol/type-system": "workspace:*",
     "@blockprotocol/type-system-rs": "workspace:*",
     "@rust/error-stack": "workspace:*",
     "@rust/hash-codec": "workspace:*",

--- a/libs/@local/graph/store/tests/codegen.rs
+++ b/libs/@local/graph/store/tests/codegen.rs
@@ -18,7 +18,7 @@ fn index() -> io::Result<()> {
         "@rust/hash-graph-authorization/types",
         ["ActionName", "Effect", "PrincipalConstraint"],
     );
-    generator.add_import_declaration("@blockprotocol/type-system-rs/types", ["EntityEditionId"]);
+    generator.add_import_declaration("@blockprotocol/type-system", ["EntityEditionId"]);
 
     for (type_id, _, type_definition) in collection.iter() {
         if type_definition.module.starts_with("hash_graph_store") {

--- a/libs/@local/graph/store/types/index.snap.d.ts
+++ b/libs/@local/graph/store/types/index.snap.d.ts
@@ -1,7 +1,7 @@
 // This file was generated from `libs/@local/graph/store/tests/codegen.rs`
 
 import type { ActionName, Effect, PrincipalConstraint } from "@rust/hash-graph-authorization/types";
-import type { EntityEditionId } from "@blockprotocol/type-system-rs/types";
+import type { EntityEditionId } from "@blockprotocol/type-system";
 export interface CreateEntityPolicyParams {
 	name: string;
 	effect: Effect;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4233,12 +4233,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@blockprotocol/type-system-rs@workspace:libs/@blockprotocol/type-system/rust"
   dependencies:
-    "@local/tsconfig": "workspace:*"
     "@rust/error-stack": "workspace:*"
     "@rust/hash-codec": "workspace:*"
     "@rust/hash-codegen": "workspace:*"
     "@rust/hash-graph-temporal-versioning": "workspace:*"
-    typescript: "npm:5.9.3"
   languageName: unknown
   linkType: soft
 
@@ -4260,6 +4258,7 @@ __metadata:
     "@rollup/plugin-node-resolve": "npm:16.0.3"
     "@rollup/plugin-typescript": "npm:12.3.0"
     "@rollup/plugin-wasm": "npm:6.2.2"
+    "@rust/hash-codec": "workspace:^"
     "@types/node": "npm:22.18.13"
     "@types/react": "npm:19.2.14"
     "@types/semver": "npm:7.7.1"
@@ -14919,7 +14918,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@rust/hash-codec@workspace:*, @rust/hash-codec@workspace:libs/@local/codec":
+"@rust/hash-codec@workspace:*, @rust/hash-codec@workspace:^, @rust/hash-codec@workspace:libs/@local/codec":
   version: 0.0.0-use.local
   resolution: "@rust/hash-codec@workspace:libs/@local/codec"
   dependencies:
@@ -14996,6 +14995,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@rust/hash-graph-authorization@workspace:libs/@local/graph/authorization"
   dependencies:
+    "@blockprotocol/type-system": "workspace:*"
     "@blockprotocol/type-system-rs": "workspace:*"
     "@local/tsconfig": "workspace:*"
     "@rust/error-stack": "workspace:*"
@@ -15103,6 +15103,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@rust/hash-graph-store@workspace:libs/@local/graph/store"
   dependencies:
+    "@blockprotocol/type-system": "workspace:*"
     "@blockprotocol/type-system-rs": "workspace:*"
     "@local/tsconfig": "workspace:*"
     "@rust/error-stack": "workspace:*"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

`libs/@blockprotocol/type-system/rust` was both a Cargo crate and a JavaScript package. The JavaScript surface — `exports`, `typesVersions`, `tsconfig.json`, `lint:tsc` — moves to `@blockprotocol/type-system`, which now owns and re-exports the crate's generated declarations. The crate's `package.json` keeps only task and dependency wiring.

First of several splits. SRE-984 depends on them.

## 🔍 What does this change?

- `scripts/copy-generated.ts` copies the generated declarations into `src/generated` and rewrites how they reference each other
- `rollup.config.js` carries them into `dist/*/generated`, so the emitted re-exports resolve
- `tsconfig.generated.json` type-checks them with `skipLibCheck` off, as the crate's `tsconfig.json` did
- `with_brand_module` replaces a hardcoded module in the generator; `hash-graph-store` and `hash-graph-authorization` take their shared types from `@blockprotocol/type-system`

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] affected the execution graph, and the `turbo.json`'s have been updated to reflect this

## 🐾 Next steps

SRE-980, SRE-981, SRE-982, SRE-983, then SRE-984.

## ❓ How to test this?

1. `turbo run lint:tsc --filter=@blockprotocol/type-system`
2. `turbo run lint:tsc --filter=@blockprotocol/graph` — breaks if the re-exports do not resolve
3. `mise run sync:turborepo && git diff --exit-code '**/package.json'`
