### PR TITLE
FE-1552: Paint heatmap bins by extent and ease streamed updates in

### DIFF
--- a/.changeset/heatmap-smoothing.md
+++ b/.changeset/heatmap-smoothing.md
@@ -1,0 +1,6 @@
+---
+"@hashintel/petrinaut": patch
+"@hashintel/petrinaut-core": patch
+---
+
+Distribution metric frames carry the extent of their bins (`binExtent`, set by width binning and GPU histogram windows), and distribution heatmaps paint each bin across the rows that extent covers, so frames binned at different strides no longer alias into alternating dark and empty rows. Streamed heatmap updates ease into the picture and settle instead of snapping, so re-deliveries no longer flash.

--- a/libs/@hashintel/petrinaut-core/src/index.ts
+++ b/libs/@hashintel/petrinaut-core/src/index.ts
@@ -278,6 +278,7 @@ export type {
   MonteCarloUserDefinedMetricAggregation,
   MonteCarloUserDefinedMetricConfig,
   MonteCarloUserDefinedDistributionMetricFrame,
+  MonteCarloUserDefinedMetricBinExtent,
   MonteCarloUserDefinedMetricDistributionBin,
   MonteCarloUserDefinedMetricFrame,
   MonteCarloUserDefinedMetricMeasureInput,

--- a/libs/@hashintel/petrinaut-core/src/simulation/index.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/index.ts
@@ -63,6 +63,7 @@ export type {
   MonteCarloUserDefinedMetricAggregation,
   MonteCarloUserDefinedMetricConfig,
   MonteCarloUserDefinedDistributionMetricFrame,
+  MonteCarloUserDefinedMetricBinExtent,
   MonteCarloUserDefinedMetricDistributionBin,
   MonteCarloUserDefinedMetricFrame,
   MonteCarloUserDefinedMetricMeasureInput,

--- a/libs/@hashintel/petrinaut-core/src/simulation/monte-carlo/index.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/monte-carlo/index.ts
@@ -44,6 +44,7 @@ export type {
   MonteCarloUserDefinedMetricAggregation,
   MonteCarloUserDefinedMetricConfig,
   MonteCarloUserDefinedDistributionMetricFrame,
+  MonteCarloUserDefinedMetricBinExtent,
   MonteCarloUserDefinedMetricDistributionBin,
   MonteCarloUserDefinedMetricFrame,
   MonteCarloUserDefinedMetricMeasureInput,

--- a/libs/@hashintel/petrinaut-core/src/simulation/monte-carlo/metrics/accumulators.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/monte-carlo/metrics/accumulators.ts
@@ -1,6 +1,7 @@
 import type {
   MonteCarloMetricDistributionBinning,
   MonteCarloUserDefinedMetricAggregation,
+  MonteCarloUserDefinedMetricBinExtent,
   MonteCarloUserDefinedMetricDistributionBin,
 } from "./types";
 
@@ -41,6 +42,20 @@ function getDistributionBinValue(
   }
 
   return Math.floor(value / binning.width) * binning.width;
+}
+
+/**
+ * The extent of the bins `getDistributionBinValue` produces: a width-binned
+ * value is labelled by its lower edge, so a bin spans `[label, label + width)`.
+ * Exact bins have none.
+ */
+export function getDistributionBinExtent(
+  binning: MonteCarloMetricDistributionBinning | undefined,
+): MonteCarloUserDefinedMetricBinExtent | undefined {
+  if (!binning || binning === "exact") {
+    return undefined;
+  }
+  return { below: 0, above: binning.width };
 }
 
 export function createMonteCarloMetricNumericAccumulator(

--- a/libs/@hashintel/petrinaut-core/src/simulation/monte-carlo/metrics/index.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/monte-carlo/metrics/index.ts
@@ -29,6 +29,7 @@ export type {
   MonteCarloUserDefinedMetricAggregation,
   MonteCarloUserDefinedMetricConfig,
   MonteCarloUserDefinedDistributionMetricFrame,
+  MonteCarloUserDefinedMetricBinExtent,
   MonteCarloUserDefinedMetricDistributionBin,
   MonteCarloUserDefinedMetricFrame,
   MonteCarloUserDefinedMetricMeasureInput,

--- a/libs/@hashintel/petrinaut-core/src/simulation/monte-carlo/metrics/types.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/monte-carlo/metrics/types.ts
@@ -180,6 +180,19 @@ export type MonteCarloUserDefinedMetricDistributionBin = readonly [
   frequency: number,
 ];
 
+/**
+ * How far every bin of a frame reaches below and above its labelled value:
+ * a bin labelled `v` holds the samples in `[v - below, v + above)`. Set by
+ * producers that bin at a known width (width binning labels a bin by its
+ * lower edge; a GPU histogram window labels a stride of integer counts by
+ * its middle count). Exact bins carry no extent: they are points, and a
+ * consumer drawing them picks the resolution.
+ */
+export type MonteCarloUserDefinedMetricBinExtent = {
+  readonly below: number;
+  readonly above: number;
+};
+
 export type MonteCarloUserDefinedScalarMetricFrame =
   MonteCarloUserDefinedMetricFrameBase & {
     outputType: "scalar";
@@ -211,6 +224,8 @@ export type MonteCarloUserDefinedDistributionMetricFrame =
   MonteCarloUserDefinedMetricFrameBase & {
     outputType: "distribution";
     bins: readonly MonteCarloUserDefinedMetricDistributionBin[];
+    /** Absent when the bins are exact values. */
+    binExtent?: MonteCarloUserDefinedMetricBinExtent;
     value: null;
     frameValue: null;
     timeValue: null;

--- a/libs/@hashintel/petrinaut-core/src/simulation/monte-carlo/metrics/user-defined.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/monte-carlo/metrics/user-defined.ts
@@ -2,6 +2,7 @@ import {
   addAllMonteCarloMetricValues,
   createMonteCarloMetricHistogramAccumulator,
   createMonteCarloMetricNumericAccumulator,
+  getDistributionBinExtent,
 } from "./accumulators";
 
 import type { MonteCarloMetricNumericAccumulatorState } from "./accumulators";
@@ -160,6 +161,7 @@ export function createMonteCarloUserDefinedMetric(
               distributionValues,
             ),
           ),
+          binExtent: getDistributionBinExtent(runOutput.binning),
           runSampleCount: runValues.length,
           timeSampleCount,
         });

--- a/libs/@hashintel/petrinaut-core/src/webgpu/gpu-experiment-handle.ts
+++ b/libs/@hashintel/petrinaut-core/src/webgpu/gpu-experiment-handle.ts
@@ -457,6 +457,8 @@ export async function createGpuMonteCarloExperiment(
       frameNumber: 0,
       metricId: metric.id,
       bins: [[count, config.runCount]] as [number, number][],
+      // An exact count: the cell of one integer.
+      binExtent: { below: 0.5, above: 0.5 },
       sampleCount: config.runCount,
     };
   });

--- a/libs/@hashintel/petrinaut-core/src/webgpu/gpu-metric-frames.ts
+++ b/libs/@hashintel/petrinaut-core/src/webgpu/gpu-metric-frames.ts
@@ -77,6 +77,7 @@ function toMetricFrame(
       frameValue: null,
       timeValue: null,
       bins: histogram.bins,
+      binExtent: histogram.binExtent,
       runSampleCount: histogram.sampleCount,
       timeSampleCount: histogram.sampleCount,
     };

--- a/libs/@hashintel/petrinaut-core/src/webgpu/runner.ts
+++ b/libs/@hashintel/petrinaut-core/src/webgpu/runner.ts
@@ -133,6 +133,13 @@ export type GpuHistogramFrame = {
   metricId: string;
   /** `[value, frequency]` pairs, ascending, zero bins omitted. */
   bins: [number, number][];
+  /**
+   * The counts a bin stands for, as a reach below and above its label: a
+   * stride-`s` window bin labelled `v` holds the integer counts in
+   * `[v - below, v + above)`, half a count either side of its outermost
+   * integers.
+   */
+  binExtent: { below: number; above: number };
   /** Runs that contributed a sample; equals the active run count. */
   sampleCount: number;
 };
@@ -568,6 +575,13 @@ function decodeHistogramFrames(options: {
       // window's means unbiased where the low edge skewed them down by
       // (stride − 1) / 2. Exact (offset 0) at stride 1.
       const binMidpoint = Math.floor((window.stride - 1) / 2);
+      // The label is the bin's middle count, so the bin reaches `binMidpoint`
+      // whole counts below it and the rest above; the half count either side
+      // is where an integer's cell begins and ends.
+      const binExtent = {
+        below: binMidpoint + 0.5,
+        above: window.stride - binMidpoint - 0.5,
+      };
       const offset =
         frame * histogramBins * metricCount + metricIndex * histogramBins;
       const bins: [number, number][] = [];
@@ -583,6 +597,7 @@ function decodeHistogramFrames(options: {
         frameNumber: firstFrame + frame,
         metricId,
         bins,
+        binExtent,
         sampleCount,
       });
     }

--- a/libs/@hashintel/petrinaut/docs/experiments.md
+++ b/libs/@hashintel/petrinaut/docs/experiments.md
@@ -118,7 +118,7 @@ A badge beside the **Summary** heading shows whether the run used the **CPU** or
 
 ### Metric charts
 
-Each metric gets a chart of its values over simulation time. A scalar metric draws a line. A distribution metric (one value per run) defaults to a **heatmap**: each time step is a column shaded on a pale-to-dark color ramp, where the darkest cell marks the value most runs had at that moment and paler shades mark rarer values. Shading is relative to each time step on its own, so a moment where runs agree and a moment where they spread out are both readable.
+Each metric gets a chart of its values over simulation time. A scalar metric draws a line. A distribution metric (one value per run) defaults to a **heatmap**: each time step is a column shaded on a pale-to-dark color ramp, where the darkest cell marks the value most runs had at that moment and paler shades mark rarer values. Shading is relative to each time step on its own, so a moment where runs agree and a moment where they spread out are both readable. While results still stream, each update eases into the picture over a few refreshes instead of snapping, so a batch landing or a re-run replacing earlier samples reads as the distribution firming up rather than flashing.
 
 The controls under each chart change what is plotted:
 

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/experiment-metric-timeline.stories.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/experiment-metric-timeline.stories.tsx
@@ -151,6 +151,64 @@ export const Complete: Story = {
   ),
 };
 
+/**
+ * Frames on two lattices at once: the host's exact initial frame (a single
+ * integer value) followed by frames binned at a stride of 2, as a windowed
+ * GPU histogram delivers them. The heatmap must paint each stride-2 bin
+ * across both rows it spans — not light one row and leave the next empty.
+ */
+function buildMixedLatticeFrames(): MetricFrame[] {
+  const distribution = (
+    frameNumber: number,
+    bins: [number, number][],
+    binExtent?: { below: number; above: number },
+  ): MetricFrame => {
+    const runSampleCount = bins.reduce((sum, [, count]) => sum + count, 0);
+    return {
+      metricId: "infected",
+      label: "Infected",
+      outputType: "distribution",
+      frameNumber,
+      time: frameNumber,
+      bins,
+      binExtent,
+      value: null,
+      frameValue: null,
+      timeValue: null,
+      runSampleCount,
+      timeSampleCount: runSampleCount,
+    };
+  };
+  const frames: MetricFrame[] = [distribution(0, [[10, 1_000]])];
+  for (let frameNumber = 1; frameNumber < FRAME_COUNT; frameNumber++) {
+    const center = 10 + frameNumber * 1.4;
+    const bins: [number, number][] = [];
+    // Bins at odd values only (lo = 11, stride 2), a bell around `center`.
+    // The GPU labels an even stride by its lower count, so bin 11 holds the
+    // counts 11 and 12: half a count below its label, one and a half above.
+    for (let value = 11; value <= 95; value += 2) {
+      const count = Math.round(
+        1_000 *
+          Math.exp(-((value - center) ** 2) / (2 * (4 + frameNumber / 6) ** 2)),
+      );
+      if (count > 0) {
+        bins.push([value, count]);
+      }
+    }
+    frames.push(distribution(frameNumber, bins, { below: 0.5, above: 1.5 }));
+  }
+  return frames;
+}
+
+export const MixedLattice: Story = {
+  name: "Mixed bin lattices (exact frame 0 + stride-2 frames)",
+  render: () => (
+    <Card caption="Frame 0 sits on the integer lattice; every later frame is binned at a stride of 2. Rows follow the finest gap, so each wide bin must fill two rows.">
+      <SizedTimeline frames={buildMixedLatticeFrames()} />
+    </Card>
+  ),
+};
+
 export const Empty: Story = {
   name: "Waiting for data",
   render: () => (

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/experiment-metric-timeline/use-metric-plot.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/experiment-metric-timeline/use-metric-plot.ts
@@ -80,6 +80,7 @@ export function useMetricPlot({
   const plotRef = useRef<uPlot | null>(null);
   const latestDataRef = useRef(plotData);
   const latestFramesRef = useRef(frames);
+  const epochRef = useRef(contentEpoch);
   /** Highest y ceiling shown by the current view; reset when the view changes. */
   const yFloorRef = useRef(0);
   const viewKeyRef = useRef("");
@@ -130,7 +131,9 @@ export function useMetricPlot({
               ? [timeDomainStart, timeDomainEnd]
               : undefined,
             yFloorRef,
-            isHeatmap ? [createDistributionHeatmapPlugin(latestFramesRef)] : [],
+            isHeatmap
+              ? [createDistributionHeatmapPlugin(latestFramesRef, epochRef)]
+              : [],
           ),
       [[], []] as uPlot.AlignedData,
       root,
@@ -216,7 +219,6 @@ export function useMetricPlot({
     timeTrace,
   ]);
 
-  const epochRef = useRef(contentEpoch);
   /**
    * An epoch change seen but not yet painted. Latched separately from the
    * scheduled frame: a same-epoch data tick can cancel the epoch-change

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/experiment-metric-timeline/use-metric-plot/distribution-heatmap.test.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/experiment-metric-timeline/use-metric-plot/distribution-heatmap.test.ts
@@ -1,17 +1,22 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  blendHeatmapGrids,
   buildHeatmapDensityGrid,
+  easeHeatmapDisplay,
+  HEATMAP_SETTLE_STEPS,
   magmaLut,
   rasterizeHeatmap,
+  settleHeatmapDisplay,
 } from "./distribution-heatmap";
 
-import type { HeatmapFrame } from "./distribution-heatmap";
+import type { HeatmapDensityGrid, HeatmapFrame } from "./distribution-heatmap";
 
 const frame = (
   time: number,
   bins: (readonly [number, number])[],
-): HeatmapFrame => ({ time, bins });
+  binExtent?: HeatmapFrame["binExtent"],
+): HeatmapFrame => ({ time, bins, binExtent });
 
 /** Tall enough that the pixel cap never constrains the lattice. */
 const TALL_PLOT = 4_000;
@@ -62,6 +67,11 @@ describe("buildHeatmapDensityGrid", () => {
     expect(grid.densities[0 * 2 + 1]).toBe(0); // value 0, column 1
     expect(grid.densities[1 * 2 + 1]).toBeCloseTo(1); // value 500, column 1
     expect(grid.densities[2 * 2 + 1]).toBe(0); // value 1000, column 1
+    // And the two-mode exact frame stays two modes: nothing is inferred
+    // from the gap between the values it happens to occupy.
+    expect(grid.densities[0 * 2]).toBeCloseTo(1); // value 0, column 0
+    expect(grid.densities[1 * 2]).toBe(0); // value 500, column 0
+    expect(grid.densities[2 * 2]).toBeCloseTo(1); // value 1000, column 0
   });
 
   it("caps the grid at the plot's pixel resolution", () => {
@@ -78,6 +88,34 @@ describe("buildHeatmapDensityGrid", () => {
     expect(grid.rows).toBe(220); // 440 device px / 2, not 1001 lattice rows
   });
 
+  it("keeps every bin when the lattice gap is below floating-point resolution", () => {
+    // Two values one ulp apart force a lattice gap of ~2e-16, so an exact
+    // bin's half-step extent vanishes against its own value; the count must
+    // still land in the value's row rather than be dropped.
+    const grid = buildHeatmapDensityGrid(
+      [
+        frame(0, [
+          [0, 1],
+          [Number.EPSILON, 1],
+          [1, 1],
+          [2, 1],
+          [3, 1],
+        ]),
+      ],
+      TALL_PLOT,
+    )!;
+    const rowOf = (value: number) =>
+      Math.round(
+        ((value - grid.valueMin) / (grid.valueMax - grid.valueMin)) *
+          (grid.rows - 1),
+      );
+    // Row 0 holds two bins and normalizes to 1; the others hold one each.
+    expect(grid.densities[rowOf(0)]).toBeCloseTo(1);
+    for (const value of [1, 2, 3]) {
+      expect(grid.densities[rowOf(value)]).toBeCloseTo(0.5);
+    }
+  });
+
   it("returns null without bins and pads a single-value range", () => {
     expect(buildHeatmapDensityGrid([frame(0, [])], TALL_PLOT)).toBeNull();
 
@@ -92,6 +130,176 @@ describe("buildHeatmapDensityGrid", () => {
       total += density;
     }
     expect(total).toBeGreaterThan(0);
+  });
+});
+
+describe("buildHeatmapDensityGrid with mixed lattices", () => {
+  it("fills every row a wide bin spans instead of striping alternate rows", () => {
+    // Frame 0 is the host's exact initial value; frame 1 is binned at a
+    // stride of 2 (a windowed GPU histogram, which labels an even stride by
+    // its lower count: bin 11 holds counts 11 and 12). The chart-wide gap
+    // is 1, so the grid has a row per unit — and each stride-2 bin must
+    // cover both of its rows evenly, not light one and leave the next empty.
+    const stride2 = { below: 0.5, above: 1.5 };
+    const grid = buildHeatmapDensityGrid(
+      [
+        frame(0, [[10, 100]]),
+        frame(
+          1,
+          [
+            [11, 50],
+            [13, 50],
+            [15, 50],
+          ],
+          stride2,
+        ),
+      ],
+      TALL_PLOT,
+    )!;
+    expect(grid.rows).toBe(6); // values 10..15
+    const column1 = (row: number) => grid.densities[row * 2 + 1]!;
+    // Rows 11..15 are uniform — each fully inside one stride-2 bin (bin 15
+    // reaches to 16, off the grid). Row 10, the exact frame's value, is a
+    // count no stride-2 bin holds.
+    for (const row of [1, 2, 3, 4, 5]) {
+      expect(column1(row)).toBeCloseTo(1);
+    }
+    expect(column1(0)).toBe(0);
+  });
+
+  it("paints a width-binned frame from each bin's lower edge", () => {
+    // Width binning labels a bin by its lower edge: bin 0 of width 2 holds
+    // [0, 2). On a unit lattice whose rows are centered on 0 and 1 it covers
+    // half of row 0's cell and all of row 1's (the rest is off the grid) —
+    // it reaches up from its label, not down to -1.
+    const grid = buildHeatmapDensityGrid(
+      [frame(0, [[1, 100]]), frame(1, [[0, 100]], { below: 0, above: 2 })],
+      TALL_PLOT,
+    )!;
+    expect(grid.rows).toBe(2); // values 0..1
+    expect(grid.densities[0 * 2 + 1]).toBeCloseTo(0.5);
+    expect(grid.densities[1 * 2 + 1]).toBeCloseTo(1);
+  });
+
+  it("keeps a bin exactly on the lattice in its own row", () => {
+    const grid = buildHeatmapDensityGrid(
+      [
+        frame(0, [
+          [0, 1],
+          [1, 3],
+          [2, 1],
+        ]),
+      ],
+      TALL_PLOT,
+    )!;
+    expect(grid.rows).toBe(3);
+    expect(grid.densities[0]).toBeCloseTo(1 / 3);
+    expect(grid.densities[1]).toBeCloseTo(1);
+    expect(grid.densities[2]).toBeCloseTo(1 / 3);
+  });
+});
+
+const twoRows = (
+  columns: number[][],
+  valueMin = 0,
+  valueMax = 1,
+): HeatmapDensityGrid => {
+  const cols = columns.length;
+  const densities = new Float32Array(2 * cols);
+  for (const [column, [low, high]] of columns.entries()) {
+    densities[0 * cols + column] = low!;
+    densities[1 * cols + column] = high!;
+  }
+  return { columns: cols, rows: 2, densities, valueMin, valueMax };
+};
+
+describe("blendHeatmapGrids", () => {
+  it("shows the next grid outright without a previous one", () => {
+    const next = twoRows([[1, 0]]);
+    expect(blendHeatmapGrids(null, next)).toBe(next);
+  });
+
+  it("mixes shared columns and takes appended columns as they are", () => {
+    const previous = twoRows([[1, 0]]);
+    const next = twoRows([
+      [0, 1],
+      [0.2, 0.8],
+    ]);
+    const blended = blendHeatmapGrids(previous, next, 0.5);
+    // Column 0 existed before: halfway between the two pictures.
+    expect(blended.densities[0]).toBeCloseTo(0.5);
+    expect(blended.densities[2]).toBeCloseTo(0.5);
+    // Column 1 is new: exactly the next grid.
+    expect(blended.densities[1]).toBeCloseTo(0.2);
+    expect(blended.densities[3]).toBeCloseTo(0.8);
+  });
+
+  it("resamples a previous grid whose lattice moved", () => {
+    // Previous covers values 0..1 (rows at 0 and 1); next covers 0..2 with
+    // rows at 0, 1, 2. Row 2 lies outside the previous range: nothing to mix.
+    const previous = twoRows([[1, 0]], 0, 1);
+    const next: HeatmapDensityGrid = {
+      columns: 1,
+      rows: 3,
+      densities: new Float32Array([0, 0, 1]),
+      valueMin: 0,
+      valueMax: 2,
+    };
+    const blended = blendHeatmapGrids(previous, next, 0.5);
+    expect(blended.densities[0]).toBeCloseTo(0.5); // previous 1 at value 0
+    expect(blended.densities[1]).toBeCloseTo(0); // previous 0 at value 1
+    expect(blended.densities[2]).toBeCloseTo(0.5); // no previous, next only
+  });
+
+  it("samples a single-row grid at its value, not its padded edge", () => {
+    // Previous has rows at 5..9 with all the density at 7; next collapsed
+    // to the single value 7 (padded to 6.5..7.5). The previous density at
+    // 7 is 1, so the blend stays 1 — sampling at the padded edge 6.5 would
+    // read halfway between rows 6 and 7 instead.
+    const previous: HeatmapDensityGrid = {
+      columns: 1,
+      rows: 5,
+      densities: new Float32Array([0, 0, 1, 0, 0]),
+      valueMin: 5,
+      valueMax: 9,
+    };
+    const next: HeatmapDensityGrid = {
+      columns: 1,
+      rows: 1,
+      densities: new Float32Array([1]),
+      valueMin: 6.5,
+      valueMax: 7.5,
+    };
+    expect(blendHeatmapGrids(previous, next, 0.5).densities[0]).toBeCloseTo(1);
+  });
+});
+
+describe("heatmap display easing", () => {
+  it("paints exactly when there is nothing to ease from", () => {
+    const target = twoRows([[0, 1]]);
+    const display = easeHeatmapDisplay(null, target);
+    expect(display.grid).toBe(target);
+    expect(display.stepsLeft).toBe(0);
+  });
+
+  it("eases in from the shown grid and settles to the exact target", () => {
+    const shown = easeHeatmapDisplay(null, twoRows([[1, 0]]));
+    const target = twoRows([[0, 1]]);
+    let display = easeHeatmapDisplay(shown, target);
+    expect(display.grid.densities[1]).toBeCloseTo(0.5);
+    expect(display.stepsLeft).toBe(HEATMAP_SETTLE_STEPS);
+
+    // Each settle step halves what remains of the old picture...
+    display = settleHeatmapDisplay(display);
+    expect(display.grid.densities[1]).toBeCloseTo(0.75);
+    display = settleHeatmapDisplay(display);
+    expect(display.grid.densities[1]).toBeCloseTo(0.875);
+    // ...and the last one is the target itself, not another half-step.
+    display = settleHeatmapDisplay(display);
+    expect(display.grid).toBe(target);
+    expect(display.stepsLeft).toBe(0);
+    // Settling a settled display is a no-op.
+    expect(settleHeatmapDisplay(display).grid).toBe(target);
   });
 });
 

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/experiment-metric-timeline/use-metric-plot/distribution-heatmap.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/experiment-metric-timeline/use-metric-plot/distribution-heatmap.ts
@@ -2,13 +2,19 @@
  * The distribution heatmap: a uPlot plugin that paints every streamed
  * distribution frame as one column of a density image.
  *
- * The pipeline is fixed. Each frame's bins are splatted onto a value-axis
+ * The pipeline is fixed. Each frame's bins are painted onto a value-axis
  * grid at the histogram's own resolution (one row per bin step, capped at
- * plot-pixel resolution), each column is normalized against its own
- * maximum (full color marks the most likely value at that time step), and
- * the grid is drawn through a magma lookup table in a single `drawImage` —
- * no per-bin canvas state, no smoothing: what is dark is exactly where the
- * runs concentrated.
+ * plot-pixel resolution), each bin spread over the rows its extent covers,
+ * each column normalized against its own maximum (full color marks the most
+ * likely value at that time step), and the grid drawn through a magma lookup
+ * table in a single `drawImage` — no per-bin canvas state: what is dark is
+ * exactly where the runs concentrated.
+ *
+ * Bins are painted by the extent their producer declared, not as points:
+ * frames on different lattices (the host-emitted exact initial frame next
+ * to GPU frames binned at a stride; a probe's guessed window next to the
+ * calibrated one) would otherwise alias into alternating dark and empty
+ * rows.
  */
 import uPlot from "uplot";
 
@@ -20,7 +26,10 @@ import type {
 } from "../shared/metric-frames";
 
 /** The slice of a distribution frame the heatmap reads. */
-export type HeatmapFrame = Pick<DistributionMetricFrame, "time" | "bins">;
+export type HeatmapFrame = Pick<
+  DistributionMetricFrame,
+  "time" | "bins" | "binExtent"
+>;
 
 /** One grid row per this many device pixels of plot height, at most. */
 const DEVICE_PIXELS_PER_ROW = 2;
@@ -39,6 +48,8 @@ type ValueLattice = {
   /** [min, max] over every bin value, padded to a span > 0. */
   range: [number, number];
   rows: number;
+  /** The smallest gap between any two bin values across the chart. */
+  minGap: number;
 };
 
 /**
@@ -82,24 +93,29 @@ function valueLattice(
     return null;
   }
   if (min === max) {
-    return { range: [min - 0.5, max + 0.5], rows: 1 };
-  }
-  if (distinct.size > rowCap) {
-    return { range: [min, max], rows: rowCap };
+    return { range: [min - 0.5, max + 0.5], rows: 1, minGap: 1 };
   }
   const sorted = [...distinct].sort((left, right) => left - right);
   let minGap = Number.POSITIVE_INFINITY;
   for (let index = 1; index < sorted.length; index++) {
     minGap = Math.min(minGap, sorted[index]! - sorted[index - 1]!);
   }
+  if (distinct.size > rowCap) {
+    return { range: [min, max], rows: rowCap, minGap };
+  }
   const latticeRows = Math.round((max - min) / minGap) + 1;
-  return { range: [min, max], rows: Math.min(latticeRows, rowCap) };
+  return { range: [min, max], rows: Math.min(latticeRows, rowCap), minGap };
 }
 
 /**
  * Rasterize the frames into a column-normalized density grid: each bin's
- * count is spread over the two grid rows nearest its value (linear splat),
- * then every column is scaled so its own densest cell is 1.
+ * count is spread over the rows its extent covers (`[v - below, v + above]`
+ * as the producer declared it; an exact bin gets the cell of one lattice
+ * step around its value), weighted by overlap, then every column is scaled
+ * so its own densest cell is 1. A bin exactly on the lattice lands wholly in
+ * its row; a bin wider than a row fills every row it spans evenly; a bin
+ * between rows shares out by area. Nothing is inferred from which values a
+ * frame happens to occupy: a sparse or two-mode frame stays sparse.
  */
 export function buildHeatmapDensityGrid(
   frames: readonly HeatmapFrame[],
@@ -111,18 +127,42 @@ export function buildHeatmapDensityGrid(
   }
   const { rows } = lattice;
   const [valueMin, valueMax] = lattice.range;
-  const span = valueMax - valueMin;
+  const rowStep = rows > 1 ? (valueMax - valueMin) / (rows - 1) : 1;
   const columns = frames.length;
   const densities = new Float32Array(rows * columns);
 
   for (let column = 0; column < columns; column++) {
-    for (const [value, count] of frames[column]!.bins) {
-      const position = ((value - valueMin) / span) * (rows - 1);
-      const lowRow = Math.floor(position);
-      const highRow = Math.min(lowRow + 1, rows - 1);
-      const highWeight = position - lowRow;
-      densities[lowRow * columns + column]! += count * (1 - highWeight);
-      densities[highRow * columns + column]! += count * highWeight;
+    const frame = frames[column]!;
+    const below = frame.binExtent?.below ?? lattice.minGap / 2;
+    const above = frame.binExtent?.above ?? lattice.minGap / 2;
+    for (const [value, count] of frame.bins) {
+      // The bin's extent in row units, where row r spans [r - 0.5, r + 0.5].
+      const lower = (value - below - valueMin) / rowStep;
+      const upper = (value + above - valueMin) / rowStep;
+      const extent = upper - lower;
+      if (extent <= 0) {
+        // Narrower than floating point resolves at this value (the chart
+        // has more distinct values than rows, so the lattice gap is far
+        // below the row step): the whole count goes to the row the value
+        // falls in. Dropping it would erase runs that happened.
+        const row = Math.round((value - valueMin) / rowStep);
+        if (row >= 0 && row < rows) {
+          densities[row * columns + column]! += count;
+        }
+        continue;
+      }
+      // Weight by overlap with the bin's full extent. The half bin reaching
+      // past the outermost row centers is off the grid and simply not drawn
+      // — renormalizing it into the edge rows made them darker than the
+      // interior, an artifact of the grid's bounds rather than the data.
+      const firstRow = Math.max(0, Math.floor(lower + 0.5));
+      const lastRow = Math.min(rows - 1, Math.floor(upper + 0.5));
+      for (let row = firstRow; row <= lastRow; row++) {
+        const overlap = Math.min(upper, row + 0.5) - Math.max(lower, row - 0.5);
+        if (overlap > 0) {
+          densities[row * columns + column]! += (count * overlap) / extent;
+        }
+      }
     }
 
     let max = 0;

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/experiment-metric-timeline/use-metric-plot/distribution-heatmap.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/experiment-metric-timeline/use-metric-plot/distribution-heatmap.ts
@@ -10,11 +10,16 @@
  * table in a single `drawImage` — no per-bin canvas state: what is dark is
  * exactly where the runs concentrated.
  *
- * Bins are painted by the extent their producer declared, not as points:
- * frames on different lattices (the host-emitted exact initial frame next
- * to GPU frames binned at a stride; a probe's guessed window next to the
- * calibrated one) would otherwise alias into alternating dark and empty
- * rows.
+ * Two things keep a streaming picture honest AND calm. Bins are painted by
+ * the extent their producer declared, not as points: frames on different
+ * lattices (the host-emitted exact initial frame next to GPU frames binned
+ * at a stride; a probe's guessed window next to the calibrated one) would
+ * otherwise alias into alternating dark and empty rows. And within one
+ * selection, each new grid eases in from the one on screen (resampled by
+ * value when the lattice moved) and settles over a few steps, so a
+ * cumulative re-delivery — a GPU tile, a re-run, a pipelined rung folding
+ * in — blends in instead of snapping the whole picture, and the stream's
+ * last delivery ends in exactly the picture its data describes.
  */
 import uPlot from "uplot";
 
@@ -179,6 +184,139 @@ export function buildHeatmapDensityGrid(
   return { columns, rows, densities, valueMin, valueMax };
 }
 
+/**
+ * How much of a new grid shows per blend step; the rest is the picture
+ * already on screen.
+ */
+export const HEATMAP_BLEND_WEIGHT = 0.5;
+
+/**
+ * The previous grid's density at `value` in `column`, sampled linearly
+ * between its rows; 0 outside its value range.
+ */
+function sampleGrid(
+  grid: HeatmapDensityGrid,
+  column: number,
+  value: number,
+): number {
+  if (grid.rows === 1) {
+    return value >= grid.valueMin && value <= grid.valueMax
+      ? grid.densities[column]!
+      : 0;
+  }
+  const position =
+    ((value - grid.valueMin) / (grid.valueMax - grid.valueMin)) *
+    (grid.rows - 1);
+  if (position < -0.5 || position > grid.rows - 0.5) {
+    return 0;
+  }
+  const lowRow = Math.max(0, Math.min(grid.rows - 1, Math.floor(position)));
+  const highRow = Math.min(grid.rows - 1, lowRow + 1);
+  const highWeight = Math.max(0, Math.min(1, position - lowRow));
+  return (
+    grid.densities[lowRow * grid.columns + column]! * (1 - highWeight) +
+    grid.densities[highRow * grid.columns + column]! * highWeight
+  );
+}
+
+/**
+ * `next` mixed with what was on screen, so a re-delivery that reshapes
+ * existing columns eases in rather than snapping. Columns `previous` never
+ * had (frames appended since) show `next` as is; a lattice that moved is
+ * bridged by sampling `previous` at each new row's value. Blending two
+ * column-normalized grids can leave a column's peak below 1 mid-transition —
+ * that lightening IS the fade, and the settle steps take it back to 1.
+ */
+export function blendHeatmapGrids(
+  previous: HeatmapDensityGrid | null,
+  next: HeatmapDensityGrid,
+  weight = HEATMAP_BLEND_WEIGHT,
+): HeatmapDensityGrid {
+  if (previous === null || weight >= 1) {
+    return next;
+  }
+  const sharedColumns = Math.min(previous.columns, next.columns);
+  if (sharedColumns === 0) {
+    return next;
+  }
+  const rowStep =
+    next.rows > 1 ? (next.valueMax - next.valueMin) / (next.rows - 1) : 0;
+  const sameLattice =
+    previous.rows === next.rows &&
+    previous.valueMin === next.valueMin &&
+    previous.valueMax === next.valueMax;
+  const densities = new Float32Array(next.densities);
+  for (let row = 0; row < next.rows; row++) {
+    // A single-row grid's value sits at the center of its padded range.
+    const value =
+      next.rows > 1
+        ? next.valueMin + row * rowStep
+        : (next.valueMin + next.valueMax) / 2;
+    for (let column = 0; column < sharedColumns; column++) {
+      const index = row * next.columns + column;
+      const before = sameLattice
+        ? previous.densities[row * previous.columns + column]!
+        : sampleGrid(previous, column, value);
+      densities[index] =
+        before * (1 - weight) + next.densities[index]! * weight;
+    }
+  }
+  return { ...next, densities };
+}
+
+/**
+ * The settle that follows a blended paint when no further data arrives:
+ * `HEATMAP_SETTLE_STEPS` redraws, `HEATMAP_SETTLE_MS` apart (the session's
+ * publish cadence), each halving what remains of the old picture, the last
+ * painting the new grid exactly. Without it the stream's final delivery
+ * would stay a permanent half-mix — column peaks below 1, the darkest cell
+ * no longer the most likely value.
+ */
+export const HEATMAP_SETTLE_STEPS = 3;
+export const HEATMAP_SETTLE_MS = 100;
+
+export type HeatmapDisplay = {
+  /** What is on screen. */
+  grid: HeatmapDensityGrid;
+  /** What the latest frames describe; `grid` converges to it. */
+  target: HeatmapDensityGrid;
+  /** Settle steps still to run before `grid` is `target`. */
+  stepsLeft: number;
+};
+
+/**
+ * The display after new frames built `target`: eased in from `shown` when
+ * there is a picture to ease from, painted exactly otherwise.
+ */
+export function easeHeatmapDisplay(
+  shown: HeatmapDisplay | null,
+  target: HeatmapDensityGrid,
+): HeatmapDisplay {
+  if (shown === null) {
+    return { grid: target, target, stepsLeft: 0 };
+  }
+  return {
+    grid: blendHeatmapGrids(shown.grid, target),
+    target,
+    stepsLeft: HEATMAP_SETTLE_STEPS,
+  };
+}
+
+/**
+ * One settle step toward the target; the last step is the target itself,
+ * so the sequence ends exact rather than asymptotically close.
+ */
+export function settleHeatmapDisplay(shown: HeatmapDisplay): HeatmapDisplay {
+  if (shown.stepsLeft <= 1) {
+    return { grid: shown.target, target: shown.target, stepsLeft: 0 };
+  }
+  return {
+    grid: blendHeatmapGrids(shown.grid, shown.target),
+    target: shown.target,
+    stepsLeft: shown.stepsLeft - 1,
+  };
+}
+
 /** Matplotlib's magma, subsampled; position 0 is lightest, 1 darkest. */
 const MAGMA_STOPS: readonly (readonly [number, number, number, number])[] = [
   [0, 252, 253, 191],
@@ -241,9 +379,15 @@ export function rasterizeHeatmap(
   return pixels;
 }
 
-export function createDistributionHeatmapPlugin(framesRef: {
-  current: readonly MetricFrame[];
-}): uPlot.Plugin {
+/**
+ * @param framesRef the frames to paint, read at draw time
+ * @param epochRef the selection the frames belong to; frames of a new epoch
+ *   start from their own data instead of easing in from the old selection
+ */
+export function createDistributionHeatmapPlugin(
+  framesRef: { current: readonly MetricFrame[] },
+  epochRef?: { current: string | undefined },
+): uPlot.Plugin {
   const lut = magmaLut();
   // One cell-resolution scratch canvas per plugin (per uPlot instance),
   // created lazily so importing this module stays DOM-free.
@@ -252,55 +396,107 @@ export function createDistributionHeatmapPlugin(framesRef: {
   // the same frames at the same plot height reuse the rasterized cells.
   let rasterCache: {
     frames: readonly MetricFrame[];
+    epoch: string | undefined;
     bboxHeight: number;
-    grid: HeatmapDensityGrid;
+    display: HeatmapDisplay;
     timeFirst: number;
     timeLast: number;
   } | null = null;
+  // The pending settle redraw, and whether the next draw IS that redraw
+  // (as opposed to one uPlot runs for its own reasons).
+  const settle: { timer: ReturnType<typeof setTimeout> | null; due: boolean } =
+    { timer: null, due: false };
+
+  const cancelSettle = () => {
+    if (settle.timer !== null) {
+      clearTimeout(settle.timer);
+      settle.timer = null;
+    }
+    settle.due = false;
+  };
+  const scheduleSettle = (u: uPlot) => {
+    cancelSettle();
+    settle.timer = setTimeout(() => {
+      settle.timer = null;
+      settle.due = true;
+      u.redraw(false, false);
+    }, HEATMAP_SETTLE_MS);
+  };
+  const paint = (grid: HeatmapDensityGrid) => {
+    cellCanvas ??= document.createElement("canvas");
+    cellCanvas.width = grid.columns;
+    cellCanvas.height = grid.rows;
+    cellCanvas
+      .getContext("2d")!
+      .putImageData(
+        new ImageData(rasterizeHeatmap(grid, lut), grid.columns, grid.rows),
+        0,
+        0,
+      );
+  };
 
   return {
     hooks: {
       draw: (u) => {
         const sourceFrames = framesRef.current;
+        const epoch = epochRef?.current;
+        const isSettleDraw = settle.due;
+        settle.due = false;
         if (
           rasterCache === null ||
           rasterCache.frames !== sourceFrames ||
+          rasterCache.epoch !== epoch ||
           rasterCache.bboxHeight !== u.bbox.height
         ) {
           const frames = distributionFramesFrom(sourceFrames);
           if (frames.length === 0) {
+            cancelSettle();
+            rasterCache = null;
             return;
           }
           const built = buildHeatmapDensityGrid(frames, u.bbox.height);
           if (!built) {
             return;
           }
+          // New frames of the same selection at the same height ease in from
+          // the displayed picture. A new selection starts from its own data
+          // (the plot's crossfade overlay bridges that transition), and a
+          // resize repaints exactly (the picture did not change, its pixels
+          // did).
+          const shown =
+            rasterCache !== null &&
+            rasterCache.epoch === epoch &&
+            rasterCache.bboxHeight === u.bbox.height
+              ? rasterCache.display
+              : null;
+          const display = easeHeatmapDisplay(shown, built);
           rasterCache = {
             frames: sourceFrames,
+            epoch,
             bboxHeight: u.bbox.height,
-            grid: built,
+            display,
             timeFirst: frames[0]!.time,
             timeLast: frames.at(-1)!.time,
           };
-
-          cellCanvas ??= document.createElement("canvas");
-          cellCanvas.width = built.columns;
-          cellCanvas.height = built.rows;
-          const cellContext = cellCanvas.getContext("2d")!;
-          cellContext.putImageData(
-            new ImageData(
-              rasterizeHeatmap(built, lut),
-              built.columns,
-              built.rows,
-            ),
-            0,
-            0,
-          );
+          paint(display.grid);
+          if (display.stepsLeft > 0) {
+            scheduleSettle(u);
+          } else {
+            cancelSettle();
+          }
+        } else if (isSettleDraw && rasterCache.display.stepsLeft > 0) {
+          const display = settleHeatmapDisplay(rasterCache.display);
+          rasterCache = { ...rasterCache, display };
+          paint(display.grid);
+          if (display.stepsLeft > 0) {
+            scheduleSettle(u);
+          }
         }
         if (cellCanvas === null) {
           return;
         }
-        const { grid, timeFirst, timeLast } = rasterCache;
+        const { timeFirst, timeLast } = rasterCache;
+        const { grid } = rasterCache.display;
 
         // Cell centers sit on the frame times and grid-row values, so the
         // image extends half a cell beyond the outermost centers. All
@@ -333,6 +529,9 @@ export function createDistributionHeatmapPlugin(framesRef: {
           yBottom - yTop + cellHeight,
         );
         ctx.restore();
+      },
+      destroy: () => {
+        cancelSettle();
       },
     },
   };


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Distribution heatmaps had two visible faults while streaming: frames binned on different lattices (the host's exact initial frame next to GPU frames binned at a stride) drew as alternating dark and empty rows, and every cumulative re-delivery — a GPU tile, a pipelined rung folding in, a calibration re-run — snapped the whole picture, which read as flashing. Bins are now painted across the rows their own width covers, and each streamed update eases into the displayed picture over a few publishes. Stacked on #9489.

## 🔗 Related links

- [FE-1552](https://linear.app/hash/issue/FE-1552) _(internal)_
- Base PR: #9489

## 🔍 What does this change?

- `buildHeatmapDensityGrid` spreads each bin's count over the rows its extent covers (`[value − w/2, value + w/2]`, weighted by overlap) instead of splatting it as a point onto its two nearest rows. `w` is the frame's own smallest bin gap (the chart-wide gap for single-bin frames), so a stride-2 bin over a 1-unit lattice fills both rows evenly. The half bin reaching past the outermost row centers is not drawn; renormalizing it into the edge rows made them darker than the interior.
- `blendHeatmapGrids` mixes the new grid with the one on screen (weight 0.5 per publish — an eighth of the old picture remains after three publishes at the session's 100 ms cadence). Shared columns blend, appended columns show as they are, and a moved lattice is bridged by sampling the previous grid at each new row's value. The plugin keeps the displayed grid and resets it when the frame set empties, so a new selection starts from its own data (the plot's crossfade overlay bridges that transition, as before).
- Adds `Simulate / ExperimentMetricTimeline → Mixed bin lattices`, a story with an exact frame 0 and stride-2 frames that reproduces the stripes on the base branch and renders continuously here.
- Updates the user guide's heatmap paragraph.

Measured on the `Bench / SweepDrawer` stories after a slider commit, sampling the already-drawn left 40% of the first chart every 75 ms (frontier columns excluded, so appended progress does not count as flicker): mean per-sample change 5.7 → 4.2 on CPU, 14.4 → 11.2 on GPU. The largest single jump is unchanged — that is the first data after the selection change, which the crossfade overlay covers on its own canvas.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] modifies an **npm**-publishable library and **I have added a changeset file(s)**

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] require changes to docs which **are made** as part of this PR

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- `distribution-heatmap.test.ts`: two new splat tests (a stride-2 frame beside an exact frame fills every spanned row evenly; a bin on the lattice stays in its own row) and four `blendHeatmapGrids` tests (no previous grid, shared vs appended columns, a moved lattice resampled by value, convergence over repeated publishes). The five pre-existing grid tests still pass unchanged.

## ❓ How to test this?

1. Open `Simulate / ExperimentMetricTimeline → Mixed bin lattices` in Storybook (`yarn workspace @hashintel/petrinaut dev:storybook`): the band is continuous, with no alternating rows.
2. Open `Bench / SweepDrawer → Cpu`, wait for the fill, then drag a parameter slider: the charts restream and successive updates ease in rather than snapping.

## 📹 Demo

_Screenshots pending — will be handed over for drag-drop._
