### PR TITLE
FE-1603: Add a /new route that opens a fresh net

### DIFF
--- a/apps/petrinaut-website/README.md
+++ b/apps/petrinaut-website/README.md
@@ -24,6 +24,14 @@ The dev server runs at [http://localhost:5173](http://localhost:5173). A plugin 
 In production, the functions in the `api` folder are automatically deployed as
 Vercel Functions.
 
+## Starting a new net
+
+`/new` creates an empty net in local storage and redirects to the editable demo,
+which opens the most recently modified net. The redirect replaces, so a reload
+cannot make a second net and Back skips the route. Empty nets earlier visits
+left behind are dropped, matching the editor's own rule when a visitor switches
+away from an untouched net.
+
 ## Example embeds and oEmbed
 
 Canonical example pages live below `/examples`. The JSON oEmbed endpoint at

--- a/apps/petrinaut-website/src/main/app/local-storage-demo/local-storage-demo-app.tsx
+++ b/apps/petrinaut-website/src/main/app/local-storage-demo/local-storage-demo-app.tsx
@@ -47,6 +47,9 @@ import { getOrCreateBrunchPrincipal } from "./brunch-principal";
 import { useFlueChatHistory } from "./use-flue-chat-history";
 import { useLocalStorageAiMessages } from "./use-local-storage-ai-messages";
 import {
+  createLocalStorageNetRecord,
+  emptySDCPN,
+  isEmptySDCPN,
   type SDCPNInLocalStorage,
   useLocalStorageSDCPNs,
 } from "./use-local-storage-sdcpns";
@@ -54,49 +57,12 @@ import { walkthroughSteps } from "./walkthrough/walkthrough-steps";
 
 import type { SharedExampleSearch } from "../../../examples/example-search";
 
-const isEmptySDCPN = (sdcpn: SDCPN) =>
-  sdcpn.places.length === 0 &&
-  sdcpn.transitions.length === 0 &&
-  sdcpn.types.length === 0 &&
-  sdcpn.parameters.length === 0 &&
-  sdcpn.differentialEquations.length === 0 &&
-  (sdcpn.subnets ?? []).length === 0 &&
-  (sdcpn.componentInstances ?? []).length === 0 &&
-  (sdcpn.scenarios ?? []).length === 0 &&
-  (sdcpn.metrics ?? []).length === 0;
-
-const emptySDCPN: SDCPN = {
-  places: [],
-  transitions: [],
-  types: [],
-  parameters: [],
-  differentialEquations: [],
-};
-
 const createDefaultStoredSDCPN = (): SDCPNInLocalStorage => ({
   id: "net-1",
   title: "New Process",
   sdcpn: emptySDCPN,
   lastUpdated: new Date(0).toISOString(),
 });
-
-/**
- * Creates the localStorage record for a newly created net, keeping the generated
- * id and last-updated timestamp in sync.
- */
-const createLocalStorageNetRecord = (params: {
-  petriNetDefinition: SDCPN;
-  title: string;
-}): SDCPNInLocalStorage => {
-  const now = new Date();
-
-  return {
-    id: `net-${now.getTime()}`,
-    title: params.title,
-    sdcpn: params.petriNetDefinition,
-    lastUpdated: now.toISOString(),
-  };
-};
 
 const DEMO_CAPABILITIES = {
   disabledExtensions: [],

--- a/apps/petrinaut-website/src/main/app/local-storage-demo/use-local-storage-sdcpns.test.ts
+++ b/apps/petrinaut-website/src/main/app/local-storage-demo/use-local-storage-sdcpns.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  emptySDCPN,
+  type SDCPNInLocalStorage,
+  startEmptyNetInStorage,
+} from "./use-local-storage-sdcpns";
+
+import type { SDCPN } from "@hashintel/petrinaut-core";
+
+const rootLocalStorageKey = "petrinaut-sdcpn";
+
+const createStorage = (initial?: string): Storage => {
+  const values = new Map<string, string>(
+    initial === undefined ? [] : [[rootLocalStorageKey, initial]],
+  );
+
+  return {
+    get length() {
+      return values.size;
+    },
+    clear: () => values.clear(),
+    getItem: (key: string) => values.get(key) ?? null,
+    key: (index: number) => [...values.keys()][index] ?? null,
+    removeItem: (key: string) => void values.delete(key),
+    setItem: (key: string, value: string) => void values.set(key, value),
+  };
+};
+
+const readNets = (storage: Storage): Record<string, SDCPNInLocalStorage> =>
+  JSON.parse(storage.getItem(rootLocalStorageKey) ?? "{}") as Record<
+    string,
+    SDCPNInLocalStorage
+  >;
+
+const drawnNet: SDCPN = {
+  ...emptySDCPN,
+  places: [
+    {
+      id: "place-1",
+      name: "Susceptible",
+      colorId: null,
+      dynamicsEnabled: false,
+      differentialEquationId: null,
+      x: 0,
+      y: 0,
+    },
+  ],
+};
+
+const storedNet = (id: string, sdcpn: SDCPN): [string, SDCPNInLocalStorage] => [
+  id,
+  { id, title: id, sdcpn, lastUpdated: new Date(0).toISOString() },
+];
+
+describe("startEmptyNetInStorage", () => {
+  test("writes an empty net into an untouched store", () => {
+    const storage = createStorage();
+
+    const net = startEmptyNetInStorage(storage);
+
+    expect(readNets(storage)).toStrictEqual({ [net.id]: net });
+    expect(net.sdcpn).toStrictEqual(emptySDCPN);
+  });
+
+  test("keeps the nets the visitor has drawn", () => {
+    const storage = createStorage(
+      JSON.stringify(Object.fromEntries([storedNet("net-drawn", drawnNet)])),
+    );
+
+    const net = startEmptyNetInStorage(storage);
+
+    expect(Object.keys(readNets(storage)).sort()).toStrictEqual(
+      ["net-drawn", net.id].sort(),
+    );
+  });
+
+  test("drops the empty nets an earlier visit left behind", () => {
+    const storage = createStorage(
+      JSON.stringify(
+        Object.fromEntries([
+          storedNet("net-empty", emptySDCPN),
+          storedNet("net-drawn", drawnNet),
+        ]),
+      ),
+    );
+
+    const net = startEmptyNetInStorage(storage);
+
+    expect(Object.keys(readNets(storage)).sort()).toStrictEqual(
+      ["net-drawn", net.id].sort(),
+    );
+  });
+
+  test("opens the new net, which is the most recently modified one", () => {
+    const storage = createStorage(
+      JSON.stringify(
+        Object.fromEntries([
+          [
+            "net-drawn",
+            {
+              id: "net-drawn",
+              title: "net-drawn",
+              sdcpn: drawnNet,
+              lastUpdated: new Date(8_640_000_000).toISOString(),
+            },
+          ],
+        ]),
+      ),
+    );
+
+    const net = startEmptyNetInStorage(storage);
+    const nets = Object.values(readNets(storage));
+    const mostRecent = nets.sort(
+      (a, b) =>
+        new Date(b.lastUpdated).getTime() - new Date(a.lastUpdated).getTime(),
+    )[0];
+
+    expect(mostRecent?.id).toBe(net.id);
+  });
+
+  test("replaces content it cannot parse", () => {
+    const storage = createStorage("not json");
+
+    const net = startEmptyNetInStorage(storage);
+
+    expect(readNets(storage)).toStrictEqual({ [net.id]: net });
+  });
+
+  test("replaces a stored value that is not a net store", () => {
+    const storage = createStorage(JSON.stringify(["net-1"]));
+
+    const net = startEmptyNetInStorage(storage);
+
+    expect(readNets(storage)).toStrictEqual({ [net.id]: net });
+  });
+});

--- a/apps/petrinaut-website/src/main/app/local-storage-demo/use-local-storage-sdcpns.ts
+++ b/apps/petrinaut-website/src/main/app/local-storage-demo/use-local-storage-sdcpns.ts
@@ -13,6 +13,89 @@ export type SDCPNInLocalStorage = {
 
 type LocalStorageSDCPNsStore = Record<string, SDCPNInLocalStorage>;
 
+export const emptySDCPN: SDCPN = {
+  places: [],
+  transitions: [],
+  types: [],
+  parameters: [],
+  differentialEquations: [],
+};
+
+export const isEmptySDCPN = (sdcpn: SDCPN) =>
+  sdcpn.places.length === 0 &&
+  sdcpn.transitions.length === 0 &&
+  sdcpn.types.length === 0 &&
+  sdcpn.parameters.length === 0 &&
+  sdcpn.differentialEquations.length === 0 &&
+  (sdcpn.subnets ?? []).length === 0 &&
+  (sdcpn.componentInstances ?? []).length === 0 &&
+  (sdcpn.scenarios ?? []).length === 0 &&
+  (sdcpn.metrics ?? []).length === 0;
+
+/**
+ * Creates the localStorage record for a newly created net, keeping the generated
+ * id and last-updated timestamp in sync.
+ */
+export const createLocalStorageNetRecord = (params: {
+  petriNetDefinition: SDCPN;
+  title: string;
+}): SDCPNInLocalStorage => {
+  const now = new Date();
+
+  return {
+    id: `net-${now.getTime()}`,
+    title: params.title,
+    sdcpn: params.petriNetDefinition,
+    lastUpdated: now.toISOString(),
+  };
+};
+
+const readStore = (storage: Storage): LocalStorageSDCPNsStore => {
+  const raw = storage.getItem(rootLocalStorageKey);
+
+  if (raw === null) {
+    return {};
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    // Content the store cannot parse is replaced. `useLocalStorage` hands the
+    // raw string to the editor, which lists no nets from it either.
+    return {};
+  }
+
+  return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+    ? (parsed as LocalStorageSDCPNsStore)
+    : {};
+};
+
+/**
+ * Adds an empty net to `storage` and returns it, dropping the empty nets earlier
+ * visits left behind. The editor prunes an empty net when the visitor switches
+ * away from it, so a URL that starts nets holds to the same rule.
+ */
+export const startEmptyNetInStorage = (
+  storage: Storage,
+): SDCPNInLocalStorage => {
+  const net = createLocalStorageNetRecord({
+    petriNetDefinition: emptySDCPN,
+    title: "New Process",
+  });
+
+  const kept = Object.entries(readStore(storage)).filter(
+    ([, stored]) => !isEmptySDCPN(stored.sdcpn),
+  );
+
+  storage.setItem(
+    rootLocalStorageKey,
+    JSON.stringify({ ...Object.fromEntries(kept), [net.id]: net }),
+  );
+
+  return net;
+};
+
 export const useLocalStorageSDCPNs = () => {
   const [storedSDCPNs, setStoredSDCPNs] =
     useLocalStorage<LocalStorageSDCPNsStore>({

--- a/apps/petrinaut-website/src/routes/-new.test.ts
+++ b/apps/petrinaut-website/src/routes/-new.test.ts
@@ -1,0 +1,80 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { isRedirect } from "@tanstack/react-router";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { Route } from "./new";
+
+import type { SDCPNInLocalStorage } from "../main/app/local-storage-demo/use-local-storage-sdcpns";
+
+/**
+ * Node supplies its own `localStorage` global that shadows the jsdom one and
+ * carries no `setItem`, so the route cannot write a net to it. An in-memory
+ * store gives it one.
+ */
+const stubStorage = () => {
+  const entries = new Map<string, string>();
+  vi.stubGlobal("localStorage", {
+    get length() {
+      return entries.size;
+    },
+    clear: () => entries.clear(),
+    getItem: (key: string) => entries.get(key) ?? null,
+    key: (index: number) => [...entries.keys()][index] ?? null,
+    removeItem: (key: string) => entries.delete(key),
+    setItem: (key: string, value: string) => entries.set(key, value),
+  } satisfies Storage);
+};
+
+const visit = () => {
+  const { beforeLoad } = Route.options;
+
+  if (typeof beforeLoad !== "function") {
+    throw new Error("/new should redirect from beforeLoad");
+  }
+
+  try {
+    // The match arguments go unused: the route reads storage, not the URL.
+    beforeLoad({} as never);
+  } catch (thrown) {
+    return thrown;
+  }
+
+  throw new Error("/new should throw a redirect");
+};
+
+const storedNets = (): SDCPNInLocalStorage[] =>
+  Object.values(
+    JSON.parse(localStorage.getItem("petrinaut-sdcpn") ?? "{}") as Record<
+      string,
+      SDCPNInLocalStorage
+    >,
+  );
+
+describe("/new", () => {
+  beforeEach(stubStorage);
+
+  test("redirects to the editor without adding a history entry", () => {
+    const thrown = visit();
+
+    expect(isRedirect(thrown)).toBe(true);
+    expect(thrown).toMatchObject({ options: { to: "/", replace: true } });
+  });
+
+  test("leaves one empty net for the editor to open", () => {
+    visit();
+
+    const nets = storedNets();
+
+    expect(nets).toHaveLength(1);
+    expect(nets[0]?.sdcpn.places).toStrictEqual([]);
+  });
+
+  test("adds no second empty net when visited again", () => {
+    visit();
+    visit();
+
+    expect(storedNets()).toHaveLength(1);
+  });
+});

--- a/apps/petrinaut-website/src/routes/new.tsx
+++ b/apps/petrinaut-website/src/routes/new.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+
+import { startEmptyNetInStorage } from "../main/app/local-storage-demo/use-local-storage-sdcpns";
+
+// `/new` renders nothing: it starts a net and hands the visitor to the editor,
+// which opens the most recently modified one. The redirect replaces, so a
+// reload cannot make a second net and Back skips the route.
+export const Route = createFileRoute("/new")({
+  beforeLoad: () => {
+    startEmptyNetInStorage(window.localStorage);
+    throw redirect({ to: "/", replace: true });
+  },
+});

--- a/libs/@local/petrinaut-arch-docs/content/website/router-integration.mdx
+++ b/libs/@local/petrinaut-arch-docs/content/website/router-integration.mdx
@@ -79,6 +79,11 @@ net the visitor has open. `/brunch` names its model with the stream keys it
 carries over, so a copied URL reproduces the run. The example pages name the
 model in the path.
 
+`/new` and `/examples` mount nothing and speak no contract. Both redirect from
+`beforeLoad`: `/examples` sends the visitor to the editable demo, and `/new`
+starts an empty net in local storage first, which the demo then opens as the
+most recently modified one.
+
 ## What a URL carries, and what it does not
 
 A single focused item is shareable; a multi-selection is not. Multi-selection


### PR DESCRIPTION
> [!IMPORTANT]
> Website route and its docs, no editor change.

## Summary

Before this PR, the website had no URL that starts a model. Opening `/` restores the most recently modified net, so creating one meant landing in an old net and then picking "Create a new empty net" from the menu or the command palette. Anything that wants to hand someone a blank editor, a docs page, a marketing link, an onboarding email, had nothing to link.

`/new` creates an empty net in local storage and redirects to `/`, which opens it as the most recently modified net. The redirect replaces, so a reload cannot make a second net and Back skips the route, the same shape `/examples` already uses.

## Links

- Ticket [FE-1603](https://linear.app/hash/issue/FE-1603)
- Docs [Router integration › Which routes speak the contract](https://petrinaut-docs-git-claude-fe-1603-new-route.stage.hash.ai/architecture/website/routes/router-integration#which-routes-speak-the-contract)

## Changes

- `/new` starts a net and redirects from `beforeLoad`
  > The route mounts nothing and speaks no search contract.
  > `redirect({ to: "/", replace: true })` keeps the route out of history, so Back returns to whatever preceded it.
- Repeated visits leave one empty net, not a pile
  > `startEmptyNetInStorage` drops the stored nets that are still empty before adding its own.
  > The editor already prunes an empty net when the visitor switches away from one, so the route holds to the same rule.
- Net record, empty-net rule, and storage key move into `use-local-storage-sdcpns.ts`
  > `emptySDCPN`, `isEmptySDCPN`, and `createLocalStorageNetRecord` were private to the demo shell, and the route writes the same store before React mounts.
  > The demo shell imports them instead of declaring its own.
- Content the store cannot parse is replaced rather than merged
  > `useLocalStorage` hands an unparseable value to the editor as a raw string, which lists no nets from it, so nothing readable is lost.

## Test coverage

- `use-local-storage-sdcpns.test.ts`:
  > An untouched store, a store holding drawn nets, and a store holding an empty net left behind; the new net is the most recently modified one; unparseable and non-object content is replaced.
- `-new.test.ts`:
  > `beforeLoad` throws a replacing redirect to `/`, leaves exactly one empty net, and adds no second one on a repeat visit.

## How to test

- Open [Petrinaut preview](https://petrinaut-git-claude-fe-1603-new-route.stage.hash.ai) on Vercel
- Draw a place on the net that opens
- Open `/new`
  > Expect URL to settle on `/`, empty canvas, title "New Process"
- Menu > Load example > any model
- Open `/new` again
- Menu, read the net list
  > Expect one "New Process", not two
- Press Back
  > Expect the example, not `/new`
