### PR TITLE
H-6763: Add temporary Brunch ask shim for Voice preview

### DIFF
--- a/apps/brunch-agent/package.json
+++ b/apps/brunch-agent/package.json
@@ -20,6 +20,7 @@
     "@flue/react": "2.0.3",
     "@flue/runtime": "2.0.3",
     "@flue/sdk": "2.0.3",
+    "@hashintel/brunch-agent": "workspace:*",
     "@hashintel/brunch-agent-binding-flue": "workspace:*",
     "@hashintel/brunch-agent-transport-aisdk": "workspace:*",
     "@hashintel/petrinaut-core": "workspace:*",

--- a/apps/brunch-agent/src/agents/chat-agent.ts
+++ b/apps/brunch-agent/src/agents/chat-agent.ts
@@ -8,6 +8,9 @@
 
 import { defineSkill, useModel, useSkill, useTool } from "@flue/runtime";
 
+import { ASK_TOOL_NAME } from "@hashintel/brunch-agent/client-tools";
+
+import { brunchAsk } from "../tools/brunch-ask.ts";
 import { ping } from "../tools/ping.ts";
 import { readPetrinautDoc } from "../tools/read-petrinaut-doc.ts";
 
@@ -31,12 +34,18 @@ export function ChatAgent() {
   useSkill(confirmPath);
   useTool(ping);
   useTool(readPetrinautDoc);
+  useTool(brunchAsk);
   return [
     "You are a concise assistant inside the Petrinaut editor.",
     "Call ping when you need to confirm the server tool path.",
     `Activate the \`${STUB_SKILL_NAME}\` skill before calling ping.`,
     "When the user asks how Petrinaut's UI works, call readPetrinautDoc.",
     "A client-tool-result signal is JSON [{ toolCallId, toolName, output }]. Treat output as the browser's result for that call and continue helping the user.",
+    `When the user explicitly requests an interview, call \`${ASK_TOOL_NAME}\`.`,
+    "Ask one concise question per turn.",
+    `After calling \`${ASK_TOOL_NAME}\`, wait for the client-tool-result signal before continuing.`,
+    `Treat the correlated \`{ answer }\` output for \`${ASK_TOOL_NAME}\` as the user's answer.`,
+    "Never claim that you modified the Petrinaut canvas.",
   ].join("\n");
 }
 

--- a/apps/brunch-agent/src/client-tool.ts
+++ b/apps/brunch-agent/src/client-tool.ts
@@ -1,5 +1,6 @@
 /** Flue-side client-tool signal contract: awaiting sentinel, result signal, tool names. */
 
+import { ASK_TOOL_NAME } from "@hashintel/brunch-agent/client-tools";
 import { readPetrinautDocToolName } from "@hashintel/petrinaut-core/ai";
 
 export const CLIENT_TOOL_RESULT_SIGNAL = "client-tool-result";
@@ -7,6 +8,7 @@ export const CLIENT_TOOL_RESULT_SIGNAL = "client-tool-result";
 export const AWAITING_CLIENT = "client" as const;
 
 export const clientToolNames: ReadonlySet<string> = new Set([
+  ASK_TOOL_NAME,
   readPetrinautDocToolName,
 ]);
 

--- a/apps/brunch-agent/src/flue-transcript.ts
+++ b/apps/brunch-agent/src/flue-transcript.ts
@@ -6,11 +6,25 @@ import {
   type FlueConversationSnapshot,
 } from "@flue/sdk";
 
+import { ASK_TOOL_NAME } from "@hashintel/brunch-agent/client-tools";
+
 import {
   CLIENT_TOOL_RESULT_SIGNAL,
   isAwaitingClient,
   providerExecutedFor,
 } from "./client-tool.ts";
+
+type UiMessageToolPart = {
+  readonly toolCallId: string;
+  readonly state: "output-available" | "output-error" | "input-available";
+  readonly input: unknown;
+  readonly output?: unknown;
+  readonly errorText?: string;
+  readonly providerExecuted?: boolean;
+} & (
+  | { readonly type: `tool-${string}` }
+  | { readonly type: "dynamic-tool"; readonly toolName: string }
+);
 
 type UiMessagePart =
   | { readonly type: "text"; readonly text: string; readonly state: "done" }
@@ -29,15 +43,7 @@ type UiMessagePart =
       readonly url: string;
       readonly filename?: string;
     }
-  | {
-      readonly type: `tool-${string}`;
-      readonly toolCallId: string;
-      readonly state: "output-available" | "output-error" | "input-available";
-      readonly input: unknown;
-      readonly output?: unknown;
-      readonly errorText?: string;
-      readonly providerExecuted?: boolean;
-    };
+  | UiMessageToolPart;
 
 const unhandledConversationPart = (part: never): never => {
   throw new Error(`Unhandled Flue conversation part: ${JSON.stringify(part)}`);
@@ -117,9 +123,13 @@ const toolPartFrom = (
     part.state === "output-available"
       ? providerExecutedFor(isAwaitingClient(part.output))
       : undefined;
+  const toolIdentity =
+    part.toolName === ASK_TOOL_NAME
+      ? { type: "dynamic-tool" as const, toolName: part.toolName }
+      : { type: `tool-${part.toolName}` as const };
   if (part.state === "output-error") {
     return {
-      type: `tool-${part.toolName}`,
+      ...toolIdentity,
       toolCallId: part.toolCallId,
       state: "output-error",
       input: part.input,
@@ -129,7 +139,7 @@ const toolPartFrom = (
   }
   if (output !== undefined) {
     return {
-      type: `tool-${part.toolName}`,
+      ...toolIdentity,
       toolCallId: part.toolCallId,
       state: "output-available",
       input: part.input,
@@ -138,7 +148,7 @@ const toolPartFrom = (
     };
   }
   return {
-    type: `tool-${part.toolName}`,
+    ...toolIdentity,
     toolCallId: part.toolCallId,
     state: "input-available",
     input: part.input,

--- a/apps/brunch-agent/src/flue-ui-stream.ts
+++ b/apps/brunch-agent/src/flue-ui-stream.ts
@@ -2,6 +2,8 @@
 
 import { type ConversationStreamChunk } from "@flue/sdk";
 
+import { ASK_TOOL_NAME } from "@hashintel/brunch-agent/client-tools";
+
 import { providerExecutedFor } from "./client-tool.ts";
 
 import type { UIMessageChunk } from "ai";
@@ -139,6 +141,7 @@ export const createFlueUiStream = (
             toolCallId: chunk.toolCallId,
             toolName: chunk.toolName,
             input: chunk.input,
+            ...(chunk.toolName === ASK_TOOL_NAME ? { dynamic: true } : {}),
             ...(providerExecuted === undefined ? {} : { providerExecuted }),
           });
           return;

--- a/apps/brunch-agent/src/tools/brunch-ask.ts
+++ b/apps/brunch-agent/src/tools/brunch-ask.ts
@@ -1,0 +1,19 @@
+import { defineTool } from "@flue/runtime";
+import * as v from "valibot";
+
+import { ASK_TOOL_NAME, AskInput } from "@hashintel/brunch-agent/client-tools";
+
+import { AWAITING_CLIENT } from "../client-tool.ts";
+
+export const brunchAsk = defineTool({
+  name: ASK_TOOL_NAME,
+  description:
+    "Ask one concise interview question. The browser executes this tool. After calling it, wait for a client-tool-result signal carrying the correlated { answer } output before continuing.",
+  input: AskInput,
+  output: v.object({
+    awaiting: v.literal(AWAITING_CLIENT),
+  }),
+  run() {
+    return { output: { awaiting: AWAITING_CLIENT }, terminate: true };
+  },
+});

--- a/apps/brunch-agent/test/flue-transcript.test.ts
+++ b/apps/brunch-agent/test/flue-transcript.test.ts
@@ -1,5 +1,7 @@
 import { expect, test } from "vitest";
 
+import { ASK_TOOL_NAME } from "@hashintel/brunch-agent/client-tools";
+
 import {
   formatFlueTranscript,
   snapshotToUiMessages,
@@ -53,6 +55,27 @@ const snapshotWithCompletedClientTool: FlueConversationSnapshot = {
   ],
 };
 
+const snapshotWithPendingAsk: FlueConversationSnapshot = {
+  ...snapshotWithPendingClientTool,
+  messages: [
+    {
+      id: "assistant-ask",
+      role: "assistant",
+      purpose: "assistant",
+      display: "visible",
+      parts: [
+        {
+          type: "dynamic-tool",
+          toolCallId: "tool-ask-1",
+          toolName: ASK_TOOL_NAME,
+          state: "input-available",
+          input: { question: "What happens after approval?" },
+        },
+      ],
+    },
+  ],
+};
+
 const snapshotWithDataPart: FlueConversationSnapshot = {
   v: 1,
   conversationId: "conversation-1",
@@ -83,6 +106,24 @@ test("history reconstruction leaves an unfinished client tool available to run",
           toolCallId: "tool-doc-1",
           state: "input-available",
           input: { doc: "ai-assistant" },
+        },
+      ],
+    },
+  ]);
+});
+
+test("history reconstructs brunch asks as dynamic tools", () => {
+  expect(snapshotToUiMessages(snapshotWithPendingAsk)).toEqual([
+    {
+      id: "assistant-ask",
+      role: "assistant",
+      parts: [
+        {
+          type: "dynamic-tool",
+          toolName: ASK_TOOL_NAME,
+          toolCallId: "tool-ask-1",
+          state: "input-available",
+          input: { question: "What happens after approval?" },
         },
       ],
     },

--- a/apps/brunch-agent/test/petrinaut-chat-result.ts
+++ b/apps/brunch-agent/test/petrinaut-chat-result.ts
@@ -21,6 +21,15 @@ export interface PetrinautChatResult {
   readonly resumedStatus: number;
   readonly resumedText: string;
   readonly resumedFinish: UIMessageChunk | undefined;
+  readonly askCall: Extract<
+    UIMessageChunk,
+    { type: "tool-input-available" }
+  > | null;
+  readonly askToolOutputsBeforeResume: readonly UIMessageChunk[];
+  readonly pendingHistoryAskState: string | undefined;
+  readonly answerResumeStatus: number;
+  readonly answerResumeText: string;
+  readonly answerResumeFinish: UIMessageChunk | undefined;
   readonly retriedStatus: number;
   readonly retriedResumeStatus: number;
   readonly historyUserEntryCount: number;

--- a/apps/brunch-agent/test/petrinaut-chat.integration.ts
+++ b/apps/brunch-agent/test/petrinaut-chat.integration.ts
@@ -13,6 +13,8 @@ import {
 import { sqlite, start } from "@flue/runtime/node";
 import { createFlueClient, FlueApiError } from "@flue/sdk";
 
+import { ASK_TOOL_NAME } from "@hashintel/brunch-agent/client-tools";
+
 import {
   ACTIVATE_SKILL_TOOL_NAME,
   CHAT_MODEL_ID,
@@ -149,9 +151,24 @@ try {
         ],
         { stopReason: "toolUse" },
       ),
+      fauxAssistantMessage(
+        [
+          fauxThinking("The user explicitly requested an interview."),
+          fauxText(
+            "The guide says the assistant can read its own documentation pages.",
+          ),
+          fauxToolCall(
+            ASK_TOOL_NAME,
+            { question: "What outcome should this process reliably produce?" },
+            { id: "tool-ask-1" },
+          ),
+        ],
+        { stopReason: "toolUse" },
+      ),
       fauxAssistantMessage([
+        fauxThinking("Use the correlated client-tool answer."),
         fauxText(
-          "The guide says the assistant can read its own documentation pages.",
+          "I received your answer: a reliable handoff. The Petrinaut canvas was not modified.",
         ),
       ]),
       fauxAssistantMessage([
@@ -179,6 +196,12 @@ try {
     if (userMessage === undefined) {
       throw new Error("panel-initial.post.json is missing the user message");
     }
+    userMessage.parts = [
+      {
+        type: "text",
+        text: "Start an interview and run the FE-1435 transport probe.",
+      },
+    ];
 
     const initialResponse = await app.fetch(
       new Request("http://brunch.test/api/chat", {
@@ -275,6 +298,64 @@ try {
       }),
     );
     const resumedChunks = chunksFrom(await resumeResponse.text());
+    const askCall =
+      resumedChunks.find(
+        (
+          chunk,
+        ): chunk is Extract<UIMessageChunk, { type: "tool-input-available" }> =>
+          chunk.type === "tool-input-available" &&
+          chunk.toolName === ASK_TOOL_NAME,
+      ) ?? null;
+    const pendingAskHistoryResponse = await app.fetch(
+      new Request(
+        `http://brunch.test/api/chat?id=${encodeURIComponent(conversationId)}`,
+        {
+          method: "GET",
+          headers: { "x-brunch-principal": principalKey },
+        },
+      ),
+    );
+    const pendingAskHistoryBody = (await pendingAskHistoryResponse.json()) as {
+      messages?: {
+        parts?: { toolCallId?: string; state?: string }[];
+      }[];
+    };
+    const pendingHistoryAskState = pendingAskHistoryBody.messages
+      ?.flatMap((message) => message.parts ?? [])
+      .find((part) => part.toolCallId === askCall?.toolCallId)?.state;
+    const answerResumeBody = {
+      id: conversationId,
+      trigger: "submit-message",
+      messageId: startChunk?.messageId,
+      messages: [
+        userMessage,
+        {
+          id: startChunk?.messageId,
+          role: "assistant",
+          parts: [
+            {
+              type: `tool-${ASK_TOOL_NAME}`,
+              toolCallId: askCall?.toolCallId,
+              state: "output-available",
+              input: askCall?.input,
+              output: { answer: "A reliable handoff." },
+            },
+          ],
+        },
+      ],
+    };
+    const answerResumeResponse = await app.fetch(
+      new Request("http://brunch.test/api/chat", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-brunch-principal": principalKey,
+          "x-request-id": "request-mission-1-ask-resume",
+        },
+        body: JSON.stringify(answerResumeBody),
+      }),
+    );
+    const answerResumeChunks = chunksFrom(await answerResumeResponse.text());
     const retriedResumeResponse = await app.fetch(
       new Request("http://brunch.test/api/chat", {
         method: "POST",
@@ -409,6 +490,19 @@ try {
         .map((chunk) => chunk.delta)
         .join(""),
       resumedFinish: resumedChunks.at(-1),
+      askCall,
+      askToolOutputsBeforeResume: resumedChunks.filter(
+        (chunk) =>
+          chunk.type === "tool-output-available" &&
+          chunk.toolCallId === askCall?.toolCallId,
+      ),
+      pendingHistoryAskState,
+      answerResumeStatus: answerResumeResponse.status,
+      answerResumeText: answerResumeChunks
+        .filter((chunk) => chunk.type === "text-delta")
+        .map((chunk) => chunk.delta)
+        .join(""),
+      answerResumeFinish: answerResumeChunks.at(-1),
       retriedStatus: retriedResponse.status,
       retriedResumeStatus: retriedResumeResponse.status,
       historyUserEntryCount: userEntryIds.length,

--- a/apps/brunch-agent/test/petrinaut-chat.integration.ts
+++ b/apps/brunch-agent/test/petrinaut-chat.integration.ts
@@ -334,7 +334,8 @@ try {
           role: "assistant",
           parts: [
             {
-              type: `tool-${ASK_TOOL_NAME}`,
+              type: "dynamic-tool",
+              toolName: ASK_TOOL_NAME,
               toolCallId: askCall?.toolCallId,
               state: "output-available",
               input: askCall?.input,

--- a/apps/brunch-agent/test/petrinaut-chat.test.ts
+++ b/apps/brunch-agent/test/petrinaut-chat.test.ts
@@ -78,26 +78,48 @@ test("the committed /api/chat door streams a plain Flue agent through server and
     expect(result.resumedText).toContain(
       "The guide says the assistant can read its own documentation pages.",
     );
+    expect(result.askCall).toMatchObject({
+      type: "tool-input-available",
+      toolName: "brunch_ask",
+      input: { question: "What outcome should this process reliably produce?" },
+    });
+    expect(result.askCall).not.toHaveProperty("providerExecuted");
+    expect(result.askToolOutputsBeforeResume).toEqual([]);
     expect(result.resumedFinish).toEqual({
+      type: "finish",
+      finishReason: "tool-calls",
+    });
+    expect(result.pendingHistoryAskState).toBe("input-available");
+    expect(result.answerResumeStatus).toBe(200);
+    expect(result.answerResumeText).toContain(
+      "I received your answer: a reliable handoff.",
+    );
+    expect(result.answerResumeFinish).toEqual({
       type: "finish",
       finishReason: "stop",
     });
     expect(result.retriedStatus).toBe(200);
     expect(result.retriedResumeStatus).toBe(200);
     expect(result.historyUserEntryCount).toBe(1);
-    expect(result.historyClientToolResultCount).toBe(1);
+    expect(result.historyClientToolResultCount).toBe(2);
 
     expect(result.historyGetStatus).toBe(200);
     expect(result.historyUserText).toContain(
-      "Run the FE-1435 transport probe.",
+      "Start an interview and run the FE-1435 transport probe.",
     );
     expect(result.foreignHistoryMessages).toBe(0);
     expect(result.unauthenticatedHistoryStatus).toBe(401);
     expect(result.foreignAgentHistoryStatus).toBe(403);
-    expect(result.transcript).toContain("Run the FE-1435 transport probe.");
+    expect(result.transcript).toContain(
+      "Start an interview and run the FE-1435 transport probe.",
+    );
     expect(result.transcript).toContain("Checking the server, then the docs.");
     expect(result.transcript).toContain("tool ping");
     expect(result.transcript).toContain("tool readPetrinautDoc");
+    expect(result.transcript).toContain("tool brunch_ask");
+    expect(result.transcript).toContain(
+      '"output":{"answer":"A reliable handoff."}',
+    );
     expect(result.transcript).toContain("tool activate_skill");
     expect(result.transcript).toContain(
       "The assistant can read its own documentation pages.",
@@ -107,20 +129,21 @@ test("the committed /api/chat door streams a plain Flue agent through server and
       toolName: "activate_skill",
       input: { name: "confirm-path" },
     });
-    expect(result.interviewerToolNames).toContain("activate_skill");
-    expect(result.interviewerToolNames).toContain("ping");
-    expect(result.interviewerToolNames).toContain("readPetrinautDoc");
-    expect(result.interviewerToolNames).not.toContain("sweep");
-    expect(result.interviewerToolNames).not.toContain("brunch_sweep");
+    expect(result.interviewerToolNames).toEqual([
+      "activate_skill",
+      "ping",
+      "readPetrinautDoc",
+      "brunch_ask",
+    ]);
     expect(result.captureIds.length).toBe(1);
     expect(result.captureExcerpts).toEqual([
-      "Run the FE-1435 transport probe.",
+      "Start an interview and run the FE-1435 transport probe.",
     ]);
     expect(result.capturePayloads).toEqual([{}]);
     expect(result.recaptureIds).toEqual(result.captureIds);
     expect(result.skippedDedupKeys.length).toBeGreaterThan(0);
     expect(result.captureUserText).toContain(
-      "Run the FE-1435 transport probe.",
+      "Start an interview and run the FE-1435 transport probe.",
     );
 
     expect(inspectionLines[0]).toMatchObject({
@@ -145,6 +168,11 @@ test("the committed /api/chat door streams a plain Flue agent through server and
       },
       {
         type: "request-finish",
+        requestId: "request-mission-1-ask-resume",
+        terminal: "completed",
+      },
+      {
+        type: "request-finish",
         requestId: "request-mission-1-resume-retry",
         terminal: "completed",
       },
@@ -156,7 +184,7 @@ test("the committed /api/chat door streams a plain Flue agent through server and
     ]);
     expect(
       inspectionLines.filter((event) => event.type === "history-read"),
-    ).toHaveLength(3);
+    ).toHaveLength(4);
 
     const resumed = await runNodeScript(
       join(testDirectory, "petrinaut-chat.integration.ts"),
@@ -176,10 +204,11 @@ test("the committed /api/chat door streams a plain Flue agent through server and
     ) as PetrinautResumeResult;
     expect(resumeResult.historyGetStatus).toBe(200);
     expect(resumeResult.historyUserText).toContain(
-      "Run the FE-1435 transport probe.",
+      "Start an interview and run the FE-1435 transport probe.",
     );
     expect(resumeResult.transcript).toContain("tool ping");
     expect(resumeResult.transcript).toContain("tool readPetrinautDoc");
+    expect(resumeResult.transcript).toContain("tool brunch_ask");
     expect(resumeResult.transcript).toContain("tool activate_skill");
   } finally {
     await rm(dbDirectory, { recursive: true, force: true });

--- a/apps/brunch-agent/test/petrinaut-chat.test.ts
+++ b/apps/brunch-agent/test/petrinaut-chat.test.ts
@@ -66,6 +66,7 @@ test("the committed /api/chat door streams a plain Flue agent through server and
       toolName: "readPetrinautDoc",
       input: { doc: "ai-assistant" },
     });
+    expect(result.clientToolCall).not.toHaveProperty("dynamic");
     expect(result.clientToolCall).not.toHaveProperty("providerExecuted");
     expect(result.clientToolOutputsOnInitial).toEqual([]);
     expect(result.initialFinish).toEqual({
@@ -82,6 +83,7 @@ test("the committed /api/chat door streams a plain Flue agent through server and
       type: "tool-input-available",
       toolName: "brunch_ask",
       input: { question: "What outcome should this process reliably produce?" },
+      dynamic: true,
     });
     expect(result.askCall).not.toHaveProperty("providerExecuted");
     expect(result.askToolOutputsBeforeResume).toEqual([]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -440,6 +440,7 @@ __metadata:
     "@flue/runtime": "npm:2.0.3"
     "@flue/sdk": "npm:2.0.3"
     "@flue/vite": "npm:2.0.3"
+    "@hashintel/brunch-agent": "workspace:*"
     "@hashintel/brunch-agent-binding-flue": "workspace:*"
     "@hashintel/brunch-agent-transport-aisdk": "workspace:*"
     "@hashintel/petrinaut-core": "workspace:*"


### PR DESCRIPTION
> [!IMPORTANT]
> **Current status:** Intentionally excluded from the accepted architecture. The temporary `brunch_ask` shim is not used; questions are represented through canonical hidden markers instead. [#9588](https://github.com/hashintel/hash/pull/9588) removes the remaining stale catalog entry without restoring the shim. Close as superseded.

## 🌟 What is the purpose of this PR?

> **Temporary Voice-preview compatibility shim. This does not complete Mission 3 or Mission 4 and does not provide durable elicitation or canvas writes. Migrate or remove it after Mission 4 lands.**

Mount the real `brunch_ask` client tool on Brunch's current `ChatAgent` so the existing Petrinaut Voice preview and widget can receive real Brunch questions and return answers through the existing client-tool resume path.

This PR only enables real Brunch questions and Voice/widget answers. The independently useful Voice interaction improvements are separated into #9512.

## 🔗 Related links

- [H-6763](https://linear.app/hash/issue/H-6763/support-for-realtime-audio-interviewing-of-domain-experts) _(internal)_
- #9500 — immediate base of this temporary PR
- #9512 — stacked Voice interaction improvements

## 🚫 Blocked by

- [ ] #9500 — this PR is stacked on its branch

## 🔍 What does this change?

- Adds a Flue `brunch_ask` client tool using the canonical `ASK_TOOL_NAME` and `AskInput`; it returns `{ awaiting: "client" }` with `terminate: true`.
- Mounts the tool in the real `ChatAgent`, registers it as client-executed for AI SDK projection, and instructs the agent to ask one concise interview question per turn, wait for the correlated result, treat `{ answer }` as the user's answer, and never claim a canvas modification.
- Reuses the generic `client-tool-result` signal path in `petrinaut-chat.ts`; no specialized ask-admission protocol is restored.
- Extends the production-path test through `ping`, `readPetrinautDoc`, pending `brunch_ask`, browser `{ answer }` submission, and continuation of the same persisted Flue conversation.

<details>
<summary>🏗️ Agent notes</summary>

**Imperative:** Unblock Voice interview testing against the real Brunch endpoint now, without waiting for the durable Mission 4 architecture.

**Throughline:** Petrinaut AI SDK `/api/chat` → production `ChatAgent` → pending `brunch_ask` client tool → existing `client-tool-result` signal → the same Flue conversation continues.

**Proof:** The integration test observes the real agent emit `brunch_ask`, projects it as `input-available` without `providerExecuted` or a server output, submits `{ answer }`, and observes the next turn plus persisted history. Existing `ping` and `readPetrinautDoc` checks remain.

**Constraints:** No `useElicitation`, elicitor agents, ask-admission protocol, sweeps, folds, completion accounting, capture-store wiring, canvas mutation, or canonical-speech changes. The interviewer tool history is exactly `activate_skill`, `ping`, `readPetrinautDoc`, and `brunch_ask`.

**Fog-line:** This shim deliberately does not decide the durable elicitation or canvas-write architecture. Mission 4 owns that boundary.

**Stop or reorient:** Migrate the shim to the Mission 4 architecture, or remove it in favor of that architecture, after Mission 4 lands.

</details>

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are an internal temporary compatibility path and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] add a workspace dependency through `package.json`; Turborepo derives the edge without a `turbo.json` change

## ⚠️ Known issues

This is intentionally not durable elicitation. It does not write captures or the Petrinaut canvas, and it must not survive Mission 4 unchanged.

## 🐾 Next steps

- Migrate or remove this compatibility shim after Mission 4 lands.
- Preserve the independently useful Voice interaction behavior in #9512 when this temporary branch is retired.

## 🛡 What tests cover this?

- `yarn workspace @apps/brunch-agent test:unit` — 10 files, 42 tests
- `yarn workspace @apps/brunch-agent lint:tsc`
- `yarn workspace @apps/brunch-agent lint:eslint` — 0 errors; 8 pre-existing warnings in untouched files
- `yarn workspace @apps/brunch-agent build`
- Focused formatting and `git diff --check`

## ❓ How to test this?

1. Check out this stacked branch and run the Brunch server with the Petrinaut Voice preview.
2. Explicitly request an interview and confirm the assistant emits a real Brunch question.
3. Answer through Voice or the widget and confirm the same conversation continues with the correlated answer.
4. Confirm no Petrinaut canvas mutation occurs.

## 📹 Demo

_Not recorded._