### PR TITLE
FE-1612: Serialize user settings updates to prevent race condition

### DIFF
--- a/apps/hash-frontend/src/components/hooks/use-update-authenticated-user.ts
+++ b/apps/hash-frontend/src/components/hooks/use-update-authenticated-user.ts
@@ -12,6 +12,10 @@ import {
 import { updateEntityMutation } from "../../graphql/queries/knowledge/entity.queries";
 import { meQuery } from "../../graphql/queries/user.queries";
 import { useAuthInfo } from "../../pages/shared/auth-info-context";
+import {
+  mergeUserPreferences,
+  trackPendingPreferencesUpdate,
+} from "../../shared/use-user-preferences";
 
 import type {
   MeQuery,
@@ -19,7 +23,10 @@ import type {
   UpdateEntityMutationVariables,
 } from "../../graphql/api-types.gen";
 import type { User } from "../../lib/user-and-org";
-import type { UserPreferences } from "../../shared/use-user-preferences";
+import type {
+  UserPreferences,
+  UserPreferencesUpdate,
+} from "../../shared/use-user-preferences";
 import type { EntityRootType } from "@blockprotocol/graph";
 import type { PropertyPatchOperation } from "@blockprotocol/type-system";
 import type { HashEntity } from "@local/hash-graph-sdk/entity";
@@ -31,14 +38,31 @@ type UpdateAuthenticatedUserParams = {
   location?: string;
   websiteUrl?: string;
   preferredPronouns?: string;
-  preferences?: UserPreferences;
+  preferences?: UserPreferencesUpdate;
+};
+
+/**
+ * User updates are serialized through this queue so that each one fetches the
+ * user entity only after the previous update (and its refetch) has settled.
+ * Without it, concurrent updates each read the same stale entity and the whole
+ * `preferences` object written last silently reverts the others' changes.
+ */
+let userUpdateQueue: Promise<unknown> = Promise.resolve();
+
+const enqueueUserUpdate = <T>(update: () => Promise<T>): Promise<T> => {
+  const result = userUpdateQueue.then(update, update);
+  userUpdateQueue = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  return result;
 };
 
 export const useUpdateAuthenticatedUser = () => {
   const { authenticatedUser, refetch } = useAuthInfo();
 
   const [getMe] = useLazyQuery<MeQuery>(meQuery, {
-    fetchPolicy: "cache-and-network",
+    fetchPolicy: "network-only",
   });
 
   const [updateEntity] = useMutation<
@@ -59,101 +83,119 @@ export const useUpdateAuthenticatedUser = () => {
         throw new Error("There is no authenticated user to update.");
       }
 
+      if (Object.keys(params).length === 0) {
+        return { updatedAuthenticatedUser: authenticatedUser };
+      }
+
+      const removePendingPreferencesUpdate = params.preferences
+        ? trackPendingPreferencesUpdate(params.preferences)
+        : undefined;
+
+      setLoading(true);
       try {
-        setLoading(true);
-        if (Object.keys(params).length === 0) {
-          return { updatedAuthenticatedUser: authenticatedUser };
-        }
+        return await enqueueUserUpdate(async () => {
+          const latestUserEntitySubgraph = await getMe()
+            .then(({ data }) => {
+              const subgraph = data
+                ? mapGqlSubgraphFieldsFragmentToSubgraph<
+                    EntityRootType<HashEntity>
+                  >(data.me.subgraph)
+                : undefined;
 
-        const latestUserEntitySubgraph = await getMe()
-          .then(({ data }) => {
-            const subgraph = data
-              ? mapGqlSubgraphFieldsFragmentToSubgraph<
-                  EntityRootType<HashEntity>
-                >(data.me.subgraph)
-              : undefined;
+              return subgraph;
+            })
+            .catch(() => undefined);
 
-            return subgraph;
-          })
-          .catch(() => undefined);
-
-        if (!latestUserEntitySubgraph) {
-          throw new Error(
-            "Could not get latest user entity when updating the authenticated user.",
-          );
-        }
-
-        const latestUserEntity = getRoots(latestUserEntitySubgraph)[0]!;
-
-        const propertyPatches: PropertyPatchOperation[] = [];
-        const {
-          shortname,
-          displayName,
-          location,
-          websiteUrl,
-          preferredPronouns,
-          preferences: applicationPreferences,
-        } = params;
-        for (const [key, value] of typedEntries({
-          shortname,
-          displayName,
-          location,
-          websiteUrl,
-          preferredPronouns,
-          applicationPreferences,
-        })) {
-          if (typeof value !== "undefined") {
-            if (key === "websiteUrl" && !value) {
-              /**
-               * We need to explicitly remove the websiteUrl property if it is an empty string,
-               * because an empty string won't pass the URL validation regex.
-               */
-              propertyPatches.push({
-                path: [systemPropertyTypes.websiteUrl.propertyTypeBaseUrl],
-                op: "remove",
-              });
-              continue;
-            }
-
-            propertyPatches.push({
-              path: [
-                key === "displayName"
-                  ? blockProtocolPropertyTypes.displayName.propertyTypeBaseUrl
-                  : systemPropertyTypes[key].propertyTypeBaseUrl,
-              ],
-              op: "add",
-              property: {
-                value,
-                metadata: {
-                  dataTypeId:
-                    key === "applicationPreferences"
-                      ? "https://blockprotocol.org/@blockprotocol/types/data-type/object/v/1"
-                      : key === "websiteUrl"
-                        ? "https://hash.ai/@h/types/data-type/uri/v/1"
-                        : "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1",
-                },
-              },
-            });
+          if (!latestUserEntitySubgraph) {
+            throw new Error(
+              "Could not get latest user entity when updating the authenticated user.",
+            );
           }
-        }
 
-        const { errors } = await updateEntity({
-          variables: {
-            entityUpdate: {
-              entityId: latestUserEntity.metadata.recordId.entityId,
-              propertyPatches,
+          const latestUserEntity = getRoots(latestUserEntitySubgraph)[0]!;
+
+          const {
+            shortname,
+            displayName,
+            location,
+            websiteUrl,
+            preferredPronouns,
+            preferences: preferencesUpdate,
+          } = params;
+
+          const applicationPreferences = preferencesUpdate
+            ? mergeUserPreferences(
+                latestUserEntity.properties[
+                  systemPropertyTypes.applicationPreferences.propertyTypeBaseUrl
+                ] as UserPreferences | undefined,
+                preferencesUpdate,
+              )
+            : undefined;
+
+          const propertyPatches: PropertyPatchOperation[] = [];
+          for (const [key, value] of typedEntries({
+            shortname,
+            displayName,
+            location,
+            websiteUrl,
+            preferredPronouns,
+            applicationPreferences,
+          })) {
+            if (typeof value !== "undefined") {
+              if (key === "websiteUrl" && !value) {
+                /**
+                 * We need to explicitly remove the websiteUrl property if it is an empty string,
+                 * because an empty string won't pass the URL validation regex.
+                 */
+                propertyPatches.push({
+                  path: [systemPropertyTypes.websiteUrl.propertyTypeBaseUrl],
+                  op: "remove",
+                });
+                continue;
+              }
+
+              propertyPatches.push({
+                path: [
+                  key === "displayName"
+                    ? blockProtocolPropertyTypes.displayName.propertyTypeBaseUrl
+                    : systemPropertyTypes[key].propertyTypeBaseUrl,
+                ],
+                op: "add",
+                property: {
+                  value,
+                  metadata: {
+                    dataTypeId:
+                      key === "applicationPreferences"
+                        ? "https://blockprotocol.org/@blockprotocol/types/data-type/object/v/1"
+                        : key === "websiteUrl"
+                          ? "https://hash.ai/@h/types/data-type/uri/v/1"
+                          : "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1",
+                  },
+                },
+              });
+            }
+          }
+
+          const { errors } = await updateEntity({
+            variables: {
+              entityUpdate: {
+                entityId: latestUserEntity.metadata.recordId.entityId,
+                propertyPatches,
+              },
             },
-          },
+          });
+
+          if (errors && errors.length > 0) {
+            return { errors };
+          }
+
+          const { authenticatedUser: updatedAuthenticatedUser } =
+            await refetch();
+
+          return { updatedAuthenticatedUser };
         });
-
-        if (errors && errors.length > 0) {
-          return { errors };
-        }
-
-        const { authenticatedUser: updatedAuthenticatedUser } = await refetch();
-
-        return { updatedAuthenticatedUser };
       } finally {
+        removePendingPreferencesUpdate?.();
         setLoading(false);
       }
     },

--- a/apps/hash-frontend/src/pages/settings/personalization.page.tsx
+++ b/apps/hash-frontend/src/pages/settings/personalization.page.tsx
@@ -1,5 +1,4 @@
 import { Box, Stack, Switch, Typography } from "@mui/material";
-import { useState } from "react";
 
 import { useUpdateAuthenticatedUser } from "../../components/hooks/use-update-authenticated-user";
 import { useUserPreferences } from "../../shared/use-user-preferences";
@@ -14,28 +13,14 @@ const SidebarItemDisplaySwitch = ({
   section: "entities" | "entityTypes";
 }) => {
   const preferences = useUserPreferences();
-  const { sidebarSections } = preferences;
 
   const [updateUser] = useUpdateAuthenticatedUser();
 
-  const [currentDisplay, setCurrentDisplay] = useState<"list" | "link">(
-    sidebarSections[section].variant,
-  );
+  const currentDisplay = preferences.sidebarSections[section].variant;
 
   const setSidebarDisplay = ({ variant }: { variant: "link" | "list" }) => {
-    setCurrentDisplay(variant);
-
     void updateUser({
-      preferences: {
-        ...preferences,
-        sidebarSections: {
-          ...sidebarSections,
-          [section]: {
-            ...sidebarSections[section],
-            variant,
-          },
-        },
-      },
+      preferences: { sidebarSections: { [section]: { variant } } },
     });
   };
 

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar/account-entities-list.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar/account-entities-list.tsx
@@ -47,26 +47,13 @@ export const AccountEntitiesList: FunctionComponent<
 > = ({ webId }) => {
   const preferences = useUserPreferences();
 
-  const [expanded, setExpanded] = useState<boolean>(
-    preferences.sidebarSections.entities.expanded,
-  );
+  const expanded = preferences.sidebarSections.entities.expanded;
 
   const [updateUser] = useUpdateAuthenticatedUser();
 
   const toggleEntitiesExpanded = () => {
-    setExpanded(!expanded);
-
     void updateUser({
-      preferences: {
-        ...preferences,
-        sidebarSections: {
-          ...preferences.sidebarSections,
-          entities: {
-            ...preferences.sidebarSections.entities,
-            expanded: !expanded,
-          },
-        },
-      },
+      preferences: { sidebarSections: { entities: { expanded: !expanded } } },
     });
   };
 

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar/account-entity-type-list.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar/account-entity-type-list.tsx
@@ -33,25 +33,14 @@ export const AccountEntityTypeList: FunctionComponent<
 > = ({ webId }) => {
   const preferences = useUserPreferences();
 
-  const [expanded, setExpanded] = useState<boolean>(
-    preferences.sidebarSections.entityTypes.expanded,
-  );
+  const expanded = preferences.sidebarSections.entityTypes.expanded;
 
   const [updateUser] = useUpdateAuthenticatedUser();
 
   const toggleTypesExpanded = () => {
-    setExpanded(!expanded);
-
     void updateUser({
       preferences: {
-        ...preferences,
-        sidebarSections: {
-          ...preferences.sidebarSections,
-          entityTypes: {
-            ...preferences.sidebarSections.entityTypes,
-            expanded: !expanded,
-          },
-        },
+        sidebarSections: { entityTypes: { expanded: !expanded } },
       },
     });
   };

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar/account-page-list.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar/account-page-list.tsx
@@ -75,26 +75,13 @@ export const AccountPageList: FunctionComponent<AccountPageListProps> = ({
 
   const preferences = useUserPreferences();
 
-  const [expanded, setExpanded] = useState<boolean>(
-    preferences.sidebarSections.pages.expanded,
-  );
+  const expanded = preferences.sidebarSections.pages.expanded;
 
   const [updateUser] = useUpdateAuthenticatedUser();
 
   const togglePagesExpanded = () => {
-    setExpanded(!expanded);
-
     void updateUser({
-      preferences: {
-        ...preferences,
-        sidebarSections: {
-          ...preferences.sidebarSections,
-          pages: {
-            ...preferences.sidebarSections.pages,
-            expanded: !expanded,
-          },
-        },
-      },
+      preferences: { sidebarSections: { pages: { expanded: !expanded } } },
     });
   };
 

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar/favorites-list.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar/favorites-list.tsx
@@ -22,26 +22,13 @@ import type { SortType } from "./shared/sort-actions-dropdown";
 export const FavoritesList = () => {
   const preferences = useUserPreferences();
 
-  const [expanded, setExpanded] = useState<boolean>(
-    preferences.sidebarSections.favorites.expanded,
-  );
+  const expanded = preferences.sidebarSections.favorites.expanded;
 
   const [updateUser] = useUpdateAuthenticatedUser();
 
   const toggleFavoritesExpanded = () => {
-    setExpanded(!expanded);
-
     void updateUser({
-      preferences: {
-        ...preferences,
-        sidebarSections: {
-          ...preferences.sidebarSections,
-          favorites: {
-            ...preferences.sidebarSections.favorites,
-            expanded: !expanded,
-          },
-        },
-      },
+      preferences: { sidebarSections: { favorites: { expanded: !expanded } } },
     });
   };
 

--- a/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar/shared/entity-or-type-sidebar-item/shared/favorite-menu-item.tsx
+++ b/apps/hash-frontend/src/shared/layout/layout-with-sidebar/sidebar/shared/entity-or-type-sidebar-item/shared/favorite-menu-item.tsx
@@ -42,16 +42,15 @@ export const FavoriteMenuItem = ({
   const [updateUser] = useUpdateAuthenticatedUser();
 
   const toggleFavorite = () => {
-    const newFavorites = isFavorite
-      ? preferences.favorites.filter(
-          (favorite) => !matchFavorite(favorite, item),
-        )
-      : [...preferences.favorites, item];
-
     void updateUser({
       preferences: {
-        ...preferences,
-        favorites: newFavorites,
+        favorites: (currentFavorites) => {
+          const withoutItem = currentFavorites.filter(
+            (favorite) => !matchFavorite(favorite, item),
+          );
+
+          return isFavorite ? withoutItem : [...withoutItem, item];
+        },
       },
     });
 

--- a/apps/hash-frontend/src/shared/use-user-preferences.ts
+++ b/apps/hash-frontend/src/shared/use-user-preferences.ts
@@ -1,3 +1,5 @@
+import { useMemo, useSyncExternalStore } from "react";
+
 import { useAuthInfo } from "../pages/shared/auth-info-context";
 
 import type { EntityId, VersionedUrl } from "@blockprotocol/type-system";
@@ -39,6 +41,20 @@ export type UserPreferences = {
   };
 };
 
+/**
+ * A partial update to {@link UserPreferences}, merged into the latest persisted
+ * preferences at write time. `favorites` may be an updater function so that
+ * concurrent favorite changes compose rather than overwrite each other.
+ */
+export type UserPreferencesUpdate = {
+  favorites?: Favorite[] | ((currentFavorites: Favorite[]) => Favorite[]);
+  sidebarSections?: {
+    [Section in keyof UserPreferences["sidebarSections"]]?: Partial<
+      UserPreferences["sidebarSections"][Section]
+    >;
+  };
+};
+
 const defaultUserPreferences: UserPreferences = {
   favorites: [],
   sidebarSections: {
@@ -59,8 +75,103 @@ const defaultUserPreferences: UserPreferences = {
   },
 };
 
+export const mergeUserPreferences = (
+  currentPreferences: UserPreferences | undefined,
+  update: UserPreferencesUpdate,
+): UserPreferences => {
+  const base = currentPreferences ?? defaultUserPreferences;
+  const { favorites, sidebarSections } = update;
+
+  return {
+    favorites:
+      typeof favorites === "function"
+        ? favorites(base.favorites)
+        : (favorites ?? base.favorites),
+    sidebarSections: {
+      entityTypes: {
+        ...base.sidebarSections.entityTypes,
+        ...sidebarSections?.entityTypes,
+      },
+      entities: {
+        ...base.sidebarSections.entities,
+        ...sidebarSections?.entities,
+      },
+      favorites: {
+        ...base.sidebarSections.favorites,
+        ...sidebarSections?.favorites,
+      },
+      pages: {
+        ...base.sidebarSections.pages,
+        ...sidebarSections?.pages,
+      },
+    },
+  };
+};
+
+/**
+ * Preference updates currently in flight, overlaid on the server-confirmed
+ * preferences by {@link useUserPreferences} so all consumers reflect changes
+ * immediately. An entry is removed once its update settles: on success the
+ * refetched user already includes it, on failure the UI reverts to the
+ * server state.
+ */
+type PendingPreferencesUpdate = { update: UserPreferencesUpdate };
+
+let pendingUpdates: readonly PendingPreferencesUpdate[] = [];
+
+const pendingUpdateListeners = new Set<() => void>();
+
+const getPendingUpdates = () => pendingUpdates;
+
+const subscribeToPendingUpdates = (onChange: () => void) => {
+  pendingUpdateListeners.add(onChange);
+  return () => {
+    pendingUpdateListeners.delete(onChange);
+  };
+};
+
+const emitPendingUpdatesChange = () => {
+  for (const onChange of pendingUpdateListeners) {
+    onChange();
+  }
+};
+
+/**
+ * Overlay an in-flight preferences update – returns a function which removes
+ * the overlay again, to be called once the update has settled.
+ */
+export const trackPendingPreferencesUpdate = (
+  update: UserPreferencesUpdate,
+): (() => void) => {
+  const entry: PendingPreferencesUpdate = { update };
+
+  pendingUpdates = [...pendingUpdates, entry];
+  emitPendingUpdatesChange();
+
+  return () => {
+    pendingUpdates = pendingUpdates.filter((pending) => pending !== entry);
+    emitPendingUpdatesChange();
+  };
+};
+
 export const useUserPreferences = (): UserPreferences => {
   const { authenticatedUser } = useAuthInfo();
 
-  return authenticatedUser?.preferences ?? defaultUserPreferences;
+  const pending = useSyncExternalStore(
+    subscribeToPendingUpdates,
+    getPendingUpdates,
+    getPendingUpdates,
+  );
+
+  const serverPreferences = authenticatedUser?.preferences;
+
+  return useMemo(
+    () =>
+      pending.reduce(
+        (mergedPreferences, { update }) =>
+          mergeUserPreferences(mergedPreferences, update),
+        serverPreferences ?? defaultUserPreferences,
+      ),
+    [pending, serverPreferences],
+  );
 };


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Prevents user setting updates from hitting a race condition.

Ideally I would have liked to have used optimistic updates and client side merging to handle this, but because the user settings api is an opaque JSON blob we can't apply patch operations on it over the network, so serializing the updates is the only way to prevent out of order operations from clobbering each other under bad network conditions.

A proper fix would involve turning the user settings into a typed object.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change
