### PR TITLE
SRE-1042: Upgrade insecure requests so the Brunch stream URL loads over HTTPS

### DIFF
--- a/apps/petrinaut-website/README.md
+++ b/apps/petrinaut-website/README.md
@@ -38,10 +38,9 @@ Canonical example pages live below `/examples`. The JSON oEmbed endpoint at
 `/api/oembed` accepts their production URLs and returns an
 `/embed/examples/...` iframe. Canonical pages send both CSP `frame-ancestors
 'none'` and `X-Frame-Options: DENY`; only the dedicated embed routes permit
-third-party framing. Every page also sends `upgrade-insecure-requests`: TLS to the Brunch agent ends at Cloudflare and
-again at the load balancer, the last hop to the agent is plain HTTP, and the agent builds its absolute
-stream URLs from that hop (`http://…`). An HTTPS page would block those as mixed content before the
-request ever leaves the browser. The returned iframe is sandboxed with
+third-party framing. Every page also sends `upgrade-insecure-requests`: the deployed Brunch agent runs behind a proxy,
+sees plain HTTP and returns `http://` stream URLs, which an HTTPS page would otherwise block as mixed
+content. The returned iframe is sandboxed with
 `allow-scripts allow-same-origin` and does not send a referrer.
 
 Because this is a client-rendered SPA, a static `index.html` discovery link

--- a/apps/petrinaut-website/README.md
+++ b/apps/petrinaut-website/README.md
@@ -38,7 +38,9 @@ Canonical example pages live below `/examples`. The JSON oEmbed endpoint at
 `/api/oembed` accepts their production URLs and returns an
 `/embed/examples/...` iframe. Canonical pages send both CSP `frame-ancestors
 'none'` and `X-Frame-Options: DENY`; only the dedicated embed routes permit
-third-party framing. The returned iframe is sandboxed with
+third-party framing. Every page also sends `upgrade-insecure-requests`: the Brunch agent sits behind a
+TLS-terminating load balancer and returns absolute `http://` stream URLs, which an HTTPS page would
+otherwise block as mixed content before the request ever leaves the browser. The returned iframe is sandboxed with
 `allow-scripts allow-same-origin` and does not send a referrer.
 
 Because this is a client-rendered SPA, a static `index.html` discovery link

--- a/apps/petrinaut-website/README.md
+++ b/apps/petrinaut-website/README.md
@@ -38,9 +38,10 @@ Canonical example pages live below `/examples`. The JSON oEmbed endpoint at
 `/api/oembed` accepts their production URLs and returns an
 `/embed/examples/...` iframe. Canonical pages send both CSP `frame-ancestors
 'none'` and `X-Frame-Options: DENY`; only the dedicated embed routes permit
-third-party framing. Every page also sends `upgrade-insecure-requests`: the Brunch agent sits behind a
-TLS-terminating load balancer and returns absolute `http://` stream URLs, which an HTTPS page would
-otherwise block as mixed content before the request ever leaves the browser. The returned iframe is sandboxed with
+third-party framing. Every page also sends `upgrade-insecure-requests`: TLS to the Brunch agent ends at Cloudflare and
+again at the load balancer, the last hop to the agent is plain HTTP, and the agent builds its absolute
+stream URLs from that hop (`http://…`). An HTTPS page would block those as mixed content before the
+request ever leaves the browser. The returned iframe is sandboxed with
 `allow-scripts allow-same-origin` and does not send a referrer.
 
 Because this is a client-rendered SPA, a static `index.html` discovery link

--- a/apps/petrinaut-website/vercel.json
+++ b/apps/petrinaut-website/vercel.json
@@ -14,7 +14,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "frame-ancestors 'none'"
+          "value": "frame-ancestors 'none'; upgrade-insecure-requests"
         },
         {
           "key": "X-Frame-Options",
@@ -27,7 +27,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "frame-ancestors *"
+          "value": "frame-ancestors *; upgrade-insecure-requests"
         },
         {
           "key": "X-Content-Type-Options",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Make the deployed Petrinaut panel able to read Brunch's streamed answers. On the deployed agent (`agent.brunch.stage.hash.ai`, `agent.brunch.app.hash.ai`) a `send()` answers with a `streamUrl` of the form `http://agent.brunch.…/agents/chat/<id>`: the agent runs behind a proxy, sees plain HTTP and builds the absolute URL from that instead of `X-Forwarded-Proto`. An HTTPS page blocks a `fetch` to an `http://` URL as mixed content before the request leaves the browser, so no redirect ever gets a chance and the chat hangs after the first message.

The `upgrade-insecure-requests` CSP directive makes the browser rewrite every `http://` request of the page to `https://` before sending it, which is exactly the hop that is missing here. Verified against both deployed agents with a Node client: the same request succeeds as soon as the redirect is followed, and the history is persisted.

## 🔗 Related links

- [SRE-1042](https://linear.app/hash/issue/SRE-1042/configure-petrinauts-deployment-variables-for-the-brunch-agent-chat) _(internal)_
- #9583 _(CORS on `/agents/*`, the other prerequisite for the browser path)_
- hashintel/internal-infra#358 _(the deployed agent)_

## 🚫 Blocked by

- Nothing

## 🔍 What does this change?

- `apps/petrinaut-website/vercel.json`: both `Content-Security-Policy` values (canonical pages and embed routes) gain `upgrade-insecure-requests`. Same-origin requests are unaffected; the site is HTTPS-only already.
- `apps/petrinaut-website/README.md`: one sentence next to the existing CSP note saying why the directive is there.

The proper fix is for the agent to honour `X-Forwarded-Proto` (or return relative stream URLs); that lives in Flue's Node server, not in this repository. This directive keeps the panel working either way.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] require changes to docs which **are made** as part of this PR

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph
