### PR TITLE
SRE-1045: Build and push amd64 images to ECR from the deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -142,6 +142,19 @@ jobs:
               ecs: [{ service: "integration-worker", cluster: "h-stage-euc1-worker", service_name: "h-stage-euc1-worker-integration" }]
             },
             {
+              package:    "@rust/hash-graph-atlas",
+              service:    "atlas-fit",
+              push:       ["ecr"],
+              # The fit runs on x86 GPU hosts, so this ECR image is amd64 rather
+              # than the arm64 default; `arch` overrides the per-registry rule.
+              arch:       ["amd64"],
+              dockerfile: "libs/@local/graph/atlas/docker/Dockerfile",
+              context:    ".",
+              # A Batch job pulls the image by tag when it is submitted; there
+              # is no ECS service to redeploy.
+              ecs:        []
+            },
+            {
               # TODO(H-6664): switch to `package`-based detection once the
               #   monorepo tooling gives @apps/petrinaut-opt a `build:docker`
               #   task and workspace dependencies; until then turbo cannot see
@@ -203,16 +216,20 @@ jobs:
               )]' <<<"$CATALOG")
           fi
 
-          # Build matrix: expand each affected entry to its arches. Skip amd64
-          # for services that don't publish to GHCR (ECR is arm64-only) and
-          # also on PR events (arch divergence in Rust/Node is rare;
-          # merge_group still validates amd64 before main).
+          # Build matrix: expand each affected entry to its architectures. An entry's
+          # `arch` list wins; without one, GHCR publishers build both and ECR-only
+          # services build arm64. ECR holds one arch per service, and that arch
+          # travels as `ecr_arch` so the push step can recognise it. PR events
+          # skip amd64 (arch divergence in Rust/Node is rare; merge_group still
+          # validates amd64 before main) unless amd64 is the only arch the entry
+          # has, since skipping it would leave that Dockerfile unbuilt until merge.
           BUILD_MATRIX=$(jq -c --argjson skip_amd64 "$SKIP_AMD64" '
             [.[] as $e
-              | ({arch: "arm64"}, {arch: "amd64"})
-              | $e + .
-              | select(($e.push | index("ghcr")) or .arch == "arm64")
-              | select($skip_amd64 != true or .arch != "amd64")
+              | ($e.arch // (if ($e.push | index("ghcr")) then ["arm64", "amd64"] else ["arm64"] end)) as $arch
+              | (if ($arch | index("arm64")) then "arm64" else $arch[0] end) as $ecr_arch
+              | $arch[]
+              | $e + {arch: ., ecr_arch: $ecr_arch}
+              | select($skip_amd64 != true or .arch != "amd64" or ($arch | index("arm64") | not))
               | del(.package, .ecs, .paths)
             ] | { include: . }' <<<"$AFFECTED_CATALOG")
 
@@ -226,7 +243,7 @@ jobs:
             [.[] | .ecs[]] | { include: . }
           ' <<<"$AFFECTED_CATALOG")
 
-          # Staging matrix: services whose arm64 image is pushed to ECR and
+          # Staging matrix: services whose image is pushed to ECR and
           # tagged :staging (one guard run per such service).
           STAGING_MATRIX=$(jq -c '
             map(select(.push | index("ecr"))) | { service: [.[].service] }
@@ -358,6 +375,7 @@ jobs:
         env:
           PUSH_LIST: ${{ join(matrix.push, ' ') }}
           ARCH: ${{ matrix.arch }}
+          ECR_ARCH: ${{ matrix.ecr_arch }}
           REF: ${{ github.ref }}
           EVENT: ${{ github.event_name }}
           SERVICE: ${{ matrix.service }}
@@ -374,7 +392,7 @@ jobs:
           [[ "$REF" == refs/heads/main ]] && is_main=true
 
           push_ecr=false
-          if [[ " $PUSH_LIST " == *" ecr "* && "$ARCH" == arm64 && "$is_main" == true && "$is_push_event" == true ]]; then
+          if [[ " $PUSH_LIST " == *" ecr "* && "$ARCH" == "$ECR_ARCH" && "$is_main" == true && "$is_push_event" == true ]]; then
             push_ecr=true
           fi
           push_ghcr=false
@@ -394,7 +412,7 @@ jobs:
             echo "push_ghcr=$push_ghcr"
             echo "push=$push"
 
-            # ECR is single-arch (arm64), tag-based. Only immutable tags here
+            # ECR holds one arch per service (`ecr_arch`), tag-based. Only immutable tags here
             # (:sha / :run); the mutable :staging tag is set by the `stage` job.
             echo "ecr_tags<<EOF"
             if $push_ecr; then
@@ -488,7 +506,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
-      # ECR images are single-arch (arm64). Advance :staging onto this commit's
+      # ECR images are single-arch per service. Advance :staging onto this commit's
       # immutable sha tag only if it is newer than the one currently tagged.
       - name: Advance :staging if newer
         uses: $/.github/actions/tag-if-newer


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Let the deploy workflow build and publish an amd64 image to ECR. Before this change every ECR image is arm64 by construction. The build matrix expands an ECR-only service to arm64 alone and the push step sends only the arm64 build to ECR, while pull-request runs skip amd64 entirely, so a service that runs on x86 hosts has no path from the repository to ECR. After it, a catalogue entry may carry an `arch` list. The first entry that does is the atlas fit image, whose GPU hosts are x86 (SRE-1046).

Every existing entry keeps its rule. Without an `arch` list the old expansion applies, GHCR publishers build both arches and ECR-only services build arm64, and the matrix those entries produce is identical under both the pull-request and the push event. The alternative, pushing the fit image to GHCR as well to inherit the amd64 build, would publish an internal batch image to a public registry and still leave ECR arm64-only.

Review focus. The matrix expansion in the `setup` job is the change everything else stands on. It derives `$arch` per entry, the list or the old rule. It derives `ecr_arch` as arm64 where the list has it and as the sole arch otherwise. Then it expands one row per arch and exempts an amd64-only entry from the pull-request skip, since a skip would leave that Dockerfile unbuilt until merge. The push step compares the row's `arch` to its `ecr_arch` where it compared to the literal `arm64`, and the `stage` job retags by the `sha-` tag and never looks at the arch, so it needs no change.

## 🔍 What does this change?

The change is legible from the "Determine changed packages" step of the `setup` job outward.

- The build-matrix jq reads an optional `arch` list per entry and adds `ecr_arch` to every row. It keeps amd64 rows on pull requests for entries whose only arch is amd64.
- The `build` job's "Compute targets" step takes `ECR_ARCH` from the matrix and pushes to ECR when the row's arch is the entry's ECR arch.
- The catalogue gains `@rust/hash-graph-atlas` as service `atlas-fit`: ECR only, `arch: ["amd64"]`, the crate's Dockerfile, the repository root as context, and no ECS service, because the Batch job pulls the image by tag at submission.
- The comments describing ECR as arm64 now describe it as one arch per service.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## 🚫 Blocked by

- [ ] The ECR repository for `atlas-fit` on the infra side. The push step assumes the repository exists, so the first push to `main` fails until it does.

## ⚠️ Known issues

- The first pull-request run that touches the atlas package builds the fit image cold on `ubuntu-24.04`: the CUDA `devel` base and a full Rust build with no persistent cache mounts. Runner disk is the thing to watch on that run.
- `SKIP_AMD64` changes meaning for one class of entry. An amd64-only service builds on every pull request that affects it, while every other service builds arm64 only. That is the price of validating its Dockerfile before merge.

## 🛡 What tests cover this?

No automated test covers the workflow. The old and the new jq expressions, run over the catalogue in this file under both `SKIP_AMD64` values, agree on every pre-existing entry, and the new one yields one `amd64` row for `atlas-fit` with `ecr_arch=amd64` under both. The file parses as YAML and passes `oxfmt --check`.

## ❓ How to test this?

1. Read the two jq expressions side by side. The diff is four lines of the expansion.
2. Extract the catalogue and the new expression from the file and run `jq -c --argjson skip_amd64 true '<expression>' <<<"$CATALOG"`, then with `false`. Confirm the pre-existing rows match the old expression's and that `atlas-fit` is present once, as `amd64`, in both.
3. On the PR's own deploy run, confirm the matrix contains `atlas-fit (amd64)` and that the arm64 services keep their rows.
