### PR TITLE
FE-1569: Add the Brunch container build and publication path

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,6 +18,7 @@
 # Petrinaut bundles its user-facing docs into the build via `?raw` imports,
 # so they must be present in the Docker context (not just README.md).
 !libs/@hashintel/petrinaut/docs/*.md
+<<<<<<< HEAD
 # Atlas compiles its wire contract into the binary with `include_str!`, so the
 # file is a build input rather than documentation the image can do without.
 !libs/@local/graph/atlas/docs/wire.md
@@ -25,6 +26,10 @@
 # graph. Admit only those production Markdown inputs.
 !libs/@hashintel/brunch-agent/packages/core/src/SYSTEM.md
 !libs/@hashintel/brunch-agent/packages/plugin-sdcpn/src/skills/sdcpn-modelling/*.md
+=======
+# Brunch imports its authored Flue skill through the application build graph.
+!apps/brunch-agent/src/skills/sdcpn-modelling/*.md
+>>>>>>> a7c67176f0 (Include the Brunch skill in container builds)
 
 ########################
 ## Same as in .gitignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -18,18 +18,11 @@
 # Petrinaut bundles its user-facing docs into the build via `?raw` imports,
 # so they must be present in the Docker context (not just README.md).
 !libs/@hashintel/petrinaut/docs/*.md
-<<<<<<< HEAD
 # Atlas compiles its wire contract into the binary with `include_str!`, so the
 # file is a build input rather than documentation the image can do without.
 !libs/@local/graph/atlas/docs/wire.md
-# Brunch imports its core prompt and authored Flue skill through the build
-# graph. Admit only those production Markdown inputs.
-!libs/@hashintel/brunch-agent/packages/core/src/SYSTEM.md
-!libs/@hashintel/brunch-agent/packages/plugin-sdcpn/src/skills/sdcpn-modelling/*.md
-=======
-# Brunch imports its authored Flue skill through the application build graph.
-!apps/brunch-agent/src/skills/sdcpn-modelling/*.md
->>>>>>> a7c67176f0 (Include the Brunch skill in container builds)
+# Brunch packages prompts and skills through `?raw` imports in their builds.
+!libs/@hashintel/brunch-agent/packages/*/src/**/*.md
 
 ########################
 ## Same as in .gitignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -21,6 +21,10 @@
 # Atlas compiles its wire contract into the binary with `include_str!`, so the
 # file is a build input rather than documentation the image can do without.
 !libs/@local/graph/atlas/docs/wire.md
+# Brunch imports its core prompt and authored Flue skill through the build
+# graph. Admit only those production Markdown inputs.
+!libs/@hashintel/brunch-agent/packages/core/src/SYSTEM.md
+!libs/@hashintel/brunch-agent/packages/plugin-sdcpn/src/skills/sdcpn-modelling/*.md
 
 ########################
 ## Same as in .gitignore

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -115,7 +115,7 @@ jobs:
             {
               package:    "@apps/brunch-agent",
               service:    "brunch-agent",
-              push:       ["ghcr"],
+              push:       ["ecr", "ghcr"],
               dockerfile: "apps/brunch-agent/docker/Dockerfile",
               context:    ".",
               ecs:        []

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -113,6 +113,14 @@ jobs:
               ecs:        []
             },
             {
+              package:    "@apps/brunch-agent",
+              service:    "brunch-agent",
+              push:       ["ghcr"],
+              dockerfile: "apps/brunch-agent/docker/Dockerfile",
+              context:    ".",
+              ecs:        []
+            },
+            {
               package:    "@apps/hash-ai-worker-ts",
               service:    "ai-worker-ts",
               push:       ["ecr", "ghcr"],

--- a/apps/brunch-agent/docker/Dockerfile
+++ b/apps/brunch-agent/docker/Dockerfile
@@ -64,13 +64,15 @@ WORKDIR /repo/apps/brunch-agent
 COPY --from=builder /repo /repo
 
 RUN groupadd --system --gid 60000 hash && \
-    useradd --system --uid 60000 --gid hash --create-home brunch
+    useradd --system --uid 60000 --gid hash --create-home brunch && \
+    install --directory --owner brunch --group hash \
+    /repo/apps/brunch-agent/.data-wipe-me
 
 USER brunch:hash
 
 EXPOSE 3000
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD ["node", "-e", "fetch('http://127.0.0.1:3000/health').then((response) => { if (!response.ok) process.exit(1); }).catch(() => process.exit(1))"]
+    CMD ["node", "-e", "fetch('http://127.0.0.1:3000/health').then((response) => process.exit(response.ok ? 0 : 1)).catch(() => process.exit(1))"]
 
 CMD ["node", "dist/server.mjs"]

--- a/apps/brunch-agent/docker/Dockerfile
+++ b/apps/brunch-agent/docker/Dockerfile
@@ -58,6 +58,7 @@ RUN turbo run build --filter '@apps/brunch-agent' --env-mode=loose && \
 FROM tools AS runner
 
 ENV NODE_ENV=production
+ENV PORT=3002
 
 WORKDIR /repo/apps/brunch-agent
 
@@ -70,9 +71,9 @@ RUN groupadd --system --gid 60000 hash && \
 
 USER brunch:hash
 
-EXPOSE 3000
+EXPOSE 3002
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD ["node", "-e", "fetch('http://127.0.0.1:3000/health').then((response) => process.exit(response.ok ? 0 : 1)).catch(() => process.exit(1))"]
+    CMD ["node", "-e", "fetch('http://127.0.0.1:3002/health').then((response) => process.exit(response.ok ? 0 : 1)).catch(() => process.exit(1))"]
 
 CMD ["node", "dist/server.mjs"]

--- a/apps/brunch-agent/docker/Dockerfile
+++ b/apps/brunch-agent/docker/Dockerfile
@@ -1,0 +1,76 @@
+# syntax=docker/dockerfile:1
+
+# Build from the repository root:
+# docker buildx build --file apps/brunch-agent/docker/Dockerfile . --load
+
+FROM debian:13.3-slim AS tools
+
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
+ENV MISE_DATA_DIR="/mise"
+ENV MISE_CACHE_DIR="/mise/cache"
+ENV PATH="/mise/shims:$PATH"
+
+COPY .config/mise /etc/mise
+
+RUN --mount=type=secret,id=GITHUB_TOKEN,env=GITHUB_TOKEN \
+    apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates curl && \
+    /etc/mise/install.sh && \
+    mise --version && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    eval "$(mise activate bash)" && \
+    mise install --locked node npm:turbo yq
+
+
+FROM tools AS pruner
+
+WORKDIR /repo
+
+COPY . .
+
+RUN mise trust && \
+    turbo prune $(.github/scripts/prune-scopes.sh '@apps/brunch-agent') --docker
+
+
+FROM tools AS builder
+
+WORKDIR /repo
+
+RUN corepack enable
+
+COPY --from=pruner /repo/out/json/ ./
+COPY --from=pruner /repo/out/yarn.lock ./yarn.lock
+COPY --from=pruner /repo/out/full/.yarn ./.yarn
+COPY --from=pruner /repo/out/full/turbo.json ./turbo.json
+
+RUN --mount=type=cache,target=/root/.yarn/berry/cache \
+    yarn install --immutable
+
+COPY --from=pruner /repo/out/full/ ./
+
+RUN turbo run build --filter '@apps/brunch-agent' --env-mode=loose && \
+    yarn workspaces focus @apps/brunch-agent --production && \
+    rm -rf apps/brunch-agent/test
+
+
+FROM tools AS runner
+
+ENV NODE_ENV=production
+
+WORKDIR /repo/apps/brunch-agent
+
+COPY --from=builder /repo /repo
+
+RUN groupadd --system --gid 60000 hash && \
+    useradd --system --uid 60000 --gid hash --create-home brunch
+
+USER brunch:hash
+
+EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD ["node", "-e", "fetch('http://127.0.0.1:3000/health').then((response) => { if (!response.ok) process.exit(1); }).catch(() => process.exit(1))"]
+
+CMD ["node", "dist/server.mjs"]

--- a/apps/brunch-agent/docs/task-dependencies.json
+++ b/apps/brunch-agent/docs/task-dependencies.json
@@ -15,6 +15,7 @@
       "@hashintel/brunch-agent-transport-aisdk#build",
       "@hashintel/petrinaut-core#build"
     ],
+    "build:docker": [],
     "dev": [
       "@hashintel/brunch-agent#build",
       "@hashintel/brunch-agent-binding-flue#build",

--- a/apps/brunch-agent/package.json
+++ b/apps/brunch-agent/package.json
@@ -7,6 +7,7 @@
   "type": "module",
   "scripts": {
     "build": "vite build && vite build --config vite.client.config.ts",
+    "build:docker": "docker buildx build --tag brunch-agent --file docker/Dockerfile ../../ --load",
     "dev": "vite dev",
     "fix:eslint": "oxlint --fix --type-aware --type-check --report-unused-disable-directives-severity=error .",
     "lint:eslint": "oxlint --type-aware --type-check --report-unused-disable-directives-severity=error .",

--- a/apps/brunch-agent/src/app.ts
+++ b/apps/brunch-agent/src/app.ts
@@ -15,10 +15,15 @@ import { createAgentRouter } from "@flue/runtime/routing";
 import { Hono } from "hono";
 
 import { ChatAgent } from "./agents/chat-agent/agent.ts";
+import { healthHandler } from "./health.ts";
 import { assetHandler } from "./http/assets.ts";
 import { agentOwnershipGuard } from "./http/ownership.ts";
 import { createPetrinautChatHandler } from "./http/petrinaut-chat.ts";
-import { CHAT_AGENT_ROUTE, PETRINAUT_CHAT_ROUTE } from "./http/routes.ts";
+import {
+  CHAT_AGENT_ROUTE,
+  HEALTH_ROUTE,
+  PETRINAUT_CHAT_ROUTE,
+} from "./http/routes.ts";
 
 instrument(createOpenTelemetryInstrumentation({ content: false }));
 
@@ -34,6 +39,8 @@ app.route(chatAgentMount, createAgentRouter(ChatAgent));
 app.on(["GET", "POST", "OPTIONS"], PETRINAUT_CHAT_ROUTE, (c) =>
   petrinautChatHandler(c.req.raw),
 );
+
+app.get(HEALTH_ROUTE, healthHandler);
 
 const uiRoot = new URL(
   // oxlint-disable-next-line typescript/no-unnecessary-condition -- import.meta.env is absent when Node executes this module directly.

--- a/apps/brunch-agent/src/health.ts
+++ b/apps/brunch-agent/src/health.ts
@@ -1,0 +1,7 @@
+import type { Context } from "hono";
+
+export const healthHandler = (context: Context): Response =>
+  context.json({ status: "pass" }, 200, {
+    "cache-control": "no-store",
+    "content-type": "application/health+json",
+  });

--- a/apps/brunch-agent/src/http/routes.ts
+++ b/apps/brunch-agent/src/http/routes.ts
@@ -2,5 +2,8 @@
 
 export const CHAT_AGENT_ROUTE = "chat";
 
+/** Cheap process-liveness probe; dependency readiness is established before listen. */
+export const HEALTH_ROUTE = "/health";
+
 /** Stock `DefaultChatTransport` endpoint used by Petrinaut's local panel. */
 export const PETRINAUT_CHAT_ROUTE = "/api/chat";

--- a/apps/brunch-agent/test/health.test.ts
+++ b/apps/brunch-agent/test/health.test.ts
@@ -1,0 +1,24 @@
+import { Hono } from "hono";
+import { expect, test, vi } from "vitest";
+
+import { healthHandler } from "../src/health.ts";
+
+test("health reports liveness without consulting dependencies", async () => {
+  const dependency = vi.fn<() => void>();
+  const app = new Hono();
+  app.get("/health", (context) => {
+    const response = healthHandler(context);
+    expect(dependency).not.toHaveBeenCalled();
+    return response;
+  });
+
+  const response = await app.request("/health");
+
+  expect(response.status).toBe(200);
+  expect(response.headers.get("cache-control")).toBe("no-store");
+  expect(response.headers.get("content-type")).toContain(
+    "application/health+json",
+  );
+  await expect(response.json()).resolves.toEqual({ status: "pass" });
+  expect(dependency).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Add the independently reviewable Brunch container boundary requested in review: a reproducible non-root production image, cheap process liveness, and CI publication to ECR and GHCR. The catalog deliberately has no ECS targets until infrastructure is provisioned.

## 🔗 Related links

- [FE-1569: Containerize and safely deploy Brunch on HASH infrastructure](https://linear.app/hash/issue/FE-1569/containerize-and-safely-deploy-brunch-on-hash-infrastructure) _(internal)_
- Followed by [the runtime persistence and telemetry PR](https://github.com/hashintel/hash/pull/9487)

## 🔍 What does this change?

- Adds the repository-root Docker build using the locked toolchain, Turbo pruning, immutable Yarn install, and uid/gid `60000` runtime.
- Adds a cheap, dependency-free `/health` liveness endpoint and container health check.
- Registers `@apps/brunch-agent` in the deploy catalog for multi-architecture ECR and GHCR publication with an empty ECS target list.
- Narrows the Docker context while retaining required production Markdown inputs.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] affected the execution graph, and the root `build:docker` task already covers it

## ⚠️ Known issues

- This publishes to ECR and GHCR. ECS remains disabled until infrastructure supplies a service target.

## 🐾 Next steps

- The upstack PR adds Postgres persistence, RDS IAM support, operational telemetry, and deployment diagnostics.
- Infrastructure will extend the catalog entry with ECR/ECS details when available.

## 🛡 What tests cover this?

- `yarn workspace @apps/brunch-agent lint:tsc`
- `yarn workspace @apps/brunch-agent build`
- `yarn workspace @apps/brunch-agent test:unit` — 16 files and 60 tests
- Deploy workflow YAML parsing
- CI exercises the Docker build and publication matrix; Docker was unavailable during the post-split local verification pass.

## ❓ How to test this?

1. Run `yarn workspace @apps/brunch-agent build:docker` with Docker available.
2. Start the image and confirm `GET /health` returns `200` with `application/health+json`.
3. Confirm the deploy matrix includes `brunch-agent` for both architecture builds and ECR/GHCR manifest publication, with no ECS deployment row.