### PR TITLE
SRE-982: Remove the graph API package's JavaScript surface

### DIFF
--- a/apps/hash-ai-worker-ts/package.json
+++ b/apps/hash-ai-worker-ts/package.json
@@ -63,7 +63,6 @@
     "@opentelemetry/api-logs": "0.220.0",
     "@opentelemetry/instrumentation": "0.220.0",
     "@opentelemetry/instrumentation-grpc": "0.220.0",
-    "@rust/hash-graph-api": "workspace:*",
     "@sentry/node": "10.64.0",
     "@temporalio/activity": "1.20.2",
     "@temporalio/common": "1.20.2",

--- a/apps/hash-ai-worker-ts/src/activities/flow-activities/generate-structural-query-action.ts
+++ b/apps/hash-ai-worker-ts/src/activities/flow-activities/generate-structural-query-action.ts
@@ -1,4 +1,3 @@
-import graphOpenApiSpec from "@rust/hash-graph-api/openapi.json" with { type: "json" };
 import dedent from "dedent";
 
 /**
@@ -13,6 +12,7 @@ import {
   getSimpleGraph,
   type SimpleEntityWithoutHref,
 } from "@local/hash-backend-utils/simplified-graph";
+import graphOpenApiSpec from "@local/hash-graph-client/openapi.json" with { type: "json" };
 import {
   queryEntitySubgraph,
   summarizeEntities,

--- a/libs/@local/graph/api/package.json
+++ b/libs/@local/graph/api/package.json
@@ -4,9 +4,6 @@
   "private": true,
   "description": "HASH Graph API",
   "license": "AGPL-3",
-  "exports": {
-    "./openapi.json": "./openapi/openapi.json"
-  },
   "scripts": {
     "codegen:generate-openapi-specs": "cargo run --bin openapi-spec-generator",
     "doc:dependency-diagram": "cargo run -p hash-repo-chores -- dependency-diagram --output docs/dependency-diagram.mmd --root hash-graph-api --root-deps-and-dependents --link-mode non-roots --include-dev-deps --include-build-deps --logging-console-level info",

--- a/libs/@local/graph/client/typescript/.gitignore
+++ b/libs/@local/graph/client/typescript/.gitignore
@@ -2,5 +2,6 @@
 .npmignore
 tsconfig.esm.json
 openapi.bundle.json
+openapi.json
 *.ts
 *.sh

--- a/libs/@local/graph/client/typescript/package.json
+++ b/libs/@local/graph/client/typescript/package.json
@@ -9,7 +9,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "rimraf dist && tsc --build tsconfig.build.json",
-    "codegen": "redocly bundle -o openapi.bundle.json ../../api/openapi/openapi.json && JAVA_OPTS='-Dlog.level=warn' openapi-generator-cli generate && rm openapi.bundle.json && fix-esm-import-path *.ts"
+    "codegen": "redocly bundle -o openapi.bundle.json ../../api/openapi/openapi.json && JAVA_OPTS='-Dlog.level=warn' openapi-generator-cli generate && rm openapi.bundle.json && fix-esm-import-path *.ts && cp ../../api/openapi/openapi.json openapi.json"
   },
   "dependencies": {
     "@openapitools/openapi-generator-cli": "2.38.0",

--- a/libs/@local/graph/client/typescript/turbo.json
+++ b/libs/@local/graph/client/typescript/turbo.json
@@ -21,7 +21,8 @@
         "common.ts",
         "configuration.ts",
         "git_push.sh",
-        "index.ts"
+        "index.ts",
+        "openapi.json"
       ]
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -486,7 +486,6 @@ __metadata:
     "@opentelemetry/api-logs": "npm:0.220.0"
     "@opentelemetry/instrumentation": "npm:0.220.0"
     "@opentelemetry/instrumentation-grpc": "npm:0.220.0"
-    "@rust/hash-graph-api": "workspace:*"
     "@sentry/node": "npm:10.64.0"
     "@temporalio/activity": "npm:1.20.2"
     "@temporalio/common": "npm:1.20.2"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

`libs/@local/graph/api` has no TypeScript. Its whole JavaScript surface was one `exports` entry pointing at the committed OpenAPI document, read by a single consumer — and that entry cannot survive the move to Cargo workspaces, since the crate will have no manifest to hang it on.

Splitting the directory would mean a package whose only content is a copy of a ten-thousand-line JSON document, so `@local/hash-graph-client` carries it instead. It already reads the document to generate itself, and every consumer already depends on it.

Builds on SRE-981.

## 🔍 What does this change?

- The client's `codegen` copies the document alongside the code it generates from it; the copy is ignored, like the rest of that package's generated output
- `hash-ai-worker-ts` imports it from the client and drops its now-unused dependency on the crate. The edge survives transitively, so a change to the document still selects the worker
- The crate's `exports` is gone; its manifest is now pure wiring

The document stays committed in the crate, so that a change to the API contract shows up in the diff of the pull request that makes it. That is worth more than the ten thousand lines cost.

Generating it instead would also put a Rust toolchain in the way of the deployment builds, which the note above the client's `build` task records as having broken before — though not of CI, which has one anyway.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

- [x] affected the execution graph, and the `turbo.json`'s have been updated to reflect this

## 🐾 Next steps

SRE-983, then SRE-984.

## ❓ How to test this?

1. `turbo run codegen --filter=@local/hash-graph-client`, then check `openapi.json` sits beside the generated client
2. `turbo run lint:tsc --filter=@apps/hash-ai-worker-ts`
3. `mise run sync:turborepo && git diff --exit-code '**/package.json'`
