### PR TITLE
H-4170: Load optional TOML files in hash-config

### DIFF
--- a/libs/@local/config/src/error.rs
+++ b/libs/@local/config/src/error.rs
@@ -7,6 +7,8 @@ use figment::{
     error::{Actual, Error as FigmentError, Kind as FigmentKind},
 };
 
+use crate::FileFormat;
+
 /// What prevented a configuration from loading.
 #[derive(Debug, derive_more::Display)]
 #[non_exhaustive]
@@ -14,12 +16,12 @@ pub enum LoadError {
     /// The merged values do not deserialize into the requested configuration type.
     #[display("the configuration could not be loaded")]
     Invalid,
-    /// A required configuration file could not be read as UTF-8.
+    /// A configuration file could not be read as UTF-8.
     #[display("the configuration file `{}` could not be read", path.display())]
     ReadFile { path: PathBuf },
-    /// A configuration file does not contain valid TOML.
-    #[display("the configuration file `{}` is not valid TOML", path.display())]
-    ParseFile { path: PathBuf },
+    /// A configuration file is invalid for the selected format.
+    #[display("the configuration file `{}` is not valid {format}", path.display())]
+    ParseFile { path: PathBuf, format: FileFormat },
 }
 
 impl Error for LoadError {}

--- a/libs/@local/config/src/file.rs
+++ b/libs/@local/config/src/file.rs
@@ -1,4 +1,4 @@
-use std::{fs, path::PathBuf};
+use std::{fs, io, path::PathBuf};
 
 use error_stack::{Report, ResultExt as _};
 use figment::{
@@ -9,20 +9,44 @@ use figment::{
 
 use crate::LoadError;
 
-/// A required TOML file contributing one configuration layer.
+/// The format used to parse a configuration file.
+#[derive(Debug, derive_more::Display)]
+#[non_exhaustive]
+pub enum FileFormat {
+    #[display("TOML")]
+    Toml,
+}
+
+/// A file to read when loading the configuration.
+#[derive(Debug)]
+pub(crate) enum FileSource {
+    Required(PathBuf),
+    Optional(PathBuf),
+}
+
+/// A parsed file contributing one configuration layer.
 pub(crate) struct File {
     path: PathBuf,
     values: Dict,
 }
 
-impl File {
-    pub(crate) fn read(path: PathBuf) -> Result<Self, Report<LoadError>> {
-        let text = fs::read_to_string(&path)
-            .change_context_lazy(|| LoadError::ReadFile { path: path.clone() })?;
+impl FileSource {
+    pub(crate) fn read(self) -> Result<Option<File>, Report<LoadError>> {
+        let (path, required) = match self {
+            Self::Required(path) => (path, true),
+            Self::Optional(path) => (path, false),
+        };
+        let text = match fs::read_to_string(&path) {
+            Err(error) if !required && error.kind() == io::ErrorKind::NotFound => return Ok(None),
+            result => result.change_context_lazy(|| LoadError::ReadFile { path: path.clone() })?,
+        };
         let values = toml::from_str(&text).map_err(|error: toml::de::Error| {
             // TOML errors retain the source document and may quote its values. Keep only the
             // position so neither the report nor its underlying frames can expose that input.
-            let mut report = Report::new(LoadError::ParseFile { path: path.clone() });
+            let mut report = Report::new(LoadError::ParseFile {
+                path: path.clone(),
+                format: FileFormat::Toml,
+            });
             if let Some(prefix) = error.span().and_then(|span| text.get(..span.start)) {
                 let line = prefix.bytes().filter(|byte| *byte == b'\n').count() + 1;
                 let column = prefix
@@ -34,7 +58,7 @@ impl File {
             report
         })?;
 
-        Ok(Self { path, values })
+        Ok(Some(File { path, values }))
     }
 }
 

--- a/libs/@local/config/src/lib.rs
+++ b/libs/@local/config/src/lib.rs
@@ -14,8 +14,8 @@ use error_stack::Report;
 use figment::Figment;
 use serde_core::{Serialize, de::DeserializeOwned};
 
-pub use self::error::LoadError;
-use self::{defaults::Defaults, error::load_report};
+use self::{defaults::Defaults, error::load_report, file::FileSource};
+pub use self::{error::LoadError, file::FileFormat};
 
 /// Builds a configuration from layered sources.
 ///
@@ -37,7 +37,7 @@ use self::{defaults::Defaults, error::load_report};
 #[derive(Default)]
 pub struct Loader {
     defaults: Figment,
-    files: Vec<PathBuf>,
+    files: Vec<FileSource>,
 }
 
 impl fmt::Debug for Loader {
@@ -78,10 +78,11 @@ impl Loader {
 
     /// Adds a required TOML file above the programmatic defaults.
     ///
-    /// Files are read by [`load`](Self::load), in the order they were added. Later files replace
-    /// earlier scalars and arrays, while maps merge recursively. Every file takes precedence over
-    /// every default, regardless of the order of builder calls. Relative paths resolve against the
-    /// working directory at load time; the file extension does not select the format.
+    /// Required and optional files are read by [`load`](Self::load), in the order they were added.
+    /// Later files replace earlier scalars and arrays, while maps merge recursively. Every file
+    /// takes precedence over every default, regardless of the order of builder calls. Relative
+    /// paths resolve against the working directory at load time; the file extension does not
+    /// select the format.
     ///
     /// # Examples
     ///
@@ -107,7 +108,41 @@ impl Loader {
     /// ```
     #[must_use]
     pub fn with_toml_file(mut self, path: impl Into<PathBuf>) -> Self {
-        self.files.push(path.into());
+        self.files.push(FileSource::Required(path.into()));
+        self
+    }
+
+    /// Adds a TOML file that may be absent at load time.
+    ///
+    /// Only [`NotFound`](std::io::ErrorKind::NotFound) is skipped; other read errors, invalid
+    /// UTF-8, and malformed TOML fail [`load`](Self::load). Present files follow the same
+    /// precedence, merge, and path rules as [`with_toml_file`](Self::with_toml_file), including
+    /// their position among required files. Missing files contribute no values, so required
+    /// configuration fields must still be supplied elsewhere.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// #[derive(serde::Deserialize)]
+    /// struct Config {
+    ///     port: u16,
+    /// }
+    ///
+    /// # figment::Jail::expect_with(|jail| {
+    /// # jail.create_file("hash-graph.local.toml", "port = 6543\n")?;
+    /// let config = hash_config::Loader::new()
+    ///     .with_defaults(serde_json::json!({ "port": 5432 }))
+    ///     .with_optional_toml_file("hash-graph.local.toml")
+    ///     .load::<Config>()
+    ///     .expect("the optional configuration file should load");
+    ///
+    /// assert_eq!(config.port, 6543);
+    /// # Ok(())
+    /// # });
+    /// ```
+    #[must_use]
+    pub fn with_optional_toml_file(mut self, path: impl Into<PathBuf>) -> Self {
+        self.files.push(FileSource::Optional(path.into()));
         self
     }
 
@@ -117,8 +152,9 @@ impl Loader {
     ///
     /// - [`LoadError::Invalid`] if a value does not fit `C`, a required value is missing, or a
     ///   default does not serialize to a map.
-    /// - [`LoadError::ReadFile`] if a required file is absent, unreadable, or not UTF-8.
-    /// - [`LoadError::ParseFile`] if a file does not contain valid TOML.
+    /// - [`LoadError::ReadFile`] if a required file is absent, or any file is unreadable or not
+    ///   UTF-8.
+    /// - [`LoadError::ParseFile`] if a file is invalid for the selected format.
     ///
     /// The report names the key, expected shape, and source when available. Rejected values and
     /// TOML source excerpts are withheld.
@@ -128,8 +164,10 @@ impl Loader {
         C: DeserializeOwned,
     {
         let mut values = self.defaults;
-        for path in self.files {
-            values = values.merge(file::File::read(path)?);
+        for source in self.files {
+            if let Some(file) = source.read()? {
+                values = values.merge(file);
+            }
         }
 
         match values.extract::<C>() {

--- a/libs/@local/config/tests/files.rs
+++ b/libs/@local/config/tests/files.rs
@@ -13,7 +13,7 @@ use error_stack::{
     fmt::{Charset, ColorMode},
 };
 use figment::Jail;
-use hash_config::{LoadError, Loader};
+use hash_config::{FileFormat, LoadError, Loader};
 use serde_json::json;
 
 const SECRET: &str = "this-value-must-not-appear-in-an-error";
@@ -237,6 +237,7 @@ fn file_missing() {
     Jail::expect_with(|jail| {
         let report = Loader::new()
             .with_defaults(json!({ "store": { "host": "localhost", "port": 5432 }, "routes": [] }))
+            .with_optional_toml_file("missing.toml")
             .with_toml_file("missing.toml")
             .load::<Config>()
             .expect_err("the absent required file should fail the load");
@@ -262,24 +263,28 @@ fn file_missing() {
 #[test]
 fn file_directory() {
     Jail::expect_with(|jail| {
-        let report = Loader::new()
-            .with_toml_file(jail.directory())
-            .load::<Config>()
-            .expect_err("the directory should fail as a configuration file");
+        for loader in [
+            Loader::new().with_toml_file(jail.directory()),
+            Loader::new().with_optional_toml_file(jail.directory()),
+        ] {
+            let report = loader
+                .load::<Config>()
+                .expect_err("the directory should fail as a configuration file");
 
-        assert_matches!(
-            report.current_context(),
-            LoadError::ReadFile { path } if path == jail.directory(),
-            "the error should identify a read failure and retain the original path"
-        );
-        assert_eq!(
-            report
-                .downcast_ref::<std::io::Error>()
-                .map(std::io::Error::kind),
-            Some(std::io::ErrorKind::IsADirectory),
-            "the report should preserve the directory IO cause"
-        );
-        assert_report("file_directory", &report, jail);
+            assert_matches!(
+                report.current_context(),
+                LoadError::ReadFile { path } if path == jail.directory(),
+                "the error should identify a read failure and retain the original path"
+            );
+            assert_eq!(
+                report
+                    .downcast_ref::<std::io::Error>()
+                    .map(std::io::Error::kind),
+                Some(std::io::ErrorKind::IsADirectory),
+                "the report should preserve the directory IO cause"
+            );
+            assert_report("file_directory", &report, jail);
+        }
         Ok(())
     });
 }
@@ -292,23 +297,27 @@ fn file_non_utf8() {
         contents.push(0xFF);
         fs::write("config.toml", contents).expect("the invalid UTF-8 fixture should be written");
 
-        let report = Loader::new()
-            .with_toml_file("config.toml")
-            .load::<Config>()
-            .expect_err("the non-UTF-8 file should fail the load");
-        assert_matches!(
-            report.current_context(),
-            LoadError::ReadFile { path } if path == Path::new("config.toml"),
-            "the error should identify a read failure and retain the original path"
-        );
-        assert_eq!(
-            report
-                .downcast_ref::<std::io::Error>()
-                .map(std::io::Error::kind),
-            Some(std::io::ErrorKind::InvalidData),
-            "the report should preserve the encoding IO cause"
-        );
-        assert_report("file_non_utf8", &report, jail);
+        for loader in [
+            Loader::new().with_toml_file("config.toml"),
+            Loader::new().with_optional_toml_file("config.toml"),
+        ] {
+            let report = loader
+                .load::<Config>()
+                .expect_err("the non-UTF-8 file should fail the load");
+            assert_matches!(
+                report.current_context(),
+                LoadError::ReadFile { path } if path == Path::new("config.toml"),
+                "the error should identify a read failure and retain the original path"
+            );
+            assert_eq!(
+                report
+                    .downcast_ref::<std::io::Error>()
+                    .map(std::io::Error::kind),
+                Some(std::io::ErrorKind::InvalidData),
+                "the report should preserve the encoding IO cause"
+            );
+            assert_report("file_non_utf8", &report, jail);
+        }
         Ok(())
     });
 }
@@ -319,20 +328,25 @@ fn file_malformed_redaction() {
     Jail::expect_with(|jail| {
         jail.create_file("config.toml", &format!("# ü\npassword = \"{SECRET}\n"))?;
 
-        let report = Loader::new()
-            .with_toml_file("config.toml")
-            .load::<Config>()
-            .expect_err("the unterminated string should fail TOML parsing");
-        assert_matches!(
-            report.current_context(),
-            LoadError::ParseFile { path } if path == Path::new("config.toml"),
-            "the error should identify malformed TOML and retain the original path"
-        );
-        assert!(
-            !report.contains::<toml::de::Error>(),
-            "the report should not retain the source-bearing TOML error"
-        );
-        assert_report("file_malformed_redaction", &report, jail);
+        for loader in [
+            Loader::new().with_toml_file("config.toml"),
+            Loader::new().with_optional_toml_file("config.toml"),
+        ] {
+            let report = loader
+                .load::<Config>()
+                .expect_err("the unterminated string should fail TOML parsing");
+            assert_matches!(
+                report.current_context(),
+                LoadError::ParseFile { path, format: FileFormat::Toml }
+                    if path == Path::new("config.toml"),
+                "the error should identify the TOML format and retain the original path"
+            );
+            assert!(
+                !report.contains::<toml::de::Error>(),
+                "the report should not retain the source-bearing TOML error"
+            );
+            assert_report("file_malformed_redaction", &report, jail);
+        }
         Ok(())
     });
 }
@@ -356,22 +370,54 @@ fn file_non_utf8_path() {
     });
 }
 
+/// Parse errors name the selected parser even when the extension suggests another format.
+#[test]
+fn file_format_explicit() {
+    Jail::expect_with(|jail| {
+        jail.create_file(
+            "config.json",
+            &json!({ "host": "localhost", "port": 5432 }).to_string(),
+        )?;
+
+        for loader in [
+            Loader::new().with_toml_file("config.json"),
+            Loader::new().with_optional_toml_file("config.json"),
+        ] {
+            let report = loader
+                .load::<Store>()
+                .expect_err("the JSON document should fail TOML parsing");
+
+            assert_matches!(
+                report.current_context(),
+                LoadError::ParseFile { path, format: FileFormat::Toml }
+                    if path == Path::new("config.json"),
+                "the error should name the selected TOML parser regardless of the file extension"
+            );
+        }
+        Ok(())
+    });
+}
+
 /// Deserialization errors retain the winning file and key while redacting the value.
 #[test]
 fn file_invalid_value() {
     Jail::expect_with(|jail| {
         jail.create_file("config.toml", &format!("[store]\nport = '{SECRET}'\n"))?;
-        let report = Loader::new()
-            .with_defaults(json!({ "store": { "host": "localhost" }, "routes": [] }))
-            .with_toml_file("config.toml")
-            .load::<Config>()
-            .expect_err("the string should not deserialize as a port");
-        assert_matches!(
-            report.current_context(),
-            LoadError::Invalid,
-            "the error should identify invalid configuration"
-        );
-        assert_report("file_invalid_value", &report, jail);
+        for loader in [
+            Loader::new().with_toml_file("config.toml"),
+            Loader::new().with_optional_toml_file("config.toml"),
+        ] {
+            let report = loader
+                .with_defaults(json!({ "store": { "host": "localhost" }, "routes": [] }))
+                .load::<Config>()
+                .expect_err("the string should not deserialize as a port");
+            assert_matches!(
+                report.current_context(),
+                LoadError::Invalid,
+                "the error should identify invalid configuration"
+            );
+            assert_report("file_invalid_value", &report, jail);
+        }
         Ok(())
     });
 }
@@ -391,6 +437,154 @@ fn file_missing_required_value() {
             "the error should identify incomplete configuration"
         );
         assert_report("file_missing_required_value", &report, jail);
+        Ok(())
+    });
+}
+
+/// An absent optional file contributes no values, including when its parent directory is absent.
+#[test]
+fn optional_file_missing() {
+    Jail::expect_with(|_jail| {
+        for path in ["missing.toml", "missing/config.toml"] {
+            let config = Loader::new()
+                .with_defaults(json!({ "host": "localhost", "port": 5432 }))
+                .with_optional_toml_file(path)
+                .load::<Store>()
+                .expect("the absent optional file should leave the defaults intact");
+
+            assert_eq!(
+                config,
+                Store {
+                    host: "localhost".to_owned(),
+                    port: 5432,
+                },
+                "the defaults should survive an absent optional file"
+            );
+        }
+        Ok(())
+    });
+}
+
+/// Skipping an absent file does not waive required configuration fields.
+#[test]
+fn optional_file_missing_required_value() {
+    Jail::expect_with(|_jail| {
+        let report = Loader::new()
+            .with_defaults(json!({ "host": "localhost" }))
+            .with_optional_toml_file("missing.toml")
+            .load::<Store>()
+            .expect_err("the missing port should still fail deserialization");
+
+        assert_matches!(
+            report.current_context(),
+            LoadError::Invalid,
+            "the error should identify an incomplete configuration"
+        );
+        assert!(
+            format!("{report:?}").contains("missing field `port`"),
+            "the report should name the missing field: {report:?}"
+        );
+        Ok(())
+    });
+}
+
+/// A file created after adding its path is read as TOML, independent of its extension.
+#[test]
+fn optional_file_deferred_read() {
+    Jail::expect_with(|jail| {
+        let loader = Loader::new().with_optional_toml_file("config.local");
+        jail.create_file("config.local", "host = 'database'\nport = 6543\n")?;
+
+        let config = loader
+            .load::<Store>()
+            .expect("the optional file created before load should be read");
+
+        assert_eq!(
+            config,
+            Store {
+                host: "database".to_owned(),
+                port: 6543,
+            },
+            "the values should come from the file created after the builder call"
+        );
+        Ok(())
+    });
+}
+
+/// A file removed before load is skipped even if it existed when its path was added.
+#[test]
+fn optional_file_removed_before_load() {
+    Jail::expect_with(|jail| {
+        jail.create_file("config.toml", "port = 6543\n")?;
+        let loader = Loader::new()
+            .with_defaults(json!({ "host": "localhost", "port": 5432 }))
+            .with_optional_toml_file("config.toml");
+        fs::remove_file("config.toml").expect("the optional file should be removed before load");
+
+        let config = loader
+            .load::<Store>()
+            .expect("the removed optional file should be skipped");
+
+        assert_eq!(
+            config.port, 5432,
+            "the default port should survive the removed optional file"
+        );
+        Ok(())
+    });
+}
+
+/// Required and optional files share one order above defaults; absent layers leave it intact.
+#[test]
+fn files_required_optional_order() {
+    Jail::expect_with(|jail| {
+        jail.create_file(
+            "required.toml",
+            "routes = ['api', 'health']\n[store]\nport = 5432\n",
+        )?;
+        jail.create_file(
+            "optional.toml",
+            "routes = ['metrics']\n[store]\nhost = 'database'\nport = 6543\n",
+        )?;
+
+        for (loader, expected_port, expected_routes) in [
+            (
+                Loader::new()
+                    .with_toml_file("required.toml")
+                    .with_optional_toml_file("missing.toml")
+                    .with_optional_toml_file("optional.toml"),
+                6543,
+                vec!["metrics"],
+            ),
+            (
+                Loader::new()
+                    .with_optional_toml_file("optional.toml")
+                    .with_toml_file("required.toml")
+                    .with_optional_toml_file("missing.toml"),
+                5432,
+                vec!["api", "health"],
+            ),
+        ] {
+            let config = loader
+                .with_defaults(json!({
+                    "store": { "host": "localhost", "port": 1234 },
+                    "routes": ["default"],
+                }))
+                .load::<Config>()
+                .expect("the required and optional files should compose above the defaults");
+
+            assert_eq!(
+                config.store.host, "database",
+                "the optional file's host should override defaults and survive either file order"
+            );
+            assert_eq!(
+                config.store.port, expected_port,
+                "the later present file should supply the port"
+            );
+            assert_eq!(
+                config.routes, expected_routes,
+                "the later present file should replace the routes"
+            );
+        }
         Ok(())
     });
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Allow binaries to add a local TOML configuration file that may be absent. `with_optional_toml_file("hash-graph.local.toml")` leaves lower-priority values intact when the file is missing, while unreadable or malformed files still fail the load.

## 🔗 Related links

- Part of [H-4170: Introduce config file for HASH](https://linear.app/hash/issue/H-4170/introduce-config-file-for-hash) _(internal)_. This PR implements one delivery slice of that work.
- Builds on [#9553: Load explicit TOML files in hash-config](https://github.com/hashintel/hash/pull/9553).

## 🚫 Blocked by

None.

## 🔍 What does this change?

- Add `Loader::with_optional_toml_file`. Read files at load time and skip only `io::ErrorKind::NotFound`; preserve other I/O causes, paths, and value redaction.
- Keep required and optional files in one ordered list above all defaults. Maps merge recursively; later scalars and arrays replace earlier values. Missing optional files contribute no values and do not waive required configuration fields.
- Add `FileFormat::Toml` to `LoadError::ParseFile` and use it in the existing error message. The selected parser determines the format, independent of the path's extension.
- Document the API with an executable example and extend the existing error snapshot tests to optional files.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] require changes to docs which **are made** as part of this PR

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

Optional loading skips errors classified as `NotFound`, including missing parent directories. Automatic discovery and additional file formats remain outside this slice.

## 🐾 Next steps

Verify provenance for content diagnostics after merging multiple sources: attribute an invalid surviving value to its supplying source, allow later values to correct earlier ones, and avoid attributing missing required values to an arbitrary file.

## 🛡 What tests cover this?

37 unit, integration, and example tests, including existing report snapshots, and 3 executable Rustdoc tests pass. Coverage includes absent files and parent directories, deferred reads, removal before load, mixed file order above defaults, read/parse/deserialization errors, redaction, and explicit format selection. Clippy with warnings denied and Rustdoc also pass.

## ❓ How to test this?

```sh
yarn workspace @rust/hash-config test:unit
cargo clippy --package hash-config --all-features --all-targets --no-deps -- -D warnings
cargo doc --package hash-config --all-features --no-deps
```

## 📹 Demo

The executable `with_optional_toml_file` Rustdoc example demonstrates a local file overriding a default port. No UI is involved.
