### PR TITLE
FE-1500: Publish the core example models in the website catalog

### DIFF
--- a/apps/petrinaut-website/scripts/generate-example-artifacts.ts
+++ b/apps/petrinaut-website/scripts/generate-example-artifacts.ts
@@ -7,6 +7,7 @@ import {
   parseSDCPNFile,
   type SDCPN,
 } from "@hashintel/petrinaut-core";
+import * as coreExamples from "@hashintel/petrinaut-core/examples";
 import {
   compileHirArtifacts,
   lowerScenarioToHir,
@@ -14,8 +15,8 @@ import {
 } from "@hashintel/petrinaut-core/hir";
 
 import {
-  exampleSlugs,
-  type ExampleSlug,
+  exampleCatalog,
+  type ExampleCatalogEntry,
 } from "../src/examples/catalog-metadata.ts";
 import { normalizeExampleDefinition } from "../src/examples/normalize-example.ts";
 
@@ -24,7 +25,7 @@ const examplesDirectory = resolve(scriptDirectory, "../src/examples");
 const modelsDirectory = resolve(examplesDirectory, "models");
 const generatedDirectory = resolve(examplesDirectory, "generated");
 
-const parseDefinition = async (slug: ExampleSlug): Promise<SDCPN> => {
+const readModelFile = async (slug: string): Promise<SDCPN> => {
   const input = JSON.parse(
     await readFile(resolve(modelsDirectory, `${slug}.json`), "utf8"),
   ) as unknown;
@@ -36,8 +37,20 @@ const parseDefinition = async (slug: ExampleSlug): Promise<SDCPN> => {
   return normalizeExampleDefinition(slug, rawDefinition);
 };
 
-const generateRuntime = async (slug: ExampleSlug) => {
-  const definition = await parseDefinition(slug);
+const loadDefinition = (entry: ExampleCatalogEntry): Promise<SDCPN> => {
+  switch (entry.source.kind) {
+    case "model-file":
+      return readModelFile(entry.slug);
+    case "core-example":
+      return Promise.resolve(
+        coreExamples[entry.source.exportName].petriNetDefinition,
+      );
+  }
+};
+
+const generateRuntime = async (entry: ExampleCatalogEntry) => {
+  const { slug } = entry;
+  const definition = await loadDefinition(entry);
   const { artifacts, failures } = compileHirArtifacts(definition);
   if (failures.length > 0) {
     throw new Error(
@@ -79,8 +92,8 @@ const generateRuntime = async (slug: ExampleSlug) => {
 
 await mkdir(generatedDirectory, { recursive: true });
 
-for (const slug of exampleSlugs) {
-  const outputPath = resolve(generatedDirectory, `${slug}.json`);
-  await writeFile(outputPath, await generateRuntime(slug), "utf8");
+for (const entry of exampleCatalog) {
+  const outputPath = resolve(generatedDirectory, `${entry.slug}.json`);
+  await writeFile(outputPath, await generateRuntime(entry), "utf8");
   process.stdout.write(`generated ${outputPath}\n`);
 }

--- a/apps/petrinaut-website/src/examples/catalog-metadata.ts
+++ b/apps/petrinaut-website/src/examples/catalog-metadata.ts
@@ -8,16 +8,34 @@
 export const PETRINAUT_DEMO_ORIGIN = "https://demo.petrinaut.org";
 
 export const exampleSlugs = [
+  "deployment-pipeline",
   "gases-1-pn-consumption-trigger",
   "gases-1-pn",
   "gases-2-spn",
   "gases-3-cpn",
   "gases-4-dcpn",
+  "probabilistic-satellite-launcher",
+  "production-with-machine-failure",
   "semiconductor-fab-drift",
+  "sir-epidemic-model",
+  "supply-chain-profit-model",
+  "supply-chain-with-disruption",
   "truck-fleet-predictive-maintenance",
 ] as const;
 
 export type ExampleSlug = (typeof exampleSlugs)[number];
+
+/**
+ * Where an example's definition comes from. Model files live next to this
+ * module as JSON; core examples are the models Petrinaut itself ships, named
+ * by their export from `@hashintel/petrinaut-core/examples`.
+ */
+export type ExampleSource =
+  | { kind: "model-file" }
+  | {
+      kind: "core-example";
+      exportName: keyof typeof import("@hashintel/petrinaut-core/examples");
+    };
 
 export type ExampleSimulationParameterBounds = Readonly<{
   min: number;
@@ -28,14 +46,37 @@ export type ExampleSimulationParameterBounds = Readonly<{
 export type ExampleCatalogEntry = Readonly<{
   slug: ExampleSlug;
   title: string;
+  source: ExampleSource;
   /** Safe UI ranges for scenario parameters, keyed by identifier. */
   parameterBounds: Readonly<Record<string, ExampleSimulationParameterBounds>>;
 }>;
 
+const modelFile = { kind: "model-file" } as const;
+
+const coreExample = (
+  exportName: Extract<ExampleSource, { kind: "core-example" }>["exportName"],
+) => ({ kind: "core-example", exportName }) as const;
+
 const catalog = [
+  {
+    slug: "deployment-pipeline",
+    title: "Deployment Pipeline",
+    source: coreExample("deploymentPipelineSDCPN"),
+    parameterBounds: {
+      deployment_rate: { min: 0.1, max: 2, step: 0.05 },
+      failure_base_rate: { min: 0.01, max: 0.3, step: 0.01 },
+      finish_rate: { min: 0.05, max: 1, step: 0.01 },
+      incident_rate: { min: 0.01, max: 0.5, step: 0.01 },
+      mean_size: { min: 0.25, max: 3, step: 0.05 },
+      resolution_rate: { min: 0.05, max: 1, step: 0.01 },
+      risk_multiplier: { min: 0.25, max: 3, step: 0.05 },
+      severity_multiplier: { min: 0.5, max: 3, step: 0.05 },
+    },
+  },
   {
     slug: "gases-1-pn-consumption-trigger",
     title: "Gases 1 — Consumption Trigger",
+    source: modelFile,
     parameterBounds: {
       draw_enabled: { min: 0, max: 1, step: 1 },
     },
@@ -43,6 +84,7 @@ const catalog = [
   {
     slug: "gases-1-pn",
     title: "Gases 1 — One Customer",
+    source: modelFile,
     parameterBounds: {
       draw_enabled: { min: 0, max: 1, step: 1 },
     },
@@ -50,6 +92,7 @@ const catalog = [
   {
     slug: "gases-2-spn",
     title: "Gases 2 — Shared Tanker",
+    source: modelFile,
     parameterBounds: {
       draw_enabled: { min: 0, max: 1, step: 1 },
       route_scale: { min: 0.5, max: 2, step: 0.1 },
@@ -58,6 +101,7 @@ const catalog = [
   {
     slug: "gases-3-cpn",
     title: "Gases 3 — Mixed Fleet",
+    source: modelFile,
     parameterBounds: {
       route_scale: { min: 0.5, max: 2, step: 0.1 },
     },
@@ -65,6 +109,7 @@ const catalog = [
   {
     slug: "gases-4-dcpn",
     title: "Gases 4 — Dynamic Coloured Net",
+    source: modelFile,
     parameterBounds: {
       hire_enabled: { min: 0, max: 1, step: 1 },
       route_scale: { min: 0.5, max: 2, step: 0.1 },
@@ -72,8 +117,31 @@ const catalog = [
     },
   },
   {
+    slug: "probabilistic-satellite-launcher",
+    title: "Probabilistic Satellite Launcher",
+    source: coreExample("probabilisticSatellitesSDCPN"),
+    parameterBounds: {
+      initial_altitude: { min: 5, max: 100, step: 1 },
+      launch_rate: { min: 0.05, max: 1, step: 0.05 },
+      number_of_satellites: { min: 1, max: 20, step: 1 },
+      satellite_initial_altitude: { min: 5, max: 100, step: 1 },
+      satellite_initial_velocity: { min: 1, max: 250, step: 1 },
+    },
+  },
+  {
+    slug: "production-with-machine-failure",
+    title: "Production With Machine Failure",
+    source: coreExample("productionMachines"),
+    parameterBounds: {
+      initial_machine_damage: { min: 0, max: 1, step: 0.05 },
+      machines_count: { min: 1, max: 10, step: 1 },
+      raw_material: { min: 1, max: 50, step: 1 },
+    },
+  },
+  {
     slug: "semiconductor-fab-drift",
     title: "Semiconductor Fab Drift",
+    source: modelFile,
     parameterBounds: {
       demand_rate: { min: 0.02, max: 0.3, step: 0.01 },
       maintenance_threshold: { min: 0.4, max: 0.99, step: 0.01 },
@@ -81,8 +149,52 @@ const catalog = [
     },
   },
   {
+    slug: "sir-epidemic-model",
+    title: "SIR Epidemic Model",
+    source: coreExample("sirModel"),
+    parameterBounds: {
+      infected_ratio: { min: 0, max: 0.2, step: 0.00005 },
+      population: { min: 100, max: 100000, step: 100 },
+    },
+  },
+  {
+    slug: "supply-chain-profit-model",
+    title: "Supply Chain Profit Model",
+    source: coreExample("supplyChainProfit"),
+    parameterBounds: {
+      batch_size: { min: 10, max: 1000, step: 10 },
+      demand_multiplier: { min: 0.25, max: 3, step: 0.05 },
+      expedite_fraction: { min: 0, max: 1, step: 0.01 },
+      marketing_spend: { min: 0, max: 100, step: 1 },
+      production_rate: { min: 10, max: 500, step: 5 },
+      replenishment_aggressiveness: { min: 0, max: 400, step: 10 },
+      selling_price: { min: 1, max: 100, step: 1 },
+    },
+  },
+  {
+    slug: "supply-chain-with-disruption",
+    title: "Supply Chain With Disruption",
+    source: coreExample("supplyChainWithDisruption"),
+    parameterBounds: {
+      a_order_multiplier: { min: 0, max: 3, step: 0.05 },
+      a_recovery_rate: { min: 0.01, max: 0.5, step: 0.01 },
+      a_share_bias: { min: 0, max: 1, step: 0.05 },
+      b_expedite_multiplier: { min: 0.5, max: 3, step: 0.05 },
+      b_order_multiplier: { min: 0, max: 3, step: 0.05 },
+      b_risk_multiplier: { min: 0.5, max: 3, step: 0.05 },
+      damage_threshold: { min: 0.1, max: 1, step: 0.01 },
+      demand_multiplier: { min: 0.25, max: 3, step: 0.05 },
+      initial_finished_goods: { min: 0, max: 50, step: 1 },
+      initial_raw_materials: { min: 0, max: 50, step: 1 },
+      lead_time_multiplier: { min: 0.5, max: 3, step: 0.05 },
+      maintenance_multiplier: { min: 0.5, max: 4, step: 0.05 },
+      supplier_recovery_multiplier: { min: 0.5, max: 4, step: 0.05 },
+    },
+  },
+  {
     slug: "truck-fleet-predictive-maintenance",
     title: "Truck Fleet Predictive Maintenance",
+    source: modelFile,
     parameterBounds: {
       base_severity_mean: { min: 0.5, max: 2, step: 0.05 },
       base_speed_mean: { min: 0.5, max: 1.5, step: 0.05 },
@@ -103,6 +215,12 @@ const catalog = [
 ] as const satisfies readonly ExampleCatalogEntry[];
 
 export const exampleCatalog: readonly ExampleCatalogEntry[] = catalog;
+
+/** The slugs whose definition is a JSON model file next to this module. */
+export type ModelFileExampleSlug = Extract<
+  (typeof catalog)[number],
+  { source: { kind: "model-file" } }
+>["slug"];
 
 export const isExampleSlug = (value: string): value is ExampleSlug =>
   exampleSlugs.some((slug) => slug === value);

--- a/apps/petrinaut-website/src/examples/catalog.test.ts
+++ b/apps/petrinaut-website/src/examples/catalog.test.ts
@@ -5,7 +5,13 @@ import {
   exampleSlugs,
   loadExample,
   loadExampleRuntime,
+  type ExampleCatalogEntry,
 } from "./catalog";
+
+const isCoreExample = (
+  entry: ExampleCatalogEntry,
+): entry is ExampleCatalogEntry & { source: { kind: "core-example" } } =>
+  entry.source.kind === "core-example";
 
 describe("example catalog", () => {
   it("has a catalog entry for every slug", () => {
@@ -38,6 +44,17 @@ describe("example catalog", () => {
           expect(bounds!.step).toBeGreaterThan(0);
         }
       }
+    },
+  );
+
+  it.each(exampleCatalog.filter(isCoreExample))(
+    "titles $slug after the core example it publishes",
+    async (entry) => {
+      // The oEmbed function reads titles from the import-free metadata, so
+      // the catalog repeats each core title; this keeps the copy honest.
+      const examples = await import("@hashintel/petrinaut-core/examples");
+
+      expect(examples[entry.source.exportName].title).toBe(entry.title);
     },
   );
 

--- a/apps/petrinaut-website/src/examples/catalog.ts
+++ b/apps/petrinaut-website/src/examples/catalog.ts
@@ -14,6 +14,7 @@ import {
   getExampleCatalogEntry,
   type ExampleCatalogEntry,
   type ExampleSlug,
+  type ModelFileExampleSlug,
 } from "./catalog-metadata";
 import { normalizeExampleDefinition } from "./normalize-example";
 
@@ -27,6 +28,7 @@ export type {
   ExampleCatalogEntry,
   ExampleSimulationParameterBounds,
   ExampleSlug,
+  ExampleSource,
 } from "./catalog-metadata";
 
 export type LoadedExample = Readonly<{
@@ -39,7 +41,10 @@ export type GeneratedExampleRuntime = Readonly<{
   scenarioHirById: Readonly<Record<string, ScenarioHir>>;
 }>;
 
-const modelLoaders: Record<ExampleSlug, () => Promise<{ default: unknown }>> = {
+const modelFileLoaders: Record<
+  ModelFileExampleSlug,
+  () => Promise<{ default: unknown }>
+> = {
   "gases-1-pn-consumption-trigger": () =>
     import("./models/gases-1-pn-consumption-trigger.json"),
   "gases-1-pn": () => import("./models/gases-1-pn.json"),
@@ -54,17 +59,49 @@ const modelLoaders: Record<ExampleSlug, () => Promise<{ default: unknown }>> = {
 
 const runtimeLoaders: Record<ExampleSlug, () => Promise<{ default: unknown }>> =
   {
+    "deployment-pipeline": () => import("./generated/deployment-pipeline.json"),
     "gases-1-pn-consumption-trigger": () =>
       import("./generated/gases-1-pn-consumption-trigger.json"),
     "gases-1-pn": () => import("./generated/gases-1-pn.json"),
     "gases-2-spn": () => import("./generated/gases-2-spn.json"),
     "gases-3-cpn": () => import("./generated/gases-3-cpn.json"),
     "gases-4-dcpn": () => import("./generated/gases-4-dcpn.json"),
+    "probabilistic-satellite-launcher": () =>
+      import("./generated/probabilistic-satellite-launcher.json"),
+    "production-with-machine-failure": () =>
+      import("./generated/production-with-machine-failure.json"),
     "semiconductor-fab-drift": () =>
       import("./generated/semiconductor-fab-drift.json"),
+    "sir-epidemic-model": () => import("./generated/sir-epidemic-model.json"),
+    "supply-chain-profit-model": () =>
+      import("./generated/supply-chain-profit-model.json"),
+    "supply-chain-with-disruption": () =>
+      import("./generated/supply-chain-with-disruption.json"),
     "truck-fleet-predictive-maintenance": () =>
       import("./generated/truck-fleet-predictive-maintenance.json"),
   };
+
+const loadModelFile = async (slug: ModelFileExampleSlug): Promise<SDCPN> => {
+  const module = await modelFileLoaders[slug]();
+  const parsed = parseSDCPNFile(module.default);
+  if (!parsed.ok) {
+    throw new Error(parsed.error);
+  }
+
+  const { title: _title, ...rawDefinition } = parsed.sdcpn;
+  return normalizeExampleDefinition(slug, rawDefinition);
+};
+
+const loadDefinition = async (entry: ExampleCatalogEntry): Promise<SDCPN> => {
+  switch (entry.source.kind) {
+    case "model-file":
+      return loadModelFile(entry.slug as ModelFileExampleSlug);
+    case "core-example": {
+      const examples = await import("@hashintel/petrinaut-core/examples");
+      return examples[entry.source.exportName].petriNetDefinition;
+    }
+  }
+};
 
 const loadedExamples = new Map<ExampleSlug, Promise<LoadedExample>>();
 const loadedRuntimes = new Map<ExampleSlug, Promise<GeneratedExampleRuntime>>();
@@ -77,18 +114,11 @@ export const loadExample = async (
     return existing;
   }
 
-  const loaded = modelLoaders[slug]().then((module) => {
-    const parsed = parseSDCPNFile(module.default);
-    if (!parsed.ok) {
-      throw new Error(parsed.error);
-    }
-
-    const { title: _title, ...rawDefinition } = parsed.sdcpn;
-    return {
-      catalog: getExampleCatalogEntry(slug)!,
-      definition: normalizeExampleDefinition(slug, rawDefinition),
-    };
-  });
+  const catalog = getExampleCatalogEntry(slug)!;
+  const loaded = loadDefinition(catalog).then((definition) => ({
+    catalog,
+    definition,
+  }));
   // A rejected import (a transient network failure, a stale chunk after a
   // redeploy) must not poison the cache: evict so the next navigation retries.
   loaded.catch(() => {


### PR DESCRIPTION
## Summary

Before this PR, the website catalog held the JSON model files kept next to the code. The models Petrinaut ships in `@hashintel/petrinaut-core/examples` were reachable only through the editor's Load example menu, so petrinaut.org had no page to link for them.

Those models join the catalog. `/examples/<slug>` and `/embed/examples/<slug>` serve them with the same routes, loaders, generated artifacts, and oEmbed support as the JSON models.

## Links

- Ticket [FE-1500](https://linear.app/hash/issue/FE-1500)

## Changes

- Catalog entries name their source
  > `model-file` is a JSON file next to the catalog. `core-example` names an export of `@hashintel/petrinaut-core/examples`.
  > The browser loader and the artifact generator resolve a definition through the source.
  > The metadata module keeps no runtime import, so the oEmbed function bundle stays small.
- Core examples get slugs, titles, and safe parameter bounds
  > Slugs are `deployment-pipeline`, `probabilistic-satellite-launcher`, `production-with-machine-failure`, `sir-epidemic-model`, `supply-chain-profit-model`, and `supply-chain-with-disruption`.
  > Every scenario parameter carries a min, max, and step around its default.
- Core titles pinned to the core objects
  > The oEmbed function reads titles from the metadata, so the catalog repeats each core title and a test compares the copy with the export.

## Test coverage

- `catalog.test.ts`:
  > Every slug has an entry, every scenario parameter has bounds around its default, generated HIR exists per scenario, core titles match their export, loads are cached.
- `oembed-endpoint.test.ts`, `oembed-discovery.test.ts`:
  > Existing oEmbed behaviour, unchanged.

## How to test

- Open [Petrinaut preview](https://petrinaut-git-claude-petrinaut-core-examples-catalog.stage.hash.ai) on Vercel
- Open `/examples/sir-epidemic-model`
  > Expect SIR model with its scenarios in Simulation Settings
- Open `/embed/examples/deployment-pipeline?scenario=scenario__incident_surge`
  > Expect deployment pipeline with Incident surge selected
