### PR TITLE
BE-837, SRE-1046: Add a Docker build for the Atlas fit job and publish it to ECR

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -153,7 +153,7 @@ blocks/**/generated
 .sentryclirc
 
 # Application data
-/var
+**/var
 seed-users.json
 
 # Block Protocol

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -146,6 +146,19 @@ jobs:
               ecs: [{ service: "integration-worker", cluster: "h-stage-euc1-worker", service_name: "h-stage-euc1-worker-integration" }]
             },
             {
+              package:    "@rust/hash-graph-atlas",
+              service:    "atlas-fit",
+              push:       ["ecr"],
+              # The fit runs on x86 GPU hosts, so this image is amd64 rather than
+              # the arm64 default; with one arch listed it is also the ECR arch.
+              arches:     ["amd64"],
+              dockerfile: "libs/@local/graph/atlas/docker/Dockerfile",
+              context:    ".",
+              # A Batch job pulls the image by tag when it is submitted; there
+              # is no ECS service to redeploy.
+              ecs:        []
+            },
+            {
               # TODO(H-6664): switch to `package`-based detection once the
               #   monorepo tooling gives @apps/petrinaut-opt a `build:docker`
               #   task and workspace dependencies; until then turbo cannot see

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -148,7 +148,7 @@ jobs:
             {
               package:    "@rust/hash-graph-atlas",
               service:    "atlas-fit",
-              push:       ["ecr"],
+              push:       ["ecr", "ghcr"],
               # The fit runs on x86 GPU hosts, so this image is amd64 rather than
               # the arm64 default; with one arch listed it is also the ECR arch.
               arches:     ["amd64"],

--- a/libs/@local/graph/atlas/docker/Dockerfile
+++ b/libs/@local/graph/atlas/docker/Dockerfile
@@ -1,0 +1,126 @@
+# syntax=docker/dockerfile:1
+
+ARG CUDA_VERSION=12.8.1
+ARG UBUNTU_VERSION=24.04
+
+FROM debian:13.3-slim AS mise
+
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
+ENV MISE_DATA_DIR="/mise"
+ENV MISE_CACHE_DIR="/mise/cache"
+ENV MISE_NODE_COREPACK=1
+ENV PATH="/mise/shims:$PATH"
+
+COPY .config/mise /etc/mise
+
+RUN --mount=type=secret,id=GITHUB_TOKEN,env=GITHUB_TOKEN \
+    apt-get update && \
+    apt-get install -y --no-install-recommends curl ca-certificates && \
+    /etc/mise/install.sh && \
+    mise --version && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    eval "$(mise activate bash)" && \
+    mise install --locked node
+
+
+FROM mise AS base
+
+WORKDIR /app
+
+RUN --mount=type=secret,id=GITHUB_TOKEN,env=GITHUB_TOKEN \
+    mise install --locked npm:turbo yq
+
+COPY . .
+# `turbo prune` does not include Cargo workspaces, so we create dummy projects for each workspace member
+RUN mise trust && \
+    turbo prune $(.github/scripts/prune-scopes.sh '@rust/hash-graph-atlas') --docker && \
+    find $(yq '.workspace.members' -o tsv Cargo.toml | tr '*' ' ') -maxdepth 2 -name Cargo.toml -exec sh -c ' \
+    [ -f "/app/out/full/$1" ] || ( \
+    mkdir -p "/app/out/full/$(dirname "$1")/src" &&  \
+    echo > "/app/out/full/$(dirname "$1")/src/lib.rs" &&  \
+    printf "[package]\nname = \"$(yq ".package.name" -p toml -oy $1)\"" > "/app/out/full/$1" \
+    )' _ {} \; && \
+    cp -R .cargo Cargo.toml Cargo.lock /app/out/full/
+
+
+# We use the explicit version here, as `nvcc` determines the version, and if absent chooses the newest toolkit known.
+FROM nvidia/cuda:${CUDA_VERSION}-devel-ubuntu${UBUNTU_VERSION} AS rust
+
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
+WORKDIR /usr/local/
+
+ENV MISE_DATA_DIR="/mise"
+ENV MISE_CACHE_DIR="/mise/cache"
+ENV MISE_CARGO_HOME="/usr/local/cargo"
+ENV PATH="/mise/shims:/usr/local/cargo/bin:$PATH"
+
+COPY .config/mise /etc/mise
+COPY rust-toolchain.toml .
+
+RUN --mount=type=secret,id=GITHUB_TOKEN,env=GITHUB_TOKEN \
+    apt-get update && \
+    apt-get install -y --no-install-recommends curl ca-certificates build-essential && \
+    /etc/mise/install.sh && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    eval "$(mise activate bash)" && \
+    mise install --locked yq protoc && \
+    echo "Installing Rust toolchain: $(yq '.toolchain.channel' rust-toolchain.toml)" && \
+    mise use --global rust[profile=minimal]@$(yq '.toolchain.channel' rust-toolchain.toml) && \
+    rustc --version && \
+    cargo --version && \
+    nvcc --version && \
+    rm rust-toolchain.toml
+
+
+FROM rust AS builder
+
+WORKDIR /usr/local/src/
+
+COPY --from=base /app/out/full/ .
+
+ARG PROFILE=production
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,target=/usr/local/src/target,sharing=locked \
+    if [[ ${PROFILE} == dev ]]; then \
+    export RUSTFLAGS="-C debuginfo=line-tables-only" && \
+    export PROFILE=dev-llvm; \
+    fi && \
+    cargo install --path libs/@local/graph/atlas --features cli --root /tmp --profile $PROFILE --locked && \
+    install -D -m 0755 /tmp/bin/hash-graph-atlas /out/usr/local/bin/hash-graph-atlas
+
+
+# Minimal version, that excludes everything except the requirements for the fit to run.
+# The `runtime` image would add cuBLAS, cuFFT, cuSPARSE, cuSOLVER and NPP.
+# This extra installation step saves about 2 GB.
+FROM nvidia/cuda:${CUDA_VERSION}-base-ubuntu${UBUNTU_VERSION} AS runner
+
+ARG CUDA_VERSION
+
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
+# The fit runs as `61000:60000`, same as the graph image.
+RUN cuda="${CUDA_VERSION%.*}" && \
+    cuda="${cuda/./-}" && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+    "cuda-nvrtc-${cuda}" "cuda-cudart-dev-${cuda}" "cuda-cccl-${cuda}" && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    ldconfig && \
+    groupadd --gid 60000 hash && \
+    useradd --uid 61000 --gid 60000 --no-create-home --home-dir / --shell /usr/sbin/nologin atlas && \
+    install -d -m 0775 -o 61000 -g 60000 /atlas-generations
+
+COPY --from=builder /out/ /
+
+ENV HASH_GRAPH_ATLAS_ROOT="/atlas-generations"
+
+USER atlas:hash
+
+ENTRYPOINT ["/usr/local/bin/hash-graph-atlas"]

--- a/libs/@local/graph/atlas/docs/task-dependencies.json
+++ b/libs/@local/graph/atlas/docs/task-dependencies.json
@@ -16,6 +16,7 @@
     "@rust/hashql-core"
   ],
   "tasks": {
+    "build:docker": [],
     "doc:dependency-diagram": [
       "@rust/hash-repo-chores#build"
     ],

--- a/libs/@local/graph/atlas/package.json
+++ b/libs/@local/graph/atlas/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "license": "AGPL-3",
   "scripts": {
+    "build:docker": "docker buildx build --build-arg PROFILE=release --tag hash-graph-atlas --file docker/Dockerfile ../../../../ --load",
     "doc:dependency-diagram": "cargo run -p hash-repo-chores -- dependency-diagram --output docs/dependency-diagram.mmd --root hash-graph-atlas --root-deps-and-dependents --link-mode non-roots --include-dev-deps --include-build-deps --logging-console-level info",
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",

--- a/libs/@local/graph/atlas/turbo.json
+++ b/libs/@local/graph/atlas/turbo.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "build:docker": {
+      "dependsOn": ["^manifest"]
+    }
+  }
+}


### PR DESCRIPTION

## 🌟 What is the purpose of this PR?

Give the atlas fit an image of its own. Before this change no Dockerfile builds `hash-graph-atlas`, so a fit runs only from a host checkout with a Rust toolchain and a CUDA toolkit installed beside it. After it, `turbo run build:docker --filter=@rust/hash-graph-atlas` produces `hash-graph-atlas`, an image whose entrypoint is the crate's own binary, and a GPU host runs a fit as `docker run --gpus all -v <root>:/atlas-generations hash-graph-atlas fit --root /atlas-generations …`. The Batch job invokes exactly that, with `/atlas-generations` writable by the container's user.

The fit gets a separate glibc image rather than a target inside the graph's Dockerfile because its GPU path cannot be static: burn's CUDA backend reaches the driver through cudarc, which opens the host's `libcuda.so.1` and the toolkit's `libnvrtc.so` at runtime, and the graph image is a static musl build. The runner is `nvidia/cuda:12.8.1-base` plus three apt packages (`cuda-nvrtc`, `cuda-cudart-dev`, `cuda-cccl`) rather than the `runtime` image. The fit opens the driver and NVRTC and nothing else, while `runtime` adds cuBLAS, cuFFT, cuSPARSE, cuSOLVER and NPP, which puts the image at 3.37 GB against 541 MB (measured on `linux/arm64`).

## 🔍 What does this change?

The change is legible from `libs/@local/graph/atlas/docker/Dockerfile` top to bottom, one stage at a time.

- `docker/Dockerfile`: `mise` installs the pinned tools, `base` prunes the workspace to the crate's scope, `rust` is the CUDA `devel` image with the repo's Rust toolchain, `builder` runs `cargo install --path libs/@local/graph/atlas --features cli --profile $PROFILE --locked` under registry, git and target caches, and `runner` is the CUDA `base` image with NVRTC, the headers, the non-root user, `HASH_GRAPH_ATLAS_ROOT=/atlas-generations` and the binary as entrypoint. `PROFILE=dev` selects the `dev-llvm` profile with line tables for a debuggable image.
- `package.json`: a `build:docker` script, which is what turbo's affected-package query sees. `docs/task-dependencies.json` gains the task.
- `.dockerignore`: `**/var` in place of `/var`, matching `.gitignore`, so the nested `var/` directories that hold generated atlas data stay out of every build context.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] affected the execution graph, and the `turbo.json`'s have been updated to reflect this
  - the root `turbo.json` already defines `build:docker` for every package carrying the script, so it needs no edit, and `libs/@local/graph/atlas/docs/task-dependencies.json` gains the task

## 🚫 Blocked by

- [ ] SRE-1046, the deploy catalog entry for `@rust/hash-graph-atlas`, merged first. The "Determine changed packages" step fails any run in which turbo marks a `build:docker` package affected that the catalog does not list, and the workflow runs on `pull_request`, so this PR's own run fails there until that entry is on `main`. The entry rides on SRE-1045, which lets an ECR entry build amd64.

## ⚠️ Known issues

- The CUDA path has not executed in this image. The build host carries no NVIDIA device, so the driver load and the first NVRTC compile happen on the first `docker run --gpus all … fit` on a GPU host.
- The build and the smoke ran on `linux/arm64`. The GPU hosts are amd64, and the first amd64 build is the deploy workflow's, once SRE-1046 lands.
- apt floats the CUDA patch level: the runner takes the newest `12.8.x` the repository serves, while the image tag pins the builder's toolkit. They share the minor, which is what the bindings and NVRTC agree on.
- A fit over the live store needs the store flags and `--openai-api-key`, and the image sets only `HASH_GRAPH_ATLAS_ROOT`. The job definition supplies the rest, and the binary has no S3 code, so the job entrypoint pulls the previous generation in and pushes the new one out.

## 🐾 Next steps

- Build the image on an amd64 CUDA host and run a fit there, first from a dump (`--offline <dump>`), then against the store from inside the VPC. That run is the first measurement of the CUDA path and of host memory under the container.
- The Batch job definition: it mounts the root and supplies the store connection and the provider key. Syncing generations to and from the bucket is the entrypoint's part of it.

## 🛡 What tests cover this?

No automated test covers a Dockerfile. `docker buildx build --check` lints it, the deploy workflow builds every affected catalogued image, and the run below checks the image's own contract.

## ❓ How to test this?

1. Check out the branch and build the image: `turbo run build:docker --filter=@rust/hash-graph-atlas`. A cold build compiles the crate and its dependencies, and a warm one reuses the cache mounts.
2. `docker run --rm hash-graph-atlas fit --help` prints the fit's option set, which shows that every shared library resolves and that the entrypoint is the crate's own binary.
3. `docker run --rm --entrypoint bash hash-graph-atlas -c 'id -u; id -g; test -w /atlas-generations && echo writable; ldconfig -p | grep -c nvrtc; ls /usr/local/cuda/include/cuda_fp16.h'` prints `61000`, `60000`, `writable`, a non-zero count and the header path.
4. On a host with an NVIDIA driver and the container toolkit: `docker run --rm --gpus all -v <dump>:/dump:ro -v <root>:/atlas-generations hash-graph-atlas fit --root /atlas-generations --offline /dump --classifier <file>` runs a fit whose projector executes on the GPU. `--device cpu` runs the same fit without one.
