### PR TITLE
BE-826: Load explicit TOML files in hash-config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2856,7 +2856,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
 dependencies = [
  "atomic",
+ "parking_lot",
  "serde",
+ "tempfile",
  "uncased",
  "version_check",
 ]
@@ -3579,12 +3581,15 @@ dependencies = [
 name = "hash-config"
 version = "0.0.0"
 dependencies = [
+ "derive_more",
  "error-stack",
  "figment",
+ "insta",
  "serde",
  "serde_core",
  "serde_json",
  "simple-mermaid",
+ "toml",
 ]
 
 [[package]]

--- a/libs/@local/config/Cargo.toml
+++ b/libs/@local/config/Cargo.toml
@@ -14,10 +14,14 @@ error-stack = { workspace = true, public = true, features = ["std"] }
 serde_core = { workspace = true, public = true }
 
 # Private third-party dependencies
+derive_more    = { workspace = true, features = ["display"] }
 figment        = { workspace = true }
 simple-mermaid = { workspace = true }
+toml           = { workspace = true, features = ["parse", "serde", "std"] }
 
 [dev-dependencies]
+figment    = { workspace = true, features = ["test"] }
+insta      = { workspace = true, features = ["filters"] }
 serde      = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 

--- a/libs/@local/config/src/error.rs
+++ b/libs/@local/config/src/error.rs
@@ -7,19 +7,18 @@ use figment::{
 };
 
 /// What prevented a configuration from loading.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, derive_more::Display)]
 #[non_exhaustive]
 pub enum LoadError {
     /// The merged values do not deserialize into the requested configuration type.
+    #[display("the configuration could not be loaded")]
     Invalid,
-}
-
-impl fmt::Display for LoadError {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Invalid => formatter.write_str("the configuration could not be loaded"),
-        }
-    }
+    /// A required configuration file could not be read as UTF-8.
+    #[display("the configuration file could not be read")]
+    ReadFile,
+    /// A configuration file does not contain valid TOML.
+    #[display("the configuration file is not valid TOML")]
+    ParseFile,
 }
 
 impl Error for LoadError {}

--- a/libs/@local/config/src/error.rs
+++ b/libs/@local/config/src/error.rs
@@ -1,4 +1,5 @@
 use core::{error::Error, fmt};
+use std::path::PathBuf;
 
 use error_stack::Report;
 use figment::{
@@ -7,18 +8,18 @@ use figment::{
 };
 
 /// What prevented a configuration from loading.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, derive_more::Display)]
+#[derive(Debug, derive_more::Display)]
 #[non_exhaustive]
 pub enum LoadError {
     /// The merged values do not deserialize into the requested configuration type.
     #[display("the configuration could not be loaded")]
     Invalid,
     /// A required configuration file could not be read as UTF-8.
-    #[display("the configuration file could not be read")]
-    ReadFile,
+    #[display("the configuration file `{}` could not be read", path.display())]
+    ReadFile { path: PathBuf },
     /// A configuration file does not contain valid TOML.
-    #[display("the configuration file is not valid TOML")]
-    ParseFile,
+    #[display("the configuration file `{}` is not valid TOML", path.display())]
+    ParseFile { path: PathBuf },
 }
 
 impl Error for LoadError {}

--- a/libs/@local/config/src/file.rs
+++ b/libs/@local/config/src/file.rs
@@ -1,0 +1,52 @@
+use std::{fs, path::PathBuf};
+
+use error_stack::{Report, ResultExt as _};
+use figment::{
+    Metadata, Profile, Provider, Source,
+    error::Error as FigmentError,
+    value::{Dict, Map},
+};
+
+use crate::LoadError;
+
+/// A required TOML file contributing one configuration layer.
+pub(crate) struct File {
+    path: PathBuf,
+    values: Dict,
+}
+
+impl File {
+    pub(crate) fn read(path: PathBuf) -> Result<Self, Report<LoadError>> {
+        let text = fs::read_to_string(&path)
+            .change_context(LoadError::ReadFile)
+            .attach_with(|| path.display().to_string())?;
+        let values = toml::from_str(&text).map_err(|error: toml::de::Error| {
+            // TOML errors retain the source document and may quote its values. Keep only the
+            // position so neither the report nor its underlying frames can expose that input.
+            let mut report = Report::new(LoadError::ParseFile).attach(path.display().to_string());
+            if let Some(prefix) = error.span().and_then(|span| text.get(..span.start)) {
+                let line = prefix.bytes().filter(|byte| *byte == b'\n').count() + 1;
+                let column = prefix
+                    .rsplit('\n')
+                    .next()
+                    .map_or(1, |line| line.chars().count() + 1);
+                report = report.attach(format!("at line {line}, column {column}"));
+            }
+            report
+        })?;
+
+        Ok(Self { path, values })
+    }
+}
+
+impl Provider for File {
+    fn metadata(&self) -> Metadata {
+        Metadata::named("file")
+            .source(Source::File(self.path.clone()))
+            .interpolater(|_profile, keys| keys.join("."))
+    }
+
+    fn data(&self) -> Result<Map<Profile, Dict>, FigmentError> {
+        Ok(Map::from([(Profile::Default, self.values.clone())]))
+    }
+}

--- a/libs/@local/config/src/file.rs
+++ b/libs/@local/config/src/file.rs
@@ -18,12 +18,11 @@ pub(crate) struct File {
 impl File {
     pub(crate) fn read(path: PathBuf) -> Result<Self, Report<LoadError>> {
         let text = fs::read_to_string(&path)
-            .change_context(LoadError::ReadFile)
-            .attach_with(|| path.display().to_string())?;
+            .change_context_lazy(|| LoadError::ReadFile { path: path.clone() })?;
         let values = toml::from_str(&text).map_err(|error: toml::de::Error| {
             // TOML errors retain the source document and may quote its values. Keep only the
             // position so neither the report nor its underlying frames can expose that input.
-            let mut report = Report::new(LoadError::ParseFile).attach(path.display().to_string());
+            let mut report = Report::new(LoadError::ParseFile { path: path.clone() });
             if let Some(prefix) = error.span().and_then(|span| text.get(..span.start)) {
                 let line = prefix.bytes().filter(|byte| *byte == b'\n').count() + 1;
                 let column = prefix

--- a/libs/@local/config/src/lib.rs
+++ b/libs/@local/config/src/lib.rs
@@ -96,7 +96,7 @@ impl Loader {
     /// # jail.create_file("hash-graph.toml", "host = 'localhost'\n")?;
     /// let config = hash_config::Loader::new()
     ///     .with_defaults(serde_json::json!({ "port": 5432 }))
-    ///     .with_file("hash-graph.toml")
+    ///     .with_toml_file("hash-graph.toml")
     ///     .load::<Config>()
     ///     .expect("the configuration file should load");
     ///
@@ -106,7 +106,7 @@ impl Loader {
     /// # });
     /// ```
     #[must_use]
-    pub fn with_file(mut self, path: impl Into<PathBuf>) -> Self {
+    pub fn with_toml_file(mut self, path: impl Into<PathBuf>) -> Self {
         self.files.push(path.into());
         self
     }

--- a/libs/@local/config/src/lib.rs
+++ b/libs/@local/config/src/lib.rs
@@ -5,8 +5,10 @@
 
 mod defaults;
 mod error;
+mod file;
 
 use core::fmt;
+use std::path::PathBuf;
 
 use error_stack::Report;
 use figment::Figment;
@@ -35,6 +37,7 @@ use self::{defaults::Defaults, error::load_report};
 #[derive(Default)]
 pub struct Loader {
     defaults: Figment,
+    files: Vec<PathBuf>,
 }
 
 impl fmt::Debug for Loader {
@@ -49,6 +52,7 @@ impl fmt::Debug for Loader {
                     .map(|metadata| &metadata.name)
                     .collect::<Vec<_>>(),
             )
+            .field("files", &self.files)
             .finish_non_exhaustive()
     }
 }
@@ -72,20 +76,63 @@ impl Loader {
         self
     }
 
+    /// Adds a required TOML file above the programmatic defaults.
+    ///
+    /// Files are read by [`load`](Self::load), in the order they were added. Later files replace
+    /// earlier scalars and arrays, while maps merge recursively. Every file takes precedence over
+    /// every default, regardless of the order of builder calls. Relative paths resolve against the
+    /// working directory at load time; the file extension does not select the format.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #[derive(serde::Deserialize)]
+    /// struct Config {
+    ///     host: String,
+    ///     port: u16,
+    /// }
+    ///
+    /// # figment::Jail::expect_with(|jail| {
+    /// # jail.create_file("hash-graph.toml", "host = 'localhost'\n")?;
+    /// let config = hash_config::Loader::new()
+    ///     .with_defaults(serde_json::json!({ "port": 5432 }))
+    ///     .with_file("hash-graph.toml")
+    ///     .load::<Config>()
+    ///     .expect("the configuration file should load");
+    ///
+    /// assert_eq!(config.host, "localhost");
+    /// assert_eq!(config.port, 5432);
+    /// # Ok(())
+    /// # });
+    /// ```
+    #[must_use]
+    pub fn with_file(mut self, path: impl Into<PathBuf>) -> Self {
+        self.files.push(path.into());
+        self
+    }
+
     /// Deserializes the merged values into `C`.
     ///
     /// # Errors
     ///
-    /// Returns [`LoadError::Invalid`] when a value does not fit `C`, when a required value is not
-    /// set, or when a default does not serialize to a map. The report names the key, the shape
-    /// that was expected, and the layer the key came from. Configuration values never appear in a
-    /// report, so it is safe to log one in full.
+    /// - [`LoadError::Invalid`] if a value does not fit `C`, a required value is missing, or a
+    ///   default does not serialize to a map.
+    /// - [`LoadError::ReadFile`] if a required file is absent, unreadable, or not UTF-8.
+    /// - [`LoadError::ParseFile`] if a file does not contain valid TOML.
+    ///
+    /// The report names the key, expected shape, and source when available. Rejected values and
+    /// TOML source excerpts are withheld.
     #[track_caller]
     pub fn load<C>(self) -> Result<C, Report<LoadError>>
     where
         C: DeserializeOwned,
     {
-        match self.defaults.extract::<C>() {
+        let mut values = self.defaults;
+        for path in self.files {
+            values = values.merge(file::File::read(path)?);
+        }
+
+        match values.extract::<C>() {
             Ok(value) => Ok(value),
             Err(error) => Err(load_report(error)),
         }

--- a/libs/@local/config/tests/defaults.rs
+++ b/libs/@local/config/tests/defaults.rs
@@ -1,7 +1,7 @@
-use core::fmt;
+use core::{assert_matches, fmt};
 use std::collections::HashMap;
 
-use hash_config::Loader;
+use hash_config::{LoadError, Loader};
 use serde_json::json;
 
 const SECRET: &str = "this-value-must-not-appear-in-an-error";
@@ -80,7 +80,11 @@ fn missing_required_value_fails() {
         .load::<Required>()
         .expect_err("the missing password should fail the load");
 
-    assert_eq!(report.current_context(), &hash_config::LoadError::Invalid);
+    assert_matches!(
+        report.current_context(),
+        LoadError::Invalid,
+        "the error should identify an invalid configuration"
+    );
     assert!(
         format!("{report:?}").contains("password"),
         "the report should name the missing field: {report:?}"
@@ -95,7 +99,11 @@ fn defaults_require_map() {
         .expect_err("a scalar default document should fail the load");
     let rendered = format!("{report:?}");
 
-    assert_eq!(report.current_context(), &hash_config::LoadError::Invalid);
+    assert_matches!(
+        report.current_context(),
+        LoadError::Invalid,
+        "the error should identify an invalid configuration"
+    );
     assert!(
         rendered.contains("invalid type: found string"),
         "the report should identify the rejected value kind: {report:?}"
@@ -114,7 +122,11 @@ fn defaults_require_string_keys() {
         .expect_err("a numeric map key should fail the load");
     let rendered = format!("{report:?}");
 
-    assert_eq!(report.current_context(), &hash_config::LoadError::Invalid);
+    assert_matches!(
+        report.current_context(),
+        LoadError::Invalid,
+        "the error should identify an invalid configuration"
+    );
     assert!(
         rendered.contains("expected `string`"),
         "the report should explain the supported key shape: {report:?}"
@@ -139,7 +151,11 @@ fn load_redacts_mistyped_values() {
         .expect_err("a string API key should not deserialize as a number");
     let rendered = format!("{report:?}");
 
-    assert_eq!(report.current_context(), &hash_config::LoadError::Invalid);
+    assert_matches!(
+        report.current_context(),
+        LoadError::Invalid,
+        "the error should identify an invalid configuration"
+    );
     assert!(
         rendered.contains("invalid type: found string"),
         "the report should identify the rejected value kind: {report:?}"
@@ -164,7 +180,11 @@ fn load_redacts_numeric_overflow() {
         .expect_err("an overflowing number should not deserialize as i8");
     let rendered = format!("{report:?}");
 
-    assert_eq!(report.current_context(), &hash_config::LoadError::Invalid);
+    assert_matches!(
+        report.current_context(),
+        LoadError::Invalid,
+        "the error should identify an invalid configuration"
+    );
     assert!(
         rendered.contains("invalid value: found unsigned integer"),
         "the report should name the rejected value kind: {report:?}"
@@ -195,7 +215,11 @@ fn load_redacts_unknown_variants() {
         .expect_err("an unknown variant name should fail the load");
     let rendered = format!("{report:?}");
 
-    assert_eq!(report.current_context(), &hash_config::LoadError::Invalid);
+    assert_matches!(
+        report.current_context(),
+        LoadError::Invalid,
+        "the error should identify an invalid configuration"
+    );
     assert!(
         rendered.contains("`Debug`") && rendered.contains("`Info`"),
         "the report should list the expected variants: {report:?}"
@@ -221,7 +245,11 @@ fn load_names_map_keys() {
         .expect_err("a string map value should not deserialize as a number");
     let rendered = format!("{report:?}");
 
-    assert_eq!(report.current_context(), &hash_config::LoadError::Invalid);
+    assert_matches!(
+        report.current_context(),
+        LoadError::Invalid,
+        "the error should identify an invalid configuration"
+    );
     assert!(
         rendered.contains("values.alpha"),
         "the report should name the key a map entry sits under: {report:?}"
@@ -248,7 +276,11 @@ fn load_names_unknown_fields() {
         .expect_err("an unknown field should fail the load");
     let rendered = format!("{report:?}");
 
-    assert_eq!(report.current_context(), &hash_config::LoadError::Invalid);
+    assert_matches!(
+        report.current_context(),
+        LoadError::Invalid,
+        "the error should identify an invalid configuration"
+    );
     assert!(
         rendered.contains("`enalbed`"),
         "the report should name the field it did not recognise: {report:?}"
@@ -304,7 +336,11 @@ fn load_reports_serde_expectations() {
         .expect_err("a string should not deserialize as the expected integer");
     let rendered = format!("{report:?}");
 
-    assert_eq!(report.current_context(), &hash_config::LoadError::Invalid);
+    assert_matches!(
+        report.current_context(),
+        LoadError::Invalid,
+        "the error should identify an invalid configuration"
+    );
     assert!(
         rendered.contains(EXPECTATION),
         "the report should carry the visitor's expectation: {report:?}"
@@ -324,7 +360,11 @@ fn load_reports_every_failing_layer() {
         .expect_err("both scalar default documents should fail the load");
     let rendered = format!("{report:?}");
 
-    assert_eq!(report.current_context(), &hash_config::LoadError::Invalid);
+    assert_matches!(
+        report.current_context(),
+        LoadError::Invalid,
+        "the error should identify an invalid configuration"
+    );
     assert!(
         rendered.contains("found unsigned integer"),
         "the report should name the first failing layer: {report:?}"
@@ -354,7 +394,11 @@ fn load_defers_and_redacts_serialization_errors() {
         .expect_err("the serialization failure should be reported by load");
     let rendered = format!("{report:?}");
 
-    assert_eq!(report.current_context(), &hash_config::LoadError::Invalid);
+    assert_matches!(
+        report.current_context(),
+        LoadError::Invalid,
+        "the error should identify an invalid configuration"
+    );
     assert!(
         rendered.contains("tests/defaults.rs"),
         "the report should name the call site of the failing layer: {report:?}"

--- a/libs/@local/config/tests/files.rs
+++ b/libs/@local/config/tests/files.rs
@@ -1,0 +1,300 @@
+#![expect(
+    clippy::result_large_err,
+    reason = "Figment's Jail fixes the test closures' error type"
+)]
+
+use std::fs;
+
+use error_stack::{
+    Report,
+    fmt::{Charset, ColorMode},
+};
+use figment::Jail;
+use hash_config::{LoadError, Loader};
+use serde_json::json;
+
+const SECRET: &str = "this-value-must-not-appear-in-an-error";
+
+#[derive(Debug, serde::Deserialize, PartialEq, Eq)]
+struct Config {
+    store: Store,
+    routes: Vec<String>,
+}
+
+#[derive(Debug, serde::Deserialize, PartialEq, Eq)]
+struct Store {
+    host: String,
+    port: u16,
+}
+
+/// Snapshot the full diagnostic after checking that redaction already happened in the loader.
+fn assert_report(name: &str, report: &Report<LoadError>, jail: &Jail) {
+    Report::set_color_mode(ColorMode::None);
+    Report::set_charset(Charset::Utf8);
+    let rendered = format!("{report:?}");
+    assert!(
+        !rendered.contains(SECRET),
+        "the unfiltered report should withhold the secret: {rendered}"
+    );
+
+    let rendered = rendered.replace(jail.directory().to_string_lossy().as_ref(), "[config-dir]");
+    let mut settings = insta::Settings::clone_current();
+    // Rust call-site positions move as code changes; TOML error positions remain part of the test.
+    settings.add_filter(r"(\.rs):\d+:\d+", "$1:[line]:[column]");
+    let _scope = settings.bind_to_scope();
+    insta::assert_snapshot!(name, rendered);
+}
+
+/// Reading is deferred until load, so adding a path does not snapshot its contents.
+#[test]
+fn file_deferred_read() {
+    Jail::expect_with(|jail| {
+        let loader = Loader::new().with_file("config.toml");
+        jail.create_file(
+            "config.toml",
+            "routes = ['api']\n[store]\nhost = 'localhost'\nport = 5432\n",
+        )?;
+
+        let config = loader
+            .load::<Config>()
+            .expect("the required TOML file should load");
+
+        assert_eq!(
+            config.store.host, "localhost",
+            "the host should come from the file"
+        );
+        assert_eq!(
+            config.store.port, 5432,
+            "the port should come from the file"
+        );
+        assert_eq!(
+            config.routes,
+            ["api"],
+            "the routes should come from the file"
+        );
+        Ok(())
+    });
+}
+
+/// Source precedence holds even when defaults are added after a file.
+#[test]
+fn file_defaults_precedence() {
+    Jail::expect_with(|jail| {
+        jail.create_file("config.toml", "[store]\nport = 6543\n")?;
+
+        for file_first in [false, true] {
+            let defaults = json!({
+                "store": { "host": "localhost", "port": 5432 },
+                "routes": ["api"],
+            });
+            let loader = if file_first {
+                Loader::new()
+                    .with_file("config.toml")
+                    .with_defaults(defaults)
+            } else {
+                Loader::new()
+                    .with_defaults(defaults)
+                    .with_file("config.toml")
+            };
+            let config = loader
+                .load::<Config>()
+                .expect("the defaults and file should compose");
+
+            assert_eq!(
+                config.store.port, 6543,
+                "the file should override every default"
+            );
+            assert_eq!(
+                config.store.host, "localhost",
+                "the default host should survive"
+            );
+            assert_eq!(config.routes, ["api"], "the default routes should survive");
+        }
+        Ok(())
+    });
+}
+
+/// Files form partial contributions: maps merge and later arrays replace whole arrays.
+#[test]
+fn files_order_and_merge() {
+    Jail::expect_with(|jail| {
+        jail.create_file(
+            "first.toml",
+            "routes = ['api', 'health']\n[store]\nport = 5432\n",
+        )?;
+        jail.create_file(
+            "second.toml",
+            "routes = ['metrics']\n[store]\nhost = 'database'\nport = 6543\n",
+        )?;
+
+        for (files, expected_port, expected_routes) in [
+            (["first.toml", "second.toml"], 6543, vec!["metrics"]),
+            (["second.toml", "first.toml"], 5432, vec!["api", "health"]),
+        ] {
+            let config = files
+                .into_iter()
+                .fold(Loader::new(), Loader::with_file)
+                .load::<Config>()
+                .expect("the partial TOML files should compose");
+
+            assert_eq!(
+                config.store.host, "database",
+                "the host should survive either file order"
+            );
+            assert_eq!(
+                config.store.port, expected_port,
+                "the later file should supply the port"
+            );
+            assert_eq!(
+                config.routes, expected_routes,
+                "the later file should replace the routes"
+            );
+        }
+        Ok(())
+    });
+}
+
+/// Explicitly naming an absent file is an error even when defaults are complete.
+#[test]
+fn file_missing() {
+    Jail::expect_with(|jail| {
+        let report = Loader::new()
+            .with_defaults(json!({ "store": { "host": "localhost", "port": 5432 }, "routes": [] }))
+            .with_file("missing.toml")
+            .load::<Config>()
+            .expect_err("the absent required file should fail the load");
+
+        assert_eq!(
+            report.current_context(),
+            &LoadError::ReadFile,
+            "the error should identify a read failure"
+        );
+        assert_eq!(
+            report
+                .downcast_ref::<std::io::Error>()
+                .map(std::io::Error::kind),
+            Some(std::io::ErrorKind::NotFound),
+            "the report should preserve the IO cause"
+        );
+        assert_report("file_missing", &report, jail);
+        Ok(())
+    });
+}
+
+/// A directory cannot silently contribute an empty file layer.
+#[test]
+fn file_directory() {
+    Jail::expect_with(|jail| {
+        let report = Loader::new()
+            .with_file(jail.directory())
+            .load::<Config>()
+            .expect_err("the directory should fail as a configuration file");
+
+        assert_eq!(
+            report.current_context(),
+            &LoadError::ReadFile,
+            "the error should identify a read failure"
+        );
+        assert_eq!(
+            report
+                .downcast_ref::<std::io::Error>()
+                .map(std::io::Error::kind),
+            Some(std::io::ErrorKind::IsADirectory),
+            "the report should preserve the directory IO cause"
+        );
+        assert_report("file_directory", &report, jail);
+        Ok(())
+    });
+}
+
+/// Invalid encoding must not expose the bytes read from the file.
+#[test]
+fn file_non_utf8() {
+    Jail::expect_with(|jail| {
+        let mut contents = SECRET.as_bytes().to_vec();
+        contents.push(0xFF);
+        fs::write("config.toml", contents).expect("the invalid UTF-8 fixture should be written");
+
+        let report = Loader::new()
+            .with_file("config.toml")
+            .load::<Config>()
+            .expect_err("the non-UTF-8 file should fail the load");
+        assert_eq!(
+            report.current_context(),
+            &LoadError::ReadFile,
+            "the error should identify a read failure"
+        );
+        assert_eq!(
+            report
+                .downcast_ref::<std::io::Error>()
+                .map(std::io::Error::kind),
+            Some(std::io::ErrorKind::InvalidData),
+            "the report should preserve the encoding IO cause"
+        );
+        assert_report("file_non_utf8", &report, jail);
+        Ok(())
+    });
+}
+
+/// A syntax error reports its position without retaining the parser's source excerpt.
+#[test]
+fn file_malformed_redaction() {
+    Jail::expect_with(|jail| {
+        jail.create_file("config.toml", &format!("# ü\npassword = \"{SECRET}\n"))?;
+
+        let report = Loader::new()
+            .with_file("config.toml")
+            .load::<Config>()
+            .expect_err("the unterminated string should fail TOML parsing");
+        assert_eq!(
+            report.current_context(),
+            &LoadError::ParseFile,
+            "the error should identify malformed TOML"
+        );
+        assert!(
+            !report.contains::<toml::de::Error>(),
+            "the report should not retain the source-bearing TOML error"
+        );
+        assert_report("file_malformed_redaction", &report, jail);
+        Ok(())
+    });
+}
+
+/// Deserialization errors retain the winning file and key while redacting the value.
+#[test]
+fn file_invalid_value() {
+    Jail::expect_with(|jail| {
+        jail.create_file("config.toml", &format!("[store]\nport = '{SECRET}'\n"))?;
+        let report = Loader::new()
+            .with_defaults(json!({ "store": { "host": "localhost" }, "routes": [] }))
+            .with_file("config.toml")
+            .load::<Config>()
+            .expect_err("the string should not deserialize as a port");
+        assert_eq!(
+            report.current_context(),
+            &LoadError::Invalid,
+            "the error should identify invalid configuration"
+        );
+        assert_report("file_invalid_value", &report, jail);
+        Ok(())
+    });
+}
+
+/// A valid partial TOML document does not supply missing required fields.
+#[test]
+fn file_missing_required_value() {
+    Jail::expect_with(|jail| {
+        jail.create_file("config.toml", "routes = []\n[store]\nhost = 'localhost'\n")?;
+        let report = Loader::new()
+            .with_file("config.toml")
+            .load::<Config>()
+            .expect_err("the absent port should fail the load");
+        assert_eq!(
+            report.current_context(),
+            &LoadError::Invalid,
+            "the error should identify incomplete configuration"
+        );
+        assert_report("file_missing_required_value", &report, jail);
+        Ok(())
+    });
+}

--- a/libs/@local/config/tests/files.rs
+++ b/libs/@local/config/tests/files.rs
@@ -49,7 +49,7 @@ fn assert_report(name: &str, report: &Report<LoadError>, jail: &Jail) {
 #[test]
 fn file_deferred_read() {
     Jail::expect_with(|jail| {
-        let loader = Loader::new().with_file("config.toml");
+        let loader = Loader::new().with_toml_file("config.toml");
         jail.create_file(
             "config.toml",
             "routes = ['api']\n[store]\nhost = 'localhost'\nport = 5432\n",
@@ -89,12 +89,12 @@ fn file_defaults_precedence() {
             });
             let loader = if file_first {
                 Loader::new()
-                    .with_file("config.toml")
+                    .with_toml_file("config.toml")
                     .with_defaults(defaults)
             } else {
                 Loader::new()
                     .with_defaults(defaults)
-                    .with_file("config.toml")
+                    .with_toml_file("config.toml")
             };
             let config = loader
                 .load::<Config>()
@@ -133,7 +133,7 @@ fn files_order_and_merge() {
         ] {
             let config = files
                 .into_iter()
-                .fold(Loader::new(), Loader::with_file)
+                .fold(Loader::new(), Loader::with_toml_file)
                 .load::<Config>()
                 .expect("the partial TOML files should compose");
 
@@ -154,13 +154,87 @@ fn files_order_and_merge() {
     });
 }
 
+/// Only the merged configuration must fit the target type, so a later file can correct a value.
+#[test]
+fn files_overridden_invalid_value() {
+    Jail::expect_with(|jail| {
+        jail.create_file(
+            "invalid.toml",
+            "routes = ['api']\n[store]\nhost = 'localhost'\nport = 'not-a-number'\n",
+        )?;
+        jail.create_file("correction.toml", "[store]\nport = 5432\n")?;
+
+        let report = Loader::new()
+            .with_toml_file("invalid.toml")
+            .load::<Config>()
+            .expect_err("the uncorrected port should fail deserialization");
+        assert_eq!(
+            report.current_context(),
+            &LoadError::Invalid,
+            "the error should identify an invalid configuration"
+        );
+
+        let config = Loader::new()
+            .with_toml_file("invalid.toml")
+            .with_toml_file("correction.toml")
+            .load::<Config>()
+            .expect("the later file should correct the port");
+
+        assert_eq!(
+            config,
+            Config {
+                store: Store {
+                    host: "localhost".to_owned(),
+                    port: 5432,
+                },
+                routes: vec!["api".to_owned()],
+            },
+            "the corrected port and untouched values should survive the merge"
+        );
+        Ok(())
+    });
+}
+
+/// An empty file contributes no values, regardless of its position among the file layers.
+#[test]
+fn files_empty_layer() {
+    Jail::expect_with(|jail| {
+        jail.create_file("empty.toml", "")?;
+        jail.create_file(
+            "config.toml",
+            "routes = ['api']\n[store]\nhost = 'localhost'\nport = 5432\n",
+        )?;
+
+        for files in [["empty.toml", "config.toml"], ["config.toml", "empty.toml"]] {
+            let config = files
+                .into_iter()
+                .fold(Loader::new(), Loader::with_toml_file)
+                .load::<Config>()
+                .expect("the empty file should compose with the configuration file");
+
+            assert_eq!(
+                config,
+                Config {
+                    store: Store {
+                        host: "localhost".to_owned(),
+                        port: 5432,
+                    },
+                    routes: vec!["api".to_owned()],
+                },
+                "the empty file should preserve the complete configuration in either position"
+            );
+        }
+        Ok(())
+    });
+}
+
 /// Explicitly naming an absent file is an error even when defaults are complete.
 #[test]
 fn file_missing() {
     Jail::expect_with(|jail| {
         let report = Loader::new()
             .with_defaults(json!({ "store": { "host": "localhost", "port": 5432 }, "routes": [] }))
-            .with_file("missing.toml")
+            .with_toml_file("missing.toml")
             .load::<Config>()
             .expect_err("the absent required file should fail the load");
 
@@ -186,7 +260,7 @@ fn file_missing() {
 fn file_directory() {
     Jail::expect_with(|jail| {
         let report = Loader::new()
-            .with_file(jail.directory())
+            .with_toml_file(jail.directory())
             .load::<Config>()
             .expect_err("the directory should fail as a configuration file");
 
@@ -216,7 +290,7 @@ fn file_non_utf8() {
         fs::write("config.toml", contents).expect("the invalid UTF-8 fixture should be written");
 
         let report = Loader::new()
-            .with_file("config.toml")
+            .with_toml_file("config.toml")
             .load::<Config>()
             .expect_err("the non-UTF-8 file should fail the load");
         assert_eq!(
@@ -243,7 +317,7 @@ fn file_malformed_redaction() {
         jail.create_file("config.toml", &format!("# ü\npassword = \"{SECRET}\n"))?;
 
         let report = Loader::new()
-            .with_file("config.toml")
+            .with_toml_file("config.toml")
             .load::<Config>()
             .expect_err("the unterminated string should fail TOML parsing");
         assert_eq!(
@@ -267,7 +341,7 @@ fn file_invalid_value() {
         jail.create_file("config.toml", &format!("[store]\nport = '{SECRET}'\n"))?;
         let report = Loader::new()
             .with_defaults(json!({ "store": { "host": "localhost" }, "routes": [] }))
-            .with_file("config.toml")
+            .with_toml_file("config.toml")
             .load::<Config>()
             .expect_err("the string should not deserialize as a port");
         assert_eq!(
@@ -286,7 +360,7 @@ fn file_missing_required_value() {
     Jail::expect_with(|jail| {
         jail.create_file("config.toml", "routes = []\n[store]\nhost = 'localhost'\n")?;
         let report = Loader::new()
-            .with_file("config.toml")
+            .with_toml_file("config.toml")
             .load::<Config>()
             .expect_err("the absent port should fail the load");
         assert_eq!(

--- a/libs/@local/config/tests/files.rs
+++ b/libs/@local/config/tests/files.rs
@@ -3,7 +3,10 @@
     reason = "Figment's Jail fixes the test closures' error type"
 )]
 
-use std::fs;
+use core::assert_matches;
+#[cfg(unix)]
+use std::{ffi::OsString, os::unix::ffi::OsStringExt as _, path::PathBuf};
+use std::{fs, path::Path};
 
 use error_stack::{
     Report,
@@ -168,9 +171,9 @@ fn files_overridden_invalid_value() {
             .with_toml_file("invalid.toml")
             .load::<Config>()
             .expect_err("the uncorrected port should fail deserialization");
-        assert_eq!(
+        assert_matches!(
             report.current_context(),
-            &LoadError::Invalid,
+            LoadError::Invalid,
             "the error should identify an invalid configuration"
         );
 
@@ -238,10 +241,10 @@ fn file_missing() {
             .load::<Config>()
             .expect_err("the absent required file should fail the load");
 
-        assert_eq!(
+        assert_matches!(
             report.current_context(),
-            &LoadError::ReadFile,
-            "the error should identify a read failure"
+            LoadError::ReadFile { path } if path == Path::new("missing.toml"),
+            "the error should identify a read failure and retain the original path"
         );
         assert_eq!(
             report
@@ -264,10 +267,10 @@ fn file_directory() {
             .load::<Config>()
             .expect_err("the directory should fail as a configuration file");
 
-        assert_eq!(
+        assert_matches!(
             report.current_context(),
-            &LoadError::ReadFile,
-            "the error should identify a read failure"
+            LoadError::ReadFile { path } if path == jail.directory(),
+            "the error should identify a read failure and retain the original path"
         );
         assert_eq!(
             report
@@ -293,10 +296,10 @@ fn file_non_utf8() {
             .with_toml_file("config.toml")
             .load::<Config>()
             .expect_err("the non-UTF-8 file should fail the load");
-        assert_eq!(
+        assert_matches!(
             report.current_context(),
-            &LoadError::ReadFile,
-            "the error should identify a read failure"
+            LoadError::ReadFile { path } if path == Path::new("config.toml"),
+            "the error should identify a read failure and retain the original path"
         );
         assert_eq!(
             report
@@ -320,16 +323,35 @@ fn file_malformed_redaction() {
             .with_toml_file("config.toml")
             .load::<Config>()
             .expect_err("the unterminated string should fail TOML parsing");
-        assert_eq!(
+        assert_matches!(
             report.current_context(),
-            &LoadError::ParseFile,
-            "the error should identify malformed TOML"
+            LoadError::ParseFile { path } if path == Path::new("config.toml"),
+            "the error should identify malformed TOML and retain the original path"
         );
         assert!(
             !report.contains::<toml::de::Error>(),
             "the report should not retain the source-bearing TOML error"
         );
         assert_report("file_malformed_redaction", &report, jail);
+        Ok(())
+    });
+}
+
+/// Read errors retain the original path even when its bytes are not valid UTF-8.
+#[cfg(unix)]
+#[test]
+fn file_non_utf8_path() {
+    Jail::expect_with(|_jail| {
+        let path = PathBuf::from(OsString::from_vec(b"config-\xFF.toml".to_vec()));
+        let report = Loader::new()
+            .with_toml_file(&path)
+            .load::<Config>()
+            .expect_err("the unreadable file path should fail the load");
+        assert_matches!(
+            report.current_context(),
+            LoadError::ReadFile { path: actual_path } if actual_path == &path,
+            "the error should identify a read failure and preserve the original path bytes"
+        );
         Ok(())
     });
 }
@@ -344,9 +366,9 @@ fn file_invalid_value() {
             .with_toml_file("config.toml")
             .load::<Config>()
             .expect_err("the string should not deserialize as a port");
-        assert_eq!(
+        assert_matches!(
             report.current_context(),
-            &LoadError::Invalid,
+            LoadError::Invalid,
             "the error should identify invalid configuration"
         );
         assert_report("file_invalid_value", &report, jail);
@@ -363,9 +385,9 @@ fn file_missing_required_value() {
             .with_toml_file("config.toml")
             .load::<Config>()
             .expect_err("the absent port should fail the load");
-        assert_eq!(
+        assert_matches!(
             report.current_context(),
-            &LoadError::Invalid,
+            LoadError::Invalid,
             "the error should identify incomplete configuration"
         );
         assert_report("file_missing_required_value", &report, jail);

--- a/libs/@local/config/tests/snapshots/files__file_directory.snap
+++ b/libs/@local/config/tests/snapshots/files__file_directory.snap
@@ -2,9 +2,8 @@
 source: libs/@local/config/tests/files.rs
 expression: rendered
 ---
-the configuration file could not be read
+the configuration file `[config-dir]` could not be read
 ├╴at libs/@local/config/src/file.rs:[line]:[column]
-├╴[config-dir]
 │
 ╰─▶ Is a directory (os error 21)
     ╰╴at libs/@local/config/src/file.rs:[line]:[column]

--- a/libs/@local/config/tests/snapshots/files__file_directory.snap
+++ b/libs/@local/config/tests/snapshots/files__file_directory.snap
@@ -1,0 +1,10 @@
+---
+source: libs/@local/config/tests/files.rs
+expression: rendered
+---
+the configuration file could not be read
+├╴at libs/@local/config/src/file.rs:[line]:[column]
+├╴[config-dir]
+│
+╰─▶ Is a directory (os error 21)
+    ╰╴at libs/@local/config/src/file.rs:[line]:[column]

--- a/libs/@local/config/tests/snapshots/files__file_invalid_value.snap
+++ b/libs/@local/config/tests/snapshots/files__file_invalid_value.snap
@@ -1,0 +1,7 @@
+---
+source: libs/@local/config/tests/files.rs
+expression: rendered
+---
+the configuration could not be loaded
+├╴at libs/@local/config/tests/files.rs:[line]:[column]
+╰╴invalid type: found string, expected u16 at `store.port` in `file` (config.toml)

--- a/libs/@local/config/tests/snapshots/files__file_malformed_redaction.snap
+++ b/libs/@local/config/tests/snapshots/files__file_malformed_redaction.snap
@@ -2,7 +2,6 @@
 source: libs/@local/config/tests/files.rs
 expression: rendered
 ---
-the configuration file is not valid TOML
+the configuration file `config.toml` is not valid TOML
 ├╴at libs/@local/config/src/file.rs:[line]:[column]
-├╴config.toml
 ╰╴at line 2, column 51

--- a/libs/@local/config/tests/snapshots/files__file_malformed_redaction.snap
+++ b/libs/@local/config/tests/snapshots/files__file_malformed_redaction.snap
@@ -1,0 +1,8 @@
+---
+source: libs/@local/config/tests/files.rs
+expression: rendered
+---
+the configuration file is not valid TOML
+├╴at libs/@local/config/src/file.rs:[line]:[column]
+├╴config.toml
+╰╴at line 2, column 51

--- a/libs/@local/config/tests/snapshots/files__file_missing.snap
+++ b/libs/@local/config/tests/snapshots/files__file_missing.snap
@@ -1,0 +1,10 @@
+---
+source: libs/@local/config/tests/files.rs
+expression: rendered
+---
+the configuration file could not be read
+├╴at libs/@local/config/src/file.rs:[line]:[column]
+├╴missing.toml
+│
+╰─▶ No such file or directory (os error 2)
+    ╰╴at libs/@local/config/src/file.rs:[line]:[column]

--- a/libs/@local/config/tests/snapshots/files__file_missing.snap
+++ b/libs/@local/config/tests/snapshots/files__file_missing.snap
@@ -2,9 +2,8 @@
 source: libs/@local/config/tests/files.rs
 expression: rendered
 ---
-the configuration file could not be read
+the configuration file `missing.toml` could not be read
 ├╴at libs/@local/config/src/file.rs:[line]:[column]
-├╴missing.toml
 │
 ╰─▶ No such file or directory (os error 2)
     ╰╴at libs/@local/config/src/file.rs:[line]:[column]

--- a/libs/@local/config/tests/snapshots/files__file_missing_required_value.snap
+++ b/libs/@local/config/tests/snapshots/files__file_missing_required_value.snap
@@ -1,0 +1,7 @@
+---
+source: libs/@local/config/tests/files.rs
+expression: rendered
+---
+the configuration could not be loaded
+├╴at libs/@local/config/tests/files.rs:[line]:[column]
+╰╴missing field `store.port` in `file` (config.toml)

--- a/libs/@local/config/tests/snapshots/files__file_non_utf8.snap
+++ b/libs/@local/config/tests/snapshots/files__file_non_utf8.snap
@@ -1,0 +1,10 @@
+---
+source: libs/@local/config/tests/files.rs
+expression: rendered
+---
+the configuration file could not be read
+├╴at libs/@local/config/src/file.rs:[line]:[column]
+├╴config.toml
+│
+╰─▶ stream did not contain valid UTF-8
+    ╰╴at libs/@local/config/src/file.rs:[line]:[column]

--- a/libs/@local/config/tests/snapshots/files__file_non_utf8.snap
+++ b/libs/@local/config/tests/snapshots/files__file_non_utf8.snap
@@ -2,9 +2,8 @@
 source: libs/@local/config/tests/files.rs
 expression: rendered
 ---
-the configuration file could not be read
+the configuration file `config.toml` could not be read
 ├╴at libs/@local/config/src/file.rs:[line]:[column]
-├╴config.toml
 │
 ╰─▶ stream did not contain valid UTF-8
     ╰╴at libs/@local/config/src/file.rs:[line]:[column]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Allow HASH applications to load required TOML files on top of programmatic defaults. Files have predictable precedence, and failures identify the source without including rejected values or TOML source excerpts.

## 🔗 Related links

- [BE-826: Load explicit TOML files in hash-config](https://linear.app/hash/issue/BE-826/load-explicit-toml-files-in-hash-config) _(internal)_
- [H-4170: Introduce config file for HASH](https://linear.app/hash/issue/H-4170/introduce-config-file-for-hash) _(internal)_

## 🚫 Blocked by

None.

## 🔍 What does this change?

- Add repeatable `Loader::with_toml_file(path)`, with file reads deferred until `load`.
- Apply every file above all defaults, regardless of builder-call order. Later files replace scalars and arrays; maps merge recursively.
- Add typed read and parse errors. Read failures retain their I/O cause; malformed TOML reports its path and position without retaining the parser error or source excerpt.
- Derive `LoadError` display messages and document the API with an executable file example.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] require changes to docs which **are made** as part of this PR

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

This slice accepts required TOML files only. Profiles, discovery, optional files, other formats, environment variables, CLI integration, and a public provenance API are outside its scope.

## 🐾 Next steps

Choose the next configuration source or inspection feature as a separate, small change.

## 🛡 What tests cover this?

- Eleven file integration tests cover deferred reads, precedence, merging, correction of an earlier mistyped value, empty file layers, missing files, directories, invalid UTF-8, malformed TOML, invalid values, and missing required fields.
- Six Insta snapshots check complete error reports alongside typed error assertions and checks that rejected values are absent before snapshot normalization.
- `yarn workspace @rust/hash-config test:unit` passes all 30 tests, including snapshots, and both executable doctests.
- Clippy with all features/targets and warnings denied, Rustdoc generation, and `git diff --check` pass.

## ❓ How to test this?

1. Run `yarn workspace @rust/hash-config test:unit`.
2. Run `cargo clippy --package hash-config --all-features --all-targets --no-deps -- -D warnings`.

## 📹 Demo

Given `hash-graph.toml`:

```toml
host = "localhost"
```

```rust
#[derive(serde::Deserialize)]
struct Config {
    host: String,
    port: u16,
}

let config = hash_config::Loader::new()
    .with_defaults(serde_json::json!({ "port": 5432 }))
    .with_toml_file("hash-graph.toml")
    .load::<Config>()?;

assert_eq!(config.host, "localhost");
assert_eq!(config.port, 5432);
```
