### PR TITLE
H-6803: Update rust-testing-skill to include test naming guidance

### DIFF
--- a/.agents/skills/rust-testing-strategy/SKILL.md
+++ b/.agents/skills/rust-testing-strategy/SKILL.md
@@ -65,10 +65,43 @@ metadata:
 ## Test Organization
 
 - Group related tests into appropriate modules
-- Use descriptive test names that explain the test scenario and expected outcome
-- Do not prefix test function names with `test_` (avoid `test::test_name` patterns)
 - Use helper functions to avoid code duplication in tests
 - Consider using parameterized tests for testing similar functionality with different inputs
+
+## Test Naming
+
+A test name is a short label with the shape `<subject>_<case>[_<variant>]`:
+
+- `<subject>` is the operation, type or function under test. It does not repeat the name of the enclosing module, because the test path already carries that.
+- `<case>` is what distinguishes this test from its siblings under the same subject: an operand shape, an input class or a code path.
+- `<variant>` narrows the case further when two tests share one, and is otherwise absent.
+
+The shape buys two things. Tests of one subject share a prefix, so a module's test list reads as a table of subject × case and `cargo nextest run -E 'test(<subject>_)'` selects the family. And the name says what the test covers while the doc comment says what it asserts and why, so neither repeats the other.
+
+What a name never carries:
+
+- A `test_` prefix, an article, a narration verb (`should`, `works`, `correctly`) or a `when`/`with`/`that` clause. The story a sentence-name would tell belongs in the test's doc comment and its assertion messages.
+- More than about six words. Three to five is the norm, and a longer name is a test doing too much, where the fix is one test per case.
+- The rejection, for a negative case. The name is the input class (`ice_invalid_subscript_type`, `rank_positions_short`, `rows_out_of_domain`), with no `err_` prefix or `_err` suffix. An outcome word is the final token only when the case alone is ambiguous (`eq_same_type_accepted`).
+
+Where the shape meets a test framework:
+
+- A property test, or an `rstest` case set, takes its name from the property it tests (`lattice_laws`, `solve_anti_symmetry`, `condensation_is_dag`).
+- Renaming a snapshot test renames the snapshot files derived from its name in the same change.
+
+```rust
+// Before: a sentence, three cases in one test, the outcome in the name.
+async fn rank_pair_tampers_name_their_own_variants() { /* … */ }
+async fn short_node_identity_table_refuses() { /* … */ }
+
+// After: one label per case, the outcome in the doc comment.
+/// Open refuses a reverse rank permutation short of the code column, under `Columns`.
+async fn rank_positions_short() { /* … */ }
+/// Open refuses a reverse rank permutation that is no permutation, under `RankInverse`.
+async fn rank_positions_constant() { /* … */ }
+/// Open refuses a node identity table short of the code column, under `Identities`.
+async fn node_identities_short() { /* … */ }
+```
 
 ## Test Code Quality
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Updates the skill to explicitly ban sentence style test names, and use proper naming conventions

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->
<!-- Libraries inside of the `@local` directory are always internal libraries which have no need for publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing


### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph




---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>