### PR TITLE
FE-1500: Document Petrinaut website in architecture docs

### DIFF
--- a/apps/petrinaut-website/README.md
+++ b/apps/petrinaut-website/README.md
@@ -2,7 +2,7 @@
 
 A website for demoing Petrinaut (libs/@hashintel/petrinaut).
 
-A SPA plus a single API function that proxies AI requests to OpenAI.
+A SPA with API functions for AI assistance and JSON oEmbed discovery.
 
 ## Quickstart
 
@@ -15,7 +15,23 @@ turbo run dev
 
 The dev server runs at [http://localhost:5173](http://localhost:5173). A plugin in `vite.config.ts` loads the API function.
 
-In production, the function in the `api` folder is automatically deployed as a Vercel Serverless Function.
+In production, the functions in the `api` folder are automatically deployed as
+Vercel Functions.
+
+## Example embeds and oEmbed
+
+Canonical example pages live below `/examples`. The JSON oEmbed endpoint at
+`/api/oembed` accepts their production URLs and returns an
+`/embed/examples/...` iframe. Canonical pages send both CSP `frame-ancestors
+'none'` and `X-Frame-Options: DENY`; only the dedicated embed routes permit
+third-party framing. The returned iframe is sandboxed with
+`allow-scripts allow-same-origin` and does not send a referrer.
+
+Because this is a client-rendered SPA, a static `index.html` discovery link
+cannot include the current example URL. `FullExamplePage` adds the standard
+`application/json+oembed` link to the document head after the route mounts.
+Consumers that do not execute JavaScript must call `/api/oembed` directly or
+use provider-pattern discovery instead.
 
 ### Optimization demo with Petrinaut Opt
 

--- a/apps/petrinaut-website/README.md
+++ b/apps/petrinaut-website/README.md
@@ -1,3 +1,8 @@
+---
+layer: website
+role: Demo site and embed host for the Petrinaut editor
+---
+
 # Petrinaut Website
 
 A website for demoing Petrinaut (libs/@hashintel/petrinaut).

--- a/apps/petrinaut-website/api/oembed.ts
+++ b/apps/petrinaut-website/api/oembed.ts
@@ -1,0 +1,257 @@
+import {
+  getExampleCatalogEntry,
+  isExampleSlug,
+  PETRINAUT_DEMO_ORIGIN,
+  type ExampleSlug,
+} from "../src/examples/catalog-metadata";
+import {
+  canonicalSearchString,
+  validateSharedExampleSearch,
+} from "../src/examples/example-search";
+
+const DEFAULT_WIDTH = 800;
+const DEFAULT_HEIGHT = 450;
+const SUCCESS_CACHE_CONTROL =
+  "public, max-age=300, s-maxage=86400, stale-while-revalidate=604800";
+
+type OEmbedResponse = Readonly<{
+  type: "rich";
+  version: "1.0";
+  title: string;
+  provider_name: "Petrinaut";
+  provider_url: typeof PETRINAUT_DEMO_ORIGIN;
+  width: number;
+  height: number;
+  html: string;
+}>;
+
+const corsHeaders = (): Headers =>
+  new Headers({
+    "Access-Control-Allow-Headers": "Accept",
+    "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
+    "Access-Control-Allow-Origin": "*",
+  });
+
+const jsonResponse = (
+  body: unknown,
+  init: ResponseInit & { cacheable?: boolean } = {},
+): Response => {
+  const { cacheable = false, ...responseInit } = init;
+  const headers = corsHeaders();
+  for (const [name, value] of new Headers(responseInit.headers)) {
+    headers.set(name, value);
+  }
+  headers.set("Cache-Control", cacheable ? SUCCESS_CACHE_CONTROL : "no-store");
+  headers.set("Content-Type", "application/json; charset=utf-8");
+
+  return new Response(JSON.stringify(body), { ...responseInit, headers });
+};
+
+const errorResponse = (
+  status: 400 | 404 | 405 | 501,
+  error: string,
+): Response => jsonResponse({ error }, { status });
+
+const readPositiveFiniteMaximum = (
+  searchParams: URLSearchParams,
+  name: "maxheight" | "maxwidth",
+): number | undefined | null => {
+  if (!searchParams.has(name)) {
+    return undefined;
+  }
+
+  const rawValue = searchParams.get(name);
+  // A consumer that always appends the optional oEmbed params sends them
+  // empty when the user set no size. That is "no maximum", not a bad request.
+  if (rawValue === null || rawValue.trim() === "") {
+    return undefined;
+  }
+
+  // oEmbed defines these as integers. `Number` would also accept `0x10`,
+  // `1e3` and ` 400 `, which are typos rather than sizes.
+  if (!/^[0-9]+$/u.test(rawValue.trim())) {
+    return null;
+  }
+
+  const value = Number(rawValue.trim());
+  return value > 0 ? value : null;
+};
+
+const fitDimensions = (
+  maxWidth: number | undefined,
+  maxHeight: number | undefined,
+): { width: number; height: number } => {
+  const scale = Math.min(
+    1,
+    maxWidth === undefined ? 1 : maxWidth / DEFAULT_WIDTH,
+    maxHeight === undefined ? 1 : maxHeight / DEFAULT_HEIGHT,
+  );
+
+  // Height follows from the clamped width, so the aspect ratio survives.
+  // Flooring each axis independently turns `?maxwidth=1` into a 1x1 embed.
+  const width = Math.max(1, Math.floor(DEFAULT_WIDTH * scale));
+  return {
+    width,
+    height: Math.max(1, Math.round((width * DEFAULT_HEIGHT) / DEFAULT_WIDTH)),
+  };
+};
+
+const escapeHtmlAttribute = (value: string): string =>
+  value
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+
+type ParsedExampleUrl = Readonly<{
+  slug: ExampleSlug;
+  embedSearch: URLSearchParams;
+}>;
+
+/**
+ * Carry over only state the embed page understands, by decoding the canonical
+ * URL through the shared contract and re-encoding it. One embed-specific rule:
+ * embeds always show a named scenario, so an explicit `none` (valid on the
+ * canonical page) resolves to the model's first scenario instead.
+ */
+const sanitizeEmbedSearch = (source: URLSearchParams): URLSearchParams => {
+  const search = validateSharedExampleSearch(Object.fromEntries(source));
+
+  return new URLSearchParams(
+    canonicalSearchString(
+      search.scenario === "none" ? { ...search, scenario: undefined } : search,
+    ),
+  );
+};
+
+const parseExampleUrl = (
+  rawUrl: string,
+): ParsedExampleUrl | { error: string; status: 400 | 404 } => {
+  let sourceUrl: URL;
+  try {
+    sourceUrl = new URL(rawUrl);
+  } catch {
+    return { error: "The url parameter must be a valid URL", status: 400 };
+  }
+
+  // A well-formed URL this provider cannot embed is 404 rather than 400.
+  // oEmbed 1.0 section 2.3.1 lists 404 for "no response for this url", and
+  // consumers branch on it to fall back to a plain link.
+  if (sourceUrl.origin !== PETRINAUT_DEMO_ORIGIN) {
+    return {
+      error: `The url parameter must use ${PETRINAUT_DEMO_ORIGIN}`,
+      status: 404,
+    };
+  }
+
+  const pathMatch = sourceUrl.pathname.match(/^\/examples\/([^/]+?)\/?$/u);
+  if (!pathMatch) {
+    return {
+      error: "The url parameter is not a canonical example URL",
+      status: 404,
+    };
+  }
+
+  const slug = pathMatch[1]!;
+  if (!isExampleSlug(slug)) {
+    return { error: `Unknown example: ${slug}`, status: 404 };
+  }
+
+  return {
+    slug,
+    embedSearch: sanitizeEmbedSearch(sourceUrl.searchParams),
+  };
+};
+
+const respond = async (request: Request): Promise<Response> => {
+  if (request.method === "OPTIONS") {
+    const headers = corsHeaders();
+    headers.set("Cache-Control", "public, max-age=86400");
+    return new Response(null, { headers, status: 204 });
+  }
+
+  const isHead = request.method === "HEAD";
+  if (request.method !== "GET" && !isHead) {
+    const response = errorResponse(405, "Method not allowed");
+    response.headers.set("Allow", "GET, HEAD, OPTIONS");
+    return response;
+  }
+
+  const endpointUrl = new URL(request.url);
+  // An empty `format=` means the consumer expressed no preference, and the
+  // parameter is case-insensitive in practice.
+  const format =
+    endpointUrl.searchParams.get("format")?.trim().toLowerCase() || null;
+  if (format !== null && format !== "json") {
+    // oEmbed 1.0 section 2.3.1: a format the provider cannot return is 501.
+    return errorResponse(501, "Only the json oEmbed format is supported");
+  }
+
+  const rawSourceUrl = endpointUrl.searchParams.get("url");
+  if (!rawSourceUrl) {
+    return errorResponse(400, "Missing required url parameter");
+  }
+
+  const parsedExampleUrl = parseExampleUrl(rawSourceUrl);
+  if ("error" in parsedExampleUrl) {
+    return errorResponse(parsedExampleUrl.status, parsedExampleUrl.error);
+  }
+
+  const maxWidth = readPositiveFiniteMaximum(
+    endpointUrl.searchParams,
+    "maxwidth",
+  );
+  if (maxWidth === null) {
+    return errorResponse(400, "maxwidth must be a positive integer");
+  }
+  const maxHeight = readPositiveFiniteMaximum(
+    endpointUrl.searchParams,
+    "maxheight",
+  );
+  if (maxHeight === null) {
+    return errorResponse(400, "maxheight must be a positive integer");
+  }
+
+  const { width, height } = fitDimensions(maxWidth, maxHeight);
+  const embedUrl = new URL(
+    `/embed/examples/${parsedExampleUrl.slug}`,
+    PETRINAUT_DEMO_ORIGIN,
+  );
+  embedUrl.search = parsedExampleUrl.embedSearch.toString();
+
+  const catalogEntry = getExampleCatalogEntry(parsedExampleUrl.slug)!;
+  const response: OEmbedResponse = {
+    type: "rich",
+    version: "1.0",
+    title: catalogEntry.title,
+    provider_name: "Petrinaut",
+    provider_url: PETRINAUT_DEMO_ORIGIN,
+    width,
+    height,
+    html: `<iframe src="${escapeHtmlAttribute(embedUrl.href)}" title="${escapeHtmlAttribute(catalogEntry.title)}" width="${width}" height="${height}" style="border:0" loading="lazy" sandbox="allow-scripts allow-same-origin" referrerpolicy="no-referrer" allowfullscreen></iframe>`,
+  };
+
+  return jsonResponse(response, { cacheable: true });
+};
+
+/**
+ * Serve Petrinaut example embeds using the JSON oEmbed 1.0 contract.
+ *
+ * Exported only through the default `{ fetch }` object, matching `chat.ts`, so
+ * Vercel's Node.js runtime treats this as a Web fetch handler and hands us a
+ * `Request`. Without that opt-in the default export is invoked with a Node.js
+ * `IncomingMessage`, which has no `Request` API.
+ *
+ * See https://vercel.com/changelog/node-js-vercel-functions-now-support-fetch-web-handlers
+ */
+const fetch = async (request: Request): Promise<Response> => {
+  const response = await respond(request);
+  // Strip the body at the single exit, so error replies to HEAD are bodiless
+  // too rather than only the 200.
+  return request.method === "HEAD"
+    ? new Response(null, { headers: response.headers, status: response.status })
+    : response;
+};
+
+export default { fetch };

--- a/apps/petrinaut-website/api/oembed.ts
+++ b/apps/petrinaut-website/api/oembed.ts
@@ -1,3 +1,9 @@
+/**
+ * @layerRoot website.api
+ * @role Server functions: JSON oEmbed discovery and the AI chat proxy
+ * @talksTo website.routes via the embed URL it returns to consumers
+ */
+
 import {
   getExampleCatalogEntry,
   isExampleSlug,

--- a/apps/petrinaut-website/src/examples/catalog-metadata.ts
+++ b/apps/petrinaut-website/src/examples/catalog-metadata.ts
@@ -5,6 +5,8 @@
  * functions that only need to validate a public URL should not bundle every
  * example model and generated simulation artifact.
  */
+export const PETRINAUT_DEMO_ORIGIN = "https://demo.petrinaut.org";
+
 export const exampleSlugs = [
   "gases-1-pn-consumption-trigger",
   "gases-1-pn",

--- a/apps/petrinaut-website/src/examples/catalog.ts
+++ b/apps/petrinaut-website/src/examples/catalog.ts
@@ -1,3 +1,8 @@
+/**
+ * @layerRoot website.examples
+ * @role Publishes example models and the URL contract every example surface speaks
+ */
+
 import {
   parseSDCPNFile,
   type HirArtifacts,

--- a/apps/petrinaut-website/src/examples/full-example-page.tsx
+++ b/apps/petrinaut-website/src/examples/full-example-page.tsx
@@ -3,6 +3,7 @@ import { useEffect } from "react";
 import { css } from "@hashintel/ds-helpers/css";
 import { Petrinaut } from "@hashintel/petrinaut/ui";
 
+import { getOEmbedDiscoveryUrl } from "./oembed-discovery";
 import { getReadonlyExampleHandle } from "./readonly-example-handle";
 import { useSharedSearchNavigation } from "./use-shared-search-navigation";
 
@@ -53,8 +54,20 @@ export const FullExamplePage = ({
     };
   }, [example.catalog.title]);
 
+  // The website is a client-rendered SPA, so the oEmbed discovery link cannot
+  // be baked into index.html; React 19 hoists this <link> into document.head.
+  // Consumers that execute the page's JavaScript can then discover the same
+  // production oEmbed endpoint used by server integrations.
+  const discoveryUrl = getOEmbedDiscoveryUrl(example.catalog.slug, search);
+
   return (
     <main className={pageStyle}>
+      <link
+        href={discoveryUrl}
+        rel="alternate"
+        title={`${example.catalog.title} oEmbed profile`}
+        type="application/json+oembed"
+      />
       <Petrinaut
         handle={handle}
         hideNetManagementControls="all"

--- a/apps/petrinaut-website/src/examples/oembed-discovery.test.ts
+++ b/apps/petrinaut-website/src/examples/oembed-discovery.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { getOEmbedDiscoveryUrl } from "./oembed-discovery";
+
+describe("getOEmbedDiscoveryUrl", () => {
+  it("uses the production origin without leaking a development port", () => {
+    const endpoint = new URL(
+      getOEmbedDiscoveryUrl("gases-1-pn", { scenario: "steady" }),
+    );
+
+    expect(endpoint.origin).toBe("https://demo.petrinaut.org");
+    expect(endpoint.searchParams.get("format")).toBe("json");
+    expect(endpoint.searchParams.get("url")).toBe(
+      "https://demo.petrinaut.org/examples/gases-1-pn?scenario=steady",
+    );
+  });
+
+  it("advertises one endpoint URL per location, whatever the address bar holds", () => {
+    // A foreign parameter is not part of the contract, so it must not produce
+    // a second endpoint URL for a response that is byte-identical.
+    const withoutForeignParam = getOEmbedDiscoveryUrl("gases-1-pn", {
+      scenario: "steady",
+    });
+    const withForeignParam = getOEmbedDiscoveryUrl("gases-1-pn", {
+      scenario: "steady",
+      ...({ utm_source: "twitter" } as Record<string, string>),
+    });
+
+    expect(withForeignParam).toBe(withoutForeignParam);
+  });
+
+  it("orders the contract parameters canonically", () => {
+    expect(
+      getOEmbedDiscoveryUrl("gases-2-spn", {
+        subnet: "subnet-a",
+        scenario: "scenario__drawing",
+      }),
+    ).toBe(
+      getOEmbedDiscoveryUrl("gases-2-spn", {
+        scenario: "scenario__drawing",
+        subnet: "subnet-a",
+      }),
+    );
+  });
+});

--- a/apps/petrinaut-website/src/examples/oembed-discovery.ts
+++ b/apps/petrinaut-website/src/examples/oembed-discovery.ts
@@ -1,0 +1,25 @@
+import { PETRINAUT_DEMO_ORIGIN } from "./catalog-metadata";
+import { canonicalSearchString } from "./example-search";
+
+import type { SharedExampleSearch } from "./example-search";
+
+/**
+ * Builds the oEmbed endpoint URL a consumer should call for this example.
+ *
+ * The advertised `url` is rebuilt from the slug and the validated search
+ * rather than copied from the address bar, so a tracking parameter on the page
+ * does not advertise a distinct endpoint URL for a byte-identical response.
+ */
+export const getOEmbedDiscoveryUrl = (
+  slug: string,
+  search: SharedExampleSearch,
+): string => {
+  const sourceUrl = new URL(`/examples/${slug}`, PETRINAUT_DEMO_ORIGIN);
+  sourceUrl.search = canonicalSearchString(search);
+
+  const endpointUrl = new URL("/api/oembed", PETRINAUT_DEMO_ORIGIN);
+  endpointUrl.searchParams.set("url", sourceUrl.href);
+  endpointUrl.searchParams.set("format", "json");
+
+  return endpointUrl.href;
+};

--- a/apps/petrinaut-website/src/examples/oembed-endpoint.test.ts
+++ b/apps/petrinaut-website/src/examples/oembed-endpoint.test.ts
@@ -1,0 +1,313 @@
+import { describe, expect, it } from "vitest";
+
+// The endpoint lives in `api/`, where every module is deployed as a Vercel
+// function, so its test lives here instead. It is imported through the default
+// export, the only one the module has: a named `fetch` export alongside it
+// stops Vercel's runtime from invoking the function.
+import oembedEndpoint from "../../api/oembed";
+
+const { fetch } = oembedEndpoint;
+
+const endpointRequest = (
+  sourceUrl?: string,
+  options: {
+    format?: string;
+    maxheight?: string;
+    maxwidth?: string;
+    method?: string;
+  } = {},
+): Request => {
+  const endpoint = new URL("https://demo.petrinaut.org/api/oembed");
+  if (sourceUrl !== undefined) {
+    endpoint.searchParams.set("url", sourceUrl);
+  }
+  for (const name of ["format", "maxheight", "maxwidth"] as const) {
+    const value = options[name];
+    if (value !== undefined) {
+      endpoint.searchParams.set(name, value);
+    }
+  }
+  return new Request(endpoint, { method: options.method ?? "GET" });
+};
+
+const responseJson = async (
+  response: Response,
+): Promise<Record<string, unknown>> =>
+  response.json() as Promise<Record<string, unknown>>;
+
+describe("Petrinaut oEmbed endpoint", () => {
+  it("returns a JSON oEmbed response for an unversioned canonical URL", async () => {
+    const response = await fetch(
+      endpointRequest("https://demo.petrinaut.org/examples/gases-1-pn"),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe(
+      "application/json; charset=utf-8",
+    );
+    expect(response.headers.get("access-control-allow-origin")).toBe("*");
+    expect(response.headers.get("cache-control")).toContain("public");
+    expect(await responseJson(response)).toEqual({
+      type: "rich",
+      version: "1.0",
+      title: "Gases 1 — One Customer",
+      provider_name: "Petrinaut",
+      provider_url: "https://demo.petrinaut.org",
+      width: 800,
+      height: 450,
+      html: '<iframe src="https://demo.petrinaut.org/embed/examples/gases-1-pn" title="Gases 1 — One Customer" width="800" height="450" style="border:0" loading="lazy" sandbox="allow-scripts allow-same-origin" referrerpolicy="no-referrer" allowfullscreen></iframe>',
+    });
+  });
+
+  it("preserves only valid embed state from the source URL", async () => {
+    const source = new URL("https://demo.petrinaut.org/examples/gases-2-spn");
+    source.searchParams.set("mode", "simulate");
+    source.searchParams.set("section", "metrics");
+    source.searchParams.set("scenario", "scenario-1");
+    source.searchParams.set("subnet", "subnet-1");
+    source.searchParams.set("itemType", "transition");
+    source.searchParams.set("itemId", "transition-1");
+    source.searchParams.set("unrelated", "discard-me");
+
+    const response = await fetch(
+      endpointRequest(source.href, { format: "json" }),
+    );
+    const body = await responseJson(response);
+
+    expect(response.status).toBe(200);
+    expect(body.html).toBe(
+      '<iframe src="https://demo.petrinaut.org/embed/examples/gases-2-spn?itemId=transition-1&amp;itemType=transition&amp;scenario=scenario-1&amp;subnet=subnet-1" title="Gases 2 — Shared Tanker" width="800" height="450" style="border:0" loading="lazy" sandbox="allow-scripts allow-same-origin" referrerpolicy="no-referrer" allowfullscreen></iframe>',
+    );
+  });
+
+  it("drops an incomplete focused-item pair", async () => {
+    const response = await fetch(
+      endpointRequest(
+        "https://demo.petrinaut.org/examples/gases-1-pn?itemType=script&itemId=place-1",
+      ),
+    );
+    const body = await responseJson(response);
+
+    expect(body.html).not.toContain("itemId");
+    expect(body.html).not.toContain("itemType");
+  });
+
+  it("drops full-page no-scenario state from embeds", async () => {
+    const response = await fetch(
+      endpointRequest(
+        "https://demo.petrinaut.org/examples/gases-1-pn?scenario=none",
+      ),
+    );
+    const body = await responseJson(response);
+
+    expect(body.html).not.toContain("scenario=");
+  });
+
+  it("URL-encodes query values and HTML-escapes the iframe source", async () => {
+    const source = new URL(
+      "https://demo.petrinaut.org/examples/semiconductor-fab-drift",
+    );
+    source.searchParams.set("scenario", '"><script>alert("x")</script>&');
+    source.searchParams.set("subnet", "one&two");
+
+    const response = await fetch(endpointRequest(source.href));
+    const body = await responseJson(response);
+    const html = body.html as string;
+
+    expect(html).not.toContain("<script>");
+    expect(html).toContain(
+      "scenario=%22%3E%3Cscript%3Ealert%28%22x%22%29%3C%2Fscript%3E%26",
+    );
+    expect(html).toContain("&amp;subnet=one%26two");
+  });
+
+  it.each([
+    [{ maxwidth: "400" }, 400, 225],
+    [{ maxheight: "225" }, 400, 225],
+    [{ maxwidth: "320", maxheight: "100" }, 177, 100],
+    [{ maxwidth: "1600", maxheight: "900" }, 800, 450],
+  ] as const)(
+    "fits a 16:9 embed inside %j without upscaling",
+    async (limits, expectedWidth, expectedHeight) => {
+      const response = await fetch(
+        endpointRequest(
+          "https://demo.petrinaut.org/examples/truck-fleet-predictive-maintenance",
+          limits,
+        ),
+      );
+      const body = await responseJson(response);
+
+      expect(body.width).toBe(expectedWidth);
+      expect(body.height).toBe(expectedHeight);
+      expect(body.html).toContain(`width="${expectedWidth}"`);
+      expect(body.html).toContain(`height="${expectedHeight}"`);
+    },
+  );
+
+  it.each([
+    ["maxwidth", "0"],
+    ["maxwidth", "-1"],
+    ["maxwidth", "Infinity"],
+    ["maxwidth", "0x10"],
+    ["maxwidth", "1e3"],
+    ["maxwidth", "1.5"],
+    ["maxheight", "not-a-number"],
+  ] as const)("rejects invalid %s=%j", async (name, value) => {
+    const response = await fetch(
+      endpointRequest("https://demo.petrinaut.org/examples/gases-1-pn", {
+        [name]: value,
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await responseJson(response)).toEqual({
+      error: `${name} must be a positive integer`,
+    });
+  });
+
+  it.each(["maxwidth", "maxheight"] as const)(
+    "treats a blank %s as no maximum",
+    async (name) => {
+      // Consumers that always append the optional params send them empty when
+      // the user set no size.
+      const response = await fetch(
+        endpointRequest("https://demo.petrinaut.org/examples/gases-1-pn", {
+          [name]: "",
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      expect(await responseJson(response)).toMatchObject({
+        width: 800,
+        height: 450,
+      });
+    },
+  );
+
+  it("keeps the aspect ratio when clamping to a maximum", async () => {
+    const response = await fetch(
+      endpointRequest("https://demo.petrinaut.org/examples/gases-1-pn", {
+        maxwidth: "400",
+      }),
+    );
+
+    const body = (await responseJson(response)) as {
+      width: number;
+      height: number;
+    };
+    expect(body.width).toBe(400);
+    expect(body.width / body.height).toBeCloseTo(800 / 450, 2);
+  });
+
+  // 400 is for a request this endpoint cannot read; a well-formed URL it
+  // simply cannot embed is 404, which is the status oEmbed 1.0 section 2.3.1
+  // defines and the one consumers fall back on.
+  it.each([
+    [undefined, 400, "Missing required url parameter"],
+    ["not-a-url", 400, "The url parameter must be a valid URL"],
+    [
+      "https://example.com/examples/gases-1-pn",
+      404,
+      "The url parameter must use https://demo.petrinaut.org",
+    ],
+    [
+      "https://demo.petrinaut.org/embed/examples/gases-1-pn",
+      404,
+      "The url parameter is not a canonical example URL",
+    ],
+    [
+      "https://demo.petrinaut.org/examples/gases-1-pn/versions/1",
+      404,
+      "The url parameter is not a canonical example URL",
+    ],
+    [
+      "https://demo.petrinaut.org/examples/not-an-example",
+      404,
+      "Unknown example: not-an-example",
+    ],
+  ] as const)(
+    "rejects an unsupported source URL (%s)",
+    async (sourceUrl, expectedStatus, expectedError) => {
+      const response = await fetch(endpointRequest(sourceUrl));
+
+      expect(response.status).toBe(expectedStatus);
+      expect(response.headers.get("cache-control")).toBe("no-store");
+      expect(await responseJson(response)).toEqual({ error: expectedError });
+    },
+  );
+
+  it("answers unimplementable format requests with 501", async () => {
+    const response = await fetch(
+      endpointRequest("https://demo.petrinaut.org/examples/gases-1-pn", {
+        format: "xml",
+      }),
+    );
+
+    expect(response.status).toBe(501);
+    expect(await responseJson(response)).toEqual({
+      error: "Only the json oEmbed format is supported",
+    });
+  });
+
+  it("serves HEAD like GET with an empty body", async () => {
+    const response = await fetch(
+      endpointRequest("https://demo.petrinaut.org/examples/gases-1-pn", {
+        method: "HEAD",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe(
+      "application/json; charset=utf-8",
+    );
+    expect(await response.text()).toBe("");
+  });
+
+  it("answers HEAD with an empty body on the error paths too", async () => {
+    const response = await fetch(
+      endpointRequest("https://example.com/examples/gases-1-pn", {
+        method: "HEAD",
+      }),
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.text()).toBe("");
+  });
+
+  it("drops a multi-item selection: an embed URL carries one item", async () => {
+    const source = new URL("https://demo.petrinaut.org/examples/gases-1-pn");
+    source.searchParams.append("items", "place:place-1");
+    source.searchParams.append("items", "transition:transition-1");
+
+    const response = await fetch(endpointRequest(source.href));
+    const body = await responseJson(response);
+
+    expect(body.html).not.toContain("items");
+    expect(body.html).not.toContain("place-1");
+  });
+
+  it("returns a CORS preflight response", async () => {
+    const response = await fetch(
+      endpointRequest(undefined, { method: "OPTIONS" }),
+    );
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get("access-control-allow-origin")).toBe("*");
+    expect(response.headers.get("access-control-allow-methods")).toBe(
+      "GET, HEAD, OPTIONS",
+    );
+  });
+
+  it("rejects unsupported methods", async () => {
+    const response = await fetch(
+      endpointRequest(undefined, { method: "POST" }),
+    );
+
+    expect(response.status).toBe(405);
+    expect(response.headers.get("allow")).toBe("GET, HEAD, OPTIONS");
+    expect(response.headers.get("access-control-allow-origin")).toBe("*");
+    expect(await responseJson(response)).toEqual({
+      error: "Method not allowed",
+    });
+  });
+});

--- a/apps/petrinaut-website/src/main/app/brunch-demo/brunch-demo-app.tsx
+++ b/apps/petrinaut-website/src/main/app/brunch-demo/brunch-demo-app.tsx
@@ -1,3 +1,8 @@
+/**
+ * @layerRoot website.brunch
+ * @role Brunch Actual Mode demo: streams a live net from a Brunch endpoint
+ */
+
 import { useSentryFeedbackAction } from "../sentry-feedback-button";
 import { BrunchActualModeRoute } from "./brunch-actual-mode-route";
 

--- a/apps/petrinaut-website/src/main/app/local-storage-demo/local-storage-demo-app.tsx
+++ b/apps/petrinaut-website/src/main/app/local-storage-demo/local-storage-demo-app.tsx
@@ -1,3 +1,8 @@
+/**
+ * @layerRoot website.local-storage-demo
+ * @role Editable demo shell: nets in local storage, one live document handle
+ */
+
 import { produce } from "immer";
 import { useEffect, useMemo, useState } from "react";
 

--- a/apps/petrinaut-website/src/main/app/optimization-demo/optimization-demo-app.tsx
+++ b/apps/petrinaut-website/src/main/app/optimization-demo/optimization-demo-app.tsx
@@ -1,3 +1,8 @@
+/**
+ * @layerRoot website.optimization
+ * @role Optimization demo: wraps the editable demo with the optimizer provider
+ */
+
 import { LocalStorageDemoApp } from "../local-storage-demo/local-storage-demo-app";
 import { PetrinautOptOptimizationProvider } from "./petrinaut-opt-optimization-provider";
 

--- a/apps/petrinaut-website/src/routes/__root.tsx
+++ b/apps/petrinaut-website/src/routes/__root.tsx
@@ -1,3 +1,8 @@
+/**
+ * @layerRoot website.routes
+ * @role Owns the URL: file-based routes, typed search params, and the route tree
+ */
+
 import { Outlet, createRootRoute } from "@tanstack/react-router";
 
 import { NotFoundPage } from "./-not-found-page";

--- a/apps/petrinaut-website/src/sentry/instrument.ts
+++ b/apps/petrinaut-website/src/sentry/instrument.ts
@@ -1,3 +1,8 @@
+/**
+ * @layerRoot website.telemetry
+ * @role Sentry initialisation and the error-tracker provider the app mounts
+ */
+
 import * as Sentry from "@sentry/react";
 
 Sentry.init({

--- a/apps/petrinaut-website/vercel.json
+++ b/apps/petrinaut-website/vercel.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
   "github": {
     "silent": true,
     "autoJobCancelation": true
@@ -7,6 +8,47 @@
   "installCommand": "./vercel-install.sh",
   "devCommand": "turbo run build && yarn preview",
   "outputDirectory": "./dist",
+  "headers": [
+    {
+      "source": "/((?!api(?:/|$)|embed/examples/).*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "frame-ancestors 'none'"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        }
+      ]
+    },
+    {
+      "source": "/embed/examples/:path*",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "frame-ancestors *"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Robots-Tag",
+          "value": "noindex"
+        }
+      ]
+    },
+    {
+      "source": "/api/(.*)",
+      "headers": [
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        }
+      ]
+    }
+  ],
   "rewrites": [
     {
       "source": "/((?!api(?:/|$)).*)",
@@ -16,6 +58,9 @@
   "functions": {
     "api/chat.ts": {
       "maxDuration": 300
+    },
+    "api/oembed.ts": {
+      "maxDuration": 10
     }
   }
 }

--- a/apps/petrinaut-website/vite.config.ts
+++ b/apps/petrinaut-website/vite.config.ts
@@ -21,34 +21,41 @@ const loadServerEnv = (mode: string) => {
   }
 };
 
-// Plugin required to serve the chat endpoint in dev.
-// In production, it will be bundled and served by Vercel.
+const apiModules = [
+  ["/api/chat", "/api/chat.ts"],
+  ["/api/oembed", "/api/oembed.ts"],
+] as const;
+
+// Plugin required to serve the Vercel fetch handlers in dev. In production,
+// each file under /api is bundled and served as its own Vercel Function.
 const petrinautApiDevPlugin = (): Plugin => ({
   name: "petrinaut-api-dev",
   apply: "serve",
   configureServer(server) {
-    // The chat endpoint ships a default `{ fetch }` so Vercel's Node.js
-    // runtime treats it as a Web fetch handler in production. We mirror the
-    // same shape here so dev and prod hit the same code path.
-    const adapter = createServerAdapter(async (request) => {
-      const { default: api } = (await server.ssrLoadModule("/api/chat.ts")) as {
-        default: { fetch: (request: Request) => Promise<Response> };
-      };
+    for (const [route, modulePath] of apiModules) {
+      // The endpoints ship a default `{ fetch }` so Vercel's Node.js runtime
+      // treats them as Web fetch handlers. Mirror that shape in development so
+      // both environments exercise exactly the same handler.
+      const adapter = createServerAdapter(async (request) => {
+        const { default: api } = (await server.ssrLoadModule(modulePath)) as {
+          default: { fetch: (request: Request) => Promise<Response> };
+        };
 
-      try {
-        return await api.fetch(request);
-      } catch (error) {
-        server.ssrFixStacktrace(error as Error);
-        throw error;
-      }
-    });
+        try {
+          return await api.fetch(request);
+        } catch (error) {
+          server.ssrFixStacktrace(error as Error);
+          throw error;
+        }
+      });
 
-    server.middlewares.use(
-      "/api/chat",
-      (request: IncomingMessage, response: ServerResponse) => {
-        void adapter(request, response);
-      },
-    );
+      server.middlewares.use(
+        route,
+        (request: IncomingMessage, response: ServerResponse) => {
+          void adapter(request, response);
+        },
+      );
+    }
   },
 });
 

--- a/libs/@hashintel/petrinaut-core/package.json
+++ b/libs/@hashintel/petrinaut-core/package.json
@@ -86,6 +86,7 @@
     "js-yaml": "4.3.1",
     "uuid": "14.0.0",
     "vscode-languageserver-types": "3.17.5",
+    "web-worker": "1.4.1",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/libs/@local/petrinaut-arch-docs/README.md
+++ b/libs/@local/petrinaut-arch-docs/README.md
@@ -106,7 +106,7 @@ carries the coupling.
 ### Inheritance is what keeps this small
 
 A file with no tags belongs to the nearest ancestor folder that declares a layer.
-That is why 37 declarations cover 413 files: you declare a layer where the
+That is why 58 declarations cover 555 files: you declare a layer where the
 architecture actually changes, not on every file.
 
 ## The output: a portable bundle

--- a/libs/@local/petrinaut-arch-docs/architecture.config.ts
+++ b/libs/@local/petrinaut-arch-docs/architecture.config.ts
@@ -64,6 +64,18 @@ export const config: ArchitectureConfig = {
       language: "python",
     },
     {
+      name: "@apps/petrinaut-website",
+      path: "apps/petrinaut-website",
+      description:
+        "Demo site and embed host: TanStack Router routes, published example models, and server functions for oEmbed discovery.",
+      language: "typescript",
+      // The whole app, not just `src`: the Vercel functions in `api/` are part
+      // of the architecture, and they deploy separately from the SPA. The
+      // `scripts` directory and root `*.config.ts` files are excluded by the
+      // shared ignore rules, so this buys `api/` without the build tooling.
+      sourceDirectory: ".",
+    },
+    {
       name: "@apps/petrinaut-opt",
       path: "apps/petrinaut-opt",
       description:
@@ -123,6 +135,9 @@ export const config: ArchitectureConfig = {
     "docs",
     "__pycache__",
     ".venv",
+    // Build and codegen tooling, which a package scanned with
+    // `sourceDirectory: "."` would otherwise pull into its root layer.
+    "scripts",
   ],
 
   /**
@@ -131,7 +146,7 @@ export const config: ArchitectureConfig = {
    * layer's file count with fixtures.
    */
   ignoredFilePattern:
-    /(?:\.(?:test|spec|stories)\.[cm]?[jt]sx?$|\.d\.ts$|\/CHANGELOG\.md$|\/LICENSE[^/]*\.md$)/u,
+    /(?:\.(?:test|spec|stories)\.[cm]?[jt]sx?$|\.d\.ts$|\.config\.[cm]?[jt]s$|\/CHANGELOG\.md$|\/LICENSE[^/]*\.md$)/u,
 
   /**
    * The bundle is the product; the Starlight site in `apps/petrinaut-docs` and

--- a/libs/@local/petrinaut-arch-docs/content/diagrams/oembed-request-flow.d2
+++ b/libs/@local/petrinaut-arch-docs/content/diagrams/oembed-request-flow.d2
@@ -1,0 +1,16 @@
+# Hand-written; rendered by the arch-docs build. Palette matches the classes in
+# src/emit/d2.ts: website nodes use the `website` class, and anything outside
+# the model the `other` class.
+direction: right
+
+consumer: "Consumer\n(CMS, blog, chat)" {style.fill: "#f2f2f2"; style.stroke: "#777777"}
+endpoint: "website.api\n/api/oembed" {style.fill: "#eef3d9"; style.stroke: "#6f8f2f"}
+catalog: "website.examples\ncatalog + contract" {style.fill: "#eef3d9"; style.stroke: "#6f8f2f"}
+embed: "website.routes\n/embed/examples/:slug" {style.fill: "#eef3d9"; style.stroke: "#6f8f2f"}
+
+consumer -> endpoint: "GET ?url=<canonical page>"
+endpoint -> catalog: "slug known? state valid?"
+catalog -> endpoint: "canonical search"
+endpoint -> consumer: "JSON: iframe html, width, height"
+consumer -> embed: "iframe src"
+embed -> consumer: "read-only editor"

--- a/libs/@local/petrinaut-arch-docs/content/diagrams/website-navigation-loop.d2
+++ b/libs/@local/petrinaut-arch-docs/content/diagrams/website-navigation-loop.d2
@@ -1,0 +1,18 @@
+# Hand-written; rendered by the arch-docs build. Palette matches the classes in
+# src/emit/d2.ts: website nodes use the `website` class, the editor the `react`
+# class, and anything outside the model the `other` class.
+direction: right
+
+url: "URL\n(?scenario, ?subnet, ?itemType, ?itemId)" {style.fill: "#f2f2f2"; style.stroke: "#777777"}
+route: "website.routes\nvalidateSearch" {style.fill: "#eef3d9"; style.stroke: "#6f8f2f"}
+contract: "website.examples\nexample-search" {style.fill: "#eef3d9"; style.stroke: "#6f8f2f"}
+hook: "useSharedSearchNavigation\n(in-memory location)" {style.fill: "#eef3d9"; style.stroke: "#6f8f2f"}
+petrinaut: "Petrinaut\nnavigation prop" {style.fill: "#e8e0ff"; style.stroke: "#7051b5"}
+
+url -> route: raw search
+route -> contract: validate
+contract -> hook: shared fields
+hook -> petrinaut: state
+petrinaut -> hook: "onNavigate(updater, {history, intent})"
+hook -> route: shared projection only
+route -> url: push or replace

--- a/libs/@local/petrinaut-arch-docs/content/index.mdx
+++ b/libs/@local/petrinaut-arch-docs/content/index.mdx
@@ -87,6 +87,13 @@ the transports, the protocol, and optimization studies.
 
 `apps/petrinaut-opt` (the Python Optuna service) and `@local/petrinaut-python`
 (its CLI bindings) are covered too, with their layers and import edges derived
-the same way as the TypeScript ones. One package is not covered at all:
-`@apps/petrinaut-website`. Adding a package is a matter of declaring layers in
-its source; see [Declaring layers](doc:maintaining/declaring-layers).
+the same way as the TypeScript ones.
+
+`@apps/petrinaut-website` is the demo site and the host that embeds the editor.
+Its layers cover the routes, the example catalog, and the Vercel functions in
+`api/`. Two pages describe how it drives Petrinaut:
+[Router integration](doc:website/router-integration) for the navigation
+contract, and [oEmbed](doc:website/oembed) for the embed endpoint.
+
+Adding a package is a matter of declaring layers in its source; see
+[Declaring layers](doc:maintaining/declaring-layers).

--- a/libs/@local/petrinaut-arch-docs/content/website/oembed.mdx
+++ b/libs/@local/petrinaut-arch-docs/content/website/oembed.mdx
@@ -1,0 +1,81 @@
+---
+title: oEmbed and iframe embedding
+description: The JSON oEmbed endpoint, the embed route it points at, and how a third-party site embeds an example.
+attachTo: website.api
+sidebar_order: 10
+---
+
+An example page is an ordinary SPA route, and its response headers forbid
+framing. Embedding goes through a second route built for it, and consumers
+discover that route through [oEmbed 1.0](https://oembed.com/).
+
+![An oEmbed request and the iframe it produces](@diagrams/oembed-request-flow.svg)
+
+## The endpoint
+
+`GET /api/oembed?url=<canonical example URL>` returns a `rich` oEmbed response.
+The handler:
+
+- accepts only `https://demo.petrinaut.org/examples/<slug>`, and answers 404
+  for a well-formed URL it cannot embed, 400 for a request it cannot read;
+- carries state over by decoding the source URL through the shared contract in
+  `website.examples` and re-encoding it, so the endpoint cannot drift from what
+  the embed route accepts;
+- fits `maxwidth` and `maxheight` by scaling down only, never up, keeping the
+  16:9 ratio, and reads them as positive integers;
+- answers 501 for a `format` other than `json`, as the spec requires, and
+  serves `HEAD` like `GET`, bodiless on every path.
+
+It imports the contract and the catalog metadata, never the editor: the
+function bundles neither React nor the model.
+
+## The embed route
+
+The response's iframe points at `/embed/examples/<slug>`, which renders the
+editor read-only. The route answers for itself when something goes wrong: a
+frame-sized panel, carrying no link, replaces both the site's full-page 404 and
+an editor chunk that fails to load.
+
+Framing policy is HTTP, not JavaScript. `vercel.json` sends
+`frame-ancestors 'none'` plus `X-Frame-Options: DENY` for every path outside
+`/api` and `/embed/examples/`, allows all ancestors under `/embed/examples/*`,
+and marks that path `X-Robots-Tag: noindex` so it is not indexed alongside the
+canonical page.
+
+The iframe carries `sandbox="allow-scripts allow-same-origin"`. Both tokens are
+required: without `allow-same-origin` the framed document runs with an opaque
+origin, its module scripts fail CORS, and the embed renders blank.
+
+## Embedding an example in your site
+
+If your platform speaks oEmbed, paste the canonical example URL and you are
+done. The example pages also carry an `application/json+oembed` discovery link
+for consumers that execute page JavaScript.
+
+Otherwise, call the endpoint and use the `html` it returns:
+
+```sh
+curl "https://demo.petrinaut.org/api/oembed?url=https%3A%2F%2Fdemo.petrinaut.org%2Fexamples%2Fgases-1-pn&maxwidth=800"
+```
+
+```html
+<iframe
+  src="https://demo.petrinaut.org/embed/examples/gases-1-pn"
+  title="Gases 1 — One Customer"
+  width="800"
+  height="450"
+  style="border: 0"
+  loading="lazy"
+  sandbox="allow-scripts allow-same-origin"
+  referrerpolicy="no-referrer"
+  allowfullscreen
+></iframe>
+```
+
+To open the embed on a particular view, add the contract's params to the source
+URL before calling the endpoint, or to the iframe `src` directly:
+`?scenario=<id>&subnet=<id>&itemType=place&itemId=<id>`. Anything else in the
+query string is ignored.
+
+Embed URLs are stable but not immutable: they always render the current model
+for that slug.

--- a/libs/@local/petrinaut-arch-docs/content/website/router-integration.mdx
+++ b/libs/@local/petrinaut-arch-docs/content/website/router-integration.mdx
@@ -1,0 +1,74 @@
+---
+title: Router integration
+description: How the site drives Petrinaut's app location from the URL, and why only part of that location is shareable.
+attachTo: website.routes
+sidebar_order: 10
+---
+
+Petrinaut imports no router. It exposes a `navigation` prop taking a
+router-neutral controller, and the host decides what a URL means. This page is
+how the website implements that contract with TanStack Router.
+
+## The three pieces
+
+`website.routes` owns the URL. Routes are file-based under `src/routes`, and
+every route that reads query params declares `validateSearch`, which is the
+only place raw query input enters the app.
+
+`website.examples` owns the contract. `example-search.ts` defines the four
+params a shareable location carries — `scenario`, `subnet`, `itemType`,
+`itemId` — validates them with zod, and encodes them back. The module imports
+neither React nor the editor, so the oEmbed function can speak the same
+contract without bundling either.
+
+`useSharedSearchNavigation` bridges the two. The editor navigates more than a
+URL carries: global mode, the Simulate section, overlays. Those live in page
+state, and only the shared projection reaches the URL.
+
+![One navigation round trip](@diagrams/website-navigation-loop.svg)
+
+## Why the location splits in two
+
+Deriving the whole controller state from the URL does not work. A control
+driving a field the URL cannot represent — the mode switcher, the
+viewport-settings overlay — would write, read back a state without that field,
+and snap to its previous value. The control appears not to respond.
+
+So the hook keeps the full `PetrinautNavigationState` in component state,
+mirrors `navigationStateToSharedSearch(state)` to the URL, and merges external
+URL changes (Back, Forward, a shared link) back into the in-memory location.
+Fields outside the contract survive that merge untouched.
+
+## Validation normalizes the location
+
+`validateSharedExampleSearch` drops everything it cannot represent: an unknown
+`itemType`, an empty `subnet`, a param outside the contract. Its output is
+therefore the canonical spelling of a location, and two searches are the same
+location when `canonicalSearchString` agrees on both. The hook uses that
+equality to suppress no-op navigations, and the oEmbed function uses the same
+encoder to build embed URLs.
+
+Query params outside the contract are not rewritten on load. TanStack Router
+only re-stringifies the URL when the parsed search changes, so stripping them
+eagerly would need a document reload, which an embed must not do. The first
+navigation drops them, because both routes write a fresh contract-only search
+rather than merging into the existing one.
+
+## What a URL carries, and what it does not
+
+A single focused item is shareable; a multi-selection is not. Multi-selection
+is a working state inside the editor, and encoding it would require a
+precedence rule between two spellings of the same location. A location with
+several items selected therefore carries no item at all.
+
+`scenario` is tri-state: absent means "the model's first scenario", `none`
+means the user explicitly chose no scenario, and any other value names one. The
+oEmbed endpoint drops an explicit `none` when it builds the embed URL, because
+an embed with no scenario has nothing to run. The embed route itself honours
+`none`, so a hand-written embed URL can still ask for no scenario.
+
+## Hosting Petrinaut without a router
+
+The prop is optional. Omit it and Petrinaut keeps its location in internal
+state, which is what Storybook and the local-storage demo do. Nothing about the
+editor's behaviour depends on a host router being present.

--- a/libs/@local/petrinaut-arch-docs/package.json
+++ b/libs/@local/petrinaut-arch-docs/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@apps/petrinaut-opt": "workspace:*",
+    "@apps/petrinaut-website": "workspace:*",
     "@hashintel/petrinaut": "workspace:*",
     "@hashintel/petrinaut-cli": "workspace:*",
     "@hashintel/petrinaut-core": "workspace:*",

--- a/libs/@local/petrinaut-arch-docs/src/emit/d2.ts
+++ b/libs/@local/petrinaut-arch-docs/src/emit/d2.ts
@@ -44,6 +44,7 @@ const styleClasses = [
   `  cli: {style.fill: "#fbe3e8"; style.stroke: "#ad3a5b"}`,
   `  python-bindings: {style.fill: "#fff4d6"; style.stroke: "#a3801f"}`,
   `  optimizer: {style.fill: "#e0f2f1"; style.stroke: "#2b7a72"}`,
+  `  website: {style.fill: "#eef3d9"; style.stroke: "#6f8f2f"}`,
   `  other: {style.fill: "#f2f2f2"; style.stroke: "#777777"}`,
   `  boundary: {style.stroke-dash: 4}`,
   `  declared: {style.stroke-dash: 2}`,
@@ -60,6 +61,7 @@ const knownRoots = [
   "cli",
   "python-bindings",
   "optimizer",
+  "website",
 ];
 
 const classFor = (id: string): string => {

--- a/libs/@local/petrinaut-arch-docs/src/graph.ts
+++ b/libs/@local/petrinaut-arch-docs/src/graph.ts
@@ -72,7 +72,7 @@ const deriveAliases = (
 
   const manifest = JSON.parse(
     readFileSync(join(packageRoot, "package.json"), "utf8"),
-  ) as { exports?: Record<string, unknown>; bin?: unknown };
+  ) as { exports?: Record<string, unknown>; bin?: unknown; private?: boolean };
 
   const aliases: Alias[] = [];
 
@@ -121,8 +121,14 @@ const deriveAliases = (
 
   // A library with no module entry points is invisible to import resolution,
   // so imports of it silently vanish from the graph. Bin-only packages are
-  // exempt: nothing can import them by specifier in the first place.
-  if (aliases.length === 0 && manifest.bin === undefined) {
+  // exempt: nothing can import them by specifier in the first place. So are
+  // private packages, which are applications rather than libraries and are
+  // never imported by name.
+  if (
+    aliases.length === 0 &&
+    manifest.bin === undefined &&
+    manifest.private !== true
+  ) {
     diagnostics.push(
       warning(
         manifestPath,

--- a/yarn.lock
+++ b/yarn.lock
@@ -913,7 +913,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@apps/petrinaut-website@workspace:apps/petrinaut-website":
+"@apps/petrinaut-website@workspace:*, @apps/petrinaut-website@workspace:apps/petrinaut-website":
   version: 0.0.0-use.local
   resolution: "@apps/petrinaut-website@workspace:apps/petrinaut-website"
   dependencies:
@@ -7618,6 +7618,7 @@ __metadata:
     vite: "npm:8.2.2"
     vitest: "npm:4.1.10"
     vscode-languageserver-types: "npm:3.17.5"
+    web-worker: "npm:1.4.1"
     zod: "npm:4.4.3"
   peerDependencies:
     typescript: ">=5.5"
@@ -9544,6 +9545,7 @@ __metadata:
   resolution: "@local/petrinaut-arch-docs@workspace:libs/@local/petrinaut-arch-docs"
   dependencies:
     "@apps/petrinaut-opt": "workspace:*"
+    "@apps/petrinaut-website": "workspace:*"
     "@hashintel/petrinaut": "workspace:*"
     "@hashintel/petrinaut-cli": "workspace:*"
     "@hashintel/petrinaut-core": "workspace:*"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Brings `@apps/petrinaut-website` into the Petrinaut architecture docs, and documents the two things the import graph cannot explain: how the site drives Petrinaut's app location from the URL, and how a third-party site embeds an example through oEmbed. Stacked on #9363.

## 🔗 Related links

- [FE-1500](https://linear.app/hash/issue/FE-1500/view-only-iframe-embed-of-a-petrinaut-net)
- [oEmbed 1.0](https://oembed.com/)

## 🔍 What does this change?

- Registers the website as a scanned package. Its source root is the app root rather than `src`, because the Vercel functions in `api/` are part of the architecture and deploy separately from the SPA.
- Declares five layers next to the code they describe: `website` (the app's README frontmatter), `website.routes`, `website.examples`, `website.api`, and `website.demo`. Everything else in the app inherits from the nearest declaring ancestor, so 5 declarations cover the package.
- Declares one edge no import produces: `website.api` reaches `website.routes` through the embed URL it hands to consumers.
- Adds `content/website/router-integration.mdx` (attached to `website.routes`): the router-neutral `navigation` contract, `validateSearch` as the single entry point for raw query input, why the location splits between the URL and page state, validation as normalization, what a URL carries, and hosting Petrinaut without a router at all.
- Adds `content/website/oembed.mdx` (attached to `website.api`): the endpoint's contract and validation, the embed route and its HTTP framing policy, why both `sandbox` tokens are required, and a copy-pasteable iframe for embedding an example.
- Adds two hand-written D2 diagrams: one navigation round trip, and one oEmbed request through to the rendered iframe.
- Wires the website into the docs build the way the other scanned packages are wired: as a `devDependency` of `@local/petrinaut-arch-docs`, so `turbo prune` keeps its source in the pruned CI workspace.
- Declares `web-worker` in `@hashintel/petrinaut-core`, with a patch changeset. `elkjs` imports it from the entry the graph-layout helper uses, and it resolved only because `apps/hash-frontend` happened to install it; the pruned workspace this PR creates has no such neighbour, and neither would an external consumer of the published package.
- Review fixes (first round, self-review): corrected three false claims — the docs landing page still said `@apps/petrinaut-website` was "not covered at all", the page said every route declares `validateSearch` (three of six do), and it credited the embed with resolving `scenario=none` when the embed honours it and the oEmbed endpoint is what drops it. Moved `@layerRoot website.routes` from `src/router.ts` to `src/routes/__root.tsx`, since a declaration scopes to its own directory and this one was claiming all of `src/`, and declared the three subtrees it had absorbed (`website.brunch`, `website.optimization`, `website.telemetry`); renamed `website.demo` to `website.local-storage-demo`, as it is one of three demos. Excluded `scripts/` and root `*.config.ts` from scanning so `sourceDirectory: "."` buys `api/` without the build tooling, and exempted private packages from the "no importable exports" warning, which this package triggered on every build. Added a `website` class to the generated-diagram palette so the hand-written diagrams match it, and fixed the `onNavigate` signature in one diagram label.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] require changes to docs which **are made** as part of this PR

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- `yarn workspace @local/petrinaut-arch-docs lint:arch-docs` covers the model: it fails on an unannotated file, an undeclared ancestor, a rule violation, and a `@talksTo` target the imports already prove.
- The docs-site build compiles the MDX and renders the D2 sources; both run in CI for this package.

## ❓ How to test this?

1. `yarn workspace @local/petrinaut-arch-docs lint:arch-docs` — expect no errors.
2. `mise x -- yarn exec turbo run dev --filter @apps/petrinaut-docs`, then open the website section.
3. Confirm the five website layers appear with their dependencies, and that both authored pages render with their diagrams.

