### PR TITLE
SRE-1002: Fail the mutable-tag advance when the current revision is unresolvable

### DIFF
--- a/.github/actions/tag-if-newer/action.yml
+++ b/.github/actions/tag-if-newer/action.yml
@@ -4,7 +4,9 @@ description: >
   `candidate-sha` is a strict descendant of the commit the mutable tag currently
   points at. This stops an out-of-order CI run — `queue: max` serializes the
   concurrency group but does NOT guarantee FIFO order — from moving a mutable
-  tag *backwards* onto an older commit. The guard relies on the surrounding
+  tag *backwards* onto an older commit. A revision that is not a commit in this
+  repository fails the action: it can never satisfy the ancestry check, so the
+  tag would silently stop advancing for good. The guard relies on the surrounding
   job's `concurrency: { queue: max }` for the check-then-set to be race-free
   (serialized); without it the read/compare/write is a TOCTOU race.
 
@@ -94,12 +96,18 @@ runs:
           advance=true
         elif [[ "$current_sha" == "$CANDIDATE_SHA" ]]; then
           echo "::notice ::$MUTABLE_TAG already at $CANDIDATE_SHA; nothing to do"
-        elif git merge-base --is-ancestor "$current_sha" "$CANDIDATE_SHA" 2>/dev/null; then
+        elif ! git cat-file -e "$current_sha^{commit}" 2>/dev/null; then
+          # No later run can advance the tag either: the revision is not going to
+          # become resolvable, so every one of them would take this branch. Fail
+          # rather than skip, or a frozen tag reads as a successful deploy.
+          echo "::error ::$MUTABLE_TAG points at $current_sha, which is not a commit in this repository. Move the tag onto a current image by hand."
+          exit 1
+        elif git merge-base --is-ancestor "$current_sha" "$CANDIDATE_SHA"; then
           # current is an ancestor of candidate → candidate is strictly newer.
           advance=true
         else
-          # candidate is an ancestor of current, they diverged, or current is
-          # unreachable (shallow clone / force-pushed). Leave the tag untouched.
+          # candidate is an ancestor of current, or they diverged. Leave the tag
+          # untouched.
           echo "::notice ::$MUTABLE_TAG at $current_sha is not older than $CANDIDATE_SHA; skipping"
         fi
         echo "advanced=$advance" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

`tag-if-newer` treated "the tagged commit is not an ancestor" and "the tagged commit is unknown to this repository" as one outcome: skip, and report success. The second means the tag can never advance again, because the revision will not become resolvable — so a frozen tag reads as a successful deploy on every later run.

That happened to `kratos` and `hydra`. Both are built `FROM` Ory base images and, before the label override landed in SRE-739, inherited Ory's `org.opencontainers.image.revision`. Their ECR `staging` tags were set on images from the day before that override and stayed there for three months while every deploy reported success.

## 🔗 Related links

- SRE-1002
- Surfaced while investigating INC-30 _(internal)_

## 🔍 What does this change?

- Fails the action when the currently tagged revision is not a commit in the repository, instead of skipping.
- Drops `2>/dev/null` from `git merge-base --is-ancestor`. It only masked that case, which is now handled ahead of it, so a genuine git error no longer reads as "not an ancestor".

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

The failure is only reachable once a tag is already stuck, and clearing it is manual: move the tag onto a current image. The error message says so. Automating the recovery would mean advancing a tag whose ordering cannot be established, which is what the guard exists to prevent.

## 🐾 Next steps

None.

## 🛡 What tests cover this?

The decision logic was exercised by hand over all five branches — unresolvable revision, ancestor, non-ancestor, absent label, and revision equal to the candidate — with only the first failing.

Every mutable tag was checked against this change before merging: both ECR `staging` tags now carry a revision present in `main`, the five GHCR `latest` tags do too, and `petrinaut-opt` carries no revision label and takes the advance branch. No tag is currently in the failing state.
