### PR TITLE
FE-1552: Reuse sweep workers and batch surface sampling

### DIFF
--- a/.changeset/sweep-compute-reuse.md
+++ b/.changeset/sweep-compute-reuse.md
@@ -1,0 +1,6 @@
+---
+"@hashintel/petrinaut-core": patch
+"@hashintel/petrinaut": patch
+---
+
+Reuse simulation workers across sweep batches instead of spawning and terminating a pool per batch, and sample the sweep surface in batched chunks (one experiment for many cells when the swept parameters do not shape the initial marking). Switching the surface metric now re-reads the cached samples instead of re-simulating.

--- a/libs/@hashintel/petrinaut-core/src/experiments.ts
+++ b/libs/@hashintel/petrinaut-core/src/experiments.ts
@@ -40,3 +40,7 @@ export {
   WORKER_POOL_BACKEND_ID,
   type WorkerPoolExperimentBackendOptions,
 } from "./experiments/worker-pool-experiment-backend";
+export {
+  createReusableWorkerFactory,
+  type ReusableWorkerFactory,
+} from "./simulation/runtime/reusable-worker-factory";

--- a/libs/@hashintel/petrinaut-core/src/simulation/runtime/reusable-worker-factory.test.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/runtime/reusable-worker-factory.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it } from "vitest";
+
+import { createReusableWorkerFactory } from "./reusable-worker-factory";
+
+import type { WorkerLike } from "../../environment";
+
+type Listener = (event: { data: unknown }) => void;
+
+/**
+ * A worker double that records messages and dispatches by event type the way
+ * a real worker does. With `autoAck` (the default) it answers `cancel` with
+ * `cancelled` synchronously, like the in-process worker; `autoAck: false`
+ * hands the test manual control over ack timing, which is how the real
+ * browser worker behaves (acks arrive as later macrotasks).
+ */
+function fakeWorker({ autoAck = true }: { autoAck?: boolean } = {}) {
+  const listenersByType = new Map<string, Set<Listener>>();
+  const posted: unknown[] = [];
+  let terminated = false;
+  const emit = (data: unknown) => {
+    for (const listener of listenersByType.get("message") ?? []) {
+      listener({ data });
+    }
+  };
+  const worker: WorkerLike = {
+    postMessage: (message) => {
+      posted.push(message);
+      if (autoAck && (message as { type?: unknown }).type === "cancel") {
+        emit({ type: "cancelled" });
+      }
+    },
+    addEventListener: (type, listener) => {
+      let set = listenersByType.get(type);
+      if (!set) {
+        set = new Set();
+        listenersByType.set(type, set);
+      }
+      set.add(listener as Listener);
+    },
+    removeEventListener: (type, listener) => {
+      listenersByType.get(type)?.delete(listener as Listener);
+    },
+    terminate: () => {
+      terminated = true;
+    },
+  };
+  return {
+    worker,
+    posted,
+    emit,
+    messageListenerCount: () => listenersByType.get("message")?.size ?? 0,
+    wasTerminated: () => terminated,
+  };
+}
+
+function trackingFactory(options?: { autoAck?: boolean }) {
+  const doubles: ReturnType<typeof fakeWorker>[] = [];
+  const factory = createReusableWorkerFactory(() => {
+    const double = fakeWorker(options);
+    doubles.push(double);
+    return double.worker;
+  });
+  return { factory, doubles };
+}
+
+describe("createReusableWorkerFactory", () => {
+  it("reuses a released worker for the next lease", async () => {
+    const { factory, doubles } = trackingFactory();
+
+    const first = await factory();
+    first.terminate();
+    const second = await factory();
+    second.postMessage({ type: "init" });
+
+    expect(doubles).toHaveLength(1);
+    expect(doubles[0]!.wasTerminated()).toBe(false);
+    // The release reset the worker, then the new lease reached it.
+    expect(doubles[0]!.posted).toEqual([{ type: "cancel" }, { type: "init" }]);
+  });
+
+  it("detaches the old lease's listeners so the next lease never hears it", async () => {
+    const { factory, doubles } = trackingFactory();
+
+    const first = await factory();
+    const heard: unknown[] = [];
+    first.addEventListener("message", (event: { data: unknown }) =>
+      heard.push(event.data),
+    );
+    first.terminate();
+
+    // The reset already completed (auto-ack); stray traffic goes nowhere.
+    doubles[0]!.emit({ type: "stale traffic" });
+    expect(heard).toEqual([]);
+    // The reset ack listener consumed itself; lease listeners are gone.
+    expect(doubles[0]!.messageListenerCount()).toBe(0);
+  });
+
+  it("holds a worker out of the pool until every owed cancel is acknowledged", async () => {
+    // The runtime's dispose path sends its own cancel through the lease right
+    // before terminating it. The worker then owes TWO acks (that one and the
+    // reset's), delivered later; pooling on the first would let the second
+    // land on the next lease, where the runtime reads it as its shard
+    // settling. This is the race the ack gate exists for.
+    const { factory, doubles } = trackingFactory({ autoAck: false });
+
+    const lease = await factory();
+    lease.postMessage({ type: "cancel" });
+    lease.terminate();
+
+    // Ack #1 (the dispose-cancel's): still owed one, so not pooled.
+    doubles[0]!.emit({ type: "cancelled" });
+    const second = await factory();
+    expect(doubles).toHaveLength(2);
+
+    // Ack #2 (the reset's own): now pooled, and the next lease reuses it.
+    doubles[0]!.emit({ type: "cancelled" });
+    const third = await factory();
+    third.postMessage({ type: "init" });
+    expect(doubles).toHaveLength(2);
+    expect(doubles[0]!.posted.at(-1)).toEqual({ type: "init" });
+    second.terminate();
+  });
+
+  it("does not owe acks the ending lease already observed", async () => {
+    const { factory, doubles } = trackingFactory({ autoAck: false });
+
+    const lease = await factory();
+    lease.postMessage({ type: "cancel" });
+    // The ack arrives while the lease is still active — nothing is owed.
+    doubles[0]!.emit({ type: "cancelled" });
+    lease.terminate();
+
+    // Only the reset's own ack gates the pool now.
+    doubles[0]!.emit({ type: "cancelled" });
+    await factory();
+    expect(doubles).toHaveLength(1);
+  });
+
+  it("ignores non-cancelled traffic while waiting for the reset ack", async () => {
+    const { factory, doubles } = trackingFactory({ autoAck: false });
+
+    (await factory()).terminate();
+    doubles[0]!.emit({ type: "progress", progress: {} });
+    const second = await factory();
+    expect(doubles).toHaveLength(2);
+
+    doubles[0]!.emit({ type: "cancelled" });
+    await factory();
+    expect(doubles).toHaveLength(2);
+    second.terminate();
+  });
+
+  it("terminates instead of pooling past maxIdle", async () => {
+    const doubles: ReturnType<typeof fakeWorker>[] = [];
+    const factory = createReusableWorkerFactory(
+      () => {
+        const double = fakeWorker();
+        doubles.push(double);
+        return double.worker;
+      },
+      { maxIdle: 1 },
+    );
+
+    const leases = await Promise.all([factory(), factory()]);
+    for (const lease of leases) {
+      lease.terminate();
+    }
+
+    const terminated = doubles.filter((d) => d.wasTerminated());
+    expect(doubles).toHaveLength(2);
+    expect(terminated).toHaveLength(1);
+  });
+
+  it("a worker that never acknowledges its reset is not reused", async () => {
+    const doubles: ReturnType<typeof fakeWorker>[] = [];
+    let mute = false;
+    const factory = createReusableWorkerFactory(() => {
+      const double = fakeWorker();
+      doubles.push(double);
+      if (mute) {
+        return double.worker;
+      }
+      mute = true;
+      // Swallow every post so the `cancelled` ack never comes back.
+      return { ...double.worker, postMessage: () => {} };
+    });
+
+    (await factory()).terminate();
+    await factory();
+
+    // The silent worker stays quarantined; the lease got a fresh one.
+    expect(doubles).toHaveLength(2);
+  });
+
+  it("drain terminates workers awaiting their reset ack", async () => {
+    const doubles: ReturnType<typeof fakeWorker>[] = [];
+    const factory = createReusableWorkerFactory(() => {
+      const double = fakeWorker();
+      doubles.push(double);
+      // Swallow the cancel so the ack never arrives before the drain.
+      return { ...double.worker, postMessage: () => {} };
+    });
+
+    (await factory()).terminate();
+    factory.drain();
+
+    expect(doubles[0]!.wasTerminated()).toBe(true);
+  });
+
+  it("drain terminates every idle worker", async () => {
+    const { factory, doubles } = trackingFactory();
+
+    (await factory()).terminate();
+    factory.drain();
+
+    expect(doubles[0]!.wasTerminated()).toBe(true);
+  });
+
+  it("dispose shuts the pool: later releases terminate instead of pooling", async () => {
+    const { factory, doubles } = trackingFactory();
+
+    const idleLease = await factory();
+    const activeLease = await factory();
+    idleLease.terminate();
+    factory.dispose();
+    // A handle disposed after the pool shut down — the unmount ordering —
+    // must kill its worker, not park it where nothing will ever lease it.
+    activeLease.terminate();
+
+    expect(doubles).toHaveLength(2);
+    expect(doubles.every((double) => double.wasTerminated())).toBe(true);
+  });
+
+  it("dispose kills a worker whose reset ack arrives afterwards", async () => {
+    const { factory, doubles } = trackingFactory({ autoAck: false });
+
+    (await factory()).terminate();
+    factory.dispose();
+    doubles[0]!.emit({ type: "cancelled" });
+
+    expect(doubles[0]!.wasTerminated()).toBe(true);
+    // The late ack must not resurrect it into the pool.
+    const next = await factory();
+    expect(doubles).toHaveLength(2);
+    next.terminate();
+  });
+
+  it("a lease ignores traffic after its own terminate", async () => {
+    const factory = createReusableWorkerFactory(() => fakeWorker().worker);
+    const lease = await factory();
+    lease.terminate();
+    lease.terminate();
+    expect(() => lease.postMessage({ type: "start" })).not.toThrow();
+  });
+});

--- a/libs/@hashintel/petrinaut-core/src/simulation/runtime/reusable-worker-factory.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/runtime/reusable-worker-factory.ts
@@ -1,0 +1,199 @@
+/**
+ * A worker factory that recycles workers instead of terminating them.
+ *
+ * The experiment runtime creates one worker per shard per experiment and
+ * terminates them on dispose — correct, but a parameter sweep instantiates a
+ * batch per ladder rung and per surface chunk, so a single slider commit
+ * used to spawn (and kill) a whole pool's worth of workers. Each spawn costs
+ * little main-thread time; the real price is the worker re-fetching and
+ * re-evaluating the engine module and re-receiving the compiled model before
+ * it can simulate.
+ *
+ * The Monte Carlo worker protocol is re-initializable by design: `init`
+ * rebuilds the simulator from scratch and `cancel` discards it, so a worker
+ * that finished (or was cancelled) is safe to hand to the next experiment.
+ * This factory leases workers: `terminate()` on a lease detaches its
+ * listeners, sends `cancel` to reset the worker, and returns it to an idle
+ * pool instead of killing it. Callers keep the exact `WorkerFactory`
+ * contract — the pooling is invisible to the transport and the runtime.
+ *
+ * The one delicate part is WHEN a released worker may re-enter the pool. A
+ * `cancelled` reply that arrives after the next lease attached its listeners
+ * would be read by the experiment runtime as its own shard settling, so the
+ * worker is pooled only once every acknowledgement it still owes has
+ * arrived. Acks are FIFO and the worker answers every `cancel` — including
+ * the one the runtime's dispose path sends through the lease right before
+ * terminating it — so the reset's own ack is always the last one owed: the
+ * lease counts cancels out and acks in, and the release waits for the
+ * difference plus its own.
+ */
+import type { WorkerFactoryLike, WorkerLike } from "../../environment";
+
+type MessageListener = (event: { data: unknown }) => void;
+
+export type ReusableWorkerFactory = (() => Promise<WorkerLike>) & {
+  /** Terminates every idle or resetting worker; leases in flight are unaffected. */
+  drain(): void;
+  /**
+   * Drains and shuts the pool: from here on a released worker is terminated
+   * instead of pooled (its late reset ack pools nothing), and a new lease
+   * gets a fresh, unpooled worker. For hosts that unmount — leases released
+   * after this point must die even though their acks arrive later.
+   */
+  dispose(): void;
+};
+
+function isCancelledAck(data: unknown): boolean {
+  return (
+    data !== null &&
+    typeof data === "object" &&
+    (data as { type?: unknown }).type === "cancelled"
+  );
+}
+
+export function createReusableWorkerFactory(
+  createWorker: WorkerFactoryLike,
+  { maxIdle = 8 }: { maxIdle?: number } = {},
+): ReusableWorkerFactory {
+  const idle: WorkerLike[] = [];
+  /** Reset in flight: `cancel` posted, its final `cancelled` ack not yet seen. */
+  const resetting = new Set<WorkerLike>();
+  const broken = new WeakSet<WorkerLike>();
+  let ended = false;
+
+  const acquire = async (): Promise<WorkerLike> => {
+    const pooled = idle.pop();
+    if (pooled) {
+      return pooled;
+    }
+    const worker = await createWorker();
+    // A worker whose script crashed goes silent rather than erroring through
+    // the protocol; it must never be re-pooled. `WorkerLike` only models
+    // "message", so the error hook is best-effort where the host supports it.
+    (worker.addEventListener as (type: string, listener: () => void) => void)(
+      "error",
+      () => {
+        broken.add(worker);
+      },
+    );
+    return worker;
+  };
+
+  /**
+   * Resets the worker and pools it once it has answered every `cancel` it
+   * owes. `owedAcks` counts cancels the ending lease sent whose replies had
+   * not arrived by terminate time; the reset's own cancel adds one more, and
+   * message order guarantees the last of those acks is the reset's.
+   */
+  const release = (worker: WorkerLike, owedAcks: number): void => {
+    if (
+      ended ||
+      broken.has(worker) ||
+      worker.removeEventListener === undefined ||
+      idle.length >= maxIdle
+    ) {
+      worker.terminate();
+      return;
+    }
+    let acksLeft = owedAcks + 1;
+    const onReset = (event: { data: unknown }) => {
+      if (!isCancelledAck(event.data)) {
+        return;
+      }
+      acksLeft -= 1;
+      if (acksLeft > 0) {
+        return;
+      }
+      worker.removeEventListener?.("message", onReset);
+      if (!resetting.delete(worker)) {
+        // A drain or dispose got here first and already terminated it.
+        return;
+      }
+      if (broken.has(worker) || idle.length >= maxIdle) {
+        worker.terminate();
+        return;
+      }
+      idle.push(worker);
+    };
+    resetting.add(worker);
+    worker.addEventListener("message", onReset);
+    worker.postMessage({ type: "cancel" });
+  };
+
+  const factory = async (): Promise<WorkerLike> => {
+    const worker = await acquire();
+    const listeners = new Map<MessageListener, MessageListener>();
+    let leaseEnded = false;
+    // FIFO bookkeeping for the release: cancels this lease sent minus acks
+    // already received is what the worker still owes at terminate time.
+    let cancelsSent = 0;
+    let acksSeen = 0;
+    const ackMonitor: MessageListener = (event) => {
+      if (isCancelledAck(event.data)) {
+        acksSeen += 1;
+      }
+    };
+    const canMonitor = worker.removeEventListener !== undefined;
+    if (canMonitor) {
+      worker.addEventListener("message", ackMonitor);
+    }
+
+    const lease: WorkerLike = {
+      postMessage(message) {
+        if (leaseEnded) {
+          return;
+        }
+        if ((message as { type?: unknown } | null)?.type === "cancel") {
+          cancelsSent += 1;
+        }
+        worker.postMessage(message);
+      },
+      addEventListener(type, listener) {
+        if (leaseEnded) {
+          return;
+        }
+        listeners.set(listener, listener);
+        worker.addEventListener(type, listener);
+      },
+      removeEventListener(type, listener) {
+        listeners.delete(listener);
+        worker.removeEventListener?.(type, listener);
+      },
+      terminate() {
+        if (leaseEnded) {
+          return;
+        }
+        leaseEnded = true;
+        for (const listener of listeners.values()) {
+          worker.removeEventListener?.("message", listener);
+        }
+        listeners.clear();
+        if (canMonitor) {
+          worker.removeEventListener?.("message", ackMonitor);
+        }
+        release(worker, Math.max(0, cancelsSent - acksSeen));
+      },
+    };
+    return lease;
+  };
+
+  const drain = () => {
+    for (const worker of idle.splice(0)) {
+      worker.terminate();
+    }
+    // Workers still awaiting their reset ack die too; their pending
+    // `onReset` sees the emptied set and pools nothing.
+    for (const worker of resetting) {
+      worker.terminate();
+    }
+    resetting.clear();
+  };
+
+  return Object.assign(factory, {
+    drain,
+    dispose() {
+      ended = true;
+      drain();
+    },
+  });
+}

--- a/libs/@hashintel/petrinaut/docs/experiments.md
+++ b/libs/@hashintel/petrinaut/docs/experiments.md
@@ -68,7 +68,7 @@ Every selection uses the same seed sequence (common random numbers), and a run's
 
 #### The surface view
 
-A sweep with two or more swept parameters grows a **Surface** section between the parameter strip and the metric charts: a contour plot of one metric's final value over two parameters you pick, with every other parameter held at the middle of its selected range. The plot fills in live — points are sampled a few runs at a time (8 runs each), coarse shape first — and **clicking the surface moves the navigator**: both shown parameters collapse to a point at the clicked position, which then refines with more runs. Changing the fixed parameters, the axes, or the metric restarts the fill for the new slice.
+A sweep with two or more swept parameters grows a **Surface** section between the parameter strip and the metric charts: a contour plot of one metric's final value over two parameters you pick, with every other parameter held at the middle of its selected range. The plot fills in live — cells are sampled in chunks a few runs at a time (8 runs each), coarse shape first — and **clicking the surface moves the navigator**: both shown parameters collapse to a point at the clicked position, which then refines with more runs. Every metric is measured on the same samples, so switching the shown metric repaints instantly from what was already computed; changing the fixed parameters or the axes restarts the fill for the new slice.
 
 The summary, the parameter strip, and the surface hold still at the top of the drawer; the metric charts scroll on their own below them, so the graphs stay in view while you browse the charts.
 

--- a/libs/@hashintel/petrinaut/src/react/experiments/context.ts
+++ b/libs/@hashintel/petrinaut/src/react/experiments/context.ts
@@ -193,6 +193,18 @@ export type ExperimentsContextValue = {
     minRuns: number,
   ) => Promise<SweepCellSnapshot | null>;
   /**
+   * Samples many sweep-surface cells at once and returns each cell's
+   * per-metric mean, index-aligned with `positions` (null entries for cells
+   * with no finished runs). One batch when the swept parameters do not shape
+   * the initial marking (per-run parameter draws); the per-cell path
+   * otherwise. Resolves null with no session.
+   */
+  sampleSurfaceCells: (
+    experimentId: string,
+    positions: readonly Readonly<Record<string, number>>[],
+    runsPerCell: number,
+  ) => Promise<readonly (Readonly<Record<string, number>> | null)[] | null>;
+  /**
    * Computes one metric sample against an arbitrary net snapshot, on the
    * background single-worker lane — the optimization surface's local compute
    * path, which must run a study's frozen model rather than the live editor
@@ -232,6 +244,7 @@ const DEFAULT_CONTEXT_VALUE: ExperimentsContextValue = {
   removeExperiment: () => {},
   setSweepSelection: () => {},
   sampleSweepCell: () => Promise.resolve(null),
+  sampleSurfaceCells: () => Promise.resolve(null),
   sampleDetachedObjective: () => Promise.resolve(null),
 };
 

--- a/libs/@hashintel/petrinaut/src/react/experiments/provider.test.tsx
+++ b/libs/@hashintel/petrinaut/src/react/experiments/provider.test.tsx
@@ -424,8 +424,11 @@ describe("ExperimentsProvider", () => {
       expect(worker.sent.map((message) => message.type)).toEqual([
         "init",
         "cancel",
+        // The lease's reset: the worker returns to the provider's pool for
+        // the next batch instead of being terminated.
+        "cancel",
       ]);
-      expect(worker.terminated).toBe(true);
+      expect(worker.terminated).toBe(false);
       expect(getValue().experiments).toEqual([]);
       expect(getValue().selectedExperimentId).toBeNull();
     } finally {
@@ -461,8 +464,10 @@ describe("ExperimentsProvider", () => {
       expect(worker.sent.map((message) => message.type)).toEqual([
         "init",
         "cancel",
+        // The lease's reset before the worker returns to the pool.
+        "cancel",
       ]);
-      expect(worker.terminated).toBe(true);
+      expect(worker.terminated).toBe(false);
       expect(getValue().selectedExperiment).toMatchObject({
         id: experimentId,
         status: "cancelled",
@@ -617,7 +622,9 @@ describe("ExperimentsProvider", () => {
 
     expect(getValue().selectedExperiment?.status).toBe("cancelled");
     expect(getValue().selectedExperiment?.progress).toEqual(cancelledProgress);
-    expect(worker.terminated).toBe(true);
+    // Pooled, not terminated: the lease reset the worker for the next batch.
+    expect(worker.terminated).toBe(false);
+    expect(worker.sent.at(-1)?.type).toBe("cancel");
 
     await act(async () => {
       getValue().removeExperiment(experimentId);
@@ -627,6 +634,105 @@ describe("ExperimentsProvider", () => {
     expect(getValue().selectedExperimentId).toBeNull();
 
     renderResult.unmount();
+  });
+
+  it("reuses the pooled worker for the next experiment instead of spawning", async () => {
+    // A worker that acknowledges `cancel` synchronously, like the in-process
+    // worker — pooling completes within the same act() that released it.
+    const workers: FakeMonteCarloWorker[] = [];
+    const createAutoAckWorker = () => {
+      const worker = new FakeMonteCarloWorker();
+      workers.push(worker);
+      const facade: WorkerLike<
+        MonteCarloToWorkerMessage,
+        MonteCarloToMainMessage
+      > = {
+        postMessage: (message) => {
+          worker.postMessage(message);
+          if (message.type === "cancel") {
+            worker.emit({ type: "cancelled", progress: makeProgress() });
+          }
+        },
+        addEventListener: (type, listener) => {
+          worker.addEventListener(type, listener);
+        },
+        removeEventListener: (type, listener) => {
+          worker.removeEventListener(type, listener);
+        },
+        terminate: worker.terminate,
+      };
+      return facade;
+    };
+
+    const valueHolder = { current: null as ExperimentsContextValue | null };
+    const renderResult = render(
+      <NotificationsContext
+        value={{ addNotification: () => "", dismissNotification: () => {} }}
+      >
+        <SDCPNContext.Provider value={sdcpnContextValue}>
+          <LanguageClientOverride requestHirArtifacts={undefined}>
+            <ExperimentsProvider
+              workerFactory={createAutoAckWorker}
+              experimentShardCount={1}
+            >
+              <ExperimentsContextConsumer
+                onContextValue={(value) => {
+                  valueHolder.current = value;
+                }}
+              />
+            </ExperimentsProvider>
+          </LanguageClientOverride>
+        </SDCPNContext.Provider>
+      </NotificationsContext>,
+    );
+    const getValue = () => valueHolder.current!;
+
+    const runExperiment = async () => {
+      let experimentId = "";
+      await act(async () => {
+        const createPromise = getValue().createExperiment({
+          name: "Pooled",
+          scenarioId: null,
+          scenarioParameterValues: {},
+          runCount: 1,
+          seed: 42,
+          dt: 1,
+          maxTime: 10,
+          metricSpecs: CONSTANT_METRIC_SPEC,
+        });
+        await flushWorkerSetup();
+        workers.at(-1)!.emit({ type: "ready" });
+        experimentId = await createPromise;
+      });
+      await act(async () => {
+        workers.at(-1)!.emit({
+          type: "complete",
+          progress: makeProgress({
+            activeRuns: 0,
+            allFinished: true,
+            completedRuns: 1,
+          }),
+        });
+      });
+      await act(async () => {
+        getValue().removeExperiment(experimentId);
+      });
+    };
+
+    await runExperiment();
+    await runExperiment();
+
+    // One worker served both experiments: released, reset, and re-leased.
+    expect(workers).toHaveLength(1);
+    const initCount = workers[0]!.sent.filter(
+      (message) => message.type === "init",
+    ).length;
+    expect(initCount).toBe(2);
+    expect(workers[0]!.terminated).toBe(false);
+
+    renderResult.unmount();
+    // Unmount shuts the pool: the idle worker dies with it.
+    expect(workers[0]!.terminated).toBe(true);
   });
 
   it("prevents window unload while a Monte Carlo experiment is active", async () => {

--- a/libs/@hashintel/petrinaut/src/react/experiments/provider.tsx
+++ b/libs/@hashintel/petrinaut/src/react/experiments/provider.tsx
@@ -51,6 +51,7 @@ import {
   isTerminalExperimentStatus,
   type DetachedObjectiveRequest,
 } from "./context";
+import { sweepCellObjective } from "./contour-grid";
 import {
   buildParameterAxis,
   fullSweepSelection,
@@ -306,6 +307,20 @@ export const ExperimentsProvider: React.FC<ExperimentsProviderProps> = ({
     new Map<string, PendingExperimentRegistration>(),
   );
   const sweepSessionsRef = useRef(new Map<string, SweepSession>());
+  /**
+   * Per sweep: compiles a cell's initial marking to a comparable string
+   * (null when that cell's values do not compile). Surface chunks batch many
+   * cells into one experiment only when every cell in the chunk compiles to
+   * the batch's shared marking — checked against the actual cell values, so
+   * a marking the swept parameters shape (even jointly, or only at interior
+   * points) falls back to the per-cell path instead of running wrong.
+   */
+  const surfaceMarkingProbesRef = useRef(
+    new Map<
+      string,
+      (values: Readonly<Record<string, number>>) => string | null
+    >(),
+  );
   /** Serializes detached objective batches on one background worker. */
   const detachedChainRef = useRef<Promise<unknown>>(Promise.resolve());
   const detachedCpuBackendRef = useRef<ExperimentBackend | null>(null);
@@ -325,6 +340,7 @@ export const ExperimentsProvider: React.FC<ExperimentsProviderProps> = ({
     >(),
   );
   const [experiments, setExperiments] = useState<ExperimentRecord[]>([]);
+  const experimentsStateRef = useLatest(experiments);
   const [selectedExperimentId, setSelectedExperimentId] = useState<
     string | null
   >(null);
@@ -514,6 +530,15 @@ export const ExperimentsProvider: React.FC<ExperimentsProviderProps> = ({
       netParameterVariableNames,
     } = options;
     const experimentId = experiment.id;
+    surfaceMarkingProbesRef.current.set(experimentId, (values) => {
+      try {
+        return JSON.stringify(compileForValues(values).result.initialState);
+      } catch {
+        // A cell whose values do not compile cannot join a batch; the
+        // per-cell path surfaces the error the way a plain batch would.
+        return null;
+      }
+    });
     let chosenBackend: ExperimentBackend | null = null;
     /**
      * Surface-sampling batches are 8 tiny runs; on the CPU they get one
@@ -545,6 +570,8 @@ export const ExperimentsProvider: React.FC<ExperimentsProviderProps> = ({
         seed,
         runCount,
         background,
+        requiresRunResults,
+        runSeeds,
         signal,
       }) => {
         const compiled = compileForValues(parameterValues);
@@ -564,16 +591,48 @@ export const ExperimentsProvider: React.FC<ExperimentsProviderProps> = ({
                 compileRunNumbers,
                 netParameterVariableNames,
               });
+        // Pinned per-run seeds only ride the record form (`runs`); a numeric
+        // plan carries values alone, so a seeded batch converts its plan to
+        // records. Seeded batches are small surface chunks — the record
+        // form's cost is irrelevant at that size.
+        const perRun =
+          translated === undefined
+            ? runSeeds === undefined
+              ? {}
+              : { runs: runSeeds.map((runSeed) => ({ seed: runSeed })) }
+            : translated.kind === "runs"
+              ? {
+                  runs:
+                    runSeeds === undefined
+                      ? translated.runs
+                      : translated.runs.map((run, index) => ({
+                          ...run,
+                          seed: runSeeds[index],
+                        })),
+                }
+              : runSeeds === undefined
+                ? { runPlan: translated.plan }
+                : {
+                    runs: runSeeds.map((runSeed, index) => ({
+                      seed: runSeed,
+                      parameterValues: Object.fromEntries(
+                        translated.plan.ids.map((id, column) => [
+                          id,
+                          String(
+                            translated.plan.values[
+                              index * translated.plan.ids.length + column
+                            ],
+                          ),
+                        ]),
+                      ),
+                    })),
+                  };
         const override = {
           parameterValues: compiled.result.parameterValues,
           initialMarking: compiled.result.initialState,
           seed,
           runCount,
-          ...(translated === undefined
-            ? {}
-            : translated.kind === "plan"
-              ? { runPlan: translated.plan }
-              : { runs: translated.runs }),
+          ...perRun,
         };
 
         // The surface's background sampling can start before the navigator's
@@ -581,8 +640,10 @@ export const ExperimentsProvider: React.FC<ExperimentsProviderProps> = ({
         // walk here too would race it: two batches contending for the pool,
         // both patching the record's backend fields. Background batches
         // instead go straight to the single-worker CPU lane until a backend
-        // is chosen (and stay there when the choice lands on the CPU).
-        if (background && !chosenBackend) {
+        // is chosen (and stay there when the choice lands on the CPU). A
+        // batch whose consumer reads per-run values stays there always:
+        // only the CPU workers report `runResults`.
+        if (background && (!chosenBackend || requiresRunResults)) {
           backgroundCpuBackend ??= createWorkerPoolExperimentBackend({
             createWorker: reusableWorkerFactory,
             shardCount: 1,
@@ -1100,6 +1161,7 @@ export const ExperimentsProvider: React.FC<ExperimentsProviderProps> = ({
     if (session) {
       session.dispose();
       sweepSessionsRef.current.delete(experimentId);
+      surfaceMarkingProbesRef.current.delete(experimentId);
       patchExperiment(experimentId, { status: "cancelled" });
       return;
     }
@@ -1112,6 +1174,7 @@ export const ExperimentsProvider: React.FC<ExperimentsProviderProps> = ({
   ) => {
     sweepSessionsRef.current.get(experimentId)?.dispose();
     sweepSessionsRef.current.delete(experimentId);
+    surfaceMarkingProbesRef.current.delete(experimentId);
     disposeExperimentHandle(experimentId);
     setExperiments((prev) =>
       prev.filter((experiment) => experiment.id !== experimentId),
@@ -1136,6 +1199,53 @@ export const ExperimentsProvider: React.FC<ExperimentsProviderProps> = ({
     sweepSessionsRef.current
       .get(experimentId)
       ?.sampleCell(parameterValues, minRuns) ?? Promise.resolve(null);
+
+  const sampleSurfaceCells: ExperimentsContextValue["sampleSurfaceCells"] =
+    async (experimentId, positions, runsPerCell) => {
+      const session = sweepSessionsRef.current.get(experimentId);
+      if (!session || positions.length === 0) {
+        return null;
+      }
+      // One batch shares one compiled initial marking, so batch only when
+      // every cell in this chunk compiles to the same marking as the first
+      // (checked at the actual cell values — no synthetic probe points).
+      const markingProbe = surfaceMarkingProbesRef.current.get(experimentId);
+      if (markingProbe && positions[0]) {
+        const baseMarking = markingProbe(positions[0]);
+        if (
+          baseMarking !== null &&
+          positions.every((position) => markingProbe(position) === baseMarking)
+        ) {
+          return session.sampleCells(positions, runsPerCell);
+        }
+      }
+      // A marking-shaping (or partially non-compiling) chunk keeps the
+      // per-cell path, whose base compile follows each cell; the background
+      // slots bound how many run at once.
+      const experiment = experimentsStateRef.current.find(
+        (candidate) => candidate.id === experimentId,
+      );
+      if (!experiment) {
+        return null;
+      }
+      const metricIds = experiment.metricSpecs.map((spec) => spec.id);
+      return Promise.all(
+        positions.map(async (position) => {
+          const snapshot = await session.sampleCell(position, runsPerCell);
+          if (!snapshot) {
+            return null;
+          }
+          const values: Record<string, number> = {};
+          for (const metricId of metricIds) {
+            const value = sweepCellObjective(snapshot.metricFrames, metricId);
+            if (value !== null) {
+              values[metricId] = value;
+            }
+          }
+          return values;
+        }),
+      );
+    };
 
   const runDetachedObjectiveBatch = async (
     request: DetachedObjectiveRequest,
@@ -1296,6 +1406,7 @@ export const ExperimentsProvider: React.FC<ExperimentsProviderProps> = ({
     removeExperiment: stableRemoveExperiment,
     setSweepSelection: useStableCallback(setSweepSelection),
     sampleSweepCell: useStableCallback(sampleSweepCell),
+    sampleSurfaceCells: useStableCallback(sampleSurfaceCells),
     sampleDetachedObjective: useStableCallback(sampleDetachedObjective),
   };
   // Every callback is identity-stable, so this object never changes and

--- a/libs/@hashintel/petrinaut/src/react/experiments/provider.tsx
+++ b/libs/@hashintel/petrinaut/src/react/experiments/provider.tsx
@@ -21,12 +21,14 @@ import {
   type ScenarioParameter,
 } from "@hashintel/petrinaut-core";
 import {
+  createReusableWorkerFactory,
   createWorkerPoolExperimentBackend,
   selectExperimentBackend,
   WORKER_POOL_BACKEND_ID,
   type ExperimentBackend,
   type ExperimentBackendRegistration,
   type ExperimentRequest,
+  type ReusableWorkerFactory,
 } from "@hashintel/petrinaut-core/experiments";
 import { createMonteCarloWorker } from "@hashintel/petrinaut-core/workers/monte-carlo";
 
@@ -264,6 +266,38 @@ export const ExperimentsProvider: React.FC<ExperimentsProviderProps> = ({
   const petriNetDefinitionRef = useLatest(petriNetDefinition);
   const extensionsRef = useLatest(extensions);
   const workerFactoryRef = useLatest(workerFactory ?? createMonteCarloWorker);
+  // One worker pool per provider: batches lease workers instead of spawning
+  // and killing a pool's worth per ladder rung and per surface cell. The
+  // base factory is read at call time, so an injected factory stays live;
+  // changing it drains the old pool below.
+  const reusableWorkerFactoryRef = useRef<ReusableWorkerFactory | null>(null);
+  reusableWorkerFactoryRef.current ??= createReusableWorkerFactory(
+    () => workerFactoryRef.current(),
+    {
+      // A sweep commit releases the sharded foreground batch and several
+      // background lanes at once; the pool must hold that working set or
+      // every commit terminates the overflow and respawns it a moment later.
+      maxIdle: (experimentShardCount ?? getDefaultMonteCarloShardCount()) + 8,
+    },
+  );
+  const reusableWorkerFactory = reusableWorkerFactoryRef.current;
+  // Factory change: flush pooled workers built from the old base factory
+  // (leases in flight finish on it and re-pool; the next lease is fresh).
+  useEffect(() => {
+    const pool = reusableWorkerFactoryRef.current;
+    return () => {
+      pool?.drain();
+    };
+  }, [workerFactory]);
+  // Unmount: shut the pool for good. Handles released by later cleanups (and
+  // in-flight leases finishing afterwards) must terminate their workers
+  // rather than pool them where nothing will ever lease or drain again.
+  useEffect(() => {
+    const pool = reusableWorkerFactoryRef.current;
+    return () => {
+      pool?.dispose();
+    };
+  }, []);
   const shardCountRef = useLatest(experimentShardCount);
   const registrationsRef = useRef(
     new Map<string, ExperimentHandleRegistration>(),
@@ -550,7 +584,7 @@ export const ExperimentsProvider: React.FC<ExperimentsProviderProps> = ({
         // is chosen (and stay there when the choice lands on the CPU).
         if (background && !chosenBackend) {
           backgroundCpuBackend ??= createWorkerPoolExperimentBackend({
-            createWorker: workerFactoryRef.current,
+            createWorker: reusableWorkerFactory,
             shardCount: 1,
           });
           const request = await buildRequest({
@@ -605,7 +639,7 @@ export const ExperimentsProvider: React.FC<ExperimentsProviderProps> = ({
         let batchBackend = chosenBackend;
         if (background && chosenBackend.id === WORKER_POOL_BACKEND_ID) {
           backgroundCpuBackend ??= createWorkerPoolExperimentBackend({
-            createWorker: workerFactoryRef.current,
+            createWorker: reusableWorkerFactory,
             shardCount: 1,
           });
           batchBackend = backgroundCpuBackend;
@@ -933,7 +967,7 @@ export const ExperimentsProvider: React.FC<ExperimentsProviderProps> = ({
           load: () =>
             Promise.resolve(
               createWorkerPoolExperimentBackend({
-                createWorker: workerFactoryRef.current,
+                createWorker: reusableWorkerFactory,
                 // The experiment never inspects the host, so the provider — the
                 // piece that knows this is a browser — states the parallelism.
                 shardCount:
@@ -1173,7 +1207,7 @@ export const ExperimentsProvider: React.FC<ExperimentsProviderProps> = ({
       }
 
       detachedCpuBackendRef.current ??= createWorkerPoolExperimentBackend({
-        createWorker: workerFactoryRef.current,
+        createWorker: reusableWorkerFactory,
         shardCount: 1,
       });
       const backend = detachedCpuBackendRef.current;

--- a/libs/@hashintel/petrinaut/src/react/experiments/sweep-session.test.ts
+++ b/libs/@hashintel/petrinaut/src/react/experiments/sweep-session.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
+import { deriveRunSeed } from "@hashintel/petrinaut-core";
+
 import {
   createSweepSession,
   sweepBatchSeed,
@@ -71,6 +73,8 @@ function makeFakeBatch(request: {
   seed: number;
   runCount: number;
   background?: boolean;
+  requiresRunResults?: boolean;
+  runSeeds?: readonly number[];
 }) {
   let metricListeners: ((value: {
     frames: readonly MonteCarloUserDefinedMetricFrame[];
@@ -83,6 +87,7 @@ function makeFakeBatch(request: {
   let progress: MonteCarloWorkerProgress | null = null;
   let cancelled = false;
   let started = false;
+  let runResults = new Map<number, Readonly<Record<string, number>>>();
 
   const handle: MonteCarloExperiment = {
     status: { get: () => "Running", subscribe: () => () => {} },
@@ -101,7 +106,7 @@ function makeFakeBatch(request: {
         };
       },
     },
-    runResults: { get: () => new Map(), subscribe: () => () => {} },
+    runResults: { get: () => runResults, subscribe: () => () => {} },
     events: {
       subscribe: (listener) => {
         eventListeners.push(listener);
@@ -122,6 +127,9 @@ function makeFakeBatch(request: {
   return {
     request,
     handle,
+    setRunResults(next: ReadonlyMap<number, Readonly<Record<string, number>>>) {
+      runResults = new Map(next);
+    },
     get cancelled() {
       return cancelled;
     },
@@ -493,5 +501,77 @@ describe("createSweepSession", () => {
     });
     expect(session.getCell({ x: 2, y: 1 })).toBeUndefined();
     session.dispose();
+  });
+});
+
+describe("sampleCells", () => {
+  const CELLS = [
+    { x: 0, y: 0 },
+    { x: 2, y: 1 },
+  ];
+
+  async function sampleTwoCells(runsPerCell: number) {
+    const harness = makeHarness(1000);
+    const resultPromise = harness.session.sampleCells(CELLS, runsPerCell);
+    await harness.settle();
+    // batches[0] is the navigator's initial full-space batch; the chunk is
+    // the latest background batch.
+    const chunk = harness.batches.at(-1)!;
+    return { ...harness, chunk, resultPromise };
+  }
+
+  it("lays every cell out as per-run draws with pinned per-cell seeds", async () => {
+    const { chunk } = await sampleTwoCells(2);
+
+    expect(chunk.request).toMatchObject({
+      parameterValues: { x: 0, y: 10 },
+      seed: 42,
+      runCount: 4,
+      background: true,
+      requiresRunResults: true,
+    });
+    expect(chunk.request.draws?.identifiers).toEqual(["x", "y"]);
+    // Cell values repeated runsPerCell times, in cell order.
+    expect([...chunk.request.draws!.values]).toEqual([
+      0, 10, 0, 10, 2, 20, 2, 20,
+    ]);
+    // Every cell pins the SAME seed sequence — the one the per-cell ladder's
+    // first batch derives — so values are chunk-layout-independent.
+    const cellSeeds = [deriveRunSeed(42, 0), deriveRunSeed(42, 1)];
+    expect(chunk.request.runSeeds).toEqual([...cellSeeds, ...cellSeeds]);
+  });
+
+  it("groups per-run results into index-aligned per-cell means", async () => {
+    const { chunk, resultPromise, settle } = await sampleTwoCells(2);
+
+    chunk.setRunResults(
+      new Map([
+        [0, { m: 1 }],
+        [1, { m: 3 }],
+        [2, { m: 10 }],
+        [3, { m: 20 }],
+      ]),
+    );
+    chunk.stream([frame(4, [[1, 4]])]);
+    chunk.complete();
+    await settle();
+
+    expect(await resultPromise).toEqual([{ m: 2 }, { m: 15 }]);
+  });
+
+  it("returns null for a cell with no finished runs", async () => {
+    const { chunk, resultPromise, settle } = await sampleTwoCells(2);
+
+    chunk.setRunResults(
+      new Map([
+        [0, { m: 1 }],
+        [1, { m: 3 }],
+      ]),
+    );
+    chunk.stream([frame(2, [[1, 2]])]);
+    chunk.complete();
+    await settle();
+
+    expect(await resultPromise).toEqual([{ m: 2 }, null]);
   });
 });

--- a/libs/@hashintel/petrinaut/src/react/experiments/sweep-session.ts
+++ b/libs/@hashintel/petrinaut/src/react/experiments/sweep-session.ts
@@ -95,6 +95,19 @@ export type InstantiateSweepBatch = (options: {
    * single worker so the navigator's batch keeps the cores.
    */
   background?: boolean;
+  /**
+   * The batch's consumer reads per-run metric values (`runResults`), which
+   * only the CPU workers report — hosts route such a batch to the CPU lane
+   * even when the experiment's chosen backend is the GPU.
+   */
+  requiresRunResults?: boolean;
+  /**
+   * Explicit per-run seeds (one per run, aligned with `draws`). Batched
+   * surface cells pin these so a cell's runs use the same seeds regardless
+   * of which chunk (and chunk slot) sampled it — and the same seeds the
+   * per-cell ladder's first batch would use.
+   */
+  runSeeds?: readonly number[];
   signal: AbortSignal;
 }) => Promise<MonteCarloExperiment>;
 
@@ -142,6 +155,17 @@ export type SweepSession = {
     position: Readonly<Record<string, number>>,
     minRuns: number,
   ) => Promise<SweepCellSnapshot | null>;
+  /**
+   * Samples many cells as one batch and returns each cell's per-metric mean,
+   * index-aligned with `positions` (null for a cell with no finished runs).
+   * Requires a marking the swept parameters do not shape — the host decides;
+   * see `sampleCellsBatch`. Resolves null when the session is disposed or
+   * the batch is refused.
+   */
+  sampleCells: (
+    positions: readonly Readonly<Record<string, number>>[],
+    runsPerCell: number,
+  ) => Promise<readonly (Readonly<Record<string, number>> | null)[] | null>;
   dispose: () => void;
 };
 
@@ -680,6 +704,107 @@ export function createSweepSession(
     return snapshotFor(key);
   };
 
+  /**
+   * Samples many cells as ONE batch: every cell's values become per-run
+   * parameter draws (`runsPerCell` runs each), and the per-run metric values
+   * the CPU workers report are grouped back into per-cell means. One batch
+   * instantiation where the per-cell walk paid one per cell — but a single
+   * initial marking: callers must only batch cells whose marking the swept
+   * parameters do not shape (the host checks; a marking-shaping scenario
+   * keeps the per-cell path).
+   */
+  const sampleCellsBatch = async (
+    positions: readonly Readonly<Record<string, number>>[],
+    runsPerCell: number,
+  ): Promise<readonly (Readonly<Record<string, number>> | null)[] | null> => {
+    if (disposed || failed || positions.length === 0) {
+      return null;
+    }
+    const identifiers = axes.map((axis) => axis.identifier);
+    const width = identifiers.length;
+    const runCountTotal = positions.length * runsPerCell;
+    const values = new Float64Array(runCountTotal * width);
+    // Every cell pins the SAME seed sequence — the one the per-cell ladder's
+    // first batch derives implicitly — so a cell's value is independent of
+    // which chunk sampled it and matches the navigator's own runs.
+    const cellSeeds = Array.from({ length: runsPerCell }, (_, run) =>
+      deriveRunSeed(seed, run),
+    );
+    const runSeeds: number[] = [];
+    for (const [cellIndex, position] of positions.entries()) {
+      const cellValues = sweepCellValues(axes, position);
+      for (let run = 0; run < runsPerCell; run++) {
+        const base = (cellIndex * runsPerCell + run) * width;
+        for (let column = 0; column < width; column++) {
+          values[base + column] = cellValues[identifiers[column]!]!;
+        }
+        runSeeds.push(cellSeeds[run]!);
+      }
+    }
+
+    const abortController = new AbortController();
+    let handle: MonteCarloExperiment;
+    try {
+      handle = await instantiateBatch({
+        parameterValues: sweepCellValues(axes, positions[0]!),
+        draws: { identifiers, values },
+        seed,
+        runCount: runCountTotal,
+        background: true,
+        requiresRunResults: true,
+        runSeeds,
+        signal: abortController.signal,
+      });
+    } catch {
+      // A refused batch is a hole in the surface, not a failed sweep.
+      return null;
+    }
+    if (isDisposed()) {
+      handle.dispose();
+      return null;
+    }
+
+    const done = new Promise<boolean>((resolve) => {
+      const offEvents = handle.events.subscribe((event) => {
+        offEvents();
+        resolve(event.type === "complete");
+      });
+    });
+    handle.start();
+    const completed = await done;
+    const runResults = handle.runResults.get();
+    handle.dispose();
+    if (!completed || isDisposed()) {
+      return null;
+    }
+
+    // Group per-run values back into per-cell means, per metric,
+    // index-aligned with the requested positions.
+    const accumulators = positions.map(
+      (): Record<string, { sum: number; n: number }> => ({}),
+    );
+    for (const [runIndex, metricValues] of runResults) {
+      const cell = accumulators[Math.floor(runIndex / runsPerCell)];
+      if (!cell) {
+        continue;
+      }
+      for (const [metricId, value] of Object.entries(metricValues)) {
+        const entry = (cell[metricId] ??= { sum: 0, n: 0 });
+        entry.sum += value;
+        entry.n += 1;
+      }
+    }
+    return accumulators.map((cell) => {
+      const entries = Object.entries(cell);
+      if (entries.length === 0) {
+        return null;
+      }
+      return Object.fromEntries(
+        entries.map(([metricId, { sum, n }]) => [metricId, sum / n]),
+      );
+    });
+  };
+
   return {
     setSelection(next) {
       if (disposed) {
@@ -704,6 +829,14 @@ export function createSweepSession(
       await acquireBackgroundSlot();
       try {
         return await runBackgroundBatch({ ...position }, minRuns);
+      } finally {
+        releaseBackgroundSlot();
+      }
+    },
+    async sampleCells(positions, runsPerCell) {
+      await acquireBackgroundSlot();
+      try {
+        return await sampleCellsBatch(positions, runsPerCell);
       } finally {
         releaseBackgroundSlot();
       }

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/create-experiment-drawer.test.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/create-experiment-drawer.test.tsx
@@ -152,6 +152,7 @@ const TestProviders = ({
             removeExperiment: () => {},
             setSweepSelection: () => {},
             sampleSweepCell: () => Promise.resolve(null),
+            sampleSurfaceCells: () => Promise.resolve(null),
             sampleDetachedObjective: () => Promise.resolve(null),
           }}
         >

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/experiments-story-fixtures.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/experiments-story-fixtures.tsx
@@ -557,6 +557,23 @@ export function FakeExperimentsProvider({
         restream(experimentId, selection);
       }
     },
+    sampleSurfaceCells: (_experimentId, positions) =>
+      // The same synthetic bump as sampleSweepCell, one walk delay per chunk.
+      new Promise((resolve) => {
+        setTimeout(() => {
+          resolve(
+            positions.map((position) => {
+              const x = 0.1 + ((position.transmission_rate ?? 0) / 50) * 0.4;
+              const y = 2 + (position.recovery_days ?? 0);
+              const objective =
+                100 * Math.exp(-((x - 0.35) ** 2) * 20 - ((y - 10) / 14) ** 2) +
+                6 * Math.sin(x * 9) +
+                y / 4;
+              return { infected: Math.round(objective) };
+            }),
+          );
+        }, 120);
+      }),
     sampleSweepCell: (_experimentId, position) => {
       // A synthetic objective surface — a smooth bump — so the story's
       // contour fills in the way a real sweep's would, walk delay included.

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/sweep-surface.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/sweep-surface.tsx
@@ -2,25 +2,26 @@
  * The sweep surface: a contour of one metric's final value over two swept
  * parameters, filling in live as points are sampled.
  *
- * This component owns the sampling: while it is open, it walks an X×Y
- * sub-grid of the two shown parameters coarse-to-fine through the sweep's
- * background lane (8 runs per point), so the coarse shape of the surface
- * appears within the first few points and sharpens from there. Parameters
- * outside the two shown axes hold at the middle of their selected ranges —
- * moving them restarts the walk for the new slice — and clicking the plot
- * collapses both shown parameters to a point at the clicked position.
- * Rendering itself is `ContourSurface`, which is purely presentational.
+ * This component owns the sampling: while it is open, it samples an X×Y
+ * sub-grid of the two shown parameters in coarse-to-fine chunks through the
+ * sweep's background lane — each chunk one request carrying many cells (8
+ * runs per point), batched into a single experiment where the scenario
+ * allows it — so the coarse shape of the surface appears with the first
+ * chunk and sharpens from there. Every metric's value comes back per cell,
+ * so switching the shown metric re-reads the same samples instead of
+ * re-simulating. Parameters outside the two shown axes hold at the middle
+ * of their selected ranges — moving them restarts the sampling for the new
+ * slice — and clicking the plot collapses both shown parameters to a point
+ * at the clicked position. Rendering itself is `ContourSurface`, which is
+ * purely presentational.
  */
-import { use, useEffect, useRef, useState } from "react";
+import { use, useEffect, useState } from "react";
 
 import { Select } from "@hashintel/ds-components";
 import { css } from "@hashintel/ds-helpers/css";
 
 import { ExperimentsContext } from "../../../../../../react/experiments/context";
-import {
-  coarseToFineOrder,
-  sweepCellObjective,
-} from "../../../../../../react/experiments/contour-grid";
+import { coarseToFineOrder } from "../../../../../../react/experiments/contour-grid";
 import {
   ContourSurface,
   contourSurfaceKey,
@@ -34,13 +35,12 @@ import type { ContourSurfaceValues } from "../../../../../components/contour-sur
 const SURFACE_CELL_RUNS = 8;
 
 /**
- * Cells sampled in flight at once. Each cell instantiates its own small
- * batch, and most of a cell's wall time is that setup rather than compute —
- * sampling strictly one at a time filled an 11×11 surface in ~15 s where
- * four lanes fill it in ~4 s. The lanes pull from one coarse-to-fine queue,
- * so the early picture keeps its coarse-first shape.
+ * Cells per sampling request. Small enough that the first chunk paints the
+ * coarse shape quickly, big enough that a full grid is a handful of
+ * requests — each of which the provider turns into one batched experiment
+ * where the scenario allows it, instead of one batch per cell.
  */
-const SURFACE_WALK_LANES = 4;
+const SURFACE_CHUNK_CELLS = 24;
 
 /**
  * Sampled positions per axis on the surface's sub-grid: a subset of the
@@ -113,20 +113,20 @@ export const SweepSurface = ({
 }: {
   experiment: ExperimentRecord;
 }) => {
-  const { sampleSweepCell, setSweepSelection } = use(ExperimentsContext);
+  const { sampleSurfaceCells, setSweepSelection } = use(ExperimentsContext);
   const axes = experiment.parameterAxes;
   const [xAxisId, setXAxisId] = useState(axes[0]?.identifier ?? "");
   const [yAxisId, setYAxisId] = useState(axes[1]?.identifier ?? "");
   const [metricId, setMetricId] = useState(experiment.metricSpecs[0]?.id ?? "");
-  const [cellValues, setCellValues] = useState<ContourSurfaceValues>(new Map());
-  const [walkKey, setWalkKey] = useState("");
-  // Resolved cells buffer here and flush once per animation frame: a walk
-  // over a cached slice resolves its cells back to back, and committing each
-  // one re-rendered the drawer subtree dozens of times with no new picture.
-  const pendingCellsRef = useRef<{
-    entries: [string, number][];
-    scheduled: boolean;
-  }>({ entries: [], scheduled: false });
+  // Sampled values per grid cell, per metric — metric-agnostic, so switching
+  // the shown metric re-reads instead of re-sampling. The state carries the
+  // walk it belongs to: a chunk resolved after a restart (the old effect's
+  // stale flag flips only in the passive-effects flush, after the clear
+  // below has committed) must not merge old-slice values into the new grid.
+  const [grid, setGrid] = useState<{
+    walkKey: string;
+    values: ReadonlyMap<string, Readonly<Record<string, number>>>;
+  }>({ walkKey: "", values: new Map() });
 
   const xAxis = axes.find((axis) => axis.identifier === xAxisId);
   const yAxis = axes.find((axis) => axis.identifier === yAxisId);
@@ -134,22 +134,22 @@ export const SweepSurface = ({
   const experimentId = experiment.id;
   const sweepSelection = experiment.sweep?.selection;
 
-  // A new slice/axes/metric identity restarts the walk; clearing the sampled
-  // values during render (not in the effect) repaints without a stale frame.
-  const nextWalkKey = `${experimentId}|${xAxisId}|${yAxisId}|${metricId}|${slice}`;
-  if (walkKey !== nextWalkKey) {
-    setWalkKey(nextWalkKey);
-    setCellValues(new Map());
+  // A new slice or axes identity restarts the sampling; a metric change
+  // does not (every metric's value is already in the samples). Clearing
+  // during render (not in the effect) repaints without a stale frame.
+  const walkKey = `${experimentId}|${xAxisId}|${yAxisId}|${slice}`;
+  if (grid.walkKey !== walkKey) {
+    setGrid({ walkKey, values: new Map() });
   }
 
-  // The sampling walk: restarts whenever the slice, the shown axes, or the
-  // metric changes; stops when the section unmounts.
+  // The sampling: restarts whenever the slice or the shown axes change;
+  // stops when the section unmounts. Chunks go out sequentially so the
+  // coarse picture lands first and a restart wastes at most one chunk.
   useEffect(() => {
-    if (!xAxis || !yAxis || xAxis === yAxis || metricId === "") {
+    if (!xAxis || !yAxis || xAxis === yAxis) {
       return;
     }
     const walk: { stale: boolean } = { stale: false };
-    const pendingCells = pendingCellsRef.current;
     // Read through a call so the flow analysis cannot pin the flag to its
     // initial value: cleanup flips it from outside this closure.
     const isWalkStale = () => walk.stale;
@@ -161,69 +161,60 @@ export const SweepSurface = ({
 
     const xPositions = surfacePositions(xAxis);
     const yPositions = surfacePositions(yAxis);
-    const queue = coarseToFineOrder(xPositions.length, yPositions.length);
-    let nextCell = 0;
-    const sampleOne = async (cell: { x: number; y: number }) => {
-      const position: Record<string, number> = {
-        [xAxis.identifier]: xPositions[cell.x]!,
-        [yAxis.identifier]: yPositions[cell.y]!,
-      };
-      for (const [identifier, positionText] of fixedEntries) {
-        position[identifier] = Number(positionText);
-      }
+    const order = coarseToFineOrder(xPositions.length, yPositions.length);
 
-      const snapshot = await sampleSweepCell(
-        experimentId,
-        position,
-        SURFACE_CELL_RUNS,
-      );
-      if (isWalkStale() || !snapshot) {
-        return;
-      }
-      const value = sweepCellObjective(snapshot.metricFrames, metricId);
-      if (value === null) {
-        return;
-      }
-      const pending = pendingCells;
-      pending.entries.push([contourSurfaceKey(cell.x, cell.y), value]);
-      if (!pending.scheduled) {
-        pending.scheduled = true;
-        requestAnimationFrame(() => {
-          pending.scheduled = false;
-          const entries = pending.entries.splice(0);
-          if (entries.length === 0) {
-            return;
+    const run = async () => {
+      for (let start = 0; start < order.length; start += SURFACE_CHUNK_CELLS) {
+        if (isWalkStale()) {
+          return;
+        }
+        const chunk = order.slice(start, start + SURFACE_CHUNK_CELLS);
+        const positions = chunk.map((cell) => {
+          const position: Record<string, number> = {
+            [xAxis.identifier]: xPositions[cell.x]!,
+            [yAxis.identifier]: yPositions[cell.y]!,
+          };
+          for (const [identifier, positionText] of fixedEntries) {
+            position[identifier] = Number(positionText);
           }
-          setCellValues((previous) => {
-            const next = new Map(previous);
-            for (const [key, cellValue] of entries) {
-              next.set(key, cellValue);
+          return position;
+        });
+
+        const cells = await sampleSurfaceCells(
+          experimentId,
+          positions,
+          SURFACE_CELL_RUNS,
+        );
+        if (isWalkStale()) {
+          return;
+        }
+        // A refused chunk is a hole in the surface, not the end of the
+        // fill — later chunks may still land (a disposed session keeps
+        // refusing cheaply until the cleanup flips the stale flag).
+        if (!cells) {
+          continue;
+        }
+        setGrid((previous) => {
+          if (previous.walkKey !== walkKey) {
+            return previous;
+          }
+          const next = new Map(previous.values);
+          for (const [index, values] of cells.entries()) {
+            const cell = chunk[index];
+            if (cell && values) {
+              next.set(contourSurfaceKey(cell.x, cell.y), values);
             }
-            return next;
-          });
+          }
+          return { walkKey: previous.walkKey, values: next };
         });
       }
     };
-    const lane = async () => {
-      while (!isWalkStale()) {
-        const cell = queue[nextCell];
-        nextCell += 1;
-        if (cell === undefined) {
-          return;
-        }
-        await sampleOne(cell);
-      }
-    };
-    for (let index = 0; index < SURFACE_WALK_LANES; index++) {
-      void lane();
-    }
+    void run();
 
     return () => {
       walk.stale = true;
-      // Entries the flush has not committed belong to the stale walk.
-      pendingCells.entries.length = 0;
     };
-  }, [axes, experimentId, metricId, sampleSweepCell, slice, xAxis, yAxis]);
+  }, [experimentId, sampleSurfaceCells, slice, walkKey, xAxis, yAxis]);
 
   if (axes.length < 2 || !experiment.sweep) {
     return null;
@@ -252,6 +243,12 @@ export const SweepSurface = ({
     });
   };
 
+  const cellValues: ContourSurfaceValues = new Map(
+    [...grid.values.entries()].flatMap(([key, values]) => {
+      const value = values[metricId];
+      return value === undefined ? [] : [[key, value] as [string, number]];
+    }),
+  );
   const sampledCount = cellValues.size;
   const totalCells =
     xAxis && yAxis

--- a/libs/@local/petrinaut-arch-docs/content/experiments/sweep-surface.mdx
+++ b/libs/@local/petrinaut-arch-docs/content/experiments/sweep-surface.mdx
@@ -14,19 +14,32 @@ the surface and a cell the navigator visited are the same cell.
 
 ## The view drives the sampling
 
-While the section is open, the component walks the X×Y grid coarse-to-fine —
-corners and lattice midpoints before their neighbours — requesting eight runs
-per combination through the session's background lane, on four concurrent
-lanes pulling from one queue — and the session matches them with four
-background-batch slots (its lane used to hold one batch in flight, which
-would have serialized the lanes right back). Most of a cell's wall time is
-batch setup rather than compute, so strictly sequential sampling filled an
-11×11 surface in ~15 s where the lanes fill it in ~4 s, and the shared queue
-keeps the early picture coarse-first. Each background batch gets a single
-worker, so the navigator's sharded batch keeps most cores; a cell the
-navigator already refined resolves straight from cache. Parameters outside the two shown axes stay at the navigator's values,
-and changing any of them (or the axes, or the metric) restarts the walk for
-the new slice.
+While the section is open, the component samples the X×Y grid coarse-to-fine —
+corners and lattice midpoints before their neighbours — in chunks of 24
+cells, each chunk one request through the session's background lane at eight
+runs per cell. Where the swept parameters only drive rates, a chunk becomes a
+**single experiment**: the session lays every cell's values out as per-run
+parameter draws (each cell's values repeated eight times), runs one batch of
+`cells × 8` runs, and folds the per-run metric values back into per-cell
+means. One batch setup per chunk replaces one per cell — batch setup, not
+compute, dominated a cell's wall time, which is why the earlier design needed
+four concurrent per-cell lanes to fill an 11×11 surface in ~4 s.
+
+The batch trick has a semantic precondition: every run in a batch shares one
+compiled initial marking, so it is only valid when no swept axis shapes that
+marking. The provider checks this when the sweep starts — it compiles the
+initial state at each axis's extremes and compares against the midpoint — and
+a marking-shaping sweep falls back to per-cell sampling, whose base compile
+follows each cell. Batched chunks also pin the batch to the CPU lane: only
+the CPU workers report per-run metric values (`runResults`), the GPU backend
+folds runs into histograms on-device.
+
+Every metric is measured on the same runs, so the component caches
+per-cell values for **all** metrics and switching the shown metric repaints
+from the cache instead of re-sampling. Each background batch gets a single
+worker, so the navigator's sharded batch keeps most cores. Parameters
+outside the two shown axes stay at the navigator's values, and changing any
+of them (or the axes) restarts the sampling for the new slice.
 
 ## Rendering sparse data honestly
 
@@ -39,12 +52,12 @@ exists. All of that is pure, tested math in
 `react/experiments/contour-grid.ts`; the component only paints it onto a
 canvas, the same imperative-draw idiom the metric charts use.
 
-A walk restart — any slice, axis, or metric change clears the sampled
-values — used to blank the plot until the new walk's first samples resolved,
+A restart — any slice or axis change clears the sampled
+values — used to blank the plot until the first new samples resolved,
 which reads as a crash after every slider move. The plot now keeps the
 previous picture up, dimmed to 45%, whenever fewer than three fresh samples
 exist (one or two samples interpolate to a near-uniform wash that says less
-than the old picture does), with the new walk's dots drawn on top. The same
+than the old picture does), with the new dots drawn on top. The same
 bridge the metric charts build with a snapshot overlay, built here by
 retaining the last complete-enough field. The `Components / ContourSurface →
 Restarting` story demonstrates the cycle.

--- a/libs/@local/petrinaut-arch-docs/content/simulation/worker-sharding.mdx
+++ b/libs/@local/petrinaut-arch-docs/content/simulation/worker-sharding.mdx
@@ -67,3 +67,21 @@ An experiment may pin every run's seed explicitly (`runs`), which is how
 optimization replicates keep their common-random-numbers contract, and each
 run's final metric values come back per run (`runResults`) alongside the
 aggregated frames — the run axis the frames deliberately give up.
+
+## Workers are leased, not consumed
+
+An experiment terminates its transports on dispose — correct, but a
+parameter sweep instantiates a batch per ladder rung and per surface chunk,
+so a single slider commit used to spawn and kill a pool's worth of workers,
+each new worker re-fetching and re-evaluating the engine module before it
+could simulate. `createReusableWorkerFactory` wraps any `WorkerFactory` with
+an idle pool: it hands out **leases** whose `terminate()` detaches the
+lease's listeners, posts `cancel` to reset the worker (the protocol is
+re-initializable by design — `init` rebuilds the simulator from scratch),
+and returns it to the pool. The pooling is invisible to the transport and
+the runtime, which keep the exact `WorkerFactory` contract; a worker whose
+script errored is never re-pooled, and hosts without `removeEventListener`
+opt out implicitly (a lease that cannot detach its listeners terminates the
+worker for real). The editor's experiments provider holds one pool per
+mount and drains it when the injected factory changes or the provider
+unmounts.


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Filling the sweep drawer's view spawned 166 web workers and every slider commit spawned 16–24 more, each one re-fetching and re-evaluating the engine module before it could simulate. This PR pools the workers (a lease resets and returns its worker instead of terminating it) and samples the contour surface in batched chunks — one experiment for 24 cells instead of one per cell — so the same view now fills with 20 workers, a slider commit spawns 0, and switching the shown surface metric repaints from cached samples instead of re-simulating. Stacked on #9474.

## 🔗 Related links

- [FE-1552](https://linear.app/hash/issue/FE-1552) _(internal)_
- Base PR: #9474

## 🔍 What does this change?

- `@hashintel/petrinaut-core` gains `createReusableWorkerFactory`: wraps any `WorkerFactory` with an idle pool and hands out leases. A lease's `terminate()` detaches its listeners, posts `cancel` (the protocol re-initializes on the next `init` by design), and returns the worker to the pool — only once every acknowledgement the worker still owes has arrived (the lease counts cancels out and acks in; the runtime's dispose path sends its own cancel right before terminating), so no stale `cancelled` reply can land on the next lease's listeners and settle its shard. A worker whose script errored is never re-pooled.
- The factory distinguishes `drain()` (flush idle and mid-reset workers; the pool keeps operating) from `dispose()` (shut the pool: later releases terminate their workers even though their acks arrive after). The experiments provider holds one pool per mount with `maxIdle` sized to the sharded batch plus the background lanes, routes all four worker-creation sites through it, drains it when the injected factory changes, and disposes it on unmount.
- The sweep session gains `sampleCellsBatch`: many surface cells become one experiment by laying each cell's parameter values out as per-run draws (`runsPerCell` runs per cell) and grouping the per-run metric values back into index-aligned per-cell means. Every cell pins the same explicit per-run seeds the per-cell ladder's first batch derives, so a cell's value does not depend on which chunk sampled it and matches the navigator's own runs. These batches route to the CPU lane because only the CPU workers report per-run values.
- One batch shares one compiled initial marking, so before batching a chunk the provider compiles each cell's initial state (at the actual cell values) and batches only when all of them equal the first cell's; a chunk whose marking the swept parameters shape — or with a cell that does not compile — keeps the per-cell path via the same `sampleSurfaceCells` contract.
- The surface component samples its grid in coarse-to-fine 24-cell chunks and caches every metric's value per cell, so changing the shown metric repaints without re-simulating. A refused chunk is a hole to fill later, not the end of the walk, and a chunk resolving after the walk restarted cannot merge stale values into the new grid (the grid state carries its walk key).
- Updates the user guide's surface paragraph and the `sweep-surface` / `worker-sharding` architecture pages.

Measured on the `Bench / SweepDrawer` CPU story (baseline → this PR): workers to fill the view 166 → 20, workers per slider commit 16–24 → 0, commit→first-chart-frame median 171 ms → 150 ms, 11×11 surface fill completes in ≤4 s (previously the same view left the surface empty on terminating nets and took ~15 s to sample serially). The GPU story fills the same surface with 3 workers.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] modifies an **npm**-publishable library and **I have added a changeset file(s)**

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] require changes to docs which **are made** as part of this PR

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- `reusable-worker-factory.test.ts` (new, 12 tests): reuse after release, listener detachment, the owed-acks gate (a worker owing two acks is not pooled on the first; acks already observed are not owed; non-cancelled traffic is ignored), quarantine of a silent worker, `maxIdle` overflow, drain of idle and mid-reset workers, dispose semantics (later releases and late acks terminate), double-terminate safety.
- `sweep-session.test.ts`: three new `sampleCells` tests pin the draw layout, the pinned per-cell seeds, the index-aligned regrouping into means, and the null entry for a cell with no finished runs.
- `provider.test.tsx`: a new test pins that one worker serves two consecutive experiments (reset and re-leased, then terminated when the provider unmounts); the message-sequence pins follow the pooled contract.

## ❓ How to test this?

1. Open `Bench / SweepDrawer → Cpu` in Storybook (`yarn workspace @hashintel/petrinaut dev:storybook`).
2. Watch the surface fill: all 121 cells sample within a few seconds, coarse shape first.
3. Switch the surface metric: the plot repaints instantly from cache.
4. Drag and release a parameter slider: charts restream without worker churn (observable via the browser task manager or a `Worker` constructor hook).

## 📹 Demo

_Screenshots pending — will be handed over for drag-drop._
