### PR TITLE
SRE-1013: Redeploy the Brunch agent on ECS when its image publishes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -127,7 +127,7 @@ jobs:
               push:       ["ecr", "ghcr"],
               dockerfile: "apps/brunch-agent/docker/Dockerfile",
               context:    ".",
-              ecs:        []
+              ecs: [{ service: "brunch-agent", cluster: "h-stage-euc1-brunch", service_name: "h-stage-euc1-brunch-agent" }]
             },
             {
               package:    "@apps/hash-ai-worker-ts",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The staging ECS service for the Brunch agent exists now (`h-stage-euc1-brunch-agent` in cluster `h-stage-euc1-brunch`, provisioned by hashintel/internal-infra#358). This registers it as the deploy target of the `brunch-agent` image, so a push to `main` that rebuilds the image also rolls the service, the same way the other backend services are redeployed.

## 🔗 Related links

- [SRE-1013](https://linear.app/hash/issue/SRE-1013) _(internal)_
- hashintel/internal-infra#358 _(the ECS service)_

## 🚫 Blocked by

- Nothing. The ECS service and the `github-oidc-hash-cd-deploy` role permissions already exist in staging.

## 🔍 What does this change?

- `deploy.yml`: the `brunch-agent` catalog entry gains `ecs: [{ service: "brunch-agent", cluster: "h-stage-euc1-brunch", service_name: "h-stage-euc1-brunch-agent" }]`. The `Redeploy brunch-agent` job runs after `Tag :staging (brunch-agent)` on pushes to `main` and on `workflow_dispatch`, exactly as for `api`, `graph` and the workers.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph
