### PR TITLE
SRE-1003: Let a deploy catalog entry choose its ECR architecture

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,9 +64,11 @@ jobs:
       # context is their own directory, so a git diff of `paths` is a complete
       # change signal. `ecs` lists the ECS task definitions to redeploy when the
       # image publishes; one app may drive several (e.g. `graph` → graph +
-      # graph-admin + type-fetcher). ECR holds one architecture per repository
-      # (Inspector does not scan manifest lists); `ecr_arch` names it and
-      # defaults to arm64.
+      # graph-admin + type-fetcher). `arches` lists what to build; it defaults
+      # to both for GHCR services (multi-arch manifest) and to arm64 otherwise.
+      # ECR holds one architecture per repository (Inspector does not scan
+      # manifest lists): the service's only arch when it builds one, else
+      # arm64, unless `ecr_arch` says otherwise.
       - name: Determine changed packages
         id: packages
         env:
@@ -192,21 +194,32 @@ jobs:
               )]' <<<"$CATALOG")
           fi
 
-          # Build matrix: expand each affected entry to its arches. GHCR
-          # services build both arches for the multi-arch manifest; ECR-only
-          # services build just their ECR arch. On PR events amd64 is skipped
-          # where arm64 covers the build (arch divergence in Rust/Node is rare;
-          # merge_group still validates amd64 before main), but never for a
-          # service whose only arch it is.
+          # Resolve each entry's arches and ECR arch (see the catalog comment),
+          # then fail loudly if the ECR arch is not among the arches built —
+          # the ECR push would otherwise silently never happen.
+          RESOLVED_CATALOG=$(jq -c '
+            [.[]
+              | (.arches // (if (.push | index("ghcr")) then ["arm64", "amd64"] else ["arm64"] end)) as $arches
+              | (.ecr_arch // (if ($arches | length) == 1 then $arches[0] else "arm64" end)) as $ecr_arch
+              | . + {arches: $arches, ecr_arch: $ecr_arch}
+            ]' <<<"$AFFECTED_CATALOG")
+          BAD_ECR_ARCH=$(jq -c '[.[] | select((.push | index("ecr")) and ((.ecr_arch as $a | .arches | index($a)) | not)) | .service]' <<<"$RESOLVED_CATALOG")
+          if [[ "$(jq length <<<"$BAD_ECR_ARCH")" -gt 0 ]]; then
+            echo "::error ::ecr_arch is not among the arches built for: $BAD_ECR_ARCH"
+            exit 1
+          fi
+
+          # Build matrix: expand each entry to its arches. On PR events amd64 is
+          # skipped where arm64 covers the build (arch divergence in Rust/Node
+          # is rare; merge_group still validates amd64 before main), but never
+          # for a service whose only arch it is.
           BUILD_MATRIX=$(jq -c --argjson skip_amd64 "$SKIP_AMD64" '
             [.[] as $e
-              | ($e.ecr_arch // "arm64") as $ecr_arch
-              | (if ($e.push | index("ghcr")) then ["arm64", "amd64"] else [$ecr_arch] end) as $arches
-              | $arches[]
-              | $e + {arch: ., ecr_arch: $ecr_arch}
-              | select($skip_amd64 != true or .arch != "amd64" or ($arches | length) == 1)
-              | del(.package, .ecs, .paths)
-            ] | { include: . }' <<<"$AFFECTED_CATALOG")
+              | $e.arches[]
+              | $e + {arch: .}
+              | select($skip_amd64 != true or .arch != "amd64" or ($e.arches | length) == 1)
+              | del(.package, .ecs, .paths, .arches)
+            ] | { include: . }' <<<"$RESOLVED_CATALOG")
 
           # Manifest matrix: services that publish multi-arch to GHCR.
           MANIFEST_MATRIX=$(jq -c '

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,7 +64,9 @@ jobs:
       # context is their own directory, so a git diff of `paths` is a complete
       # change signal. `ecs` lists the ECS task definitions to redeploy when the
       # image publishes; one app may drive several (e.g. `graph` → graph +
-      # graph-admin + type-fetcher).
+      # graph-admin + type-fetcher). ECR holds one architecture per repository
+      # (Inspector does not scan manifest lists); `ecr_arch` names it and
+      # defaults to arm64.
       - name: Determine changed packages
         id: packages
         env:
@@ -190,16 +192,19 @@ jobs:
               )]' <<<"$CATALOG")
           fi
 
-          # Build matrix: expand each affected entry to its arches. Skip amd64
-          # for services that don't publish to GHCR (ECR is arm64-only) and
-          # also on PR events (arch divergence in Rust/Node is rare;
-          # merge_group still validates amd64 before main).
+          # Build matrix: expand each affected entry to its arches. GHCR
+          # services build both arches for the multi-arch manifest; ECR-only
+          # services build just their ECR arch. On PR events amd64 is skipped
+          # where arm64 covers the build (arch divergence in Rust/Node is rare;
+          # merge_group still validates amd64 before main), but never for a
+          # service whose only arch it is.
           BUILD_MATRIX=$(jq -c --argjson skip_amd64 "$SKIP_AMD64" '
             [.[] as $e
-              | ({arch: "arm64"}, {arch: "amd64"})
-              | $e + .
-              | select(($e.push | index("ghcr")) or .arch == "arm64")
-              | select($skip_amd64 != true or .arch != "amd64")
+              | ($e.ecr_arch // "arm64") as $ecr_arch
+              | (if ($e.push | index("ghcr")) then ["arm64", "amd64"] else [$ecr_arch] end) as $arches
+              | $arches[]
+              | $e + {arch: ., ecr_arch: $ecr_arch}
+              | select($skip_amd64 != true or .arch != "amd64" or ($arches | length) == 1)
               | del(.package, .ecs, .paths)
             ] | { include: . }' <<<"$AFFECTED_CATALOG")
 
@@ -213,8 +218,8 @@ jobs:
             [.[] | .ecs[]] | { include: . }
           ' <<<"$AFFECTED_CATALOG")
 
-          # Staging matrix: services whose arm64 image is pushed to ECR and
-          # tagged :staging (one guard run per such service).
+          # Staging matrix: services whose image is pushed to ECR and tagged
+          # :staging (one guard run per such service).
           STAGING_MATRIX=$(jq -c '
             map(select(.push | index("ecr"))) | { service: [.[].service] }
           ' <<<"$AFFECTED_CATALOG")
@@ -342,6 +347,7 @@ jobs:
         env:
           PUSH_LIST: ${{ join(matrix.push, ' ') }}
           ARCH: ${{ matrix.arch }}
+          ECR_ARCH: ${{ matrix.ecr_arch }}
           REF: ${{ github.ref }}
           EVENT: ${{ github.event_name }}
           SERVICE: ${{ matrix.service }}
@@ -358,7 +364,7 @@ jobs:
           [[ "$REF" == refs/heads/main ]] && is_main=true
 
           push_ecr=false
-          if [[ " $PUSH_LIST " == *" ecr "* && "$ARCH" == arm64 && "$is_main" == true && "$is_push_event" == true ]]; then
+          if [[ " $PUSH_LIST " == *" ecr "* && "$ARCH" == "$ECR_ARCH" && "$is_main" == true && "$is_push_event" == true ]]; then
             push_ecr=true
           fi
           push_ghcr=false
@@ -378,8 +384,9 @@ jobs:
             echo "push_ghcr=$push_ghcr"
             echo "push=$push"
 
-            # ECR is single-arch (arm64), tag-based. Only immutable tags here
-            # (:sha / :run); the mutable :staging tag is set by the `stage` job.
+            # ECR is single-arch (the entry's ecr_arch), tag-based. Only
+            # immutable tags here (:sha / :run); the mutable :staging tag is
+            # set by the `stage` job.
             echo "ecr_tags<<EOF"
             if $push_ecr; then
               echo "$ecr_host/$ECR_REPO/$SERVICE:sha-$SHA"
@@ -472,7 +479,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
-      # ECR images are single-arch (arm64). Advance :staging onto this commit's
+      # ECR images are single-arch. Advance :staging onto this commit's
       # immutable sha tag only if it is newer than the one currently tagged.
       - name: Advance :staging if newer
         uses: $/.github/actions/tag-if-newer


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

ECR holds one architecture per repository, because Amazon Inspector does not scan manifest lists. Until now that architecture was hard-wired to arm64 for every service, and publishing to GHCR implied building both architectures. The upcoming `atlas-fit` image (GPU fit job on x86 instances) is amd64-only and goes to ECR and GHCR, so the deploy catalog gains two optional fields.

## 🔍 What does this change?

- `.github/workflows/deploy.yml`: an optional `arches` per catalog entry (default: both for GHCR services, arm64 otherwise) and an optional `ecr_arch` (default: the only arch when a service builds one, else arm64). The build matrix expands `arches`; the ECR push compares against `ecr_arch` instead of a literal `arm64`; the pull-request-time amd64 skip no longer drops a service whose only architecture is amd64. The setup step fails loudly when `ecr_arch` is not among `arches`, since the ECR push would otherwise silently never happen.
- No catalog entry changes. Every existing service resolves to the same build matrix and tags as before; the `atlas-fit` entry follows with its Dockerfile (H-6806).

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🛡 What tests cover this?

- The resolve and build-matrix `jq` programs run against a sample catalog (`graph` ECR+GHCR, `kratos` ECR-only, `atlas-fit` ECR+GHCR with `arches: ["amd64"]`, a multi-arch entry with `ecr_arch: "amd64"`) in push and pull-request mode: existing services keep their matrix, `atlas-fit` builds amd64 only in both modes.
- The consistency check flags an entry whose `ecr_arch` is outside its `arches` and passes GHCR-only entries.
- `actionlint` reports the same findings as on `main`; the workflow parses.
