### PR TITLE
FE-1552: Make the surface a drag control and show parallel batches in the summary

### DIFF
--- a/.changeset/sweep-drawer-ux.md
+++ b/.changeset/sweep-drawer-ux.md
@@ -1,0 +1,5 @@
+---
+"@hashintel/petrinaut": patch
+---
+
+The sweep surface navigates by drag as well as click (live crosshair and value readout, commit on release) and marks the navigator's current position; the experiment summary shows a compact toggleable list of every batch computing in parallel, with the progress bar tracking the selected combination's runs instead of one batch's simulated time.

--- a/libs/@hashintel/petrinaut/docs/experiments.md
+++ b/libs/@hashintel/petrinaut/docs/experiments.md
@@ -68,7 +68,7 @@ Every selection uses the same seed sequence (common random numbers), and a run's
 
 #### The surface view
 
-A sweep with two or more swept parameters grows a **Surface** section between the parameter strip and the metric charts: a contour plot of one metric's final value over two parameters you pick, with every other parameter held at the middle of its selected range. The plot fills in live and coarse-first — the four corners, then ever finer subdivisions, each level a complete picture (8 runs per point) — and **clicking the surface moves the navigator**: both shown parameters collapse to a point at the clicked position, which then refines with more runs. Your selected point always computes first: the metric charts start streaming before surface sampling begins, and after every slider move the surface waits for the new selection's first frames before continuing. Every metric is measured on the same samples, so switching the shown metric repaints instantly from what was already computed; changing the fixed parameters or the axes restarts the fill for the new slice.
+A sweep with two or more swept parameters grows a **Surface** section between the parameter strip and the metric charts: a contour plot of one metric's final value over two parameters you pick, with every other parameter held at the middle of its selected range. The plot fills in live and coarse-first — the four corners, then ever finer subdivisions, each level a complete picture (8 runs per point) — and **the surface is itself a control**: click, or press and drag with a live crosshair and value readout, and on release both shown parameters collapse to a point there, which then refines with more runs. An orange ring marks where the navigator currently sits. Your selected point always computes first: the metric charts start streaming before surface sampling begins, and after every slider move the surface waits for the new selection's first frames before continuing. Every metric is measured on the same samples, so switching the shown metric repaints instantly from what was already computed; changing the fixed parameters or the axes restarts the fill for the new slice.
 
 The summary, the parameter strip, and the surface hold still at the top of the drawer; the metric charts scroll on their own below them, so the graphs stay in view while you browse the charts.
 
@@ -142,6 +142,8 @@ There is no built-in restart action -- to re-run with the same configuration, **
 A confirmation prompt blocks browser/tab close while any experiment is initializing or running.
 
 ### Notifications
+
+The Summary's progress bar tracks the selected combination (runs sampled over the run budget). While anything computes, a **"N computing"** chip appears beside it — a sweep runs several simulations in parallel (the selection's own batches, surface chunks, cell refinements) — and clicking the chip expands a compact list with each batch's kind and progress. Selection batches are the priority work and sort first.
 
 A small toast appears when an experiment **completes** or **errors**, even if its drawer isn't open. The top-bar **Active experiments** popover (see below) lets you jump to any in-flight experiment from anywhere in the app.
 

--- a/libs/@hashintel/petrinaut/src/react/experiments/context.test.ts
+++ b/libs/@hashintel/petrinaut/src/react/experiments/context.test.ts
@@ -28,6 +28,7 @@ function makeRecord(overrides: Partial<ExperimentRecord>): ExperimentRecord {
     finishedAt: null,
     progress: null,
     metricFrames: [],
+    sweepBatches: [],
     parameterAxes: [],
     sweep: null,
     latestMetricFramesById: {},

--- a/libs/@hashintel/petrinaut/src/react/experiments/context.ts
+++ b/libs/@hashintel/petrinaut/src/react/experiments/context.ts
@@ -4,7 +4,13 @@ import type {
   ExperimentParameterAxis,
   ExperimentParameterInput,
 } from "./parameter-grid";
-import type { SweepCellSnapshot, SweepSelection } from "./sweep-session";
+import type {
+  SweepBatchStatus,
+  SweepCellSnapshot,
+  SweepSelection,
+} from "./sweep-session";
+
+export type { SweepBatchStatus } from "./sweep-session";
 import type {
   SDCPN,
   MonteCarloExpressionMetricSpec,
@@ -125,6 +131,12 @@ export type ExperimentRecord = {
   parameterAxes: readonly ExperimentParameterAxis[];
   /** Live sweep state; null for a plain experiment. */
   sweep: ExperimentSweepState | null;
+  /**
+   * Every batch the sweep session is computing right now — the selection's
+   * own ladder rungs plus the background surface and refine batches. Empty
+   * for a plain experiment and whenever nothing computes.
+   */
+  sweepBatches: readonly SweepBatchStatus[];
 };
 
 /** Navigator-facing state of a sweep experiment. */

--- a/libs/@hashintel/petrinaut/src/react/experiments/provider.tsx
+++ b/libs/@hashintel/petrinaut/src/react/experiments/provider.tsx
@@ -317,6 +317,8 @@ export const ExperimentsProvider: React.FC<ExperimentsProviderProps> = ({
    * a marking the swept parameters shape (even jointly, or only at interior
    * points) falls back to the per-cell path instead of running wrong.
    */
+  /** Per sweep: unsubscribes the batch-activity feed when the session goes. */
+  const sweepBatchSubscriptionsRef = useRef(new Map<string, () => void>());
   const surfaceMarkingProbesRef = useRef(
     new Map<
       string,
@@ -352,7 +354,14 @@ export const ExperimentsProvider: React.FC<ExperimentsProviderProps> = ({
     const registrations = registrationsRef.current;
     const pendingRegistrations = pendingRegistrationsRef.current;
     const sweepSessions = sweepSessionsRef.current;
+    const sweepBatchSubscriptions = sweepBatchSubscriptionsRef.current;
     return () => {
+      // Before disposing the sessions: dispose fires a final (empty) batch
+      // notification, which must not reach setExperiments mid-unmount.
+      for (const unsubscribe of sweepBatchSubscriptions.values()) {
+        unsubscribe();
+      }
+      sweepBatchSubscriptions.clear();
       for (const registration of pendingRegistrations.values()) {
         registration.abortController.abort();
       }
@@ -777,6 +786,11 @@ export const ExperimentsProvider: React.FC<ExperimentsProviderProps> = ({
       },
     });
 
+    const offBatches = session.batches.subscribe(() => {
+      patchExperiment(experimentId, { sweepBatches: session.batches.get() });
+    });
+    sweepBatchSubscriptionsRef.current.set(experimentId, offBatches);
+
     sweepSessionsRef.current.set(experimentId, session);
   };
 
@@ -914,6 +928,7 @@ export const ExperimentsProvider: React.FC<ExperimentsProviderProps> = ({
       progress: null,
       latestMetricFramesById: {},
       metricFrames: [],
+      sweepBatches: [],
       parameterAxes: axes,
       sweep:
         axes.length > 0
@@ -1195,6 +1210,8 @@ export const ExperimentsProvider: React.FC<ExperimentsProviderProps> = ({
       session.dispose();
       sweepSessionsRef.current.delete(experimentId);
       surfaceMarkingProbesRef.current.delete(experimentId);
+      sweepBatchSubscriptionsRef.current.get(experimentId)?.();
+      sweepBatchSubscriptionsRef.current.delete(experimentId);
       patchExperiment(experimentId, { status: "cancelled" });
       return;
     }
@@ -1208,6 +1225,8 @@ export const ExperimentsProvider: React.FC<ExperimentsProviderProps> = ({
     sweepSessionsRef.current.get(experimentId)?.dispose();
     sweepSessionsRef.current.delete(experimentId);
     surfaceMarkingProbesRef.current.delete(experimentId);
+    sweepBatchSubscriptionsRef.current.get(experimentId)?.();
+    sweepBatchSubscriptionsRef.current.delete(experimentId);
     disposeExperimentHandle(experimentId);
     setExperiments((prev) =>
       prev.filter((experiment) => experiment.id !== experimentId),

--- a/libs/@hashintel/petrinaut/src/react/experiments/provider.tsx
+++ b/libs/@hashintel/petrinaut/src/react/experiments/provider.tsx
@@ -575,8 +575,11 @@ export const ExperimentsProvider: React.FC<ExperimentsProviderProps> = ({
       axes,
       runCount: experiment.runCount,
       seed: experiment.seed,
-      // ~2 publishes per frame at 60fps; the charts cannot show more.
-      publishThrottleMs: 40,
+      // Leading-edge, so the first frames publish instantly; while a batch
+      // streams, ~10 re-renders a second read as live on a chart and leave
+      // the rest of the UI (sliders, drags, the editor behind the drawer)
+      // most of each frame's budget.
+      publishThrottleMs: 100,
       instantiateBatch: async ({
         parameterValues,
         draws,

--- a/libs/@hashintel/petrinaut/src/react/experiments/sweep-session.test.ts
+++ b/libs/@hashintel/petrinaut/src/react/experiments/sweep-session.test.ts
@@ -523,6 +523,41 @@ describe("createSweepSession", () => {
   });
 });
 
+describe("batches", () => {
+  it("lists live batches selection-first and drops them as they finish", async () => {
+    const { session, batches, settle } = makeHarness(25, point(0, 0));
+    await settle();
+    expect(session.batches.get()).toMatchObject([
+      { kind: "selection", runCount: 8, completedRuns: 0 },
+    ]);
+
+    void session.sampleCells([{ x: 0, y: 0 }], 2);
+    await settle();
+    expect(session.batches.get().map((batch) => batch.kind)).toEqual([
+      "selection",
+      "surface",
+    ]);
+
+    // The pipelined successor joins the list once the first rung streams.
+    batches[0]!.stream([frame(8, [[1, 8]])]);
+    await settle();
+    expect(session.batches.get().map((batch) => batch.kind)).toEqual([
+      "selection",
+      "selection",
+      "surface",
+    ]);
+
+    batches[0]!.complete();
+    await settle();
+    expect(
+      session.batches.get().filter((batch) => batch.kind === "selection"),
+    ).toHaveLength(1);
+
+    session.dispose();
+    expect(session.batches.get()).toEqual([]);
+  });
+});
+
 describe("pipelined ladder rungs", () => {
   it("starts the next rung once the current one streams, before it completes", async () => {
     const { session, batches, settle } = makeHarness(25, point(0, 0));

--- a/libs/@hashintel/petrinaut/src/react/experiments/sweep-session.ts
+++ b/libs/@hashintel/petrinaut/src/react/experiments/sweep-session.ts
@@ -57,6 +57,21 @@ export type SweepCellSnapshot = {
 };
 
 /** What the session streams to its owner on every meaningful change. */
+/** One batch currently computing, for the host's activity display. */
+export type SweepBatchStatus = {
+  id: number;
+  /**
+   * What the batch is for. "selection" is the navigator's own ladder — the
+   * priority work; "surface" is a contour chunk; "refine" is a single cell
+   * brought up to depth. Selection batches sort first.
+   */
+  kind: "selection" | "surface" | "refine";
+  /** Runs this batch owns. */
+  runCount: number;
+  /** Runs it has finished so far. */
+  completedRuns: number;
+};
+
 export type SweepSessionUpdate = {
   selection: SweepSelection;
   /** Cached batches of the selection plus the in-flight batch, merged. */
@@ -148,6 +163,16 @@ export type SweepSession = {
    * work keeps the navigator's own point first in line at all times.
    */
   whenSelectionStreamed: () => Promise<void>;
+  /**
+   * Every batch currently computing, foreground and background alike. A
+   * store of its own rather than part of `onUpdate`, so a background
+   * batch's progress ticks animate the host's activity list without
+   * republishing the selection's frames.
+   */
+  batches: {
+    get: () => readonly SweepBatchStatus[];
+    subscribe: (listener: () => void) => () => void;
+  };
   /**
    * Reads a point's finished-batch snapshot, by quantized position.
    * The surface sampler uses this to reuse navigator work.
@@ -473,6 +498,83 @@ export function createSweepSession(
     disposed || loopGeneration !== generation;
 
   /**
+   * The live batch registry behind `session.batches`: every computing batch
+   * registers itself with its handle, and progress ticks refresh a snapshot
+   * on a coarse throttle — this feeds a small activity display, not the
+   * charts, so a tick every ~100 ms is plenty.
+   */
+  const BATCH_TICK_MS = 100;
+  let batchSequence = 0;
+  const activeBatches = new Map<
+    number,
+    {
+      kind: SweepBatchStatus["kind"];
+      runCount: number;
+      handle: MonteCarloExperiment;
+    }
+  >();
+  const KIND_ORDER: Record<SweepBatchStatus["kind"], number> = {
+    selection: 0,
+    surface: 1,
+    refine: 2,
+  };
+  let batchesSnapshot: readonly SweepBatchStatus[] = [];
+  const batchListeners = new Set<() => void>();
+  const refreshBatches = () => {
+    batchesSnapshot = [...activeBatches.entries()]
+      .map(([id, batch]) => ({
+        id,
+        kind: batch.kind,
+        runCount: batch.runCount,
+        completedRuns: batch.handle.progress.get()?.completedRuns ?? 0,
+      }))
+      .sort(
+        (left, right) =>
+          KIND_ORDER[left.kind] - KIND_ORDER[right.kind] || left.id - right.id,
+      );
+    for (const listener of batchListeners) {
+      listener();
+    }
+  };
+  const batchTick: {
+    timer: ReturnType<typeof setTimeout> | null;
+    pending: boolean;
+  } = { timer: null, pending: false };
+  const refreshBatchesThrottled = () => {
+    if (batchTick.timer !== null) {
+      batchTick.pending = true;
+      return;
+    }
+    refreshBatches();
+    batchTick.timer = setTimeout(() => {
+      batchTick.timer = null;
+      if (batchTick.pending) {
+        batchTick.pending = false;
+        refreshBatchesThrottled();
+      }
+    }, BATCH_TICK_MS);
+  };
+  const registerBatch = (
+    kind: SweepBatchStatus["kind"],
+    batchRunCount: number,
+    handle: MonteCarloExperiment,
+  ): (() => void) => {
+    const id = ++batchSequence;
+    activeBatches.set(id, { kind, runCount: batchRunCount, handle });
+    const offProgress = handle.progress.subscribe(refreshBatchesThrottled);
+    // Counts change on the leading edge: a batch appearing (or leaving)
+    // should not wait out the tick.
+    refreshBatches();
+    return () => {
+      if (!activeBatches.delete(id)) {
+        return;
+      }
+      offProgress();
+      refreshBatches();
+    };
+  };
+
+  /**
    * One in-flight ladder batch. Rungs cover disjoint run ranges with
    * prefix-stable draws and seeds, so a successor can compute while its
    * predecessor is still running; only the FOLD into the cache is ordered.
@@ -602,6 +704,8 @@ export function createSweepSession(
     };
 
     handle.start();
+    const unregisterBatch = registerBatch("selection", target - from, handle);
+    void done.then(unregisterBatch);
 
     return {
       target,
@@ -879,7 +983,13 @@ export function createSweepSession(
       });
     });
     handle.start();
+    const unregisterBatch = registerBatch(
+      "refine",
+      target - snapshot.runsCompleted,
+      handle,
+    );
     const completed = await done;
+    unregisterBatch();
     const frames = handle.metrics.get().frames;
     handle.dispose();
 
@@ -1014,7 +1124,9 @@ export function createSweepSession(
             }
           });
     handle.start();
+    const unregisterBatch = registerBatch("surface", runCountTotal, handle);
     const completed = await done;
+    unregisterBatch();
     offRunResults?.();
     const runResults = handle.runResults.get();
     handle.dispose();
@@ -1026,6 +1138,15 @@ export function createSweepSession(
   };
 
   return {
+    batches: {
+      get: () => batchesSnapshot,
+      subscribe: (listener) => {
+        batchListeners.add(listener);
+        return () => {
+          batchListeners.delete(listener);
+        };
+      },
+    },
     whenSelectionStreamed() {
       if (disposed || failed || streamedGeneration === generation) {
         return Promise.resolve();
@@ -1073,6 +1194,8 @@ export function createSweepSession(
       disposed = true;
       generation += 1;
       markSelectionStreamed();
+      activeBatches.clear();
+      refreshBatches();
       abortCurrent?.();
       abortCurrent = null;
     },

--- a/libs/@hashintel/petrinaut/src/ui/components/contour-surface.stories.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/components/contour-surface.stories.tsx
@@ -179,9 +179,7 @@ const ClickableSurface = () => {
               ]
             : []
         }
-        onClickFraction={(fractionX, fractionY) =>
-          setClicked([fractionX, fractionY])
-        }
+        onPickFraction={(fraction) => setClicked([fraction.x, fraction.y])}
         aria-label="Clickable surface"
       />
       <p style={{ fontSize: 12, color: "#888", marginTop: 8 }}>

--- a/libs/@hashintel/petrinaut/src/ui/components/contour-surface.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/components/contour-surface.tsx
@@ -25,7 +25,7 @@
  * two samples interpolate to a near-uniform wash that says less than the
  * dimmed old picture does.
  */
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { css } from "@hashintel/ds-helpers/css";
 
@@ -75,6 +75,44 @@ const canvasStyle = css({
   display: "block",
   width: "[100%]",
   cursor: "crosshair",
+  // Horizontal touch drags navigate; vertical swipes stay the browser's to
+  // scroll the drawer (the browser takes the pointer over and fires
+  // pointercancel, which aborts the drag without committing).
+  touchAction: "pan-y",
+  userSelect: "none",
+});
+
+// The drag crosshair: two hairlines and a ring, positioned in percentages so
+// pointer moves never repaint the (expensive) field raster below them.
+const crosshairLineXStyle = css({
+  position: "absolute",
+  top: "[0]",
+  bottom: "[0]",
+  width: "[1px]",
+  backgroundColor: "[rgba(217, 119, 6, 0.65)]",
+  pointerEvents: "none",
+});
+
+const crosshairLineYStyle = css({
+  position: "absolute",
+  left: "[0]",
+  right: "[0]",
+  height: "[1px]",
+  backgroundColor: "[rgba(217, 119, 6, 0.65)]",
+  pointerEvents: "none",
+});
+
+const crosshairDotStyle = css({
+  position: "absolute",
+  width: "[11px]",
+  height: "[11px]",
+  borderRadius: "full",
+  borderWidth: "[2px]",
+  borderStyle: "solid",
+  borderColor: "[rgba(217, 119, 6, 0.95)]",
+  backgroundColor: "[rgba(255, 255, 255, 0.6)]",
+  transform: "translate(-50%, -50%)",
+  pointerEvents: "none",
 });
 
 /** Everything one plot instance keeps between paints. */
@@ -319,6 +357,13 @@ function paint(options: {
   }
 }
 
+export type ContourSurfaceFraction = {
+  /** Rightward fraction of the plot area, in [0, 1]. */
+  x: number;
+  /** Upward fraction of the plot area, in [0, 1]. */
+  y: number;
+};
+
 export const ContourSurface = ({
   nx,
   ny,
@@ -326,7 +371,8 @@ export const ContourSurface = ({
   markers = [],
   height = 280,
   contentKey,
-  onClickFraction,
+  onPickFraction,
+  onPreviewFraction,
   "aria-label": ariaLabel,
 }: {
   /** Grid extent in index space: value keys lie in [0, nx-1] × [0, ny-1]. */
@@ -343,10 +389,16 @@ export const ContourSurface = ({
    */
   contentKey?: string;
   /**
-   * A click on the plot, as fractions of its area: x rightward, y upward,
-   * both in [0, 1].
+   * A position picked on the plot. A click commits where it lands; a drag
+   * shows a crosshair while the pointer moves and commits on release, so the
+   * plot works as a control, not just a target.
    */
-  onClickFraction?: (fractionX: number, fractionY: number) => void;
+  onPickFraction?: (fraction: ContourSurfaceFraction) => void;
+  /**
+   * The position under the pointer while a drag is in progress — for a live
+   * readout beside the plot — and null when the drag ends or cancels.
+   */
+  onPreviewFraction?: (fraction: ContourSurfaceFraction | null) => void;
   "aria-label"?: string;
 }) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -401,16 +453,78 @@ export const ContourSurface = ({
     };
   }, [contentKey, height, markers, nx, ny, size, values]);
 
-  const handleClick = (event: React.MouseEvent<HTMLCanvasElement>) => {
-    if (!onClickFraction) {
-      return;
-    }
+  // The one pointer this component armed on pointerdown. Touch pointers get
+  // implicit capture whether or not we asked, so capture state cannot tell
+  // "our drag" from "a stray finger": only the armed id navigates, a second
+  // pointer is ignored, and a display-only plot (no onPickFraction) never
+  // arms at all.
+  const [drag, setDrag] = useState<{
+    pointerId: number;
+    fraction: ContourSurfaceFraction;
+  } | null>(null);
+  const dragPreview = drag?.fraction ?? null;
+
+  const fractionAt = (
+    event: React.PointerEvent<HTMLCanvasElement>,
+  ): ContourSurfaceFraction => {
     const bounds = event.currentTarget.getBoundingClientRect();
     const clamp = (fraction: number) => Math.min(Math.max(fraction, 0), 1);
-    onClickFraction(
-      clamp((event.clientX - bounds.left) / bounds.width),
-      clamp(1 - (event.clientY - bounds.top) / bounds.height),
-    );
+    return {
+      x: clamp((event.clientX - bounds.left) / bounds.width),
+      y: clamp(1 - (event.clientY - bounds.top) / bounds.height),
+    };
+  };
+
+  const handlePointerDown = (event: React.PointerEvent<HTMLCanvasElement>) => {
+    if (
+      !onPickFraction ||
+      event.button !== 0 ||
+      !event.isPrimary ||
+      drag !== null
+    ) {
+      return;
+    }
+    event.currentTarget.setPointerCapture(event.pointerId);
+    const fraction = fractionAt(event);
+    setDrag({ pointerId: event.pointerId, fraction });
+    onPreviewFraction?.(fraction);
+  };
+
+  const handlePointerMove = (event: React.PointerEvent<HTMLCanvasElement>) => {
+    if (drag === null || drag.pointerId !== event.pointerId) {
+      return;
+    }
+    const fraction = fractionAt(event);
+    setDrag({ pointerId: event.pointerId, fraction });
+    onPreviewFraction?.(fraction);
+  };
+
+  const endDrag = (event: React.PointerEvent<HTMLCanvasElement>): boolean => {
+    if (drag === null || drag.pointerId !== event.pointerId) {
+      return false;
+    }
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    setDrag(null);
+    onPreviewFraction?.(null);
+    return true;
+  };
+
+  const handlePointerUp = (event: React.PointerEvent<HTMLCanvasElement>) => {
+    if (endDrag(event)) {
+      // Commit where the pointer released — a plain click is the degenerate
+      // drag that never moved.
+      onPickFraction?.(fractionAt(event));
+    }
+  };
+
+  // Cancel (the browser taking a touch over to scroll) and lost capture (a
+  // context menu swallowing the release) both abort without committing.
+  const handlePointerCancel = (
+    event: React.PointerEvent<HTMLCanvasElement>,
+  ) => {
+    endDrag(event);
   };
 
   return (
@@ -420,8 +534,31 @@ export const ContourSurface = ({
         className={canvasStyle}
         style={{ height }}
         aria-label={ariaLabel}
-        onClick={handleClick}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerCancel}
+        onLostPointerCapture={handlePointerCancel}
       />
+      {dragPreview ? (
+        <>
+          <div
+            className={crosshairLineXStyle}
+            style={{ left: `${dragPreview.x * 100}%` }}
+          />
+          <div
+            className={crosshairLineYStyle}
+            style={{ top: `${(1 - dragPreview.y) * 100}%` }}
+          />
+          <div
+            className={crosshairDotStyle}
+            style={{
+              left: `${dragPreview.x * 100}%`,
+              top: `${(1 - dragPreview.y) * 100}%`,
+            }}
+          />
+        </>
+      ) : null}
     </div>
   );
 };

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/components/TopBar/running-experiments-popover.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/components/TopBar/running-experiments-popover.tsx
@@ -108,6 +108,17 @@ function formatProgress(experiment: ExperimentRecord): string {
 }
 
 function getProgressPercent(experiment: ExperimentRecord): number {
+  // Sweeps run several batches in parallel; their bar tracks the selected
+  // combination's runs — the same meaning as the drawer's bar — instead of
+  // one batch's simulated time, which saws to 100% once per ladder rung.
+  if (experiment.sweep) {
+    return experiment.runCount > 0
+      ? Math.min(
+          100,
+          (experiment.sweep.runsSampled / experiment.runCount) * 100,
+        )
+      : 0;
+  }
   const progress = experiment.progress;
   if (!progress || experiment.maxTime <= 0) {
     return 0;

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/experiments-story-fixtures.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/experiments-story-fixtures.tsx
@@ -110,6 +110,7 @@ export function makeExperiment(
             frameNumber: status === "complete" ? 180 : 45,
           }),
     latestMetricFramesById: {},
+    sweepBatches: [],
     parameterAxes: [],
     sweep: null,
     metricFrames: [],
@@ -157,6 +158,7 @@ export function makeParameterSweepExperiment(): ExperimentRecord {
         runOutput: { type: "distribution", binning: "exact" },
       },
     ],
+    sweepBatches: [],
     parameterAxes: [
       {
         identifier: "transmission_rate",
@@ -341,6 +343,7 @@ const createFakeExperiment = (
   progress: null,
   latestMetricFramesById: {},
   metricFrames: [],
+  sweepBatches: [],
   parameterAxes: [],
   sweep: null,
 });

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/sweep-navigator.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/sweep-navigator.tsx
@@ -89,7 +89,7 @@ const statusStyle = css({
   fontVariantNumeric: "tabular-nums",
 });
 
-function formatAxisValue(value: number): string {
+export function formatAxisValue(value: number): string {
   if (Number.isInteger(value)) {
     return String(value);
   }

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/sweep-surface.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/sweep-surface.tsx
@@ -27,14 +27,19 @@ import { css } from "@hashintel/ds-helpers/css";
 
 import { ExperimentsContext } from "../../../../../../react/experiments/context";
 import { quadTreeLevels } from "../../../../../../react/experiments/contour-grid";
+import { axisValueAt } from "../../../../../../react/experiments/parameter-grid";
 import {
   ContourSurface,
   contourSurfaceKey,
 } from "../../../../../components/contour-surface";
+import { formatAxisValue } from "./sweep-navigator";
 
 import type { ExperimentRecord } from "../../../../../../react/experiments/context";
 import type { ExperimentParameterAxis } from "../../../../../../react/experiments/parameter-grid";
-import type { ContourSurfaceValues } from "../../../../../components/contour-surface";
+import type {
+  ContourSurfaceFraction,
+  ContourSurfaceValues,
+} from "../../../../../components/contour-surface";
 
 /** Runs a surface point needs before it appears. */
 const SURFACE_CELL_RUNS = 8;
@@ -140,6 +145,8 @@ export const SweepSurface = ({
     walkKey: string;
     values: ReadonlyMap<string, Readonly<Record<string, number>>>;
   }>({ walkKey: "", values: new Map() });
+  /** The position under the pointer mid-drag; null outside a drag. */
+  const [preview, setPreview] = useState<ContourSurfaceFraction | null>(null);
 
   const xAxis = axes.find((axis) => axis.identifier === xAxisId);
   const yAxis = axes.find((axis) => axis.identifier === yAxisId);
@@ -277,19 +284,50 @@ export const SweepSurface = ({
     text: spec.label,
   }));
 
-  const handleClickFraction = (fractionX: number, fractionY: number) => {
+  const handlePickFraction = (fraction: ContourSurfaceFraction) => {
     if (!xAxis || !yAxis || !sweepSelection) {
       return;
     }
-    // Clicking collapses both shown axes to a point at the clicked position.
-    const xPosition = Math.round(fractionX * xAxis.stepCount);
-    const yPosition = Math.round(fractionY * yAxis.stepCount);
+    // Releasing (or clicking) collapses both shown axes to a point there.
+    const xPosition = Math.round(fraction.x * xAxis.stepCount);
+    const yPosition = Math.round(fraction.y * yAxis.stepCount);
     setSweepSelection(experimentId, {
       ...sweepSelection,
       [xAxis.identifier]: { from: xPosition, to: xPosition },
       [yAxis.identifier]: { from: yPosition, to: yPosition },
     });
   };
+
+  /**
+   * The surface-grid index of the sampled cell nearest the selection's
+   * midpoint. Grid indices map nonlinearly to axis positions on sub-sampled
+   * integer axes (rounding makes the spacing uneven), so the marker finds
+   * the nearest sampled position rather than scaling a fraction.
+   */
+  const selectionGridIndex = (axis: ExperimentParameterAxis): number => {
+    const range = sweepSelection?.[axis.identifier];
+    if (!range) {
+      return 0;
+    }
+    const midpoint = (range.from + range.to) / 2;
+    const positions = surfacePositions(axis);
+    let nearest = 0;
+    for (const [index, position] of positions.entries()) {
+      if (
+        Math.abs(position - midpoint) < Math.abs(positions[nearest]! - midpoint)
+      ) {
+        nearest = index;
+      }
+    }
+    return nearest;
+  };
+
+  /** The quantized axis value a plot fraction lands on, for the readout. */
+  const valueAtFraction = (
+    axis: NonNullable<typeof xAxis>,
+    fraction: number,
+  ): string =>
+    formatAxisValue(axisValueAt(axis, Math.round(fraction * axis.stepCount)));
 
   const cellValues: ContourSurfaceValues = new Map(
     [...grid.values.entries()].flatMap(([key, values]) => {
@@ -337,13 +375,24 @@ export const SweepSurface = ({
           ny={surfacePositions(yAxis).length}
           contentKey={`${xAxisId}|${yAxisId}|${metricId}`}
           values={cellValues}
-          onClickFraction={handleClickFraction}
+          markers={[
+            // Where the navigator currently sits on this slice — the plot is
+            // a control, so it shows its own value.
+            {
+              x: selectionGridIndex(xAxis),
+              y: selectionGridIndex(yAxis),
+              emphasis: true,
+            },
+          ]}
+          onPickFraction={handlePickFraction}
+          onPreviewFraction={setPreview}
           aria-label="Sweep surface"
         />
       ) : null}
       <span className={captionStyle}>
-        {sampledCount} of {totalCells} points sampled at {SURFACE_CELL_RUNS}+
-        runs · click to navigate
+        {preview && xAxis && yAxis
+          ? `${xAxis.identifier} = ${valueAtFraction(xAxis, preview.x)} · ${yAxis.identifier} = ${valueAtFraction(yAxis, preview.y)} — release to navigate`
+          : `${sampledCount} of ${totalCells} points sampled at ${SURFACE_CELL_RUNS}+ runs · drag or click to navigate`}
       </span>
     </div>
   );

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/view-experiment-drawer.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/view-experiment-drawer.tsx
@@ -18,6 +18,7 @@ import {
 import { formatDurationMs } from "./format-duration";
 import { SweepNavigator } from "./sweep-navigator";
 import { SweepSurface } from "./sweep-surface";
+import { ComputeActivity } from "./view-experiment-drawer/compute-activity";
 
 /**
  * Which backend ran an experiment.
@@ -73,18 +74,8 @@ const statValueStyle = css({
   whiteSpace: "nowrap",
 });
 
-const progressBarStyle = css({
-  height: "[6px]",
-  width: "full",
-  backgroundColor: "neutral.s30",
-  borderRadius: "full",
-  overflow: "hidden",
+const activityStyle = css({
   marginTop: "2",
-});
-
-const progressFillStyle = css({
-  height: "full",
-  backgroundColor: "neutral.s120",
 });
 
 const errorStyle = css({
@@ -243,10 +234,6 @@ const ExperimentSummary = ({
   experiment: ExperimentRecord;
 }) => {
   const progress = experiment.progress;
-  const progressPercent =
-    progress && experiment.maxTime > 0
-      ? Math.min(100, (progress.time / experiment.maxTime) * 100)
-      : 0;
   const now = useNow(isExperimentActive(experiment));
   const elapsedMs = getExperimentElapsedMs(experiment, now);
   const hasFinished = experiment.finishedAt !== null;
@@ -296,11 +283,8 @@ const ExperimentSummary = ({
           </span>
         </div>
       </div>
-      <div className={progressBarStyle}>
-        <div
-          className={progressFillStyle}
-          style={{ width: `${progressPercent}%` }}
-        />
+      <div className={activityStyle}>
+        <ComputeActivity experiment={experiment} />
       </div>
       {experiment.error ? (
         <span className={errorStyle}>{experiment.error}</span>

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/view-experiment-drawer.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/view-experiment-drawer.tsx
@@ -48,30 +48,66 @@ const summaryStyle = css({
   marginBottom: "3",
 });
 
-const summaryGridStyle = css({
-  display: "grid",
-  gridTemplateColumns: "[repeat(3, minmax(0, 1fr))]",
-  gap: "3",
+// Every stat carries its own leading hairline, and the strip shifts left by
+// exactly one divider-plus-gap so each row's first divider lands outside the
+// clipping wrapper — wrapped rows therefore start flush, not with a floating
+// rule (a sibling selector cannot see flex line breaks).
+const summaryStripClipStyle = css({
+  overflow: "hidden",
+});
+
+const summaryStripStyle = css({
+  display: "flex",
+  flexWrap: "wrap",
+  alignItems: "center",
+  rowGap: "2",
+  marginLeft: "[-17px]",
 });
 
 const statStyle = css({
   display: "flex",
   flexDirection: "column",
+  gap: "[1px]",
+  minWidth: "[0]",
+  paddingLeft: "4",
+  marginLeft: "[1px]",
+  borderLeftWidth: "[1px]",
+  borderLeftStyle: "solid",
+  borderLeftColor: "neutral.bd.subtle",
+  paddingRight: "4",
 });
 
 const statLabelStyle = css({
-  fontSize: "xs",
+  fontSize: "[10px]",
   fontWeight: "medium",
-  color: "neutral.s80",
+  letterSpacing: "[0.04em]",
+  textTransform: "uppercase",
+  color: "neutral.s70",
 });
 
 const statValueStyle = css({
   fontSize: "sm",
   fontWeight: "medium",
   color: "neutral.s120",
+  fontVariantNumeric: "tabular-nums",
   overflow: "hidden",
   textOverflow: "ellipsis",
   whiteSpace: "nowrap",
+});
+
+// Inline-block inside the value span, so a long value still ellipsizes (a
+// flex value container turns its text into an item ellipsis cannot reach).
+const statusDotStyle = css({
+  display: "inline-block",
+  width: "[7px]",
+  height: "[7px]",
+  borderRadius: "full",
+  marginRight: "1.5",
+  verticalAlign: "[1px]",
+  backgroundColor: "neutral.s60",
+  "&[data-tone=active]": { backgroundColor: "blue.s100" },
+  "&[data-tone=done]": { backgroundColor: "green.s90" },
+  "&[data-tone=error]": { backgroundColor: "red.s100" },
 });
 
 const activityStyle = css({
@@ -131,6 +167,23 @@ type MetricFrame = ExperimentRecord["metricFrames"][number];
 
 function formatNumber(value: number): string {
   return Number.isInteger(value) ? String(value) : value.toFixed(3);
+}
+
+function statusTone(
+  experiment: ExperimentRecord,
+): "active" | "done" | "error" | "neutral" {
+  switch (experiment.status) {
+    case "initializing":
+    case "running":
+      return "active";
+    case "complete":
+      return "done";
+    case "error":
+      return "error";
+    case "idle":
+    case "cancelled":
+      return "neutral";
+  }
 }
 
 function formatStatus(experiment: ExperimentRecord): string {
@@ -240,47 +293,55 @@ const ExperimentSummary = ({
 
   return (
     <div className={summaryStyle}>
-      <div className={summaryGridStyle}>
-        <div className={statStyle}>
-          <span className={statLabelStyle}>Status</span>
-          <span className={statValueStyle}>{formatStatus(experiment)}</span>
-        </div>
-        <div className={statStyle}>
-          <span className={statLabelStyle}>Scenario</span>
-          <span className={statValueStyle}>
-            {experiment.scenarioName ?? "Default"}
-          </span>
-        </div>
-        <div className={statStyle}>
-          <span className={statLabelStyle}>Runs</span>
-          <span className={statValueStyle}>
-            {progress
-              ? `${progress.activeRuns} active, ${progress.completedRuns} complete`
-              : experiment.runCount}
-          </span>
-        </div>
-        {(progress?.erroredRuns ?? 0) > 0 ? (
+      <div className={summaryStripClipStyle}>
+        <div className={summaryStripStyle}>
           <div className={statStyle}>
-            <span className={statLabelStyle}>Errors</span>
-            <span className={statValueStyle}>{progress?.erroredRuns}</span>
+            <span className={statLabelStyle}>Status</span>
+            <span className={statValueStyle}>
+              <span
+                className={statusDotStyle}
+                data-tone={statusTone(experiment)}
+              />
+              {formatStatus(experiment)}
+            </span>
           </div>
-        ) : null}
-        <div className={statStyle}>
-          <span className={statLabelStyle}>Time</span>
-          <span className={statValueStyle}>
-            {formatNumber(progress?.time ?? 0)} /{" "}
-            {formatNumber(experiment.maxTime)}
-          </span>
-        </div>
-        <div className={statStyle}>
-          <span className={statLabelStyle}>
-            {hasFinished ? "Duration" : "Elapsed"}
-          </span>
-          <span className={statValueStyle}>
-            {/* Wall-clock, as distinct from the simulated "Time" above it. Dashed
+          <div className={statStyle}>
+            <span className={statLabelStyle}>Scenario</span>
+            <span className={statValueStyle}>
+              {experiment.scenarioName ?? "Default"}
+            </span>
+          </div>
+          <div className={statStyle}>
+            <span className={statLabelStyle}>Runs</span>
+            <span className={statValueStyle}>
+              {progress
+                ? `${progress.activeRuns} active, ${progress.completedRuns} complete`
+                : experiment.runCount}
+            </span>
+          </div>
+          {(progress?.erroredRuns ?? 0) > 0 ? (
+            <div className={statStyle}>
+              <span className={statLabelStyle}>Errors</span>
+              <span className={statValueStyle}>{progress?.erroredRuns}</span>
+            </div>
+          ) : null}
+          <div className={statStyle}>
+            <span className={statLabelStyle}>Time</span>
+            <span className={statValueStyle}>
+              {formatNumber(progress?.time ?? 0)} /{" "}
+              {formatNumber(experiment.maxTime)}
+            </span>
+          </div>
+          <div className={statStyle}>
+            <span className={statLabelStyle}>
+              {hasFinished ? "Duration" : "Elapsed"}
+            </span>
+            <span className={statValueStyle}>
+              {/* Wall-clock, as distinct from the simulated "Time" above it. Dashed
                 out rather than shown as zero when stepping never began. */}
-            {elapsedMs === null ? "—" : formatDurationMs(elapsedMs)}
-          </span>
+              {elapsedMs === null ? "—" : formatDurationMs(elapsedMs)}
+            </span>
+          </div>
         </div>
       </div>
       <div className={activityStyle}>

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/view-experiment-drawer/compute-activity.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/view-experiment-drawer/compute-activity.tsx
@@ -1,0 +1,226 @@
+/**
+ * The summary's compute readout: an overall progress bar plus a compact,
+ * toggleable list of every batch computing right now.
+ *
+ * The single bar dates from one-simulation-at-a-time; a sweep now runs the
+ * selection's ladder, surface chunks, and cell refinements in parallel. The
+ * bar keeps meaning "the selected combination's progress" (runs sampled over
+ * the run budget — the thing the charts show), and the list underneath shows
+ * the parallelism: one row per live batch with its kind, priority, and its
+ * own progress. Collapsed, it is one line ("N computing"); nothing renders
+ * when nothing computes.
+ */
+import { useState } from "react";
+
+import { Icon } from "@hashintel/ds-components";
+import { css } from "@hashintel/ds-helpers/css";
+
+import type {
+  ExperimentRecord,
+  SweepBatchStatus,
+} from "../../../../../../../react/experiments/context";
+
+const barTrackStyle = css({
+  height: "[6px]",
+  width: "full",
+  backgroundColor: "neutral.s30",
+  borderRadius: "full",
+  overflow: "hidden",
+});
+
+const barFillStyle = css({
+  height: "full",
+  borderRadius: "full",
+  backgroundColor: "neutral.s120",
+  transition: "[width 160ms ease-out]",
+});
+
+const metaRowStyle = css({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  gap: "2",
+  marginTop: "1",
+  minHeight: "[20px]",
+});
+
+const metaLabelStyle = css({
+  fontSize: "[11px]",
+  color: "neutral.s80",
+  fontVariantNumeric: "tabular-nums",
+});
+
+const toggleStyle = css({
+  display: "inline-flex",
+  alignItems: "center",
+  gap: "1",
+  paddingX: "1.5",
+  paddingY: "[2px]",
+  borderRadius: "sm",
+  borderWidth: "[0]",
+  fontSize: "[11px]",
+  fontWeight: "medium",
+  color: "neutral.s100",
+  backgroundColor: "neutral.s10",
+  cursor: "pointer",
+  _hover: { backgroundColor: "neutral.s20" },
+});
+
+const computingDotStyle = css({
+  width: "[6px]",
+  height: "[6px]",
+  borderRadius: "full",
+  backgroundColor: "blue.s100",
+});
+
+const batchListStyle = css({
+  display: "flex",
+  flexDirection: "column",
+  gap: "[3px]",
+  marginTop: "1",
+  padding: "1.5",
+  borderWidth: "[1px]",
+  borderStyle: "solid",
+  borderColor: "neutral.bd.subtle",
+  borderRadius: "sm",
+  backgroundColor: "neutral.s10",
+});
+
+const batchRowStyle = css({
+  display: "grid",
+  gridTemplateColumns: "[76px minmax(0, 1fr) 88px]",
+  alignItems: "center",
+  gap: "2",
+  minHeight: "[16px]",
+});
+
+const batchLabelStyle = css({
+  display: "inline-flex",
+  alignItems: "center",
+  gap: "1",
+  fontSize: "[11px]",
+  color: "neutral.s100",
+  whiteSpace: "nowrap",
+});
+
+const batchDotStyle = css({
+  width: "[6px]",
+  height: "[6px]",
+  borderRadius: "full",
+  flexShrink: "0",
+  backgroundColor: "neutral.s60",
+  "&[data-tone=priority]": { backgroundColor: "blue.s100" },
+});
+
+const batchTrackStyle = css({
+  height: "[4px]",
+  borderRadius: "full",
+  backgroundColor: "neutral.s30",
+  overflow: "hidden",
+});
+
+const batchFillStyle = css({
+  height: "full",
+  borderRadius: "full",
+  backgroundColor: "neutral.s90",
+  transition: "[width 160ms ease-out]",
+  "&[data-tone=priority]": { backgroundColor: "blue.s100" },
+});
+
+const batchCountStyle = css({
+  fontSize: "[11px]",
+  color: "neutral.s80",
+  fontVariantNumeric: "tabular-nums",
+  textAlign: "right",
+  whiteSpace: "nowrap",
+});
+
+const BATCH_KIND_META: Record<
+  SweepBatchStatus["kind"],
+  { label: string; tone: "priority" | "background" }
+> = {
+  selection: { label: "Selection", tone: "priority" },
+  surface: { label: "Surface", tone: "background" },
+  refine: { label: "Refine", tone: "background" },
+};
+
+const BatchRow = ({ batch }: { batch: SweepBatchStatus }) => {
+  const meta = BATCH_KIND_META[batch.kind];
+  const percent =
+    batch.runCount > 0
+      ? Math.min(100, (batch.completedRuns / batch.runCount) * 100)
+      : 0;
+
+  return (
+    <div className={batchRowStyle}>
+      <span className={batchLabelStyle}>
+        <span className={batchDotStyle} data-tone={meta.tone} />
+        {meta.label}
+      </span>
+      <div className={batchTrackStyle}>
+        <div
+          className={batchFillStyle}
+          data-tone={meta.tone}
+          style={{ width: `${percent}%` }}
+        />
+      </div>
+      <span className={batchCountStyle}>
+        {batch.completedRuns.toLocaleString("en-US")} /{" "}
+        {batch.runCount.toLocaleString("en-US")} runs
+      </span>
+    </div>
+  );
+};
+
+export const ComputeActivity = ({
+  experiment,
+}: {
+  experiment: ExperimentRecord;
+}) => {
+  const [expanded, setExpanded] = useState(false);
+  const batches = experiment.sweepBatches;
+  const sweep = experiment.sweep;
+
+  // The bar means "the selected combination's progress": runs sampled over
+  // the budget for a sweep, simulated time for a plain experiment.
+  const percent = sweep
+    ? experiment.runCount > 0
+      ? Math.min(100, (sweep.runsSampled / experiment.runCount) * 100)
+      : 0
+    : experiment.progress && experiment.maxTime > 0
+      ? Math.min(100, (experiment.progress.time / experiment.maxTime) * 100)
+      : 0;
+  const barLabel = sweep
+    ? `Selection · ${sweep.runsSampled.toLocaleString("en-US")} / ${experiment.runCount.toLocaleString("en-US")} runs`
+    : `Time · ${(experiment.progress?.time ?? 0).toLocaleString("en-US")} / ${experiment.maxTime.toLocaleString("en-US")}`;
+
+  return (
+    <div>
+      <div className={barTrackStyle}>
+        <div className={barFillStyle} style={{ width: `${percent}%` }} />
+      </div>
+      <div className={metaRowStyle}>
+        <span className={metaLabelStyle}>{barLabel}</span>
+        {batches.length > 0 ? (
+          <button
+            type="button"
+            className={toggleStyle}
+            aria-expanded={expanded}
+            onClick={() => setExpanded((previous) => !previous)}
+          >
+            <span className={computingDotStyle} />
+            {batches.length} computing
+            <Icon name={expanded ? "chevronUp" : "chevronDown"} size="xxs" />
+          </button>
+        ) : null}
+      </div>
+      {expanded && batches.length > 0 ? (
+        <div className={batchListStyle}>
+          {batches.map((batch) => (
+            <BatchRow key={batch.id} batch={batch} />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+};

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/optimization-surface.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/optimization-surface.tsx
@@ -489,7 +489,13 @@ export const OptimizationSurface = ({
     text: axis.identifier,
   }));
 
-  const handleClickFraction = (fractionX: number, fractionY: number) => {
+  const handlePickFraction = ({
+    x: fractionX,
+    y: fractionY,
+  }: {
+    x: number;
+    y: number;
+  }) => {
     if (!xAxis || !yAxis) {
       return;
     }
@@ -561,7 +567,7 @@ export const OptimizationSurface = ({
           contentKey={`${xAxisId}|${yAxisId}`}
           values={cellValues}
           markers={trialMarkers}
-          onClickFraction={handleClickFraction}
+          onPickFraction={handlePickFraction}
           aria-label="Optimization surface"
         />
       ) : null}

--- a/libs/@local/petrinaut-arch-docs/content/experiments/sweep-surface.mdx
+++ b/libs/@local/petrinaut-arch-docs/content/experiments/sweep-surface.mdx
@@ -61,6 +61,12 @@ and a wide CPU lane). Parameters outside the two shown axes stay at the
 navigator's values, and changing any of them (or the axes) restarts the
 sampling for the new slice.
 
+The plot is a control in both directions: an orange ring marks the
+navigator's current position on the slice, and a press-drag shows a CSS
+crosshair (positioned in percentages, so pointer moves never repaint the
+field raster) with a live value readout in the caption; releasing collapses
+both shown axes to a point there, exactly as a click does.
+
 ## Rendering sparse data honestly
 
 At any moment most cells are unsampled, so the picture must make sense at


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The sweep drawer's feedback loop gets three upgrades: the contour surface becomes a control you can drag (live crosshair and value readout, commit on release, with the navigator's position marked), the summary shows every simulation computing in parallel as a compact toggleable list instead of one inherited single-run progress bar, and the summary itself tightens into a stat strip. Stacked on #9478.

## 🔗 Related links

- [FE-1552](https://linear.app/hash/issue/FE-1552) _(internal)_
- Base PR: #9478

## 🔍 What does this change?

- The contour surface navigates by drag as well as click: press shows a crosshair (CSS overlay positioned in percentages, so pointer moves never repaint the field raster) with the parameter values under the pointer in the caption; release collapses both shown axes there. An orange ring marks where the navigator currently sits (nearest sampled cell, correct on unevenly sub-sampled integer axes). Drags track one armed pointer id — a second finger is ignored, `touch-action: pan-y` leaves vertical swipes to scroll the drawer (the browser's pointercancel aborts without committing), and `lostpointercapture` cleans up when something swallows the release. The optimization surface inherits the same interaction.
- The sweep session keeps a registry of every computing batch — the selection's ladder rungs, surface chunks, cell refinements — as a `batches` store (progress ticks throttled to 100 ms), exposed on the record as `sweepBatches`. The summary renders it as a "N computing" chip that expands into compact rows: kind, its own progress bar, run counts, selection batches first and tinted as the priority work.
- The progress bar's meaning changes from one batch's simulated time (which sawed to 100% once per ladder rung) to the selected combination's runs over the run budget; the top-bar Active-experiments popover is aligned to the same meaning, so the two bars agree.
- The summary grid becomes a single wrapping stat strip with hairline dividers (dividers clip at row starts, so wrapped rows begin flush) and a status dot (blue running, green complete, red error).
- Updates the user guide's experiments page and the `sweep-surface` architecture page.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] modifies an **npm**-publishable library and **I have added a changeset file(s)**

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] require changes to docs which **are made** as part of this PR

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- `sweep-session.test.ts`: a new test pins the batch registry (selection-first ordering, the pipelined successor joining, batches dropping as they finish, dispose clearing).
- Existing contour-surface, provider, and drawer suites cover the surrounding paths; the drag interaction and the activity list were verified by driving the `Bench / SweepDrawer` story with Playwright (drag readout, commit on release, chip expansion mid-compute).

## ❓ How to test this?

1. Open `Bench / SweepDrawer → Cpu` in Storybook (`yarn workspace @hashintel/petrinaut dev:storybook`).
2. While it computes, click the "N computing" chip: the list shows the selection batch first, then surface chunks, each with its own progress.
3. Press and drag on the surface: a crosshair follows with the parameter values in the caption; release and the navigator jumps there, charts restreaming.
4. Note the orange ring marking the committed position, and the summary's status dot and stat strip.

## 📹 Demo

_Screenshots pending — will be handed over for drag-drop._
