### PR TITLE
BE-811: Revoke active sessions when a Kratos recovery code is redeemed

### DIFF
--- a/infra/compose/kratos/kratos.yml
+++ b/infra/compose/kratos/kratos.yml
@@ -149,6 +149,9 @@ selfservice:
       enabled: true
       # Set `ui_url` through the `SELFSERVICE_FLOWS_RECOVERY_UI_URL` environment variable
       use: code
+      after:
+        hooks:
+          - hook: revoke_active_sessions
 
     settings:
       # Set `ui_url` through the `SELFSERVICE_FLOWS_SETTINGS_UI_URL` environment variable


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Recovery issues a session but changes no credential, so `revoke_active_sessions` — configured only under `settings.after.password`.

## 🔍 What does this change?

- Adds `revoke_active_sessions` to `selfservice.flows.recovery.after.hooks`. It spares the session recovery just issued, so the flow still completes.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph
