### PR TITLE
FE-1579: Remove the ignored CLI package from the mixed Petrinaut changeset

### DIFF
--- a/.changeset/trial-replicates-parallel.md
+++ b/.changeset/trial-replicates-parallel.md
@@ -1,6 +1,5 @@
 ---
 "@hashintel/petrinaut-core": patch
-"@hashintel/petrinaut-cli": patch
 ---
 
 Optimization trials run their seeded replicates in parallel as one sharded experiment. The Monte Carlo worker protocol attaches to any thread runtime, and the CLI's `--threads <n>` bounds the workers, defaulting to one per core minus one.


### PR DESCRIPTION
> [!IMPORTANT]
> Release tooling only, nothing user-facing.

## Summary

Before this PR, the Release workflow failed on every push to `main`. `.changeset/trial-replicates-parallel.md` named `@hashintel/petrinaut-cli`, which the changesets config ignores, alongside `@hashintel/petrinaut-core`, which it does not. Changesets refuses a changeset that mixes ignored and released packages, so `changeset version` aborted before assembling a release plan and no package published.

Drops the `@hashintel/petrinaut-cli` entry and keeps the `@hashintel/petrinaut-core` patch. `@hashintel/petrinaut-cli` is private and pinned to `0.0.0-private`, so the entry never produced a version bump. `changeset status` now assembles the plan again.

## Links

- Ticket [FE-1579](https://linear.app/hash/issue/FE-1579)
- Reference [Failing Release run](https://github.com/hashintel/hash/actions/runs/33789317294/job/100761892304)

## Changes

- `trial-replicates-parallel` changeset releases `@hashintel/petrinaut-core` alone
  > Changelog text is unchanged. The entry it drops was a no-op for versioning.


## Test coverage

- `yarn changeset status`:
  > Assembles the release plan and reports patches for `@hashintel/petrinaut`, `@hashintel/petrinaut-core` and `@hashintel/ds-components`.

## How to test

- `yarn changeset status`
- Expect three packages bumped at patch, no error
