### PR TITLE
BE-809: hgraph: type middleware authentication rejections by their error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4060,6 +4060,7 @@ dependencies = [
  "clap",
  "derive_more",
  "error-stack",
+ "futures",
  "governor",
  "http 1.4.2",
  "opentelemetry",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4056,7 +4056,6 @@ version = "0.0.0"
 dependencies = [
  "axum",
  "axum-core",
- "bytes",
  "clap",
  "derive_more",
  "error-stack",

--- a/libs/@local/graph/api/src/rest/admin.rs
+++ b/libs/@local/graph/api/src/rest/admin.rs
@@ -114,12 +114,12 @@ where
         KRATOS_HTTP_TIMEOUT,
     ));
 
-    let router = probe::router().merge(protected.route_layer(AuthenticationLayer {
+    let router = probe::router().merge(protected.route_layer(AuthenticationLayer::<_, ActorId> {
         provider: authentication_provider,
         service_secret: Arc::clone(&service_secret),
         metrics: Arc::clone(&authentication_metrics),
         bootstrap_route: auth::is_bootstrap_route,
-        caller: core::marker::PhantomData::<ActorId>,
+        caller: core::marker::PhantomData,
     }));
 
     // Layering an empty router panics, so the group only exists with its routes.

--- a/libs/@local/graph/api/src/rest/admin.rs
+++ b/libs/@local/graph/api/src/rest/admin.rs
@@ -18,7 +18,7 @@
 //!
 //! # Authentication
 //!
-//! All routes except `/health` run behind [`auth::authentication_middleware`], with the operator
+//! All routes except `/health` run behind [`AuthenticationLayer`], with the operator
 //! chain: Cloudflare Access JWT, then service delegation. A Kratos session does **not**
 //! authenticate here — these endpoints erase entities and delete users, and the handlers do not
 //! authorize beyond requiring some actor, so operators arrive through Access and internal services
@@ -49,7 +49,9 @@ use hash_graph_store::{
     pool::StorePool as _,
     user_deletion::{self, UserDeletionError},
 };
-use hash_middleware::authentication::provider::AuthenticationProvider;
+#[cfg(feature = "unsafe-dev-endpoints")]
+use hash_middleware::authentication::ServiceSecretLayer;
+use hash_middleware::authentication::{AuthenticationLayer, provider::AuthenticationProvider};
 use hash_status::{Status, StatusCode};
 use serde::Deserialize as _;
 #[cfg(feature = "unsafe-dev-endpoints")]
@@ -107,31 +109,18 @@ where
         .route("/entities/delete", post(delete_entities))
         .route("/users/delete", post(delete_user));
 
-    #[cfg(feature = "unsafe-dev-endpoints")]
-    let secret_gate_secret = Arc::clone(&service_secret);
-    #[cfg(feature = "unsafe-dev-endpoints")]
-    let secret_gate_metrics = Arc::clone(&authentication_metrics);
-
     let kratos = Arc::new(KratosIdentityProvider::new(
         external_services.kratos_admin_url.clone(),
         KRATOS_HTTP_TIMEOUT,
     ));
 
-    let router = probe::router().merge(protected.route_layer(axum::middleware::from_fn(
-        move |request, next| {
-            let provider = Arc::clone(&authentication_provider);
-            let service_secret = Arc::clone(&service_secret);
-            let metrics = Arc::clone(&authentication_metrics);
-            auth::authentication_middleware::<_, ActorId>(
-                provider,
-                service_secret,
-                metrics,
-                auth::is_bootstrap_route,
-                request,
-                next,
-            )
-        },
-    )));
+    let router = probe::router().merge(protected.route_layer(AuthenticationLayer {
+        provider: authentication_provider,
+        service_secret: Arc::clone(&service_secret),
+        metrics: Arc::clone(&authentication_metrics),
+        bootstrap_route: auth::is_bootstrap_route,
+        caller: core::marker::PhantomData::<ActorId>,
+    }));
 
     // Layering an empty router panics, so the group only exists with its routes.
     #[cfg(feature = "unsafe-dev-endpoints")]
@@ -142,11 +131,10 @@ where
             .route("/data-types", delete(delete_data_types))
             .route("/property-types", delete(delete_property_types))
             .route("/entity-types", delete(delete_entity_types))
-            .route_layer(axum::middleware::from_fn(move |request, next| {
-                let service_secret = Arc::clone(&secret_gate_secret);
-                let metrics = Arc::clone(&secret_gate_metrics);
-                auth::service_secret_middleware(service_secret, metrics, request, next)
-            })),
+            .route_layer(ServiceSecretLayer {
+                service_secret,
+                metrics: authentication_metrics,
+            }),
     );
 
     router

--- a/libs/@local/graph/api/src/rest/admin.rs
+++ b/libs/@local/graph/api/src/rest/admin.rs
@@ -114,10 +114,16 @@ where
         KRATOS_HTTP_TIMEOUT,
     ));
 
-    let router = probe::router().merge(protected.route_layer(AuthenticationLayer::<_, ActorId> {
-        provider: authentication_provider,
+    #[cfg(feature = "unsafe-dev-endpoints")]
+    let secret_layer = ServiceSecretLayer {
         service_secret: Arc::clone(&service_secret),
         metrics: Arc::clone(&authentication_metrics),
+    };
+
+    let router = probe::router().merge(protected.route_layer(AuthenticationLayer::<_, ActorId> {
+        provider: authentication_provider,
+        service_secret,
+        metrics: authentication_metrics,
         bootstrap_route: auth::is_bootstrap_route,
         caller: core::marker::PhantomData,
     }));
@@ -131,10 +137,7 @@ where
             .route("/data-types", delete(delete_data_types))
             .route("/property-types", delete(delete_property_types))
             .route("/entity-types", delete(delete_entity_types))
-            .route_layer(ServiceSecretLayer {
-                service_secret,
-                metrics: authentication_metrics,
-            }),
+            .route_layer(secret_layer),
     );
 
     router

--- a/libs/@local/graph/api/src/rest/auth.rs
+++ b/libs/@local/graph/api/src/rest/auth.rs
@@ -20,10 +20,7 @@ pub use hash_graph_authentication::{
 };
 use hash_graph_authorization::policies::store::PrincipalStore;
 use hash_graph_store::pool::StorePool;
-pub use hash_middleware::authentication::{
-    AuthenticatedActorId, AuthenticationMetrics, authentication_middleware,
-    service_secret_middleware,
-};
+pub use hash_middleware::authentication::{AuthenticatedActorId, AuthenticationMetrics};
 
 /// Configuration for Cloudflare Access authentication.
 #[derive(Debug, Clone)]
@@ -99,8 +96,10 @@ where
 
 /// Returns whether the path is a bootstrap route.
 ///
-/// [`authentication_middleware`] takes this as its bootstrap predicate: these routes require the
+/// [`AuthenticationLayer`] takes this as its bootstrap predicate: these routes require the
 /// service secret regardless of any actor credential, and pass without an actor.
+///
+/// [`AuthenticationLayer`]: hash_middleware::authentication::AuthenticationLayer
 #[must_use]
 pub fn is_bootstrap_route(path: &str) -> bool {
     if path == "/policies/seed" {
@@ -117,23 +116,22 @@ mod tests {
     use core::ops::ControlFlow;
     use std::collections::HashMap;
 
-    use axum::{Router, body::Body, middleware, routing::get};
+    use axum::{Router, body::Body, routing::get};
     use error_stack::Report;
     use hash_graph_authentication::{
         actor::tests::FixedActorResolver, delegation::ServiceDelegationProvider,
     };
     use hash_middleware::authentication::{
+        AuthenticationLayer,
         provider::{AuthenticationProvider, Caller},
-        request::AuthenticationError,
+        request::{AuthenticationError, AuthenticationErrorKind},
     };
     use http::{HeaderMap, Request, StatusCode};
     use tower::ServiceExt as _;
     use type_system::principal::actor::ActorId;
     use uuid::Uuid;
 
-    use super::{
-        AuthenticatedActorId, AuthenticationMetrics, authentication_middleware, is_bootstrap_route,
-    };
+    use super::{AuthenticatedActorId, AuthenticationMetrics, is_bootstrap_route};
 
     fn request(uri: &str) -> Request<Body> {
         Request::builder()
@@ -213,19 +211,13 @@ mod tests {
         let metrics = Arc::new(AuthenticationMetrics::new(&opentelemetry::global::meter(
             "test",
         )));
-        routes().layer(middleware::from_fn(move |request, next| {
-            let provider = Arc::clone(&provider);
-            let service_secret = Arc::clone(&service_secret);
-            let metrics = Arc::clone(&metrics);
-            authentication_middleware::<_, Option<ActorId>>(
-                provider,
-                service_secret,
-                metrics,
-                is_bootstrap_route,
-                request,
-                next,
-            )
-        }))
+        routes().layer(AuthenticationLayer {
+            provider,
+            service_secret,
+            metrics,
+            bootstrap_route: is_bootstrap_route,
+            caller: core::marker::PhantomData::<Option<ActorId>>,
+        })
     }
 
     #[tokio::test]
@@ -318,7 +310,7 @@ mod tests {
     }
 
     /// A provider rejecting every request with the error under test.
-    struct FailingProvider(AuthenticationError);
+    struct FailingProvider(AuthenticationErrorKind);
 
     impl<C: Caller> AuthenticationProvider<C> for FailingProvider {
         fn authenticate(
@@ -326,7 +318,9 @@ mod tests {
             _headers: &HeaderMap,
         ) -> impl Future<Output = ControlFlow<Result<C, Report<AuthenticationError>>>> + Send
         {
-            core::future::ready(ControlFlow::Break(Err(Report::new(self.0.clone()))))
+            core::future::ready(ControlFlow::Break(Err(Report::new(
+                AuthenticationError::new(self.0.clone()),
+            ))))
         }
     }
 
@@ -334,10 +328,10 @@ mod tests {
     #[tokio::test]
     async fn rejection_bodies_carry_the_client_message() {
         let cases = [
-            (AuthenticationError::InvalidActorIdHeader, 400),
-            (AuthenticationError::InvalidSession, 401),
-            (AuthenticationError::ProviderUnreachable, 503),
-            (AuthenticationError::InvalidProviderResponse, 500),
+            (AuthenticationErrorKind::InvalidActorIdHeader, 400),
+            (AuthenticationErrorKind::InvalidSession, 401),
+            (AuthenticationErrorKind::ProviderUnreachable, 503),
+            (AuthenticationErrorKind::InvalidProviderResponse, 500),
         ];
 
         for (error, status) in cases {
@@ -346,24 +340,15 @@ mod tests {
             }))
             .expect("the error document should serialize");
 
-            let provider = Arc::new(FailingProvider(error));
-            let service_secret: Arc<str> = Arc::from(SERVICE_SECRET);
-            let metrics = Arc::new(AuthenticationMetrics::new(&opentelemetry::global::meter(
-                "test",
-            )));
-            let router = routes().layer(middleware::from_fn(move |request, next| {
-                let provider = Arc::clone(&provider);
-                let service_secret = Arc::clone(&service_secret);
-                let metrics = Arc::clone(&metrics);
-                authentication_middleware::<_, ActorId>(
-                    provider,
-                    service_secret,
-                    metrics,
-                    is_bootstrap_route,
-                    request,
-                    next,
-                )
-            }));
+            let router = routes().layer(AuthenticationLayer {
+                provider: Arc::new(FailingProvider(error)),
+                service_secret: Arc::from(SERVICE_SECRET),
+                metrics: Arc::new(AuthenticationMetrics::new(&opentelemetry::global::meter(
+                    "test",
+                ))),
+                bootstrap_route: is_bootstrap_route,
+                caller: core::marker::PhantomData::<ActorId>,
+            });
 
             let response = router
                 .oneshot(request("/protected"))

--- a/libs/@local/graph/api/src/rest/auth.rs
+++ b/libs/@local/graph/api/src/rest/auth.rs
@@ -211,12 +211,12 @@ mod tests {
         let metrics = Arc::new(AuthenticationMetrics::new(&opentelemetry::global::meter(
             "test",
         )));
-        routes().layer(AuthenticationLayer {
+        routes().layer(AuthenticationLayer::<_, Option<ActorId>> {
             provider,
             service_secret,
             metrics,
             bootstrap_route: is_bootstrap_route,
-            caller: core::marker::PhantomData::<Option<ActorId>>,
+            caller: core::marker::PhantomData,
         })
     }
 
@@ -340,14 +340,14 @@ mod tests {
             }))
             .expect("the error document should serialize");
 
-            let router = routes().layer(AuthenticationLayer {
+            let router = routes().layer(AuthenticationLayer::<_, ActorId> {
                 provider: Arc::new(FailingProvider(error)),
                 service_secret: Arc::from(SERVICE_SECRET),
                 metrics: Arc::new(AuthenticationMetrics::new(&opentelemetry::global::meter(
                     "test",
                 ))),
                 bootstrap_route: is_bootstrap_route,
-                caller: core::marker::PhantomData::<ActorId>,
+                caller: core::marker::PhantomData,
             });
 
             let response = router

--- a/libs/@local/graph/api/src/rest/mod.rs
+++ b/libs/@local/graph/api/src/rest/mod.rs
@@ -71,7 +71,13 @@ use hash_graph_temporal_versioning::{
 };
 use hash_graph_type_fetcher::TypeFetcher;
 use hash_graph_types::Embedding;
-use hash_middleware::authentication::provider::{AuthenticationProvider, Caller};
+use hash_middleware::{
+    authentication::{
+        AuthenticationLayer,
+        provider::{AuthenticationProvider, Caller},
+    },
+    rate_limit::{IpGateLayer, PrincipalLimitLayer},
+};
 use hash_status::Status;
 use hash_temporal_client::TemporalClient;
 use include_dir::{Dir, include_dir};
@@ -581,40 +587,25 @@ fn attach_request_middlewares<P, C>(
 ) -> Router
 where
     P: AuthenticationProvider<C> + Send + Sync + 'static,
-    C: Caller + Send + 'static,
+    C: Caller + Send + Sync + 'static,
 {
-    let auth_secret = Arc::clone(&service_secret);
-    let gate_secret = Arc::clone(&service_secret);
-    let gate_limiters = Arc::clone(&rate_limiters);
-
     routes
-        .route_layer(axum::middleware::from_fn(move |request, next| {
-            rate_limit::principal_limit_middleware(
-                Arc::clone(&rate_limiters),
-                Arc::clone(&service_secret),
-                request,
-                next,
-            )
-        }))
-        .route_layer(axum::middleware::from_fn(move |request, next| {
-            auth::authentication_middleware::<_, C>(
-                Arc::clone(&provider),
-                Arc::clone(&auth_secret),
-                Arc::clone(&authentication_metrics),
-                auth::is_bootstrap_route,
-                request,
-                next,
-            )
-        }))
+        .route_layer(PrincipalLimitLayer {
+            limiters: Arc::clone(&rate_limiters),
+            service_secret: Arc::clone(&service_secret),
+        })
+        .route_layer(AuthenticationLayer {
+            provider,
+            service_secret: Arc::clone(&service_secret),
+            metrics: authentication_metrics,
+            bootstrap_route: auth::is_bootstrap_route,
+            caller: core::marker::PhantomData::<C>,
+        })
         .merge(unauthenticated)
-        .layer(axum::middleware::from_fn(move |request, next| {
-            rate_limit::ip_gate_middleware(
-                Arc::clone(&gate_limiters),
-                Arc::clone(&gate_secret),
-                request,
-                next,
-            )
-        }))
+        .layer(IpGateLayer {
+            limiters: rate_limiters,
+            service_secret,
+        })
 }
 
 /// A [`Router`] that serves all of the REST API routes, and the `OpenAPI` specification.

--- a/libs/@local/graph/api/src/rest/mod.rs
+++ b/libs/@local/graph/api/src/rest/mod.rs
@@ -594,12 +594,12 @@ where
             limiters: Arc::clone(&rate_limiters),
             service_secret: Arc::clone(&service_secret),
         })
-        .route_layer(AuthenticationLayer {
+        .route_layer(AuthenticationLayer::<_, C> {
             provider,
             service_secret: Arc::clone(&service_secret),
             metrics: authentication_metrics,
             bootstrap_route: auth::is_bootstrap_route,
-            caller: core::marker::PhantomData::<C>,
+            caller: core::marker::PhantomData,
         })
         .merge(unauthenticated)
         .layer(IpGateLayer {

--- a/libs/@local/graph/api/src/rest/rate_limit.rs
+++ b/libs/@local/graph/api/src/rest/rate_limit.rs
@@ -6,9 +6,7 @@
 
 use core::num::NonZeroU32;
 
-pub use hash_middleware::rate_limit::{
-    ClientIpSource, RateLimitMode, RateLimiters, ip_gate_middleware, principal_limit_middleware,
-};
+pub use hash_middleware::rate_limit::{ClientIpSource, RateLimitMode, RateLimiters};
 
 /// Configuration for the request rate limits.
 ///
@@ -127,7 +125,9 @@ mod tests {
     use core::net::{IpAddr, SocketAddr};
 
     use axum::{Router, body::Body, extract::ConnectInfo, routing::get};
-    use hash_middleware::authentication::provider::StaticAuthenticationProvider;
+    use hash_middleware::{
+        authentication::provider::StaticAuthenticationProvider, rate_limit::IpGateLayer,
+    };
     use http::{Request, StatusCode};
     use tower::ServiceExt as _;
     use type_system::principal::actor::ActorId;
@@ -296,17 +296,12 @@ mod tests {
         let limiters =
             RateLimiters::start(&(&config(1)).into(), &opentelemetry::global::meter("test"));
         let service_secret: Arc<str> = Arc::from(SERVICE_SECRET);
-        let router =
-            Router::new()
-                .route("/entities", get(async || "ok"))
-                .layer(axum::middleware::from_fn(move |request, next| {
-                    super::ip_gate_middleware(
-                        Arc::clone(&limiters),
-                        Arc::clone(&service_secret),
-                        request,
-                        next,
-                    )
-                }));
+        let router = Router::new()
+            .route("/entities", get(async || "ok"))
+            .layer(IpGateLayer {
+                limiters,
+                service_secret,
+            });
         let client: IpAddr = "192.0.2.1".parse().expect("the address should parse");
 
         assert_eq!(

--- a/libs/@local/graph/authentication/src/actor.rs
+++ b/libs/@local/graph/authentication/src/actor.rs
@@ -64,8 +64,8 @@ where
 /// - [`ActorNotFound`] if the actor does not exist
 /// - [`StoreError`] if the underlying store returns an error
 ///
-/// [`ActorNotFound`]: AuthenticationError::ActorNotFound
-/// [`StoreError`]: AuthenticationError::StoreError
+/// [`ActorNotFound`]: hash_middleware::authentication::request::AuthenticationErrorKind::ActorNotFound
+/// [`StoreError`]: hash_middleware::authentication::request::AuthenticationErrorKind::StoreError
 pub(crate) async fn resolve_actor<R>(
     actor_resolver: &R,
     actor_id: ActorEntityUuid,
@@ -78,10 +78,10 @@ where
         .await
         .map_err(|report| match report.current_context() {
             DetermineActorError::ActorNotFound { .. } => {
-                report.change_context(AuthenticationError::ActorNotFound { actor_id })
+                report.change_context(AuthenticationError::actor_not_found(actor_id))
             }
             DetermineActorError::StoreError => {
-                report.change_context(AuthenticationError::StoreError)
+                report.change_context(AuthenticationError::store_error())
             }
         })
 }
@@ -94,9 +94,9 @@ where
 /// - [`ActorNotFound`] if the actor does not exist
 /// - [`StoreError`] if the underlying store returns an error
 ///
-/// [`NotAUser`]: AuthenticationError::NotAUser
-/// [`ActorNotFound`]: AuthenticationError::ActorNotFound
-/// [`StoreError`]: AuthenticationError::StoreError
+/// [`NotAUser`]: hash_middleware::authentication::request::AuthenticationErrorKind::NotAUser
+/// [`ActorNotFound`]: hash_middleware::authentication::request::AuthenticationErrorKind::ActorNotFound
+/// [`StoreError`]: hash_middleware::authentication::request::AuthenticationErrorKind::StoreError
 pub(crate) async fn resolve_user_actor<R>(
     actor_resolver: &R,
     actor_id: ActorEntityUuid,
@@ -107,7 +107,7 @@ where
     match resolve_actor(actor_resolver, actor_id).await? {
         ActorId::User(user_id) => Ok(user_id),
         ActorId::Machine(_) | ActorId::Ai(_) => {
-            Err(Report::new(AuthenticationError::NotAUser { actor_id }))
+            Err(Report::new(AuthenticationError::not_a_user(actor_id)))
         }
     }
 }

--- a/libs/@local/graph/authentication/src/cloudflare.rs
+++ b/libs/@local/graph/authentication/src/cloudflare.rs
@@ -356,7 +356,7 @@ i3YB+IEvO6Qr8c5tSNv9NB0=
 
         let report = expect_rejection::<ActorId>(provider.authenticate(&headers).await);
         assert_matches!(
-            report.current_context().kind,
+            report.current_context().kind(),
             AuthenticationErrorKind::MalformedCredential,
             "a non-ASCII Access token should be rejected as malformed, not ignored"
         );
@@ -391,7 +391,7 @@ i3YB+IEvO6Qr8c5tSNv9NB0=
                 .await,
         );
         assert_matches!(
-            report.current_context().kind,
+            report.current_context().kind(),
             AuthenticationErrorKind::InvalidAccessToken,
             "the token should fail authentication"
         );
@@ -416,7 +416,7 @@ i3YB+IEvO6Qr8c5tSNv9NB0=
         let report =
             expect_rejection::<ActorId>(provider.authenticate(&access_token_header(&token)).await);
         assert_matches!(
-            report.current_context().kind,
+            report.current_context().kind(),
             AuthenticationErrorKind::InvalidAccessToken,
             "a token signed with a disallowed algorithm should fail authentication"
         );
@@ -440,7 +440,7 @@ i3YB+IEvO6Qr8c5tSNv9NB0=
         let report =
             expect_rejection::<ActorId>(provider.authenticate(&access_token_header(&forged)).await);
         assert_matches!(
-            report.current_context().kind,
+            report.current_context().kind(),
             AuthenticationErrorKind::InvalidAccessToken,
             "a token with a signature from another token should fail authentication"
         );
@@ -472,7 +472,7 @@ i3YB+IEvO6Qr8c5tSNv9NB0=
                 .await,
         );
         assert_matches!(
-            report.current_context().kind,
+            report.current_context().kind(),
             AuthenticationErrorKind::InvalidAccessToken,
             "a token without `{claim}` should fail authentication"
         );
@@ -517,7 +517,7 @@ i3YB+IEvO6Qr8c5tSNv9NB0=
                 .await,
         );
         assert_matches!(
-            report.current_context().kind,
+            report.current_context().kind(),
             AuthenticationErrorKind::InvalidAccessToken,
             "a token without an email claim should fail authentication"
         );
@@ -533,7 +533,7 @@ i3YB+IEvO6Qr8c5tSNv9NB0=
                 .await,
         );
         assert_matches!(
-            report.current_context().kind,
+            report.current_context().kind(),
             AuthenticationErrorKind::IdentityWithoutActor,
             "a resolver failure should surface as the resolver's rejection"
         );
@@ -555,7 +555,7 @@ i3YB+IEvO6Qr8c5tSNv9NB0=
         let report =
             expect_rejection::<ActorId>(provider.authenticate(&access_token_header(&token)).await);
         assert_matches!(
-            report.current_context().kind,
+            report.current_context().kind(),
             AuthenticationErrorKind::InvalidAccessToken,
             "the token should fail authentication"
         );
@@ -578,7 +578,7 @@ i3YB+IEvO6Qr8c5tSNv9NB0=
                 .await,
         );
         assert_matches!(
-            report.current_context().kind,
+            report.current_context().kind(),
             AuthenticationErrorKind::ProviderUnreachable,
             "a failing JWKS endpoint should fail as provider unavailability, not as a bad token"
         );

--- a/libs/@local/graph/authentication/src/cloudflare.rs
+++ b/libs/@local/graph/authentication/src/cloudflare.rs
@@ -28,11 +28,11 @@ pub trait ResolveEmailActor: Send + Sync {
     /// - [`NotProvisioned`] if the identity has no Graph actor provisioned
     /// - [`ActorNotFound`], [`NotAUser`], or [`StoreError`] from actor validation
     ///
-    /// [`IdentityWithoutActor`]: AuthenticationError::IdentityWithoutActor
-    /// [`NotProvisioned`]: AuthenticationError::NotProvisioned
-    /// [`ActorNotFound`]: AuthenticationError::ActorNotFound
-    /// [`NotAUser`]: AuthenticationError::NotAUser
-    /// [`StoreError`]: AuthenticationError::StoreError
+    /// [`IdentityWithoutActor`]: hash_middleware::authentication::request::AuthenticationErrorKind::IdentityWithoutActor
+    /// [`NotProvisioned`]: hash_middleware::authentication::request::AuthenticationErrorKind::NotProvisioned
+    /// [`ActorNotFound`]: hash_middleware::authentication::request::AuthenticationErrorKind::ActorNotFound
+    /// [`NotAUser`]: hash_middleware::authentication::request::AuthenticationErrorKind::NotAUser
+    /// [`StoreError`]: hash_middleware::authentication::request::AuthenticationErrorKind::StoreError
     fn resolve_email_actor(
         &self,
         email: &str,
@@ -69,22 +69,22 @@ where
         let claims = self.jwt_validator.validate(token).await.map_err(|report| {
             match report.current_context() {
                 JwtError::JwksFetch => {
-                    report.change_context(AuthenticationError::ProviderUnreachable)
+                    report.change_context(AuthenticationError::provider_unreachable())
                 }
                 // The provider named a key it cannot supply a usable entry for, so every token
                 // signed with it fails. Reporting that as a bad token would answer 401 at debug
                 // level and hide an outage behind "your token is invalid".
                 JwtError::UnusableKey { .. } => {
-                    report.change_context(AuthenticationError::InvalidProviderResponse)
+                    report.change_context(AuthenticationError::invalid_provider_response())
                 }
                 JwtError::Validation | JwtError::MissingKeyId | JwtError::UnknownKeyId { .. } => {
-                    report.change_context(AuthenticationError::InvalidAccessToken)
+                    report.change_context(AuthenticationError::invalid_access_token())
                 }
             }
         })?;
 
         let Some(email) = claims.email else {
-            return Err(Report::new(AuthenticationError::InvalidAccessToken)
+            return Err(Report::new(AuthenticationError::invalid_access_token())
                 .attach("the token carries no email claim"));
         };
 
@@ -106,7 +106,9 @@ where
         };
 
         let Ok(token) = token.to_str() else {
-            return ControlFlow::Break(Err(Report::new(AuthenticationError::MalformedCredential)));
+            return ControlFlow::Break(Err(Report::new(
+                AuthenticationError::malformed_credential(),
+            )));
         };
 
         ControlFlow::Break(
@@ -119,7 +121,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use core::{net::SocketAddr, ops::ControlFlow, time::Duration};
+    use core::{assert_matches, net::SocketAddr, ops::ControlFlow, time::Duration};
     use std::{
         collections::HashMap,
         time::{SystemTime, UNIX_EPOCH},
@@ -129,7 +131,7 @@ mod tests {
     use error_stack::Report;
     use hash_middleware::authentication::{
         provider::{AuthenticationProvider as _, expect_rejection},
-        request::AuthenticationError,
+        request::{AuthenticationError, AuthenticationErrorKind},
     };
     use http::{HeaderMap, HeaderValue, StatusCode};
     use jsonwebtoken::{Algorithm, EncodingKey, Header};
@@ -194,7 +196,7 @@ i3YB+IEvO6Qr8c5tSNv9NB0=
                 self.actors
                     .get(email)
                     .copied()
-                    .ok_or_else(|| Report::new(AuthenticationError::IdentityWithoutActor)),
+                    .ok_or_else(|| Report::new(AuthenticationError::identity_without_actor())),
             )
         }
     }
@@ -353,11 +355,9 @@ i3YB+IEvO6Qr8c5tSNv9NB0=
         );
 
         let report = expect_rejection::<ActorId>(provider.authenticate(&headers).await);
-        assert!(
-            matches!(
-                report.current_context(),
-                AuthenticationError::MalformedCredential
-            ),
+        assert_matches!(
+            report.current_context().kind,
+            AuthenticationErrorKind::MalformedCredential,
             "a non-ASCII Access token should be rejected as malformed, not ignored"
         );
     }
@@ -390,13 +390,10 @@ i3YB+IEvO6Qr8c5tSNv9NB0=
                 .authenticate(&access_token_header(&mint_token(&claims)))
                 .await,
         );
-        assert!(
-            matches!(
-                report.current_context(),
-                AuthenticationError::InvalidAccessToken
-            ),
-            "the token should fail authentication, got {:?}",
-            report.current_context()
+        assert_matches!(
+            report.current_context().kind,
+            AuthenticationErrorKind::InvalidAccessToken,
+            "the token should fail authentication"
         );
     }
 
@@ -418,11 +415,9 @@ i3YB+IEvO6Qr8c5tSNv9NB0=
 
         let report =
             expect_rejection::<ActorId>(provider.authenticate(&access_token_header(&token)).await);
-        assert!(
-            matches!(
-                report.current_context(),
-                AuthenticationError::InvalidAccessToken
-            ),
+        assert_matches!(
+            report.current_context().kind,
+            AuthenticationErrorKind::InvalidAccessToken,
             "a token signed with a disallowed algorithm should fail authentication"
         );
     }
@@ -444,11 +439,9 @@ i3YB+IEvO6Qr8c5tSNv9NB0=
 
         let report =
             expect_rejection::<ActorId>(provider.authenticate(&access_token_header(&forged)).await);
-        assert!(
-            matches!(
-                report.current_context(),
-                AuthenticationError::InvalidAccessToken
-            ),
+        assert_matches!(
+            report.current_context().kind,
+            AuthenticationErrorKind::InvalidAccessToken,
             "a token with a signature from another token should fail authentication"
         );
     }
@@ -478,13 +471,10 @@ i3YB+IEvO6Qr8c5tSNv9NB0=
                 .authenticate(&access_token_header(&mint_token(&claims)))
                 .await,
         );
-        assert!(
-            matches!(
-                report.current_context(),
-                AuthenticationError::InvalidAccessToken
-            ),
-            "a token without `{claim}` should fail authentication, got {:?}",
-            report.current_context()
+        assert_matches!(
+            report.current_context().kind,
+            AuthenticationErrorKind::InvalidAccessToken,
+            "a token without `{claim}` should fail authentication"
         );
     }
 
@@ -526,11 +516,9 @@ i3YB+IEvO6Qr8c5tSNv9NB0=
                 .authenticate(&access_token_header(&mint_token(&claims)))
                 .await,
         );
-        assert!(
-            matches!(
-                report.current_context(),
-                AuthenticationError::InvalidAccessToken
-            ),
+        assert_matches!(
+            report.current_context().kind,
+            AuthenticationErrorKind::InvalidAccessToken,
             "a token without an email claim should fail authentication"
         );
     }
@@ -544,11 +532,9 @@ i3YB+IEvO6Qr8c5tSNv9NB0=
                 .authenticate(&access_token_header(&mint_token(&valid_claims(EMAIL))))
                 .await,
         );
-        assert!(
-            matches!(
-                report.current_context(),
-                AuthenticationError::IdentityWithoutActor
-            ),
+        assert_matches!(
+            report.current_context().kind,
+            AuthenticationErrorKind::IdentityWithoutActor,
             "a resolver failure should surface as the resolver's rejection"
         );
     }
@@ -568,13 +554,10 @@ i3YB+IEvO6Qr8c5tSNv9NB0=
 
         let report =
             expect_rejection::<ActorId>(provider.authenticate(&access_token_header(&token)).await);
-        assert!(
-            matches!(
-                report.current_context(),
-                AuthenticationError::InvalidAccessToken
-            ),
-            "the token should fail authentication, got {:?}",
-            report.current_context()
+        assert_matches!(
+            report.current_context().kind,
+            AuthenticationErrorKind::InvalidAccessToken,
+            "the token should fail authentication"
         );
     }
 
@@ -594,11 +577,9 @@ i3YB+IEvO6Qr8c5tSNv9NB0=
                 .authenticate(&access_token_header(&mint_token(&valid_claims(EMAIL))))
                 .await,
         );
-        assert!(
-            matches!(
-                report.current_context(),
-                AuthenticationError::ProviderUnreachable
-            ),
+        assert_matches!(
+            report.current_context().kind,
+            AuthenticationErrorKind::ProviderUnreachable,
             "a failing JWKS endpoint should fail as provider unavailability, not as a bad token"
         );
     }

--- a/libs/@local/graph/authentication/src/delegation.rs
+++ b/libs/@local/graph/authentication/src/delegation.rs
@@ -52,7 +52,9 @@ where
             return ControlFlow::Continue(());
         }
         if !presents_service_secret(headers, &self.secret) {
-            return ControlFlow::Break(Err(Report::new(AuthenticationError::InvalidServiceSecret)));
+            return ControlFlow::Break(Err(Report::new(
+                AuthenticationError::invalid_service_secret(),
+            )));
         }
 
         let actor_uuid = match actor_id_from_header(headers) {
@@ -90,7 +92,7 @@ where
             // chain requiring an actor is missing the delegated actor, not the credential.
             ControlFlow::Break(Ok(None)) => ControlFlow::Break(
                 C::anonymous()
-                    .map_err(|_error| Report::new(AuthenticationError::MissingDelegatedActor)),
+                    .map_err(|_error| Report::new(AuthenticationError::missing_delegated_actor())),
             ),
             ControlFlow::Break(Err(report)) => ControlFlow::Break(Err(report)),
         }
@@ -99,13 +101,13 @@ where
 
 #[cfg(test)]
 mod tests {
-    use core::ops::ControlFlow;
+    use core::{assert_matches, ops::ControlFlow};
     use std::collections::HashMap;
 
     use error_stack::Report;
     use hash_middleware::authentication::{
         provider::{AuthenticationProvider as _, Caller, expect_rejection},
-        request::{ACTOR_ID_HEADER, AuthenticationError},
+        request::{ACTOR_ID_HEADER, AuthenticationError, AuthenticationErrorKind},
         service_secret::SERVICE_AUTH_SCHEME,
     };
     use http::HeaderMap;
@@ -228,13 +230,10 @@ mod tests {
             )
             .await,
         );
-        assert!(
-            matches!(
-                report.current_context(),
-                AuthenticationError::ActorNotFound { .. }
-            ),
-            "a delegated actor that does not exist should be rejected, got {:?}",
-            report.current_context()
+        assert_matches!(
+            report.current_context().kind,
+            AuthenticationErrorKind::ActorNotFound { .. },
+            "a delegated actor that does not exist should be rejected"
         );
     }
 
@@ -261,11 +260,9 @@ mod tests {
             )
             .await,
         );
-        assert!(
-            matches!(
-                report.current_context(),
-                AuthenticationError::InvalidServiceSecret
-            ),
+        assert_matches!(
+            report.current_context().kind,
+            AuthenticationErrorKind::InvalidServiceSecret,
             "a wrong service secret should be rejected"
         );
     }
@@ -285,11 +282,9 @@ mod tests {
         let report = expect_rejection(
             authenticate::<ActorId>(&provider(), &headers(Some(SERVICE_SECRET), None)).await,
         );
-        assert!(
-            matches!(
-                report.current_context(),
-                AuthenticationError::MissingDelegatedActor
-            ),
+        assert_matches!(
+            report.current_context().kind,
+            AuthenticationErrorKind::MissingDelegatedActor,
             "the service secret should require the actor-ID header"
         );
     }
@@ -303,13 +298,10 @@ mod tests {
             )
             .await,
         );
-        assert!(
-            matches!(
-                report.current_context(),
-                AuthenticationError::ActorNotFound { .. }
-            ),
-            "an unknown delegated actor should never degrade to the public actor, got {:?}",
-            report.current_context()
+        assert_matches!(
+            report.current_context().kind,
+            AuthenticationErrorKind::ActorNotFound { .. },
+            "an unknown delegated actor should never degrade to the public actor"
         );
     }
 
@@ -344,11 +336,9 @@ mod tests {
             )
             .await,
         );
-        assert!(
-            matches!(
-                report.current_context(),
-                AuthenticationError::MissingDelegatedActor
-            ),
+        assert_matches!(
+            report.current_context().kind,
+            AuthenticationErrorKind::MissingDelegatedActor,
             "the nil actor header should be rejected where an actor is required"
         );
     }
@@ -371,11 +361,9 @@ mod tests {
         );
 
         let report = expect_rejection(authenticate::<ActorId>(&provider(), &request_headers).await);
-        assert!(
-            matches!(
-                report.current_context(),
-                AuthenticationError::InvalidActorIdHeader
-            ),
+        assert_matches!(
+            report.current_context().kind,
+            AuthenticationErrorKind::InvalidActorIdHeader,
             "a malformed actor-ID header should be rejected as invalid"
         );
     }

--- a/libs/@local/graph/authentication/src/delegation.rs
+++ b/libs/@local/graph/authentication/src/delegation.rs
@@ -231,7 +231,7 @@ mod tests {
             .await,
         );
         assert_matches!(
-            report.current_context().kind,
+            report.current_context().kind(),
             AuthenticationErrorKind::ActorNotFound { .. },
             "a delegated actor that does not exist should be rejected"
         );
@@ -261,7 +261,7 @@ mod tests {
             .await,
         );
         assert_matches!(
-            report.current_context().kind,
+            report.current_context().kind(),
             AuthenticationErrorKind::InvalidServiceSecret,
             "a wrong service secret should be rejected"
         );
@@ -283,7 +283,7 @@ mod tests {
             authenticate::<ActorId>(&provider(), &headers(Some(SERVICE_SECRET), None)).await,
         );
         assert_matches!(
-            report.current_context().kind,
+            report.current_context().kind(),
             AuthenticationErrorKind::MissingDelegatedActor,
             "the service secret should require the actor-ID header"
         );
@@ -299,7 +299,7 @@ mod tests {
             .await,
         );
         assert_matches!(
-            report.current_context().kind,
+            report.current_context().kind(),
             AuthenticationErrorKind::ActorNotFound { .. },
             "an unknown delegated actor should never degrade to the public actor"
         );
@@ -337,7 +337,7 @@ mod tests {
             .await,
         );
         assert_matches!(
-            report.current_context().kind,
+            report.current_context().kind(),
             AuthenticationErrorKind::MissingDelegatedActor,
             "the nil actor header should be rejected where an actor is required"
         );
@@ -362,7 +362,7 @@ mod tests {
 
         let report = expect_rejection(authenticate::<ActorId>(&provider(), &request_headers).await);
         assert_matches!(
-            report.current_context().kind,
+            report.current_context().kind(),
             AuthenticationErrorKind::InvalidActorIdHeader,
             "a malformed actor-ID header should be rejected as invalid"
         );

--- a/libs/@local/graph/authentication/src/kratos/identity.rs
+++ b/libs/@local/graph/authentication/src/kratos/identity.rs
@@ -271,7 +271,7 @@ mod tests {
             .await
             .expect_err("an ambiguous verified address should fail rather than pick an account");
         assert_matches!(
-            report.current_context().kind,
+            report.current_context().kind(),
             AuthenticationErrorKind::InvalidProviderResponse,
             "the ambiguity should fail as an invalid provider state"
         );
@@ -325,12 +325,12 @@ mod tests {
     #[case::unverified_address(
         json!([identity_json(Some(case_actor()), json!([unverified_address(EMAIL)]))]),
         known_user(case_actor()),
-        |error: &AuthenticationError| matches!(error.kind, AuthenticationErrorKind::IdentityWithoutActor)
+        |error: &AuthenticationError| matches!(error.kind(), AuthenticationErrorKind::IdentityWithoutActor)
     )]
     #[case::no_identity_for_email(
         json!([]),
         HashMap::new(),
-        |error: &AuthenticationError| matches!(error.kind, AuthenticationErrorKind::IdentityWithoutActor)
+        |error: &AuthenticationError| matches!(error.kind(), AuthenticationErrorKind::IdentityWithoutActor)
     )]
     #[case::identity_without_the_looked_up_address(
         json!([identity_json(
@@ -338,22 +338,22 @@ mod tests {
             json!([verified_address("other@example.com")]),
         )]),
         known_user(case_actor()),
-        |error: &AuthenticationError| matches!(error.kind, AuthenticationErrorKind::IdentityWithoutActor)
+        |error: &AuthenticationError| matches!(error.kind(), AuthenticationErrorKind::IdentityWithoutActor)
     )]
     #[case::unprovisioned_identity(
         json!([identity_json(None, json!([verified_address(EMAIL)]))]),
         HashMap::new(),
-        |error: &AuthenticationError| matches!(error.kind, AuthenticationErrorKind::NotProvisioned { .. })
+        |error: &AuthenticationError| matches!(error.kind(), AuthenticationErrorKind::NotProvisioned { .. })
     )]
     #[case::unknown_actor(
         json!([identity_json(Some(case_actor()), json!([verified_address(EMAIL)]))]),
         HashMap::new(),
-        |error: &AuthenticationError| matches!(error.kind, AuthenticationErrorKind::ActorNotFound { .. })
+        |error: &AuthenticationError| matches!(error.kind(), AuthenticationErrorKind::ActorNotFound { .. })
     )]
     #[case::machine_actor(
         json!([identity_json(Some(case_actor()), json!([verified_address(EMAIL)]))]),
         HashMap::from([(case_actor(), ActorId::Machine(MachineId::new(case_actor())))]),
-        |error: &AuthenticationError| matches!(error.kind, AuthenticationErrorKind::NotAUser { .. })
+        |error: &AuthenticationError| matches!(error.kind(), AuthenticationErrorKind::NotAUser { .. })
     )]
     #[tokio::test]
     async fn unresolvable_email_fails_resolution(
@@ -392,7 +392,7 @@ mod tests {
             .await
             .expect_err("an empty email should be rejected");
         assert_matches!(
-            report.current_context().kind,
+            report.current_context().kind(),
             AuthenticationErrorKind::InvalidAccessToken,
             "an empty email should fail as an invalid token"
         );
@@ -411,7 +411,7 @@ mod tests {
             .await
             .expect_err("an undeserializable identity response should fail resolution");
         assert_matches!(
-            report.current_context().kind,
+            report.current_context().kind(),
             AuthenticationErrorKind::InvalidProviderResponse,
             "an undeserializable identity response should fail as an invalid provider response"
         );

--- a/libs/@local/graph/authentication/src/kratos/identity.rs
+++ b/libs/@local/graph/authentication/src/kratos/identity.rs
@@ -51,12 +51,12 @@ impl<R> KratosEmailActorResolver<R> {
 /// Restates an admin API failure as a failure to authenticate.
 fn authentication_error(report: Report<KratosAdminError>) -> Report<AuthenticationError> {
     let context = match report.current_context() {
-        KratosAdminError::Rejected => AuthenticationError::ProviderRejection,
-        KratosAdminError::InvalidResponse => AuthenticationError::InvalidProviderResponse,
+        KratosAdminError::Rejected => AuthenticationError::provider_rejection(),
+        KratosAdminError::InvalidResponse => AuthenticationError::invalid_provider_response(),
         // An empty claim names no address to resolve, which is the token's fault rather than the
         // provider's.
-        KratosAdminError::EmptyIdentifier => AuthenticationError::InvalidAccessToken,
-        KratosAdminError::Unreachable => AuthenticationError::ProviderUnreachable,
+        KratosAdminError::EmptyIdentifier => AuthenticationError::invalid_access_token(),
+        KratosAdminError::Unreachable => AuthenticationError::provider_unreachable(),
     };
     report.change_context(context)
 }
@@ -81,22 +81,22 @@ async fn verified_identity(
             .any(|address| address.verified && address.value.eq_ignore_ascii_case(email))
     });
     let Some(identity) = matching.next() else {
-        return Err(Report::new(AuthenticationError::IdentityWithoutActor));
+        return Err(Report::new(AuthenticationError::identity_without_actor()));
     };
     // The address is the identity's credentials identifier, which the provider keeps unique —
     // several identities holding it as verified violate that invariant, and picking one would
     // authenticate an arbitrary account.
     if matching.next().is_some() {
-        return Err(Report::new(AuthenticationError::InvalidProviderResponse));
+        return Err(Report::new(AuthenticationError::invalid_provider_response()));
     }
 
     let Some(actor_uuid) = identity
         .metadata_public
         .and_then(|metadata| metadata.graph_actor_id)
     else {
-        return Err(Report::new(AuthenticationError::NotProvisioned {
-            identity_id: identity.id,
-        }));
+        return Err(Report::new(AuthenticationError::not_provisioned(
+            identity.id,
+        )));
     };
 
     Ok(ActorEntityUuid::new(actor_uuid))
@@ -122,11 +122,11 @@ where
 
 #[cfg(test)]
 mod tests {
-    use core::time::Duration;
+    use core::{assert_matches, time::Duration};
     use std::collections::HashMap;
 
     use axum::{Json, Router, extract::Query, response::IntoResponse as _, routing::get};
-    use hash_middleware::authentication::request::AuthenticationError;
+    use hash_middleware::authentication::request::{AuthenticationError, AuthenticationErrorKind};
     use http::StatusCode;
     use reqwest::Url;
     use rstest::rstest;
@@ -270,13 +270,10 @@ mod tests {
             .resolve_email_actor(EMAIL)
             .await
             .expect_err("an ambiguous verified address should fail rather than pick an account");
-        assert!(
-            matches!(
-                report.current_context(),
-                AuthenticationError::InvalidProviderResponse
-            ),
-            "the ambiguity should fail as an invalid provider state, got {:?}",
-            report.current_context()
+        assert_matches!(
+            report.current_context().kind,
+            AuthenticationErrorKind::InvalidProviderResponse,
+            "the ambiguity should fail as an invalid provider state"
         );
     }
 
@@ -328,12 +325,12 @@ mod tests {
     #[case::unverified_address(
         json!([identity_json(Some(case_actor()), json!([unverified_address(EMAIL)]))]),
         known_user(case_actor()),
-        |error: &AuthenticationError| matches!(error, AuthenticationError::IdentityWithoutActor)
+        |error: &AuthenticationError| matches!(error.kind, AuthenticationErrorKind::IdentityWithoutActor)
     )]
     #[case::no_identity_for_email(
         json!([]),
         HashMap::new(),
-        |error: &AuthenticationError| matches!(error, AuthenticationError::IdentityWithoutActor)
+        |error: &AuthenticationError| matches!(error.kind, AuthenticationErrorKind::IdentityWithoutActor)
     )]
     #[case::identity_without_the_looked_up_address(
         json!([identity_json(
@@ -341,22 +338,22 @@ mod tests {
             json!([verified_address("other@example.com")]),
         )]),
         known_user(case_actor()),
-        |error: &AuthenticationError| matches!(error, AuthenticationError::IdentityWithoutActor)
+        |error: &AuthenticationError| matches!(error.kind, AuthenticationErrorKind::IdentityWithoutActor)
     )]
     #[case::unprovisioned_identity(
         json!([identity_json(None, json!([verified_address(EMAIL)]))]),
         HashMap::new(),
-        |error: &AuthenticationError| matches!(error, AuthenticationError::NotProvisioned { .. })
+        |error: &AuthenticationError| matches!(error.kind, AuthenticationErrorKind::NotProvisioned { .. })
     )]
     #[case::unknown_actor(
         json!([identity_json(Some(case_actor()), json!([verified_address(EMAIL)]))]),
         HashMap::new(),
-        |error: &AuthenticationError| matches!(error, AuthenticationError::ActorNotFound { .. })
+        |error: &AuthenticationError| matches!(error.kind, AuthenticationErrorKind::ActorNotFound { .. })
     )]
     #[case::machine_actor(
         json!([identity_json(Some(case_actor()), json!([verified_address(EMAIL)]))]),
         HashMap::from([(case_actor(), ActorId::Machine(MachineId::new(case_actor())))]),
-        |error: &AuthenticationError| matches!(error, AuthenticationError::NotAUser { .. })
+        |error: &AuthenticationError| matches!(error.kind, AuthenticationErrorKind::NotAUser { .. })
     )]
     #[tokio::test]
     async fn unresolvable_email_fails_resolution(
@@ -394,13 +391,10 @@ mod tests {
             .resolve_email_actor("")
             .await
             .expect_err("an empty email should be rejected");
-        assert!(
-            matches!(
-                report.current_context(),
-                AuthenticationError::InvalidAccessToken
-            ),
-            "an empty email should fail as an invalid token, got {:?}",
-            report.current_context()
+        assert_matches!(
+            report.current_context().kind,
+            AuthenticationErrorKind::InvalidAccessToken,
+            "an empty email should fail as an invalid token"
         );
     }
 
@@ -416,11 +410,9 @@ mod tests {
             .resolve_email_actor(EMAIL)
             .await
             .expect_err("an undeserializable identity response should fail resolution");
-        assert!(
-            matches!(
-                report.current_context(),
-                AuthenticationError::InvalidProviderResponse
-            ),
+        assert_matches!(
+            report.current_context().kind,
+            AuthenticationErrorKind::InvalidProviderResponse,
             "an undeserializable identity response should fail as an invalid provider response"
         );
         assert!(

--- a/libs/@local/graph/authentication/src/kratos/mod.rs
+++ b/libs/@local/graph/authentication/src/kratos/mod.rs
@@ -122,13 +122,13 @@ async fn read_provider_body(response: Response) -> Result<String, Report<Provide
 /// - [`ProviderRejection`] if Kratos reported a client error
 /// - [`ProviderUnreachable`] for any other unsuccessful status, or if the body cannot be read
 ///
-/// [`ProviderRejection`]: AuthenticationError::ProviderRejection
-/// [`ProviderUnreachable`]: AuthenticationError::ProviderUnreachable
+/// [`ProviderRejection`]: hash_middleware::authentication::request::AuthenticationErrorKind::ProviderRejection
+/// [`ProviderUnreachable`]: hash_middleware::authentication::request::AuthenticationErrorKind::ProviderUnreachable
 async fn read_response_body(response: Response) -> Result<String, Report<AuthenticationError>> {
     read_provider_body(response).await.map_err(|report| {
         let context = match report.current_context() {
-            ProviderFailure::Rejected => AuthenticationError::ProviderRejection,
-            ProviderFailure::Unavailable => AuthenticationError::ProviderUnreachable,
+            ProviderFailure::Rejected => AuthenticationError::provider_rejection(),
+            ProviderFailure::Unavailable => AuthenticationError::provider_unreachable(),
         };
         report.change_context(context)
     })
@@ -136,13 +136,14 @@ async fn read_response_body(response: Response) -> Result<String, Report<Authent
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use core::net::SocketAddr;
+    use core::{assert_matches, net::SocketAddr};
 
     use axum::Router;
+    use hash_middleware::authentication::request::AuthenticationErrorKind;
     use reqwest::{Response, Url};
     use rstest::rstest;
 
-    use super::{AuthenticationError, read_response_body};
+    use super::read_response_body;
 
     /// Binds a fake Kratos on an ephemeral port and returns its base URL.
     pub(crate) async fn spawn_fake_kratos(router: Router) -> Url {
@@ -184,13 +185,10 @@ pub(crate) mod tests {
         let report = read_response_body(response_with(status, "{}"))
             .await
             .expect_err("a client error should fail");
-        assert!(
-            matches!(
-                report.current_context(),
-                AuthenticationError::ProviderRejection
-            ),
-            "a client error should report a provider rejection, got {:?}",
-            report.current_context()
+        assert_matches!(
+            report.current_context().kind,
+            AuthenticationErrorKind::ProviderRejection,
+            "a client error should report a provider rejection"
         );
     }
 
@@ -206,13 +204,10 @@ pub(crate) mod tests {
         let report = read_response_body(response_with(status, "{}"))
             .await
             .expect_err("an unsuccessful status should fail");
-        assert!(
-            matches!(
-                report.current_context(),
-                AuthenticationError::ProviderUnreachable
-            ),
-            "an unsuccessful status should report provider unavailability, got {:?}",
-            report.current_context()
+        assert_matches!(
+            report.current_context().kind,
+            AuthenticationErrorKind::ProviderUnreachable,
+            "an unsuccessful status should report provider unavailability"
         );
     }
 

--- a/libs/@local/graph/authentication/src/kratos/mod.rs
+++ b/libs/@local/graph/authentication/src/kratos/mod.rs
@@ -186,7 +186,7 @@ pub(crate) mod tests {
             .await
             .expect_err("a client error should fail");
         assert_matches!(
-            report.current_context().kind,
+            report.current_context().kind(),
             AuthenticationErrorKind::ProviderRejection,
             "a client error should report a provider rejection"
         );
@@ -205,7 +205,7 @@ pub(crate) mod tests {
             .await
             .expect_err("an unsuccessful status should fail");
         assert_matches!(
-            report.current_context().kind,
+            report.current_context().kind(),
             AuthenticationErrorKind::ProviderUnreachable,
             "an unsuccessful status should report provider unavailability"
         );

--- a/libs/@local/graph/authentication/src/kratos/session.rs
+++ b/libs/@local/graph/authentication/src/kratos/session.rs
@@ -418,7 +418,7 @@ mod tests {
 
         let report = expect_rejection::<ActorId>(provider.authenticate(&headers).await);
         assert_matches!(
-            report.current_context().kind,
+            report.current_context().kind(),
             AuthenticationErrorKind::MalformedCredential,
             "a non-ASCII session token should be rejected as malformed, not ignored"
         );
@@ -439,27 +439,27 @@ mod tests {
     #[case::unprovisioned_identity(
         FakeSession::unprovisioned(),
         HashMap::new(),
-        |error: &AuthenticationError| matches!(error.kind, AuthenticationErrorKind::NotProvisioned { .. })
+        |error: &AuthenticationError| matches!(error.kind(), AuthenticationErrorKind::NotProvisioned { .. })
     )]
     #[case::unknown_actor(
         FakeSession::active_for(case_actor()),
         HashMap::new(),
-        |error: &AuthenticationError| matches!(error.kind, AuthenticationErrorKind::ActorNotFound { .. })
+        |error: &AuthenticationError| matches!(error.kind(), AuthenticationErrorKind::ActorNotFound { .. })
     )]
     #[case::machine_actor(
         FakeSession::active_for(case_actor()),
         HashMap::from([(case_actor(), ActorId::Machine(MachineId::new(case_actor())))]),
-        |error: &AuthenticationError| matches!(error.kind, AuthenticationErrorKind::NotAUser { .. })
+        |error: &AuthenticationError| matches!(error.kind(), AuthenticationErrorKind::NotAUser { .. })
     )]
     #[case::inactive_session(
         FakeSession::inactive_for(case_actor()),
         known_user(case_actor()),
-        |error: &AuthenticationError| matches!(error.kind, AuthenticationErrorKind::InvalidSession)
+        |error: &AuthenticationError| matches!(error.kind(), AuthenticationErrorKind::InvalidSession)
     )]
     #[case::session_without_active_flag(
         FakeSession::without_active_flag(case_actor()),
         known_user(case_actor()),
-        |error: &AuthenticationError| matches!(error.kind, AuthenticationErrorKind::InvalidSession)
+        |error: &AuthenticationError| matches!(error.kind(), AuthenticationErrorKind::InvalidSession)
     )]
     #[tokio::test]
     async fn invalid_session_fails_authentication(
@@ -529,7 +529,7 @@ mod tests {
         let report =
             expect_rejection::<ActorId>(provider.authenticate(&session_token_header()).await);
         assert_matches!(
-            report.current_context().kind,
+            report.current_context().kind(),
             AuthenticationErrorKind::InvalidSession,
             "a forbidden session should fail as an invalid session, not as provider unavailability"
         );
@@ -542,7 +542,7 @@ mod tests {
         let report =
             expect_rejection::<ActorId>(provider.authenticate(&session_token_header()).await);
         assert_matches!(
-            report.current_context().kind,
+            report.current_context().kind(),
             AuthenticationErrorKind::ProviderUnreachable,
             "a redirecting provider should fail verification instead of being followed"
         );
@@ -559,7 +559,7 @@ mod tests {
         let report =
             expect_rejection::<ActorId>(provider.authenticate(&session_token_header()).await);
         assert_matches!(
-            report.current_context().kind,
+            report.current_context().kind(),
             AuthenticationErrorKind::ProviderRejection,
             "a rate-limited provider should fail as a provider rejection, not as an invalid \
              session"
@@ -587,7 +587,7 @@ mod tests {
         let report =
             expect_rejection::<ActorId>(provider.authenticate(&session_token_header()).await);
         assert_matches!(
-            report.current_context().kind,
+            report.current_context().kind(),
             AuthenticationErrorKind::ProviderUnreachable,
             "a provider exceeding the HTTP timeout should fail as provider unavailability"
         );
@@ -601,7 +601,7 @@ mod tests {
         let report =
             expect_rejection::<ActorId>(provider.authenticate(&session_token_header()).await);
         assert_matches!(
-            report.current_context().kind,
+            report.current_context().kind(),
             AuthenticationErrorKind::InvalidProviderResponse,
             "an undeserializable whoami response should fail as an invalid provider response"
         );
@@ -645,7 +645,7 @@ mod tests {
         let report = expect_rejection::<ActorId>(chain.authenticate(&headers).await);
 
         assert_matches!(
-            report.current_context().kind,
+            report.current_context().kind(),
             AuthenticationErrorKind::InvalidSession,
             "an invalid session should reject even when a valid delegation pair is present"
         );

--- a/libs/@local/graph/authentication/src/kratos/session.rs
+++ b/libs/@local/graph/authentication/src/kratos/session.rs
@@ -44,7 +44,7 @@ fn extract_session_credential(
             token
                 .to_str()
                 .map(SessionCredential::Token)
-                .change_context(AuthenticationError::MalformedCredential),
+                .change_context(AuthenticationError::malformed_credential()),
         );
     }
 
@@ -160,13 +160,13 @@ where
         let response = request
             .send()
             .await
-            .change_context(AuthenticationError::ProviderUnreachable)?;
+            .change_context(AuthenticationError::provider_unreachable())?;
 
         // Kratos answers an unknown or expired session with 401 or 403, which is a credential
         // failure rather than a provider fault.
         let status = response.status();
         if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
-            return Err(Report::new(AuthenticationError::InvalidSession)
+            return Err(Report::new(AuthenticationError::invalid_session())
                 .attach(provider_response(status, response.text().await)));
         }
 
@@ -175,11 +175,11 @@ where
         // bodies that do get attached, here and in `read_response_body`, are Kratos error
         // responses without identity data.
         let whoami: WhoamiResponse = serde_json::from_str(&body)
-            .change_context(AuthenticationError::InvalidProviderResponse)?;
+            .change_context(AuthenticationError::invalid_provider_response())?;
 
         // The schema does not require `active`, so only an explicit `true` passes.
         if whoami.active != Some(true) {
-            return Err(Report::new(AuthenticationError::InvalidSession)
+            return Err(Report::new(AuthenticationError::invalid_session())
                 .attach(format!("whoami reported active = {:?}", whoami.active)));
         }
 
@@ -188,9 +188,9 @@ where
             .metadata_public
             .and_then(|metadata| metadata.graph_actor_id)
         else {
-            return Err(Report::new(AuthenticationError::NotProvisioned {
-                identity_id: whoami.identity.id,
-            }));
+            return Err(Report::new(AuthenticationError::not_provisioned(
+                whoami.identity.id,
+            )));
         };
         Ok(ActorEntityUuid::new(actor_uuid))
     }
@@ -227,13 +227,13 @@ where
 
 #[cfg(test)]
 mod tests {
-    use core::{ops::ControlFlow, time::Duration};
+    use core::{assert_matches, ops::ControlFlow, time::Duration};
     use std::collections::HashMap;
 
     use axum::{Json, Router, response::IntoResponse as _, routing::get};
     use hash_middleware::authentication::{
         provider::{AuthenticationProvider as _, expect_rejection},
-        request::{ACTOR_ID_HEADER, AuthenticationError},
+        request::{ACTOR_ID_HEADER, AuthenticationError, AuthenticationErrorKind},
         service_secret::SERVICE_AUTH_SCHEME,
     };
     use http::{HeaderMap, HeaderValue, StatusCode};
@@ -417,11 +417,9 @@ mod tests {
         );
 
         let report = expect_rejection::<ActorId>(provider.authenticate(&headers).await);
-        assert!(
-            matches!(
-                report.current_context(),
-                AuthenticationError::MalformedCredential
-            ),
+        assert_matches!(
+            report.current_context().kind,
+            AuthenticationErrorKind::MalformedCredential,
             "a non-ASCII session token should be rejected as malformed, not ignored"
         );
     }
@@ -441,27 +439,27 @@ mod tests {
     #[case::unprovisioned_identity(
         FakeSession::unprovisioned(),
         HashMap::new(),
-        |error: &AuthenticationError| matches!(error, AuthenticationError::NotProvisioned { .. })
+        |error: &AuthenticationError| matches!(error.kind, AuthenticationErrorKind::NotProvisioned { .. })
     )]
     #[case::unknown_actor(
         FakeSession::active_for(case_actor()),
         HashMap::new(),
-        |error: &AuthenticationError| matches!(error, AuthenticationError::ActorNotFound { .. })
+        |error: &AuthenticationError| matches!(error.kind, AuthenticationErrorKind::ActorNotFound { .. })
     )]
     #[case::machine_actor(
         FakeSession::active_for(case_actor()),
         HashMap::from([(case_actor(), ActorId::Machine(MachineId::new(case_actor())))]),
-        |error: &AuthenticationError| matches!(error, AuthenticationError::NotAUser { .. })
+        |error: &AuthenticationError| matches!(error.kind, AuthenticationErrorKind::NotAUser { .. })
     )]
     #[case::inactive_session(
         FakeSession::inactive_for(case_actor()),
         known_user(case_actor()),
-        |error: &AuthenticationError| matches!(error, AuthenticationError::InvalidSession)
+        |error: &AuthenticationError| matches!(error.kind, AuthenticationErrorKind::InvalidSession)
     )]
     #[case::session_without_active_flag(
         FakeSession::without_active_flag(case_actor()),
         known_user(case_actor()),
-        |error: &AuthenticationError| matches!(error, AuthenticationError::InvalidSession)
+        |error: &AuthenticationError| matches!(error.kind, AuthenticationErrorKind::InvalidSession)
     )]
     #[tokio::test]
     async fn invalid_session_fails_authentication(
@@ -530,11 +528,9 @@ mod tests {
 
         let report =
             expect_rejection::<ActorId>(provider.authenticate(&session_token_header()).await);
-        assert!(
-            matches!(
-                report.current_context(),
-                AuthenticationError::InvalidSession
-            ),
+        assert_matches!(
+            report.current_context().kind,
+            AuthenticationErrorKind::InvalidSession,
             "a forbidden session should fail as an invalid session, not as provider unavailability"
         );
     }
@@ -545,11 +541,9 @@ mod tests {
 
         let report =
             expect_rejection::<ActorId>(provider.authenticate(&session_token_header()).await);
-        assert!(
-            matches!(
-                report.current_context(),
-                AuthenticationError::ProviderUnreachable
-            ),
+        assert_matches!(
+            report.current_context().kind,
+            AuthenticationErrorKind::ProviderUnreachable,
             "a redirecting provider should fail verification instead of being followed"
         );
     }
@@ -564,11 +558,9 @@ mod tests {
 
         let report =
             expect_rejection::<ActorId>(provider.authenticate(&session_token_header()).await);
-        assert!(
-            matches!(
-                report.current_context(),
-                AuthenticationError::ProviderRejection
-            ),
+        assert_matches!(
+            report.current_context().kind,
+            AuthenticationErrorKind::ProviderRejection,
             "a rate-limited provider should fail as a provider rejection, not as an invalid \
              session"
         );
@@ -594,11 +586,9 @@ mod tests {
 
         let report =
             expect_rejection::<ActorId>(provider.authenticate(&session_token_header()).await);
-        assert!(
-            matches!(
-                report.current_context(),
-                AuthenticationError::ProviderUnreachable
-            ),
+        assert_matches!(
+            report.current_context().kind,
+            AuthenticationErrorKind::ProviderUnreachable,
             "a provider exceeding the HTTP timeout should fail as provider unavailability"
         );
     }
@@ -610,11 +600,9 @@ mod tests {
 
         let report =
             expect_rejection::<ActorId>(provider.authenticate(&session_token_header()).await);
-        assert!(
-            matches!(
-                report.current_context(),
-                AuthenticationError::InvalidProviderResponse
-            ),
+        assert_matches!(
+            report.current_context().kind,
+            AuthenticationErrorKind::InvalidProviderResponse,
             "an undeserializable whoami response should fail as an invalid provider response"
         );
         assert!(
@@ -656,11 +644,9 @@ mod tests {
 
         let report = expect_rejection::<ActorId>(chain.authenticate(&headers).await);
 
-        assert!(
-            matches!(
-                report.current_context(),
-                AuthenticationError::InvalidSession
-            ),
+        assert_matches!(
+            report.current_context().kind,
+            AuthenticationErrorKind::InvalidSession,
             "an invalid session should reject even when a valid delegation pair is present"
         );
     }

--- a/libs/@local/graph/authentication/tests/kratos.rs
+++ b/libs/@local/graph/authentication/tests/kratos.rs
@@ -158,7 +158,7 @@ async fn unverified_address_does_not_resolve() -> Result<(), Box<dyn Error>> {
 
     let report = resolved.expect_err("an unverified address should not resolve");
     assert_matches!(
-        report.current_context().kind,
+        report.current_context().kind(),
         AuthenticationErrorKind::IdentityWithoutActor,
         "an unverified address should fail as an identity without actor"
     );
@@ -177,7 +177,7 @@ async fn identity_without_graph_actor_does_not_resolve() -> Result<(), Box<dyn E
 
     let report = resolved.expect_err("an unprovisioned identity should not resolve");
     assert_matches!(
-        report.current_context().kind,
+        report.current_context().kind(),
         AuthenticationErrorKind::NotProvisioned { .. },
         "an identity without a Graph actor should fail as unprovisioned"
     );
@@ -192,7 +192,7 @@ async fn address_without_an_identity_does_not_resolve() {
         .expect_err("an address without an identity should not resolve");
 
     assert_matches!(
-        report.current_context().kind,
+        report.current_context().kind(),
         AuthenticationErrorKind::IdentityWithoutActor,
         "an unknown address should fail as an identity without actor"
     );

--- a/libs/@local/graph/authentication/tests/kratos.rs
+++ b/libs/@local/graph/authentication/tests/kratos.rs
@@ -16,7 +16,7 @@
 //! assertion failure aborts the test before its cleanup, leaving the identity behind — acceptable
 //! because the addresses are unique per run and CI discards the container.
 
-use core::{error::Error, time::Duration};
+use core::{assert_matches, error::Error, time::Duration};
 
 use hash_graph_authentication::{
     actor::ResolveActor,
@@ -24,7 +24,7 @@ use hash_graph_authentication::{
     kratos::{IdentityDeletion, KratosAdminClient, KratosAdminConfig, KratosEmailActorResolver},
 };
 use hash_graph_authorization::policies::store::error::DetermineActorError;
-use hash_middleware::authentication::request::AuthenticationError;
+use hash_middleware::authentication::request::AuthenticationErrorKind;
 use reqwest::{Client, Url};
 use serde_json::json;
 use type_system::principal::actor::{ActorEntityUuid, ActorId, UserId};
@@ -157,13 +157,10 @@ async fn unverified_address_does_not_resolve() -> Result<(), Box<dyn Error>> {
     delete_identity(&client, &identity_id).await?;
 
     let report = resolved.expect_err("an unverified address should not resolve");
-    assert!(
-        matches!(
-            report.current_context(),
-            AuthenticationError::IdentityWithoutActor
-        ),
-        "an unverified address should fail as an identity without actor, got {:?}",
-        report.current_context()
+    assert_matches!(
+        report.current_context().kind,
+        AuthenticationErrorKind::IdentityWithoutActor,
+        "an unverified address should fail as an identity without actor"
     );
     Ok(())
 }
@@ -179,13 +176,10 @@ async fn identity_without_graph_actor_does_not_resolve() -> Result<(), Box<dyn E
     delete_identity(&client, &identity_id).await?;
 
     let report = resolved.expect_err("an unprovisioned identity should not resolve");
-    assert!(
-        matches!(
-            report.current_context(),
-            AuthenticationError::NotProvisioned { .. }
-        ),
-        "an identity without a Graph actor should fail as unprovisioned, got {:?}",
-        report.current_context()
+    assert_matches!(
+        report.current_context().kind,
+        AuthenticationErrorKind::NotProvisioned { .. },
+        "an identity without a Graph actor should fail as unprovisioned"
     );
     Ok(())
 }
@@ -197,13 +191,10 @@ async fn address_without_an_identity_does_not_resolve() {
         .await
         .expect_err("an address without an identity should not resolve");
 
-    assert!(
-        matches!(
-            report.current_context(),
-            AuthenticationError::IdentityWithoutActor
-        ),
-        "an unknown address should fail as an identity without actor, got {:?}",
-        report.current_context()
+    assert_matches!(
+        report.current_context().kind,
+        AuthenticationErrorKind::IdentityWithoutActor,
+        "an unknown address should fail as an identity without actor"
     );
 }
 

--- a/libs/@local/middleware/Cargo.toml
+++ b/libs/@local/middleware/Cargo.toml
@@ -25,6 +25,7 @@ clap = { workspace = true, optional = true, features = ["derive"] }
 # Private third-party dependencies
 bytes                              = { workspace = true }
 derive_more                        = { workspace = true, features = ["display", "error"] }
+futures.workspace                  = true
 governor                           = { workspace = true }
 opentelemetry-semantic-conventions = { workspace = true, features = ["semconv_experimental"] }
 serde                              = { workspace = true, features = ["derive"] }

--- a/libs/@local/middleware/Cargo.toml
+++ b/libs/@local/middleware/Cargo.toml
@@ -23,7 +23,6 @@ tower-service = { workspace = true, public = true }
 clap = { workspace = true, optional = true, features = ["derive"] }
 
 # Private third-party dependencies
-bytes                              = { workspace = true }
 derive_more                        = { workspace = true, features = ["display", "error"] }
 futures                            = { workspace = true }
 governor                           = { workspace = true }

--- a/libs/@local/middleware/Cargo.toml
+++ b/libs/@local/middleware/Cargo.toml
@@ -25,7 +25,7 @@ clap = { workspace = true, optional = true, features = ["derive"] }
 # Private third-party dependencies
 bytes                              = { workspace = true }
 derive_more                        = { workspace = true, features = ["display", "error"] }
-futures.workspace                  = true
+futures                            = { workspace = true }
 governor                           = { workspace = true }
 opentelemetry-semantic-conventions = { workspace = true, features = ["semconv_experimental"] }
 serde                              = { workspace = true, features = ["derive"] }

--- a/libs/@local/middleware/src/authentication/mod.rs
+++ b/libs/@local/middleware/src/authentication/mod.rs
@@ -113,6 +113,7 @@ impl AuthenticationMetrics {
 ///
 /// A rejection records itself when it drops, whether or not a response was rendered from it,
 /// so no holder logs or counts one.
+#[derive(Clone)]
 pub enum AuthenticationRejection {
     /// The credentials did not resolve to a caller the route admits.
     Authentication {

--- a/libs/@local/middleware/src/authentication/mod.rs
+++ b/libs/@local/middleware/src/authentication/mod.rs
@@ -7,16 +7,18 @@
 //! chain's [`Caller`] type: a chain over [`ActorId`] rejects it, a chain over `Option<ActorId>`
 //! verifies it as anonymous.
 //!
-//! Bootstrap routes — the paths the service names through the layer's predicate — require the
-//! service secret regardless of the chain and pass even when no actor resolves. Routes that take
-//! no actor at all are gated by [`ServiceSecretLayer`] instead.
+//! Bootstrap routes, the paths the service names through the layer's predicate, require the
+//! service secret regardless of the chain. With the secret presented they tolerate exactly one
+//! failure: a verified service credential that names no delegated actor. Every other rejection
+//! still fails the request. Routes that take no actor at all use [`ServiceSecretLayer`]
+//! instead.
 
 pub mod provider;
 pub mod request;
 pub mod service_secret;
 
 use alloc::sync::Arc;
-use core::{convert::Infallible, future, marker::PhantomData, task};
+use core::{future, marker::PhantomData, task};
 
 use axum::{
     extract::{FromRequestParts, OptionalFromRequestParts},
@@ -39,11 +41,30 @@ use self::{
 };
 use crate::response::error_response;
 
-/// Instruments recording authentication rejections.
+/// How a request proceeded although its credential resolution failed.
+#[derive(Copy, Clone)]
+enum Degradation {
+    /// A verified rejection resolved as anonymous on a chain serving anonymous callers.
+    Anonymous,
+    /// A bootstrap route admitted the service credential without its delegated actor.
+    Bootstrap,
+}
+
+impl Degradation {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Anonymous => "anonymous",
+            Self::Bootstrap => "bootstrap",
+        }
+    }
+}
+
+/// Instruments recording credential failures.
 ///
 /// A route wired without the middleware answers with an internal error that is not counted here.
 pub struct AuthenticationMetrics {
     rejections: Counter<u64>,
+    degradations: Counter<u64>,
 }
 
 impl AuthenticationMetrics {
@@ -54,6 +75,11 @@ impl AuthenticationMetrics {
             rejections: meter
                 .u64_counter("hash.authentication.rejections")
                 .with_description("Requests rejected for their credentials")
+                .with_unit("{request}")
+                .build(),
+            degradations: meter
+                .u64_counter("hash.authentication.degradations")
+                .with_description("Requests served although their credential failed")
                 .with_unit("{request}")
                 .build(),
         }
@@ -71,12 +97,22 @@ impl AuthenticationMetrics {
             ],
         );
     }
+
+    fn record_degradation(&self, error: &AuthenticationError, degradation: Degradation) {
+        self.degradations.add(
+            1,
+            &[
+                KeyValue::new("mechanism", degradation.as_str()),
+                KeyValue::new("fault_domain", error.fault_domain().as_str()),
+            ],
+        );
+    }
 }
 
 /// The response a request that failed authentication is answered with.
 ///
-/// The failure is logged and counted when the rejection drops, whether or not a response was
-/// rendered from it.
+/// A rejection records itself when it drops, whether or not a response was rendered from it,
+/// so no holder logs or counts one.
 pub enum AuthenticationRejection {
     /// The credentials did not resolve to a caller the route admits.
     Authentication {
@@ -91,11 +127,26 @@ pub enum AuthenticationRejection {
     Misconfigured,
 }
 
+impl IntoResponse for AuthenticationRejection {
+    fn into_response(self) -> Response {
+        match &self {
+            Self::Authentication { report, .. } => {
+                let error = report.current_context();
+                error_response(error.status_code(), error.kind().client_message())
+            }
+            Self::Misconfigured => error_response(
+                http::StatusCode::INTERNAL_SERVER_ERROR,
+                "internal server error",
+            ),
+        }
+    }
+}
+
 impl Drop for AuthenticationRejection {
     fn drop(&mut self) {
         match self {
             Self::Authentication { report, metrics } => {
-                AuthenticationError::log(report);
+                AuthenticationError::ensure_logged(report);
                 metrics.record_rejection(report.current_context());
             }
             Self::Misconfigured => {
@@ -103,21 +154,6 @@ impl Drop for AuthenticationRejection {
                     "`AuthenticatedActorId` extracted on a route without authentication middleware"
                 );
             }
-        }
-    }
-}
-
-impl IntoResponse for AuthenticationRejection {
-    fn into_response(self) -> Response {
-        match &self {
-            Self::Authentication { report, .. } => {
-                let error = report.current_context();
-                error_response(error.status_code(), error.client_message().to_owned())
-            }
-            Self::Misconfigured => error_response(
-                http::StatusCode::INTERNAL_SERVER_ERROR,
-                "internal server error".to_owned(),
-            ),
         }
     }
 }
@@ -270,9 +306,11 @@ fn store_outcome<B>(
 /// it as anonymous, and whether an anonymous caller may proceed is the handler's to state,
 /// through which extractor it takes.
 ///
-/// Bootstrap routes are service operations: `bootstrap_route` names their paths, they require the
-/// service secret regardless of any actor credential, and they pass even when no actor resolves.
-/// A service without such routes passes `|_| false`.
+/// Bootstrap routes are service operations: `bootstrap_route` names their paths and they require
+/// the service secret regardless of any actor credential. With the secret presented, the one
+/// rejection they tolerate is a verified service credential that names no delegated actor, and
+/// every other failure still rejects the request. A service without such routes passes
+/// `|_| false`.
 ///
 /// Routes that take no actor are gated by [`ServiceSecretLayer`] instead.
 ///
@@ -329,7 +367,7 @@ pub struct AuthenticationLayer<P, C> {
 
     /// Selects the caller type the chain resolves to: [`ActorId`] rejects uncredentialed
     /// requests, `Option<ActorId>` serves them anonymously.
-    pub caller: PhantomData<C>,
+    pub caller: PhantomData<fn() -> C>,
 }
 
 impl<P, C> Clone for AuthenticationLayer<P, C> {
@@ -362,7 +400,7 @@ impl<P, C, S> tower::Layer<S> for AuthenticationLayer<P, C> {
 /// The service [`AuthenticationLayer`] wraps its inner service into.
 pub struct AuthenticationService<P, C, S> {
     inner: S,
-    _caller: PhantomData<C>,
+    _caller: PhantomData<fn() -> C>,
 
     provider: Arc<P>,
     service_secret: Arc<str>,
@@ -385,7 +423,7 @@ impl<P, C, S: Clone> Clone for AuthenticationService<P, C, S> {
 
 impl<B, P, C, S> tower::Service<http::Request<B>> for AuthenticationService<P, C, S>
 where
-    S: tower::Service<http::Request<B>, Error = Infallible> + Clone,
+    S: tower::Service<http::Request<B>> + Clone,
     C: Caller,
     P: AuthenticationProvider<C>,
 {
@@ -414,7 +452,7 @@ where
         let metrics = Arc::clone(&self.metrics);
 
         Either::Left(async move {
-            let outcome = resolve_request_actor(&*provider, req.headers())
+            let outcome = resolve_request_actor(&*provider, req.headers(), &metrics)
                 .await
                 .map(Caller::into_actor)
                 .map_err(Arc::new);
@@ -423,10 +461,11 @@ where
                 Err(report)
                     if bootstrap
                         && matches!(
-                            report.current_context().kind,
+                            report.current_context().kind(),
                             AuthenticationErrorKind::MissingDelegatedActor
                         ) =>
                 {
+                    metrics.record_degradation(report.current_context(), Degradation::Bootstrap);
                     Err(report)
                 }
                 Err(report) => {
@@ -520,11 +559,11 @@ impl<S: Sync> OptionalFromRequestParts<S> for AuthenticatedActorId {
 #[cfg(test)]
 mod tests {
     use alloc::sync::Arc;
-    use core::marker::PhantomData;
+    use core::{future::Future, marker::PhantomData, ops::ControlFlow};
 
     use axum::{Router, body::Body, routing::get};
     use error_stack::Report;
-    use http::{Request, StatusCode};
+    use http::{HeaderMap, Request, StatusCode};
     use tower::ServiceExt as _;
     use type_system::principal::actor::{ActorEntityUuid, ActorId, UserId};
     use uuid::Uuid;
@@ -535,7 +574,7 @@ mod tests {
     };
     use crate::{
         authentication::{
-            provider::StaticAuthenticationProvider,
+            provider::{AuthenticationProvider, Caller, StaticAuthenticationProvider},
             request::{AuthenticationError, AuthenticationErrorKind},
         },
         test_metrics::{RecordedMetrics, noop_meter},
@@ -611,6 +650,21 @@ mod tests {
             .header("Authorization", format!("HASH-Service {secret}"))
             .body(Body::empty())
             .expect("the request should build")
+    }
+
+    /// A provider chain whose service credential verified without naming a delegated actor.
+    struct MissingDelegation;
+
+    impl<C: Caller> AuthenticationProvider<C> for MissingDelegation {
+        fn authenticate(
+            &self,
+            _headers: &HeaderMap,
+        ) -> impl Future<Output = ControlFlow<Result<C, Report<AuthenticationError>>>> + Send
+        {
+            core::future::ready(ControlFlow::Break(Err(Report::new(
+                AuthenticationError::missing_delegated_actor(),
+            ))))
+        }
     }
 
     #[tokio::test]
@@ -992,6 +1046,71 @@ mod tests {
             recorded.counter("hash.authentication.rejections", &[]),
             0,
             "an anonymously served request should not count as a rejection"
+        );
+    }
+
+    /// A verified rejection that resolves as anonymous counts as a degradation, never as a
+    /// rejection: the request was served.
+    #[tokio::test]
+    async fn anonymous_degrade_counts_as_degradation() {
+        let recorded = RecordedMetrics::new();
+        let router = router_recording(
+            StaticAuthenticationProvider::Rejected,
+            Arc::new(AuthenticationMetrics::new(&recorded.meter())),
+        );
+
+        let response = router
+            .oneshot(request("/anonymous-allowed"))
+            .await
+            .expect("the router should respond");
+        assert_eq!(response.status(), StatusCode::OK);
+
+        assert_eq!(
+            recorded.counter(
+                "hash.authentication.degradations",
+                &[("mechanism", "anonymous"), ("fault_domain", "caller")],
+            ),
+            1,
+            "the anonymous degrade should count with its mechanism and fault domain"
+        );
+        assert_eq!(
+            recorded.counter("hash.authentication.rejections", &[]),
+            0,
+            "a degraded request should not count as a rejection"
+        );
+    }
+
+    /// The tolerated bootstrap failure counts as a degradation, never as a rejection: the
+    /// request was served.
+    #[tokio::test]
+    async fn bootstrap_toleration_counts_as_degradation() {
+        let recorded = RecordedMetrics::new();
+        let router = routes().layer(AuthenticationLayer::<_, Option<ActorId>> {
+            provider: Arc::new(MissingDelegation),
+            service_secret: Arc::from(SERVICE_SECRET),
+            metrics: Arc::new(AuthenticationMetrics::new(&recorded.meter())),
+            bootstrap_route: is_bootstrap_route,
+            caller: PhantomData,
+        });
+
+        let response = router
+            .oneshot(request_with_secret("/bootstrap", SERVICE_SECRET))
+            .await
+            .expect("the router should respond");
+        assert_eq!(response.status(), StatusCode::OK);
+
+        assert_eq!(
+            recorded.counter(
+                "hash.authentication.degradations",
+                &[("mechanism", "bootstrap"), ("fault_domain", "caller")],
+            ),
+            1,
+            "the tolerated bootstrap failure should count with its mechanism and fault domain"
+        );
+        assert_eq!(
+            recorded.counter("hash.authentication.rejections", &[]),
+            0,
+            "a tolerated request should not count as a rejection"
         );
     }
 

--- a/libs/@local/middleware/src/authentication/mod.rs
+++ b/libs/@local/middleware/src/authentication/mod.rs
@@ -47,6 +47,7 @@ pub struct AuthenticationMetrics {
 }
 
 impl AuthenticationMetrics {
+    /// Creates the instruments on `meter`.
     #[must_use]
     pub fn new(meter: &Meter) -> Self {
         Self {
@@ -72,36 +73,53 @@ impl AuthenticationMetrics {
     }
 }
 
-#[derive(Clone)]
+/// The response a request that failed authentication is answered with.
+///
+///
+/// Metrics are recorded when the rejection is dropped, which happens once [`IntoResponse`]
+/// has rendered the response. It is independent of the fact whether a rejection will be rendered
+/// or not.
 pub enum AuthenticationRejection {
+    /// The credentials did not resolve to a caller the route admits.
     Authentication {
+        /// Why the credentials were rejected.
         report: Arc<Report<AuthenticationError>>,
+        /// The instruments the rejection is counted on.
         metrics: Arc<AuthenticationMetrics>,
     },
+    /// [`AuthenticatedActorId`] was extracted on a route without [`AuthenticationLayer`].
+    ///
+    /// Answered as an internal error: the fault is the router's wiring, never the request.
     Misconfigured,
 }
 
-impl IntoResponse for AuthenticationRejection {
-    fn into_response(self) -> Response {
+impl Drop for AuthenticationRejection {
+    fn drop(&mut self) {
         match self {
             Self::Authentication { report, metrics } => {
-                AuthenticationError::log(&report);
-
-                let error = report.current_context();
-
-                metrics.record_rejection(error);
-                error_response(error.status_code(), error.client_message().to_owned())
+                AuthenticationError::log(report);
+                metrics.record_rejection(report.current_context());
             }
             Self::Misconfigured => {
                 tracing::error!(
                     "`AuthenticatedActorId` extracted on a route without authentication middleware"
                 );
-
-                error_response(
-                    http::StatusCode::INTERNAL_SERVER_ERROR,
-                    "internal server error".to_owned(),
-                )
             }
+        }
+    }
+}
+
+impl IntoResponse for AuthenticationRejection {
+    fn into_response(self) -> Response {
+        match &self {
+            Self::Authentication { report, .. } => {
+                let error = report.current_context();
+                error_response(error.status_code(), error.client_message().to_owned())
+            }
+            Self::Misconfigured => error_response(
+                http::StatusCode::INTERNAL_SERVER_ERROR,
+                "internal server error".to_owned(),
+            ),
         }
     }
 }
@@ -179,7 +197,9 @@ fn service_secret_rejection(
 /// ```
 #[derive(Clone)]
 pub struct ServiceSecretLayer {
+    /// The secret a request must present.
     pub service_secret: Arc<str>,
+    /// The instruments rejections are counted on.
     pub metrics: Arc<AuthenticationMetrics>,
 }
 
@@ -195,6 +215,7 @@ impl<S> tower::Layer<S> for ServiceSecretLayer {
     }
 }
 
+/// The service [`ServiceSecretLayer`] wraps its inner service into.
 #[derive(Clone)]
 pub struct ServiceSecretService<S> {
     service_secret: Arc<str>,
@@ -299,11 +320,17 @@ fn store_outcome<B>(
 /// );
 /// ```
 pub struct AuthenticationLayer<P, C> {
+    /// The provider chain requests resolve against.
     pub provider: Arc<P>,
+    /// The secret bootstrap routes require.
     pub service_secret: Arc<str>,
+    /// The instruments rejections are counted on.
     pub metrics: Arc<AuthenticationMetrics>,
+    /// Names the bootstrap routes by path.
     pub bootstrap_route: fn(&str) -> bool,
 
+    /// Selects the caller type the chain resolves to: [`ActorId`] rejects uncredentialed
+    /// requests, `Option<ActorId>` serves them anonymously.
     pub caller: PhantomData<C>,
 }
 
@@ -334,6 +361,7 @@ impl<P, C, S> tower::Layer<S> for AuthenticationLayer<P, C> {
     }
 }
 
+/// The service [`AuthenticationLayer`] wraps its inner service into.
 pub struct AuthenticationService<P, C, S> {
     inner: S,
     _caller: PhantomData<C>,
@@ -497,16 +525,21 @@ mod tests {
     use core::marker::PhantomData;
 
     use axum::{Router, body::Body, routing::get};
+    use error_stack::Report;
     use http::{Request, StatusCode};
     use tower::ServiceExt as _;
     use type_system::principal::actor::{ActorEntityUuid, ActorId, UserId};
     use uuid::Uuid;
 
     use super::{
-        AuthenticatedActorId, AuthenticationLayer, AuthenticationMetrics, ServiceSecretLayer,
+        AuthenticatedActorId, AuthenticationLayer, AuthenticationMetrics, AuthenticationRejection,
+        ServiceSecretLayer,
     };
     use crate::{
-        authentication::provider::StaticAuthenticationProvider,
+        authentication::{
+            provider::StaticAuthenticationProvider,
+            request::{AuthenticationError, AuthenticationErrorKind},
+        },
         test_metrics::{RecordedMetrics, noop_meter},
     };
 
@@ -961,6 +994,33 @@ mod tests {
             recorded.counter("hash.authentication.rejections", &[]),
             0,
             "an anonymously served request should not count as a rejection"
+        );
+    }
+
+    /// Recording rides the rejection's drop, so a path that builds one and never renders it
+    /// still reaches the meter.
+    #[test]
+    fn unrendered_rejection_counts() {
+        let recorded = RecordedMetrics::new();
+        let metrics = Arc::new(AuthenticationMetrics::new(&recorded.meter()));
+
+        drop(AuthenticationRejection::Authentication {
+            report: Arc::new(Report::new(AuthenticationError::new(
+                AuthenticationErrorKind::MissingCredentials,
+            ))),
+            metrics: Arc::clone(&metrics),
+        });
+
+        assert_eq!(
+            recorded.counter(
+                "hash.authentication.rejections",
+                &[
+                    ("http.response.status_code", "401"),
+                    ("fault_domain", "caller"),
+                ],
+            ),
+            1,
+            "a dropped rejection should count without being rendered"
         );
     }
 

--- a/libs/@local/middleware/src/authentication/mod.rs
+++ b/libs/@local/middleware/src/authentication/mod.rs
@@ -112,7 +112,8 @@ impl AuthenticationMetrics {
 /// The response a request that failed authentication is answered with.
 ///
 /// A rejection records itself when it drops, whether or not a response was rendered from it,
-/// so no holder logs or counts one.
+/// so no holder logs or counts one. The log and the count are latched on the shared error, so
+/// a rejection cloned or rebuilt over the same report still reaches the log and the meter once.
 #[derive(Clone)]
 pub enum AuthenticationRejection {
     /// The credentials did not resolve to a caller the route admits.
@@ -148,7 +149,7 @@ impl Drop for AuthenticationRejection {
         match self {
             Self::Authentication { report, metrics } => {
                 AuthenticationError::ensure_logged(report);
-                metrics.record_rejection(report.current_context());
+                AuthenticationError::ensure_rejection_recorded(report, metrics);
             }
             Self::Misconfigured => {
                 tracing::error!(
@@ -1139,6 +1140,67 @@ mod tests {
             ),
             1,
             "a dropped rejection should count without being rendered"
+        );
+    }
+
+    /// A clone copies the [`Arc`]s, so both drops see one error and the count latches on it.
+    #[test]
+    fn cloned_rejection_counts_once() {
+        let recorded = RecordedMetrics::new();
+        let metrics = Arc::new(AuthenticationMetrics::new(&recorded.meter()));
+
+        let rejection = AuthenticationRejection::Authentication {
+            report: Arc::new(Report::new(AuthenticationError::new(
+                AuthenticationErrorKind::MissingCredentials,
+            ))),
+            metrics: Arc::clone(&metrics),
+        };
+        let clone = rejection.clone();
+        drop(rejection);
+        drop(clone);
+
+        assert_eq!(
+            recorded.counter(
+                "hash.authentication.rejections",
+                &[
+                    ("http.response.status_code", "401"),
+                    ("fault_domain", "caller"),
+                ],
+            ),
+            1,
+            "clones share one error, which counts one rejected request"
+        );
+    }
+
+    /// Extractors rebuild a rejection from the report the extension stores, so several
+    /// extractions on one request drop several rejections over one error.
+    #[test]
+    fn rebuilt_rejection_counts_once() {
+        let recorded = RecordedMetrics::new();
+        let metrics = Arc::new(AuthenticationMetrics::new(&recorded.meter()));
+        let report = Arc::new(Report::new(AuthenticationError::new(
+            AuthenticationErrorKind::MissingCredentials,
+        )));
+
+        drop(AuthenticationRejection::Authentication {
+            report: Arc::clone(&report),
+            metrics: Arc::clone(&metrics),
+        });
+        drop(AuthenticationRejection::Authentication {
+            report,
+            metrics: Arc::clone(&metrics),
+        });
+
+        assert_eq!(
+            recorded.counter(
+                "hash.authentication.rejections",
+                &[
+                    ("http.response.status_code", "401"),
+                    ("fault_domain", "caller"),
+                ],
+            ),
+            1,
+            "rejections over one report are one rejected request"
         );
     }
 

--- a/libs/@local/middleware/src/authentication/mod.rs
+++ b/libs/@local/middleware/src/authentication/mod.rs
@@ -75,10 +75,8 @@ impl AuthenticationMetrics {
 
 /// The response a request that failed authentication is answered with.
 ///
-///
-/// Metrics are recorded when the rejection is dropped, which happens once [`IntoResponse`]
-/// has rendered the response. It is independent of the fact whether a rejection will be rendered
-/// or not.
+/// The failure is logged and counted when the rejection drops, whether or not a response was
+/// rendered from it.
 pub enum AuthenticationRejection {
     /// The credentials did not resolve to a caller the route admits.
     Authentication {

--- a/libs/@local/middleware/src/authentication/mod.rs
+++ b/libs/@local/middleware/src/authentication/mod.rs
@@ -1,30 +1,30 @@
 //! Request authentication for axum routers.
 //!
-//! A service layers [`authentication_middleware`] over its routes with the provider chain it
-//! builds, and handlers receive the acting actor through the [`AuthenticatedActorId`] extractor —
-//! taking it as an `Option` is how a handler serves anonymous callers. A request with an invalid
+//! A service layers [`AuthenticationLayer`] over its routes with the provider chain it builds,
+//! and handlers receive the acting actor through the [`AuthenticatedActorId`] extractor — taking
+//! it as an `Option` is how a handler serves anonymous callers. A request with an invalid
 //! credential never reaches a handler, and a request without credentials resolves through the
 //! chain's [`Caller`] type: a chain over [`ActorId`] rejects it, a chain over `Option<ActorId>`
 //! verifies it as anonymous.
 //!
-//! Bootstrap routes — the paths the service names through the middleware's predicate — require
-//! the service secret regardless of the chain and pass even when no actor resolves. Routes that
-//! take no
-//! actor at all are gated by [`service_secret_middleware`] instead.
+//! Bootstrap routes — the paths the service names through the layer's predicate — require the
+//! service secret regardless of the chain and pass even when no actor resolves. Routes that take
+//! no actor at all are gated by [`ServiceSecretLayer`] instead.
 
 pub mod provider;
 pub mod request;
 pub mod service_secret;
 
 use alloc::sync::Arc;
+use core::{convert::Infallible, future, marker::PhantomData, task};
 
 use axum::{
-    extract::{FromRequestParts, OptionalFromRequestParts, Request},
+    extract::{FromRequestParts, OptionalFromRequestParts},
     http::request::Parts,
-    middleware::Next,
-    response::Response,
+    response::{IntoResponse, Response},
 };
 use error_stack::Report;
+use futures::{TryFutureExt as _, future::Either};
 use opentelemetry::{
     KeyValue,
     metrics::{Counter, Meter},
@@ -34,7 +34,7 @@ use type_system::principal::actor::ActorId;
 
 use self::{
     provider::{AuthenticationProvider, Caller},
-    request::{AuthenticationError, log_rejection, resolve_request_actor},
+    request::{AuthenticationError, AuthenticationErrorKind, resolve_request_actor},
     service_secret::{presents_service_secret, service_credential},
 };
 use crate::response::error_response;
@@ -72,6 +72,40 @@ impl AuthenticationMetrics {
     }
 }
 
+#[derive(Clone)]
+pub enum AuthenticationRejection {
+    Authentication {
+        report: Arc<Report<AuthenticationError>>,
+        metrics: Arc<AuthenticationMetrics>,
+    },
+    Misconfigured,
+}
+
+impl IntoResponse for AuthenticationRejection {
+    fn into_response(self) -> Response {
+        match self {
+            Self::Authentication { report, metrics } => {
+                AuthenticationError::log(&report);
+
+                let error = report.current_context();
+
+                metrics.record_rejection(error);
+                error_response(error.status_code(), error.client_message().to_owned())
+            }
+            Self::Misconfigured => {
+                tracing::error!(
+                    "`AuthenticatedActorId` extracted on a route without authentication middleware"
+                );
+
+                error_response(
+                    http::StatusCode::INTERNAL_SERVER_ERROR,
+                    "internal server error".to_owned(),
+                )
+            }
+        }
+    }
+}
+
 /// The resolved authentication of a request, stored as a request extension, alongside the
 /// metrics the rejections it leads to are recorded on.
 ///
@@ -99,46 +133,31 @@ impl ResolvedAuthentication {
     }
 }
 
-/// Converts an authentication failure into the response returned to the client, counting it.
-///
-/// The response carries the client-safe message. Identifiers and the report's attachments stay in
-/// the server-side logs, where [`log_rejection`] has already reported them.
-fn rejection(metrics: &AuthenticationMetrics, report: &Report<AuthenticationError>) -> Response {
-    let error = report.current_context();
-    metrics.record_rejection(error);
-    error_response(error.status_code(), error.client_message().to_owned())
-}
-
-/// Reports a rejection and converts it into the response returned to the client.
-fn logged_rejection(metrics: &AuthenticationMetrics, error: AuthenticationError) -> Response {
-    let report = Report::new(error);
-    log_rejection(&report);
-    rejection(metrics, &report)
-}
-
 /// Returns the rejection for a request that does not carry the service secret, [`None`] when it
 /// does.
 fn service_secret_rejection(
     headers: &http::HeaderMap,
     service_secret: &str,
-    metrics: &AuthenticationMetrics,
-) -> Option<Response> {
+    metrics: &Arc<AuthenticationMetrics>,
+) -> Option<AuthenticationRejection> {
     if presents_service_secret(headers, service_secret) {
         return None;
     }
 
     // A presented credential that does not match says the sender believed it had one, which the
     // fault domain separates from a request carrying none at all.
-    Some(logged_rejection(
-        metrics,
-        if service_credential(headers).is_some() {
-            AuthenticationError::InvalidServiceSecret
-        } else {
-            AuthenticationError::MissingServiceSecret
-        },
-    ))
-}
+    let kind = if service_credential(headers).is_some() {
+        AuthenticationErrorKind::InvalidServiceSecret
+    } else {
+        AuthenticationErrorKind::MissingServiceSecret
+    };
 
+    let report = Report::new(AuthenticationError::new(kind));
+    Some(AuthenticationRejection::Authentication {
+        report: Arc::new(report),
+        metrics: Arc::clone(metrics),
+    })
+}
 /// Rejects requests that do not carry the service secret.
 ///
 /// No credential is resolved, so no actor reaches the handler.
@@ -147,74 +166,103 @@ fn service_secret_rejection(
 ///
 /// ```
 /// # use std::sync::Arc;
-/// # use axum::{Router, middleware, routing::get};
-/// use hash_middleware::authentication::{AuthenticationMetrics, service_secret_middleware};
+/// # use axum::{Router, routing::get};
+/// use hash_middleware::authentication::{AuthenticationMetrics, ServiceSecretLayer};
 ///
 /// # let meter = opentelemetry::global::meter("doc");
-/// let service_secret: Arc<str> = Arc::from("service-secret");
-/// let metrics = Arc::new(AuthenticationMetrics::new(&meter));
 /// let router: Router = Router::new()
 ///     .route("/snapshot", get(async || "gated"))
-///     .route_layer(middleware::from_fn(move |request, next| {
-///         service_secret_middleware(
-///             Arc::clone(&service_secret),
-///             Arc::clone(&metrics),
-///             request,
-///             next,
-///         )
-///     }));
+///     .route_layer(ServiceSecretLayer {
+///         service_secret: Arc::from("service-secret"),
+///         metrics: Arc::new(AuthenticationMetrics::new(&meter)),
+///     });
 /// ```
-pub async fn service_secret_middleware(
+#[derive(Clone)]
+pub struct ServiceSecretLayer {
+    pub service_secret: Arc<str>,
+    pub metrics: Arc<AuthenticationMetrics>,
+}
+
+impl<S> tower::Layer<S> for ServiceSecretLayer {
+    type Service = ServiceSecretService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        ServiceSecretService {
+            service_secret: Arc::clone(&self.service_secret),
+            metrics: Arc::clone(&self.metrics),
+            inner,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct ServiceSecretService<S> {
     service_secret: Arc<str>,
     metrics: Arc<AuthenticationMetrics>,
-    request: Request,
-    next: Next,
-) -> Response {
-    if let Some(rejection) = service_secret_rejection(request.headers(), &service_secret, &metrics)
-    {
-        return rejection;
+    inner: S,
+}
+
+impl<B, S> tower::Service<axum::http::Request<B>> for ServiceSecretService<S>
+where
+    S: tower::Service<axum::http::Request<B>>,
+{
+    type Error = S::Error;
+    type Response = Result<S::Response, AuthenticationRejection>;
+
+    type Future = impl Future<Output = Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut task::Context<'_>) -> task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
     }
 
-    next.run(request).await
+    fn call(&mut self, req: axum::http::Request<B>) -> Self::Future {
+        if let Some(rejection) =
+            service_secret_rejection(req.headers(), &self.service_secret, &self.metrics)
+        {
+            Either::Right(future::ready(Ok(Err(rejection))))
+        } else {
+            Either::Left(self.inner.call(req).map_ok(Ok))
+        }
+    }
 }
 
 /// Records the authenticated actor on the request span and stores the outcome as a request
 /// extension.
-fn store_outcome(
-    request: &mut Request,
+fn store_outcome<B>(
+    request: &mut http::Request<B>,
     outcome: Result<Option<ActorId>, Arc<Report<AuthenticationError>>>,
     metrics: Arc<AuthenticationMetrics>,
 ) {
     if let Ok(Some(actor_id)) = &outcome {
         tracing::Span::current().record("actor_entity_uuid", tracing::field::display(actor_id));
     }
+
     request
         .extensions_mut()
         .insert(ResolvedAuthentication { outcome, metrics });
 }
 
-/// Resolves the request's credentials against `provider` and rejects the request when they are
-/// invalid.
+/// Resolves the request's credentials against the provider chain and rejects the request when
+/// they are invalid.
 ///
 /// Layer it over every route whose handlers take [`AuthenticatedActorId`] — the extractor serves
-/// only routes this middleware covers. A request without credentials resolves through the chain's
+/// only routes this layer covers. A request without credentials resolves through the chain's
 /// [`Caller`] type: a chain over [`ActorId`] rejects it, a chain over `Option<ActorId>` verifies
 /// it as anonymous, and whether an anonymous caller may proceed is the handler's to state,
 /// through which extractor it takes.
 ///
 /// Bootstrap routes are service operations: `bootstrap_route` names their paths, they require the
 /// service secret regardless of any actor credential, and they pass even when no actor resolves.
-/// A service
-/// without such routes passes `|_| false`.
+/// A service without such routes passes `|_| false`.
 ///
-/// Routes that take no actor are gated by [`service_secret_middleware`] instead.
+/// Routes that take no actor are gated by [`ServiceSecretLayer`] instead.
 ///
 /// # Example
 ///
 /// ```
-/// # use core::ops::ControlFlow;
+/// # use core::{marker::PhantomData, ops::ControlFlow};
 /// # use std::sync::Arc;
-/// # use axum::{Router, middleware, routing::get};
+/// # use axum::{Router, routing::get};
 /// # use error_stack::Report;
 /// # use hash_middleware::authentication::{
 /// #     provider::{AuthenticationProvider, Caller},
@@ -222,7 +270,7 @@ fn store_outcome(
 /// # };
 /// # use http::HeaderMap;
 /// use hash_middleware::authentication::{
-///     AuthenticatedActorId, AuthenticationMetrics, authentication_middleware,
+///     AuthenticatedActorId, AuthenticationLayer, AuthenticationMetrics,
 /// };
 /// use type_system::principal::actor::ActorId;
 ///
@@ -240,64 +288,138 @@ fn store_outcome(
 /// }
 ///
 /// # let meter = opentelemetry::global::meter("doc");
-/// let provider = Arc::new(Verifier);
-/// let service_secret: Arc<str> = Arc::from("service-secret");
-/// let metrics = Arc::new(AuthenticationMetrics::new(&meter));
-/// let router: Router =
-///     Router::new()
-///         .route("/whoami", get(whoami))
-///         .route_layer(middleware::from_fn(move |request, next| {
-///             authentication_middleware::<_, ActorId>(
-///                 Arc::clone(&provider),
-///                 Arc::clone(&service_secret),
-///                 Arc::clone(&metrics),
-///                 |_path| false,
-///                 request,
-///                 next,
-///             )
-///         }));
+/// let router: Router = Router::new().route("/whoami", get(whoami)).route_layer(
+///     AuthenticationLayer::<_, ActorId> {
+///         provider: Arc::new(Verifier),
+///         service_secret: Arc::from("service-secret"),
+///         metrics: Arc::new(AuthenticationMetrics::new(&meter)),
+///         bootstrap_route: |_path| false,
+///         caller: PhantomData,
+///     },
+/// );
 /// ```
-pub async fn authentication_middleware<P, C>(
+pub struct AuthenticationLayer<P, C> {
+    pub provider: Arc<P>,
+    pub service_secret: Arc<str>,
+    pub metrics: Arc<AuthenticationMetrics>,
+    pub bootstrap_route: fn(&str) -> bool,
+
+    pub caller: PhantomData<C>,
+}
+
+impl<P, C> Clone for AuthenticationLayer<P, C> {
+    fn clone(&self) -> Self {
+        Self {
+            provider: Arc::clone(&self.provider),
+            service_secret: Arc::clone(&self.service_secret),
+            metrics: Arc::clone(&self.metrics),
+            bootstrap_route: self.bootstrap_route,
+            caller: PhantomData,
+        }
+    }
+}
+
+impl<P, C, S> tower::Layer<S> for AuthenticationLayer<P, C> {
+    type Service = AuthenticationService<P, C, S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        AuthenticationService {
+            inner,
+            _caller: PhantomData,
+            provider: Arc::clone(&self.provider),
+            service_secret: Arc::clone(&self.service_secret),
+            metrics: Arc::clone(&self.metrics),
+            bootstrap_route: self.bootstrap_route,
+        }
+    }
+}
+
+pub struct AuthenticationService<P, C, S> {
+    inner: S,
+    _caller: PhantomData<C>,
+
     provider: Arc<P>,
     service_secret: Arc<str>,
     metrics: Arc<AuthenticationMetrics>,
     bootstrap_route: fn(&str) -> bool,
-    mut request: Request,
-    next: Next,
-) -> Response
-where
-    P: AuthenticationProvider<C>,
-    C: Caller,
-{
-    let bootstrap = bootstrap_route(request.uri().path());
-    if bootstrap
-        && let Some(rejection) =
-            service_secret_rejection(request.headers(), &service_secret, &metrics)
-    {
-        return rejection;
-    }
-
-    let outcome = resolve_request_actor(&*provider, request.headers())
-        .await
-        .map(Caller::into_actor)
-        .map_err(Arc::new);
-
-    match &outcome {
-        Err(report)
-            if bootstrap
-                && matches!(
-                    report.current_context(),
-                    AuthenticationError::MissingDelegatedActor
-                ) => {}
-        Err(report) => return rejection(&metrics, report),
-        Ok(_) => {}
-    }
-
-    store_outcome(&mut request, outcome, metrics);
-    next.run(request).await
 }
 
-/// Axum extractor providing the acting principal resolved by [`authentication_middleware`].
+impl<P, C, S: Clone> Clone for AuthenticationService<P, C, S> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            _caller: PhantomData,
+            provider: Arc::clone(&self.provider),
+            service_secret: Arc::clone(&self.service_secret),
+            metrics: Arc::clone(&self.metrics),
+            bootstrap_route: self.bootstrap_route,
+        }
+    }
+}
+
+impl<B, P, C, S> tower::Service<http::Request<B>> for AuthenticationService<P, C, S>
+where
+    S: tower::Service<http::Request<B>, Error = Infallible> + Clone,
+    C: Caller,
+    P: AuthenticationProvider<C>,
+{
+    type Error = S::Error;
+    type Response = Result<S::Response, AuthenticationRejection>;
+
+    type Future = impl Future<Output = Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut task::Context<'_>) -> task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: http::Request<B>) -> Self::Future {
+        let clone = self.inner.clone();
+        let mut next = core::mem::replace(&mut self.inner, clone);
+
+        let bootstrap = (self.bootstrap_route)(req.uri().path());
+        if bootstrap
+            && let Some(rejection) =
+                service_secret_rejection(req.headers(), &self.service_secret, &self.metrics)
+        {
+            return Either::Right(future::ready(Ok(Err(rejection))));
+        }
+
+        let provider = Arc::clone(&self.provider);
+        let metrics = Arc::clone(&self.metrics);
+
+        Either::Left(async move {
+            let outcome = resolve_request_actor(&*provider, req.headers())
+                .await
+                .map(Caller::into_actor)
+                .map_err(Arc::new);
+
+            let outcome = match outcome {
+                Err(report)
+                    if bootstrap
+                        && matches!(
+                            report.current_context().kind,
+                            AuthenticationErrorKind::MissingDelegatedActor
+                        ) =>
+                {
+                    Err(report)
+                }
+                Err(report) => {
+                    return Ok(Err(AuthenticationRejection::Authentication {
+                        report,
+                        metrics,
+                    }));
+                }
+                Ok(value) => Ok(value),
+            };
+
+            store_outcome(&mut req, outcome, metrics);
+
+            next.call(req).await.map(Ok)
+        })
+    }
+}
+
+/// Axum extractor providing the acting principal resolved by [`AuthenticationLayer`].
 ///
 /// Taking this extractor is how a handler states that it requires an actor: an anonymous caller
 /// is rejected here rather than reaching the handler. Handlers that serve callers without an
@@ -307,39 +429,35 @@ where
 pub struct AuthenticatedActorId(pub ActorId);
 
 impl<S: Sync> FromRequestParts<S> for AuthenticatedActorId {
-    type Rejection = Response;
+    type Rejection = AuthenticationRejection;
 
     fn from_request_parts(
         parts: &mut Parts,
         _state: &S,
     ) -> impl Future<Output = Result<Self, Self::Rejection>> + Send {
-        core::future::ready(match parts.extensions.get::<ResolvedAuthentication>() {
+        future::ready(match parts.extensions.get::<ResolvedAuthentication>() {
             Some(ResolvedAuthentication {
                 outcome: Ok(Some(actor_id)),
                 ..
             }) => Ok(Self(*actor_id)),
-            // Resolution succeeded and found no actor; the rejection originates here, in the
-            // handler's requirement, so this is the site that reports it.
+
             Some(ResolvedAuthentication {
                 outcome: Ok(None),
                 metrics,
-            }) => Err(logged_rejection(
-                metrics,
-                AuthenticationError::MissingCredentials,
-            )),
+            }) => Err(AuthenticationRejection::Authentication {
+                report: Arc::new(Report::new(AuthenticationError::new(
+                    AuthenticationErrorKind::MissingCredentials,
+                ))),
+                metrics: Arc::clone(metrics),
+            }),
             Some(ResolvedAuthentication {
                 outcome: Err(report),
                 metrics,
-            }) => Err(rejection(metrics, report)),
-            None => {
-                tracing::error!(
-                    "`AuthenticatedActorId` extracted on a route without authentication middleware"
-                );
-                Err(error_response(
-                    http::StatusCode::INTERNAL_SERVER_ERROR,
-                    "internal server error".to_owned(),
-                ))
-            }
+            }) => Err(AuthenticationRejection::Authentication {
+                report: Arc::clone(report),
+                metrics: Arc::clone(metrics),
+            }),
+            None => Err(AuthenticationRejection::Misconfigured),
         })
     }
 }
@@ -350,13 +468,13 @@ impl<S: Sync> FromRequestParts<S> for AuthenticatedActorId {
 /// actor. An invalid credential is still rejected — [`None`] means the chain resolved the request
 /// as anonymous, never that a credential failed.
 impl<S: Sync> OptionalFromRequestParts<S> for AuthenticatedActorId {
-    type Rejection = Response;
+    type Rejection = AuthenticationRejection;
 
     fn from_request_parts(
         parts: &mut Parts,
         _state: &S,
     ) -> impl Future<Output = Result<Option<Self>, Self::Rejection>> + Send {
-        core::future::ready(match parts.extensions.get::<ResolvedAuthentication>() {
+        future::ready(match parts.extensions.get::<ResolvedAuthentication>() {
             Some(ResolvedAuthentication {
                 outcome: Ok(caller),
                 ..
@@ -364,16 +482,11 @@ impl<S: Sync> OptionalFromRequestParts<S> for AuthenticatedActorId {
             Some(ResolvedAuthentication {
                 outcome: Err(report),
                 metrics,
-            }) => Err(rejection(metrics, report)),
-            None => {
-                tracing::error!(
-                    "`AuthenticatedActorId` extracted on a route without authentication middleware"
-                );
-                Err(error_response(
-                    http::StatusCode::INTERNAL_SERVER_ERROR,
-                    "internal server error".to_owned(),
-                ))
-            }
+            }) => Err(AuthenticationRejection::Authentication {
+                report: Arc::clone(report),
+                metrics: Arc::clone(metrics),
+            }),
+            None => Err(AuthenticationRejection::Misconfigured),
         })
     }
 }
@@ -381,14 +494,17 @@ impl<S: Sync> OptionalFromRequestParts<S> for AuthenticatedActorId {
 #[cfg(test)]
 mod tests {
     use alloc::sync::Arc;
+    use core::marker::PhantomData;
 
-    use axum::{Router, body::Body, middleware, routing::get};
+    use axum::{Router, body::Body, routing::get};
     use http::{Request, StatusCode};
     use tower::ServiceExt as _;
     use type_system::principal::actor::{ActorEntityUuid, ActorId, UserId};
     use uuid::Uuid;
 
-    use super::{AuthenticatedActorId, AuthenticationMetrics, authentication_middleware};
+    use super::{
+        AuthenticatedActorId, AuthenticationLayer, AuthenticationMetrics, ServiceSecretLayer,
+    };
     use crate::{
         authentication::provider::StaticAuthenticationProvider,
         test_metrics::{RecordedMetrics, noop_meter},
@@ -434,21 +550,13 @@ mod tests {
         provider: StaticAuthenticationProvider,
         metrics: Arc<AuthenticationMetrics>,
     ) -> Router {
-        let provider = Arc::new(provider);
-        let service_secret: Arc<str> = Arc::from(SERVICE_SECRET);
-        routes().layer(middleware::from_fn(move |request, next| {
-            let provider = Arc::clone(&provider);
-            let service_secret = Arc::clone(&service_secret);
-            let metrics = Arc::clone(&metrics);
-            authentication_middleware::<_, Option<ActorId>>(
-                provider,
-                service_secret,
-                metrics,
-                is_bootstrap_route,
-                request,
-                next,
-            )
-        }))
+        routes().layer(AuthenticationLayer::<_, Option<ActorId>> {
+            provider: Arc::new(provider),
+            service_secret: Arc::from(SERVICE_SECRET),
+            metrics,
+            bootstrap_route: is_bootstrap_route,
+            caller: PhantomData,
+        })
     }
 
     fn request(uri: &str) -> Request<Body> {
@@ -623,22 +731,13 @@ mod tests {
 
     /// A router requiring an actor.
     fn actor_required_router(provider: StaticAuthenticationProvider) -> Router {
-        let provider = Arc::new(provider);
-        let service_secret: Arc<str> = Arc::from(SERVICE_SECRET);
-        let metrics = Arc::new(AuthenticationMetrics::new(&noop_meter()));
-        routes().layer(middleware::from_fn(move |request, next| {
-            let provider = Arc::clone(&provider);
-            let service_secret = Arc::clone(&service_secret);
-            let metrics = Arc::clone(&metrics);
-            authentication_middleware::<_, ActorId>(
-                provider,
-                service_secret,
-                metrics,
-                is_bootstrap_route,
-                request,
-                next,
-            )
-        }))
+        routes().layer(AuthenticationLayer::<_, ActorId> {
+            provider: Arc::new(provider),
+            service_secret: Arc::from(SERVICE_SECRET),
+            metrics: Arc::new(AuthenticationMetrics::new(&noop_meter())),
+            bootstrap_route: is_bootstrap_route,
+            caller: PhantomData,
+        })
     }
 
     #[tokio::test]
@@ -694,13 +793,10 @@ mod tests {
 
     /// A router gated by the service secret alone, as bulk-destructive admin routes are.
     fn secret_gated_router() -> Router {
-        let service_secret: Arc<str> = Arc::from(SERVICE_SECRET);
-        let metrics = Arc::new(AuthenticationMetrics::new(&noop_meter()));
-        routes().layer(middleware::from_fn(move |request, next| {
-            let service_secret = Arc::clone(&service_secret);
-            let metrics = Arc::clone(&metrics);
-            super::service_secret_middleware(service_secret, metrics, request, next)
-        }))
+        routes().layer(ServiceSecretLayer {
+            service_secret: Arc::from(SERVICE_SECRET),
+            metrics: Arc::new(AuthenticationMetrics::new(&noop_meter())),
+        })
     }
 
     #[tokio::test]

--- a/libs/@local/middleware/src/authentication/provider.rs
+++ b/libs/@local/middleware/src/authentication/provider.rs
@@ -35,7 +35,7 @@ pub trait Caller: Send + Sized + sealed::Sealed {
     ///
     /// - [`MissingCredentials`] if the caller type requires an actor
     ///
-    /// [`MissingCredentials`]: AuthenticationError::MissingCredentials
+    /// [`MissingCredentials`]: AuthenticationErrorKind::MissingCredentials
     fn anonymous() -> Result<Self, AuthenticationError>;
 
     /// Returns the actor, or [`None`] for an anonymous caller.

--- a/libs/@local/middleware/src/authentication/provider.rs
+++ b/libs/@local/middleware/src/authentication/provider.rs
@@ -6,6 +6,7 @@ use error_stack::Report;
 use http::HeaderMap;
 use type_system::principal::actor::ActorId;
 
+use super::request::AuthenticationErrorKind;
 use crate::authentication::request::AuthenticationError;
 
 mod sealed {
@@ -47,7 +48,9 @@ impl Caller for ActorId {
     }
 
     fn anonymous() -> Result<Self, AuthenticationError> {
-        Err(AuthenticationError::MissingCredentials)
+        Err(AuthenticationError::new(
+            AuthenticationErrorKind::MissingCredentials,
+        ))
     }
 
     fn into_actor(self) -> Option<ActorId> {
@@ -142,12 +145,12 @@ where
         core::future::ready(match self {
             Self::NotRecognized => ControlFlow::Continue(()),
             Self::Verified(actor) => ControlFlow::Break(Ok(C::from_actor(*actor))),
-            Self::Rejected => {
-                ControlFlow::Break(Err(Report::new(AuthenticationError::InvalidSession)))
-            }
-            Self::Unreachable => {
-                ControlFlow::Break(Err(Report::new(AuthenticationError::ProviderUnreachable)))
-            }
+            Self::Rejected => ControlFlow::Break(Err(Report::new(AuthenticationError::new(
+                AuthenticationErrorKind::InvalidSession,
+            )))),
+            Self::Unreachable => ControlFlow::Break(Err(Report::new(AuthenticationError::new(
+                AuthenticationErrorKind::ProviderUnreachable,
+            )))),
         })
     }
 }
@@ -172,14 +175,14 @@ pub fn expect_rejection<C: core::fmt::Debug>(
 
 #[cfg(test)]
 mod tests {
-    use core::ops::ControlFlow;
+    use core::{assert_matches, ops::ControlFlow};
 
     use http::HeaderMap;
     use type_system::principal::actor::{ActorEntityUuid, ActorId, UserId};
     use uuid::Uuid;
 
     use super::{AuthenticationProvider as _, Caller, StaticAuthenticationProvider};
-    use crate::authentication::request::AuthenticationError;
+    use crate::authentication::request::{AuthenticationError, AuthenticationErrorKind};
 
     fn random_user() -> ActorId {
         ActorId::User(UserId::new(ActorEntityUuid::new(Uuid::new_v4())))
@@ -195,11 +198,12 @@ mod tests {
 
     #[test]
     fn anonymous_caller_fails_where_an_actor_is_required() {
-        assert!(
-            matches!(
-                <ActorId as Caller>::anonymous(),
-                Err(AuthenticationError::MissingCredentials)
-            ),
+        assert_matches!(
+            <ActorId as Caller>::anonymous(),
+            Err(AuthenticationError {
+                kind: AuthenticationErrorKind::MissingCredentials,
+                ..
+            }),
             "a required caller should reject anonymity"
         );
     }
@@ -213,8 +217,9 @@ mod tests {
         );
 
         let decision: ControlFlow<Result<ActorId, _>> = chain.authenticate(&HeaderMap::new()).await;
-        assert!(
-            matches!(decision, ControlFlow::Break(Ok(resolved)) if resolved == actor),
+        assert_matches!(
+            decision,
+            ControlFlow::Break(Ok(resolved)) if resolved == actor,
             "the chain should fall through to the second provider"
         );
     }
@@ -228,8 +233,9 @@ mod tests {
         );
 
         let decision: ControlFlow<Result<ActorId, _>> = chain.authenticate(&HeaderMap::new()).await;
-        assert!(
-            matches!(decision, ControlFlow::Break(Ok(resolved)) if resolved == actor),
+        assert_matches!(
+            decision,
+            ControlFlow::Break(Ok(resolved)) if resolved == actor,
             "the chain should stop at the first verified credential"
         );
     }
@@ -242,8 +248,9 @@ mod tests {
         );
 
         let decision: ControlFlow<Result<ActorId, _>> = chain.authenticate(&HeaderMap::new()).await;
-        assert!(
-            matches!(decision, ControlFlow::Break(Err(_))),
+        assert_matches!(
+            decision,
+            ControlFlow::Break(Err(_)),
             "a rejection by the first provider should never fall through to the second"
         );
     }
@@ -256,8 +263,9 @@ mod tests {
         );
 
         let decision: ControlFlow<Result<ActorId, _>> = chain.authenticate(&HeaderMap::new()).await;
-        assert!(
-            matches!(decision, ControlFlow::Continue(())),
+        assert_matches!(
+            decision,
+            ControlFlow::Continue(()),
             "the chain should recognize nothing when no provider does"
         );
     }

--- a/libs/@local/middleware/src/authentication/provider.rs
+++ b/libs/@local/middleware/src/authentication/provider.rs
@@ -182,7 +182,7 @@ mod tests {
     use uuid::Uuid;
 
     use super::{AuthenticationProvider as _, Caller, StaticAuthenticationProvider};
-    use crate::authentication::request::{AuthenticationError, AuthenticationErrorKind};
+    use crate::authentication::request::AuthenticationErrorKind;
 
     fn random_user() -> ActorId {
         ActorId::User(UserId::new(ActorEntityUuid::new(Uuid::new_v4())))
@@ -200,10 +200,7 @@ mod tests {
     fn anonymous_caller_fails_where_an_actor_is_required() {
         assert_matches!(
             <ActorId as Caller>::anonymous(),
-            Err(AuthenticationError {
-                kind: AuthenticationErrorKind::MissingCredentials,
-                ..
-            }),
+            Err(error) if *error.kind() == AuthenticationErrorKind::MissingCredentials,
             "a required caller should reject anonymity"
         );
     }

--- a/libs/@local/middleware/src/authentication/request.rs
+++ b/libs/@local/middleware/src/authentication/request.rs
@@ -194,13 +194,18 @@ impl AuthenticationErrorKind {
     }
 }
 
+/// An authentication failure, classified by its [`AuthenticationErrorKind`].
+///
+/// The kind decides the status code, the fault domain, and the client message.
 #[derive(Debug)]
 pub struct AuthenticationError {
+    /// What failed.
     pub kind: AuthenticationErrorKind,
     logged: Atomic<bool>,
 }
 
 impl AuthenticationError {
+    /// Creates the error for `kind`, not yet logged.
     #[must_use]
     pub const fn new(kind: AuthenticationErrorKind) -> Self {
         Self {
@@ -307,6 +312,12 @@ impl AuthenticationError {
         Self::new(AuthenticationErrorKind::StoreError)
     }
 
+    /// Logs the report at the level its fault domain assigns.
+    ///
+    /// Service faults log as errors, operator faults as warnings, and caller faults at debug: a
+    /// caller-repairable rejection must not hand anonymous traffic the log volume. Each error
+    /// logs once: a later call on a report whose error already logged does nothing, so every
+    /// layer that sees a rejection may call this without duplicating the record.
     pub fn log(report: &Report<Self>) {
         let this = report.current_context();
 
@@ -379,7 +390,7 @@ impl core::error::Error for AuthenticationError {}
 /// - [`MissingCredentials`] if no provider recognized a credential and the caller type requires an
 ///   actor
 ///
-/// [`MissingCredentials`]: AuthenticationError::MissingCredentials
+/// [`MissingCredentials`]: AuthenticationErrorKind::MissingCredentials
 pub async fn resolve_request_actor<P, C>(
     provider: &P,
     headers: &HeaderMap,
@@ -469,8 +480,8 @@ pub(crate) fn every_error(
 /// - [`MissingDelegatedActor`] if the header is absent
 /// - [`InvalidActorIdHeader`] if the header is not a valid UUID
 ///
-/// [`MissingDelegatedActor`]: AuthenticationError::MissingDelegatedActor
-/// [`InvalidActorIdHeader`]: AuthenticationError::InvalidActorIdHeader
+/// [`MissingDelegatedActor`]: AuthenticationErrorKind::MissingDelegatedActor
+/// [`InvalidActorIdHeader`]: AuthenticationErrorKind::InvalidActorIdHeader
 pub fn actor_id_from_header(headers: &HeaderMap) -> Result<ActorEntityUuid, AuthenticationError> {
     let header_value = headers
         .get(ACTOR_ID_HEADER)

--- a/libs/@local/middleware/src/authentication/request.rs
+++ b/libs/@local/middleware/src/authentication/request.rs
@@ -204,16 +204,20 @@ impl AuthenticationErrorKind {
 pub struct AuthenticationError {
     /// What failed.
     kind: AuthenticationErrorKind,
+    /// Whether the error has been logged.
     logged: Atomic<bool>,
+    /// Whether the error has been counted as a rejection.
+    recorded: Atomic<bool>,
 }
 
 impl AuthenticationError {
-    /// Creates the error for `kind`, not yet logged.
+    /// Creates the error for `kind`, not yet logged or counted.
     #[must_use]
     pub const fn new(kind: AuthenticationErrorKind) -> Self {
         Self {
             kind,
             logged: Atomic::<bool>::new(false),
+            recorded: Atomic::<bool>::new(false),
         }
     }
 
@@ -337,8 +341,9 @@ impl AuthenticationError {
     /// Service faults log as errors, operator faults as warnings, and caller faults at debug: a
     /// caller-repairable rejection must not hand anonymous traffic the log volume. Each error
     /// logs once: a later call on a report whose error already logged does nothing, so every
-    /// layer that sees a rejection may call this without duplicating the record.
-    pub(super) fn ensure_logged(report: &Report<Self>) {
+    /// layer that sees a rejection may call this without duplicating the record. Returns whether
+    /// this call was the one that logged.
+    pub(super) fn ensure_logged(report: &Report<Self>) -> bool {
         let this = report.current_context();
 
         // Claim the log, but only if it hasn't been logged yet.
@@ -353,20 +358,50 @@ impl AuthenticationError {
             )
             .is_err()
         {
-            return;
+            return false;
         }
 
         match this.kind.fault_domain() {
             FaultDomain::Service => {
                 tracing::error!(error = ?report, "credential verification failed");
             }
-
             FaultDomain::Operator => tracing::warn!(
                 error = ?report,
                 "credential rejected, pointing at provisioning or deployment configuration"
             ),
             FaultDomain::Caller => tracing::debug!(error = ?report, "credential rejected"),
         }
+
+        true
+    }
+
+    /// Ensures the rejection is counted on `metrics`, once per error.
+    ///
+    /// Each error counts once: a later call on a report whose error already counted does
+    /// nothing, so every rejection built over the same report may drop without inflating the
+    /// counter. Returns whether this call was the one that counted.
+    pub(super) fn ensure_rejection_recorded(
+        report: &Report<Self>,
+        metrics: &AuthenticationMetrics,
+    ) -> bool {
+        let this = report.current_context();
+
+        // `Relaxed` is permissible here, as it is only used to avoid double-counting rejections.
+        if this
+            .recorded
+            .compare_exchange(
+                false,
+                true,
+                atomic::Ordering::Relaxed,
+                atomic::Ordering::Relaxed,
+            )
+            .is_err()
+        {
+            return false;
+        }
+
+        metrics.record_rejection(this);
+        true
     }
 }
 
@@ -736,12 +771,6 @@ mod tests {
         }
     }
 
-    /// The level a rejection is logged at follows its fault domain.
-    ///
-    /// Pins the mapping at the logging site: [`fault_domain`] alone says nothing about which
-    /// macro the resolver reaches for.
-    ///
-    /// [`fault_domain`]: AuthenticationError::fault_domain
     /// Keeps the registered-dispatcher list plural for the rest of the process.
     ///
     /// With at most one registered dispatcher, tracing-core rebuilds a first-hit callsite's
@@ -760,6 +789,37 @@ mod tests {
         });
     }
 
+    /// The claim is exclusive: the first call logs and every later call reads the taken latch.
+    #[test]
+    fn log_latches() {
+        keep_dispatcher_list_plural();
+
+        let report = Report::new(AuthenticationError::missing_credentials());
+
+        assert!(AuthenticationError::ensure_logged(&report));
+        assert!(!AuthenticationError::ensure_logged(&report));
+    }
+
+    /// The claim is exclusive: the first call counts and every later call reads the taken latch.
+    #[test]
+    fn record_latches() {
+        let report = Report::new(AuthenticationError::missing_credentials());
+        let metrics = test_metrics();
+
+        assert!(AuthenticationError::ensure_rejection_recorded(
+            &report, &metrics
+        ));
+        assert!(!AuthenticationError::ensure_rejection_recorded(
+            &report, &metrics
+        ));
+    }
+
+    /// The level a rejection is logged at follows its fault domain.
+    ///
+    /// Pins the mapping at the logging site: [`fault_domain`] alone says nothing about which
+    /// macro the resolver reaches for.
+    ///
+    /// [`fault_domain`]: AuthenticationError::fault_domain
     #[test]
     fn rejections_log_at_their_domains_level() {
         keep_dispatcher_list_plural();

--- a/libs/@local/middleware/src/authentication/request.rs
+++ b/libs/@local/middleware/src/authentication/request.rs
@@ -1,6 +1,11 @@
 //! Resolution of a request's credentials to the acting principal.
 
-use core::{ops::ControlFlow, str::FromStr as _};
+use core::{
+    fmt,
+    ops::ControlFlow,
+    str::FromStr as _,
+    sync::{atomic, atomic::Atomic},
+};
 
 use error_stack::Report;
 use http::{HeaderMap, StatusCode};
@@ -40,7 +45,7 @@ impl FaultDomain {
 
 /// Errors that can occur while authenticating a request.
 #[derive(Debug, Clone, derive_more::Display)]
-pub enum AuthenticationError {
+pub enum AuthenticationErrorKind {
     /// No credentials were provided with the request.
     #[display("no credentials provided")]
     MissingCredentials,
@@ -100,9 +105,7 @@ pub enum AuthenticationError {
     StoreError,
 }
 
-impl core::error::Error for AuthenticationError {}
-
-impl AuthenticationError {
+impl AuthenticationErrorKind {
     /// Returns the status code reported to the client for this error.
     #[must_use]
     pub const fn status_code(&self) -> StatusCode {
@@ -191,20 +194,175 @@ impl AuthenticationError {
     }
 }
 
-/// Reports a rejection at the level its [`FaultDomain`] calls for.
-///
-/// The one place a rejection is reported, so a report reaching a response has been logged exactly
-/// once, wherever it was produced.
-pub(crate) fn log_rejection(report: &Report<AuthenticationError>) {
-    match report.current_context().fault_domain() {
-        FaultDomain::Service => tracing::error!(error = ?report, "credential verification failed"),
-        FaultDomain::Operator => tracing::warn!(
-            error = ?report,
-            "credential rejected, pointing at provisioning or deployment configuration"
-        ),
-        FaultDomain::Caller => tracing::debug!(error = ?report, "credential rejected"),
+#[derive(Debug)]
+pub struct AuthenticationError {
+    pub kind: AuthenticationErrorKind,
+    logged: Atomic<bool>,
+}
+
+impl AuthenticationError {
+    #[must_use]
+    pub const fn new(kind: AuthenticationErrorKind) -> Self {
+        Self {
+            kind,
+            logged: Atomic::<bool>::new(false),
+        }
+    }
+
+    /// Creates an error for [`AuthenticationErrorKind::MissingCredentials`].
+    #[must_use]
+    pub const fn missing_credentials() -> Self {
+        Self::new(AuthenticationErrorKind::MissingCredentials)
+    }
+
+    /// Creates an error for [`AuthenticationErrorKind::MalformedCredential`].
+    #[must_use]
+    pub const fn malformed_credential() -> Self {
+        Self::new(AuthenticationErrorKind::MalformedCredential)
+    }
+
+    /// Creates an error for [`AuthenticationErrorKind::InvalidActorIdHeader`].
+    #[must_use]
+    pub const fn invalid_actor_id_header() -> Self {
+        Self::new(AuthenticationErrorKind::InvalidActorIdHeader)
+    }
+
+    /// Creates an error for [`AuthenticationErrorKind::MissingServiceSecret`].
+    #[must_use]
+    pub const fn missing_service_secret() -> Self {
+        Self::new(AuthenticationErrorKind::MissingServiceSecret)
+    }
+
+    /// Creates an error for [`AuthenticationErrorKind::InvalidServiceSecret`].
+    #[must_use]
+    pub const fn invalid_service_secret() -> Self {
+        Self::new(AuthenticationErrorKind::InvalidServiceSecret)
+    }
+
+    /// Creates an error for [`AuthenticationErrorKind::MissingDelegatedActor`].
+    #[must_use]
+    pub const fn missing_delegated_actor() -> Self {
+        Self::new(AuthenticationErrorKind::MissingDelegatedActor)
+    }
+
+    /// Creates an error for [`AuthenticationErrorKind::ProviderUnreachable`].
+    #[must_use]
+    pub const fn provider_unreachable() -> Self {
+        Self::new(AuthenticationErrorKind::ProviderUnreachable)
+    }
+
+    /// Creates an error for [`AuthenticationErrorKind::ProviderRejection`].
+    #[must_use]
+    pub const fn provider_rejection() -> Self {
+        Self::new(AuthenticationErrorKind::ProviderRejection)
+    }
+
+    /// Creates an error for [`AuthenticationErrorKind::InvalidProviderResponse`].
+    #[must_use]
+    pub const fn invalid_provider_response() -> Self {
+        Self::new(AuthenticationErrorKind::InvalidProviderResponse)
+    }
+
+    /// Creates an error for [`AuthenticationErrorKind::InvalidSession`].
+    #[must_use]
+    pub const fn invalid_session() -> Self {
+        Self::new(AuthenticationErrorKind::InvalidSession)
+    }
+
+    /// Creates an error for [`AuthenticationErrorKind::InvalidAccessToken`].
+    #[must_use]
+    pub const fn invalid_access_token() -> Self {
+        Self::new(AuthenticationErrorKind::InvalidAccessToken)
+    }
+
+    /// Creates an error for [`AuthenticationErrorKind::IdentityWithoutActor`].
+    #[must_use]
+    pub const fn identity_without_actor() -> Self {
+        Self::new(AuthenticationErrorKind::IdentityWithoutActor)
+    }
+
+    /// Creates an error for [`AuthenticationErrorKind::NotProvisioned`].
+    #[must_use]
+    pub fn not_provisioned(identity_id: impl Into<String>) -> Self {
+        Self::new(AuthenticationErrorKind::NotProvisioned {
+            identity_id: identity_id.into(),
+        })
+    }
+
+    /// Creates an error for [`AuthenticationErrorKind::ActorNotFound`].
+    #[must_use]
+    pub const fn actor_not_found(actor_id: ActorEntityUuid) -> Self {
+        Self::new(AuthenticationErrorKind::ActorNotFound { actor_id })
+    }
+
+    /// Creates an error for [`AuthenticationErrorKind::NotAUser`].
+    #[must_use]
+    pub const fn not_a_user(actor_id: ActorEntityUuid) -> Self {
+        Self::new(AuthenticationErrorKind::NotAUser { actor_id })
+    }
+
+    /// Creates an error for [`AuthenticationErrorKind::StoreError`].
+    #[must_use]
+    pub const fn store_error() -> Self {
+        Self::new(AuthenticationErrorKind::StoreError)
+    }
+
+    pub fn log(report: &Report<Self>) {
+        let this = report.current_context();
+
+        // Claim the log, but only if it hasn't been logged yet.
+        // `Relaxed` is fine here, as it's only used to avoid duplicate logs.
+        if this
+            .logged
+            .compare_exchange(
+                false,
+                true,
+                atomic::Ordering::Relaxed,
+                atomic::Ordering::Relaxed,
+            )
+            .is_err()
+        {
+            return;
+        }
+
+        match this.kind.fault_domain() {
+            FaultDomain::Service => {
+                tracing::error!(error = ?report, "credential verification failed");
+            }
+
+            FaultDomain::Operator => tracing::warn!(
+                error = ?report,
+                "credential rejected, pointing at provisioning or deployment configuration"
+            ),
+            FaultDomain::Caller => tracing::debug!(error = ?report, "credential rejected"),
+        }
     }
 }
+
+impl core::ops::Deref for AuthenticationError {
+    type Target = AuthenticationErrorKind;
+
+    fn deref(&self) -> &Self::Target {
+        &self.kind
+    }
+}
+
+impl From<AuthenticationErrorKind> for AuthenticationError {
+    fn from(kind: AuthenticationErrorKind) -> Self {
+        Self {
+            kind,
+            logged: Atomic::<bool>::new(false),
+        }
+    }
+}
+
+impl fmt::Display for AuthenticationError {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.kind, fmt)
+    }
+}
+
+impl core::error::Error for AuthenticationError {}
 
 /// Resolves the acting principal from the request headers.
 ///
@@ -235,7 +393,8 @@ where
     match provider.authenticate(headers).await {
         ControlFlow::Break(Ok(caller)) => Ok(caller),
         ControlFlow::Break(Err(report)) => {
-            log_rejection(&report);
+            AuthenticationError::log(&report);
+
             // A verified rejection degrades to anonymous where the chain serves anonymous
             // callers — never to another credential: an ambient credential must not take over
             // an expired explicit choice.
@@ -255,7 +414,7 @@ where
             }
             C::anonymous().map_err(|error| {
                 let report = Report::new(error);
-                log_rejection(&report);
+                AuthenticationError::log(&report);
                 report
             })
         }
@@ -271,26 +430,26 @@ where
 pub(crate) fn every_error(
     identity_id: &str,
     actor_id: ActorEntityUuid,
-) -> [AuthenticationError; core::mem::variant_count::<AuthenticationError>()] {
+) -> [AuthenticationError; core::mem::variant_count::<AuthenticationErrorKind>()] {
     let errors = [
-        AuthenticationError::MissingCredentials,
-        AuthenticationError::MalformedCredential,
-        AuthenticationError::InvalidActorIdHeader,
-        AuthenticationError::MissingServiceSecret,
-        AuthenticationError::InvalidServiceSecret,
-        AuthenticationError::MissingDelegatedActor,
-        AuthenticationError::ProviderUnreachable,
-        AuthenticationError::ProviderRejection,
-        AuthenticationError::InvalidProviderResponse,
-        AuthenticationError::InvalidSession,
-        AuthenticationError::InvalidAccessToken,
-        AuthenticationError::IdentityWithoutActor,
-        AuthenticationError::NotProvisioned {
+        AuthenticationErrorKind::MissingCredentials,
+        AuthenticationErrorKind::MalformedCredential,
+        AuthenticationErrorKind::InvalidActorIdHeader,
+        AuthenticationErrorKind::MissingServiceSecret,
+        AuthenticationErrorKind::InvalidServiceSecret,
+        AuthenticationErrorKind::MissingDelegatedActor,
+        AuthenticationErrorKind::ProviderUnreachable,
+        AuthenticationErrorKind::ProviderRejection,
+        AuthenticationErrorKind::InvalidProviderResponse,
+        AuthenticationErrorKind::InvalidSession,
+        AuthenticationErrorKind::InvalidAccessToken,
+        AuthenticationErrorKind::IdentityWithoutActor,
+        AuthenticationErrorKind::NotProvisioned {
             identity_id: identity_id.to_owned(),
         },
-        AuthenticationError::ActorNotFound { actor_id },
-        AuthenticationError::NotAUser { actor_id },
-        AuthenticationError::StoreError,
+        AuthenticationErrorKind::ActorNotFound { actor_id },
+        AuthenticationErrorKind::NotAUser { actor_id },
+        AuthenticationErrorKind::StoreError,
     ];
 
     for (index, error) in errors.iter().enumerate() {
@@ -300,7 +459,7 @@ pub(crate) fn every_error(
         assert!(!repeated, "`{error}` should appear exactly once");
     }
 
-    errors
+    errors.map(AuthenticationError::from)
 }
 
 /// Parses the actor from the unverified actor-ID header.
@@ -315,14 +474,18 @@ pub(crate) fn every_error(
 pub fn actor_id_from_header(headers: &HeaderMap) -> Result<ActorEntityUuid, AuthenticationError> {
     let header_value = headers
         .get(ACTOR_ID_HEADER)
-        .ok_or(AuthenticationError::MissingDelegatedActor)?;
+        .ok_or(AuthenticationError::new(
+            AuthenticationErrorKind::MissingDelegatedActor,
+        ))?;
 
     header_value
         .to_str()
         .ok()
         .and_then(|header_string| Uuid::from_str(header_string).ok())
         .map(ActorEntityUuid::new)
-        .ok_or(AuthenticationError::InvalidActorIdHeader)
+        .ok_or(AuthenticationError::new(
+            AuthenticationErrorKind::InvalidActorIdHeader,
+        ))
 }
 
 #[cfg(test)]
@@ -339,8 +502,9 @@ mod tests {
     use uuid::Uuid;
 
     use super::{AuthenticationError, FaultDomain, every_error, resolve_request_actor};
-    use crate::authentication::provider::{
-        AuthenticationProvider, Caller, StaticAuthenticationProvider,
+    use crate::authentication::{
+        provider::{AuthenticationProvider, Caller, StaticAuthenticationProvider},
+        request::AuthenticationErrorKind,
     };
 
     /// The attachment the rejecting provider adds, standing in for what a real provider records
@@ -348,7 +512,7 @@ mod tests {
     const PROVIDER_DETAIL: &str = "provider response (401): session expired";
 
     /// A provider rejecting every request with the given error, carrying an attachment.
-    struct RejectingProvider(fn() -> AuthenticationError);
+    struct RejectingProvider(fn() -> AuthenticationErrorKind);
 
     impl<C: Caller> AuthenticationProvider<C> for RejectingProvider {
         fn authenticate(
@@ -356,9 +520,10 @@ mod tests {
             _headers: &HeaderMap,
         ) -> impl Future<Output = ControlFlow<Result<C, Report<AuthenticationError>>>> + Send
         {
-            core::future::ready(ControlFlow::Break(Err(
-                Report::new((self.0)()).attach(PROVIDER_DETAIL)
-            )))
+            core::future::ready(ControlFlow::Break(Err(Report::new(
+                AuthenticationError::new((self.0)()),
+            )
+            .attach(PROVIDER_DETAIL))))
         }
     }
 
@@ -420,8 +585,9 @@ mod tests {
                 .expect_err(
                     "a rejected credential should fail even when an actor-ID header is present"
                 )
-                .current_context(),
-            AuthenticationError::InvalidSession,
+                .current_context()
+                .kind,
+            AuthenticationErrorKind::InvalidSession,
             "the rejection should carry the provider's reason"
         );
     }
@@ -438,8 +604,9 @@ mod tests {
                 .expect_err(
                     "the actor-ID header should not resolve without a provider recognizing it"
                 )
-                .current_context(),
-            AuthenticationError::MissingCredentials,
+                .current_context()
+                .kind,
+            AuthenticationErrorKind::MissingCredentials,
             "the rejection should name the missing credentials"
         );
     }
@@ -469,8 +636,9 @@ mod tests {
             matches!(
                 outcome
                     .expect_err("an unverifiable credential should fail the request")
-                    .current_context(),
-                AuthenticationError::ProviderUnreachable
+                    .current_context()
+                    .kind,
+                AuthenticationErrorKind::ProviderUnreachable
             ),
             "the rejection should carry the verification failure"
         );
@@ -497,8 +665,9 @@ mod tests {
             matches!(
                 required
                     .expect_err("the expired credential should fail where an actor is required")
-                    .current_context(),
-                AuthenticationError::InvalidSession
+                    .current_context()
+                    .kind,
+                AuthenticationErrorKind::InvalidSession
             ),
             "the rejection should carry the expired credential's reason"
         );
@@ -513,8 +682,9 @@ mod tests {
         assert_matches!(
             outcome
                 .expect_err("a request without credentials should fail authentication")
-                .current_context(),
-            AuthenticationError::MissingCredentials,
+                .current_context()
+                .kind,
+            AuthenticationErrorKind::MissingCredentials,
             "the rejection should name the missing credentials"
         );
     }
@@ -546,15 +716,16 @@ mod tests {
     async fn rejections_log_at_their_domains_level() {
         let cases = [
             (
-                (|| AuthenticationError::ProviderUnreachable) as fn() -> AuthenticationError,
+                (|| AuthenticationErrorKind::ProviderUnreachable)
+                    as fn() -> AuthenticationErrorKind,
                 tracing::Level::ERROR,
             ),
             (
-                || AuthenticationError::IdentityWithoutActor,
+                || AuthenticationErrorKind::IdentityWithoutActor,
                 tracing::Level::WARN,
             ),
             (
-                || AuthenticationError::InvalidSession,
+                || AuthenticationErrorKind::InvalidSession,
                 tracing::Level::DEBUG,
             ),
         ];
@@ -612,7 +783,7 @@ mod tests {
     /// rejection cannot be diagnosed from the report alone.
     #[tokio::test]
     async fn rejection_carries_the_providers_attachment() {
-        let provider = RejectingProvider(|| AuthenticationError::InvalidSession);
+        let provider = RejectingProvider(|| AuthenticationErrorKind::InvalidSession);
 
         let report = resolve_request_actor::<_, ActorId>(&provider, &HeaderMap::new())
             .await
@@ -642,17 +813,17 @@ mod tests {
         let actor_id = ActorEntityUuid::new(Uuid::new_v4());
         let errors = [
             (
-                AuthenticationError::NotProvisioned {
+                AuthenticationErrorKind::NotProvisioned {
                     identity_id: identity_id.to_owned(),
                 },
                 identity_id.to_owned(),
             ),
             (
-                AuthenticationError::ActorNotFound { actor_id },
+                AuthenticationErrorKind::ActorNotFound { actor_id },
                 actor_id.to_string(),
             ),
             (
-                AuthenticationError::NotAUser { actor_id },
+                AuthenticationErrorKind::NotAUser { actor_id },
                 actor_id.to_string(),
             ),
         ];

--- a/libs/@local/middleware/src/authentication/request.rs
+++ b/libs/@local/middleware/src/authentication/request.rs
@@ -12,7 +12,10 @@ use http::{HeaderMap, StatusCode};
 use type_system::principal::actor::ActorEntityUuid;
 use uuid::Uuid;
 
-use crate::authentication::provider::{AuthenticationProvider, Caller};
+use crate::authentication::{
+    AuthenticationMetrics, Degradation,
+    provider::{AuthenticationProvider, Caller},
+};
 
 /// Name of the header carrying an unverified actor ID.
 pub const ACTOR_ID_HEADER: &str = "X-Authenticated-User-Actor-Id";
@@ -44,7 +47,7 @@ impl FaultDomain {
 }
 
 /// Errors that can occur while authenticating a request.
-#[derive(Debug, Clone, derive_more::Display)]
+#[derive(Debug, Clone, derive_more::Display, PartialEq, Eq)]
 pub enum AuthenticationErrorKind {
     /// No credentials were provided with the request.
     #[display("no credentials provided")]
@@ -200,7 +203,7 @@ impl AuthenticationErrorKind {
 #[derive(Debug)]
 pub struct AuthenticationError {
     /// What failed.
-    pub kind: AuthenticationErrorKind,
+    kind: AuthenticationErrorKind,
     logged: Atomic<bool>,
 }
 
@@ -212,6 +215,23 @@ impl AuthenticationError {
             kind,
             logged: Atomic::<bool>::new(false),
         }
+    }
+
+    #[must_use]
+    pub const fn kind(&self) -> &AuthenticationErrorKind {
+        &self.kind
+    }
+
+    pub const fn status_code(&self) -> StatusCode {
+        self.kind.status_code()
+    }
+
+    pub const fn fault_domain(&self) -> FaultDomain {
+        self.kind.fault_domain()
+    }
+
+    pub const fn is_verified_rejection(&self) -> bool {
+        self.kind.is_verified_rejection()
     }
 
     /// Creates an error for [`AuthenticationErrorKind::MissingCredentials`].
@@ -312,13 +332,13 @@ impl AuthenticationError {
         Self::new(AuthenticationErrorKind::StoreError)
     }
 
-    /// Logs the report at the level its fault domain assigns.
+    /// Ensures the report is logged, at the level its fault domain assigns.
     ///
     /// Service faults log as errors, operator faults as warnings, and caller faults at debug: a
     /// caller-repairable rejection must not hand anonymous traffic the log volume. Each error
     /// logs once: a later call on a report whose error already logged does nothing, so every
     /// layer that sees a rejection may call this without duplicating the record.
-    pub fn log(report: &Report<Self>) {
+    pub(super) fn ensure_logged(report: &Report<Self>) {
         let this = report.current_context();
 
         // Claim the log, but only if it hasn't been logged yet.
@@ -350,23 +370,6 @@ impl AuthenticationError {
     }
 }
 
-impl core::ops::Deref for AuthenticationError {
-    type Target = AuthenticationErrorKind;
-
-    fn deref(&self) -> &Self::Target {
-        &self.kind
-    }
-}
-
-impl From<AuthenticationErrorKind> for AuthenticationError {
-    fn from(kind: AuthenticationErrorKind) -> Self {
-        Self {
-            kind,
-            logged: Atomic::<bool>::new(false),
-        }
-    }
-}
-
 impl fmt::Display for AuthenticationError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&self.kind, fmt)
@@ -380,8 +383,8 @@ impl core::error::Error for AuthenticationError {}
 /// The provider is the only credential path: a request without a recognized credential resolves
 /// through [`Caller::anonymous`], and so does one whose credential the provider verified and
 /// rejected — an expired session reads public data like a request without one. A failure to
-/// verify keeps failing the request. Chain providers as pairs, nested for more than two, to
-/// accept several credential kinds.
+/// verify keeps failing the request. A degrade to anonymous is counted on `metrics`. Chain
+/// providers as pairs, nested for more than two, to accept several credential kinds.
 ///
 /// # Errors
 ///
@@ -394,6 +397,7 @@ impl core::error::Error for AuthenticationError {}
 pub async fn resolve_request_actor<P, C>(
     provider: &P,
     headers: &HeaderMap,
+    metrics: &AuthenticationMetrics,
 ) -> Result<C, Report<AuthenticationError>>
 where
     P: AuthenticationProvider<C>,
@@ -404,7 +408,7 @@ where
     match provider.authenticate(headers).await {
         ControlFlow::Break(Ok(caller)) => Ok(caller),
         ControlFlow::Break(Err(report)) => {
-            AuthenticationError::log(&report);
+            AuthenticationError::ensure_logged(&report);
 
             // A verified rejection degrades to anonymous where the chain serves anonymous
             // callers — never to another credential: an ambient credential must not take over
@@ -412,6 +416,7 @@ where
             if report.current_context().is_verified_rejection()
                 && let Ok(caller) = C::anonymous()
             {
+                metrics.record_degradation(report.current_context(), Degradation::Anonymous);
                 Ok(caller)
             } else {
                 Err(report)
@@ -425,7 +430,7 @@ where
             }
             C::anonymous().map_err(|error| {
                 let report = Report::new(error);
-                AuthenticationError::log(&report);
+                AuthenticationError::ensure_logged(&report);
                 report
             })
         }
@@ -467,10 +472,14 @@ pub(crate) fn every_error(
         let repeated = errors[..index]
             .iter()
             .any(|earlier| core::mem::discriminant(earlier) == core::mem::discriminant(error));
-        assert!(!repeated, "`{error}` should appear exactly once");
+        assert!(
+            !repeated,
+            "`{}` should appear exactly once",
+            error.client_message()
+        );
     }
 
-    errors.map(AuthenticationError::from)
+    errors.map(AuthenticationError::new)
 }
 
 /// Parses the actor from the unverified actor-ID header.
@@ -503,17 +512,18 @@ pub fn actor_id_from_header(headers: &HeaderMap) -> Result<ActorEntityUuid, Auth
 mod tests {
     use alloc::sync::Arc;
     use core::{assert_matches, ops::ControlFlow};
-    use std::sync::Mutex;
+    use std::sync::{Mutex, OnceLock};
 
     use error_stack::Report;
     use http::HeaderMap;
-    use tracing::instrument::WithSubscriber as _;
+    use tracing::{Dispatch, dispatcher};
     use tracing_subscriber::layer::SubscriberExt as _;
     use type_system::principal::actor::{ActorEntityUuid, ActorId, UserId};
     use uuid::Uuid;
 
     use super::{AuthenticationError, FaultDomain, every_error, resolve_request_actor};
     use crate::authentication::{
+        AuthenticationMetrics,
         provider::{AuthenticationProvider, Caller, StaticAuthenticationProvider},
         request::AuthenticationErrorKind,
     };
@@ -521,6 +531,10 @@ mod tests {
     /// The attachment the rejecting provider adds, standing in for what a real provider records
     /// about the credential it refused.
     const PROVIDER_DETAIL: &str = "provider response (401): session expired";
+
+    fn test_metrics() -> AuthenticationMetrics {
+        AuthenticationMetrics::new(&crate::test_metrics::noop_meter())
+    }
 
     /// A provider rejecting every request with the given error, carrying an attachment.
     struct RejectingProvider(fn() -> AuthenticationErrorKind);
@@ -576,7 +590,8 @@ mod tests {
         let actor_id = random_user();
         let provider = StaticAuthenticationProvider::Verified(actor_id);
 
-        let outcome: Result<ActorId, _> = resolve_request_actor(&provider, &HeaderMap::new()).await;
+        let outcome: Result<ActorId, _> =
+            resolve_request_actor(&provider, &HeaderMap::new(), &test_metrics()).await;
 
         assert!(
             matches!(outcome, Ok(resolved) if resolved == actor_id),
@@ -589,7 +604,8 @@ mod tests {
         let provider = StaticAuthenticationProvider::Rejected;
         let headers = actor_id_header(ActorEntityUuid::new(Uuid::new_v4()));
 
-        let outcome: Result<ActorId, _> = resolve_request_actor(&provider, &headers).await;
+        let outcome: Result<ActorId, _> =
+            resolve_request_actor(&provider, &headers, &test_metrics()).await;
 
         assert_matches!(
             outcome
@@ -608,7 +624,8 @@ mod tests {
         let provider = StaticAuthenticationProvider::NotRecognized;
         let headers = actor_id_header(ActorEntityUuid::new(Uuid::new_v4()));
 
-        let outcome: Result<ActorId, _> = resolve_request_actor(&provider, &headers).await;
+        let outcome: Result<ActorId, _> =
+            resolve_request_actor(&provider, &headers, &test_metrics()).await;
 
         assert_matches!(
             outcome
@@ -627,7 +644,7 @@ mod tests {
         let provider = StaticAuthenticationProvider::Rejected;
 
         let outcome: Result<Option<ActorId>, _> =
-            resolve_request_actor(&provider, &HeaderMap::new()).await;
+            resolve_request_actor(&provider, &HeaderMap::new(), &test_metrics()).await;
 
         assert!(
             matches!(outcome, Ok(None)),
@@ -641,7 +658,7 @@ mod tests {
         let provider = StaticAuthenticationProvider::Unreachable;
 
         let outcome: Result<Option<ActorId>, _> =
-            resolve_request_actor(&provider, &HeaderMap::new()).await;
+            resolve_request_actor(&provider, &HeaderMap::new(), &test_metrics()).await;
 
         assert!(
             matches!(
@@ -665,13 +682,14 @@ mod tests {
         );
 
         let anonymous: Result<Option<ActorId>, _> =
-            resolve_request_actor(&chain, &HeaderMap::new()).await;
+            resolve_request_actor(&chain, &HeaderMap::new(), &test_metrics()).await;
         assert!(
             matches!(anonymous, Ok(None)),
             "the expired credential should degrade to anonymous, not to the second credential"
         );
 
-        let required: Result<ActorId, _> = resolve_request_actor(&chain, &HeaderMap::new()).await;
+        let required: Result<ActorId, _> =
+            resolve_request_actor(&chain, &HeaderMap::new(), &test_metrics()).await;
         assert!(
             matches!(
                 required
@@ -688,7 +706,8 @@ mod tests {
     async fn missing_credentials_fail_authentication() {
         let provider = StaticAuthenticationProvider::NotRecognized;
 
-        let outcome: Result<ActorId, _> = resolve_request_actor(&provider, &HeaderMap::new()).await;
+        let outcome: Result<ActorId, _> =
+            resolve_request_actor(&provider, &HeaderMap::new(), &test_metrics()).await;
 
         assert_matches!(
             outcome
@@ -723,8 +742,33 @@ mod tests {
     /// macro the resolver reaches for.
     ///
     /// [`fault_domain`]: AuthenticationError::fault_domain
-    #[tokio::test]
-    async fn rejections_log_at_their_domains_level() {
+    /// Keeps the registered-dispatcher list plural for the rest of the process.
+    ///
+    /// With at most one registered dispatcher, tracing-core rebuilds a first-hit callsite's
+    /// interest from the calling thread's default dispatcher (`Rebuilder::JustOne`). A parallel
+    /// test thread with no default dispatcher then caches `never` for a callsite this test just
+    /// enabled, and the event is skipped before the scoped subscriber is consulted. Two
+    /// dispatchers that never drop keep `has_just_one` false, so every rebuild reads the real
+    /// registry list under its lock, and that list contains this test's live dispatch.
+    fn keep_dispatcher_list_plural() {
+        static KEEPERS: OnceLock<[Dispatch; 2]> = OnceLock::new();
+        KEEPERS.get_or_init(|| {
+            [
+                Dispatch::new(tracing_subscriber::registry()),
+                Dispatch::new(tracing_subscriber::registry()),
+            ]
+        });
+    }
+
+    #[test]
+    fn rejections_log_at_their_domains_level() {
+        keep_dispatcher_list_plural();
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("should be a valid runtime configuration");
+
         let cases = [
             (
                 (|| AuthenticationErrorKind::ProviderUnreachable)
@@ -744,24 +788,23 @@ mod tests {
         for (error, expected) in cases {
             let levels = EventLevels::default();
             let subscriber = tracing_subscriber::registry().with(levels.clone());
-            let provider = RejectingProvider(error);
-            // A test that reached these call sites without a subscriber cached them as
-            // uninteresting process-wide, and a scoped subscriber does not invalidate that.
-            tracing::callsite::rebuild_interest_cache();
+            let dispatch = Dispatch::new(subscriber);
 
-            async {
-                let _outcome: Result<ActorId, _> =
-                    resolve_request_actor(&provider, &HeaderMap::new()).await;
-            }
-            .with_subscriber(subscriber)
-            .await;
+            let provider = RejectingProvider(error);
+
+            dispatcher::with_default(&dispatch, || {
+                runtime.block_on(async move {
+                    let _outcome: Result<ActorId, _> =
+                        resolve_request_actor(&provider, &HeaderMap::new(), &test_metrics()).await;
+                });
+            });
 
             let recorded = levels.0.lock().expect("the event log should lock");
             assert_eq!(
                 recorded.as_slice(),
                 [expected],
                 "`{}` should be logged once, at its domain's level",
-                error()
+                error().client_message()
             );
         }
 
@@ -770,17 +813,18 @@ mod tests {
         // the process-global callsite interest cache and cannot run in parallel.
         let levels = EventLevels::default();
         let subscriber = tracing_subscriber::registry().with(levels.clone());
-        tracing::callsite::rebuild_interest_cache();
 
-        async {
-            let _outcome: Result<ActorId, _> = resolve_request_actor(
-                &StaticAuthenticationProvider::NotRecognized,
-                &HeaderMap::new(),
-            )
-            .await;
-        }
-        .with_subscriber(subscriber)
-        .await;
+        let dispatch = Dispatch::new(subscriber);
+        dispatcher::with_default(&dispatch, || {
+            runtime.block_on(async move {
+                let _outcome: Result<ActorId, _> = resolve_request_actor(
+                    &StaticAuthenticationProvider::NotRecognized,
+                    &HeaderMap::new(),
+                    &test_metrics(),
+                )
+                .await;
+            });
+        });
 
         let recorded = levels.0.lock().expect("the event log should lock");
         assert_eq!(
@@ -796,9 +840,10 @@ mod tests {
     async fn rejection_carries_the_providers_attachment() {
         let provider = RejectingProvider(|| AuthenticationErrorKind::InvalidSession);
 
-        let report = resolve_request_actor::<_, ActorId>(&provider, &HeaderMap::new())
-            .await
-            .expect_err("a rejected credential should fail");
+        let report =
+            resolve_request_actor::<_, ActorId>(&provider, &HeaderMap::new(), &test_metrics())
+                .await
+                .expect_err("a rejected credential should fail");
 
         assert!(
             format!("{report:?}").contains(PROVIDER_DETAIL),
@@ -811,7 +856,7 @@ mod tests {
     fn client_messages_are_never_empty() {
         for error in every_error("identity-id", ActorEntityUuid::new(Uuid::new_v4())) {
             assert!(
-                !error.client_message().is_empty(),
+                !error.kind().client_message().is_empty(),
                 "`{error}` should report a client message"
             );
         }
@@ -840,9 +885,10 @@ mod tests {
         ];
 
         for (error, identifier) in errors {
+            let report = Report::new(AuthenticationError::new(error));
             assert!(
-                error.to_string().contains(&identifier),
-                "the log representation of `{error}` should carry the identifier"
+                format!("{report:?}").contains(&identifier),
+                "the log representation of `{report:?}` should carry the identifier"
             );
         }
     }

--- a/libs/@local/middleware/src/lib.rs
+++ b/libs/@local/middleware/src/lib.rs
@@ -11,15 +11,15 @@
 //!   principal behind it — its module documentation states the ordering contract.
 //! - [`telemetry`] spans every request and joins the caller's OpenTelemetry trace.
 //!
-//! The providers are the extension point; the credential vocabulary is not. A new failure mode
-//! extends [`AuthenticationError`], a new caller type the sealed [`Caller`] — both are changes to
-//! this crate.
+//! The providers are the extension point, and the credential vocabulary is not. A new failure
+//! mode extends [`AuthenticationErrorKind`], a new caller type the sealed [`Caller`], and both
+//! are changes to this crate.
 //!
 //! [`provider`]: authentication::provider
 //! [`AuthenticationProvider`]: authentication::provider::AuthenticationProvider
 //! [`Caller`]: authentication::provider::Caller
 //! [`AuthenticatedActorId`]: authentication::AuthenticatedActorId
-//! [`AuthenticationError`]: authentication::request::AuthenticationError
+//! [`AuthenticationErrorKind`]: authentication::request::AuthenticationErrorKind
 //!
 //! # Example
 //!

--- a/libs/@local/middleware/src/lib.rs
+++ b/libs/@local/middleware/src/lib.rs
@@ -27,20 +27,20 @@
 //! limiter — requests traverse them in that order — with the tracing layer on the outside:
 //!
 //! ```
-//! use core::{num::NonZeroU32, ops::ControlFlow};
+//! use core::{marker::PhantomData, num::NonZeroU32, ops::ControlFlow};
 //! use std::sync::Arc;
 //!
-//! use axum::{Router, middleware, routing::get};
+//! use axum::{Router, routing::get};
 //! use error_stack::Report;
 //! use hash_middleware::{
 //!     authentication::{
-//!         AuthenticatedActorId, AuthenticationMetrics, authentication_middleware,
+//!         AuthenticatedActorId, AuthenticationLayer, AuthenticationMetrics,
 //!         provider::{AuthenticationProvider, Caller},
 //!         request::AuthenticationError,
 //!     },
 //!     rate_limit::{
-//!         ClientIpSource, RateLimitConfig, RateLimitMode, RateLimiters, ip_gate_middleware,
-//!         principal_limit_middleware,
+//!         ClientIpSource, IpGateLayer, PrincipalLimitLayer, RateLimitConfig, RateLimitMode,
+//!         RateLimiters,
 //!     },
 //!     telemetry::HttpTracingLayer,
 //! };
@@ -82,43 +82,25 @@
 //!     &meter,
 //! );
 //!
-//! let provider = Arc::new(Verifier);
 //! let service_secret: Arc<str> = Arc::from("service-secret");
-//! let auth_secret = Arc::clone(&service_secret);
-//! let auth_metrics = Arc::new(AuthenticationMetrics::new(&meter));
-//! let principal_limiters = Arc::clone(&limiters);
-//! let principal_secret = Arc::clone(&service_secret);
-//! let gate_limiters = Arc::clone(&limiters);
-//! let gate_secret = Arc::clone(&service_secret);
 //!
 //! let router: Router = Router::new()
 //!     .route("/whoami", get(whoami))
-//!     .route_layer(middleware::from_fn(move |request, next| {
-//!         principal_limit_middleware(
-//!             Arc::clone(&principal_limiters),
-//!             Arc::clone(&principal_secret),
-//!             request,
-//!             next,
-//!         )
-//!     }))
-//!     .route_layer(middleware::from_fn(move |request, next| {
-//!         authentication_middleware::<_, ActorId>(
-//!             Arc::clone(&provider),
-//!             Arc::clone(&auth_secret),
-//!             Arc::clone(&auth_metrics),
-//!             |_path| false,
-//!             request,
-//!             next,
-//!         )
-//!     }))
-//!     .layer(middleware::from_fn(move |request, next| {
-//!         ip_gate_middleware(
-//!             Arc::clone(&gate_limiters),
-//!             Arc::clone(&gate_secret),
-//!             request,
-//!             next,
-//!         )
-//!     }))
+//!     .route_layer(PrincipalLimitLayer {
+//!         limiters: Arc::clone(&limiters),
+//!         service_secret: Arc::clone(&service_secret),
+//!     })
+//!     .route_layer(AuthenticationLayer::<_, ActorId> {
+//!         provider: Arc::new(Verifier),
+//!         service_secret: Arc::clone(&service_secret),
+//!         metrics: Arc::new(AuthenticationMetrics::new(&meter)),
+//!         bootstrap_route: |_path| false,
+//!         caller: PhantomData,
+//!     })
+//!     .layer(IpGateLayer {
+//!         limiters,
+//!         service_secret,
+//!     })
 //!     .layer(HttpTracingLayer::new(|path| path == "/health"));
 //!
 //! // Serve the router with `into_make_service_with_connect_info::<SocketAddr>()`, so the gate
@@ -129,7 +111,7 @@
 //!
 //! # Workspace dependencies
 #![doc = simple_mermaid::mermaid!("../docs/dependency-diagram.mmd")]
-#![feature(impl_trait_in_assoc_type)]
+#![feature(impl_trait_in_assoc_type, generic_atomic)]
 #![cfg_attr(test, feature(variant_count))]
 
 extern crate alloc;

--- a/libs/@local/middleware/src/lib.rs
+++ b/libs/@local/middleware/src/lib.rs
@@ -109,6 +109,18 @@
 //! # }
 //! ```
 //!
+//! # Feature flags
+//!
+//! Both are off by default.
+//!
+//! - `clap`: derives `clap::ValueEnum` on [`RateLimitMode`] and [`ClientIpSource`], so a service
+//!   parses them straight from its command line.
+//! - `test-utils`: exposes the fixed-outcome provider `StaticAuthenticationProvider` and
+//!   `expect_rejection` to dependent crates' tests.
+//!
+//! [`RateLimitMode`]: rate_limit::RateLimitMode
+//! [`ClientIpSource`]: rate_limit::ClientIpSource
+//!
 //! # Workspace dependencies
 #![doc = simple_mermaid::mermaid!("../docs/dependency-diagram.mmd")]
 #![feature(impl_trait_in_assoc_type, generic_atomic)]

--- a/libs/@local/middleware/src/rate_limit/address.rs
+++ b/libs/@local/middleware/src/rate_limit/address.rs
@@ -6,7 +6,7 @@ use core::{
     str::FromStr,
 };
 
-use axum::extract::{ConnectInfo, Request};
+use axum::extract::ConnectInfo;
 use http::HeaderName;
 
 /// The key an address-keyed budget is charged against.
@@ -90,7 +90,10 @@ impl Fallback {
 /// the closest proxy received from, so every client behind that one shares a budget.
 ///
 /// Accepts a bare address or an `address:port` pair.
-pub(super) fn from_header(request: &Request, header: &HeaderName) -> Result<BucketKey, Fallback> {
+pub(super) fn from_header<B>(
+    request: &http::Request<B>,
+    header: &HeaderName,
+) -> Result<BucketKey, Fallback> {
     let Some(value) = request.headers().get_all(header).iter().next_back() else {
         return Err(Fallback::HeaderMissing);
     };
@@ -103,7 +106,7 @@ pub(super) fn from_header(request: &Request, header: &HeaderName) -> Result<Buck
 ///
 /// [`None`] when the router was served without [`ConnectInfo`], which leaves nothing to key a
 /// budget by.
-pub(super) fn peer(request: &Request) -> Option<BucketKey> {
+pub(super) fn peer<B>(request: &http::Request<B>) -> Option<BucketKey> {
     request
         .extensions()
         .get::<ConnectInfo<SocketAddr>>()

--- a/libs/@local/middleware/src/rate_limit/mod.rs
+++ b/libs/@local/middleware/src/rate_limit/mod.rs
@@ -34,12 +34,7 @@ mod config;
 mod tests;
 
 use alloc::sync::Arc;
-use core::{
-    fmt, future,
-    num::{NonZero, NonZeroU64},
-    task,
-    time::Duration,
-};
+use core::{fmt, future, num::NonZero, task, time::Duration};
 use std::sync::LazyLock;
 
 use axum::{
@@ -345,8 +340,23 @@ impl IntoResponse for RateLimitRejection {
 /// A request found to be over its budget.
 struct Denial {
     /// Whole seconds until the budget admits the request again, at least one.
-    retry_after: NonZeroU64,
+    retry_after: NonZero<u64>,
     mode: RateLimitMode,
+}
+
+impl Denial {
+    const fn apply(self) -> Option<TooManyRequests> {
+        match self {
+            Self {
+                mode: RateLimitMode::Observe,
+                retry_after: _,
+            } => None,
+            Self {
+                mode: RateLimitMode::Enforce,
+                retry_after,
+            } => Some(TooManyRequests { retry_after }),
+        }
+    }
 }
 
 /// The shared limiter state both rate-limiting middlewares charge against.
@@ -548,7 +558,7 @@ impl RateLimiters {
         self.metrics
             .denial(budget, self.mode.denial_outcome(), wait);
         let seconds = wait.as_secs() + u64::from(wait.subsec_nanos() > 0);
-        let retry_after = NonZeroU64::new(seconds).unwrap_or(NonZeroU64::MIN);
+        let retry_after = NonZero::new(seconds).unwrap_or(NonZero::<u64>::MIN);
         tracing::debug!(
             budget = budget.as_str(),
             key = %key,
@@ -675,16 +685,13 @@ where
             return Either::Right(self.inner.call(req).map_ok(Ok));
         };
 
-        match self.limiters.charge(Budget::Gate(key)) {
-            Ok(())
-            | Err(Denial {
-                mode: RateLimitMode::Observe,
-                retry_after: _,
-            }) => Either::Right(self.inner.call(req).map_ok(Ok)),
-            Err(Denial {
-                mode: RateLimitMode::Enforce,
-                retry_after,
-            }) => Either::Left(future::ready(Ok(Err(TooManyRequests { retry_after })))),
+        match self
+            .limiters
+            .charge(Budget::Gate(key))
+            .map_err(Denial::apply)
+        {
+            Ok(()) | Err(None) => Either::Right(self.inner.call(req).map_ok(Ok)),
+            Err(Some(error)) => Either::Left(future::ready(Ok(Err(error)))),
         }
     }
 }
@@ -827,11 +834,11 @@ where
         let actor = match resolved.outcome() {
             Ok(actor) => *actor,
             Err(error) => {
-                // The authentication layer stores an error only as `MissingDelegatedActor` on a
-                // bootstrap route, and those requests present the service secret and passed above.
-                // Reaching this means the middleware order broke, so the report's attachments are
-                // the only account of what the provider saw — `Display` would print the first
-                // context and drop them.
+                // A stored error means a bootstrap route tolerated the failure, and those
+                // requests presented the service secret and passed above. Reaching this
+                // arm means the middleware order broke, so the report's attachments are the only
+                // account of what the provider saw: `Display` would print the first context and
+                // drop them.
                 tracing::error!(error = ?error, "authentication error reached the rate limiter unrejected");
 
                 self.limiters
@@ -865,18 +872,9 @@ where
             Budget::Anonymous(key)
         };
 
-        match self.limiters.charge(budget) {
-            Ok(())
-            | Err(Denial {
-                mode: RateLimitMode::Observe,
-                retry_after: _,
-            }) => Either::Right(self.inner.call(req).map_ok(Ok)),
-            Err(Denial {
-                mode: RateLimitMode::Enforce,
-                retry_after,
-            }) => Either::Left(future::ready(Ok(Err(
-                TooManyRequests { retry_after }.into()
-            )))),
+        match self.limiters.charge(budget).map_err(Denial::apply) {
+            Ok(()) | Err(None) => Either::Right(self.inner.call(req).map_ok(Ok)),
+            Err(Some(error)) => Either::Left(future::ready(Ok(Err(error.into())))),
         }
     }
 }

--- a/libs/@local/middleware/src/rate_limit/mod.rs
+++ b/libs/@local/middleware/src/rate_limit/mod.rs
@@ -1,17 +1,17 @@
 //! Rate limiting for HTTP request handling.
 //!
-//! Two middlewares share the limiter state in `RateLimiters`. `ip_gate_middleware` runs ahead of
-//! the authentication middleware and throttles each client address before credential
-//! verification. `principal_limit_middleware` runs behind it and budgets requests by the resolved
-//! principal: the actor for authenticated requests, counted across every address it connects
-//! from, and the client address for anonymous ones.
+//! Two middlewares share the limiter state in `RateLimiters`. [`IpGateLayer`] runs ahead of the
+//! authentication layer and throttles each client address before credential verification.
+//! [`PrincipalLimitLayer`] runs behind it and budgets requests by the resolved principal: the
+//! actor for authenticated requests, counted across every address it connects from, and the
+//! client address for anonymous ones.
 //!
 //! Requests presenting the service secret pass both middlewares unchecked. Both middlewares and
-//! [`authentication_middleware`] have to share one secret: the principal limiter treats a stored
+//! [`AuthenticationLayer`] have to share one secret: the principal limiter treats a stored
 //! authentication error as unreachable because the requests it could arise from passed by secret
 //! above.
 //!
-//! [`authentication_middleware`]: crate::authentication::authentication_middleware
+//! [`AuthenticationLayer`]: crate::authentication::AuthenticationLayer
 //!
 //! A request over its budget receives `429 Too Many Requests` with `Retry-After` in
 //! [`RateLimitMode::Enforce`], the default, and is served unchanged in
@@ -34,11 +34,19 @@ mod config;
 mod tests;
 
 use alloc::sync::Arc;
-use core::{fmt, num::NonZeroU64, time::Duration};
+use core::{
+    fmt, future,
+    num::{NonZero, NonZeroU64},
+    task,
+    time::Duration,
+};
 use std::sync::LazyLock;
 
-use axum::{body::Body, extract::Request, middleware::Next, response::Response};
-use bytes::Bytes;
+use axum::{
+    body::Body,
+    response::{IntoResponse, Response},
+};
+use futures::{TryFutureExt as _, future::Either};
 use governor::{
     Quota, RateLimiter,
     clock::{Clock as _, DefaultClock},
@@ -284,6 +292,47 @@ impl RateLimitMetrics {
     }
 }
 
+pub struct TooManyRequests {
+    pub retry_after: NonZero<u64>,
+}
+
+impl IntoResponse for TooManyRequests {
+    fn into_response(self) -> Response {
+        static BODY: LazyLock<&'static [u8]> =
+            LazyLock::new(|| error_body("rate limit exceeded").leak());
+
+        let mut response = Response::new(Body::from(*BODY));
+        *response.status_mut() = http::StatusCode::TOO_MANY_REQUESTS;
+        let headers = response.headers_mut();
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+        headers.insert(RETRY_AFTER, HeaderValue::from(self.retry_after.get()));
+        response
+    }
+}
+
+pub enum RateLimitRejection {
+    TooManyRequests(TooManyRequests),
+    InternalError,
+}
+
+impl From<TooManyRequests> for RateLimitRejection {
+    fn from(error: TooManyRequests) -> Self {
+        Self::TooManyRequests(error)
+    }
+}
+
+impl IntoResponse for RateLimitRejection {
+    fn into_response(self) -> Response {
+        match self {
+            Self::TooManyRequests(too_many_requests) => too_many_requests.into_response(),
+            Self::InternalError => error_response(
+                http::StatusCode::INTERNAL_SERVER_ERROR,
+                "internal server error",
+            ),
+        }
+    }
+}
+
 /// A request found to be over its budget.
 struct Denial {
     /// Whole seconds until the budget admits the request again, at least one.
@@ -291,20 +340,10 @@ struct Denial {
     mode: RateLimitMode,
 }
 
-impl Denial {
-    /// Answers the request, awaiting `served` where the mode does not enforce the denial.
-    async fn apply(self, served: impl Future<Output = Response>) -> Response {
-        match self.mode {
-            RateLimitMode::Enforce => too_many_requests(self.retry_after),
-            RateLimitMode::Observe => served.await,
-        }
-    }
-}
-
 /// The shared limiter state both rate-limiting middlewares charge against.
 ///
-/// [`start`] one per router from the configuration and hand it to [`ip_gate_middleware`] and
-/// [`principal_limit_middleware`]; it maintains itself for as long as it is held.
+/// [`start`] one per router from the configuration and hand it to [`IpGateLayer`] and
+/// [`PrincipalLimitLayer`]; it maintains itself for as long as it is held.
 ///
 /// [`start`]: Self::start
 pub struct RateLimiters {
@@ -409,10 +448,11 @@ impl RateLimiters {
     ///
     /// Falls back to the connection's address when the configured header is unusable, which keys
     /// every client behind that proxy into one budget.
-    fn client_key(&self, request: &Request) -> Option<BucketKey> {
+    fn client_key<B>(&self, request: &http::Request<B>) -> Option<BucketKey> {
         let Some(header) = self.client_ip_source.header() else {
             return address::peer(request);
         };
+
         match address::from_header(request, header) {
             Ok(key) => Some(key),
             Err(fallback) => {
@@ -537,8 +577,8 @@ where
 /// ```
 /// # use core::num::NonZeroU32;
 /// # use std::sync::Arc;
-/// # use axum::{Router, middleware, routing::get};
-/// use hash_middleware::rate_limit::{RateLimiters, ip_gate_middleware};
+/// # use axum::{Router, routing::get};
+/// use hash_middleware::rate_limit::{IpGateLayer, RateLimiters};
 /// # use hash_middleware::rate_limit::{ClientIpSource, RateLimitConfig, RateLimitMode};
 ///
 /// # #[tokio::main(flavor = "current_thread")]
@@ -555,49 +595,85 @@ where
 /// #     rate_limit_actor_burst: quota(100),
 /// # };
 /// # let meter = opentelemetry::global::meter("doc");
-/// let limiters = RateLimiters::start(&config, &meter);
-/// let service_secret: Arc<str> = Arc::from("service-secret");
-///
 /// // A `layer` rather than a `route_layer`, so unmatched paths draw on a budget too.
-/// let router: Router =
-///     Router::new()
-///         .route("/entities", get(async || "ok"))
-///         .layer(middleware::from_fn(move |request, next| {
-///             ip_gate_middleware(
-///                 Arc::clone(&limiters),
-///                 Arc::clone(&service_secret),
-///                 request,
-///                 next,
-///             )
-///         }));
+/// let router: Router = Router::new()
+///     .route("/entities", get(async || "ok"))
+///     .layer(IpGateLayer {
+///         limiters: RateLimiters::start(&config, &meter),
+///         service_secret: Arc::from("service-secret"),
+///     });
 /// # }
 /// ```
-pub async fn ip_gate_middleware(
+#[derive(Clone)]
+pub struct IpGateLayer {
+    pub limiters: Arc<RateLimiters>,
+    pub service_secret: Arc<str>,
+}
+
+impl<S> tower::Layer<S> for IpGateLayer {
+    type Service = IpGateService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        IpGateService {
+            inner,
+            limiters: Arc::clone(&self.limiters),
+            service_secret: Arc::clone(&self.service_secret),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct IpGateService<S> {
+    inner: S,
+
     limiters: Arc<RateLimiters>,
     service_secret: Arc<str>,
-    mut request: Request,
-    next: Next,
-) -> Response {
-    if presents_service_secret(request.headers(), &service_secret) {
-        limiters
-            .metrics
-            .unchecked(Stage::Gate, UncheckedReason::ServiceSecret);
-        return next.run(request).await;
+}
+
+impl<B, S> tower::Service<http::Request<B>> for IpGateService<S>
+where
+    S: tower::Service<http::Request<B>>,
+{
+    type Error = S::Error;
+    type Response = Result<S::Response, TooManyRequests>;
+
+    type Future = impl Future<Output = Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut task::Context<'_>) -> task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
     }
 
-    let resolved = limiters.client_key(&request);
-    request.extensions_mut().insert(resolved.map_or(
-        ResolvedClientAddress::Unknown,
-        ResolvedClientAddress::Bucketed,
-    ));
-    let Some(key) = resolved else {
-        limiters.note_unknown_address();
-        return next.run(request).await;
-    };
+    fn call(&mut self, mut req: http::Request<B>) -> Self::Future {
+        if presents_service_secret(req.headers(), &self.service_secret) {
+            self.limiters
+                .metrics
+                .unchecked(Stage::Gate, UncheckedReason::ServiceSecret);
 
-    match limiters.charge(Budget::Gate(key)) {
-        Ok(()) => next.run(request).await,
-        Err(denial) => denial.apply(next.run(request)).await,
+            return Either::Right(self.inner.call(req).map_ok(Ok));
+        }
+
+        let resolved = self.limiters.client_key(&req);
+        req.extensions_mut().insert(resolved.map_or(
+            ResolvedClientAddress::Unknown,
+            ResolvedClientAddress::Bucketed,
+        ));
+
+        let Some(key) = resolved else {
+            self.limiters.note_unknown_address();
+            return Either::Right(self.inner.call(req).map_ok(Ok));
+        };
+
+        match self.limiters.charge(Budget::Gate(key)) {
+            Ok(())
+            | Err(Denial {
+                mode: RateLimitMode::Observe,
+                retry_after: _,
+            }) => Either::Right(self.inner.call(req).map_ok(Ok)),
+            Err(Denial {
+                mode: RateLimitMode::Enforce,
+                retry_after,
+            }) => Either::Left(future::ready(Ok(Err(TooManyRequests { retry_after })))),
+        }
     }
 }
 
@@ -613,20 +689,18 @@ pub async fn ip_gate_middleware(
 /// documentation shows the full stack:
 ///
 /// ```
-/// # use core::{num::NonZeroU32, ops::ControlFlow};
+/// # use core::{marker::PhantomData, num::NonZeroU32, ops::ControlFlow};
 /// # use std::sync::Arc;
-/// # use axum::{Router, middleware, routing::get};
+/// # use axum::{Router, routing::get};
 /// # use error_stack::Report;
 /// # use hash_middleware::authentication::{
-/// #     AuthenticationMetrics, authentication_middleware,
+/// #     AuthenticationLayer, AuthenticationMetrics,
 /// #     provider::{AuthenticationProvider, Caller},
 /// #     request::AuthenticationError,
 /// # };
 /// # use http::HeaderMap;
 /// # use type_system::principal::actor::ActorId;
-/// use hash_middleware::rate_limit::{
-///     RateLimiters, ip_gate_middleware, principal_limit_middleware,
-/// };
+/// use hash_middleware::rate_limit::{IpGateLayer, PrincipalLimitLayer, RateLimiters};
 /// # use hash_middleware::rate_limit::{ClientIpSource, RateLimitConfig, RateLimitMode};
 ///
 /// # struct Verifier;
@@ -655,129 +729,139 @@ pub async fn ip_gate_middleware(
 /// let limiters = RateLimiters::start(&config, &meter);
 /// let service_secret: Arc<str> = Arc::from("service-secret");
 /// # let provider = Arc::new(Verifier);
-/// # let auth_secret = Arc::clone(&service_secret);
 /// # let auth_metrics = Arc::new(AuthenticationMetrics::new(&meter));
-/// let principal_limiters = Arc::clone(&limiters);
-/// let principal_secret = Arc::clone(&service_secret);
 ///
 /// let router: Router = Router::new()
 ///     .route("/entities", get(async || "ok"))
-///     .route_layer(middleware::from_fn(move |request, next| {
-///         principal_limit_middleware(
-///             Arc::clone(&principal_limiters),
-///             Arc::clone(&principal_secret),
-///             request,
-///             next,
-///         )
-///     }))
-///     .route_layer(middleware::from_fn(move |request, next| {
-///         # let provider = Arc::clone(&provider);
-///         # let auth_secret = Arc::clone(&auth_secret);
-///         # let auth_metrics = Arc::clone(&auth_metrics);
-///         authentication_middleware::<_, Option<ActorId>>(
-///             provider,
-///             auth_secret,
-///             auth_metrics,
-///             |_path| false,
-///             request,
-///             next,
-///         )
-///     }))
-///     .layer(middleware::from_fn(move |request, next| {
-///         ip_gate_middleware(
-///             Arc::clone(&limiters),
-///             Arc::clone(&service_secret),
-///             request,
-///             next,
-///         )
-///     }));
+///     .route_layer(PrincipalLimitLayer {
+///         limiters: Arc::clone(&limiters),
+///         service_secret: Arc::clone(&service_secret),
+///     })
+///     .route_layer(AuthenticationLayer::<_, Option<ActorId>> {
+///         provider,
+///         service_secret: Arc::clone(&service_secret),
+///         metrics: auth_metrics,
+///         bootstrap_route: |_path| false,
+///         caller: PhantomData,
+///     })
+///     .layer(IpGateLayer {
+///         limiters,
+///         service_secret,
+///     });
 /// # }
 /// ```
-pub async fn principal_limit_middleware(
+#[derive(Clone)]
+pub struct PrincipalLimitLayer {
+    pub limiters: Arc<RateLimiters>,
+    pub service_secret: Arc<str>,
+}
+
+impl<S> tower::Layer<S> for PrincipalLimitLayer {
+    type Service = PrincipalLimitService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        PrincipalLimitService {
+            inner,
+            limiters: Arc::clone(&self.limiters),
+            service_secret: Arc::clone(&self.service_secret),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct PrincipalLimitService<S> {
+    inner: S,
+
     limiters: Arc<RateLimiters>,
     service_secret: Arc<str>,
-    request: Request,
-    next: Next,
-) -> Response {
-    if presents_service_secret(request.headers(), &service_secret) {
-        limiters
-            .metrics
-            .unchecked(Stage::Principal, UncheckedReason::ServiceSecret);
-        return next.run(request).await;
+}
+
+impl<B, S> tower::Service<http::Request<B>> for PrincipalLimitService<S>
+where
+    S: tower::Service<http::Request<B>>,
+{
+    type Error = S::Error;
+    type Response = Result<S::Response, RateLimitRejection>;
+
+    type Future = impl Future<Output = Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut task::Context<'_>) -> task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
     }
-    let Some(resolved) = request.extensions().get::<ResolvedAuthentication>() else {
-        tracing::error!(
-            path = request.uri().path(),
-            "`principal_limit_middleware` ran on a route without authentication middleware"
-        );
-        limiters
-            .metrics
-            .misconfiguration(Misconfiguration::MissingAuthentication);
-        return internal_error();
-    };
-    let actor = match resolved.outcome() {
-        Ok(actor) => *actor,
-        Err(error) => {
-            // `authentication_middleware` stores an error only as `MissingDelegatedActor` on a
-            // bootstrap route, and those requests present the service secret and passed above.
-            // Reaching this means the middleware order broke, so the report's attachments are
-            // the only account of what the provider saw — `Display` would print the first
-            // context and drop them.
-            tracing::error!(error = ?error, "authentication error reached the rate limiter unrejected");
-            limiters
+
+    fn call(&mut self, req: http::Request<B>) -> Self::Future {
+        if presents_service_secret(req.headers(), &self.service_secret) {
+            self.limiters
                 .metrics
-                .misconfiguration(Misconfiguration::UnrejectedAuthenticationError);
-            return internal_error();
+                .unchecked(Stage::Principal, UncheckedReason::ServiceSecret);
+            return Either::Right(self.inner.call(req).map_ok(Ok));
         }
-    };
 
-    let budget = if let Some(actor) = actor {
-        Budget::Actor(actor)
-    } else {
-        let Some(resolved) = request.extensions().get::<ResolvedClientAddress>() else {
+        let Some(resolved) = req.extensions().get::<ResolvedAuthentication>() else {
             tracing::error!(
-                path = request.uri().path(),
-                "`principal_limit_middleware` ran on a route without the address gate"
+                path = req.uri().path(),
+                "`PrincipalLimitLayer` ran on a route without authentication middleware"
             );
-            limiters
-                .metrics
-                .misconfiguration(Misconfiguration::MissingAddressGate);
-            return internal_error();
-        };
-        let Some(key) = resolved.key() else {
-            // Counted per stage, so the gate's count of this address does not stand in for the
-            // principal stage.
-            limiters
-                .metrics
-                .unchecked(Stage::Principal, UncheckedReason::UnknownAddress);
-            return next.run(request).await;
-        };
-        Budget::Anonymous(key)
-    };
 
-    match limiters.charge(budget) {
-        Ok(()) => next.run(request).await,
-        Err(denial) => denial.apply(next.run(request)).await,
+            self.limiters
+                .metrics
+                .misconfiguration(Misconfiguration::MissingAuthentication);
+            return Either::Left(future::ready(Ok(Err(RateLimitRejection::InternalError))));
+        };
+
+        let actor = match resolved.outcome() {
+            Ok(actor) => *actor,
+            Err(error) => {
+                // The authentication layer stores an error only as `MissingDelegatedActor` on a
+                // bootstrap route, and those requests present the service secret and passed above.
+                // Reaching this means the middleware order broke, so the report's attachments are
+                // the only account of what the provider saw — `Display` would print the first
+                // context and drop them.
+                tracing::error!(error = ?error, "authentication error reached the rate limiter unrejected");
+
+                self.limiters
+                    .metrics
+                    .misconfiguration(Misconfiguration::UnrejectedAuthenticationError);
+                return Either::Left(future::ready(Ok(Err(RateLimitRejection::InternalError))));
+            }
+        };
+
+        let budget = if let Some(actor) = actor {
+            Budget::Actor(actor)
+        } else {
+            let Some(resolved) = req.extensions().get::<ResolvedClientAddress>() else {
+                tracing::error!(
+                    path = req.uri().path(),
+                    "`PrincipalLimitLayer` ran on a route without the address gate"
+                );
+                self.limiters
+                    .metrics
+                    .misconfiguration(Misconfiguration::MissingAddressGate);
+                return Either::Left(future::ready(Ok(Err(RateLimitRejection::InternalError))));
+            };
+            let Some(key) = resolved.key() else {
+                // Counted per stage, so the gate's count of this address does not stand in for the
+                // principal stage.
+                self.limiters
+                    .metrics
+                    .unchecked(Stage::Principal, UncheckedReason::UnknownAddress);
+                return Either::Right(self.inner.call(req).map_ok(Ok));
+            };
+            Budget::Anonymous(key)
+        };
+
+        match self.limiters.charge(budget) {
+            Ok(())
+            | Err(Denial {
+                mode: RateLimitMode::Observe,
+                retry_after: _,
+            }) => Either::Right(self.inner.call(req).map_ok(Ok)),
+            Err(Denial {
+                mode: RateLimitMode::Enforce,
+                retry_after,
+            }) => Either::Left(future::ready(Ok(Err(
+                TooManyRequests { retry_after }.into()
+            )))),
+        }
     }
-}
-
-/// The body every enforced denial answers with, built once.
-static TOO_MANY_REQUESTS: LazyLock<Bytes> =
-    LazyLock::new(|| Bytes::from(error_body("rate limit exceeded".to_owned())));
-
-/// Builds the 429 response for a denied request.
-fn too_many_requests(retry_after: NonZeroU64) -> Response {
-    let mut response = Response::new(Body::from(TOO_MANY_REQUESTS.clone()));
-    *response.status_mut() = http::StatusCode::TOO_MANY_REQUESTS;
-    let headers = response.headers_mut();
-    headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
-    headers.insert(RETRY_AFTER, HeaderValue::from(retry_after.get()));
-    response
-}
-
-fn internal_error() -> Response {
-    error_response(
-        http::StatusCode::INTERNAL_SERVER_ERROR,
-        "internal server error".to_owned(),
-    )
 }

--- a/libs/@local/middleware/src/rate_limit/mod.rs
+++ b/libs/@local/middleware/src/rate_limit/mod.rs
@@ -292,7 +292,9 @@ impl RateLimitMetrics {
     }
 }
 
+/// The `429 Too Many Requests` answer for a request over its budget.
 pub struct TooManyRequests {
+    /// Whole seconds until the crossed budget admits the request again, at least one.
     pub retry_after: NonZero<u64>,
 }
 
@@ -310,8 +312,15 @@ impl IntoResponse for TooManyRequests {
     }
 }
 
+/// The response a request the principal limiter cannot serve is answered with.
+///
+/// [`IpGateLayer`] rejects with [`TooManyRequests`] alone: only the principal limiter, building
+/// on the layers above it, can find a route miswired.
 pub enum RateLimitRejection {
+    /// The request is over its budget.
     TooManyRequests(TooManyRequests),
+    /// The route is wired without the middleware the principal limiter builds on, answered as
+    /// an internal error.
     InternalError,
 }
 
@@ -606,7 +615,9 @@ where
 /// ```
 #[derive(Clone)]
 pub struct IpGateLayer {
+    /// The shared limiter state requests are charged against.
     pub limiters: Arc<RateLimiters>,
+    /// The secret whose presenters pass unchecked.
     pub service_secret: Arc<str>,
 }
 
@@ -622,6 +633,7 @@ impl<S> tower::Layer<S> for IpGateLayer {
     }
 }
 
+/// The service [`IpGateLayer`] wraps its inner service into.
 #[derive(Clone)]
 pub struct IpGateService<S> {
     inner: S,
@@ -752,7 +764,9 @@ where
 /// ```
 #[derive(Clone)]
 pub struct PrincipalLimitLayer {
+    /// The shared limiter state requests are charged against.
     pub limiters: Arc<RateLimiters>,
+    /// The secret whose presenters pass unchecked.
     pub service_secret: Arc<str>,
 }
 
@@ -768,6 +782,7 @@ impl<S> tower::Layer<S> for PrincipalLimitLayer {
     }
 }
 
+/// The service [`PrincipalLimitLayer`] wraps its inner service into.
 #[derive(Clone)]
 pub struct PrincipalLimitService<S> {
     inner: S,

--- a/libs/@local/middleware/src/rate_limit/tests.rs
+++ b/libs/@local/middleware/src/rate_limit/tests.rs
@@ -2,13 +2,12 @@
 
 use alloc::sync::Arc;
 use core::{
+    marker::PhantomData,
     net::{IpAddr, Ipv4Addr, SocketAddr},
     sync::atomic::{AtomicUsize, Ordering},
 };
 
-use axum::{
-    Router, body::Body, extract::ConnectInfo, middleware, response::Response, routing::get,
-};
+use axum::{Router, body::Body, extract::ConnectInfo, response::Response, routing::get};
 use error_stack::Report;
 use http::{Request, StatusCode};
 use tower::ServiceExt as _;
@@ -16,13 +15,13 @@ use type_system::principal::actor::{ActorEntityUuid, ActorId, UserId};
 use uuid::Uuid;
 
 use super::{
-    ClientIpSource, RateLimitConfig, RateLimitMode, RateLimiters, ip_gate_middleware,
-    principal_limit_middleware,
+    ClientIpSource, IpGateLayer, PrincipalLimitLayer, RateLimitConfig, RateLimitMode, RateLimiters,
 };
 use crate::{
     authentication::{
-        AuthenticationMetrics, ResolvedAuthentication, authentication_middleware,
-        provider::StaticAuthenticationProvider, request::AuthenticationError,
+        AuthenticationLayer, AuthenticationMetrics, ResolvedAuthentication,
+        provider::StaticAuthenticationProvider,
+        request::{AuthenticationError, AuthenticationErrorKind},
     },
     test_metrics::{RecordedMetrics, noop_meter},
 };
@@ -57,18 +56,12 @@ fn config(burst: u32) -> RateLimitConfig {
 }
 
 fn gate_router_with(limiters: &Arc<RateLimiters>) -> Router {
-    let limiters = Arc::clone(limiters);
-    let service_secret: Arc<str> = Arc::from(SERVICE_SECRET);
     Router::new()
         .route("/entities", get(async || "ok"))
-        .route_layer(middleware::from_fn(move |request, next| {
-            ip_gate_middleware(
-                Arc::clone(&limiters),
-                Arc::clone(&service_secret),
-                request,
-                next,
-            )
-        }))
+        .route_layer(IpGateLayer {
+            limiters: Arc::clone(limiters),
+            service_secret: Arc::from(SERVICE_SECRET),
+        })
 }
 
 fn gate_router(config: &RateLimitConfig) -> Router {
@@ -80,18 +73,12 @@ fn principal_router(config: &RateLimitConfig) -> Router {
 }
 
 fn principal_router_with(limiters: &Arc<RateLimiters>) -> Router {
-    let limiters = Arc::clone(limiters);
-    let service_secret: Arc<str> = Arc::from(SERVICE_SECRET);
     Router::new()
         .route("/entities", get(async || "ok"))
-        .route_layer(middleware::from_fn(move |request, next| {
-            principal_limit_middleware(
-                Arc::clone(&limiters),
-                Arc::clone(&service_secret),
-                request,
-                next,
-            )
-        }))
+        .route_layer(PrincipalLimitLayer {
+            limiters: Arc::clone(limiters),
+            service_secret: Arc::from(SERVICE_SECRET),
+        })
 }
 
 /// Stacks the three request middlewares in the order a REST router wires them.
@@ -103,44 +90,24 @@ fn full_stack_router_with(
     limiters: &Arc<RateLimiters>,
     provider: StaticAuthenticationProvider,
 ) -> Router {
-    let limiters = Arc::clone(limiters);
-    let provider = Arc::new(provider);
-    let metrics = auth_metrics();
     let service_secret: Arc<str> = Arc::from(SERVICE_SECRET);
-    let gate_limiters = Arc::clone(&limiters);
-    let gate_secret = Arc::clone(&service_secret);
-    let principal_secret = Arc::clone(&service_secret);
     Router::new()
         .route("/entities", get(async || "ok"))
-        .route_layer(middleware::from_fn(move |request, next| {
-            principal_limit_middleware(
-                Arc::clone(&limiters),
-                Arc::clone(&principal_secret),
-                request,
-                next,
-            )
-        }))
-        .route_layer(middleware::from_fn(move |request, next| {
-            let provider = Arc::clone(&provider);
-            let service_secret = Arc::clone(&service_secret);
-            let metrics = Arc::clone(&metrics);
-            authentication_middleware::<_, Option<ActorId>>(
-                provider,
-                service_secret,
-                metrics,
-                |_path| false,
-                request,
-                next,
-            )
-        }))
-        .route_layer(middleware::from_fn(move |request, next| {
-            ip_gate_middleware(
-                Arc::clone(&gate_limiters),
-                Arc::clone(&gate_secret),
-                request,
-                next,
-            )
-        }))
+        .route_layer(PrincipalLimitLayer {
+            limiters: Arc::clone(limiters),
+            service_secret: Arc::clone(&service_secret),
+        })
+        .route_layer(AuthenticationLayer::<_, Option<ActorId>> {
+            provider: Arc::new(provider),
+            service_secret: Arc::clone(&service_secret),
+            metrics: auth_metrics(),
+            bootstrap_route: |_path| false,
+            caller: PhantomData,
+        })
+        .route_layer(IpGateLayer {
+            limiters: Arc::clone(limiters),
+            service_secret,
+        })
 }
 
 fn request_to(path: &str, peer: IpAddr) -> Request<Body> {
@@ -659,12 +626,7 @@ async fn enforced_denials_skip_the_inner_stack() {
         rate_limit_anonymous_burst: non_zero(10),
         ..config(1)
     });
-    let provider = Arc::new(StaticAuthenticationProvider::NotRecognized);
-    let metrics = auth_metrics();
     let service_secret: Arc<str> = Arc::from(SERVICE_SECRET);
-    let gate_limiters = Arc::clone(&limiters);
-    let gate_secret = Arc::clone(&service_secret);
-    let principal_secret = Arc::clone(&service_secret);
     let router = Router::new()
         .route(
             "/entities",
@@ -673,35 +635,21 @@ async fn enforced_denials_skip_the_inner_stack() {
                 "ok"
             }),
         )
-        .route_layer(middleware::from_fn(move |request, next| {
-            principal_limit_middleware(
-                Arc::clone(&limiters),
-                Arc::clone(&principal_secret),
-                request,
-                next,
-            )
-        }))
-        .route_layer(middleware::from_fn(move |request, next| {
-            let provider = Arc::clone(&provider);
-            let service_secret = Arc::clone(&service_secret);
-            let metrics = Arc::clone(&metrics);
-            authentication_middleware::<_, Option<ActorId>>(
-                provider,
-                service_secret,
-                metrics,
-                |_path| false,
-                request,
-                next,
-            )
-        }))
-        .route_layer(middleware::from_fn(move |request, next| {
-            ip_gate_middleware(
-                Arc::clone(&gate_limiters),
-                Arc::clone(&gate_secret),
-                request,
-                next,
-            )
-        }));
+        .route_layer(PrincipalLimitLayer {
+            limiters: Arc::clone(&limiters),
+            service_secret: Arc::clone(&service_secret),
+        })
+        .route_layer(AuthenticationLayer::<_, Option<ActorId>> {
+            provider: Arc::new(StaticAuthenticationProvider::NotRecognized),
+            service_secret: Arc::clone(&service_secret),
+            metrics: auth_metrics(),
+            bootstrap_route: |_path| false,
+            caller: PhantomData,
+        })
+        .route_layer(IpGateLayer {
+            limiters,
+            service_secret,
+        });
     let client = address("192.0.2.1");
 
     assert_eq!(
@@ -732,9 +680,9 @@ async fn authentication_error_fails_loudly() {
 
     let mut request = request(IpAddr::V4(Ipv4Addr::LOCALHOST));
     request.extensions_mut().insert(ResolvedAuthentication::new(
-        Err(Arc::new(Report::new(
-            AuthenticationError::MissingDelegatedActor,
-        ))),
+        Err(Arc::new(Report::new(AuthenticationError::new(
+            AuthenticationErrorKind::MissingDelegatedActor,
+        )))),
         auth_metrics(),
     ));
 
@@ -1006,27 +954,16 @@ async fn maintenance_releases_replenished_keys_from_every_store() {
     let recorded = RecordedMetrics::new();
     let limiters = RateLimiters::start(&quotas, &recorded.meter());
     let service_secret: Arc<str> = Arc::from(SERVICE_SECRET);
-    let gate_limiters = Arc::clone(&limiters);
-    let gate_secret = Arc::clone(&service_secret);
-    let principal_limiters = Arc::clone(&limiters);
     let router = Router::new()
         .route("/entities", get(async || "ok"))
-        .route_layer(middleware::from_fn(move |request, next| {
-            principal_limit_middleware(
-                Arc::clone(&principal_limiters),
-                Arc::clone(&service_secret),
-                request,
-                next,
-            )
-        }))
-        .route_layer(middleware::from_fn(move |request, next| {
-            ip_gate_middleware(
-                Arc::clone(&gate_limiters),
-                Arc::clone(&gate_secret),
-                request,
-                next,
-            )
-        }));
+        .route_layer(PrincipalLimitLayer {
+            limiters: Arc::clone(&limiters),
+            service_secret: Arc::clone(&service_secret),
+        })
+        .route_layer(IpGateLayer {
+            limiters: Arc::clone(&limiters),
+            service_secret,
+        });
 
     let client = address("192.0.2.1");
     assert_eq!(

--- a/libs/@local/middleware/src/response.rs
+++ b/libs/@local/middleware/src/response.rs
@@ -1,7 +1,5 @@
 //! The error documents the middlewares answer rejections with.
 
-use alloc::borrow::Cow;
-
 use axum::{body::Body, response::Response};
 use http::{HeaderValue, header::CONTENT_TYPE};
 use serde::Serialize;
@@ -11,22 +9,16 @@ use serde::Serialize;
 /// The client-safe message alone; the HTTP status line carries the classification.
 #[derive(Serialize)]
 struct ErrorDocument {
-    message: Cow<'static, str>,
+    message: &'static str,
 }
 
 /// Serializes the error document for a rejection.
-pub(crate) fn error_body(message: impl Into<Cow<'static, str>>) -> Vec<u8> {
-    serde_json::to_vec(&ErrorDocument {
-        message: message.into(),
-    })
-    .expect("the error document should serialize")
+pub(crate) fn error_body(message: &'static str) -> Vec<u8> {
+    serde_json::to_vec(&ErrorDocument { message }).expect("the error document should serialize")
 }
 
 /// Answers a rejection with its error document.
-pub(crate) fn error_response(
-    status: http::StatusCode,
-    message: impl Into<Cow<'static, str>>,
-) -> Response {
+pub(crate) fn error_response(status: http::StatusCode, message: &'static str) -> Response {
     let mut response = Response::new(Body::from(error_body(message)));
     *response.status_mut() = status;
     response

--- a/libs/@local/middleware/src/response.rs
+++ b/libs/@local/middleware/src/response.rs
@@ -1,5 +1,7 @@
 //! The error documents the middlewares answer rejections with.
 
+use alloc::borrow::Cow;
+
 use axum::{body::Body, response::Response};
 use http::{HeaderValue, header::CONTENT_TYPE};
 use serde::Serialize;
@@ -9,16 +11,22 @@ use serde::Serialize;
 /// The client-safe message alone; the HTTP status line carries the classification.
 #[derive(Serialize)]
 struct ErrorDocument {
-    message: String,
+    message: Cow<'static, str>,
 }
 
 /// Serializes the error document for a rejection.
-pub(crate) fn error_body(message: String) -> Vec<u8> {
-    serde_json::to_vec(&ErrorDocument { message }).expect("the error document should serialize")
+pub(crate) fn error_body(message: impl Into<Cow<'static, str>>) -> Vec<u8> {
+    serde_json::to_vec(&ErrorDocument {
+        message: message.into(),
+    })
+    .expect("the error document should serialize")
 }
 
 /// Answers a rejection with its error document.
-pub(crate) fn error_response(status: http::StatusCode, message: String) -> Response {
+pub(crate) fn error_response(
+    status: http::StatusCode,
+    message: impl Into<Cow<'static, str>>,
+) -> Response {
     let mut response = Response::new(Body::from(error_body(message)));
     *response.status_mut() = status;
     response


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

`hash-middleware` runs authentication and rate limiting as `async fn`s behind `axum::middleware::from_fn`. A mount site captures its state in a closure and clones an `Arc` per layer per request, and a middleware that rejects a request renders the `Response` itself, so the reason a request failed is unavailable to any outer layer.

After this change each one is a `tower::Layer` with a service of its own. State lives in the service, so construction at a mount site is a struct literal. A rejection travels as a typed value, because the service response type is `Result<S::Response, Rejection>` and each rejection renders through `IntoResponse` at the router's edge.

Reporting a failure also stops depending on the function that handles it. The report state lives on `AuthenticationError`, so `AuthenticationError::log` claims a latch and returns early once some site has claimed it. `resolve_request_actor` reports where the provider rejects, which includes the verified rejection that degrades to anonymous and reaches no render at all, and `AuthenticationRejection::into_response` reports where a rejection reaches the client. One log line per failure follows from those two sites rather than from a convention each middleware kept, and the level follows the error's fault domain.

The alternative was to keep `from_fn` and pass the rejection out through a request extension. An extension leaves the response type erased and the per-request `Arc` clones in place, so an outer layer has nothing to match on and the typing would have been a convention rather than a signature.

What to verify:

- The rejection belongs to the service signature, so an outer layer matches a value instead of inspecting a rendered response.
- Each service passes `poll_ready` through to the service it wraps, and a rejecting `call` returns without touching that service at all.
- Layer order holds at both mount sites, with the ip budget outermost and the principal budget behind authentication.
- The crate-level doctest in `src/lib.rs` states the construction contract.

## 🔍 What does this change?

Each service names its own future through `impl_trait_in_assoc_type` rather than boxing it. `AuthenticationError` becomes a struct over `AuthenticationErrorKind` with a const constructor per kind and `Deref` to the kind, which is what lets the call sites in `hash-graph-authentication` construct a failure by name.

## 🛡 What tests cover this?

The existing `hash-middleware` unit tests cover the layers through their routers. The rewrite updated construction in `src/rate_limit/tests.rs` and moved no assertion, so the same expectations hold against the new types. The crate-level doctest exercises a router built from the layer literals, and `libs/@local/graph/authentication/tests/kratos.rs` follows the new constructors.

## ❓ How to test this?

1. `cargo nextest run -p hash-middleware` and `cargo test --doc -p hash-middleware`.
2. Read `src/authentication/mod.rs` from `AuthenticationRejection` outward, then `src/rate_limit/mod.rs`. Both follow one shape, so the first explains the second.
3. Against a running graph API, send a request with no credential, one with a malformed credential, and one over the principal budget. Confirm the status code and client message of each, and one log line per rejected request.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>