### PR TITLE
SRE-1042: Allow one wildcard label in the Brunch CORS allow-list for preview origins

### DIFF
--- a/apps/brunch-agent/README.md
+++ b/apps/brunch-agent/README.md
@@ -46,30 +46,32 @@ liveness only; it does not query Postgres or Anthropic.
 
 Production database configuration uses dedicated fields:
 
-| Variable                      | Required when | Purpose                                                                                                 |
-| ----------------------------- | ------------- | ------------------------------------------------------------------------------------------------------- |
-| `BRUNCH_POSTGRES_AUTH_MODE`   | Always        | `iam` or `password`                                                                                     |
-| `BRUNCH_POSTGRES_HOST`        | Always        | Exact RDS endpoint used for TLS and IAM signing                                                         |
-| `BRUNCH_POSTGRES_PORT`        | Always        | PostgreSQL port                                                                                         |
-| `BRUNCH_POSTGRES_DATABASE`    | Always        | Flue database                                                                                           |
-| `BRUNCH_POSTGRES_USER`        | Always        | PostgreSQL role                                                                                         |
-| `BRUNCH_POSTGRES_TLS_CA_PATH` | Always        | Trusted RDS CA bundle; the image sets it to the bundled AWS global bundle, override only for another CA |
-| `BRUNCH_POSTGRES_AWS_REGION`  | IAM only      | Region used by the RDS signer; rejected in password mode                                                |
-| `BRUNCH_POSTGRES_PASSWORD`    | Password only | Runtime-injected database password; rejected in IAM mode                                                |
-| `HASH_OTLP_ENDPOINT`          | Always        | HASH OTLP/gRPC collector endpoint                                                                       |
-| `OTEL_SERVICE_NAME`           | Optional      | OTel service name; defaults to `Brunch Agent`                                                           |
-| `BRUNCH_CORS_ALLOWED_ORIGINS` | Optional      | Exact-origin browser JavaScript allowlist for `/agents/*`; missing or blank grants no CORS access       |
+| Variable                      | Required when | Purpose                                                                                                   |
+| ----------------------------- | ------------- | --------------------------------------------------------------------------------------------------------- |
+| `BRUNCH_POSTGRES_AUTH_MODE`   | Always        | `iam` or `password`                                                                                       |
+| `BRUNCH_POSTGRES_HOST`        | Always        | Exact RDS endpoint used for TLS and IAM signing                                                           |
+| `BRUNCH_POSTGRES_PORT`        | Always        | PostgreSQL port                                                                                           |
+| `BRUNCH_POSTGRES_DATABASE`    | Always        | Flue database                                                                                             |
+| `BRUNCH_POSTGRES_USER`        | Always        | PostgreSQL role                                                                                           |
+| `BRUNCH_POSTGRES_TLS_CA_PATH` | Always        | Trusted RDS CA bundle; the image sets it to the bundled AWS global bundle, override only for another CA   |
+| `BRUNCH_POSTGRES_AWS_REGION`  | IAM only      | Region used by the RDS signer; rejected in password mode                                                  |
+| `BRUNCH_POSTGRES_PASSWORD`    | Password only | Runtime-injected database password; rejected in IAM mode                                                  |
+| `HASH_OTLP_ENDPOINT`          | Always        | HASH OTLP/gRPC collector endpoint                                                                         |
+| `OTEL_SERVICE_NAME`           | Optional      | OTel service name; defaults to `Brunch Agent`                                                             |
+| `BRUNCH_CORS_ALLOWED_ORIGINS` | Optional      | Browser JavaScript allowlist for `/agents/*`: exact origins or `https://*.domain`; blank grants no access |
 
-`BRUNCH_CORS_ALLOWED_ORIGINS` is a comma-separated list of exact origins whose browser JavaScript
-may read cross-origin responses from `/agents/*`. For example:
+`BRUNCH_CORS_ALLOWED_ORIGINS` is a comma-separated list of origins whose browser JavaScript may
+read cross-origin responses from `/agents/*`. An entry is either an exact origin or a wildcard for
+exactly one leading host label, which covers per-branch preview deployments. For example:
 
 ```sh
-BRUNCH_CORS_ALLOWED_ORIGINS=https://app.example.com,https://preview.example.com
+BRUNCH_CORS_ALLOWED_ORIGINS=https://app.example.com,https://*.preview.example.com
 ```
 
-Prefer stable preview hostnames and list an exact preview origin only when that deployment needs
-Brunch access. Each ephemeral preview origin must be listed explicitly. The variable does not
-accept wildcards, non-root paths, queries, fragments, credentials, or non-HTTP(S) schemes. Missing or blank
+`https://*.preview.example.com` admits `https://feature-x.preview.example.com` but not
+`https://preview.example.com`, `https://a.b.preview.example.com`, or another scheme or port. The
+wildcard must be the whole first label in front of a domain with at least two labels. Non-root
+paths, queries, fragments, credentials, and non-HTTP(S) schemes are rejected. Missing or blank
 configuration grants no cross-origin browser access while preserving same-origin requests. CORS
 controls browser JavaScript access; it is not a server-side access gate and does not restrict
 non-browser callers. The deployment still requires its separate identity, authorization, ingress,

--- a/apps/brunch-agent/src/http/cors.ts
+++ b/apps/brunch-agent/src/http/cors.ts
@@ -28,9 +28,12 @@ const AGENT_CORS_RESPONSE_HEADERS = [
 const exactHttpOriginPattern =
   /^https?:\/\/(?:\[[0-9a-f:.]+\]|[^\s:/?#@\\]+)(?::[0-9]+)?\/?$/iu;
 
+// One wildcard label in front of a domain with at least two labels: `*.stage.hash.ai`, never `*.ai`.
+const wildcardHostPattern = /^\*\.[^.*]+(?:\.[^.*]+)+$/u;
+
 const invalidOriginConfiguration = (): Error =>
   new Error(
-    `${BRUNCH_CORS_ALLOWED_ORIGINS_ENV} must contain only comma-separated exact HTTP(S) origins`,
+    `${BRUNCH_CORS_ALLOWED_ORIGINS_ENV} must contain only comma-separated exact HTTP(S) origins, optionally with one leading wildcard label such as https://*.example.com`,
   );
 
 const normalizeCorsOrigin = (value: string): string => {
@@ -52,13 +55,52 @@ const normalizeCorsOrigin = (value: string): string => {
     url.pathname !== "/" ||
     url.search !== "" ||
     url.hash !== "" ||
-    url.hostname.includes("*") ||
     url.origin === "null"
   ) {
     throw invalidOriginConfiguration();
   }
 
+  if (url.hostname.includes("*") && !wildcardHostPattern.test(url.hostname)) {
+    throw invalidOriginConfiguration();
+  }
+
   return url.origin;
+};
+
+/**
+ * Wildcard entries match exactly one host label, like a wildcard TLS certificate:
+ * `https://*.stage.hash.ai` admits `https://petrinaut-git-main.stage.hash.ai` but not
+ * `https://stage.hash.ai` or `https://a.b.stage.hash.ai`.
+ */
+const isAllowedOrigin = (
+  allowedOrigins: readonly string[],
+  origin: string,
+): boolean => {
+  let url: URL;
+  try {
+    url = new URL(origin);
+  } catch {
+    return false;
+  }
+  if (url.origin === "null") {
+    return false;
+  }
+
+  return allowedOrigins.some((entry) => {
+    if (!entry.includes("*")) {
+      return entry === url.origin;
+    }
+    const pattern = new URL(entry);
+    if (pattern.protocol !== url.protocol || pattern.port !== url.port) {
+      return false;
+    }
+    const suffix = pattern.hostname.slice(1); // ".stage.hash.ai"
+    if (!url.hostname.endsWith(suffix)) {
+      return false;
+    }
+    const label = url.hostname.slice(0, -suffix.length);
+    return label.length > 0 && !label.includes(".");
+  });
 };
 
 export const parseCorsAllowedOrigins = (
@@ -80,7 +122,8 @@ export const createAgentCors = (
   allowedOrigins: readonly string[],
 ): MiddlewareHandler => {
   const honoCors = cors({
-    origin: [...allowedOrigins],
+    origin: (origin) =>
+      isAllowedOrigin(allowedOrigins, origin) ? origin : null,
     allowMethods: AGENT_CORS_METHODS,
     allowHeaders: AGENT_CORS_REQUEST_HEADERS,
     exposeHeaders: AGENT_CORS_RESPONSE_HEADERS,

--- a/apps/brunch-agent/test/cors.test.ts
+++ b/apps/brunch-agent/test/cors.test.ts
@@ -49,13 +49,40 @@ describe("parseCorsAllowedOrigins", () => {
     "https://app.example.com?preview=true",
     "https://app.example.com#",
     "https://app.example.com#preview",
-    "https://*.example.com",
     "not-an-origin",
   ])("rejects invalid or broader-than-origin entry %s", (value) => {
     expect(() => parseCorsAllowedOrigins(value)).toThrow(
       BRUNCH_CORS_ALLOWED_ORIGINS_ENV,
     );
   });
+
+  test("accepts one leading wildcard label in front of a domain", () => {
+    expect(
+      parseCorsAllowedOrigins(
+        "https://*.stage.example.com, HTTPS://*.Stage.Example.com:443, https://*.preview.example.com:8443, https://*.example.com",
+      ),
+    ).toEqual([
+      "https://*.stage.example.com",
+      "https://*.preview.example.com:8443",
+      "https://*.example.com",
+    ]);
+  });
+
+  test.each([
+    "https://*",
+    "https://*.com",
+    "https://preview-*.example.com",
+    "https://*.*.example.com",
+    "https://app.*.example.com",
+    "https://**.example.com",
+  ])(
+    "rejects wildcard entry %s that is not one leading label before a domain",
+    (value) => {
+      expect(() => parseCorsAllowedOrigins(value)).toThrow(
+        BRUNCH_CORS_ALLOWED_ORIGINS_ENV,
+      );
+    },
+  );
 
   test.each([
     "https:example.com",
@@ -79,9 +106,13 @@ const identity = {
 const instanceId = flueConversationIdFrom(identity);
 const conversationUrl = `http://brunch.test${mount}/${instanceId}`;
 
-const buildCorsTestApp = () => {
+const wildcardOrigin = "https://*.stage.example.com";
+
+const buildCorsTestApp = (
+  allowedOrigins: readonly string[] = [allowedOrigin],
+) => {
   const app = new Hono();
-  app.use("/agents/*", createAgentCors([allowedOrigin]));
+  app.use("/agents/*", createAgentCors(allowedOrigins));
   app.use(`${mount}/*`, agentOwnershipGuard(`${mount}/`));
   app.all(`${mount}/*`, (context) => context.text("admitted"));
   app.get(HEALTH_ROUTE, (context) => context.text("healthy"));
@@ -224,3 +255,40 @@ test.each(["/", HEALTH_ROUTE, "/assets/app.js"])(
     expect(response.headers.get("access-control-allow-origin")).toBeNull();
   },
 );
+
+test.each([
+  "https://petrinaut-git-main.stage.example.com",
+  "https://x.stage.example.com",
+])(
+  "grants a wildcard-matched preview origin %s a preflight",
+  async (origin) => {
+    const response = await buildCorsTestApp([wildcardOrigin]).fetch(
+      new Request(conversationUrl, {
+        method: "OPTIONS",
+        headers: { Origin: origin, "Access-Control-Request-Method": "GET" },
+      }),
+    );
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get("access-control-allow-origin")).toBe(origin);
+  },
+);
+
+test.each([
+  "https://stage.example.com",
+  "https://a.b.stage.example.com",
+  "https://evil-stage.example.com",
+  "https://stage.example.com.attacker.example",
+  "http://preview.stage.example.com",
+  "https://preview.stage.example.com:8443",
+])("gives %s no CORS grant under a one-label wildcard", async (origin) => {
+  const response = await buildCorsTestApp([wildcardOrigin]).fetch(
+    new Request(conversationUrl, {
+      method: "OPTIONS",
+      headers: { Origin: origin, "Access-Control-Request-Method": "GET" },
+    }),
+  );
+
+  expect(response.status).toBe(204);
+  expect(response.headers.get("access-control-allow-origin")).toBeNull();
+});

--- a/libs/@hashintel/brunch-agent/MISSION.md
+++ b/libs/@hashintel/brunch-agent/MISSION.md
@@ -3,15 +3,14 @@
 ## Status
 
 **Live as of 2026-09-08** for
-[FE-1626](https://linear.app/hash/issue/FE-1626/add-cors-handling-to-brunch-agents-agents-routes-for-the-petrinaut)
-on `kafe/fe-1626-cors-agents-routes`, cut directly from `main` after
-[FE-1574](https://github.com/hashintel/hash/pull/9528) established
-`/agents/chat/:instanceId` as the Petrinaut browser's Brunch transport and
-[FE-1625](https://github.com/hashintel/hash/pull/9573) made the image deployable.
-This file is the branch's sole execution authority.
+[SRE-1042](https://linear.app/hash/issue/SRE-1042/configure-petrinauts-deployment-variables-for-the-brunch-agent-chat)
+on `t/sre-1042-allow-wildcard-origins-for-brunch-previews`, cut from `main` after
+[FE-1626](https://github.com/hashintel/hash/pull/9583) established the exact-origin allow-list for
+`/agents/*`. This file is the branch's sole execution authority.
 
-The owner selected deployment-configured exact origins over wildcard preview-host patterns or a
-new same-origin proxy. CORS governs whether a conforming browser exposes a cross-origin response
+Exact origins alone do not fit the deployment: every Petrinaut preview has its own
+`https://petrinaut-git-<branch>.stage.hash.ai` origin, so the allow-list additionally accepts a
+wildcard for exactly one leading host label. CORS governs whether a conforming browser exposes a cross-origin response
 to client code; it does not authenticate or restrict non-browser callers, authorize a
 conversation, or make public exposure safe by itself.
 
@@ -35,10 +34,12 @@ Petrinaut browser at one configured exact origin
 → response exposes the Flue/Durable Streams headers the browser SDK reads
 ```
 
-`BRUNCH_CORS_ALLOWED_ORIGINS` is read once at startup as a comma-separated list of exact HTTP(S)
-origins. Parsing trims whitespace, normalizes an optional trailing slash through `URL.origin`, and
-deduplicates values. Credentials, non-root paths, queries, fragments, wildcards, opaque origins,
-and non-HTTP(S) schemes are startup configuration errors. Missing or blank configuration means an
+`BRUNCH_CORS_ALLOWED_ORIGINS` is read once at startup as a comma-separated list of HTTP(S)
+origins, each either exact or with a wildcard as the whole leading host label in front of a domain
+with at least two labels (`https://*.stage.hash.ai`). A wildcard matches exactly one label, like a
+wildcard TLS certificate. Parsing trims whitespace, normalizes an optional trailing slash through
+`URL.origin`, and deduplicates values. Credentials, non-root paths, queries, fragments, wildcards in
+any other position, opaque origins, and non-HTTP(S) schemes are startup configuration errors. Missing or blank configuration means an
 empty allowlist: same-origin and non-browser callers continue through the existing route, but
 browser code at another origin receives no CORS grant. See the
 [Brunch application README](../../../apps/brunch-agent/README.md#production-container) for
@@ -99,8 +100,9 @@ configuration, a deployed endpoint, or end-to-end remote verification.
   CORS response logic.
 - Keep one Flue product route and the existing ownership guard. CORS must not add, proxy, rename, or
   reinterpret an agent route.
-- The origin list is exact. Do not hard-code Petrinaut domains, accept wildcard entries, infer trust
-  from `.stage.hash.ai`, reflect arbitrary `Origin` values, or silently skip malformed entries.
+- The origin list is explicit: exact origins or one-label wildcards, matched by scheme, host and
+  port. Do not hard-code Petrinaut domains, reflect arbitrary `Origin` values, or silently skip
+  malformed entries.
 - Keep credentials disabled. The current browser client uses explicit ownership headers, not
   cookies, and those headers are not authentication.
 - Answer preflight before ownership while preserving ownership enforcement on every non-preflight
@@ -115,7 +117,7 @@ configuration, a deployed endpoint, or end-to-end remote verification.
 
 ```text
 ~ libs/@hashintel/brunch-agent/MISSION.md      branch authority
-+ apps/brunch-agent/src/http/cors.ts           exact-origin parsing and Hono middleware
+~ apps/brunch-agent/src/http/cors.ts           exact and one-label wildcard origins, Hono middleware
 ~ apps/brunch-agent/src/app.ts                 mount CORS before ownership on /agents/*
 + apps/brunch-agent/test/cors.test.ts          parser, allowed, rejected, preflight, route-scope tests
 ~ apps/brunch-agent/README.md                  deployment variable and security boundary
@@ -127,10 +129,9 @@ configuration, a deployed endpoint, or end-to-end remote verification.
 - Infrastructure repository access is unavailable in this worktree, so this branch can prove only
   the application contract. Runtime deployment configuration must supply the chosen origins before
   remote verification.
-- Exact origins intentionally do not cover every ephemeral deployment URL. Prefer stable,
-  explicitly named origins; add an ephemeral origin only when a named test requires it. Re-enter
-  constrained patterns or a same-origin proxy only if maintaining the exact list becomes observed
-  operational strain.
+- A one-label wildcard admits every host directly under the configured domain, not only Petrinaut
+  previews. Narrow the deployed pattern or return to exact origins if that breadth becomes a
+  problem in practice.
 - The allowed and exposed headers are pinned to the installed Flue and Durable Streams clients.
   Re-evaluate them from client source when either dependency changes.
 
@@ -154,5 +155,5 @@ separate release gates.
   `VITE_BRUNCH_CHAT_ENDPOINT`, Voice deployment variables, and the deployed browser verification
   after this application contract lands.
 - FE-1615 and FE-1616 retain authentication and rate-limit work. CORS does not discharge either.
-- A same-origin Petrinaut proxy or constrained preview-host pattern re-enters only under observed
-  exact-list maintenance strain.
+- A same-origin Petrinaut proxy stays deferred; the one-label wildcard covers the preview
+  deployments the exact list could not.


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Let the Petrinaut preview deployments talk to the deployed Brunch agent. Every Vercel preview gets its own origin (`https://petrinaut-git-<branch>.stage.hash.ai`), and `BRUNCH_CORS_ALLOWED_ORIGINS` only accepted exact origins, so a preview could only be admitted by redeploying the agent with that one hostname added. Verified today against `agent.brunch.stage.hash.ai`: the preflight from a preview origin comes back 204 without `Access-Control-Allow-Origin`, and the panel stops with "not allowed by Access-Control-Allow-Origin".

## 🔗 Related links

- [SRE-1042](https://linear.app/hash/issue/SRE-1042/configure-petrinauts-deployment-variables-for-the-brunch-agent-chat) _(internal)_
- #9583 _(introduced the allow-list)_

## 🚫 Blocked by

- Nothing

## 🔍 What does this change?

- `parseCorsAllowedOrigins` accepts entries with exactly one wildcard as the whole leading host label, in front of a domain with at least two labels: `https://*.stage.hash.ai` is valid, `https://*.ai`, `https://preview-*.example.com` and `https://a.*.example.com` are not. Everything else the parser rejected before (paths, queries, credentials, non-HTTP schemes, forgiving URL forms) stays rejected.
- A wildcard matches exactly one label, like a wildcard TLS certificate: `https://*.stage.hash.ai` admits `https://petrinaut-git-main.stage.hash.ai` but not `https://stage.hash.ai`, `https://a.b.stage.hash.ai`, a different scheme or a different port.
- `createAgentCors` hands `hono/cors` an `origin` function instead of a list; exact entries behave as before.
- README documents the syntax; tests cover accepted and rejected patterns and the matcher on preflights.
- `libs/@hashintel/brunch-agent/MISSION.md` reflects the new behaviour where it previously ruled wildcards out (status, configuration, constraints, fog-line, deferred).

The infrastructure side follows separately: the ECS task will set `https://demo.petrinaut.org,https://*.stage.hash.ai` once this is the deployed image, since today's image would refuse to start on a `*`.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] require changes to docs which **are made** as part of this PR

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph
