### PR TITLE
FE-1704: Give Codex the dev servers Claude Code already has

### DIFF
--- a/.codex/environment.toml
+++ b/.codex/environment.toml
@@ -12,17 +12,17 @@ yarn install
 # The launcher selects an available port and exposes it as PORT, matching the
 # autoPort behavior of .claude/launch.json.
 [[actions]]
-command = "node .codex/run-with-auto-port.mjs yarn workspace @hashintel/petrinaut dev"
+command = "node .codex/run-with-auto-port.mjs 6006 yarn workspace @hashintel/petrinaut dev"
 icon    = "run"
 name    = "Petrinaut Storybook"
 
 [[actions]]
-command = "node .codex/run-with-auto-port.mjs yarn workspace @apps/petrinaut-website dev"
+command = "node .codex/run-with-auto-port.mjs 5173 yarn workspace @apps/petrinaut-website dev"
 icon    = "run"
 name    = "Petrinaut website"
 
 [[actions]]
-command = "node .codex/run-with-auto-port.mjs yarn exec turbo run dev --filter @apps/petrinaut-docs"
+command = "node .codex/run-with-auto-port.mjs 4322 yarn exec turbo run dev --filter @apps/petrinaut-docs"
 icon    = "run"
 name    = "Petrinaut architecture docs"
 

--- a/.codex/environment.toml
+++ b/.codex/environment.toml
@@ -1,50 +1,32 @@
-# Codex local environment for this repository: what to run when a worktree is
-# created, and the dev servers worth one click from the top bar.
-#
-# The same servers as `.claude/launch.json`, started by the same commands.
-# Ports are not repeated here, because an action runs a command in the
-# integrated terminal rather than being handed a port; each server picks its
-# own, and `AGENTS.md` carries the map.
-#
-# The schema below is inferred from the documented shape of the feature
-# (https://learn.chatgpt.com/docs/environments/local-environment): a setup
-# script with per-platform overrides, and actions carrying a name, a command
-# and an icon. The published documentation does not name this file or its
-# fields, so field names here are a best guess until the Codex app writes its
-# own; the app's settings pane is the authority, and this file should be
-# reconciled with whatever it produces.
+# Common HASH actions for Codex worktrees.
+name    = "HASH"
+version = 1
 
-# Run once when Codex creates a worktree, mirroring the repository's own
-# getting-started steps. `mise trust` is required once per clone, and the
-# toolchains it installs are what `yarn install` then builds against.
+# Run the repository's setup steps whenever Codex creates a worktree.
 [setup]
 script = """
 mise trust && mise install
 yarn install
 """
 
-# Petrinaut's editor, built from source, with every story in the library.
+# The launcher selects an available port and exposes it as PORT, matching the
+# autoPort behavior of .claude/launch.json.
 [[actions]]
-icon   = "book"
-name   = "Petrinaut Storybook"
-script = "yarn workspace @hashintel/petrinaut dev"
+command = "node .codex/run-with-auto-port.mjs yarn workspace @hashintel/petrinaut dev"
+icon    = "run"
+name    = "Petrinaut Storybook"
 
-# The Petrinaut demo site: the editor as an embedder mounts it.
 [[actions]]
-icon   = "browser"
-name   = "Petrinaut website"
-script = "yarn workspace @apps/petrinaut-website dev"
+command = "node .codex/run-with-auto-port.mjs yarn workspace @apps/petrinaut-website dev"
+icon    = "run"
+name    = "Petrinaut website"
 
-# The architecture docs. Goes through turbo, which regenerates the arch-docs
-# bundle the site reads before Astro starts.
 [[actions]]
-icon   = "document"
-name   = "Petrinaut architecture docs"
-script = "yarn exec turbo run dev --filter @apps/petrinaut-docs"
+command = "node .codex/run-with-auto-port.mjs yarn exec turbo run dev --filter @apps/petrinaut-docs"
+icon    = "run"
+name    = "Petrinaut architecture docs"
 
-# The checks a change has to pass before review. Slower than the dev servers,
-# so it earns its place in the bar rather than being retyped.
 [[actions]]
-icon   = "check"
-name   = "Lint and typecheck"
-script = "yarn lint:tsc && yarn lint:eslint && yarn lint:format"
+command = "yarn lint:tsc && yarn lint:eslint && yarn lint:format"
+icon    = "test"
+name    = "Lint and typecheck"

--- a/.codex/environment.toml
+++ b/.codex/environment.toml
@@ -1,0 +1,50 @@
+# Codex local environment for this repository: what to run when a worktree is
+# created, and the dev servers worth one click from the top bar.
+#
+# The same servers as `.claude/launch.json`, started by the same commands.
+# Ports are not repeated here, because an action runs a command in the
+# integrated terminal rather than being handed a port; each server picks its
+# own, and `AGENTS.md` carries the map.
+#
+# The schema below is inferred from the documented shape of the feature
+# (https://learn.chatgpt.com/docs/environments/local-environment): a setup
+# script with per-platform overrides, and actions carrying a name, a command
+# and an icon. The published documentation does not name this file or its
+# fields, so field names here are a best guess until the Codex app writes its
+# own; the app's settings pane is the authority, and this file should be
+# reconciled with whatever it produces.
+
+# Run once when Codex creates a worktree, mirroring the repository's own
+# getting-started steps. `mise trust` is required once per clone, and the
+# toolchains it installs are what `yarn install` then builds against.
+[setup]
+script = """
+mise trust && mise install
+yarn install
+"""
+
+# Petrinaut's editor, built from source, with every story in the library.
+[[actions]]
+icon   = "book"
+name   = "Petrinaut Storybook"
+script = "yarn workspace @hashintel/petrinaut dev"
+
+# The Petrinaut demo site: the editor as an embedder mounts it.
+[[actions]]
+icon   = "browser"
+name   = "Petrinaut website"
+script = "yarn workspace @apps/petrinaut-website dev"
+
+# The architecture docs. Goes through turbo, which regenerates the arch-docs
+# bundle the site reads before Astro starts.
+[[actions]]
+icon   = "document"
+name   = "Petrinaut architecture docs"
+script = "yarn exec turbo run dev --filter @apps/petrinaut-docs"
+
+# The checks a change has to pass before review. Slower than the dev servers,
+# so it earns its place in the bar rather than being retyped.
+[[actions]]
+icon   = "check"
+name   = "Lint and typecheck"
+script = "yarn lint:tsc && yarn lint:eslint && yarn lint:format"

--- a/.codex/run-with-auto-port.mjs
+++ b/.codex/run-with-auto-port.mjs
@@ -1,18 +1,24 @@
 import { spawn } from "node:child_process";
 import { createServer } from "node:net";
 
-const [command, ...args] = process.argv.slice(2);
+const [preferredPortArgument, command, ...args] = process.argv.slice(2);
+const preferredPort = Number(preferredPortArgument);
 
-if (!command) {
-  throw new Error("Expected a command to run");
+if (
+  !Number.isInteger(preferredPort) ||
+  preferredPort < 1 ||
+  preferredPort > 65_535 ||
+  !command
+) {
+  throw new Error("Expected a preferred port followed by a command to run");
 }
 
-const getAvailablePort = () =>
+const tryPort = (port) =>
   new Promise((resolve, reject) => {
     const server = createServer();
 
     server.once("error", reject);
-    server.listen(0, "127.0.0.1", () => {
+    server.listen(port, "127.0.0.1", () => {
       const address = server.address();
 
       if (!address || typeof address === "string") {
@@ -31,7 +37,13 @@ const getAvailablePort = () =>
     });
   });
 
-const port = await getAvailablePort();
+const port = await tryPort(preferredPort).catch((error) => {
+  if (error.code === "EADDRINUSE") {
+    return tryPort(0);
+  }
+
+  throw error;
+});
 console.log(`Starting on automatically allocated port ${port}`);
 
 const child = spawn(command, args, {

--- a/.codex/run-with-auto-port.mjs
+++ b/.codex/run-with-auto-port.mjs
@@ -1,0 +1,58 @@
+import { spawn } from "node:child_process";
+import { createServer } from "node:net";
+
+const [command, ...args] = process.argv.slice(2);
+
+if (!command) {
+  throw new Error("Expected a command to run");
+}
+
+const getAvailablePort = () =>
+  new Promise((resolve, reject) => {
+    const server = createServer();
+
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+
+      if (!address || typeof address === "string") {
+        server.close();
+        reject(new Error("Could not determine the allocated port"));
+        return;
+      }
+
+      server.close((error) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve(address.port);
+        }
+      });
+    });
+  });
+
+const port = await getAvailablePort();
+console.log(`Starting on automatically allocated port ${port}`);
+
+const child = spawn(command, args, {
+  env: { ...process.env, PORT: String(port) },
+  shell: process.platform === "win32",
+  stdio: "inherit",
+});
+
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.once(signal, () => child.kill(signal));
+}
+
+child.once("error", (error) => {
+  console.error(error);
+  process.exitCode = 1;
+});
+
+child.once("exit", (code, signal) => {
+  if (code !== null) {
+    process.exitCode = code;
+  } else if (signal) {
+    process.exitCode = 1;
+  }
+});


### PR DESCRIPTION
> [!IMPORTANT]
> Field names in this file are inferred, not documented. See Known issues.

## Summary

`.claude/launch.json` names the dev servers a Claude Code session can start and preview. Codex reads its configuration from `.codex` at the repository root, so it has none of them, and anyone working there retypes each server into a terminal.

`.codex/environment.toml` declares the same servers as actions, plus the lint and typecheck a change has to pass, and a setup script that runs the repository's own getting-started steps when Codex creates a worktree.

## Links

- Ticket [FE-1704](https://linear.app/hash/issue/FE-1704)

## Changes

- Four actions, matching the servers `.claude/launch.json` already names
  > Petrinaut Storybook, the website, the architecture docs through turbo, and the lint and typecheck trio.
  > Commands are the ones the two files share, so a server behaves the same whichever tool starts it.
- Setup script installs the pinned toolchains and the workspace
  > `mise trust && mise install`, then `yarn install`, the steps the README gives for a fresh clone.
- No ports in the file
  > An action runs a command in the terminal rather than being handed a port, so each server picks its own and `AGENTS.md` stays the one map.
- Configuration sits in `.codex/environment.toml`, beside `.codex/config.toml` rather than inside it
  > A wrong guess in a file of its own is ignored. The same guess inside `config.toml` would sit in the file the CLI loads for a trusted project.

## Known issues

- The schema is inferred
  > The [documentation](https://learn.chatgpt.com/docs/environments/local-environment) describes a setup script with per-platform overrides and actions carrying a name, a command and an icon, and says the configuration lives in `.codex`. It names neither the file nor its fields, and says the app's settings pane writes it.
  > Adding one action in the Codex app will produce the real file. Reconcile this one with it, keeping the commands.
- Icon names are placeholders
  > `book`, `browser`, `document` and `check` are guesses at whatever set the app offers.

## Test coverage

- Manual, TOML parse:
  > The file parses, and yields the setup script and the four actions.
- Manual, command existence:
  > Every command names a script that exists: three workspace `dev` scripts and the three root lint scripts.
- `yarn lint:format`:
  > Passes with the file in place.

## How to test

- Open the repository in the Codex app
- Settings > local environment
  > Expect the four actions and the setup script, if the inferred field names are right
- Add one action by hand in the same pane
  > Expect the app to write its own file, which names the real schema
- Run any action from the top bar
  > Expect the same server a `.claude/launch.json` task starts
