### PR TITLE
FE-1633: Give every dev server a port of its own

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -26,7 +26,7 @@
         "--filter",
         "@apps/petrinaut-docs"
       ],
-      "port": 4321,
+      "port": 4322,
       "autoPort": true
     }
   ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,12 +55,38 @@ Every dev server binds a port of its own, so any set of them can run at once:
 | 4321  | `@apps/brunch-agent` chat -- `strictPort`, paired with the panel |
 | 4322  | `@apps/petrinaut-docs`                                           |
 | 4915  | `@apps/brunch-agent` panel -- `strictPort`                       |
+| 5001  | `@apps/hash-api`                                                 |
 | 5173  | `@apps/petrinaut-website`                                        |
 | 6006  | `@hashintel/petrinaut` Storybook                                 |
 | 6007  | `@hashintel/refractive` Storybook                                |
 | 61000 | `@hashintel/ds-components` Ladle                                 |
 
-`PORT` overrides the default for every one of them except the two Brunch servers, which take `BRUNCH_CHAT_PORT` and `BRUNCH_PANEL_PORT` instead: one variable each, because the pair binds two ports and the panel proxies to whatever the chat variable names. Set them on `yarn dev:brunch`, which passes its environment to both servers. Turbo runs a dev task in strict environment mode and forwards only the variables its `turbo.json` lists in `env` or `passThroughEnv`, so a dev server that reads a port variable declares it there. `.claude/launch.json` names the servers a Claude Code session can preview; keep its `port` in step with the table when a default moves.
+`PORT` overrides the default for every one of them except the Optimizer service, which the dev script publishes at 4004 and compose moves with `PETRINAUT_OPT_PORT`, and the two Brunch servers, which take `BRUNCH_CHAT_PORT` and `BRUNCH_PANEL_PORT` instead: one variable each, because the pair binds two ports and the panel proxies to whatever the chat variable names. Set them on `yarn dev:brunch`, which passes its environment to both servers. Turbo runs a dev task in strict environment mode and forwards only the variables its `turbo.json` lists in `env` or `passThroughEnv`, so a dev server that reads a port variable declares it there. `.claude/launch.json` names the servers a Claude Code session can preview; keep its `port` in step with the table when a default moves.
+
+The compose stack and the graph take these, so a new dev server stays off them as well. Where a variable moves the port, the table names it:
+
+| Port       | Service                     | Moved by                       |
+| ---------- | --------------------------- | ------------------------------ |
+| 1025       | Mailslurper SMTP            |                                |
+| 3001       | Grafana                     |                                |
+| 3100       | Temporal UI                 | `HASH_TEMPORAL_UI_PORT`        |
+| 4000       | Graph API HTTP              | `HASH_GRAPH_HTTP_PORT`         |
+| 4001       | Graph admin API             | `HASH_GRAPH_ADMIN_PORT`        |
+| 4002       | Graph HaRPC                 | `HASH_GRAPH_RPC_PORT`          |
+| 4003       | Graph Atlas                 | `HASH_GRAPH_ATLAS_PORT`        |
+| 4040       | Pyroscope                   |                                |
+| 4317       | OpenTelemetry collector     |                                |
+| 4433, 4434 | Kratos public and admin API |                                |
+| 4436, 4437 | Mailslurper web and API     |                                |
+| 4444, 4445 | Hydra public and admin API  |                                |
+| 4455       | Type fetcher                | `HASH_GRAPH_TYPE_FETCHER_PORT` |
+| 5432       | Postgres                    | `POSTGRES_PORT`                |
+| 6379       | Redis                       |                                |
+| 7233       | Temporal server             | `HASH_TEMPORAL_SERVER_PORT`    |
+| 8200       | Vault                       | `HASH_VAULT_PORT`              |
+| 9000, 9001 | MinIO API and console       |                                |
+
+The Brunch agent's `start` and `start:test` scripts and its production image listen on 3002, where the integration tests expect it; the dev pair uses 4321 and 4915.
 
 ### Starting Services
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ Every dev server binds a port of its own, so any set of them can run at once:
 | 6007  | `@hashintel/refractive` Storybook                                |
 | 61000 | `@hashintel/ds-components` Ladle                                 |
 
-`PORT` overrides the default for every one of them except the two Brunch servers, whose ports are a contract between the pair. `.claude/launch.json` names the servers a Claude Code session can preview; keep its `port` in step with the table when a default moves.
+`PORT` overrides the default for every one of them except the two Brunch servers, which take `BRUNCH_CHAT_PORT` and `BRUNCH_PANEL_PORT` instead: one variable each, because the pair binds two ports and the panel proxies to whatever the chat variable names. Set them on `yarn dev:brunch`, which passes its environment to both servers. `.claude/launch.json` names the servers a Claude Code session can preview; keep its `port` in step with the table when a default moves.
 
 ### Starting Services
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ Every dev server binds a port of its own, so any set of them can run at once:
 | 6007  | `@hashintel/refractive` Storybook                                |
 | 61000 | `@hashintel/ds-components` Ladle                                 |
 
-`PORT` overrides the default for every one of them except the two Brunch servers, which take `BRUNCH_CHAT_PORT` and `BRUNCH_PANEL_PORT` instead: one variable each, because the pair binds two ports and the panel proxies to whatever the chat variable names. Set them on `yarn dev:brunch`, which passes its environment to both servers. `.claude/launch.json` names the servers a Claude Code session can preview; keep its `port` in step with the table when a default moves.
+`PORT` overrides the default for every one of them except the two Brunch servers, which take `BRUNCH_CHAT_PORT` and `BRUNCH_PANEL_PORT` instead: one variable each, because the pair binds two ports and the panel proxies to whatever the chat variable names. Set them on `yarn dev:brunch`, which passes its environment to both servers. Turbo runs a dev task in strict environment mode and forwards only the variables its `turbo.json` lists in `env` or `passThroughEnv`, so a dev server that reads a port variable declares it there. `.claude/launch.json` names the servers a Claude Code session can preview; keep its `port` in step with the table when a default moves.
 
 ### Starting Services
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,24 @@ Package-specific standing instructions live in that package’s `AGENTS.md`. On-
 - Backend only: `yarn dev:backend` or `yarn dev:backend:api`
 - Frontend only: `yarn dev:frontend`
 
+### Dev server ports
+
+Every dev server binds a port of its own, so any set of them can run at once:
+
+| Port  | Server                                                           |
+| ----- | ---------------------------------------------------------------- |
+| 3000  | `@apps/hash-frontend`                                            |
+| 4004  | Petrinaut Optimizer service (`--with-optimizer-service`)         |
+| 4321  | `@apps/brunch-agent` chat -- `strictPort`, paired with the panel |
+| 4322  | `@apps/petrinaut-docs`                                           |
+| 4915  | `@apps/brunch-agent` panel -- `strictPort`                       |
+| 5173  | `@apps/petrinaut-website`                                        |
+| 6006  | `@hashintel/petrinaut` Storybook                                 |
+| 6007  | `@hashintel/refractive` Storybook                                |
+| 61000 | `@hashintel/ds-components` Ladle                                 |
+
+`PORT` overrides the default for every one of them except the two Brunch servers, whose ports are a contract between the pair. `.claude/launch.json` names the servers a Claude Code session can preview; keep its `port` in step with the table when a default moves.
+
 ### Starting Services
 
 - Start all services: `yarn start`

--- a/apps/brunch-agent/src/http/local-origins.ts
+++ b/apps/brunch-agent/src/http/local-origins.ts
@@ -1,14 +1,34 @@
-/** Listen addresses the local Brunch↔Petrinaut pair must emit and assume. */
+/**
+ * Listen addresses the local Brunch↔Petrinaut pair must emit and assume.
+ *
+ * Each port is named by an environment variable, so a second pair can run
+ * beside the first. The panel derives everything it assumes about the chat
+ * server from these two addresses, so setting the variables on the one command
+ * that starts both keeps the pair agreeing with itself.
+ *
+ * `strictPort` stays on either side. It refuses a port already taken rather
+ * than drifting to the next free one, which the pair cannot survive: the
+ * panel's proxy would reach whatever holds the chat port, and a drifted panel
+ * would serve the editor at an address nobody is watching. An explicit port is
+ * honoured, an accidental clash is reported.
+ */
+
+const listenPort = (variable: string, fallback: number): number => {
+  const requested = Number(process.env[variable]);
+  return Number.isInteger(requested) && requested > 0 && requested < 65536
+    ? requested
+    : fallback;
+};
 
 export const localChatListen = {
   host: "127.0.0.1",
-  port: 4321,
+  port: listenPort("BRUNCH_CHAT_PORT", 4321),
   strictPort: true,
 } as const;
 
 export const localPanelListen = {
   host: "127.0.0.1",
-  port: 4915,
+  port: listenPort("BRUNCH_PANEL_PORT", 4915),
   strictPort: true,
 } as const;
 

--- a/apps/brunch-agent/test/local-dev-origins.test.ts
+++ b/apps/brunch-agent/test/local-dev-origins.test.ts
@@ -82,6 +82,21 @@ test("forwards the deployment CORS allowlist to local development", () => {
   );
 });
 
+test("forwards the port variables to both dev tasks through Turbo", () => {
+  const turboConfig = JSON.parse(readAppFile("turbo.json")) as {
+    tasks: {
+      dev: { passThroughEnv: string[] };
+      "petrinaut:dev": { passThroughEnv: string[] };
+    };
+  };
+
+  expect(turboConfig.tasks.dev.passThroughEnv).toContain("BRUNCH_CHAT_PORT");
+  // The panel derives its proxy target from the chat port, so it needs both.
+  expect(turboConfig.tasks["petrinaut:dev"].passThroughEnv).toEqual(
+    expect.arrayContaining(["BRUNCH_CHAT_PORT", "BRUNCH_PANEL_PORT"]),
+  );
+});
+
 test("an explicit port moves the listener and everything derived from it", async () => {
   const moved = await importWithPorts("4331", "4925");
 

--- a/apps/brunch-agent/test/local-dev-origins.test.ts
+++ b/apps/brunch-agent/test/local-dev-origins.test.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
 
-import { expect, test } from "vitest";
+import { afterEach, expect, test, vi } from "vitest";
 
 import { mergePetrinautPanelConfig } from "../petrinaut-local.vite.config.ts";
 import {
@@ -12,6 +12,19 @@ import {
 
 const readAppFile = (relativePath: string): string =>
   readFileSync(new URL(`../${relativePath}`, import.meta.url), "utf8");
+
+/** The module reads the port variables once, as it is imported. */
+const importWithPorts = async (chatPort: string, panelPort: string) => {
+  vi.resetModules();
+  vi.stubEnv("BRUNCH_CHAT_PORT", chatPort);
+  vi.stubEnv("BRUNCH_PANEL_PORT", panelPort);
+  return import("../src/http/local-origins.ts");
+};
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
 
 test("dev listens on the chat origin the panel proxy already assumes", () => {
   expect(defaultChatOrigin).toBe("http://127.0.0.1:4321");
@@ -67,4 +80,27 @@ test("forwards the deployment CORS allowlist to local development", () => {
   expect(turboConfig.tasks.dev.passThroughEnv).toContain(
     "BRUNCH_CORS_ALLOWED_ORIGINS",
   );
+});
+
+test("an explicit port moves the listener and everything derived from it", async () => {
+  const moved = await importWithPorts("4331", "4925");
+
+  expect(moved.localChatListen.port).toBe(4331);
+  expect(moved.defaultChatOrigin).toBe("http://127.0.0.1:4331");
+  expect(moved.localPanelListen.port).toBe(4925);
+  expect(moved.petrinautLocalServer(moved.defaultChatOrigin).port).toBe(4925);
+});
+
+test("a port that is not a usable number falls back to the default", async () => {
+  const chatOnly = await importWithPorts("4331", "not-a-port");
+
+  expect(chatOnly.localChatListen.port).toBe(4331);
+  expect(chatOnly.localPanelListen.port).toBe(4915);
+});
+
+test("an overridden port keeps strictPort, so a clash is reported not absorbed", async () => {
+  const moved = await importWithPorts("4331", "4925");
+
+  expect(moved.localChatListen.strictPort).toBe(true);
+  expect(moved.localPanelListen.strictPort).toBe(true);
 });

--- a/apps/brunch-agent/turbo.json
+++ b/apps/brunch-agent/turbo.json
@@ -12,6 +12,7 @@
       "passThroughEnv": [
         "ANTHROPIC_API_KEY",
         "BRUNCH_CHAT_MODEL",
+        "BRUNCH_CHAT_PORT",
         "BRUNCH_CORS_ALLOWED_ORIGINS",
         "BRUNCH_DEV_DB_PATH",
         "BRUNCH_TRANSPORT_AISDK_INSPECT",
@@ -24,7 +25,12 @@
       "dependsOn": ["^build"],
       "cache": false,
       "persistent": true,
-      "passThroughEnv": ["BRUNCH_CHAT_ORIGIN", "PETRINAUT_WEBSITE_ROOT"]
+      "passThroughEnv": [
+        "BRUNCH_CHAT_ORIGIN",
+        "BRUNCH_CHAT_PORT",
+        "BRUNCH_PANEL_PORT",
+        "PETRINAUT_WEBSITE_ROOT"
+      ]
     },
     "start": {
       "dependsOn": ["build"]

--- a/apps/hash-api/turbo.json
+++ b/apps/hash-api/turbo.json
@@ -23,7 +23,8 @@
       "dependsOn": ["^manifest"]
     },
     "dev": {
-      "dependsOn": ["codegen", "^build"]
+      "dependsOn": ["codegen", "^build"],
+      "passThroughEnv": ["PORT"]
     },
     "test:unit": {
       "dependsOn": ["codegen", "^build"]

--- a/apps/hash-frontend/turbo.json
+++ b/apps/hash-frontend/turbo.json
@@ -23,7 +23,8 @@
       "dependsOn": ["^manifest"]
     },
     "dev": {
-      "dependsOn": ["codegen", "^build"]
+      "dependsOn": ["codegen", "^build"],
+      "passThroughEnv": ["PORT"]
     },
     "test:unit": {
       "dependsOn": ["codegen", "^build"]

--- a/apps/petrinaut-docs/package.json
+++ b/apps/petrinaut-docs/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "scripts": {
     "build": "astro build && node scripts/check-built-css.mjs",
-    "dev": "astro dev --port ${PORT:-4321}",
+    "dev": "astro dev --port ${PORT:-4322}",
     "lint:tsc": "astro check --minimumSeverity error",
     "preview": "astro preview",
     "sync:bundle": "node scripts/sync-bundle.mjs"

--- a/apps/petrinaut-website/turbo.json
+++ b/apps/petrinaut-website/turbo.json
@@ -15,7 +15,8 @@
       "outputs": ["src/routeTree.gen.ts"]
     },
     "dev": {
-      "dependsOn": ["codegen", "examples:generate", "^build"]
+      "dependsOn": ["codegen", "examples:generate", "^build"],
+      "passThroughEnv": ["PORT"]
     },
     "examples:generate": {
       "dependsOn": ["^build"],

--- a/libs/@hashintel/ds-components/.ladle/config.mjs
+++ b/libs/@hashintel/ds-components/.ladle/config.mjs
@@ -2,7 +2,7 @@
 export default {
   base: process.env.LADLE_BASE_PATH || "/",
   stories: "src/**/*.stories.{js,ts,tsx,mdx}",
-  port: 61000,
+  port: Number(process.env.PORT ?? 61000),
   viteConfig: "./vite.config.ts",
   outDir: ".build/ladle",
   envDir: ".",

--- a/libs/@hashintel/ds-components/turbo.json
+++ b/libs/@hashintel/ds-components/turbo.json
@@ -24,11 +24,13 @@
     "dev": {
       "cache": false,
       "dependsOn": ["codegen", "^build"],
+      "passThroughEnv": ["PORT"],
       "persistent": true
     },
     "dev:ladle": {
       "cache": false,
       "dependsOn": ["codegen", "^build"],
+      "passThroughEnv": ["PORT"],
       "persistent": true
     },
     "fix": {

--- a/libs/@hashintel/petrinaut/turbo.json
+++ b/libs/@hashintel/petrinaut/turbo.json
@@ -10,7 +10,8 @@
       "dependsOn": ["^build"]
     },
     "dev": {
-      "dependsOn": ["^build"]
+      "dependsOn": ["^build"],
+      "passThroughEnv": ["PORT"]
     }
   }
 }

--- a/libs/@hashintel/refractive/package.json
+++ b/libs/@hashintel/refractive/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "vite build",
     "build-storybook": "storybook build",
-    "dev": "storybook dev -p 6006",
+    "dev": "storybook dev -p ${PORT:-6007}",
     "dev:lib": "vite build --watch",
     "fix:eslint": "oxlint --fix --type-aware --report-unused-disable-directives-severity=error .",
     "lint:eslint": "oxlint --type-aware --report-unused-disable-directives-severity=error .",

--- a/libs/@hashintel/refractive/turbo.json
+++ b/libs/@hashintel/refractive/turbo.json
@@ -3,6 +3,9 @@
   "tasks": {
     "build": {
       "outputs": ["./dist/**"]
+    },
+    "dev": {
+      "passThroughEnv": ["PORT"]
     }
   }
 }


### PR DESCRIPTION
> [!IMPORTANT]
> Dev tooling, nothing user-facing.

## Summary

Before this PR, two pairs of dev servers wanted the same port. Petrinaut docs and the Brunch chat server both defaulted to 4321, and the chat server binds it with `strictPort` as one half of its contract with the panel, so whichever started second lost. Both Storybooks asked for 6006. Refractive's Storybook and ds-components' Ladle pinned their ports in the command and the config, so neither could take the port a preview task assigned it.

Every dev server now binds a port of its own, and a variable moves any of them: `PORT` for the single servers, `BRUNCH_CHAT_PORT` and `BRUNCH_PANEL_PORT` for the pair. `AGENTS.md` carries the map, so the next server added has somewhere to look before picking a number.

## Links

- Ticket [FE-1633](https://linear.app/hash/issue/FE-1633)

## Changes

- Petrinaut docs default to 4322
  > 4321 stays free for the Brunch chat server, which cannot move: its port and the panel's are a contract between the pair, declared `strictPort` at both ends.
- Refractive Storybook defaults to 6007
  > 6006 belongs to the Petrinaut Storybook. The two are separate component sets and get run together.
- Refractive Storybook and ds-components Ladle read `PORT`
  > Both hardcoded a port, so a preview that assigned another one got a server listening elsewhere.
  > `${PORT:-6007}` and `Number(process.env.PORT ?? 61000)` match how the other dev tasks already read it.
- Brunch listen ports come from `BRUNCH_CHAT_PORT` and `BRUNCH_PANEL_PORT`
  > Both were literals, so the pair could only run on 4321 and 4915.
  > `BRUNCH_CHAT_ORIGIN` moved what the panel assumed about the chat server, never what either bound.
- Brunch keeps `strictPort` on both servers
  > Drift is what the pair cannot survive: the panel proxies `/agents/chat` to a literal chat origin, and a panel on an unexpected port serves the editor where nobody is looking.
  > Naming the ports makes an explicit move possible without making an accidental one silent.
- Turbo forwards the port variables to the dev tasks
  > Strict environment mode forwards only the variables a task's `turbo.json` lists, so `turbo run dev --filter` stayed on the defaults.
  > Every dev task that reads `PORT` now declares it, `BRUNCH_CHAT_PORT` reaches both Brunch tasks and `BRUNCH_PANEL_PORT` the panel's.
- `.claude/launch.json` follows the docs to 4322
  > The three preview tasks now name three ports no other server wants.
- `AGENTS.md` gains the port tables
  > One lists every dev server and its port, with the ports the Brunch contract and the Optimizer container fix.
  > A second lists the ports the compose stack and the graph take, with the variable that moves each.

## Test coverage

- Manual, `@apps/petrinaut-docs`:
  > Astro binds 4322 through the preview task and leaves 4321 unbound.
- `local-dev-origins.test.ts`:
  > An overridden port moves the listener, the chat origin and the proxy target together.
  > A value that is not a usable port falls back, and `strictPort` survives the override.
  > Both Brunch dev tasks list their port variables in `turbo.json`.
- Manual, yarn script shell:
  > `${PORT:-6007}` expands to 6007 unset and to the assigned port when set.
- Existing lint and typecheck suites for `@apps/petrinaut-docs`, `@hashintel/refractive` and `@hashintel/ds-components`.

## How to test

- `yarn workspace @apps/petrinaut-docs dev`
  > Expect Astro on 4322
- `lsof -nP -iTCP:4321 -sTCP:LISTEN`
  > Expect no listener
- `yarn workspace @apps/brunch-agent dev` alongside it
  > Expect chat server on 4321, no strictPort failure
- `yarn workspace @hashintel/refractive dev`
  > Expect Storybook on 6007
- `PORT=61234 yarn workspace @hashintel/ds-components dev:ladle`
  > Expect Ladle on 61234
- `PORT=61234 yarn exec turbo run dev:ladle --filter @hashintel/ds-components`
  > Expect Ladle on 61234 through Turbo as well
- `BRUNCH_CHAT_PORT=4331 BRUNCH_PANEL_PORT=4925 yarn dev:brunch`
  > Expect chat on 4331, panel on 4925, chat reachable from the panel
