### PR TITLE
FE-1500: add the embedded Petrinaut preview

### DIFF
--- a/.changeset/petrinaut-core-preview-doc.md
+++ b/.changeset/petrinaut-core-preview-doc.md
@@ -1,0 +1,6 @@
+---
+"@hashintel/petrinaut-core": patch
+---
+
+Register the `preview` user-guide page, so the in-app assistant can read the
+embedded Preview's documentation.

--- a/.changeset/petrinaut-embedded-preview.md
+++ b/.changeset/petrinaut-embedded-preview.md
@@ -1,6 +1,5 @@
 ---
 "@hashintel/petrinaut": patch
-"@hashintel/petrinaut-core": patch
 ---
 
 Add `PetrinautPreview`, a compact read-only embed surface exported from

--- a/.changeset/petrinaut-embedded-preview.md
+++ b/.changeset/petrinaut-embedded-preview.md
@@ -1,0 +1,8 @@
+---
+"@hashintel/petrinaut": patch
+"@hashintel/petrinaut-core": patch
+---
+
+Add `PetrinautPreview`, a compact read-only embed surface exported from
+`@hashintel/petrinaut/preview` that reuses the editor's canvas, navigation,
+and property-inspection components.

--- a/libs/@hashintel/petrinaut-core/src/ai.ts
+++ b/libs/@hashintel/petrinaut-core/src/ai.ts
@@ -95,6 +95,7 @@ export const petrinautDocNames = [
   "experiments",
   "optimization",
   "actual-mode",
+  "preview",
   "ai-assistant",
   "visual-settings",
   "compilation-output",
@@ -122,6 +123,8 @@ export const petrinautDocSummaries: Record<PetrinautDocName, string> = {
     "Optuna search over a selected scenario's flat parameters: explicit scenario selection, fixed vs optimized parameters and typed domains, one saved or run-local custom-code metric with maximize/minimize direction (not Experiment metric shortcuts), streamed trials, cancellation, and results.",
   "actual-mode":
     "Actual mode: host-provided live execution view, Brunch stream URL route, read-only extension-free net, current limits.",
+  preview:
+    "Compact read-only PetrinautPreview for host-controlled embeds: shared SDCPN canvas, pan/zoom/fit/minimap, selection and responsive inspector, root/subnet navigation, URL-state ownership, omitted editing and management UI, and host-owned iframe security.",
   "ai-assistant":
     "In-app AI assistant: opening the panel, one text and Voice mode transcript/composer, waveform start, inline Voice state and provenance, typed handoff, consent/recovery, prompt chips, tool cards, read-only/simulate-mode rules, host configuration.",
   "visual-settings":

--- a/libs/@hashintel/petrinaut/docs/README.md
+++ b/libs/@hashintel/petrinaut/docs/README.md
@@ -39,6 +39,7 @@ Petrinaut has three global modes in the top bar, though **Actual** is only enabl
 - [Experiments](experiments.md) -- Run Monte Carlo batches and inspect token-count distributions over time.
 - [Optimization](optimization.md) -- Search scenario parameter ranges to maximize or minimize a metric.
 - [Actual Mode](actual-mode.md) -- View a host-provided live Petri net execution, currently via Brunch.
+- [Embedded Preview](preview.md) -- Explore a compact, read-only Petri net embedded in a host application.
 - [AI Assistant](ai-assistant.md) -- Build, review, and revise nets with text or inline Voice mode.
 - [Visual Settings](visual-settings.md) -- Configure the editor appearance and behavior.
 - [Compilation Output](compilation-output.md) -- Inspect how your net's code compiled, and what stops it running on the GPU.

--- a/libs/@hashintel/petrinaut/docs/preview.md
+++ b/libs/@hashintel/petrinaut/docs/preview.md
@@ -15,8 +15,8 @@ elements.
 Select a place, transition, arc, or other supported item to inspect it. The
 preview presents the same property information as Petrinaut's inspector,
 without source editing or other authoring controls. On a wide embed the
-inspector opens as an overlay on the right. On a narrow embed it opens as a
-bottom sheet so the canvas remains usable.
+inspector docks to the right of the canvas. On a narrow embed it sits under
+the canvas so the canvas remains usable.
 
 Use the compact net selector to move between the root net and its subnets. The
 canvas, selection, and inspector update together when you change nets.

--- a/libs/@hashintel/petrinaut/docs/preview.md
+++ b/libs/@hashintel/petrinaut/docs/preview.md
@@ -1,0 +1,41 @@
+# Embedded Preview
+
+`PetrinautPreview` is a compact, read-only surface for showing a Petri net
+inside another application. It is intended for iframe embeds and other
+host-controlled pages where the full Petrinaut editor would be too large.
+
+The preview uses the same SDCPN canvas as the full editor. Nodes, arcs,
+markings, and other supported visual details therefore appear consistently in
+both surfaces. You can pan and zoom the canvas, fit the net into view, and use
+the minimap. You cannot move, connect, add, delete, or otherwise edit net
+elements.
+
+## Inspecting a net
+
+Select a place, transition, arc, or other supported item to inspect it. The
+preview presents the same property information as Petrinaut's inspector,
+without source editing or other authoring controls. On a wide embed the
+inspector opens as an overlay on the right. On a narrow embed it opens as a
+bottom sheet so the canvas remains usable.
+
+Use the compact net selector to move between the root net and its subnets. The
+canvas, selection, and inspector update together when you change nets.
+
+## Navigation and embedding
+
+The application hosting `PetrinautPreview` owns navigation. It can reflect the
+selected subnet or item in its URL and restore that state when the page loads;
+the preview does not install or access an application router itself.
+
+The Petrinaut demo's oEmbed route replaces its current iframe URL when preview
+state changes. This keeps the embed deep-linkable without adding iframe entries
+to the embedding page's Browser Back / Forward history.
+
+`PetrinautPreview` supplies the read-only Petrinaut interface, but it does not
+decide whether a page may be framed. The host is responsible for its iframe
+markup, content-security policy, sandbox permissions, and any other embedding
+or security headers.
+
+The preview intentionally omits source code, editing tools, mode and document
+management controls, experiments, optimizations, and the AI assistant. Use the
+full Petrinaut interface when those workflows are needed.

--- a/libs/@hashintel/petrinaut/package.json
+++ b/libs/@hashintel/petrinaut/package.json
@@ -37,6 +37,10 @@
       "types": "./dist/ui.d.ts",
       "default": "./dist/ui.js"
     },
+    "./preview": {
+      "types": "./dist/preview.d.ts",
+      "default": "./dist/preview.js"
+    },
     "./styles.css": "./dist/main.css",
     "./dist/main.css": "./dist/main.css",
     "./panda-preset": {

--- a/libs/@hashintel/petrinaut/src/preview.ts
+++ b/libs/@hashintel/petrinaut/src/preview.ts
@@ -1,2 +1,12 @@
-/** Public source entry for `@hashintel/petrinaut/preview`. */
-export * from "./ui/preview";
+/**
+ * Public source entry for `@hashintel/petrinaut/preview`.
+ *
+ * Names each export rather than re-exporting a folder: the repository's
+ * file-structuring rule keeps `index.ts` barrels out, and an explicit list
+ * makes the published surface of this entry readable in one place.
+ */
+export type { PetrinautPreviewNavigationState } from "./ui/preview/navigation-adapter";
+export { PetrinautPreview } from "./ui/preview/petrinaut-preview";
+export type { PetrinautPreviewProps } from "./ui/preview/petrinaut-preview";
+export type { PetrinautNavigationController } from "./react/navigation";
+export type { ViewportAction } from "./ui/types/viewport-action";

--- a/libs/@hashintel/petrinaut/src/preview.ts
+++ b/libs/@hashintel/petrinaut/src/preview.ts
@@ -1,0 +1,2 @@
+/** Public source entry for `@hashintel/petrinaut/preview`. */
+export * from "./ui/preview";

--- a/libs/@hashintel/petrinaut/src/react/index.ts
+++ b/libs/@hashintel/petrinaut/src/react/index.ts
@@ -28,6 +28,14 @@ export type { ActualModeContextValue } from "./actual-mode-context";
 export { PetrinautProvider } from "./petrinaut-provider";
 export type { PetrinautProviderProps } from "./petrinaut-provider";
 export {
+  PetrinautCanvasProvider,
+  PetrinautDocumentProvider,
+} from "./petrinaut-provider-layers";
+export type {
+  PetrinautCanvasProviderProps,
+  PetrinautDocumentProviderProps,
+} from "./petrinaut-provider-layers";
+export {
   defaultPetrinautNavigationHistoryPolicy,
   defaultPetrinautNavigationState,
   openPetrinautSimulationResource,

--- a/libs/@hashintel/petrinaut/src/react/petrinaut-provider-layers.tsx
+++ b/libs/@hashintel/petrinaut/src/react/petrinaut-provider-layers.tsx
@@ -1,0 +1,84 @@
+import { ExecutionFrameProvider } from "./execution-frame/provider";
+import { PetrinautInstanceContext } from "./instance-context";
+import {
+  NetManagementContext,
+  type NetManagement,
+} from "./net-management-context";
+import { PlaybackProvider } from "./playback/provider";
+import { SDCPNProvider } from "./sdcpn-provider";
+import { ActiveNetProvider } from "./state/active-net-provider";
+import { CanvasViewportProvider } from "./state/canvas-viewport-provider";
+import { EditorProvider } from "./state/editor-provider";
+import { UndoRedoContext } from "./state/undo-redo-context";
+import { UserSettingsProvider } from "./state/user-settings-provider";
+import { useHandleHistoryAsUndoRedo } from "./use-handle-history-as-undo-redo";
+
+import type { Petrinaut } from "@hashintel/petrinaut-core";
+import type { ReactNode } from "react";
+
+export type PetrinautDocumentProviderProps = {
+  children: ReactNode;
+  instance: Petrinaut;
+  netManagement: NetManagement;
+};
+
+/**
+ * The document bridge shared by the full editor and lightweight Preview.
+ * It deliberately contains no workers. User settings live here so every host
+ * mounts them once, above a simulation provider that reads the Ad-hoc
+ * scenarios setting.
+ */
+export const PetrinautDocumentProvider: React.FC<
+  PetrinautDocumentProviderProps
+> = ({ children, instance, netManagement }) => {
+  const handleHistoryUndoRedo = useHandleHistoryAsUndoRedo(
+    instance.handle.history,
+  );
+
+  const document = (
+    <UserSettingsProvider>
+      <SDCPNProvider>{children}</SDCPNProvider>
+    </UserSettingsProvider>
+  );
+
+  return (
+    <PetrinautInstanceContext value={instance}>
+      <NetManagementContext value={netManagement}>
+        {handleHistoryUndoRedo ? (
+          <UndoRedoContext value={handleHistoryUndoRedo}>
+            {document}
+          </UndoRedoContext>
+        ) : (
+          document
+        )}
+      </NetManagementContext>
+    </PetrinautInstanceContext>
+  );
+};
+
+export type PetrinautCanvasProviderProps = {
+  children: ReactNode;
+};
+
+/**
+ * Runtime contexts needed by the existing SDCPN canvas. It consumes the
+ * nearest simulation context when one is mounted and otherwise uses the
+ * inert default, which keeps the read-only Preview free of simulation workers.
+ *
+ * The per-net viewport lives here rather than in the document layer: the
+ * canvas is its only consumer, and mounting it here gives the Preview the
+ * same remembered framing as the editor.
+ */
+export const PetrinautCanvasProvider: React.FC<
+  PetrinautCanvasProviderProps
+> = ({ children }) => (
+  <CanvasViewportProvider>
+    <PlaybackProvider>
+      <ActiveNetProvider>
+        <EditorProvider>
+          <ExecutionFrameProvider>{children}</ExecutionFrameProvider>
+        </EditorProvider>
+      </ActiveNetProvider>
+    </PlaybackProvider>
+  </CanvasViewportProvider>
+);

--- a/libs/@hashintel/petrinaut/src/react/petrinaut-provider.tsx
+++ b/libs/@hashintel/petrinaut/src/react/petrinaut-provider.tsx
@@ -20,7 +20,6 @@ import type {
 } from "@hashintel/petrinaut-core";
 import type { ReactNode } from "react";
 
-
 export type PetrinautProviderProps = {
   /** The Core instance whose stores the bridges subscribe to. */
   instance: Petrinaut;

--- a/libs/@hashintel/petrinaut/src/react/petrinaut-provider.tsx
+++ b/libs/@hashintel/petrinaut/src/react/petrinaut-provider.tsx
@@ -1,34 +1,25 @@
-import { type ReactNode } from "react";
-
-import {
-  type Petrinaut,
-  type LspWorkerFactory,
-  type WorkerFactory,
-} from "@hashintel/petrinaut-core";
-
-import { ExecutionFrameProvider } from "./execution-frame/provider";
 import { ExperimentsProvider } from "./experiments/provider";
-import { PetrinautInstanceContext } from "./instance-context";
 import { LanguageClientProvider } from "./lsp/provider";
 import {
   PetrinautNavigationProvider,
   type PetrinautNavigationController,
 } from "./navigation";
-import {
-  NetManagementContext,
-  type NetManagement,
-} from "./net-management-context";
 import { NotificationsProvider } from "./notifications/provider";
 import { OptimizationsProvider } from "./optimizations/provider";
-import { PlaybackProvider } from "./playback/provider";
-import { SDCPNProvider } from "./sdcpn-provider";
+import {
+  PetrinautCanvasProvider,
+  PetrinautDocumentProvider,
+} from "./petrinaut-provider-layers";
 import { SimulationProvider } from "./simulation/provider";
-import { ActiveNetProvider } from "./state/active-net-provider";
-import { CanvasViewportProvider } from "./state/canvas-viewport-provider";
-import { EditorProvider } from "./state/editor-provider";
-import { UndoRedoContext } from "./state/undo-redo-context";
-import { UserSettingsProvider } from "./state/user-settings-provider";
-import { useHandleHistoryAsUndoRedo } from "./use-handle-history-as-undo-redo";
+
+import type { NetManagement } from "./net-management-context";
+import type {
+  Petrinaut,
+  LspWorkerFactory,
+  WorkerFactory,
+} from "@hashintel/petrinaut-core";
+import type { ReactNode } from "react";
+
 
 export type PetrinautProviderProps = {
   /** The Core instance whose stores the bridges subscribe to. */
@@ -50,7 +41,11 @@ export type PetrinautProviderProps = {
    * LSP worker themselves rather than relying on the inlined-blob default.
    */
   lspWorkerFactory?: LspWorkerFactory;
-  /** Optional host-owned, router-neutral app location. */
+  /**
+   * Optional host-owned app location. This keeps Petrinaut router-neutral
+   * while allowing URLs and Back / Forward to control workspaces, resources,
+   * subnets, complete selection, and supported overlays.
+   */
   navigation?: PetrinautNavigationController;
   children: ReactNode;
 };
@@ -70,67 +65,36 @@ export const PetrinautProvider: React.FC<PetrinautProviderProps> = ({
   navigation,
   children,
 }) => {
-  const handleHistoryUndoRedo = useHandleHistoryAsUndoRedo(
-    instance.handle.history,
-  );
-
-  // Keyed by handle id so a net switch fully resets net-scoped worker state
-  // and uncontrolled app locations.
-  const inner = (
-    <SDCPNProvider>
+  return (
+    <PetrinautDocumentProvider
+      instance={instance}
+      netManagement={netManagement}
+    >
       <PetrinautNavigationProvider
         controller={navigation}
         key={instance.handle.id}
       >
+        {/* Keyed by handle id so a net switch resets net-scoped workers. */}
         <LanguageClientProvider
           key={instance.handle.id}
           workerFactory={lspWorkerFactory}
         >
           <NotificationsProvider>
-            {/* Above SimulationProvider: the simulation provider reads the
-                Ad-hoc scenarios setting to gate the inline definition. */}
-            <UserSettingsProvider>
-              <CanvasViewportProvider>
-                <SimulationProvider
-                  key={instance.handle.id}
-                  workerFactory={simulationWorkerFactory}
-                >
-                  <ExperimentsProvider workerFactory={monteCarloWorkerFactory}>
-                    <OptimizationsProvider>
-                      <PlaybackProvider>
-                        <ActiveNetProvider>
-                          <EditorProvider>
-                            <ExecutionFrameProvider>
-                              {children}
-                            </ExecutionFrameProvider>
-                          </EditorProvider>
-                        </ActiveNetProvider>
-                      </PlaybackProvider>
-                    </OptimizationsProvider>
-                  </ExperimentsProvider>
-                </SimulationProvider>
-              </CanvasViewportProvider>
-            </UserSettingsProvider>
+            {/* The simulation provider reads the Ad-hoc scenarios user
+                setting, which the document layer above provides. */}
+            <SimulationProvider
+              key={instance.handle.id}
+              workerFactory={simulationWorkerFactory}
+            >
+              <ExperimentsProvider workerFactory={monteCarloWorkerFactory}>
+                <OptimizationsProvider>
+                  <PetrinautCanvasProvider>{children}</PetrinautCanvasProvider>
+                </OptimizationsProvider>
+              </ExperimentsProvider>
+            </SimulationProvider>
           </NotificationsProvider>
         </LanguageClientProvider>
       </PetrinautNavigationProvider>
-    </SDCPNProvider>
-  );
-
-  return (
-    <PetrinautInstanceContext value={instance}>
-      <NetManagementContext value={netManagement}>
-        {handleHistoryUndoRedo ? (
-          // Only override UndoRedoContext when the handle actually provides
-          // history — otherwise leave any outer UndoRedoContext (e.g. one
-          // injected by the legacy `<Petrinaut>` adapter) untouched.
-          <UndoRedoContext value={handleHistoryUndoRedo}>
-            {inner}
-          </UndoRedoContext>
-        ) : (
-          inner
-        )}
-      </NetManagementContext>
-    </PetrinautInstanceContext>
+    </PetrinautDocumentProvider>
   );
 };

--- a/libs/@hashintel/petrinaut/src/ui/hooks/use-canvas-insets.ts
+++ b/libs/@hashintel/petrinaut/src/ui/hooks/use-canvas-insets.ts
@@ -2,6 +2,7 @@ import { use } from "react";
 
 import { EditorContext } from "../../react/state/editor-context";
 import { PANEL_MARGIN } from "../constants/ui";
+import { usePetrinautPresentation } from "../views/shared/presentation-context";
 
 /** How much of the canvas each edge's panels cover, in CSS pixels. */
 export interface CanvasInsets {
@@ -47,5 +48,13 @@ export const getCanvasInsets = (state: PanelLayoutState): CanvasInsets => ({
  * The panels overlay the canvas rather than shrinking it, so a floating
  * control cannot read this off its own layout.
  */
-export const useCanvasInsets = (): CanvasInsets =>
-  getCanvasInsets(use(EditorContext));
+const NO_INSETS: CanvasInsets = { left: 0, right: 0, bottom: 0 };
+
+export const useCanvasInsets = (): CanvasInsets => {
+  const presentation = usePetrinautPresentation();
+  const editor = use(EditorContext);
+
+  // Where the panels sit beside the canvas rather than over it, the canvas is
+  // already the space it occupies and there is nothing to keep clear of.
+  return presentation.panelsOverlayCanvas ? getCanvasInsets(editor) : NO_INSETS;
+};

--- a/libs/@hashintel/petrinaut/src/ui/petrinaut.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/petrinaut.tsx
@@ -121,7 +121,7 @@ export type PetrinautProps = {
    * surface while suppressing authoring actions for route-scoped read-only
    * examples. The default remains `editor`.
    */
-  presentationProfile?: PetrinautPresentationProfile;
+  presentationProfile?: Exclude<PetrinautPresentationProfile, "preview">;
 };
 
 const noop = () => {};

--- a/libs/@hashintel/petrinaut/src/ui/preview/index.ts
+++ b/libs/@hashintel/petrinaut/src/ui/preview/index.ts
@@ -1,5 +1,0 @@
-export type { PetrinautPreviewNavigationState } from "./navigation-adapter";
-export { PetrinautPreview } from "./petrinaut-preview";
-export type { PetrinautPreviewProps } from "./petrinaut-preview";
-export type { PetrinautNavigationController } from "../../react/navigation";
-export type { ViewportAction } from "../types/viewport-action";

--- a/libs/@hashintel/petrinaut/src/ui/preview/index.ts
+++ b/libs/@hashintel/petrinaut/src/ui/preview/index.ts
@@ -1,0 +1,5 @@
+export type { PetrinautPreviewNavigationState } from "./navigation-adapter";
+export { PetrinautPreview } from "./petrinaut-preview";
+export type { PetrinautPreviewProps } from "./petrinaut-preview";
+export type { PetrinautNavigationController } from "../../react/navigation";
+export type { ViewportAction } from "../types/viewport-action";

--- a/libs/@hashintel/petrinaut/src/ui/preview/navigation-adapter.test.ts
+++ b/libs/@hashintel/petrinaut/src/ui/preview/navigation-adapter.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { defaultPetrinautNavigationState } from "../../react/navigation";
+import {
+  createPreviewNavigationAdapter,
+  toPreviewNavigationState,
+  type PetrinautPreviewNavigationState,
+} from "./navigation-adapter";
+
+import type { PetrinautNavigationController } from "../../react/navigation";
+
+describe("Preview navigation adapter", () => {
+  test("pins editor-only state while preserving Preview state", () => {
+    const controller: PetrinautNavigationController<PetrinautPreviewNavigationState> =
+      {
+        state: {
+          scenarioId: "scenario-a",
+          subnetId: "subnet-a",
+          selection: [{ type: "place", id: "place-a" }],
+        },
+        onNavigate: vi.fn(),
+      };
+
+    expect(createPreviewNavigationAdapter(controller).state).toEqual({
+      ...defaultPetrinautNavigationState,
+      mode: "edit",
+      simulateView: "scenarios",
+      scenarioId: "scenario-a",
+      subnetId: "subnet-a",
+      selection: [{ type: "place", id: "place-a" }],
+    });
+  });
+
+  test("projects full-state updaters back onto the Preview contract", () => {
+    const onNavigate =
+      vi.fn<
+        PetrinautNavigationController<PetrinautPreviewNavigationState>["onNavigate"]
+      >();
+    const controller: PetrinautNavigationController<PetrinautPreviewNavigationState> =
+      {
+        state: {
+          scenarioId: undefined,
+          subnetId: null,
+          selection: [],
+        },
+        onNavigate,
+      };
+    const adapter = createPreviewNavigationAdapter(controller);
+    const options = {
+      history: "replace" as const,
+      intent: { cause: "user", action: "selection" } as const,
+    };
+
+    adapter.onNavigate(
+      (state) => ({
+        ...state,
+        mode: "actual",
+        simulateResource: { type: "metric", id: "metric-a" },
+        scenarioId: "scenario-b",
+        subnetId: "subnet-b",
+        selection: [{ type: "transition", id: "transition-b" }],
+      }),
+      options,
+    );
+
+    expect(onNavigate).toHaveBeenCalledOnce();
+    const [update, receivedOptions] = onNavigate.mock.calls[0]!;
+    expect(update(controller.state)).toEqual({
+      scenarioId: "scenario-b",
+      subnetId: "subnet-b",
+      selection: [{ type: "transition", id: "transition-b" }],
+    });
+    expect(receivedOptions).toEqual(options);
+  });
+
+  test("drops editor-only navigation fields", () => {
+    expect(
+      toPreviewNavigationState({
+        ...defaultPetrinautNavigationState,
+        mode: "simulate",
+        simulateView: "metrics",
+        simulateResource: { type: "metric", id: "metric-a" },
+        overlay: { type: "viewport-settings" },
+      }),
+    ).toEqual({
+      scenarioId: undefined,
+      subnetId: null,
+      selection: [],
+    });
+  });
+});

--- a/libs/@hashintel/petrinaut/src/ui/preview/navigation-adapter.ts
+++ b/libs/@hashintel/petrinaut/src/ui/preview/navigation-adapter.ts
@@ -1,0 +1,44 @@
+import {
+  defaultPetrinautNavigationState,
+  type PetrinautNavigationController,
+  type PetrinautNavigationState,
+} from "../../react/navigation";
+
+/** The app-location subset supported by the compact Preview. */
+export type PetrinautPreviewNavigationState = Pick<
+  PetrinautNavigationState,
+  "scenarioId" | "subnetId" | "selection"
+>;
+
+const toFullNavigationState = (
+  state: Readonly<PetrinautPreviewNavigationState>,
+): PetrinautNavigationState => ({
+  ...defaultPetrinautNavigationState,
+  mode: "edit",
+  simulateView: "scenarios",
+  scenarioId: state.scenarioId,
+  subnetId: state.subnetId,
+  selection: state.selection,
+});
+
+export const toPreviewNavigationState = (
+  state: Readonly<PetrinautNavigationState>,
+): PetrinautPreviewNavigationState => ({
+  scenarioId: state.scenarioId,
+  subnetId: state.subnetId,
+  selection: state.selection,
+});
+
+/** Adapts Preview's deliberately smaller URL contract to the shared providers. */
+export const createPreviewNavigationAdapter = (
+  controller: PetrinautNavigationController<PetrinautPreviewNavigationState>,
+): PetrinautNavigationController => ({
+  state: toFullNavigationState(controller.state),
+  historyPolicy: controller.historyPolicy,
+  onNavigate: (update, options) => {
+    controller.onNavigate(
+      (state) => toPreviewNavigationState(update(toFullNavigationState(state))),
+      options,
+    );
+  },
+});

--- a/libs/@hashintel/petrinaut/src/ui/preview/petrinaut-preview.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/preview/petrinaut-preview.tsx
@@ -60,30 +60,33 @@ const previewRootStyle = css({
   color: "neutral.fg.body",
 });
 
+// The editor's top bar at embed height: the same flat 1px outline, padding
+// rhythm, and title weight, with no shadow.
 const previewHeaderStyle = css({
   position: "relative",
   zIndex: "sticky",
   display: "flex",
   alignItems: "center",
-  gap: "2",
+  gap: "[12px]",
   height: "12",
   flexShrink: "0",
-  paddingX: "3",
-  borderBottomWidth: "thin",
-  borderBottomColor: "neutral.bd.subtle",
+  boxSizing: "border-box",
+  paddingX: "[16px]",
   backgroundColor: "neutral.s00",
-  boxShadow: "[0 1px 3px rgba(0, 0, 0, 0.04)]",
+  outlineWidth: "[1px]",
+  outlineStyle: "solid",
+  outlineColor: "neutral.s40",
 });
 
 const previewTitleStyle = css({
   flex: "1",
   minWidth: "0",
+  marginX: "2",
   overflow: "hidden",
   textOverflow: "ellipsis",
   whiteSpace: "nowrap",
-  fontFamily: "[Inter Tight, Inter, sans-serif]",
   fontSize: "sm",
-  fontWeight: "semibold",
+  fontWeight: "medium",
   color: "neutral.fg.heading",
 });
 
@@ -92,15 +95,27 @@ const previewBadgeStyle = css({
   alignItems: "center",
   gap: "1",
   flexShrink: "0",
-  paddingX: "2",
-  paddingY: "1",
-  borderRadius: "full",
+  paddingX: "1.5",
+  paddingY: "0.5",
   backgroundColor: "neutral.s15",
   color: "neutral.s90",
   fontSize: "[10px]",
   fontWeight: "semibold",
   textTransform: "uppercase",
   letterSpacing: "[0.4px]",
+});
+
+// The canvas and the docked inspector share the row; narrow viewports stack
+// the inspector under the canvas instead.
+const previewMainStyle = css({
+  position: "relative",
+  display: "flex",
+  flex: "1",
+  minWidth: "0",
+  minHeight: "0",
+  "@media (max-width: 640px)": {
+    flexDirection: "column",
+  },
 });
 
 const previewCanvasStyle = css({
@@ -199,8 +214,10 @@ export const PetrinautPreview: FunctionComponent<PetrinautPreviewProps> = ({
                   </span>
                   <span className={previewBadgeStyle}>View only</span>
                 </header>
-                <main className={previewCanvasStyle}>
-                  <SDCPNView viewportActions={viewportActions} />
+                <main className={previewMainStyle}>
+                  <div className={previewCanvasStyle}>
+                    <SDCPNView viewportActions={viewportActions} />
+                  </div>
                   <PreviewPropertiesPanel />
                 </main>
               </div>

--- a/libs/@hashintel/petrinaut/src/ui/preview/petrinaut-preview.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/preview/petrinaut-preview.tsx
@@ -1,0 +1,213 @@
+/**
+ * @layerRoot ui.preview
+ * @role Composes the shared canvas and inspectors into a compact read-only embed
+ */
+
+import "@fontsource-variable/inter";
+import "@fontsource-variable/inter-tight";
+import "@fontsource-variable/jetbrains-mono";
+import "@xyflow/react/dist/style.css";
+import "../index.css";
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  type FunctionComponent,
+} from "react";
+
+import { PortalContainerContext } from "@hashintel/ds-components";
+import { css, cx } from "@hashintel/ds-helpers/css";
+import {
+  createJsonDocHandle,
+  createPetrinaut,
+  type Petrinaut as PetrinautInstance,
+  type SDCPN,
+} from "@hashintel/petrinaut-core";
+
+import {
+  PetrinautNavigationProvider,
+  type PetrinautNavigationController,
+} from "../../react/navigation";
+import {
+  PetrinautCanvasProvider,
+  PetrinautDocumentProvider,
+} from "../../react/petrinaut-provider-layers";
+import { SDCPNView } from "../views/SDCPN/sdcpn-view";
+import { PetrinautPresentationProvider } from "../views/shared/presentation-context";
+import {
+  createPreviewNavigationAdapter,
+  type PetrinautPreviewNavigationState,
+} from "./navigation-adapter";
+import { PreviewNetNavigation } from "./preview-net-navigation";
+import { PreviewPropertiesPanel } from "./properties-panel";
+
+import type { NetManagement } from "../../react/net-management-context";
+import type { ViewportAction } from "../types/viewport-action";
+
+const noop = () => {};
+
+const previewRootStyle = css({
+  position: "relative",
+  display: "flex",
+  flexDirection: "column",
+  width: "full",
+  height: "full",
+  minWidth: "0",
+  minHeight: "0",
+  overflow: "hidden",
+  backgroundColor: "neutral.s25",
+  color: "neutral.fg.body",
+});
+
+const previewHeaderStyle = css({
+  position: "relative",
+  zIndex: "sticky",
+  display: "flex",
+  alignItems: "center",
+  gap: "2",
+  height: "12",
+  flexShrink: "0",
+  paddingX: "3",
+  borderBottomWidth: "thin",
+  borderBottomColor: "neutral.bd.subtle",
+  backgroundColor: "neutral.s00",
+  boxShadow: "[0 1px 3px rgba(0, 0, 0, 0.04)]",
+});
+
+const previewTitleStyle = css({
+  flex: "1",
+  minWidth: "0",
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+  fontFamily: "[Inter Tight, Inter, sans-serif]",
+  fontSize: "sm",
+  fontWeight: "semibold",
+  color: "neutral.fg.heading",
+});
+
+const previewBadgeStyle = css({
+  display: "flex",
+  alignItems: "center",
+  gap: "1",
+  flexShrink: "0",
+  paddingX: "2",
+  paddingY: "1",
+  borderRadius: "full",
+  backgroundColor: "neutral.s15",
+  color: "neutral.s90",
+  fontSize: "[10px]",
+  fontWeight: "semibold",
+  textTransform: "uppercase",
+  letterSpacing: "[0.4px]",
+});
+
+const previewCanvasStyle = css({
+  position: "relative",
+  flex: "1",
+  minWidth: "0",
+  minHeight: "0",
+});
+
+export type PetrinautPreviewProps = {
+  /** The immutable model snapshot to display. */
+  definition: SDCPN;
+  /** Stable identity for the in-memory document created by Preview. */
+  documentId?: string;
+  title?: string;
+  /**
+   * Optional host-owned navigation. The host may project this state into any
+   * router; Preview itself does not depend on a router implementation.
+   */
+  navigation?: PetrinautNavigationController<PetrinautPreviewNavigationState>;
+  /** Host actions displayed alongside the canvas zoom controls. */
+  viewportActions?: ViewportAction[];
+};
+
+/**
+ * Compact, read-only Petrinaut surface intended for an iframe embed.
+ *
+ * The component creates a history-free read-only document and renders the
+ * exact same {@link SDCPNView} as the editor. It intentionally mounts neither
+ * Monaco/LSP nor experiments, optimizations, AI, or simulation controls.
+ */
+export const PetrinautPreview: FunctionComponent<PetrinautPreviewProps> = ({
+  definition,
+  documentId,
+  navigation,
+  title = "Petrinaut model",
+  viewportActions,
+}) => {
+  const generatedDocumentId = useId();
+  const portalContainerRef = useRef<HTMLDivElement>(null);
+  const handle = useMemo(
+    () =>
+      createJsonDocHandle({
+        id: documentId ?? `petrinaut-preview-${generatedDocumentId}`,
+        initial: definition,
+        capabilities: { readonly: true },
+        historyLimit: 0,
+      }),
+    [definition, documentId, generatedDocumentId],
+  );
+  const instance = useMemo<PetrinautInstance>(
+    () => createPetrinaut({ document: handle, readonly: true }),
+    [handle],
+  );
+  const navigationAdapter = useMemo(
+    () => (navigation ? createPreviewNavigationAdapter(navigation) : undefined),
+    [navigation],
+  );
+  const netManagement = useMemo<NetManagement>(
+    () => ({
+      title,
+      setTitle: noop,
+      existingNets: [],
+      createNewNet: noop,
+      loadPetriNet: noop,
+    }),
+    [title],
+  );
+
+  useEffect(() => () => instance.dispose(), [instance]);
+
+  return (
+    <PortalContainerContext value={portalContainerRef}>
+      <PetrinautDocumentProvider
+        instance={instance}
+        netManagement={netManagement}
+      >
+        <PetrinautNavigationProvider
+          controller={navigationAdapter}
+          initialState={{
+            mode: "edit",
+            simulateView: "scenarios",
+          }}
+          key={handle.id}
+        >
+          <PetrinautPresentationProvider profile="preview">
+            <PetrinautCanvasProvider>
+              <div
+                ref={portalContainerRef}
+                className={cx(previewRootStyle, "petrinaut-root")}
+              >
+                <header className={previewHeaderStyle}>
+                  <PreviewNetNavigation />
+                  <span className={previewTitleStyle} title={title}>
+                    {title}
+                  </span>
+                  <span className={previewBadgeStyle}>View only</span>
+                </header>
+                <main className={previewCanvasStyle}>
+                  <SDCPNView viewportActions={viewportActions} />
+                  <PreviewPropertiesPanel />
+                </main>
+              </div>
+            </PetrinautCanvasProvider>
+          </PetrinautPresentationProvider>
+        </PetrinautNavigationProvider>
+      </PetrinautDocumentProvider>
+    </PortalContainerContext>
+  );
+};

--- a/libs/@hashintel/petrinaut/src/ui/preview/preview-net-navigation.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/preview/preview-net-navigation.tsx
@@ -1,0 +1,61 @@
+import { use, useRef, useState } from "react";
+
+import { Button, Icon, Popover } from "@hashintel/ds-components";
+import { css } from "@hashintel/ds-helpers/css";
+
+import { ActiveNetContext } from "../../react/state/active-net-context";
+import { SDCPNContext } from "../../react/state/sdcpn-context";
+import { NetNavigationList } from "../views/Editor/panels/LeftSideBar/subviews/nets-list";
+
+const popoverWidthStyle = css({
+  width: "[min(320px, calc(100vw - 24px))]",
+});
+
+/** Compact host for the editor's shared root/subnet navigation list. */
+export const PreviewNetNavigation: React.FC = () => {
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const [open, setOpen] = useState(false);
+  const { activeSubnetId } = use(ActiveNetContext);
+  const {
+    petriNetDefinition: { subnets },
+  } = use(SDCPNContext);
+
+  if (!subnets?.length) {
+    return null;
+  }
+
+  const activeNetName =
+    subnets.find(({ id }) => id === activeSubnetId)?.name ?? "Root";
+
+  return (
+    <>
+      <Button
+        ref={triggerRef}
+        size="xs"
+        variant="ghost"
+        prefix={<Icon name="diagramNested" size="xs" />}
+        suffix={<Icon name="chevronDown" size="xs" />}
+        aria-label={`Select net. Current net: ${activeNetName}`}
+        onClick={() => setOpen((wasOpen) => !wasOpen)}
+      >
+        {activeNetName}
+      </Button>
+      {open && (
+        <Popover
+          triggerRef={triggerRef}
+          position="bottom-start"
+          onClose={() => setOpen(false)}
+        >
+          <Popover.Container className={popoverWidthStyle}>
+            <Popover.Header title="Nets" />
+            <Popover.Body>
+              {/* Picking a net closes the menu: on a compact embed it would
+                  otherwise cover the net the user just chose. */}
+              <NetNavigationList onSelect={() => setOpen(false)} />
+            </Popover.Body>
+          </Popover.Container>
+        </Popover>
+      )}
+    </>
+  );
+};

--- a/libs/@hashintel/petrinaut/src/ui/preview/properties-panel.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/preview/properties-panel.tsx
@@ -4,33 +4,35 @@ import { usePanelTarget } from "../../react/state/use-selection";
 import { GlassPanel } from "../components/glass-panel";
 import { SelectedItemProperties } from "../views/Editor/panels/PropertiesPanel/selected-item-properties";
 
+// Docked beside the canvas like the editor's inspector: a flat bordered
+// column with square corners, no shadow or blur.
 const previewPanelStyle = css({
-  position: "absolute",
-  zIndex: "[calc(var(--z-index-sticky) - 3)]",
-  top: "2",
-  right: "2",
-  bottom: "[72px]",
-  width: "[clamp(280px, 36vw, 360px)]",
+  flexShrink: "0",
+  width: "[clamp(250px, 34vw, 320px)]",
+  minHeight: "0",
   overflow: "hidden",
-  borderWidth: "thin",
-  borderRadius: "lg",
-  boxShadow: "[0 8px 24px rgba(0, 0, 0, 0.14)]",
+  borderLeftWidth: "thin",
   "@media (max-width: 640px)": {
-    top: "[auto]",
-    left: "2",
     width: "auto",
-    height: "[min(42%, 280px)]",
+    height: "[min(40%, 240px)]",
+    borderLeftWidth: "0",
+    borderTopWidth: "thin",
   },
 });
 
 const previewPanelContentStyle = css({
   overflowY: "auto",
+  // The inspector content is shared with the full editor and sized for it;
+  // rendering it slightly smaller keeps the embed sheet compact without
+  // forking the editor components.
+  zoom: "[0.85]",
 });
 
 /**
  * Space-constrained shell for the shared selected-item property content. It is
- * a side panel at normal embed widths and becomes a bottom sheet on narrow
- * viewports; the entity-specific content is identical to the full editor.
+ * a column docked to the right of the canvas at normal embed widths and a band
+ * under it on narrow viewports; the entity-specific content is identical to
+ * the full editor.
  */
 export const PreviewPropertiesPanel: React.FC<{ className?: string }> = ({
   className,

--- a/libs/@hashintel/petrinaut/src/ui/preview/properties-panel.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/preview/properties-panel.tsx
@@ -1,0 +1,52 @@
+import { css, cx } from "@hashintel/ds-helpers/css";
+
+import { usePanelTarget } from "../../react/state/use-selection";
+import { GlassPanel } from "../components/glass-panel";
+import { SelectedItemProperties } from "../views/Editor/panels/PropertiesPanel/selected-item-properties";
+
+const previewPanelStyle = css({
+  position: "absolute",
+  zIndex: "[calc(var(--z-index-sticky) - 3)]",
+  top: "2",
+  right: "2",
+  bottom: "[72px]",
+  width: "[clamp(280px, 36vw, 360px)]",
+  overflow: "hidden",
+  borderWidth: "thin",
+  borderRadius: "lg",
+  boxShadow: "[0 8px 24px rgba(0, 0, 0, 0.14)]",
+  "@media (max-width: 640px)": {
+    top: "[auto]",
+    left: "2",
+    width: "auto",
+    height: "[min(42%, 280px)]",
+  },
+});
+
+const previewPanelContentStyle = css({
+  overflowY: "auto",
+});
+
+/**
+ * Space-constrained shell for the shared selected-item property content. It is
+ * a side panel at normal embed widths and becomes a bottom sheet on narrow
+ * viewports; the entity-specific content is identical to the full editor.
+ */
+export const PreviewPropertiesPanel: React.FC<{ className?: string }> = ({
+  className,
+}) => {
+  const panelTarget = usePanelTarget();
+
+  if (panelTarget.kind === "none") {
+    return null;
+  }
+
+  return (
+    <GlassPanel
+      className={cx(previewPanelStyle, className)}
+      contentClassName={previewPanelContentStyle}
+    >
+      <SelectedItemProperties />
+    </GlassPanel>
+  );
+};

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/LeftSideBar/subviews/nets-list.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/LeftSideBar/subviews/nets-list.tsx
@@ -139,7 +139,10 @@ const ROOT_STOP_ID = "root";
 const targetKey = (target: FocusStopTarget): string =>
   `${target.stopId}:${target.column}`;
 
-const NetsListContent: React.FC = () => {
+export const NetNavigationList: React.FC<{
+  /** Called after a net is picked, so a menu host can close itself. */
+  onSelect?: () => void;
+}> = ({ onSelect }) => {
   const presentation = usePetrinautPresentation();
   const {
     petriNetDefinition: { subnets },
@@ -192,6 +195,12 @@ const NetsListContent: React.FC = () => {
       inputRef.current?.select();
     }
   }, [editingId]);
+
+  const handleSelect = (subnetId: string | null) => {
+    setActiveSubnetId(subnetId);
+    onSelect?.();
+  };
+
 
   const startEditing = (subnetId: string, currentName: string) => {
     if (isReadOnly) return;
@@ -276,8 +285,8 @@ const NetsListContent: React.FC = () => {
       <div
         {...rowFocusProps(ROOT_STOP_ID)}
         className={itemStyle({ active: activeSubnetId === null })}
-        onClick={() => setActiveSubnetId(null)}
-        onKeyDown={onRowKeyDown(ROOT_STOP_ID, () => setActiveSubnetId(null))}
+        onClick={() => handleSelect(null)}
+        onKeyDown={onRowKeyDown(ROOT_STOP_ID, () => handleSelect(null))}
         role="option"
         aria-selected={activeSubnetId === null}
         tabIndex={tabIndexFor({ stopId: ROOT_STOP_ID, column: 0 })}
@@ -299,7 +308,7 @@ const NetsListContent: React.FC = () => {
             className={itemStyle({ active: activeSubnetId === subnet.id })}
             onClick={() => {
               if (editingId !== subnet.id) {
-                setActiveSubnetId(subnet.id);
+                handleSelect(subnet.id);
               }
             }}
             onDoubleClick={() => {
@@ -308,7 +317,7 @@ const NetsListContent: React.FC = () => {
               }
             }}
             onKeyDown={onRowKeyDown(subnet.id, () =>
-              setActiveSubnetId(subnet.id),
+              handleSelect(subnet.id),
             )}
             role="option"
             aria-selected={activeSubnetId === subnet.id}
@@ -369,7 +378,7 @@ export const netsListSubView: SubView = {
   title: "Nets",
   tooltip:
     "View the root net and reusable subnets. Mark subnet places as ports, then instantiate subnets as components in the root net.",
-  component: NetsListContent,
+  component: NetNavigationList,
   renderHeaderAction: () => <NetsHeaderAction />,
   headerActionMutates: true,
   defaultCollapsed: false,

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/LeftSideBar/subviews/nets-list.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/LeftSideBar/subviews/nets-list.tsx
@@ -201,7 +201,6 @@ export const NetNavigationList: React.FC<{
     onSelect?.();
   };
 
-
   const startEditing = (subnetId: string, currentName: string) => {
     if (isReadOnly) return;
     setEditingId(subnetId);
@@ -316,9 +315,7 @@ export const NetNavigationList: React.FC<{
                 startEditing(subnet.id, subnet.name);
               }
             }}
-            onKeyDown={onRowKeyDown(subnet.id, () =>
-              handleSelect(subnet.id),
-            )}
+            onKeyDown={onRowKeyDown(subnet.id, () => handleSelect(subnet.id))}
             role="option"
             aria-selected={activeSubnetId === subnet.id}
             tabIndex={tabIndexFor({ stopId: subnet.id, column: 0 })}

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/place-properties/subviews/place-initial-state/subview.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/place-properties/subviews/place-initial-state/subview.tsx
@@ -11,6 +11,7 @@ import { css } from "@hashintel/ds-helpers/css";
 
 import { PlaybackContext } from "../../../../../../../../react/playback/context";
 import { SimulationContext } from "../../../../../../../../react/simulation/context";
+import { useIsReadOnly } from "../../../../../../../../react/state/use-is-read-only";
 import { UI_MESSAGES } from "../../../../../../../constants/ui-messages";
 import { usePetrinautPresentation } from "../../../../../../shared/presentation-context";
 import { usePlacePropertiesContext } from "../../context";
@@ -100,6 +101,9 @@ const ClearStateHeaderAction: React.FC = () => {
  */
 const PlaceInitialStateContent: React.FC = () => {
   const { place, placeType } = usePlacePropertiesContext();
+  // A read-only document reaches this editor through the embedded Preview as
+  // well as a read-only host, and the initial marking is authored data.
+  const isReadOnly = useIsReadOnly();
 
   const { initialMarking, setInitialMarking, selectedScenarioId } =
     use(SimulationContext);
@@ -169,11 +173,11 @@ const PlaceInitialStateContent: React.FC = () => {
         className={stateFieldStyle}
         label="Token count"
         size="sm"
-        disabled={hasSimulationFrames}
+        disabled={hasSimulationFrames || isReadOnly}
       >
         <Tooltip
           content={UI_MESSAGES.READ_ONLY_MODE}
-          disableTooltip={!hasSimulationFrames}
+          disableTooltip={!hasSimulationFrames && !isReadOnly}
         >
           <NumberInput
             min={0}
@@ -181,7 +185,7 @@ const PlaceInitialStateContent: React.FC = () => {
             onChange={(tokenCount) => {
               setInitialMarking(place.id, Math.max(0, tokenCount ?? 0));
             }}
-            disabled={hasSimulationFrames}
+            disabled={hasSimulationFrames || isReadOnly}
           />
         </Tooltip>
       </Form.Field>
@@ -189,7 +193,12 @@ const PlaceInitialStateContent: React.FC = () => {
   }
 
   return (
-    <InitialStateEditor key={place.id} place={place} placeType={placeType} />
+    <InitialStateEditor
+      key={place.id}
+      place={place}
+      placeType={placeType}
+      readOnly={isReadOnly}
+    />
   );
 };
 

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel/petrinaut-docs-content.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel/petrinaut-docs-content.ts
@@ -12,6 +12,7 @@ import examples from "../../../../../../docs/examples.md?raw";
 import experiments from "../../../../../../docs/experiments.md?raw";
 import optimization from "../../../../../../docs/optimization.md?raw";
 import petriNetExtensions from "../../../../../../docs/petri-net-extensions.md?raw";
+import preview from "../../../../../../docs/preview.md?raw";
 import scenarios from "../../../../../../docs/scenarios.md?raw";
 import simulation from "../../../../../../docs/simulation.md?raw";
 import usefulPatterns from "../../../../../../docs/useful-patterns.md?raw";
@@ -39,6 +40,7 @@ const rawDocsByName: Record<PetrinautDocName, string> = {
   experiments,
   optimization,
   "actual-mode": actualMode,
+  preview,
   "ai-assistant": aiAssistant,
   "visual-settings": visualSettings,
   "compilation-output": compilationOutput,

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/components/viewport-controls.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/components/viewport-controls.tsx
@@ -46,6 +46,9 @@ export const ViewportControls: React.FC<{
       { cause: "user", action: "overlay" },
     );
   };
+  const chromeBackground = presentation.blurredChrome
+    ? blurredBackground
+    : undefined;
   // Fit view goes through the canvas controller like the zooms: these
   // controls sit above the renderer contract and must not reach for a
   // renderer's own API.
@@ -73,7 +76,7 @@ export const ViewportControls: React.FC<{
         tooltip="Zoom in"
         tooltipOptions={{ position: "left" }}
         iconName="plus"
-        className={blurredBackground}
+        className={chromeBackground}
         onClick={zoomIn}
       />
       <Button
@@ -83,7 +86,7 @@ export const ViewportControls: React.FC<{
         tooltip="Zoom out"
         tooltipOptions={{ position: "left" }}
         iconName="dash"
-        className={blurredBackground}
+        className={chromeBackground}
         onClick={zoomOut}
       />
       <Button
@@ -93,7 +96,7 @@ export const ViewportControls: React.FC<{
         tooltip="Fit view"
         tooltipOptions={{ position: "left" }}
         iconName="collapse"
-        className={blurredBackground}
+        className={chromeBackground}
         onClick={fitView}
       />
       {presentation.showViewportSettings && (
@@ -105,7 +108,7 @@ export const ViewportControls: React.FC<{
             tooltip="Fullscreen"
             tooltipOptions={{ position: "left" }}
             iconName="expand"
-            className={blurredBackground}
+            className={chromeBackground}
             onClick={collapseAllPanels}
           />
           <Button
@@ -115,7 +118,7 @@ export const ViewportControls: React.FC<{
             tooltip="Lock view"
             tooltipOptions={{ position: "left" }}
             iconName="lockOpen"
-            className={blurredBackground}
+            className={chromeBackground}
             onClick={() => {
               // Placeholder for future lock view functionality
             }}
@@ -127,7 +130,7 @@ export const ViewportControls: React.FC<{
             tooltip="Settings"
             tooltipOptions={{ position: "left" }}
             iconName="gear"
-            className={blurredBackground}
+            className={chromeBackground}
             onClick={() => setIsSettingsOpen(true)}
           />
           <ViewportSettingsDialog
@@ -146,7 +149,7 @@ export const ViewportControls: React.FC<{
           tooltip={action.tooltip}
           tooltipOptions={{ position: "left" }}
           onClick={action.onClick}
-          className={cx(action.className, blurredBackground)}
+          className={cx(action.className, chromeBackground)}
           prefix={action.icon}
         />
       ))}

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/mini-map.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/mini-map.tsx
@@ -5,6 +5,7 @@ import { css } from "@hashintel/ds-helpers/css";
 
 import { EditorContext } from "../../../../../../react/state/editor-context";
 import { PANEL_MARGIN } from "../../../../../constants/ui";
+import { usePetrinautPresentation } from "../../../../shared/presentation-context";
 import { miniMapPlaceFillColor } from "../../../styles/type-colors";
 
 import type { NodeType } from "./react-flow-types";
@@ -102,8 +103,13 @@ const MiniMapNode: React.FC<MiniMapNodeProps> = ({ id, x, y }) => {
 export const MiniMap: React.FC<Omit<MiniMapProps, "style">> = (props) => {
   const { hasSelection, propertiesPanelWidth, isPanelAnimating } =
     use(EditorContext);
+  const presentation = usePetrinautPresentation();
 
-  const isPropertiesPanelVisible = hasSelection;
+  // The editor mounts its resizable properties panel to the right of the
+  // canvas; the preview renders its own floating inspector instead, so the
+  // editor panel width must not displace the minimap there.
+  const isPropertiesPanelVisible =
+    hasSelection && presentation.profile !== "preview";
   // True inset from the canvas edges (react-flow's default 15px panel margin
   // is zeroed below) — matches the viewport controls' offset.
   const minimapOffset = 12;

--- a/libs/@hashintel/petrinaut/src/ui/views/shared/presentation-context.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/shared/presentation-context.tsx
@@ -16,6 +16,15 @@ export type PetrinautPresentationCapabilities = {
   showMinimap: boolean;
   /** Prefer controls sized for a compact embed over the full editor sizing. */
   compactControls: boolean;
+  /**
+   * Whether the panels around the canvas float over it. The editor's panels
+   * do, so floating controls have to keep clear of them; the Preview docks its
+   * inspector as a flex sibling, which shrinks the canvas instead, and
+   * reserving the same width there pushes the controls inward twice.
+   */
+  panelsOverlayCanvas: boolean;
+  /** Blur the chrome that floats over the canvas. */
+  blurredChrome: boolean;
 };
 
 const PRESENTATION_CAPABILITIES: Record<
@@ -30,6 +39,8 @@ const PRESENTATION_CAPABILITIES: Record<
     showViewportSettings: true,
     showMinimap: true,
     compactControls: false,
+    panelsOverlayCanvas: true,
+    blurredChrome: true,
   },
   review: {
     profile: "review",
@@ -39,6 +50,8 @@ const PRESENTATION_CAPABILITIES: Record<
     showViewportSettings: true,
     showMinimap: true,
     compactControls: false,
+    panelsOverlayCanvas: true,
+    blurredChrome: true,
   },
   preview: {
     profile: "preview",
@@ -48,6 +61,8 @@ const PRESENTATION_CAPABILITIES: Record<
     showViewportSettings: false,
     showMinimap: true,
     compactControls: true,
+    panelsOverlayCanvas: false,
+    blurredChrome: false,
   },
 };
 

--- a/libs/@hashintel/petrinaut/src/ui/views/shared/presentation-context.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/shared/presentation-context.tsx
@@ -1,6 +1,6 @@
 import { createContext, use, type PropsWithChildren } from "react";
 
-export type PetrinautPresentationProfile = "editor" | "review";
+export type PetrinautPresentationProfile = "editor" | "review" | "preview";
 
 export type PetrinautPresentationCapabilities = {
   profile: PetrinautPresentationProfile;
@@ -39,6 +39,15 @@ const PRESENTATION_CAPABILITIES: Record<
     showViewportSettings: true,
     showMinimap: true,
     compactControls: false,
+  },
+  preview: {
+    profile: "preview",
+    showMutationActions: false,
+    showSourceCode: false,
+    showCustomVisualizers: false,
+    showViewportSettings: false,
+    showMinimap: true,
+    compactControls: true,
   },
 };
 

--- a/libs/@hashintel/petrinaut/vite.config.ts
+++ b/libs/@hashintel/petrinaut/vite.config.ts
@@ -31,12 +31,14 @@ const isExternalDependency = (id: string) =>
 export default defineConfig(({ command }) => ({
   build: {
     lib: {
-      // Keep the legacy `main` entry for back-compat alongside the React/UI
-      // split from RFC 0001 and the preset consumed by host Panda pipelines.
+      // Public entry points: the legacy `main` (back-compat), the React/UI
+      // split per RFC 0001, and a Preview entry that excludes editor-only
+      // providers. Each emits its own JS + dts bundle.
       entry: {
         main: "src/main.ts",
         react: "src/react/index.ts",
         ui: "src/ui/index.ts",
+        preview: "src/preview.ts",
         // Panda preset consumed by hosts that compile Petrinaut's styles
         // through their own Panda pipeline (see panda.ship.config.ts).
         "panda-preset": "src/panda-preset.ts",


### PR DESCRIPTION
## Summary

Before this PR, embedding a net meant mounting the full `Petrinaut` component in read-only mode. That loads Monaco, the language server, experiments, optimizations, and the AI assistant for a page that only shows a model, and its chrome is sized for authoring.

`PetrinautPreview`, exported from `@hashintel/petrinaut/preview`, is a compact read-only surface for showing a net inside another application. It reuses the editor's canvas, navigation, and property inspection and mounts none of the authoring tooling. Its chrome follows the editor's: a flat outlined header, a square badge, and an inspector docked beside the canvas.

## Links

- Ticket [FE-1500](https://linear.app/hash/issue/FE-1500)
- Docs [Preview](https://github.com/hashintel/hash/blob/codex/fe-1500-viewer/libs/@hashintel/petrinaut/docs/preview.md)

## Changes

#### Provider layers

- `PetrinautProvider` splits into `PetrinautDocumentProvider` and `PetrinautCanvasProvider`
  > The document layer holds the instance, net management, the undo/redo bridge, user settings, and the SDCPN store.
  > The canvas layer holds playback, active net, editor, and execution frame.
  > User settings sit in the document layer so a simulation provider mounted between the layers reads the Ad-hoc scenarios setting.
- Provider behaviour is unchanged for the full editor

#### Preview surface

- `PetrinautPreview` in `src/ui/preview/`
  > In-memory read-only document, header with net selector, title, and View only badge, the shared `SDCPNView`, and the compact inspector.
- Navigation adapter projects the preview's URL contract onto the full controller
  > `PetrinautPreviewNavigationState` carries scenario, subnet, and selection.
- Compact properties panel docked beside the canvas
  > A flat bordered column on wide embeds, a band under the canvas on narrow ones, content slightly scaled down.
- `preview` presentation profile
  > No mutation actions, no source code, no custom visualizers, no viewport settings, compact controls.
  > The editor's `presentationProfile` prop excludes it.
- Embed-scale chrome follows the editor's top bar
  > 48px header with the same flat 1px outline and title weight, square badge, no shadow or blur anywhere.
  > The minimap no longer dodges the editor's absent right panel in the preview profile.
- User guide page `docs/preview.md` registered in the docs index and the AI assistant's doc list

#### Review fixes

- The Preview keeps its own canvas chrome rules
  > `panelsOverlayCanvas` is false for the preview profile, so the viewport controls and the recentre hook stop reserving a properties-panel width that the Preview docks beside the canvas rather than over it.
  > `blurredChrome` is false there too, so the controls lose the editor's backdrop filter.
- The State subview honours a read-only document
  > The Preview's handle is read-only, but the token-count input and the spreadsheet never consulted that, so an initial marking could be edited from a read-only embed.
- One changeset per publishable package
  > The core entry now describes what that package changes here, which is registering the `preview` user-guide page.

## Test coverage

- `navigation-adapter.test.ts`:
  > Projection between the preview contract and the full navigation state.
- `ai.test.ts`, `petrinaut-docs-content.test.ts`:
  > Registration of the new user guide page.
- `build:lib`:
  > The new `preview` entry builds.

## How to test

- `yarn workspace @hashintel/petrinaut build:lib`
- Render `<PetrinautPreview definition={...} title="..." />` from `@hashintel/petrinaut/preview` in a host page
- Pan, zoom, fit, minimap
- Select a node
  > Expect inspector docked right of the canvas with square corners
- Net selector > a subnet
  > Expect no editing affordance anywhere


