### PR TITLE
FE-1500: switch the example embed to the Petrinaut preview

### DIFF
--- a/apps/petrinaut-website/src/examples/embedded-example-page.tsx
+++ b/apps/petrinaut-website/src/examples/embedded-example-page.tsx
@@ -2,15 +2,19 @@ import { lazy, Suspense, type FunctionComponent } from "react";
 
 import { css } from "@hashintel/ds-helpers/css";
 
-import { getReadonlyExampleHandle } from "./readonly-example-handle";
-import { useSharedSearchNavigation } from "./use-shared-search-navigation";
+import { previewSearchToNavigationState } from "./navigation-search";
 
-import type { LoadedExample } from "./catalog";
+import type { GeneratedExampleRuntime, LoadedExample } from "./catalog";
 import type { SharedExampleSearch } from "./example-search";
+import type {
+  PetrinautPreviewNavigationState,
+  PetrinautPreviewQuickSimulation,
+} from "@hashintel/petrinaut/preview";
+import type { PetrinautNavigationController } from "@hashintel/petrinaut/react";
 
-const LazyPetrinaut = lazy(async () => {
-  const { Petrinaut } = await import("@hashintel/petrinaut/ui");
-  return { default: Petrinaut };
+const LazyPetrinautPreview = lazy(async () => {
+  const { PetrinautPreview } = await import("@hashintel/petrinaut/preview");
+  return { default: PetrinautPreview };
 });
 
 // The page frame and the loading fallback render outside Petrinaut, and the
@@ -36,55 +40,37 @@ const loadingStyle = css({
   fontSize: "[14px]",
 });
 
-const embedTitleStyle = css({
-  minWidth: "0",
-  overflow: "hidden",
-  color: "neutral.s90",
-  fontSize: "sm",
-  fontWeight: "medium",
-  textOverflow: "ellipsis",
-  whiteSpace: "nowrap",
-});
-
 export type EmbeddedExamplePageProps = {
   example: LoadedExample;
-  /** Writes the shared search subset back to the embed URL. */
-  onSearchChange: (
-    search: SharedExampleSearch,
-    history: "push" | "replace",
-  ) => void;
+  runtime: GeneratedExampleRuntime;
+  onNavigate: PetrinautNavigationController<PetrinautPreviewNavigationState>["onNavigate"];
   search: SharedExampleSearch;
 };
 
-/**
- * Embed of an example: the full Petrinaut component in its read-only
- * presentation, navigated through the shared search contract.
- */
 export const EmbeddedExamplePage: FunctionComponent<
   EmbeddedExamplePageProps
-> = ({ example, onSearchChange, search }) => {
-  const handle = getReadonlyExampleHandle(example);
-  const navigation = useSharedSearchNavigation(search, onSearchChange, {
-    // The embed lives in an iframe; it must not grow the host page's history.
-    historyPolicy: () => "replace",
-  });
+> = ({ example, onNavigate, runtime, search }) => {
+  const navigation: PetrinautNavigationController<PetrinautPreviewNavigationState> =
+    {
+      state: previewSearchToNavigationState(search),
+      historyPolicy: () => "replace",
+      onNavigate,
+    };
+  const quickSimulation: PetrinautPreviewQuickSimulation = {
+    ...runtime,
+    parameterBounds: example.catalog.parameterBounds,
+  };
 
   return (
     <main className={pageStyle}>
       <Suspense
         fallback={<div className={loadingStyle}>Loading Petrinaut…</div>}
       >
-        <LazyPetrinaut
-          handle={handle}
-          hideNetManagementControls="all"
+        <LazyPetrinautPreview
+          definition={example.definition}
+          documentId={`example:${example.catalog.slug}`}
           navigation={navigation}
-          presentationProfile="review"
-          readonly
-          slots={{
-            topBarStart: (
-              <span className={embedTitleStyle}>{example.catalog.title}</span>
-            ),
-          }}
+          quickSimulation={quickSimulation}
           title={example.catalog.title}
         />
       </Suspense>

--- a/apps/petrinaut-website/src/examples/example-search.property.test.ts
+++ b/apps/petrinaut-website/src/examples/example-search.property.test.ts
@@ -6,6 +6,10 @@ import {
   sharedSearchesMatch,
   validateSharedExampleSearch,
 } from "./example-search";
+import {
+  navigationStateToPreviewSearch,
+  previewSearchToNavigationState,
+} from "./navigation-search";
 
 const knownKeys = ["scenario", "subnet", "itemType", "itemId"] as const;
 
@@ -50,7 +54,7 @@ describe("example search contract laws", () => {
   });
 
   test.prop([searchInput])(
-    "validation is idempotent, so the embed entry redirect terminates",
+    "validation is idempotent, so re-validating a location is a no-op",
     (input) => {
       const once = validateSharedExampleSearch(input);
       const twice = validateSharedExampleSearch(once);
@@ -67,6 +71,18 @@ describe("example search contract laws", () => {
         Object.fromEntries(new URLSearchParams(canonicalSearchString(search))),
       );
       expect(sharedSearchesMatch(decoded, search)).toBe(true);
+    },
+  );
+});
+
+describe("preview codec", () => {
+  test.prop([searchInput])(
+    "the preview codec spells locations exactly like the shared contract",
+    (input) => {
+      const search = validateSharedExampleSearch(input);
+      expect(
+        navigationStateToPreviewSearch(previewSearchToNavigationState(search)),
+      ).toEqual(search);
     },
   );
 });

--- a/apps/petrinaut-website/src/examples/navigation-search.test.ts
+++ b/apps/petrinaut-website/src/examples/navigation-search.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  applyPreviewNavigationUpdate,
   navigationStateToSharedSearch,
   sharedSearchToNavigationState,
 } from "./navigation-search";
@@ -41,5 +42,38 @@ describe("navigation state projection", () => {
     expect(state.mode).toBe("edit");
     expect(state.overlay).toBeNull();
     expect(state.simulateResource).toBeNull();
+  });
+});
+
+describe("preview navigation writes", () => {
+  it("keeps the fields the Preview does not navigate", () => {
+    // An embed can arrive carrying these: oEmbed copies the source page's mode
+    // into the iframe URL. Writing the Preview's own projection alone dropped
+    // them on the first selection.
+    const next = applyPreviewNavigationUpdate(
+      { mode: "simulate", view: "metrics", overlay: "create-experiment" },
+      (current) => ({
+        ...current,
+        selection: [{ type: "place", id: "place-1" }],
+      }),
+    );
+
+    expect(next).toMatchObject({
+      mode: "simulate",
+      view: "metrics",
+      overlay: "create-experiment",
+      itemType: "place",
+      itemId: "place-1",
+    });
+  });
+
+  it("still writes the fields the Preview does navigate", () => {
+    const next = applyPreviewNavigationUpdate(
+      { itemType: "place", itemId: "place-1" },
+      (current) => ({ ...current, selection: [], subnetId: "subnet-2" }),
+    );
+
+    expect(next.subnet).toBe("subnet-2");
+    expect(next.itemId).toBeUndefined();
   });
 });

--- a/apps/petrinaut-website/src/examples/navigation-search.ts
+++ b/apps/petrinaut-website/src/examples/navigation-search.ts
@@ -23,10 +23,12 @@ import {
   type SharedSimulateView,
 } from "./example-search";
 
+import type { PetrinautPreviewNavigationState } from "@hashintel/petrinaut/preview";
 import type {
   EditorGlobalMode,
   PetrinautNavigationOverlay,
   PetrinautNavigationState,
+  PetrinautNavigationUpdater,
   SimulateViewMode,
 } from "@hashintel/petrinaut/react";
 
@@ -39,6 +41,14 @@ const scenarioFromSearch = (
   }
   return search.scenario === "none" ? null : search.scenario;
 };
+
+export const previewSearchToNavigationState = (
+  search: SharedExampleSearch,
+): PetrinautPreviewNavigationState => ({
+  scenarioId: scenarioFromSearch(search),
+  subnetId: search.subnet ?? null,
+  selection: selectionFromInput(search as Record<string, unknown>),
+});
 
 const scenarioToSearch = (
   scenarioId: string | null | undefined,
@@ -99,3 +109,24 @@ export const navigationStateToSharedSearch = (
     ...selectionToSearch(state.selection),
   };
 };
+
+/**
+ * The Preview navigates a narrower location than the editor — no mode, no
+ * Simulate section, no overlay — so its projection is only the three fields it
+ * has.
+ */
+export const navigationStateToPreviewSearch = (
+  state: Readonly<PetrinautPreviewNavigationState>,
+): SharedExampleSearch => ({
+  scenario: scenarioToSearch(state.scenarioId),
+  subnet: state.subnetId ?? undefined,
+  ...selectionToSearch(state.selection),
+});
+
+export const applyPreviewNavigationUpdate = (
+  search: SharedExampleSearch,
+  update: PetrinautNavigationUpdater<PetrinautPreviewNavigationState>,
+): SharedExampleSearch =>
+  navigationStateToPreviewSearch(
+    update(previewSearchToNavigationState(search)),
+  );

--- a/apps/petrinaut-website/src/examples/navigation-search.ts
+++ b/apps/petrinaut-website/src/examples/navigation-search.ts
@@ -123,10 +123,23 @@ export const navigationStateToPreviewSearch = (
   ...selectionToSearch(state.selection),
 });
 
+/**
+ * Applies a Preview navigation to a search, keeping the fields the Preview
+ * does not navigate.
+ *
+ * Writing the projection alone would drop `mode`, `view` and `overlay` on the
+ * first selection, and an embed can arrive carrying them: oEmbed copies the
+ * source page's `mode` into the iframe URL. A surface that does not understand
+ * a field must not destroy it.
+ */
 export const applyPreviewNavigationUpdate = (
   search: SharedExampleSearch,
   update: PetrinautNavigationUpdater<PetrinautPreviewNavigationState>,
-): SharedExampleSearch =>
-  navigationStateToPreviewSearch(
+): SharedExampleSearch => ({
+  mode: search.mode,
+  view: search.view,
+  overlay: search.overlay,
+  ...navigationStateToPreviewSearch(
     update(previewSearchToNavigationState(search)),
-  );
+  ),
+});

--- a/apps/petrinaut-website/src/routes/embed.examples.$slug.tsx
+++ b/apps/petrinaut-website/src/routes/embed.examples.$slug.tsx
@@ -6,26 +6,34 @@ import {
   useSearch,
 } from "@tanstack/react-router";
 
-import { isExampleSlug, loadExample } from "../examples/catalog";
+import {
+  isExampleSlug,
+  loadExample,
+  loadExampleRuntime,
+} from "../examples/catalog";
 import { EmbeddedExamplePage } from "../examples/embedded-example-page";
 import { validateSharedExampleSearch } from "../examples/example-search";
+import { applyPreviewNavigationUpdate } from "../examples/navigation-search";
 import { EmbedStatusPanel } from "./-embed-status-panel";
 
 const routePath = "/embed/examples/$slug" as const;
 
 function EmbeddedExampleRoute() {
   const navigate = useNavigate({ from: routePath });
-  const example = useLoaderData({ from: routePath });
+  const { example, runtime } = useLoaderData({ from: routePath });
 
   return (
     <EmbeddedExamplePage
-      // The page holds URL-unrepresentable location in state; remount per
-      // example so one model's state cannot leak into the next.
+      // Remount per example so one model's state cannot leak into the next.
       key={example.catalog.slug}
       example={example}
-      onSearchChange={(search, history) => {
-        void navigate({ replace: history === "replace", search });
+      onNavigate={(update, { history }) => {
+        void navigate({
+          replace: history === "replace",
+          search: (previous) => applyPreviewNavigationUpdate(previous, update),
+        });
       }}
+      runtime={runtime}
       search={useSearch({ from: routePath })}
     />
   );
@@ -38,20 +46,26 @@ export const Route = createFileRoute("/embed/examples/$slug")({
     }
   },
   component: EmbeddedExampleRoute,
-  // The editor is imported lazily, so a chunk that fails to load throws after
-  // mount. Without a boundary here the root unmounts and the frame goes blank
-  // on someone else's page.
+  // The Preview is imported lazily, so a chunk that fails to load throws
+  // after mount. Without a boundary here the root unmounts and the frame goes
+  // blank on someone else's page.
   errorComponent: () => (
     <EmbedStatusPanel
       body="Reload the page to try again."
       title="This Petrinaut embed failed to load"
     />
   ),
-  loader: ({ params }) => {
+  loader: async ({ params }) => {
     if (!isExampleSlug(params.slug)) {
       throw notFound();
     }
-    return loadExample(params.slug);
+
+    const [example, runtime] = await Promise.all([
+      loadExample(params.slug),
+      loadExampleRuntime(params.slug),
+    ]);
+
+    return { example, runtime };
   },
   // The site-wide not-found page is a full viewport panel with a link that
   // would navigate the embedder's frame, so the embed answers for itself.


### PR DESCRIPTION
## Summary

Before this PR, `/embed/examples/<slug>` mounted the full read-only `Petrinaut` component. Every embed loaded Monaco and the language server to show a model, and offered no way to run it.

The route switches to `PetrinautPreview` with Quick Simulation. The compact surface loads no language tooling and runs the model's named scenarios from build-time artifacts. The embed URL contract does not change.

https://github.com/user-attachments/assets/e459fea4-5218-4ce1-b04a-4c147bff15a4

## Links

- Ticket [FE-1500](https://linear.app/hash/issue/FE-1500)

## Changes

- `EmbeddedExamplePage` lazy-loads `PetrinautPreview` from `@hashintel/petrinaut/preview`
  > `quickSimulation` comes from the build-time HIR artifacts via `loadExampleRuntime` plus the catalog's parameter bounds.
  > Step size and horizon use the simulation defaults.
- Embed route loads the runtime artifacts alongside the model
  > Loader resolves `loadExample` and `loadExampleRuntime` together.
  > Navigation applies `applyPreviewNavigationUpdate` to the previous search, so the URL carries the same shared subset through the preview-typed codec.
- `validateSharedExampleSearch` stays the route's search contract
  > A fast-check property asserts the preview codec produces the same search as the shared codec on every generated input, so existing embed URLs keep working.

#### Review fixes

- A Preview navigation keeps the contract fields it does not own
  > Writing the Preview's own projection dropped `mode`, `view` and `overlay` on the first selection, and an embed can arrive carrying them because oEmbed copies the source page's `mode` into the iframe URL.

## Test coverage

- `example-search.property.test.ts`:
  > Preview-codec laws, including the codec-equivalence property that pins the URL contract across the switch.
- `navigation-search.test.ts`, `example-search.test.ts`:
  > Existing shared codec laws, unchanged.

## How to test

#### Embed on the Preview

- Open [Petrinaut /embed/examples/gases-1-pn](https://petrinaut-git-claude-fe-1500-embed-preview.stage.hash.ai/embed/examples/gases-1-pn) on Vercel
  > Expect compact preview instead of full editor
- Quick Simulation > Play
  > Expect run to advance with the timeline

#### URL contract unchanged

- Open a `scenario`, `subnet`, or `itemType` and `itemId` URL from the previous embed
  > Expect it to resolve identically


