### PR TITLE
FE-1552: Pipeline ladder rungs and shard surface chunks adaptively

### DIFF
--- a/.changeset/parallel-orchestration.md
+++ b/.changeset/parallel-orchestration.md
@@ -1,0 +1,5 @@
+---
+"@hashintel/petrinaut": patch
+---
+
+Sweep compute parallelism: surface chunk batches shard across the CPU pool whenever the navigator's ladder is idle or computing on the GPU; the ladder pipelines its rungs (the next rung starts once the current one streams); and surface cells paint as each shard completes instead of waiting for the whole chunk.

--- a/libs/@hashintel/petrinaut/src/react/experiments/context.ts
+++ b/libs/@hashintel/petrinaut/src/react/experiments/context.ts
@@ -203,6 +203,9 @@ export type ExperimentsContextValue = {
     experimentId: string,
     positions: readonly Readonly<Record<string, number>>[],
     runsPerCell: number,
+    onPartial?: (
+      cells: readonly (Readonly<Record<string, number>> | null)[],
+    ) => void,
   ) => Promise<readonly (Readonly<Record<string, number>> | null)[] | null>;
   /**
    * Computes one metric sample against an arbitrary net snapshot, on the

--- a/libs/@hashintel/petrinaut/src/react/experiments/provider.tsx
+++ b/libs/@hashintel/petrinaut/src/react/experiments/provider.tsx
@@ -546,6 +546,8 @@ export const ExperimentsProvider: React.FC<ExperimentsProviderProps> = ({
      * a sweep whose surface view is never opened spawns nothing extra.
      */
     let backgroundCpuBackend: ExperimentBackend | null = null;
+    /** The same lane, sharded — used whenever the foreground frees the pool. */
+    let backgroundWideCpuBackend: ExperimentBackend | null = null;
 
     const onNote = (note: { message: string }) => {
       addNotification({
@@ -571,6 +573,7 @@ export const ExperimentsProvider: React.FC<ExperimentsProviderProps> = ({
         runCount,
         background,
         requiresRunResults,
+        foregroundActive,
         runSeeds,
         signal,
       }) => {
@@ -639,20 +642,48 @@ export const ExperimentsProvider: React.FC<ExperimentsProviderProps> = ({
         // first batch has finished the backend-selection walk. Running the
         // walk here too would race it: two batches contending for the pool,
         // both patching the record's backend fields. Background batches
-        // instead go straight to the single-worker CPU lane until a backend
-        // is chosen (and stay there when the choice lands on the CPU). A
-        // batch whose consumer reads per-run values stays there always:
-        // only the CPU workers report `runResults`.
+        // instead go straight to the CPU lane until a backend is chosen (and
+        // stay there when the choice lands on the CPU). A batch whose
+        // consumer reads per-run values stays there always: only the CPU
+        // workers report `runResults`.
+        //
+        // The lane's WIDTH adapts to foreground pressure: while the
+        // navigator's ladder computes on the CPU pool, a background batch
+        // takes one worker so the sharded foreground keeps the cores; once
+        // the ladder idles — or computes on the GPU, using no CPU workers at
+        // all — the same batch shards across the freed pool. The divisor
+        // mirrors the surface's three concurrent chunks, so the wide lanes
+        // together fill the pool instead of tripling it.
         if (background && (!chosenBackend || requiresRunResults)) {
-          backgroundCpuBackend ??= createWorkerPoolExperimentBackend({
-            createWorker: reusableWorkerFactory,
-            shardCount: 1,
-          });
+          const cpuForegroundBusy =
+            foregroundActive === true &&
+            (chosenBackend === null ||
+              chosenBackend.id === WORKER_POOL_BACKEND_ID);
+          let laneBackend: ExperimentBackend;
+          if (cpuForegroundBusy) {
+            backgroundCpuBackend ??= createWorkerPoolExperimentBackend({
+              createWorker: reusableWorkerFactory,
+              shardCount: 1,
+            });
+            laneBackend = backgroundCpuBackend;
+          } else {
+            backgroundWideCpuBackend ??= createWorkerPoolExperimentBackend({
+              createWorker: reusableWorkerFactory,
+              shardCount: Math.max(
+                2,
+                Math.floor(
+                  (shardCountRef.current ?? getDefaultMonteCarloShardCount()) /
+                    3,
+                ),
+              ),
+            });
+            laneBackend = backgroundWideCpuBackend;
+          }
           const request = await buildRequest({
-            needsHirTrees: backgroundCpuBackend.needsHirTrees,
+            needsHirTrees: laneBackend.needsHirTrees,
             override,
           });
-          const assessment = await backgroundCpuBackend.assess(request);
+          const assessment = await laneBackend.assess(request);
           if (!assessment.eligible) {
             throw new Error(describeBlockers(assessment.blockers));
           }

--- a/libs/@hashintel/petrinaut/src/react/experiments/provider.tsx
+++ b/libs/@hashintel/petrinaut/src/react/experiments/provider.tsx
@@ -1234,7 +1234,7 @@ export const ExperimentsProvider: React.FC<ExperimentsProviderProps> = ({
       ?.sampleCell(parameterValues, minRuns) ?? Promise.resolve(null);
 
   const sampleSurfaceCells: ExperimentsContextValue["sampleSurfaceCells"] =
-    async (experimentId, positions, runsPerCell) => {
+    async (experimentId, positions, runsPerCell, onPartial) => {
       const session = sweepSessionsRef.current.get(experimentId);
       if (!session || positions.length === 0) {
         return null;
@@ -1254,7 +1254,7 @@ export const ExperimentsProvider: React.FC<ExperimentsProviderProps> = ({
           baseMarking !== null &&
           positions.every((position) => markingProbe(position) === baseMarking)
         ) {
-          return session.sampleCells(positions, runsPerCell);
+          return session.sampleCells(positions, runsPerCell, onPartial);
         }
       }
       // A marking-shaping (or partially non-compiling) chunk keeps the
@@ -1267,8 +1267,12 @@ export const ExperimentsProvider: React.FC<ExperimentsProviderProps> = ({
         return null;
       }
       const metricIds = experiment.metricSpecs.map((spec) => spec.id);
+      // The per-cell path streams too: each resolved cell reports the chunk's
+      // progress so far, index-aligned like the batched path.
+      const partial: (Readonly<Record<string, number>> | null)[] =
+        positions.map(() => null);
       return Promise.all(
-        positions.map(async (position) => {
+        positions.map(async (position, index) => {
           const snapshot = await session.sampleCell(position, runsPerCell);
           if (!snapshot) {
             return null;
@@ -1280,6 +1284,8 @@ export const ExperimentsProvider: React.FC<ExperimentsProviderProps> = ({
               values[metricId] = value;
             }
           }
+          partial[index] = values;
+          onPartial?.([...partial]);
           return values;
         }),
       );

--- a/libs/@hashintel/petrinaut/src/react/experiments/provider.tsx
+++ b/libs/@hashintel/petrinaut/src/react/experiments/provider.tsx
@@ -275,10 +275,12 @@ export const ExperimentsProvider: React.FC<ExperimentsProviderProps> = ({
   reusableWorkerFactoryRef.current ??= createReusableWorkerFactory(
     () => workerFactoryRef.current(),
     {
-      // A sweep commit releases the sharded foreground batch and several
-      // background lanes at once; the pool must hold that working set or
-      // every commit terminates the overflow and respawns it a moment later.
-      maxIdle: (experimentShardCount ?? getDefaultMonteCarloShardCount()) + 8,
+      // A sweep commit releases the whole working set at once: TWO sharded
+      // foreground batches (the ladder pipelines its rungs) plus the surface
+      // lanes. The pool must hold that set or every commit terminates the
+      // overflow and respawns it a moment later.
+      maxIdle:
+        2 * (experimentShardCount ?? getDefaultMonteCarloShardCount()) + 8,
     },
   );
   const reusableWorkerFactory = reusableWorkerFactoryRef.current;

--- a/libs/@hashintel/petrinaut/src/react/experiments/sweep-session.test.ts
+++ b/libs/@hashintel/petrinaut/src/react/experiments/sweep-session.test.ts
@@ -74,6 +74,7 @@ function makeFakeBatch(request: {
   runCount: number;
   background?: boolean;
   requiresRunResults?: boolean;
+  foregroundActive?: boolean;
   runSeeds?: readonly number[];
 }) {
   let metricListeners: ((value: {
@@ -501,6 +502,27 @@ describe("createSweepSession", () => {
     });
     expect(session.getCell({ x: 2, y: 1 })).toBeUndefined();
     session.dispose();
+  });
+});
+
+describe("foregroundActive hint", () => {
+  it("marks chunk batches by whether the refine ladder is computing", async () => {
+    const { session, batches, settle } = makeHarness(8, point(0, 0));
+    await settle();
+
+    // The ladder's only rung is in flight: background chunks yield.
+    void session.sampleCells([{ x: 0, y: 0 }], 2);
+    await settle();
+    expect(batches.at(-1)!.request.foregroundActive).toBe(true);
+
+    batches[0]!.stream([frame(8, [[1, 8]])]);
+    batches[0]!.complete();
+    await settle();
+
+    // The ladder reached its target and idles: chunks may go wide.
+    void session.sampleCells([{ x: 1, y: 0 }], 2);
+    await settle();
+    expect(batches.at(-1)!.request.foregroundActive).toBe(false);
   });
 });
 

--- a/libs/@hashintel/petrinaut/src/react/experiments/sweep-session.test.ts
+++ b/libs/@hashintel/petrinaut/src/react/experiments/sweep-session.test.ts
@@ -89,6 +89,7 @@ function makeFakeBatch(request: {
   let cancelled = false;
   let started = false;
   let runResults = new Map<number, Readonly<Record<string, number>>>();
+  let runResultsListeners: (() => void)[] = [];
 
   const handle: MonteCarloExperiment = {
     status: { get: () => "Running", subscribe: () => () => {} },
@@ -107,7 +108,18 @@ function makeFakeBatch(request: {
         };
       },
     },
-    runResults: { get: () => runResults, subscribe: () => () => {} },
+    runResults: {
+      get: () => runResults,
+      subscribe: (listener) => {
+        const notify = () => listener(runResults);
+        runResultsListeners.push(notify);
+        return () => {
+          runResultsListeners = runResultsListeners.filter(
+            (entry) => entry !== notify,
+          );
+        };
+      },
+    },
     events: {
       subscribe: (listener) => {
         eventListeners.push(listener);
@@ -130,6 +142,9 @@ function makeFakeBatch(request: {
     handle,
     setRunResults(next: ReadonlyMap<number, Readonly<Record<string, number>>>) {
       runResults = new Map(next);
+      for (const notify of runResultsListeners) {
+        notify();
+      }
     },
     get cancelled() {
       return cancelled;
@@ -703,6 +718,42 @@ describe("sampleCells", () => {
     chunk.complete();
     await settle();
 
+    expect(await resultPromise).toEqual([{ m: 2 }, { m: 15 }]);
+  });
+
+  it("streams partial per-cell means as shards complete", async () => {
+    const harness = makeHarness(1000);
+    const partials: (readonly (Readonly<Record<string, number>> | null)[])[] =
+      [];
+    const resultPromise = harness.session.sampleCells(CELLS, 2, (cells) =>
+      partials.push(cells),
+    );
+    await harness.settle();
+    const chunk = harness.batches.at(-1)!;
+
+    // First shard lands: only cell 0's runs are in; cell 1 is still null.
+    chunk.setRunResults(
+      new Map([
+        [0, { m: 1 }],
+        [1, { m: 3 }],
+      ]),
+    );
+    expect(partials.at(-1)).toEqual([{ m: 2 }, null]);
+
+    // Second shard: both cells now carry means.
+    chunk.setRunResults(
+      new Map([
+        [0, { m: 1 }],
+        [1, { m: 3 }],
+        [2, { m: 10 }],
+        [3, { m: 20 }],
+      ]),
+    );
+    expect(partials.at(-1)).toEqual([{ m: 2 }, { m: 15 }]);
+
+    chunk.stream([frame(4, [[1, 4]])]);
+    chunk.complete();
+    await harness.settle();
     expect(await resultPromise).toEqual([{ m: 2 }, { m: 15 }]);
   });
 

--- a/libs/@hashintel/petrinaut/src/react/experiments/sweep-session.test.ts
+++ b/libs/@hashintel/petrinaut/src/react/experiments/sweep-session.test.ts
@@ -204,10 +204,13 @@ function makeHarness(runCount: number, initialSelection?: SweepSelection) {
   });
 
   const settle = async () => {
-    // Instantiation resolves through microtasks; three flushes cover the chain.
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
+    // Instantiation resolves through microtasks; the flush count covers the
+    // longest chain (the pipelined loop's startNext -> startRung -> draws ->
+    // instantiate) with headroom, so adding an await does not break every
+    // test again.
+    for (let flush = 0; flush < 12; flush++) {
+      await Promise.resolve();
+    }
   };
 
   return { session, batches, updates, onError, settle };
@@ -501,6 +504,61 @@ describe("createSweepSession", () => {
       runsCompleted: 8,
     });
     expect(session.getCell({ x: 2, y: 1 })).toBeUndefined();
+    session.dispose();
+  });
+});
+
+describe("pipelined ladder rungs", () => {
+  it("starts the next rung once the current one streams, before it completes", async () => {
+    const { session, batches, settle } = makeHarness(25, point(0, 0));
+    await settle();
+    expect(batches).toHaveLength(1);
+
+    batches[0]!.stream([frame(8, [[1, 8]])]);
+    await settle();
+
+    // Rung 2 (runs 8..24) is already in flight while rung 1 still computes.
+    expect(batches).toHaveLength(2);
+    expect(batches[1]!.started).toBe(true);
+    expect(batches[1]!.request.runCount).toBe(17);
+    expect(batches[1]!.request.seed).toBe(sweepBatchSeed(42, 8));
+    session.dispose();
+  });
+
+  it("folds out-of-order completions in order", async () => {
+    const { session, batches, updates, settle } = makeHarness(25, point(0, 0));
+    await settle();
+    batches[0]!.stream([frame(8, [[1, 8]])]);
+    await settle();
+
+    // The successor finishes first; its fold waits for rung 1.
+    batches[1]!.stream([frame(17, [[2, 17]])]);
+    batches[1]!.complete();
+    await settle();
+    expect(updates.at(-1)!.runsCompleted).toBe(0);
+
+    batches[0]!.complete();
+    await settle();
+    expect(updates.at(-1)!.runsCompleted).toBe(25);
+    expect(updates.at(-1)!.computing).toBe(false);
+    session.dispose();
+  });
+
+  it("a selection change aborts both live rungs", async () => {
+    const { session, batches, settle } = makeHarness(25, point(0, 0));
+    await settle();
+    batches[0]!.stream([frame(8, [[1, 8]])]);
+    await settle();
+    expect(batches).toHaveLength(2);
+
+    session.setSelection(point(1, 0));
+    await settle();
+
+    expect(batches[0]!.cancelled).toBe(true);
+    expect(batches[1]!.cancelled).toBe(true);
+    // The new selection's own first rung is in flight.
+    expect(batches).toHaveLength(3);
+    expect(batches[2]!.request.parameterValues).toEqual({ x: 1, y: 10 });
     session.dispose();
   });
 });

--- a/libs/@hashintel/petrinaut/src/react/experiments/sweep-session.ts
+++ b/libs/@hashintel/petrinaut/src/react/experiments/sweep-session.ts
@@ -180,6 +180,7 @@ export type SweepSession = {
   sampleCells: (
     positions: readonly Readonly<Record<string, number>>[],
     runsPerCell: number,
+    onPartial?: SampleCellsPartialListener,
   ) => Promise<readonly (Readonly<Record<string, number>> | null)[] | null>;
   dispose: () => void;
 };
@@ -266,6 +267,16 @@ function abortError(): Error {
  * of instantiating a million-run batch; the array form is written once and
  * translated without materializing anything per run.
  */
+/**
+ * Receives a batch's per-cell means as they firm up mid-flight — one call per
+ * completed shard, index-aligned with the requested positions; a cell with no
+ * finished runs yet is null. Values are means over the runs finished so far,
+ * so they refine toward the resolved result.
+ */
+export type SampleCellsPartialListener = (
+  cells: readonly (Readonly<Record<string, number>> | null)[],
+) => void;
+
 export type SweepRunDraws = {
   /** The drawn identifiers (ranged axes), in axis order. */
   identifiers: readonly string[];
@@ -901,6 +912,7 @@ export function createSweepSession(
   const sampleCellsBatch = async (
     positions: readonly Readonly<Record<string, number>>[],
     runsPerCell: number,
+    onPartial?: SampleCellsPartialListener,
   ): Promise<readonly (Readonly<Record<string, number>> | null)[] | null> => {
     if (disposed || failed || positions.length === 0) {
       return null;
@@ -950,45 +962,67 @@ export function createSweepSession(
       return null;
     }
 
+    // Group per-run values back into per-cell means, per metric,
+    // index-aligned with the requested positions. A partial result set (some
+    // shards still running) yields means over the runs finished so far.
+    const groupCells = (
+      runResults: ReadonlyMap<number, Readonly<Record<string, number>>>,
+    ): (Readonly<Record<string, number>> | null)[] => {
+      const accumulators = positions.map(
+        (): Record<string, { sum: number; n: number }> => ({}),
+      );
+      for (const [runIndex, metricValues] of runResults) {
+        const cell = accumulators[Math.floor(runIndex / runsPerCell)];
+        if (!cell) {
+          continue;
+        }
+        for (const [metricId, value] of Object.entries(metricValues)) {
+          const entry = (cell[metricId] ??= { sum: 0, n: 0 });
+          entry.sum += value;
+          entry.n += 1;
+        }
+      }
+      return accumulators.map((cell) => {
+        const entries = Object.entries(cell);
+        if (entries.length === 0) {
+          return null;
+        }
+        return Object.fromEntries(
+          entries.map(([metricId, { sum, n }]) => [metricId, sum / n]),
+        );
+      });
+    };
+
     const done = new Promise<boolean>((resolve) => {
       const offEvents = handle.events.subscribe((event) => {
         offEvents();
         resolve(event.type === "complete");
       });
     });
+    // CPU workers report per-run values as each shard completes; a sharded
+    // chunk therefore paints its cells in slices instead of all at once.
+    const offRunResults =
+      onPartial === undefined
+        ? null
+        : handle.runResults.subscribe(() => {
+            if (isDisposed()) {
+              return;
+            }
+            const partial = groupCells(handle.runResults.get());
+            if (partial.some((cell) => cell !== null)) {
+              onPartial(partial);
+            }
+          });
     handle.start();
     const completed = await done;
+    offRunResults?.();
     const runResults = handle.runResults.get();
     handle.dispose();
     if (!completed || isDisposed()) {
       return null;
     }
 
-    // Group per-run values back into per-cell means, per metric,
-    // index-aligned with the requested positions.
-    const accumulators = positions.map(
-      (): Record<string, { sum: number; n: number }> => ({}),
-    );
-    for (const [runIndex, metricValues] of runResults) {
-      const cell = accumulators[Math.floor(runIndex / runsPerCell)];
-      if (!cell) {
-        continue;
-      }
-      for (const [metricId, value] of Object.entries(metricValues)) {
-        const entry = (cell[metricId] ??= { sum: 0, n: 0 });
-        entry.sum += value;
-        entry.n += 1;
-      }
-    }
-    return accumulators.map((cell) => {
-      const entries = Object.entries(cell);
-      if (entries.length === 0) {
-        return null;
-      }
-      return Object.fromEntries(
-        entries.map(([metricId, { sum, n }]) => [metricId, sum / n]),
-      );
-    });
+    return groupCells(runResults);
   };
 
   return {
@@ -1027,10 +1061,10 @@ export function createSweepSession(
         releaseBackgroundSlot();
       }
     },
-    async sampleCells(positions, runsPerCell) {
+    async sampleCells(positions, runsPerCell, onPartial) {
       await acquireBackgroundSlot();
       try {
-        return await sampleCellsBatch(positions, runsPerCell);
+        return await sampleCellsBatch(positions, runsPerCell, onPartial);
       } finally {
         releaseBackgroundSlot();
       }

--- a/libs/@hashintel/petrinaut/src/react/experiments/sweep-session.ts
+++ b/libs/@hashintel/petrinaut/src/react/experiments/sweep-session.ts
@@ -455,28 +455,51 @@ export function createSweepSession(
   // Reads go through a function so the narrowing-based lint cannot claim the
   // flag is constant: it flips inside closures the checker treats as opaque.
   const isDisposed = (): boolean => disposed;
+  const isFailed = (): boolean => failed;
 
   /** Whether `loopGeneration` still owns the session's compute slot. */
   const isStale = (loopGeneration: number): boolean =>
     disposed || loopGeneration !== generation;
 
   /**
-   * Runs one ladder batch for the current selection and folds it into the
-   * cache. Returns whether the loop should continue climbing.
+   * One in-flight ladder batch. Rungs cover disjoint run ranges with
+   * prefix-stable draws and seeds, so a successor can compute while its
+   * predecessor is still running; only the FOLD into the cache is ordered.
    */
-  const executeBatch = async (
+  type LadderRung = {
+    target: number;
+    handle: MonteCarloExperiment;
+    /** Resolves with how the batch ended (external abort included). */
+    done: Promise<"complete" | "stopped">;
+    /** Resolves on the first metric frames — or on `done`, so races never hang. */
+    streamed: Promise<void>;
+    abort: () => void;
+    /** Unsubscribes the rung's handle listeners. */
+    detach: () => void;
+  };
+
+  /**
+   * Starts one ladder batch for runs `[from, target)` of the current
+   * selection. Returns null when the batch was superseded (abort, stale
+   * generation) or failed — failure marks the session failed and publishes.
+   */
+  const startRung = async (
     loopGeneration: number,
-    key: string,
-    snapshot: SweepCellSnapshot,
+    from: number,
     target: number,
-  ): Promise<"continue" | "stop"> => {
+    abortSet: Set<() => void>,
+    onLiveTick: () => void,
+  ): Promise<LadderRung | null> => {
     const abortController = new AbortController();
     // Until the handle exists, aborting the controller is all a restart can
     // do; instantiation rejects with AbortError and the stale loop exits.
-    const abortThisBatch = () => {
+    let abortRung = () => {
       abortController.abort();
     };
-    abortCurrent = abortThisBatch;
+    const abortEntry = () => {
+      abortRung();
+    };
+    abortSet.add(abortEntry);
 
     let draws: SweepRunDraws | undefined;
     try {
@@ -484,14 +507,15 @@ export function createSweepSession(
         seed,
         axes,
         selection,
-        snapshot.runsCompleted,
+        from,
         target,
         abortController.signal,
       );
     } catch {
       // Only an abort escapes the draw build, and an abort means a restart
       // or a dispose already superseded this generation.
-      return "stop";
+      abortSet.delete(abortEntry);
+      return null;
     }
 
     let handle: MonteCarloExperiment;
@@ -499,13 +523,14 @@ export function createSweepSession(
       handle = await instantiateBatch({
         parameterValues: sweepSelectionMidValues(axes, selection),
         ...(draws === undefined ? {} : { draws }),
-        seed: sweepBatchSeed(seed, snapshot.runsCompleted),
-        runCount: target - snapshot.runsCompleted,
+        seed: sweepBatchSeed(seed, from),
+        runCount: target - from,
         signal: abortController.signal,
       });
     } catch (error) {
+      abortSet.delete(abortEntry);
       if (isStale(loopGeneration)) {
-        return "stop";
+        return null;
       }
       failed = true;
       onError(
@@ -515,64 +540,38 @@ export function createSweepSession(
       // Nothing more will stream for this selection; unblock waiters so the
       // surface's own attempts can run (and refuse) instead of hanging.
       markSelectionStreamed();
-      return "stop";
+      return null;
     }
 
     if (isStale(loopGeneration)) {
+      abortSet.delete(abortEntry);
       handle.dispose();
-      return "stop";
+      return null;
     }
 
     // Resolved externally as well as by terminal events: an aborted batch's
     // transports are torn down before a `cancelled` event can travel back,
     // so waiting only on events would hang the loop.
     let resolveDone: (outcome: "complete" | "stopped") => void = () => {};
-    const batchDone = new Promise<"complete" | "stopped">((resolve) => {
+    const done = new Promise<"complete" | "stopped">((resolve) => {
       resolveDone = resolve;
     });
+    let resolveStreamed: () => void = () => {};
+    const streamed = new Promise<void>((resolve) => {
+      resolveStreamed = resolve;
+    });
+    void done.then(() => {
+      resolveStreamed();
+      abortSet.delete(abortEntry);
+    });
 
-    const publishLive = () => {
-      if (isStale(loopGeneration)) {
-        return;
+    const offMetrics = handle.metrics.subscribe(() => {
+      if (handle.metrics.get().frames.length > 0) {
+        resolveStreamed();
       }
-      publish({
-        inFlightFrames: handle.metrics.get().frames,
-        inFlightRuns: handle.progress.get()?.completedRuns ?? 0,
-        runTarget: target,
-        progress: handle.progress.get(),
-        computing: true,
-      });
-    };
-    // Leading-edge publish with trailing coalescing: with many shards each
-    // message wave fires metrics and progress ticks back to back, and every
-    // one re-rendered the whole drawer.
-    const throttleMs = options.publishThrottleMs ?? 0;
-    // In an object so reads go through a property the narrowing-based lint
-    // treats as opaque: the fields flip inside timer callbacks.
-    const throttle: {
-      timer: ReturnType<typeof setTimeout> | null;
-      pending: boolean;
-    } = { timer: null, pending: false };
-    const publishLiveThrottled = () => {
-      if (throttleMs === 0) {
-        publishLive();
-        return;
-      }
-      if (throttle.timer !== null) {
-        throttle.pending = true;
-        return;
-      }
-      publishLive();
-      throttle.timer = setTimeout(() => {
-        throttle.timer = null;
-        if (throttle.pending) {
-          throttle.pending = false;
-          publishLiveThrottled();
-        }
-      }, throttleMs);
-    };
-    const offMetrics = handle.metrics.subscribe(publishLiveThrottled);
-    const offProgress = handle.progress.subscribe(publishLiveThrottled);
+      onLiveTick();
+    });
+    const offProgress = handle.progress.subscribe(onLiveTick);
     const offEvents = handle.events.subscribe((event) => {
       if (event.type === "complete") {
         resolveDone("complete");
@@ -585,7 +584,7 @@ export function createSweepSession(
       resolveDone("stopped");
     });
 
-    abortCurrent = () => {
+    abortRung = () => {
       abortController.abort();
       handle.cancel();
       resolveDone("stopped");
@@ -593,47 +592,30 @@ export function createSweepSession(
 
     handle.start();
 
-    const outcome = await batchDone;
-    offMetrics();
-    offProgress();
-    offEvents();
-    // A trailing tick after the fold would re-merge the batch's frames on
-    // top of a cache that already contains them — double counting.
-    if (throttle.timer !== null) {
-      clearTimeout(throttle.timer);
-      throttle.timer = null;
-    }
-    throttle.pending = false;
-
-    if (failed && !isStale(loopGeneration)) {
-      // The session idles after a failure; leave the last good frames up
-      // rather than a spinner that will never finish.
-      publish({ runTarget: null, computing: false });
-    }
-    const finishedFrames = handle.metrics.get().frames;
-    handle.dispose();
-    // A stale batch finishing late must not disarm the successor generation's
-    // abort hook.
-    if (abortCurrent === abortThisBatch) {
-      abortCurrent = null;
-    }
-
-    if (outcome === "complete") {
-      // Fold the batch into the cache even when the user has moved on —
-      // completed rays are never thrown away.
-      cache.set(key, {
-        runsCompleted: target,
-        metricFrames: mergeMetricFramesAcrossCells([
-          snapshot.metricFrames,
-          finishedFrames,
-        ]),
-      });
-      return disposed ? "stop" : "continue";
-    }
-
-    return "stop";
+    return {
+      target,
+      handle,
+      done,
+      streamed,
+      abort: abortEntry,
+      detach: () => {
+        offMetrics();
+        offProgress();
+        offEvents();
+      },
+    };
   };
 
+  /**
+   * Climbs the run ladder for the current selection, PIPELINED: as soon as
+   * the current rung streams its first frames, the next rung starts — run
+   * ranges are disjoint and draws/seeds are prefix-stable, so the successor
+   * computes valid runs while its predecessor finishes. Folds stay strictly
+   * ordered: a rung folds only after every earlier rung folded, and a rung
+   * that stops discards its started successor (a gap can never enter the
+   * cache). At most two rungs are in flight, bounding what a slider move
+   * throws away.
+   */
   const refineLoop = async (loopGeneration: number): Promise<void> => {
     computingGeneration = loopGeneration;
     const releaseCompute = () => {
@@ -641,27 +623,174 @@ export function createSweepSession(
         computingGeneration = null;
       }
     };
-    while (!isStale(loopGeneration) && !failed) {
-      const key = sweepSelectionKey(axes, selection);
-      const snapshot = snapshotFor(key);
-      const target = getNextRunTarget(snapshot.runsCompleted, runCount);
+    const key = sweepSelectionKey(axes, selection);
+    const live: LadderRung[] = [];
+    const abortSet = new Set<() => void>();
+    abortCurrent = () => {
+      for (const abort of abortSet) {
+        abort();
+      }
+    };
 
+    const publishAllLive = () => {
+      if (isStale(loopGeneration) || live.length === 0) {
+        return;
+      }
+      const first = live[0]!;
+      const frameSets = live
+        .map((rung) => rung.handle.metrics.get().frames)
+        .filter((frames) => frames.length > 0);
+      publish({
+        inFlightFrames:
+          frameSets.length > 1
+            ? mergeMetricFramesAcrossCells(frameSets)
+            : frameSets[0],
+        inFlightRuns: live.reduce(
+          (total, rung) =>
+            total + (rung.handle.progress.get()?.completedRuns ?? 0),
+          0,
+        ),
+        runTarget: live.at(-1)!.target,
+        progress: first.handle.progress.get(),
+        computing: true,
+      });
+    };
+    // Leading-edge publish with trailing coalescing: with many shards each
+    // message wave fires metrics and progress ticks back to back, and every
+    // one re-rendered the whole drawer. Loop-level, so both live rungs share
+    // one cadence; a trailing tick reads current state, so a tick landing
+    // after a fold publishes cache + the remaining rung — never double.
+    const throttleMs = options.publishThrottleMs ?? 0;
+    // In an object so reads go through a property the narrowing-based lint
+    // treats as opaque: the fields flip inside timer callbacks.
+    const throttle: {
+      timer: ReturnType<typeof setTimeout> | null;
+      pending: boolean;
+    } = { timer: null, pending: false };
+    const publishLiveThrottled = () => {
+      if (throttleMs === 0) {
+        publishAllLive();
+        return;
+      }
+      if (throttle.timer !== null) {
+        throttle.pending = true;
+        return;
+      }
+      publishAllLive();
+      throttle.timer = setTimeout(() => {
+        throttle.timer = null;
+        if (throttle.pending) {
+          throttle.pending = false;
+          publishLiveThrottled();
+        }
+      }, throttleMs);
+    };
+
+    /** The fold chain: what the cache will hold once ordered folds land. */
+    let chainSnapshot = snapshotFor(key);
+    let nextFrom = chainSnapshot.runsCompleted;
+
+    const startNext = async (): Promise<boolean> => {
+      const target = getNextRunTarget(nextFrom, runCount);
       if (target === null) {
-        releaseCompute();
+        return false;
+      }
+      if (live.length === 0) {
+        publish({ runTarget: target, computing: true });
+      }
+      const rung = await startRung(
+        loopGeneration,
+        nextFrom,
+        target,
+        abortSet,
+        publishLiveThrottled,
+      );
+      if (rung === null) {
+        return false;
+      }
+      nextFrom = target;
+      live.push(rung);
+      return true;
+    };
+
+    const drainLive = () => {
+      for (const rung of live.splice(0)) {
+        rung.abort();
+        rung.detach();
+        rung.handle.dispose();
+      }
+    };
+
+    const started = await startNext();
+    if (!started) {
+      releaseCompute();
+      if (!isStale(loopGeneration) && !disposed && !failed) {
         publish({ runTarget: null, computing: false });
-        return;
       }
-
-      publish({ runTarget: target, computing: true });
-
-      const outcome = await executeBatch(loopGeneration, key, snapshot, target);
-      if (outcome === "stop") {
-        releaseCompute();
-        return;
-      }
-      // Loop: next ladder rung for the (possibly unchanged) selection.
+      return;
     }
+
+    while (live.length > 0) {
+      const current = live[0]!;
+
+      // Pipeline: once the current rung streams, start its successor.
+      if (live.length === 1 && !failed) {
+        const first = await Promise.race([
+          current.streamed.then(() => "streamed" as const),
+          current.done.then(() => "done" as const),
+        ]);
+        if (first === "streamed" && !isStale(loopGeneration) && !isFailed()) {
+          await startNext();
+        }
+      }
+
+      const outcome = await current.done;
+      current.detach();
+      const finishedFrames = current.handle.metrics.get().frames;
+      current.handle.dispose();
+      live.shift();
+
+      if (outcome !== "complete") {
+        // A stopped rung breaks the fold chain: its started successor's runs
+        // can never fold without a gap, so they are discarded.
+        drainLive();
+        break;
+      }
+
+      // Fold in order, even when the user has moved on — completed rays are
+      // never thrown away.
+      chainSnapshot = {
+        runsCompleted: current.target,
+        metricFrames: mergeMetricFramesAcrossCells([
+          chainSnapshot.metricFrames,
+          finishedFrames,
+        ]),
+      };
+      cache.set(key, chainSnapshot);
+      // Reflect the fold (runsCompleted advanced) without waiting for the
+      // successor's next tick; with no successor the exit publish covers it.
+      publishLiveThrottled();
+
+      if (disposed || isStale(loopGeneration) || failed) {
+        drainLive();
+        break;
+      }
+      if (live.length === 0 && !(await startNext())) {
+        break;
+      }
+    }
+
+    if (throttle.timer !== null) {
+      clearTimeout(throttle.timer);
+      throttle.timer = null;
+    }
+    throttle.pending = false;
     releaseCompute();
+    if (!isStale(loopGeneration) && !disposed) {
+      // The session idles — after finishing the ladder or after a failure;
+      // either way leave the last good frames up rather than a spinner.
+      publish({ runTarget: null, computing: false });
+    }
   };
 
   const restart = () => {

--- a/libs/@hashintel/petrinaut/src/react/experiments/sweep-session.ts
+++ b/libs/@hashintel/petrinaut/src/react/experiments/sweep-session.ts
@@ -102,6 +102,14 @@ export type InstantiateSweepBatch = (options: {
    */
   requiresRunResults?: boolean;
   /**
+   * Whether the session's own refine ladder was computing when this
+   * background batch was requested. Hosts use it to size the batch: while
+   * the foreground is busy on the CPU pool a background batch stays on one
+   * worker, and once the ladder idles (or computes elsewhere, e.g. the GPU)
+   * the same batch may shard across the now-free pool.
+   */
+  foregroundActive?: boolean;
+  /**
    * Explicit per-run seeds (one per run, aligned with `draws`). Batched
    * surface cells pin these so a cell's runs use the same seeds regardless
    * of which chunk (and chunk slot) sampled it — and the same seeds the
@@ -355,6 +363,14 @@ export function createSweepSession(
   /** Increments per selection change; a stale loop sees it and stops. */
   let generation = 0;
   let abortCurrent: (() => void) | null = null;
+  /**
+   * Generation whose refine loop is currently between its first batch and
+   * going idle; null when the ladder finished or failed. Background batches
+   * read this to know whether the foreground owns the compute right now.
+   */
+  let computingGeneration: number | null = null;
+  const isForegroundComputing = (): boolean =>
+    computingGeneration === generation;
 
   const snapshotFor = (key: string): SweepCellSnapshot =>
     cache.get(key) ?? { runsCompleted: 0, metricFrames: [] };
@@ -619,12 +635,19 @@ export function createSweepSession(
   };
 
   const refineLoop = async (loopGeneration: number): Promise<void> => {
+    computingGeneration = loopGeneration;
+    const releaseCompute = () => {
+      if (computingGeneration === loopGeneration) {
+        computingGeneration = null;
+      }
+    };
     while (!isStale(loopGeneration) && !failed) {
       const key = sweepSelectionKey(axes, selection);
       const snapshot = snapshotFor(key);
       const target = getNextRunTarget(snapshot.runsCompleted, runCount);
 
       if (target === null) {
+        releaseCompute();
         publish({ runTarget: null, computing: false });
         return;
       }
@@ -633,10 +656,12 @@ export function createSweepSession(
 
       const outcome = await executeBatch(loopGeneration, key, snapshot, target);
       if (outcome === "stop") {
+        releaseCompute();
         return;
       }
       // Loop: next ladder rung for the (possibly unchanged) selection.
     }
+    releaseCompute();
   };
 
   const restart = () => {
@@ -783,6 +808,7 @@ export function createSweepSession(
         runCount: runCountTotal,
         background: true,
         requiresRunResults: true,
+        foregroundActive: isForegroundComputing(),
         runSeeds,
         signal: abortController.signal,
       });

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/sweep-surface.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/sweep-surface.tsx
@@ -202,10 +202,35 @@ export const SweepSurface = ({
         return position;
       });
 
+      const mergeCells = (
+        cells: readonly (Readonly<Record<string, number>> | null)[],
+      ) => {
+        setGrid((previous) => {
+          if (previous.walkKey !== walkKey) {
+            return previous;
+          }
+          const next = new Map(previous.values);
+          for (const [index, values] of cells.entries()) {
+            const cell = chunk[index];
+            if (cell && values) {
+              next.set(contourSurfaceKey(cell.x, cell.y), values);
+            }
+          }
+          return { walkKey: previous.walkKey, values: next };
+        });
+      };
+
       const cells = await sampleSurfaceCells(
         experimentId,
         positions,
         SURFACE_CELL_RUNS,
+        // Cells paint as each shard (or fallback cell) completes, instead of
+        // waiting for the whole chunk.
+        (partialCells) => {
+          if (!isWalkStale()) {
+            mergeCells(partialCells);
+          }
+        },
       );
       // A refused chunk is a hole in the surface, not the end of the fill —
       // later chunks may still land (a disposed session keeps refusing
@@ -213,19 +238,7 @@ export const SweepSurface = ({
       if (isWalkStale() || !cells) {
         return;
       }
-      setGrid((previous) => {
-        if (previous.walkKey !== walkKey) {
-          return previous;
-        }
-        const next = new Map(previous.values);
-        for (const [index, values] of cells.entries()) {
-          const cell = chunk[index];
-          if (cell && values) {
-            next.set(contourSurfaceKey(cell.x, cell.y), values);
-          }
-        }
-        return { walkKey: previous.walkKey, values: next };
-      });
+      mergeCells(cells);
     };
 
     // Parallel lanes pulling from one queue: chunks stream back roughly in

--- a/libs/@local/petrinaut-arch-docs/content/experiments/parameter-sweeps.mdx
+++ b/libs/@local/petrinaut-arch-docs/content/experiments/parameter-sweeps.mdx
@@ -32,9 +32,15 @@ from the first frames and sharpens as runs land.
 
 Either kind climbs the ladder — 8, 25, 100, 500, 1000, then ×5/×2, capped by
 the run budget — in batches that fold into a cache keyed by the whole
-selection (a point is a degenerate range). A batch cancelled by a selection
-change is discarded whole; revisiting any earlier selection restores its runs
-and resumes from its cached rung.
+selection (a point is a degenerate range). The climb is **pipelined**: run
+ranges are disjoint and draws and seeds are prefix-stable in the run index,
+so as soon as a rung streams its first frames the next rung starts alongside
+it — at most two in flight, which hides each rung's setup and straggler tail
+without committing the whole ladder up front. Folds stay strictly ordered: a
+rung folds only after every earlier rung folded, and a rung cancelled by a
+selection change discards its started successor whole (a gap can never enter
+the cache). Revisiting any earlier selection restores its runs and resumes
+from its cached rung.
 
 Per-run parameter values travel as `ExperimentRequest.runPlan` — one
 run-major `Float64Array` plus the overridden names, uniform by construction.

--- a/libs/@local/petrinaut-arch-docs/content/experiments/sweep-surface.mdx
+++ b/libs/@local/petrinaut-arch-docs/content/experiments/sweep-surface.mdx
@@ -28,7 +28,10 @@ eight times), runs one batch of `cells × 8` runs, and folds the per-run
 metric values back into per-cell means. One batch setup per chunk replaces
 one per cell — batch setup, not compute, dominated a cell's wall time, which
 is why the earlier design needed four concurrent per-cell lanes to fill an
-11×11 surface in ~4 s.
+11×11 surface in ~4 s. Cells do not wait for the whole chunk either: CPU
+workers report per-run values as each shard completes, so a sharded chunk
+streams its cells in slices (`sampleCells`'s partial listener), and the
+per-cell fallback reports each resolved cell the same way.
 
 The navigator's own selection outranks all of this. Every chunk dispatch
 awaits `session.whenSelectionStreamed()` — a gate that opens once the

--- a/libs/@local/petrinaut-arch-docs/content/experiments/sweep-surface.mdx
+++ b/libs/@local/petrinaut-arch-docs/content/experiments/sweep-surface.mdx
@@ -48,10 +48,15 @@ folds runs into histograms on-device.
 
 Every metric is measured on the same runs, so the component caches
 per-cell values for **all** metrics and switching the shown metric repaints
-from the cache instead of re-sampling. Each background batch gets a single
-worker, so the navigator's sharded batch keeps most cores. Parameters
-outside the two shown axes stay at the navigator's values, and changing any
-of them (or the axes) restarts the sampling for the new slice.
+from the cache instead of re-sampling. A chunk's width adapts to foreground
+pressure: while the navigator's ladder computes on the CPU pool each chunk
+batch takes a single worker, so the sharded foreground keeps the cores; once
+the ladder idles — or the experiment computes on the GPU, which uses no CPU
+workers — the same chunk shards across the freed pool (the session stamps
+each chunk request with `foregroundActive`, and the provider keeps a narrow
+and a wide CPU lane). Parameters outside the two shown axes stay at the
+navigator's values, and changing any of them (or the axes) restarts the
+sampling for the new slice.
 
 ## Rendering sparse data honestly
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The sweep view computed one batch at a time in two places: the navigator's ladder waited for each rung to finish before starting the next, and surface chunks were fixed at one worker each even when the rest of the pool sat idle. This PR pipelines the ladder, lets surface chunks shard across whatever the foreground isn't using, and paints surface cells as each shard completes instead of at chunk boundaries. Stacked on #9476.

## 🔗 Related links

- [FE-1552](https://linear.app/hash/issue/FE-1552) _(internal)_
- Base PR: #9476

## 🔍 What does this change?

- Surface chunk batches adapt their width to foreground pressure: the session stamps each chunk request with whether its refine ladder is computing (`foregroundActive`), and the provider keeps a narrow (one-worker) and a wide (sharded) CPU lane — while the ladder computes on the CPU pool a chunk takes one worker, and once the ladder idles or the experiment computes on the GPU the same chunk shards across the freed pool.
- The ladder pipelines its rungs: run ranges are disjoint and draws and seeds are prefix-stable, so as soon as a rung streams its first frames the next rung starts alongside it — at most two in flight. Folds stay strictly ordered (a rung folds only after every earlier rung folded; a stopped rung discards its started successor so a gap can never enter the cache), and both live rungs' frames merge into one published view.
- `sampleCells` accepts a partial listener: CPU workers report per-run values as each shard completes, so a sharded chunk streams its cells in slices, and the per-cell fallback reports each resolved cell the same way. The surface merges partials through the same walk-key-guarded path as final results.
- The worker pool's `maxIdle` covers the pipelined working set (two sharded foreground batches plus the surface lanes); a smaller pool terminated the overflow on every slider commit and respawned it a moment later.
- Updates the `parameter-sweeps` and `sweep-surface` architecture pages.

Measured on the `Bench / SweepDrawer` CPU story (previous PR → this one): navigator reaches its full 1000 runs at 1312 ms after page load (was 1488 ms, with the runs counter climbing smoothly through rung boundaries instead of plateauing), surface full fill unchanged at ~1.6 s, worker churn per slider commit 0 → 1.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] modifies an **npm**-publishable library and **I have added a changeset file(s)**

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] require changes to docs which **are made** as part of this PR

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

- On the GPU backend the pipelined ladder can hold two GPU experiments concurrently, doubling GPU buffer residency for the overlap window. Bounded and not observed to fail; flagged for review.

## 🛡 What tests cover this?

- `sweep-session.test.ts` (26 tests): new pins for the `foregroundActive` hint (flips with the ladder's computing state), pipelining (successor starts on first stream with the derived seed; out-of-order completions fold in order; a selection change aborts both live rungs), and partial streaming (per-cell means firm up shard by shard, nulls for cells with no runs yet).
- Existing contour-grid, provider, and factory suites cover the surrounding paths.

## ❓ How to test this?

1. Open `Bench / SweepDrawer → Cpu` in Storybook (`yarn workspace @hashintel/petrinaut dev:storybook`).
2. Watch the run counter climb smoothly through the ladder instead of pausing at each rung.
3. Watch the surface: after the navigator's runs finish, cells land in visibly larger waves (sharded chunks streaming shard by shard).
4. On `→ Gpu`, the surface fills at full width immediately since the navigator uses no CPU workers.

## 📹 Demo

_Screenshots pending — will be handed over for drag-drop._
