### PR TITLE
FE-1628: Add custom header + footer options to Select component

### DIFF
--- a/.changeset/rare-mangos-create.md
+++ b/.changeset/rare-mangos-create.md
@@ -1,0 +1,5 @@
+---
+"@hashintel/ds-components": patch
+---
+
+Add header + footer options to selectable list + other minor ui improvements

--- a/libs/@hashintel/ds-components/src/components/Breadcumbs/breadcrumbs-item.tsx
+++ b/libs/@hashintel/ds-components/src/components/Breadcumbs/breadcrumbs-item.tsx
@@ -6,6 +6,7 @@ import { useIsomorphicLayoutEffect } from "../../util/use-isomorphic-layout-effe
 import { Icon, type IconName } from "../Icon/icon";
 import { Menu, type MenuItem } from "../Menu/menu";
 import { Tooltip } from "../Tooltip/tooltip";
+import { menuCustomContent } from "./breadcrumbs.recipe";
 
 import type { FormInputSize } from "../../util/form-shared";
 import type { ItemOrGroup } from "../Menu/SelectableList/selectable-list";
@@ -85,13 +86,44 @@ export const collectEntries = (children: React.ReactNode): BreadcrumbEntry[] =>
 export const isCollapsible = (entry: BreadcrumbEntry): boolean =>
   entry.item !== undefined && !entry.item.noCollapse;
 
+/**
+ * Whether `children` renders as plain text and can take the truncating
+ * `label` class. Composed children like `{first} {last}` arrive as an array
+ * of strings, so arrays of text count too; nullish/boolean entries render
+ * nothing and don't disqualify. Anything containing elements renders via
+ * `custom`, untruncated.
+ */
+const isTextChildren = (children: React.ReactNode): boolean => {
+  if (Array.isArray(children)) {
+    return children.every(isTextChildren);
+  }
+  return (
+    typeof children === "string" ||
+    typeof children === "number" ||
+    children == null ||
+    typeof children === "boolean"
+  );
+};
+
+/** A crumb's content as menu-item text: custom (non-text) content gets a flex wrapper. */
+const toMenuText = (children: React.ReactNode): React.ReactNode =>
+  isTextChildren(children) ? (
+    children
+  ) : (
+    <span className={menuCustomContent}>{children}</span>
+  );
+
 /** Converts a crumb's `subItems` (breadcrumb-shaped, possibly grouped or nested) into Menu items. */
 function toMenuSubEntries(
   entries: Array<ItemOrGroup<BreadcrumbSubItem>>,
   idPrefix: string,
 ): Array<ItemOrGroup<MenuItem>> {
   const toEntry = (subItem: BreadcrumbSubItem, id: string): MenuItem => {
-    const base = { id, text: subItem.children, icon: subItem.iconName };
+    const base = {
+      id,
+      text: toMenuText(subItem.children),
+      icon: subItem.iconName,
+    };
     if (subItem.subItems) {
       return { ...base, subItems: toMenuSubEntries(subItem.subItems, id) };
     }
@@ -119,7 +151,7 @@ export const toMenuItem = (
 ): MenuItem => {
   const base = {
     id: `breadcrumb-${originalIndex}`,
-    text: item.collapsedChildren ?? item.children,
+    text: toMenuText(item.collapsedChildren ?? item.children),
     icon: item.iconName,
   };
   if (item.subItems) {
@@ -143,25 +175,6 @@ export const chevronIcons = (
   size === "lg"
     ? { right: "chevronRight", down: "chevronDown" }
     : { right: "chevronRightHeavy", down: "chevronDownHeavy" };
-
-/**
- * Whether `children` renders as plain text and can take the truncating
- * `label` class. Composed children like `{first} {last}` arrive as an array
- * of strings, so arrays of text count too; nullish/boolean entries render
- * nothing and don't disqualify. Anything containing elements renders via
- * `custom`, untruncated.
- */
-const isTextChildren = (children: React.ReactNode): boolean => {
-  if (Array.isArray(children)) {
-    return children.every(isTextChildren);
-  }
-  return (
-    typeof children === "string" ||
-    typeof children === "number" ||
-    children == null ||
-    typeof children === "boolean"
-  );
-};
 
 export const ItemContent = ({
   item,

--- a/libs/@hashintel/ds-components/src/components/Breadcumbs/breadcrumbs-item.tsx
+++ b/libs/@hashintel/ds-components/src/components/Breadcumbs/breadcrumbs-item.tsx
@@ -6,7 +6,6 @@ import { useIsomorphicLayoutEffect } from "../../util/use-isomorphic-layout-effe
 import { Icon, type IconName } from "../Icon/icon";
 import { Menu, type MenuItem } from "../Menu/menu";
 import { Tooltip } from "../Tooltip/tooltip";
-import { menuCustomContent } from "./breadcrumbs.recipe";
 
 import type { FormInputSize } from "../../util/form-shared";
 import type { ItemOrGroup } from "../Menu/SelectableList/selectable-list";
@@ -105,14 +104,6 @@ const isTextChildren = (children: React.ReactNode): boolean => {
   );
 };
 
-/** A crumb's content as menu-item text: custom (non-text) content gets a flex wrapper. */
-const toMenuText = (children: React.ReactNode): React.ReactNode =>
-  isTextChildren(children) ? (
-    children
-  ) : (
-    <span className={menuCustomContent}>{children}</span>
-  );
-
 /** Converts a crumb's `subItems` (breadcrumb-shaped, possibly grouped or nested) into Menu items. */
 function toMenuSubEntries(
   entries: Array<ItemOrGroup<BreadcrumbSubItem>>,
@@ -121,7 +112,7 @@ function toMenuSubEntries(
   const toEntry = (subItem: BreadcrumbSubItem, id: string): MenuItem => {
     const base = {
       id,
-      text: toMenuText(subItem.children),
+      text: subItem.children,
       icon: subItem.iconName,
     };
     if (subItem.subItems) {
@@ -151,7 +142,7 @@ export const toMenuItem = (
 ): MenuItem => {
   const base = {
     id: `breadcrumb-${originalIndex}`,
-    text: toMenuText(item.collapsedChildren ?? item.children),
+    text: item.collapsedChildren ?? item.children,
     icon: item.iconName,
   };
   if (item.subItems) {

--- a/libs/@hashintel/ds-components/src/components/Breadcumbs/breadcrumbs-item.tsx
+++ b/libs/@hashintel/ds-components/src/components/Breadcumbs/breadcrumbs-item.tsx
@@ -37,9 +37,10 @@ export type BreadcrumbSubItem = {
 
 export type BreadcrumbItemProps = BreadcrumbSubItem & {
   /**
-   * Caps the crumb's width while it is visible in the trail (it does not apply
-   * inside the ellipsis menu); a longer label truncates with an ellipsis and
-   * gains a tooltip showing the full label (unless `tooltip` is already set).
+   * Caps the crumb's width — hover pill included — while it is visible in the
+   * trail (it does not apply inside the ellipsis menu); a longer label
+   * truncates with an ellipsis and gains a tooltip showing the full label
+   * (unless `tooltip` is already set).
    */
   maxWidth?: React.CSSProperties["maxWidth"];
   /**

--- a/libs/@hashintel/ds-components/src/components/Breadcumbs/breadcrumbs.recipe.ts
+++ b/libs/@hashintel/ds-components/src/components/Breadcumbs/breadcrumbs.recipe.ts
@@ -52,43 +52,30 @@ export const styles = sva({
       display: "inline-flex",
       alignItems: "center",
       minWidth: "0",
-      maxWidth: "full",
-      position: "relative",
-      isolation: "isolate",
       font: "[inherit]",
       // Pin a real line-height: `font: inherit` would otherwise pull it from an
       // ancestor, and the Tooltip trigger wrapper sets `line-height: 0`, which
       // would collapse the label (overflow: hidden) to zero height.
       lineHeight: "[1.2]",
+      // The hover-fill pill is the element's own padded box (padding is set
+      // per size variant, cancelled in layout by equal negative margins), so
+      // popovers anchored to the crumb align with the pill automatically.
+      boxSizing: "border-box",
+      borderRadius: "md",
       transition: "colors",
-      // The hover-fill pill; its insets are set per size variant.
-      _before: {
-        content: '""',
-        position: "absolute",
-        zIndex: "[-1]",
-        borderRadius: "md",
-        transition: "[background-color 0.15s ease]",
-      },
       "&:is(a, button):not([aria-disabled=true])": {
         cursor: "pointer",
       },
       "&:is(a, button):not([aria-disabled=true]):hover": {
         color: "neutral.s110",
-      },
-      "&:is(a, button):not([aria-disabled=true]):hover::before": {
         background: "neutral.a30",
       },
       // A menu crumb stays highlighted while its dropdown is open.
       "&[aria-expanded=true]": {
         color: "neutral.s110",
-      },
-      "&[aria-expanded=true]::before": {
         background: "neutral.a30",
       },
       "&:focus-visible": {
-        outlineStyle: "none",
-      },
-      "&:focus-visible::before": {
         outlineWidth: "2px",
         outlineStyle: "solid",
         outlineColor: "black.a60",
@@ -124,44 +111,28 @@ export const styles = sva({
       alignItems: "center",
       justifyContent: "center",
       flexShrink: "0",
-      position: "relative",
-      isolation: "isolate",
       color: "neutral.s100",
       cursor: "pointer",
       background: "[none]",
       border: "0",
-      padding: "0",
-      transition: "colors",
       // The icon-sized trigger is far below the 24px minimum target size
-      // (WCAG 2.5.8); extend the hit area without affecting layout — and
-      // therefore without affecting the width measurement. The same pseudo
-      // doubles as the crumbs' button-shaped hover fill and focus-ring shape;
-      // its inset is set per size variant to match the item pills' height.
-      _before: {
-        content: '""',
-        position: "absolute",
-        zIndex: "[-1]",
-        borderRadius: "md",
-        // Background only — see the crumb link's ::before.
-        transition: "[background-color 0.15s ease]",
-      },
+      // (WCAG 2.5.8); the per-size padding extends the hit area, forms the
+      // button-shaped hover fill / focus-ring shape matching the item pills,
+      // and anchors the ellipsis menu. Equal negative margins cancel it in
+      // layout, so the trail (and the width measurement) stays icon-sized —
+      // `measure()` compensates where it measures this box directly.
+      boxSizing: "border-box",
+      borderRadius: "md",
+      transition: "colors",
       "&:hover": {
         color: "neutral.s110",
-      },
-      "&:hover::before": {
         background: "neutral.a30",
       },
       "&[aria-expanded=true]": {
         color: "neutral.s110",
-      },
-      "&[aria-expanded=true]::before": {
         background: "neutral.a30",
       },
-      // `outlineStyle`, not `outline: none` — see the crumb link.
       "&:focus-visible": {
-        outlineStyle: "none",
-      },
-      "&:focus-visible::before": {
         outlineWidth: "2px",
         outlineStyle: "solid",
         outlineColor: "black.a60",
@@ -198,7 +169,10 @@ export const styles = sva({
         list: { textStyle: "xxs" },
         link: {
           gap: "[3px]",
-          _before: { insetBlock: "[-2.5px]", insetInline: "[-3.5px]" },
+          paddingBlock: "[2.5px]",
+          paddingInline: "[3.5px]",
+          marginBlock: "[-2.5px]",
+          marginInline: "[-3.5px]",
         },
         icon: { "&&": { "--icon-size": "8px" } },
         dropdownIcon: {
@@ -208,14 +182,18 @@ export const styles = sva({
         separator: { paddingInline: "[5px]", "&&": { "--icon-size": "8px" } },
         ellipsisTrigger: {
           "& svg": { "--icon-size": "10px" },
-          _before: { inset: "[-4.5px]" },
+          padding: "[4.5px]",
+          margin: "[-4.5px]",
         },
       },
       xs: {
         list: { textStyle: "xs" },
         link: {
           gap: "[4px]",
-          _before: { insetBlock: "[-2.5px]", insetInline: "[-4.5px]" },
+          paddingBlock: "[2.5px]",
+          paddingInline: "[4.5px]",
+          marginBlock: "[-2.5px]",
+          marginInline: "[-4.5px]",
         },
         icon: { "&&": { "--icon-size": "9px" } },
         dropdownIcon: {
@@ -225,14 +203,18 @@ export const styles = sva({
         separator: { paddingInline: "[6px]", "&&": { "--icon-size": "9px" } },
         ellipsisTrigger: {
           "& svg": { "--icon-size": "12px" },
-          _before: { inset: "[-5.5px]" },
+          padding: "[5.5px]",
+          margin: "[-5.5px]",
         },
       },
       sm: {
         list: { textStyle: "sm" },
         link: {
           gap: "[4px]",
-          _before: { insetBlock: "[-3.5px]", insetInline: "[-5px]" },
+          paddingBlock: "[3.5px]",
+          paddingInline: "[5px]",
+          marginBlock: "[-3.5px]",
+          marginInline: "[-5px]",
         },
         icon: { "&&": { "--icon-size": "12px" } },
         dropdownIcon: {
@@ -242,14 +224,18 @@ export const styles = sva({
         separator: { paddingInline: "2", "&&": { "--icon-size": "12px" } },
         ellipsisTrigger: {
           "& svg": { "--icon-size": "14px" },
-          _before: { inset: "[-6px]" },
+          padding: "[6px]",
+          margin: "[-6px]",
         },
       },
       md: {
         list: { textStyle: "base" },
         link: {
           gap: "[5px]",
-          _before: { insetBlock: "[-3.5px]", insetInline: "[-6px]" },
+          paddingBlock: "[3.5px]",
+          paddingInline: "[6px]",
+          marginBlock: "[-3.5px]",
+          marginInline: "[-6px]",
         },
         icon: { "&&": { "--icon-size": "14px" } },
         dropdownIcon: {
@@ -259,21 +245,26 @@ export const styles = sva({
         separator: { paddingInline: "[9px]", "&&": { "--icon-size": "14px" } },
         ellipsisTrigger: {
           "& svg": { "--icon-size": "16px" },
-          _before: { inset: "[-7px]" },
+          padding: "[7px]",
+          margin: "[-7px]",
         },
       },
       lg: {
         list: { textStyle: "lg" },
         link: {
           gap: "[6px]",
-          _before: { insetBlock: "[-4px]", insetInline: "[-6px]" },
+          paddingBlock: "[4px]",
+          paddingInline: "[6px]",
+          marginBlock: "[-4px]",
+          marginInline: "[-6px]",
         },
         icon: { "&&": { "--icon-size": "16px" } },
         dropdownIcon: { "&&": { "--icon-size": "17px" } },
         separator: { paddingInline: "[9px]", "&&": { "--icon-size": "20px" } },
         ellipsisTrigger: {
           "& svg": { "--icon-size": "20px" },
-          _before: { inset: "[-6.5px]" },
+          padding: "[6.5px]",
+          margin: "[-6.5px]",
         },
       },
     },

--- a/libs/@hashintel/ds-components/src/components/Breadcumbs/breadcrumbs.recipe.ts
+++ b/libs/@hashintel/ds-components/src/components/Breadcumbs/breadcrumbs.recipe.ts
@@ -1,4 +1,9 @@
-import { sva } from "@hashintel/ds-helpers/css";
+import { css, sva } from "@hashintel/ds-helpers/css";
+
+export const menuCustomContent = css({
+  display: "flex",
+  minWidth: "0",
+});
 
 export const styles = sva({
   slots: [

--- a/libs/@hashintel/ds-components/src/components/Breadcumbs/breadcrumbs.recipe.ts
+++ b/libs/@hashintel/ds-components/src/components/Breadcumbs/breadcrumbs.recipe.ts
@@ -1,9 +1,4 @@
-import { css, sva } from "@hashintel/ds-helpers/css";
-
-export const menuCustomContent = css({
-  display: "flex",
-  minWidth: "0",
-});
+import { sva } from "@hashintel/ds-helpers/css";
 
 export const styles = sva({
   slots: [

--- a/libs/@hashintel/ds-components/src/components/Breadcumbs/breadcrumbs.tsx
+++ b/libs/@hashintel/ds-components/src/components/Breadcumbs/breadcrumbs.tsx
@@ -113,11 +113,20 @@ const BreadCrumbsRoot = ({
       (Number.parseFloat(rootStyle.paddingLeft) || 0) -
       (Number.parseFloat(rootStyle.paddingRight) || 0);
 
+    // The trigger's rect includes its hover-pill padding, but that padding is
+    // cancelled in layout by negative margins — the trail space it takes is
+    // its margin-box width. (Cells measure their <li>, which already is one.)
+    const triggerStyle = getComputedStyle(ellipsisTrigger);
+    const bareEllipsisWidth =
+      ellipsisTrigger.getBoundingClientRect().width +
+      (Number.parseFloat(triggerStyle.marginLeft) || 0) +
+      (Number.parseFloat(triggerStyle.marginRight) || 0);
+
     const next = computeCollapse({
       cellWidths,
       collapsible: [...collapsibleKey].map((flag) => flag === "1"),
       ellipsisWidth: ellipsisCell.getBoundingClientRect().width,
-      bareEllipsisWidth: ellipsisTrigger.getBoundingClientRect().width,
+      bareEllipsisWidth,
       available,
       maxItems,
     });

--- a/libs/@hashintel/ds-components/src/components/Filter/sort-menu.tsx
+++ b/libs/@hashintel/ds-components/src/components/Filter/sort-menu.tsx
@@ -157,7 +157,7 @@ export const SortMenu = <SortKey extends string = string>({
   };
 
   // Left/right arrows flip the highlighted row's displayed direction
-  // Keys typed into the search row report its row id, which matches no sorter, so
+  // Keys typed into the search header report a null highlighted id, so
   // caret movement in the input is never intercepted.
   const handleContentKeyDown = (
     event: React.KeyboardEvent,
@@ -231,31 +231,15 @@ export const SortMenu = <SortKey extends string = string>({
     };
   });
 
-  const menuItems: MenuItem[] = searchable
-    ? [
-        {
-          id: "sort-menu-search",
-          custom: (
-            <SelectableListSearch
-              value={search}
-              onChange={setSearch}
-              aria-label="Search sort options"
-            />
-          ),
-        },
-        ...sorterItems,
-        ...(visibleSorters.length === 0
-          ? [
-              {
-                id: "sort-menu-search-empty",
-                custom: (
-                  <span className={searchEmpty()}>No matching sorts</span>
-                ),
-              },
-            ]
-          : []),
-      ]
-    : sorterItems;
+  const menuItems: MenuItem[] =
+    searchable && visibleSorters.length === 0
+      ? [
+          {
+            id: "sort-menu-search-empty",
+            custom: <span className={searchEmpty()}>No matching sorts</span>,
+          },
+        ]
+      : sorterItems;
 
   const selectedSorter = value
     ? items.find((sorter) => sorter.sortKey === value.sortKey)
@@ -351,6 +335,16 @@ export const SortMenu = <SortKey extends string = string>({
       trigger={trigger}
       items={menuItems}
       className={menuContent()}
+      header={
+        searchable ? (
+          <SelectableListSearch
+            value={search}
+            onChange={setSearch}
+            aria-label="Search sort options"
+          />
+        ) : undefined
+      }
+      swapHeaderFooterOnFlip
       onOpen={(open) => {
         if (!open) {
           setDraftDirections({});

--- a/libs/@hashintel/ds-components/src/components/Menu/SelectableList/selectable-list-item.recipe.ts
+++ b/libs/@hashintel/ds-components/src/components/Menu/SelectableList/selectable-list-item.recipe.ts
@@ -6,6 +6,7 @@ export const styles = sva({
   slots: [
     "item",
     "textColumn",
+    "customText",
     "description",
     "indicator",
     "tick",
@@ -41,6 +42,12 @@ export const styles = sva({
       minWidth: "0",
       overflow: "hidden",
       textOverflow: "ellipsis",
+    },
+    // Non-string item text gets this flex wrapper so inline-block content
+    // doesn't pick up line-box leading (plain strings keep the ellipsis).
+    customText: {
+      display: "flex",
+      minWidth: "0",
     },
     description: {
       display: "block",

--- a/libs/@hashintel/ds-components/src/components/Menu/SelectableList/selectable-list-item.tsx
+++ b/libs/@hashintel/ds-components/src/components/Menu/SelectableList/selectable-list-item.tsx
@@ -93,7 +93,11 @@ export const ItemBody = ({
         />
       )}
       <span className={classes.textColumn}>
-        {item.text}
+        {typeof item.text === "string" ? (
+          item.text
+        ) : (
+          <span className={classes.customText}>{item.text}</span>
+        )}
         {item.description !== undefined && item.description !== null && (
           <span className={classes.description}>{item.description}</span>
         )}

--- a/libs/@hashintel/ds-components/src/components/Menu/SelectableList/selectable-list-search.recipe.ts
+++ b/libs/@hashintel/ds-components/src/components/Menu/SelectableList/selectable-list-search.recipe.ts
@@ -6,15 +6,26 @@ export const searchRow = cva({
     alignItems: "center",
     gap: "1.5",
     marginTop:
-      "[calc(-1 * (var(--spacing-1) + var(--selectable-list-padding-y)))]",
+      "[calc(-1 * (var(--selectable-list-content-padding) + var(--selectable-list-padding-y)))]",
     marginInline:
-      "[calc(-1 * (var(--selectable-list-padding-x) + var(--spacing-1)))]",
+      "[calc(-1 * (var(--selectable-list-padding-x) + var(--selectable-list-content-padding)))]",
     marginBottom: "0.5",
     paddingInline: "[var(--selectable-list-padding-x)]",
     paddingTop: "1.5",
     paddingBottom: "1",
     background: "neutral.s10",
     borderBottom: "1px solid {colors.neutral.s35}",
+    // Inside a swap-on-flip header of an upward-opening dropdown the search
+    // lands on the bottom edge; mirror its chrome vertically
+    "[data-placement^='top'] [data-selectable-list-swap-on-flip] &": {
+      marginTop: "0.5",
+      marginBottom:
+        "[calc(-1 * (var(--selectable-list-content-padding) + var(--selectable-list-padding-y)))]",
+      paddingTop: "1",
+      paddingBottom: "1.5",
+      borderBottom: "none",
+      borderTop: "1px solid {colors.neutral.s35}",
+    },
   },
 });
 

--- a/libs/@hashintel/ds-components/src/components/Menu/SelectableList/selectable-list-search.recipe.ts
+++ b/libs/@hashintel/ds-components/src/components/Menu/SelectableList/selectable-list-search.recipe.ts
@@ -15,19 +15,6 @@ export const searchRow = cva({
     paddingBottom: "1",
     background: "neutral.s10",
     borderBottom: "1px solid {colors.neutral.s35}",
-    // When the dropdown flips above the trigger, move the search to the
-    // bottom edge so it stays adjacent to the trigger (the list content is a
-    // flex column, so `order` relocates it without changing DOM order)
-    "[data-placement^='top'] &": {
-      order: "[1]",
-      marginTop: "0.5",
-      marginBottom:
-        "[calc(-1 * (var(--spacing-1) + var(--selectable-list-padding-y)))]",
-      paddingTop: "1",
-      paddingBottom: "1.5",
-      borderBottom: "none",
-      borderTop: "1px solid {colors.neutral.s35}",
-    },
   },
 });
 

--- a/libs/@hashintel/ds-components/src/components/Menu/SelectableList/selectable-list-search.tsx
+++ b/libs/@hashintel/ds-components/src/components/Menu/SelectableList/selectable-list-search.tsx
@@ -8,10 +8,12 @@ import {
 } from "./selectable-list-search.recipe";
 
 /**
- * A search field to embed as a custom row at the top of a SelectableList
- * (`{ custom: <SelectableListSearch ... /> }`). It focuses itself when
- * mounted — pair with a lazily mounted dropdown so focus lands when it opens
- * (the double rAF lets ark move focus to the list content first).
+ * A search field for the header of a SelectableList
+ * (`header={<SelectableListSearch ... />}`) — pair with
+ * `swapHeaderFooterOnFlip` so it hugs the trigger edge when the dropdown
+ * flips to open upward. It focuses itself when mounted — pair with a lazily
+ * mounted dropdown so focus lands when it opens (the double rAF lets ark
+ * move focus to the list content first).
  */
 export const SelectableListSearch = ({
   value,

--- a/libs/@hashintel/ds-components/src/components/Menu/SelectableList/selectable-list-util.ts
+++ b/libs/@hashintel/ds-components/src/components/Menu/SelectableList/selectable-list-util.ts
@@ -75,6 +75,10 @@ export const isGroup = (
 /** Prefix of ids assigned internally to custom items declared without one. */
 const internalCustomIdPrefix = "__custom-";
 
+/** Internal row ids for a header/footer taking part in keyboard navigation. */
+export const headerRowId = `${internalCustomIdPrefix}header`;
+export const footerRowId = `${internalCustomIdPrefix}footer`;
+
 export const useItemsWithCustomIds = (
   items: Array<ItemOrGroup<Item>>,
 ): Array<ItemOrGroup<Item>> =>
@@ -194,9 +198,26 @@ type TabStop =
  * - Any other key pressed inside a custom row is stopped from reaching the
  *   menu machine, which would otherwise hijack Enter, Space, Home/End and
  *   typeahead from the focused child. Escape is let through for dismissal.
+ *
+ * A header/footer rendered by the list (marked with `headerRowId` /
+ * `footerRowId`) participates as a custom row at the corresponding edge.
  */
-export const useCustomRowNavigation = (items: Array<ItemOrGroup<Item>>) => {
-  const positions = useMemo(() => collectNavPositions(items), [items]);
+export const useCustomRowNavigation = (
+  items: Array<ItemOrGroup<Item>>,
+  edges?: { hasHeader?: boolean; hasFooter?: boolean },
+) => {
+  const hasHeader = edges?.hasHeader ?? false;
+  const hasFooter = edges?.hasFooter ?? false;
+  const positions = useMemo(() => {
+    const rows = collectNavPositions(items);
+    if (hasHeader) {
+      rows.unshift({ kind: "custom", id: headerRowId });
+    }
+    if (hasFooter) {
+      rows.push({ kind: "custom", id: footerRowId });
+    }
+    return rows;
+  }, [items, hasHeader, hasFooter]);
 
   return (event: React.KeyboardEvent, menu: UseMenuContext) => {
     const content = event.currentTarget;

--- a/libs/@hashintel/ds-components/src/components/Menu/SelectableList/selectable-list.fixtures.tsx
+++ b/libs/@hashintel/ds-components/src/components/Menu/SelectableList/selectable-list.fixtures.tsx
@@ -1,5 +1,6 @@
 import { css } from "@hashintel/ds-helpers/css";
 
+import { Button } from "../../Button/button";
 import { type Item, type ItemOrGroup } from "./selectable-list";
 
 const tones = ["neutral", "brand", "error"] as const;
@@ -142,6 +143,18 @@ const itemWithCustomText: Item = {
     </span>
   ),
   onClick: noop,
+};
+
+// A custom row hosting a real button: not highlightable by the menu, but
+// clickable and reachable with Tab. autoFocus="never" stops ark's open-focus
+// from landing on it as a popover menu's first tabbable.
+const customItemButton: Item = {
+  id: "custom-button-row",
+  custom: (
+    <Button variant="subtle" size="xs" autoFocus="never" onClick={noop}>
+      Custom row: a Button
+    </Button>
+  ),
 };
 
 const kitchenSinkItem: Item = {
@@ -292,7 +305,7 @@ export const groupedItems: ItemOrGroup<Item>[] = [
         ✦ Custom group label ✦
       </span>
     ),
-    items: [itemWithCustomText],
+    items: [itemWithCustomText, customItemButton],
   },
   {
     id: "group-kitchen-sink",
@@ -306,6 +319,7 @@ export const itemsWithSubActions: ItemOrGroup<Item>[] = [
   itemWithGroupedSubActions,
   itemWithNestedSubActions,
   itemWithoutSubActions,
+  customItemButton,
 ];
 
 const customButtonStyle = css({

--- a/libs/@hashintel/ds-components/src/components/Menu/SelectableList/selectable-list.recipe.ts
+++ b/libs/@hashintel/ds-components/src/components/Menu/SelectableList/selectable-list.recipe.ts
@@ -74,6 +74,11 @@ export const styles = sva({
       padding: "1",
     },
     customItem: {
+      // Flex, so inline-block children (e.g. a Button) don't pick up line-box
+      // leading from the row's line-height. Centered rather than stretched to
+      // leave the children's heights alone.
+      display: "flex",
+      alignItems: "center",
       width: "full",
       paddingX: "[var(--selectable-list-padding-x)]",
       paddingY: "[var(--selectable-list-padding-y)]",

--- a/libs/@hashintel/ds-components/src/components/Menu/SelectableList/selectable-list.recipe.ts
+++ b/libs/@hashintel/ds-components/src/components/Menu/SelectableList/selectable-list.recipe.ts
@@ -3,17 +3,28 @@ import { sva } from "@hashintel/ds-helpers/css";
 import type { FormInputSize } from "../../../util/form-shared";
 
 export const styles = sva({
-  slots: ["content", "group", "groupLabel", "emptyContainer", "customItem"],
+  slots: [
+    "content",
+    "group",
+    "groupLabel",
+    "emptyContainer",
+    "customItem",
+    "scrollArea",
+    "header",
+    "footer",
+  ],
   base: {
     content: {
-      // A flex column so rows can re-order themselves by placement (the
-      // search row moves to the bottom edge when the dropdown flips upward).
-      // Children must not shrink, or long lists would compress rows to fit
-      // maxHeight instead of scrolling.
+      // A flex column so the header/footer can swap edges by placement when
+      // reverseHeadAndFootOnFlip is set. Children must not shrink, or long
+      // lists would compress rows to fit maxHeight instead of scrolling.
       display: "flex",
       flexDirection: "column",
       "& > *": {
         flexShrink: "0",
+      },
+      "& > [data-selectable-list-scroll]": {
+        flexShrink: "1",
       },
       backgroundColor: "white",
       border: "1px solid {colors.bd.subtle}",
@@ -64,10 +75,46 @@ export const styles = sva({
       width: "full",
       paddingX: "[var(--selectable-list-padding-x)]",
       paddingY: "[var(--selectable-list-padding-y)]",
-      // A search row moves to the bottom edge when the dropdown flips upward
+    },
+    scrollArea: {
+      display: "flex",
+      flexDirection: "column",
+      minHeight: "0",
+      overflowY: "auto",
+      scrollbarWidth: "[thin]",
+      "& > *": {
+        flexShrink: "0",
+      },
+    },
+    header: {
+      paddingX: "[var(--selectable-list-padding-x)]",
+      paddingY: "[var(--selectable-list-padding-y)]",
+      borderBottom: "1px solid {colors.neutral.s30}",
+      marginBottom: "1",
+      // With reverse-on-flip, an upward-opening dropdown puts the header on
+      // the bottom edge (nearest the trigger), swapping its divider side
       "[data-placement^='top'] &": {
-        "&:has([data-selectable-list-search])": {
+        "&[data-selectable-list-reverse-on-flip]": {
           order: "[1]",
+          borderBottomWidth: "0",
+          borderTop: "1px solid {colors.neutral.s30}",
+          marginBottom: "0",
+          marginTop: "1",
+        },
+      },
+    },
+    footer: {
+      paddingX: "[var(--selectable-list-padding-x)]",
+      paddingY: "[var(--selectable-list-padding-y)]",
+      borderTop: "1px solid {colors.neutral.s30}",
+      marginTop: "1",
+      "[data-placement^='top'] &": {
+        "&[data-selectable-list-reverse-on-flip]": {
+          order: "[-1]",
+          borderTopWidth: "0",
+          borderBottom: "1px solid {colors.neutral.s30}",
+          marginTop: "0",
+          marginBottom: "1",
         },
       },
     },
@@ -93,6 +140,12 @@ export const styles = sva({
         customItem: {
           textStyle: "xxs",
         },
+        header: {
+          textStyle: "xxs",
+        },
+        footer: {
+          textStyle: "xxs",
+        },
       },
       xs: {
         content: {
@@ -109,6 +162,12 @@ export const styles = sva({
           textStyle: "xxs",
         },
         customItem: {
+          textStyle: "xs",
+        },
+        header: {
+          textStyle: "xs",
+        },
+        footer: {
           textStyle: "xs",
         },
       },
@@ -129,6 +188,12 @@ export const styles = sva({
         customItem: {
           textStyle: "sm",
         },
+        header: {
+          textStyle: "sm",
+        },
+        footer: {
+          textStyle: "sm",
+        },
       },
       md: {
         content: {
@@ -147,6 +212,12 @@ export const styles = sva({
         customItem: {
           textStyle: "base",
         },
+        header: {
+          textStyle: "base",
+        },
+        footer: {
+          textStyle: "base",
+        },
       },
       lg: {
         content: {
@@ -163,6 +234,12 @@ export const styles = sva({
           textStyle: "sm",
         },
         customItem: {
+          textStyle: "base",
+        },
+        header: {
+          textStyle: "base",
+        },
+        footer: {
           textStyle: "base",
         },
       },

--- a/libs/@hashintel/ds-components/src/components/Menu/SelectableList/selectable-list.recipe.ts
+++ b/libs/@hashintel/ds-components/src/components/Menu/SelectableList/selectable-list.recipe.ts
@@ -16,7 +16,7 @@ export const styles = sva({
   base: {
     content: {
       // A flex column so the header/footer can swap edges by placement when
-      // reverseHeadAndFootOnFlip is set. Children must not shrink, or long
+      // swapHeaderFooterOnFlip is set. Children must not shrink, or long
       // lists would compress rows to fit maxHeight instead of scrolling.
       display: "flex",
       flexDirection: "column",
@@ -26,6 +26,7 @@ export const styles = sva({
       "& > [data-selectable-list-scroll]": {
         flexShrink: "1",
       },
+      padding: "[var(--selectable-list-content-padding)]",
       backgroundColor: "white",
       border: "1px solid {colors.bd.subtle}",
       borderRadius: "lg",
@@ -89,30 +90,31 @@ export const styles = sva({
     header: {
       paddingX: "[var(--selectable-list-padding-x)]",
       paddingY: "[var(--selectable-list-padding-y)]",
-      borderBottom: "1px solid {colors.neutral.s30}",
       marginBottom: "1",
-      // With reverse-on-flip, an upward-opening dropdown puts the header on
-      // the bottom edge (nearest the trigger), swapping its divider side
+      // A search header brings its own full-bleed chrome (see searchRow)
+      "&:has([data-selectable-list-search])": {
+        marginBottom: "0",
+      },
+      // With swap-on-flip, an upward-opening dropdown puts the header on
+      // the bottom edge (nearest the trigger)
       "[data-placement^='top'] &": {
-        "&[data-selectable-list-reverse-on-flip]": {
+        "&[data-selectable-list-swap-on-flip]": {
           order: "[1]",
-          borderBottomWidth: "0",
-          borderTop: "1px solid {colors.neutral.s30}",
           marginBottom: "0",
           marginTop: "1",
+          "&:has([data-selectable-list-search])": {
+            marginTop: "0",
+          },
         },
       },
     },
     footer: {
       paddingX: "[var(--selectable-list-padding-x)]",
       paddingY: "[var(--selectable-list-padding-y)]",
-      borderTop: "1px solid {colors.neutral.s30}",
       marginTop: "1",
       "[data-placement^='top'] &": {
-        "&[data-selectable-list-reverse-on-flip]": {
+        "&[data-selectable-list-swap-on-flip]": {
           order: "[-1]",
-          borderTopWidth: "0",
-          borderBottom: "1px solid {colors.neutral.s30}",
           marginTop: "0",
           marginBottom: "1",
         },
@@ -123,7 +125,7 @@ export const styles = sva({
     size: {
       xxs: {
         content: {
-          padding: "0.5",
+          "--selectable-list-content-padding": "var(--spacing-0\\.5)",
           "--selectable-list-padding-x": "var(--spacing-1\\.5)",
           "--selectable-list-padding-y": "var(--spacing-0\\.5)",
         },
@@ -149,7 +151,7 @@ export const styles = sva({
       },
       xs: {
         content: {
-          padding: "0.5",
+          "--selectable-list-content-padding": "var(--spacing-0\\.5)",
           "--selectable-list-padding-x": "var(--spacing-2)",
           "--selectable-list-padding-y": "3px",
         },
@@ -173,7 +175,7 @@ export const styles = sva({
       },
       sm: {
         content: {
-          padding: "1",
+          "--selectable-list-content-padding": "var(--spacing-1)",
           "--selectable-list-padding-x": "var(--spacing-2)",
           "--selectable-list-padding-y": "3px",
         },
@@ -197,7 +199,7 @@ export const styles = sva({
       },
       md: {
         content: {
-          padding: "1",
+          "--selectable-list-content-padding": "var(--spacing-1)",
           "--selectable-list-padding-x": "var(--spacing-2\\.5)",
           "--selectable-list-padding-y": "4px",
         },
@@ -221,7 +223,7 @@ export const styles = sva({
       },
       lg: {
         content: {
-          padding: "1.5",
+          "--selectable-list-content-padding": "var(--spacing-1\\.5)",
           "--selectable-list-padding-x": "var(--spacing-2\\.5)",
           "--selectable-list-padding-y": "4px",
         },

--- a/libs/@hashintel/ds-components/src/components/Menu/SelectableList/selectable-list.recipe.ts
+++ b/libs/@hashintel/ds-components/src/components/Menu/SelectableList/selectable-list.recipe.ts
@@ -10,6 +10,7 @@ export const styles = sva({
     "emptyContainer",
     "customItem",
     "scrollArea",
+    "scrollSizer",
     "header",
     "footer",
   ],
@@ -80,14 +81,28 @@ export const styles = sva({
     scrollArea: {
       display: "flex",
       flexDirection: "column",
-      minHeight: "0",
+      // A tall header/footer may squeeze the scroll area, but no further
+      // than 200px — or the list's natural height when that is smaller
+      // (measured into the variable by the component). Any excess overflows
+      // to the outer content instead.
+      minHeight: "[min(200px, var(--selectable-list-items-height, 0px))]",
       overflowY: "auto",
       scrollbarWidth: "[thin]",
       "& > *": {
         flexShrink: "0",
       },
     },
+    scrollSizer: {
+      display: "flex",
+      flexDirection: "column",
+      "& > *": {
+        flexShrink: "0",
+      },
+    },
     header: {
+      width: "[min-content]",
+      minWidth: "[100%]",
+      boxSizing: "border-box",
       paddingX: "[var(--selectable-list-padding-x)]",
       paddingY: "[var(--selectable-list-padding-y)]",
       marginBottom: "1",
@@ -109,6 +124,9 @@ export const styles = sva({
       },
     },
     footer: {
+      width: "[min-content]",
+      minWidth: "[100%]",
+      boxSizing: "border-box",
       paddingX: "[var(--selectable-list-padding-x)]",
       paddingY: "[var(--selectable-list-padding-y)]",
       marginTop: "1",

--- a/libs/@hashintel/ds-components/src/components/Menu/SelectableList/selectable-list.stories.tsx
+++ b/libs/@hashintel/ds-components/src/components/Menu/SelectableList/selectable-list.stories.tsx
@@ -104,8 +104,9 @@ export const HeaderAndFooter: Story<SelectableListProps> = (args) => (
     className={css({
       // The static menu has no positioner to set --available-height, so
       // provide it here — short enough that the items must scroll, showing
-      // the header and footer stay pinned outside the scroll area.
-      "--available-height": "240px",
+      // the header and footer stay pinned outside the scroll area (but tall
+      // enough for the scroll area's 200px floor).
+      "--available-height": "320px",
     })}
   >
     <StaticMenu>

--- a/libs/@hashintel/ds-components/src/components/Menu/SelectableList/selectable-list.stories.tsx
+++ b/libs/@hashintel/ds-components/src/components/Menu/SelectableList/selectable-list.stories.tsx
@@ -113,8 +113,41 @@ export const HeaderAndFooter: Story<SelectableListProps> = (args) => (
         {...args}
         items={groupedItems}
         selected={defaultSelected}
-        header={<span>Header — outside the scroll area</span>}
-        footer={<span>Footer — outside the scroll area</span>}
+        header={
+          // The slots are undecorated; dividers are the consumer's to draw.
+          // For an edge-to-edge one, pull out of the slot AND content padding
+          // with the list's padding vars, re-applying them as own padding.
+          <span
+            className={css({
+              display: "block",
+              marginX:
+                "[calc(-1 * (var(--selectable-list-padding-x) + var(--selectable-list-content-padding)))]",
+              marginBottom: "[calc(-1 * var(--selectable-list-padding-y))]",
+              paddingX:
+                "[calc(var(--selectable-list-padding-x) + var(--selectable-list-content-padding))]",
+              paddingBottom: "[var(--selectable-list-padding-y)]",
+              borderBottom: "1px solid {colors.neutral.s30}",
+            })}
+          >
+            Header — outside the scroll area
+          </span>
+        }
+        footer={
+          <span
+            className={css({
+              display: "block",
+              marginX:
+                "[calc(-1 * (var(--selectable-list-padding-x) + var(--selectable-list-content-padding)))]",
+              marginTop: "[calc(-1 * var(--selectable-list-padding-y))]",
+              paddingX:
+                "[calc(var(--selectable-list-padding-x) + var(--selectable-list-content-padding))]",
+              paddingTop: "[var(--selectable-list-padding-y)]",
+              borderTop: "1px solid {colors.neutral.s30}",
+            })}
+          >
+            Footer — outside the scroll area
+          </span>
+        }
       />
     </StaticMenu>
   </div>

--- a/libs/@hashintel/ds-components/src/components/Menu/SelectableList/selectable-list.stories.tsx
+++ b/libs/@hashintel/ds-components/src/components/Menu/SelectableList/selectable-list.stories.tsx
@@ -99,6 +99,27 @@ export const CustomItems: Story<SelectableListProps> = (args) => (
   </div>
 );
 
+export const HeaderAndFooter: Story<SelectableListProps> = (args) => (
+  <div
+    className={css({
+      // The static menu has no positioner to set --available-height, so
+      // provide it here — short enough that the items must scroll, showing
+      // the header and footer stay pinned outside the scroll area.
+      "--available-height": "240px",
+    })}
+  >
+    <StaticMenu>
+      <SelectableList
+        {...args}
+        items={groupedItems}
+        selected={defaultSelected}
+        header={<span>Header — outside the scroll area</span>}
+        footer={<span>Footer — outside the scroll area</span>}
+      />
+    </StaticMenu>
+  </div>
+);
+
 export const Disabled: Story<SelectableListProps> = (args) => (
   <StaticMenu>
     <SelectableList

--- a/libs/@hashintel/ds-components/src/components/Menu/SelectableList/selectable-list.tsx
+++ b/libs/@hashintel/ds-components/src/components/Menu/SelectableList/selectable-list.tsx
@@ -295,6 +295,9 @@ export const SelectableList = ({
   selected,
   size = "md",
   emptyState,
+  header,
+  footer,
+  reverseHeadAndFootOnFlip = false,
 }: {
   /** Which ark-ui primitive set to render inside. Defaults to Menu. */
   as?: SelectableListAs;
@@ -303,6 +306,15 @@ export const SelectableList = ({
   size?: FormInputSize;
   selected?: string[] | Set<string>;
   emptyState?: React.ReactNode;
+  /** Pinned above the items, outside the scrollable area. */
+  header?: React.ReactNode;
+  /** Pinned below the items, outside the scrollable area. */
+  footer?: React.ReactNode;
+  /**
+   * Swap the header and footer when the dropdown flips to open upward
+   * (placement `top*`), keeping the header on the edge nearest the trigger.
+   */
+  reverseHeadAndFootOnFlip?: boolean;
 }) => {
   const selectedSet = useMemo(() => new Set(selected ?? []), [selected]);
   const normalizedItems = useItemsWithCustomIds(items);
@@ -321,11 +333,44 @@ export const SelectableList = ({
     contentClassName: classes.content,
   };
 
-  const body = isEmpty ? (
+  const listBody = isEmpty ? (
     <div className={classes.emptyContainer}>{emptyState}</div>
   ) : (
     normalizedItems.map((item) => renderEntry(item, ctx))
   );
+
+  const hasHeader = header !== undefined && header !== null;
+  const hasFooter = footer !== undefined && footer !== null;
+  const reverseOnFlip = reverseHeadAndFootOnFlip ? "" : undefined;
+
+  // With a header/footer, scrolling moves to an inner wrapper so they stay
+  // pinned while the items scroll.
+  const body =
+    hasHeader || hasFooter ? (
+      <>
+        {hasHeader && (
+          <div
+            className={classes.header}
+            data-selectable-list-reverse-on-flip={reverseOnFlip}
+          >
+            {header}
+          </div>
+        )}
+        <div className={classes.scrollArea} data-selectable-list-scroll="">
+          {listBody}
+        </div>
+        {hasFooter && (
+          <div
+            className={classes.footer}
+            data-selectable-list-reverse-on-flip={reverseOnFlip}
+          >
+            {footer}
+          </div>
+        )}
+      </>
+    ) : (
+      listBody
+    );
 
   if (as === "Select") {
     return (

--- a/libs/@hashintel/ds-components/src/components/Menu/SelectableList/selectable-list.tsx
+++ b/libs/@hashintel/ds-components/src/components/Menu/SelectableList/selectable-list.tsx
@@ -3,7 +3,7 @@
 import { Menu } from "@ark-ui/react/menu";
 import { Portal } from "@ark-ui/react/portal";
 import { Select } from "@ark-ui/react/select";
-import { createContext, use, useMemo } from "react";
+import { createContext, use, useEffect, useMemo, useRef } from "react";
 
 import { cx } from "@hashintel/ds-helpers/css";
 
@@ -345,6 +345,26 @@ export const SelectableList = ({
 
   const isEmpty = normalizedItems.length === 0;
 
+  // The scroll area may not shrink below min(200px, the list's natural
+  // height) — see the recipe. CSS cannot compare a length with an intrinsic
+  // size, so measure the natural height into a variable via a sizer element.
+  const scrollSizerRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const sizer = scrollSizerRef.current;
+    const scrollArea = sizer?.parentElement;
+    if (!sizer || !scrollArea) {
+      return undefined;
+    }
+    const observer = new ResizeObserver(() => {
+      scrollArea.style.setProperty(
+        "--selectable-list-items-height",
+        `${sizer.offsetHeight}px`,
+      );
+    });
+    observer.observe(sizer);
+    return () => observer.disconnect();
+  }, [hasHeader, hasFooter]);
+
   const ctx: RenderCtx = {
     as,
     size,
@@ -378,7 +398,9 @@ export const SelectableList = ({
           </div>
         )}
         <div className={classes.scrollArea} data-selectable-list-scroll="">
-          {listBody}
+          <div ref={scrollSizerRef} className={classes.scrollSizer}>
+            {listBody}
+          </div>
         </div>
         {hasFooter && (
           <div

--- a/libs/@hashintel/ds-components/src/components/Menu/SelectableList/selectable-list.tsx
+++ b/libs/@hashintel/ds-components/src/components/Menu/SelectableList/selectable-list.tsx
@@ -15,7 +15,9 @@ import {
   type CustomItem,
   type Item,
   type ItemOrGroup,
+  footerRowId,
   getItemId,
+  headerRowId,
   isCustomItem,
   isGroup,
   useCustomRowNavigation,
@@ -107,6 +109,28 @@ const NestedMenu = ({
 };
 
 /**
+ * Keydown handler for presentational rows (custom rows and the header/
+ * footer): stops keys from reaching the menu machine, which would otherwise
+ * hijack Enter, Space, Home/End and typeahead from the focused child. In a
+ * Select, arrows and Enter fall through to zag's content handler so the list
+ * highlight/selection can be driven from inside the row (zag already ignores
+ * typing from editable elements, but Space and Home/End would act on both the
+ * caret and the list, so they stay stopped along with everything else).
+ */
+const handleRowKeyDown = (as: SelectableListAs, event: React.KeyboardEvent) => {
+  const passThrough =
+    event.key === "Tab" ||
+    event.key === "Escape" ||
+    (as === "Select" &&
+      (event.key === "ArrowDown" ||
+        event.key === "ArrowUp" ||
+        event.key === "Enter"));
+  if (!passThrough) {
+    event.stopPropagation();
+  }
+};
+
+/**
  * A custom row is deliberately not selectable item so the
  * menu machine never highlights it and arrow keys skip it.
  */
@@ -118,23 +142,7 @@ const CustomRow = ({ item, ctx }: { item: CustomItem; ctx: RenderCtx }) => {
       role="presentation"
       className={classes.customItem}
       data-selectable-list-custom={getItemId(item)}
-      onKeyDown={(event) => {
-        // In a Select, arrows and Enter fall through to zag's content handler
-        // so the list highlight/selection can be driven from inside the row
-        // (zag already ignores typing from editable elements, but Space and
-        // Home/End would act on both the caret and the list, so they stay
-        // stopped along with everything else).
-        const passThrough =
-          event.key === "Tab" ||
-          event.key === "Escape" ||
-          (ctx.as === "Select" &&
-            (event.key === "ArrowDown" ||
-              event.key === "ArrowUp" ||
-              event.key === "Enter"));
-        if (!passThrough) {
-          event.stopPropagation();
-        }
-      }}
+      onKeyDown={(event) => handleRowKeyDown(ctx.as, event)}
     >
       {item.custom}
     </div>
@@ -297,7 +305,7 @@ export const SelectableList = ({
   emptyState,
   header,
   footer,
-  reverseHeadAndFootOnFlip = false,
+  swapHeaderFooterOnFlip = false,
 }: {
   /** Which ark-ui primitive set to render inside. Defaults to Menu. */
   as?: SelectableListAs;
@@ -306,19 +314,30 @@ export const SelectableList = ({
   size?: FormInputSize;
   selected?: string[] | Set<string>;
   emptyState?: React.ReactNode;
-  /** Pinned above the items, outside the scrollable area. */
+  /**
+   * Pinned above the items, outside the scrollable area. Undecorated —
+   * supply your own divider if needed.
+   */
   header?: React.ReactNode;
-  /** Pinned below the items, outside the scrollable area. */
+  /**
+   * Pinned below the items, outside the scrollable area. Undecorated —
+   * supply your own divider if needed.
+   */
   footer?: React.ReactNode;
   /**
    * Swap the header and footer when the dropdown flips to open upward
    * (placement `top*`), keeping the header on the edge nearest the trigger.
    */
-  reverseHeadAndFootOnFlip?: boolean;
+  swapHeaderFooterOnFlip?: boolean;
 }) => {
   const selectedSet = useMemo(() => new Set(selected ?? []), [selected]);
   const normalizedItems = useItemsWithCustomIds(items);
-  const handleCustomRowKeyDown = useCustomRowNavigation(normalizedItems);
+  const hasHeader = header !== undefined && header !== null;
+  const hasFooter = footer !== undefined && footer !== null;
+  const handleCustomRowKeyDown = useCustomRowNavigation(normalizedItems, {
+    hasHeader,
+    hasFooter,
+  });
   const classes = styles({
     size,
     component: as === "Menu" ? "menu" : "select",
@@ -339,19 +358,21 @@ export const SelectableList = ({
     normalizedItems.map((item) => renderEntry(item, ctx))
   );
 
-  const hasHeader = header !== undefined && header !== null;
-  const hasFooter = footer !== undefined && footer !== null;
-  const reverseOnFlip = reverseHeadAndFootOnFlip ? "" : undefined;
+  const swapOnFlip = swapHeaderFooterOnFlip ? "" : undefined;
 
   // With a header/footer, scrolling moves to an inner wrapper so they stay
-  // pinned while the items scroll.
+  // pinned while the items scroll. Both edges take part in keyboard
+  // navigation as custom rows (skipped by arrows, Tab stops when focusable).
   const body =
     hasHeader || hasFooter ? (
       <>
         {hasHeader && (
           <div
+            role="presentation"
             className={classes.header}
-            data-selectable-list-reverse-on-flip={reverseOnFlip}
+            data-selectable-list-custom={headerRowId}
+            data-selectable-list-swap-on-flip={swapOnFlip}
+            onKeyDown={(event) => handleRowKeyDown(as, event)}
           >
             {header}
           </div>
@@ -361,8 +382,11 @@ export const SelectableList = ({
         </div>
         {hasFooter && (
           <div
+            role="presentation"
             className={classes.footer}
-            data-selectable-list-reverse-on-flip={reverseOnFlip}
+            data-selectable-list-custom={footerRowId}
+            data-selectable-list-swap-on-flip={swapOnFlip}
+            onKeyDown={(event) => handleRowKeyDown(as, event)}
           >
             {footer}
           </div>

--- a/libs/@hashintel/ds-components/src/components/Menu/menu.stories.tsx
+++ b/libs/@hashintel/ds-components/src/components/Menu/menu.stories.tsx
@@ -53,6 +53,9 @@ function withSelection(
       ),
     };
   }
+  if ("custom" in entry) {
+    return entry as MenuItem;
+  }
   const nested = (entry as { subItems?: Array<ItemOrGroup<Item>> }).subItems;
   if (nested) {
     return {

--- a/libs/@hashintel/ds-components/src/components/Menu/menu.stories.tsx
+++ b/libs/@hashintel/ds-components/src/components/Menu/menu.stories.tsx
@@ -159,6 +159,36 @@ export const PlainButtonTrigger: Story<MenuProps> = (args) => {
   );
 };
 
+export const LongHeaderAndFooter: Story<MenuProps> = (args) => {
+  const { selected, toggle } = useToggleSelection();
+  const items = useMemo(
+    () => groupedItems.map((entry) => withSelection(entry, selected, toggle)),
+    [selected, toggle],
+  );
+  return (
+    <Menu
+      {...args}
+      trigger={<Button variant="solid">Open menu</Button>}
+      items={items}
+      header={
+        <span>
+          This is a very long header for the menu, spelling out in generous
+          detail the context of every action below, wrapping across several
+          lines while staying pinned above the scrollable items.
+        </span>
+      }
+      footer={
+        <span>
+          An equally long footer with fine print: none of the options above take
+          effect until confirmed elsewhere, and this note also wraps across
+          several lines while staying pinned below the scrollable items.
+        </span>
+      }
+      swapHeaderFooterOnFlip
+    />
+  );
+};
+
 export const EllipsisMenu: Story<MenuProps> = (args) => {
   const ellipsis = useToggleSelection();
   const bell = useToggleSelection();

--- a/libs/@hashintel/ds-components/src/components/Menu/menu.tsx
+++ b/libs/@hashintel/ds-components/src/components/Menu/menu.tsx
@@ -49,6 +49,9 @@ export const Menu = ({
   trigger,
   position = "bottom-start",
   className,
+  header,
+  footer,
+  swapHeaderFooterOnFlip,
   onOpen,
   onKeyDown,
 }: {
@@ -56,6 +59,18 @@ export const Menu = ({
   trigger: React.ReactElement;
   position?: Position;
   className?: string;
+  /**
+   * Pinned above the items, outside the scrollable area. Undecorated —
+   * supply your own divider if needed.
+   */
+  header?: React.ReactNode;
+  /**
+   * Pinned below the items, outside the scrollable area. Undecorated —
+   * supply your own divider if needed.
+   */
+  footer?: React.ReactNode;
+  /** Swap the header/footer to the opposite edge when the menu opens upward. */
+  swapHeaderFooterOnFlip?: boolean;
   onOpen?: (open: boolean) => void;
   /** Key events from the open menu */
   onKeyDown?: (
@@ -100,6 +115,9 @@ export const Menu = ({
                   className={className}
                   selected={selected}
                   size="sm"
+                  header={header}
+                  footer={footer}
+                  swapHeaderFooterOnFlip={swapHeaderFooterOnFlip}
                 />
               </ArkMenu.Positioner>
             </Portal>

--- a/libs/@hashintel/ds-components/src/components/Select/multi-select.stories.tsx
+++ b/libs/@hashintel/ds-components/src/components/Select/multi-select.stories.tsx
@@ -2,15 +2,93 @@ import { useState } from "react";
 
 import { css } from "@hashintel/ds-helpers/css";
 
+import { formInputSizes } from "../../util/form-shared";
 import { Select } from "./select";
 
+import type { FormInputWidth } from "../../util/form-shared";
 import type { ItemOrGroup } from "../Menu/SelectableList/selectable-list";
 import type { MultiSelectItem, SelectItem } from "./select";
 import type { Story, StoryDefault } from "@ladle/react";
 
+type SelectProps = React.ComponentProps<typeof Select>;
+type MultiSelectProps = Extract<SelectProps, { multiple: true }>;
+type Variant = NonNullable<SelectProps["variant"]>;
+type Align = NonNullable<SelectProps["align"]>;
+
+const variants = ["default", "subtle"] as const satisfies readonly Variant[];
+const alignments = [
+  "left",
+  "center",
+  "right",
+] as const satisfies readonly Align[];
+const widths = [
+  "xs",
+  "sm",
+  "md",
+  "lg",
+  "fullWidth",
+  "fitContent",
+] as const satisfies readonly FormInputWidth[];
+
 export default {
   title: "Components/Select",
-} satisfies StoryDefault;
+  argTypes: {
+    placeholder: {
+      control: { type: "text" },
+      description: "Placeholder text shown when the input is empty",
+    },
+    disabled: {
+      control: { type: "boolean" },
+      description: "Disable the input",
+    },
+    invalid: {
+      control: { type: "boolean" },
+      description: "Mark the input as invalid",
+    },
+    readonly: {
+      control: { type: "boolean" },
+      description: "Render the input as read-only text",
+    },
+    loading: {
+      control: { type: "boolean" },
+      description: "Show a loading indicator",
+    },
+    variant: {
+      control: { type: "radio" },
+      options: variants,
+      description: "Visual variant of the input",
+    },
+    align: {
+      control: { type: "radio" },
+      options: alignments,
+      description: "Text alignment within the input",
+    },
+    size: {
+      control: { type: "select" },
+      options: formInputSizes,
+      description: "Input height",
+    },
+    width: {
+      control: { type: "select" },
+      options: widths,
+      description: "Preset input width",
+    },
+    hideArrow: {
+      control: { type: "boolean" },
+      description: "Hide the dropdown arrow",
+    },
+  },
+  args: {
+    disabled: false,
+    invalid: false,
+    readonly: false,
+    loading: false,
+    variant: "default",
+    align: "left",
+    size: "md",
+    hideArrow: false,
+  },
+} satisfies StoryDefault<MultiSelectProps>;
 
 const sampleItems: Array<ItemOrGroup<SelectItem>> = [
   { value: "apple", text: "Apple" },
@@ -97,6 +175,25 @@ const tonedItems = [
   { value: "error", text: "Error", tone: "error" as const },
 ];
 
+const groupedItems: Array<ItemOrGroup<MultiSelectItem>> = [
+  {
+    id: "group-one",
+    label: "Group one",
+    items: [
+      { value: "apple", text: "Apple" },
+      { value: "banana", text: "Banana" },
+    ],
+  },
+  {
+    id: "group-two",
+    label: "Group two",
+    items: [
+      { value: "cherry", text: "Cherry" },
+      { value: "date", text: "Date" },
+    ],
+  },
+];
+
 const suffixItems: Array<MultiSelectItem> = [
   { value: "apple", text: "Apple", suffix: "52 kcal", showOnlyButton: true },
   {
@@ -110,7 +207,11 @@ const suffixItems: Array<MultiSelectItem> = [
   { value: "date", text: "Date", suffix: "282 kcal" },
 ];
 
-export const Multiple: Story = () => {
+export const Multiple: Story<MultiSelectProps> = (args) => {
+  const spreadArgs = args as Omit<
+    MultiSelectProps,
+    "items" | "value" | "onChange" | "required"
+  >;
   const [fruits, setFruits] = useState<string[]>(["apple", "banana"]);
   const [byVariant, setByVariant] = useState<Record<string, string[]>>({
     checkbox: ["apple"],
@@ -125,6 +226,10 @@ export const Multiple: Story = () => {
     highlight: ["neutral", "brand", "error"],
   });
   const [capped, setCapped] = useState<string[]>(["apple", "banana"]);
+  const [groupedValues, setGroupedValues] = useState<string[]>([
+    "apple",
+    "cherry",
+  ]);
   const [suffixValues, setSuffixValues] = useState<string[]>([
     "apple",
     "banana",
@@ -139,11 +244,22 @@ export const Multiple: Story = () => {
       <div className={groupStyle}>
         <span style={subheadingStyle}>Default (checkbox items)</span>
         <Select
+          {...spreadArgs}
           multiple
           items={sampleItems}
           value={fruits}
           onChange={setFruits}
           placeholder="Select fruits..."
+        />
+      </div>
+      <div className={groupStyle}>
+        <span style={subheadingStyle}>Item groups</span>
+        <Select
+          {...spreadArgs}
+          multiple
+          items={groupedItems}
+          value={groupedValues}
+          onChange={setGroupedValues}
         />
       </div>
       <div className={groupStyle}>
@@ -165,6 +281,7 @@ export const Multiple: Story = () => {
           {multiItemVariants.map((itemVariant) => (
             <Select
               key={itemVariant}
+              {...spreadArgs}
               multiple
               items={sampleItems.map((item) => ({
                 ...item,
@@ -197,6 +314,7 @@ export const Multiple: Story = () => {
           {multiItemVariants.map((itemVariant) => (
             <Select
               key={itemVariant}
+              {...spreadArgs}
               multiple
               items={tonedItems.map((item) => ({
                 ...item,
@@ -216,6 +334,7 @@ export const Multiple: Story = () => {
           (Date has a suffix but no Only button)
         </span>
         <Select
+          {...spreadArgs}
           multiple
           items={suffixItems}
           value={suffixValues}
@@ -228,6 +347,7 @@ export const Multiple: Story = () => {
           selected
         </span>
         <Select
+          {...spreadArgs}
           multiple
           maxItems={2}
           searchable={{ searchable: true, onSearch: noop }}
@@ -241,6 +361,7 @@ export const Multiple: Story = () => {
           renderItem + renderSelectedItem (receives all selected values)
         </span>
         <Select
+          {...spreadArgs}
           multiple
           items={colorItems}
           value={colors}
@@ -265,6 +386,7 @@ export const Multiple: Story = () => {
           Searchable — onSearch reported: "{lastSearch}"
         </span>
         <Select
+          {...spreadArgs}
           multiple
           searchable={{ searchable: true, onSearch: setLastSearch }}
           items={sampleItems}
@@ -275,6 +397,7 @@ export const Multiple: Story = () => {
       <div className={groupStyle}>
         <span style={subheadingStyle}>Clearable</span>
         <Select
+          {...spreadArgs}
           multiple
           items={sampleItems}
           value={clearableValues}
@@ -285,6 +408,7 @@ export const Multiple: Story = () => {
       <div className={groupStyle}>
         <span style={subheadingStyle}>Readonly</span>
         <Select
+          {...spreadArgs}
           multiple
           items={sampleItems}
           value={["apple", "cherry"]}

--- a/libs/@hashintel/ds-components/src/components/Select/select.recipe.ts
+++ b/libs/@hashintel/ds-components/src/components/Select/select.recipe.ts
@@ -215,11 +215,15 @@ export const selectRecipe = sva({
       right: "[100%]",
       maskImage: "[linear-gradient(to right, transparent, black)]",
     },
+    // At least as wide as the trigger, growing to fit item content up to
+    // 18rem. !important beats the SelectableList content min-width (140px).
     list: {
       ...formWidths.base,
-      width: "var(--reference-width)",
-      maxWidth: "var(--reference-width)",
-      minWidth: "[var(--form-min-width) !important]",
+      "--select-list-reference-width": "var(--reference-width)",
+      width: "[fit-content]",
+      minWidth:
+        "[max(var(--select-list-reference-width), var(--form-min-width)) !important]",
+      maxWidth: "[max(var(--select-list-reference-width), 18rem)]",
     },
   },
   variants: {
@@ -290,10 +294,8 @@ export const selectRecipe = sva({
           },
         },
         list: {
-          width:
-            "[calc(var(--reference-width) + var(--base-input-padding-x) * 2)]",
-          maxWidth:
-            "[calc(var(--reference-width) + var(--base-input-padding-x) * 2)]",
+          "--select-list-reference-width":
+            "calc(var(--reference-width) + var(--base-input-padding-x) * 2)",
           marginLeft: "[calc(-1 * var(--base-input-padding-x))]",
         },
       },
@@ -412,7 +414,7 @@ export const selectRecipe = sva({
         },
         list: {
           width: "[auto]",
-          maxWidth: "[auto]",
+          maxWidth: "[none]",
         },
       },
     },

--- a/libs/@hashintel/ds-components/src/components/Select/select.stories.tsx
+++ b/libs/@hashintel/ds-components/src/components/Select/select.stories.tsx
@@ -37,6 +37,26 @@ const sampleItems: Array<ItemOrGroup<SelectItem>> = [
   { value: "date", text: "Date" },
 ];
 
+const groupedItemsForRow = (label: string): Array<ItemOrGroup<SelectItem>> => [
+  {
+    id: "group-one",
+    label: "Group one",
+    items: [
+      { value: label, text: label },
+      { value: "apple", text: "Apple" },
+      { value: "banana", text: "Banana" },
+    ],
+  },
+  {
+    id: "group-two",
+    label: "Group two",
+    items: [
+      { value: "cherry", text: "Cherry" },
+      { value: "date", text: "Date" },
+    ],
+  },
+];
+
 type RowVariant = {
   variant: Variant;
   readonly: boolean;
@@ -195,6 +215,7 @@ const stateRows: Array<{
   key: string;
   label: string;
   clearable?: boolean;
+  grouped?: boolean;
   extraProps: Partial<SingleSelectProps>;
 }> = [
   { key: "disabled", label: "Disabled", extraProps: { disabled: true } },
@@ -249,6 +270,12 @@ const stateRows: Array<{
         ),
       },
     },
+  },
+  {
+    key: "item-groups",
+    label: "Item groups",
+    grouped: true,
+    extraProps: { required: true },
   },
 ];
 
@@ -342,7 +369,9 @@ export const Default: Story<SingleSelectProps> = (args) => (
             const itemsForRow: Array<ItemOrGroup<SelectItem>> =
               row.key === "loading"
                 ? []
-                : [{ value: row.label, text: row.label }, ...sampleItems];
+                : row.grouped
+                  ? groupedItemsForRow(row.label)
+                  : [{ value: row.label, text: row.label }, ...sampleItems];
             return stateColumns.map((col) => {
               const value =
                 row.key === "loading"

--- a/libs/@hashintel/ds-components/src/components/Select/select.tsx
+++ b/libs/@hashintel/ds-components/src/components/Select/select.tsx
@@ -314,7 +314,7 @@ const SearchHighlightSync = ({
   return null;
 };
 
-/** Flattens groups and drops custom rows (e.g. the search field), which must not enter the collection as selectable options */
+/** Flattens groups and drops custom rows (e.g. the empty-search note), which must not enter the collection as selectable options */
 function flattenItems(items: Array<ItemOrGroup<Item>>): Item[] {
   const flat: Item[] = [];
   for (const entry of items) {
@@ -536,33 +536,19 @@ export const Select = <TValue extends string>({
       };
       mapped.unshift(noneItem);
     }
-    if (!showSearch) {
-      return mapped;
+    if (showSearch && mapped.length === 0) {
+      return [
+        {
+          id: `${noneValue}-search-empty`,
+          custom: (
+            <span className={searchEmpty()}>
+              {searching ? "No matching options" : resolvedEmptyState}
+            </span>
+          ),
+        },
+      ];
     }
-    const rows: Array<ItemOrGroup<Item>> = [
-      {
-        id: `${noneValue}-search`,
-        custom: (
-          <SelectableListSearch
-            value={search}
-            onChange={handleSearchChange}
-            aria-label="Search options"
-          />
-        ),
-      },
-      ...mapped,
-    ];
-    if (mapped.length === 0) {
-      rows.push({
-        id: `${noneValue}-search-empty`,
-        custom: (
-          <span className={searchEmpty()}>
-            {searching ? "No matching options" : resolvedEmptyState}
-          </span>
-        ),
-      });
-    }
-    return rows;
+    return mapped;
   }, [
     visibleItems,
     isOptional,
@@ -572,8 +558,6 @@ export const Select = <TValue extends string>({
     selectableAtMaxSet,
     selectOnly,
     showSearch,
-    search,
-    handleSearchChange,
     searchTerms,
     resolvedEmptyState,
   ]);
@@ -779,6 +763,16 @@ export const Select = <TValue extends string>({
             selected={selectedValues}
             size={size}
             emptyState={resolvedEmptyState}
+            header={
+              showSearch ? (
+                <SelectableListSearch
+                  value={search}
+                  onChange={handleSearchChange}
+                  aria-label="Search options"
+                />
+              ) : undefined
+            }
+            swapHeaderFooterOnFlip
           />
         </ArkSelect.Positioner>
       </Portal>

--- a/libs/@hashintel/ds-components/src/components/Toggle/toggle.recipe.ts
+++ b/libs/@hashintel/ds-components/src/components/Toggle/toggle.recipe.ts
@@ -186,7 +186,7 @@ export const styles = sva({
             backgroundColor: "neutral.s65",
           },
           "&[data-disabled][data-state='unchecked']": {
-            backgroundColor: "neutral.s35 !important",
+            backgroundColor: "neutral.s30 !important",
           },
         },
       },
@@ -199,7 +199,7 @@ export const styles = sva({
             backgroundColor: "red.s65",
           },
           "&[data-disabled][data-state='unchecked']": {
-            backgroundColor: "red.s35 !important",
+            backgroundColor: "red.s30 !important",
           },
         },
       },


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR adds new header + footer props to SelectableList + Menu, and wraps a collection of UI improvements centered around the Select adjacent components. In particular it:
- Fixes menu alignment on breadcrumb collapsed items
- Improves ellipsis/truncation logic in Select for very small Select widths
- Improves alignment of custom items in SelectableList
- Switches search in select to use the header prop so that it never can be scrolled out of view
- Improves scrolling + max-height logic for selectable list 
- Adds new test cases to stories  

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change
