### PR TITLE
FE-1620: Fix turbo petrinaut dev script

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -4,6 +4,10 @@ min_version = "2026.8.10"
 [env]
 TURBO_GLOBAL_WARNING_DISABLED = 1
 _.file                        = [".env", ".env.local"]
+# Yarn's node-modules linker loses bin registrations for workspaces whose peer-virtualized
+# instance of a tool (e.g. vite) isn't the copy hoisted to the root — triggered by petrinaut-docs' hoistingLimits.
+# Yarn's script shell falls back to PATH, so exposing the root bins fixes this.
+_.path = ["{{config_root}}/node_modules/.bin"]
 
 [settings]
 idiomatic_version_file_enable_tools = ["rust"]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Running `turbo --filter @hashintel/petrinaut dev` was still broken after upgrading everything to vite due to ` "installConfig": { "hoistingLimits": "dependencies" }` being set in petrinaut-docs. This fixes the issue by adding node_modules/.bin to turbo's path.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change
