### PR TITLE
FE-1606: Adjust offstate colors

### DIFF
--- a/libs/@hashintel/ds-components/src/components/Toggle/toggle.recipe.ts
+++ b/libs/@hashintel/ds-components/src/components/Toggle/toggle.recipe.ts
@@ -25,7 +25,7 @@ export const styles = sva({
       padding: "[calc(var(--toggle-padding) + 1px)]",
       borderRadius: "full",
       boxShadow:
-        "[inset 0 2px 4px rgba(0, 0, 0, 0.05), inset 0 0 0 1px var(--colors-black-a10)]",
+        "[inset 0 2px 4px rgba(0, 0, 0, 0.03), inset 0 0 0 1px var(--colors-black-a05)]",
       outlineColor: "black.a40",
       transition:
         "[background-color 0.15s ease, outline 0.15s ease, box-shadow 0.15s ease]",
@@ -155,7 +155,7 @@ export const styles = sva({
             backgroundColor: "blue.s85",
           },
           "&[data-state='checked']:hover:not([data-disabled])": {
-            backgroundColor: "blue.s75",
+            backgroundColor: "blue.s80",
           },
           "&[data-disabled][data-state='checked']": {
             backgroundColor: "blue.s55 !important",
@@ -168,7 +168,7 @@ export const styles = sva({
             backgroundColor: "green.s80",
           },
           "&[data-state='checked']:hover:not([data-disabled])": {
-            backgroundColor: "green.s70",
+            backgroundColor: "green.s75",
           },
           "&[data-disabled][data-state='checked']": {
             backgroundColor: "green.s55 !important",
@@ -180,26 +180,26 @@ export const styles = sva({
       neutral: {
         control: {
           "&[data-state='unchecked']": {
-            backgroundColor: "neutral.s30",
+            backgroundColor: "neutral.s60",
           },
           "&[data-state='unchecked']:hover:not([data-disabled])": {
-            backgroundColor: "neutral.s40",
+            backgroundColor: "neutral.s65",
           },
           "&[data-disabled][data-state='unchecked']": {
-            backgroundColor: "neutral.s30 !important",
+            backgroundColor: "neutral.s35 !important",
           },
         },
       },
       error: {
         control: {
           "&[data-state='unchecked']": {
-            backgroundColor: "red.s40",
+            backgroundColor: "red.s60",
           },
           "&[data-state='unchecked']:hover:not([data-disabled])": {
-            backgroundColor: "red.s50",
+            backgroundColor: "red.s65",
           },
           "&[data-disabled][data-state='unchecked']": {
-            backgroundColor: "red.s30 !important",
+            backgroundColor: "red.s35 !important",
           },
         },
       },
@@ -208,7 +208,7 @@ export const styles = sva({
       true: {
         control: {
           boxShadow:
-            "[0 0 0 1px var(--colors-red-s70), inset 0 2px 4px rgba(0, 0, 0, 0.05)]",
+            "[0 0 0 1px var(--colors-red-s70), inset 0 2px 4px rgba(0, 0, 0, 0.03)]",
           "&::after": {
             content: '""',
             position: "absolute",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Update Toggle offstate UI to look less like the toggle is disabled.

Before:
<img width="828" height="471" alt="Screenshot 2026-09-07 at 11 12 17" src="https://github.com/user-attachments/assets/83394860-fb09-4b97-a792-9f69d421b3d5" />

After:
<img width="767" height="457" alt="Screenshot 2026-09-07 at 11 12 12" src="https://github.com/user-attachments/assets/83a27e99-0685-457f-8c8a-47b1237fa2aa" />

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change
