### PR TITLE
FE-1634: Deliver per-frame canvas values by subscription, and index the net

### DIFF
--- a/.changeset/canvas-frame-subscription.md
+++ b/.changeset/canvas-frame-subscription.md
@@ -1,0 +1,5 @@
+---
+"@hashintel/petrinaut": patch
+---
+
+Playback re-renders only the places and transitions whose values moved, so large nets play back several times faster.

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/canvas-focus.test.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/canvas-focus.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { generateArcId, getArcEndpointKey } from "@hashintel/petrinaut-core";
 
-import { buildCanvasFocus } from "./canvas-focus";
+import { buildNetAdjacency, resolveCanvasFocus } from "./canvas-focus";
 
 import type { ActiveNetDefinition } from "../../../react/state/active-net-context";
 import type { Place, Transition } from "@hashintel/petrinaut-core";
@@ -58,13 +58,15 @@ const t1ToP2 = generateArcId({ inputId: "t1", outputId: placeKey("p2") });
 const p2ToT2 = generateArcId({ inputId: placeKey("p2"), outputId: "t2" });
 const t2ToP1 = generateArcId({ inputId: "t2", outputId: placeKey("p1") });
 
-const focusOn = (id: string) =>
-  buildCanvasFocus({ net, hoveredId: id, selectedIds: new Set() });
+const adjacency = buildNetAdjacency(net);
 
-describe("buildCanvasFocus", () => {
+const focusOn = (id: string) =>
+  resolveCanvasFocus({ adjacency, hoveredId: id, selectedIds: new Set() });
+
+describe("resolveCanvasFocus", () => {
   it("focuses nothing when nothing is hovered or selected", () => {
-    const focus = buildCanvasFocus({
-      net,
+    const focus = resolveCanvasFocus({
+      adjacency,
       hoveredId: null,
       selectedIds: new Set(),
     });
@@ -97,11 +99,11 @@ describe("buildCanvasFocus", () => {
   it("marks a neighbour that is both a source and a sink as bidirectional", () => {
     // t1 consumes from p1 and produces into p1, so p1 is both upstream and
     // downstream of it.
-    const focus = buildCanvasFocus({
-      net: {
+    const focus = resolveCanvasFocus({
+      adjacency: buildNetAdjacency({
         ...net,
         transitions: [transition("t1", ["p1"], ["p1"])],
-      },
+      }),
       hoveredId: "t1",
       selectedIds: new Set(),
     });
@@ -118,8 +120,8 @@ describe("buildCanvasFocus", () => {
   });
 
   it("treats an arc between two focused nodes as part of the focus", () => {
-    const focus = buildCanvasFocus({
-      net,
+    const focus = resolveCanvasFocus({
+      adjacency,
       hoveredId: null,
       selectedIds: new Set(["p1", "t1"]),
     });
@@ -130,8 +132,8 @@ describe("buildCanvasFocus", () => {
   });
 
   it("takes its focus from the hover, keeping the selection ringed", () => {
-    const focus = buildCanvasFocus({
-      net,
+    const focus = resolveCanvasFocus({
+      adjacency,
       hoveredId: "t2",
       selectedIds: new Set(["t1"]),
     });
@@ -145,13 +147,31 @@ describe("buildCanvasFocus", () => {
   });
 
   it("focuses nothing when the selection names no canvas item", () => {
-    const focus = buildCanvasFocus({
-      net,
+    const focus = resolveCanvasFocus({
+      adjacency,
       hoveredId: null,
       selectedIds: new Set(["some-type-id"]),
     });
 
     expect(focus.active).toBe(false);
     expect(focus.nodeFocus("p1")).toBe("none");
+  });
+  it("indexes a node's neighbours once, for lookup", () => {
+    const index = buildNetAdjacency(net);
+
+    expect(index.canvasIds.has("t1")).toBe(true);
+    expect(index.canvasIds.has("some-type-id")).toBe(false);
+    expect(index.byNode.get("t1")?.upstream).toEqual(["p1"]);
+    expect(index.byNode.get("t1")?.downstream).toEqual(["p2"]);
+    expect(index.byNode.get("lonely")).toEqual({
+      upstream: [],
+      downstream: [],
+      incoming: [],
+      outgoing: [],
+    });
+    expect(index.arcEnds.get(t1ToP2)).toEqual({
+      sourceId: "t1",
+      targetId: "p2",
+    });
   });
 });

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/canvas-focus.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/canvas-focus.ts
@@ -17,7 +17,6 @@ import {
 } from "@hashintel/petrinaut-core";
 
 import type { ActiveNetDefinition } from "../../../react/state/active-net-context";
-import type { Transition } from "@hashintel/petrinaut-core";
 
 /**
  * Where a node sits relative to the focused item. An unrelated node has no
@@ -53,10 +52,131 @@ export type CanvasFocus = {
   arcFocus: (id: string) => CanvasArcFocus;
 };
 
-type CanvasFocusInput = {
-  net: ActiveNetDefinition;
+/** What one node is joined to, in token-flow direction. */
+type NodeAdjacency = {
+  /** Nodes feeding this one. */
+  upstream: string[];
+  /** Nodes this one feeds. */
+  downstream: string[];
+  /** Arcs carrying tokens into this one. */
+  incoming: string[];
+  /** Arcs carrying tokens out of it. */
+  outgoing: string[];
+};
+
+/**
+ * The net's shape, indexed for lookup.
+ *
+ * Built once per net and reused across renders, so resolving a focus costs
+ * the size of the neighbourhood rather than a walk over every transition and
+ * arc in the net.
+ */
+export type NetAdjacency = {
+  /** Every id the canvas draws: nodes and arcs. */
+  canvasIds: ReadonlySet<string>;
+  byNode: ReadonlyMap<string, NodeAdjacency>;
+  /** The nodes an arc joins, for a focus that lands on the arc itself. */
+  arcEnds: ReadonlyMap<string, { sourceId: string; targetId: string }>;
+};
+
+const emptyAdjacency = (): NodeAdjacency => ({
+  upstream: [],
+  downstream: [],
+  incoming: [],
+  outgoing: [],
+});
+
+/**
+ * Index one net. Walks its transitions once; every later question about a
+ * neighbourhood is a map lookup.
+ */
+export const buildNetAdjacency = (net: ActiveNetDefinition): NetAdjacency => {
+  const byNode = new Map<string, NodeAdjacency>();
+  const arcEnds = new Map<string, { sourceId: string; targetId: string }>();
+  const canvasIds = new Set<string>();
+
+  const entryFor = (id: string): NodeAdjacency => {
+    const existing = byNode.get(id);
+    if (existing) {
+      return existing;
+    }
+    const created = emptyAdjacency();
+    byNode.set(id, created);
+    return created;
+  };
+
+  for (const place of net.places) {
+    canvasIds.add(place.id);
+    entryFor(place.id);
+  }
+  for (const transition of net.transitions) {
+    canvasIds.add(transition.id);
+    entryFor(transition.id);
+  }
+  for (const instance of net.componentInstances) {
+    canvasIds.add(instance.id);
+    entryFor(instance.id);
+  }
+
+  const join = (arcId: string, sourceId: string, targetId: string) => {
+    canvasIds.add(arcId);
+    arcEnds.set(arcId, { sourceId, targetId });
+    const source = entryFor(sourceId);
+    const target = entryFor(targetId);
+    source.downstream.push(targetId);
+    source.outgoing.push(arcId);
+    target.upstream.push(sourceId);
+    target.incoming.push(arcId);
+  };
+
+  for (const transition of net.transitions) {
+    for (const inputArc of transition.inputArcs) {
+      const endpoint = getArcEndpoint(inputArc);
+      join(
+        generateArcId({
+          inputId: getArcEndpointKey(endpoint),
+          outputId: transition.id,
+        }),
+        getArcEndpointNodeId(endpoint),
+        transition.id,
+      );
+    }
+
+    for (const outputArc of transition.outputArcs) {
+      const endpoint = getArcEndpoint(outputArc);
+      join(
+        generateArcId({
+          inputId: transition.id,
+          outputId: getArcEndpointKey(endpoint),
+        }),
+        transition.id,
+        getArcEndpointNodeId(endpoint),
+      );
+    }
+  }
+
+  return { canvasIds, byNode, arcEnds };
+};
+
+const NOTHING_FOCUSED: CanvasFocus = {
+  active: false,
+  nodeFocus: () => "none",
+  arcFocus: () => "none",
+};
+
+/**
+ * The focus roles for one net, read off its index. Ids that name something
+ * off the canvas — a type or a parameter selected in the sidebar, say — focus
+ * nothing, so selecting one leaves the net drawn plainly.
+ */
+export const resolveCanvasFocus = ({
+  adjacency,
+  hoveredId,
+  selectedIds,
+}: {
+  adjacency: NetAdjacency;
   /**
-   * The hovered item, after the hover delay. Takes precedence over the
+   * The hovered item, once the pointer has settled. Takes precedence over the
    * selection, so pointing at a node previews its neighbourhood without
    * disturbing what is selected.
    */
@@ -67,74 +187,16 @@ type CanvasFocusInput = {
    * the user lose sight of what they have selected.
    */
   selectedIds: ReadonlySet<string>;
-};
-
-type DirectedArc = { id: string; sourceId: string; targetId: string };
-
-/** Every arc in token-flow direction: place → transition → place. */
-const directedArcs = (transitions: readonly Transition[]): DirectedArc[] => {
-  const arcs: DirectedArc[] = [];
-
-  for (const transition of transitions) {
-    for (const inputArc of transition.inputArcs) {
-      const endpoint = getArcEndpoint(inputArc);
-      arcs.push({
-        id: generateArcId({
-          inputId: getArcEndpointKey(endpoint),
-          outputId: transition.id,
-        }),
-        sourceId: getArcEndpointNodeId(endpoint),
-        targetId: transition.id,
-      });
-    }
-
-    for (const outputArc of transition.outputArcs) {
-      const endpoint = getArcEndpoint(outputArc);
-      arcs.push({
-        id: generateArcId({
-          inputId: transition.id,
-          outputId: getArcEndpointKey(endpoint),
-        }),
-        sourceId: transition.id,
-        targetId: getArcEndpointNodeId(endpoint),
-      });
+}): CanvasFocus => {
+  const selectedCanvasIds = new Set<string>();
+  for (const id of selectedIds) {
+    if (adjacency.canvasIds.has(id)) {
+      selectedCanvasIds.add(id);
     }
   }
 
-  return arcs;
-};
-
-const NOTHING_FOCUSED: CanvasFocus = {
-  active: false,
-  nodeFocus: () => "none",
-  arcFocus: () => "none",
-};
-
-/**
- * The focus roles for one net. Ids that name something off the canvas — a
- * type or a parameter selected in the sidebar, say — focus nothing, so
- * selecting one leaves the net drawn plainly.
- */
-export const buildCanvasFocus = ({
-  net,
-  hoveredId,
-  selectedIds,
-}: CanvasFocusInput): CanvasFocus => {
-  const arcs = directedArcs(net.transitions);
-
-  const canvasIds = new Set<string>([
-    ...net.places.map(({ id }) => id),
-    ...net.transitions.map(({ id }) => id),
-    ...net.componentInstances.map(({ id }) => id),
-    ...arcs.map(({ id }) => id),
-  ]);
-
-  const selectedCanvasIds = new Set(
-    [...selectedIds].filter((id) => canvasIds.has(id)),
-  );
-
   const focusIds =
-    hoveredId !== null && canvasIds.has(hoveredId)
+    hoveredId !== null && adjacency.canvasIds.has(hoveredId)
       ? new Set([hoveredId])
       : selectedCanvasIds;
 
@@ -142,29 +204,32 @@ export const buildCanvasFocus = ({
     return NOTHING_FOCUSED;
   }
 
-  const isFocused = (id: string) =>
-    focusIds.has(id) || selectedCanvasIds.has(id);
-
+  // Only the focused items are visited, so this costs the neighbourhood
+  // rather than the net.
   const upstream = new Set<string>();
   const downstream = new Set<string>();
   const incoming = new Set<string>();
   const outgoing = new Set<string>();
 
-  for (const arc of arcs) {
-    if (focusIds.has(arc.targetId)) {
-      upstream.add(arc.sourceId);
-      incoming.add(arc.id);
-    }
-    if (focusIds.has(arc.sourceId)) {
-      downstream.add(arc.targetId);
-      outgoing.add(arc.id);
+  for (const id of focusIds) {
+    const node = adjacency.byNode.get(id);
+    if (node) {
+      for (const other of node.upstream) upstream.add(other);
+      for (const other of node.downstream) downstream.add(other);
+      for (const arc of node.incoming) incoming.add(arc);
+      for (const arc of node.outgoing) outgoing.add(arc);
+      continue;
     }
     // A focused arc puts the nodes it joins either side of the focus.
-    if (focusIds.has(arc.id)) {
-      upstream.add(arc.sourceId);
-      downstream.add(arc.targetId);
+    const ends = adjacency.arcEnds.get(id);
+    if (ends) {
+      upstream.add(ends.sourceId);
+      downstream.add(ends.targetId);
     }
   }
+
+  const isFocused = (id: string) =>
+    focusIds.has(id) || selectedCanvasIds.has(id);
 
   return {
     active: true,

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/canvas-focus.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/canvas-focus.ts
@@ -79,13 +79,6 @@ export type NetAdjacency = {
   arcEnds: ReadonlyMap<string, { sourceId: string; targetId: string }>;
 };
 
-const emptyAdjacency = (): NodeAdjacency => ({
-  upstream: [],
-  downstream: [],
-  incoming: [],
-  outgoing: [],
-});
-
 /**
  * Index one net. Walks its transitions once; every later question about a
  * neighbourhood is a map lookup.
@@ -100,7 +93,12 @@ export const buildNetAdjacency = (net: ActiveNetDefinition): NetAdjacency => {
     if (existing) {
       return existing;
     }
-    const created = emptyAdjacency();
+    const created: NodeAdjacency = {
+      upstream: [],
+      downstream: [],
+      incoming: [],
+      outgoing: [],
+    };
     byNode.set(id, created);
     return created;
   };

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/canvas-frame-store.test.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/canvas-frame-store.test.tsx
@@ -107,17 +107,26 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe("CanvasFrameStoreProvider", () => {
-  it("shows the initial marking before a run, and no badge outside simulate mode", () => {
+  it("shows the initial marking before a run, from the first paint", () => {
     const marking: InitialMarking = { p1: 3, p2: [{ value: 1 }, { value: 2 }] };
-    const { rerender } = render(
-      canvas({ globalMode: "edit", initialMarking: marking }),
-    );
-    expect(shown("p1")).toBe("none");
-    expect(shown("t1")).toBe("none");
+    render(canvas({ globalMode: "simulate", initialMarking: marking }));
 
-    rerender(canvas({ globalMode: "simulate", initialMarking: marking }));
     expect(shown("p1")).toBe("3");
     expect(shown("p2")).toBe("2");
+    expect(shown("t1")).toBe("none");
+    // The first render already read the marking, so the store's first
+    // publication changed nothing and caused no second render.
+    expect(renders.get("p1")).toBe(1);
+  });
+
+  it("shows no badge outside simulate mode", () => {
+    const { rerender } = render(
+      canvas({ globalMode: "simulate", initialMarking: { p1: 3 } }),
+    );
+    expect(shown("p1")).toBe("3");
+
+    rerender(canvas({ globalMode: "edit", initialMarking: { p1: 3 } }));
+    expect(shown("p1")).toBe("none");
   });
 
   it("follows the viewed frame", () => {

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/canvas-frame-store.test.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/canvas-frame-store.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  emptyExecutionFrameSource,
+  ExecutionFrameSourceContext,
+} from "../../../react/execution-frame/context";
+import { SimulationContext } from "../../../react/simulation/context";
+import { EditorContext } from "../../../react/state/editor-context";
+import {
+  CanvasFrameStoreProvider,
+  usePlaceTokenCount,
+  useTransitionFrame,
+} from "./canvas-frame-store";
+
+import type { ExecutionFrameSource } from "../../../react/execution-frame/context";
+import type {
+  InitialMarking,
+  SimulationContextValue,
+  SimulationFrameReader,
+} from "../../../react/simulation/context";
+import type { EditorContextValue } from "../../../react/state/editor-context";
+
+const renders = new Map<string, number>();
+const countRender = (key: string) =>
+  renders.set(key, (renders.get(key) ?? 0) + 1);
+
+const Tokens: React.FC<{ placeId: string }> = ({ placeId }) => {
+  countRender(placeId);
+  const tokens = usePlaceTokenCount(placeId);
+  return <output data-testid={placeId}>{tokens ?? "none"}</output>;
+};
+
+const Firings: React.FC<{ transitionId: string }> = ({ transitionId }) => {
+  countRender(transitionId);
+  const frame = useTransitionFrame(transitionId);
+  return (
+    <output data-testid={transitionId}>{frame?.firingCount ?? "none"}</output>
+  );
+};
+
+/**
+ * Made once, so the provider hands the same element down on every frame, as
+ * the view does. The items re-render only when the store tells them to.
+ */
+const items = (
+  <>
+    <Tokens placeId="p1" />
+    <Tokens placeId="p2" />
+    <Firings transitionId="t1" />
+  </>
+);
+
+/** A frame in which each transition has fired the given number of times. */
+const frame = (
+  tokens: Record<string, number>,
+  firingCounts: Record<string, number>,
+): Partial<ExecutionFrameSource> => ({
+  totalFrames: 1,
+  currentViewedFrame: {
+    number: 0,
+    places: Object.fromEntries(
+      Object.entries(tokens).map(([placeId, tokenCount]) => [
+        placeId,
+        { tokenCount },
+      ]),
+    ),
+  },
+  currentFrameReader: {
+    getTransitionState: (transitionId: string) => ({
+      firingCount: firingCounts[transitionId] ?? 0,
+      firedInThisFrame: false,
+      timeSinceLastFiringMs: 0,
+    }),
+  } as unknown as SimulationFrameReader,
+});
+
+const canvas = ({
+  source = {},
+  globalMode = "simulate",
+  initialMarking = {},
+}: {
+  source?: Partial<ExecutionFrameSource>;
+  globalMode?: EditorContextValue["globalMode"];
+  initialMarking?: InitialMarking;
+}) => (
+  <ExecutionFrameSourceContext
+    value={{ ...emptyExecutionFrameSource, ...source }}
+  >
+    <SimulationContext value={{ initialMarking } as SimulationContextValue}>
+      <EditorContext value={{ globalMode } as EditorContextValue}>
+        <CanvasFrameStoreProvider>{items}</CanvasFrameStoreProvider>
+      </EditorContext>
+    </SimulationContext>
+  </ExecutionFrameSourceContext>
+);
+
+const shown = (testId: string) => screen.getByTestId(testId).textContent;
+
+beforeEach(() => {
+  renders.clear();
+});
+
+afterEach(cleanup);
+
+describe("CanvasFrameStoreProvider", () => {
+  it("shows the initial marking before a run, and no badge outside simulate mode", () => {
+    const marking: InitialMarking = { p1: 3, p2: [{ value: 1 }, { value: 2 }] };
+    const { rerender } = render(
+      canvas({ globalMode: "edit", initialMarking: marking }),
+    );
+    expect(shown("p1")).toBe("none");
+    expect(shown("t1")).toBe("none");
+
+    rerender(canvas({ globalMode: "simulate", initialMarking: marking }));
+    expect(shown("p1")).toBe("3");
+    expect(shown("p2")).toBe("2");
+  });
+
+  it("follows the viewed frame", () => {
+    const { rerender } = render(canvas({}));
+
+    rerender(canvas({ source: frame({ p1: 5 }, { t1: 2 }) }));
+    expect(shown("p1")).toBe("5");
+    expect(shown("p2")).toBe("none");
+    expect(shown("t1")).toBe("2");
+  });
+
+  it("re-renders only the items whose values moved", () => {
+    const { rerender } = render(
+      canvas({ source: frame({ p1: 1, p2: 1 }, { t1: 0 }) }),
+    );
+    const before = new Map(renders);
+    const rendersSince = (key: string) =>
+      (renders.get(key) ?? 0) - (before.get(key) ?? 0);
+
+    rerender(canvas({ source: frame({ p1: 2, p2: 1 }, { t1: 1 }) }));
+    expect(shown("p1")).toBe("2");
+    expect(shown("t1")).toBe("1");
+    expect(rendersSince("p1")).toBe(1);
+    expect(rendersSince("p2")).toBe(0);
+    expect(rendersSince("t1")).toBe(1);
+
+    // The same values again, in a new frame: nothing on the canvas moves.
+    rerender(canvas({ source: frame({ p1: 2, p2: 1 }, { t1: 1 }) }));
+    expect(rendersSince("p1")).toBe(1);
+    expect(rendersSince("p2")).toBe(0);
+    expect(rendersSince("t1")).toBe(1);
+  });
+});

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/canvas-frame-store.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/canvas-frame-store.tsx
@@ -2,12 +2,10 @@
  * Per-frame values for the canvas, delivered by subscription rather than by
  * rebuilding the scene.
  *
- * A playback frame moves one number per place and one per transition. Those
- * used to ride on the React Flow node data, so a frame rebuilt every node and
- * arc and re-rendered the lot to move a handful of numbers. Here the values
- * live in a store whose identity never changes: the provider re-renders as
- * frames arrive, its `children` element does not, and an item subscribes to
- * its own value and re-renders only when that value moves.
+ * A playback frame moves one number per place and one per transition. The
+ * values live in a store whose identity never changes: the provider
+ * re-renders as frames arrive, its `children` element does not, and an item
+ * subscribes to its own value and re-renders only when that value moves.
  */
 
 import {
@@ -46,7 +44,7 @@ const EMPTY_SNAPSHOT: FrameSnapshot = {
   framesAvailable: false,
 };
 
-export type CanvasFrameStore = {
+type CanvasFrameStore = {
   subscribe: (listener: () => void) => () => void;
   /** Tokens to show on a place, or null for no badge. */
   getTokenCount: (placeId: string) => number | null;
@@ -69,11 +67,7 @@ const sameTransitionState = (
   right: TransitionFrameState | null,
 ): boolean =>
   left === right ||
-  (left !== null &&
-    right !== null &&
-    left.firingCount === right.firingCount &&
-    left.firedInThisFrame === right.firedInThisFrame &&
-    left.timeSinceLastFiringMs === right.timeSinceLastFiringMs);
+  (left !== null && right !== null && left.firingCount === right.firingCount);
 
 /**
  * Reads the frame source and publishes it to the canvas.
@@ -94,8 +88,8 @@ export const CanvasFrameStoreProvider: React.FC<React.PropsWithChildren> = ({
   const listeners = useRef(new Set<() => void>());
   /**
    * Read through on demand, so a frame costs the transitions actually
-   * mounted. Each entry is kept while its content holds, so a transition that
-   * did not move keeps its value and does not re-render.
+   * mounted. Each entry is kept while its firing count holds, so a transition
+   * that did not fire keeps its value and does not re-render.
    */
   const transitionCache = useRef(
     new Map<string, TransitionFrameState | null>(),
@@ -153,7 +147,7 @@ export const CanvasFrameStoreProvider: React.FC<React.PropsWithChildren> = ({
     };
 
     // Re-read each transition that is mounted, and keep the previous value
-    // where the transition did not move, so only what changed re-renders.
+    // where the transition did not fire, so only what changed re-renders.
     const cache = transitionCache.current;
     for (const [transitionId, previous] of cache) {
       const next = currentFrameReader?.getTransitionState(transitionId) ?? null;

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/canvas-frame-store.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/canvas-frame-store.tsx
@@ -1,0 +1,212 @@
+/**
+ * Per-frame values for the canvas, delivered by subscription rather than by
+ * rebuilding the scene.
+ *
+ * A playback frame moves one number per place and one per transition. Those
+ * used to ride on the React Flow node data, so a frame rebuilt every node and
+ * arc and re-rendered the lot to move a handful of numbers. Here the values
+ * live in a store whose identity never changes: the provider re-renders as
+ * frames arrive, its `children` element does not, and an item subscribes to
+ * its own value and re-renders only when that value moves.
+ */
+
+import {
+  createContext,
+  use,
+  useEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
+
+import { ExecutionFrameSourceContext } from "../../../react/execution-frame/context";
+import { SimulationContext } from "../../../react/simulation/context";
+import { EditorContext } from "../../../react/state/editor-context";
+
+import type {
+  InitialMarking,
+  SimulationFrameReader,
+  SimulationFrameState,
+} from "../../../react/simulation/context";
+import type { TransitionFrameState } from "./renderers/react-flow/react-flow-canvas/react-flow-types";
+
+type FrameSnapshot = {
+  reader: SimulationFrameReader | null;
+  viewedFrame: SimulationFrameState | null;
+  initialMarking: InitialMarking;
+  simulateMode: boolean;
+  framesAvailable: boolean;
+};
+
+const EMPTY_SNAPSHOT: FrameSnapshot = {
+  reader: null,
+  viewedFrame: null,
+  initialMarking: {},
+  simulateMode: false,
+  framesAvailable: false,
+};
+
+export type CanvasFrameStore = {
+  subscribe: (listener: () => void) => () => void;
+  /** Tokens to show on a place, or null for no badge. */
+  getTokenCount: (placeId: string) => number | null;
+  /** A transition's state in the viewed frame, or null when no run exists. */
+  getTransitionFrame: (transitionId: string) => TransitionFrameState | null;
+  getFramesAvailable: () => boolean;
+};
+
+const EMPTY_STORE: CanvasFrameStore = {
+  subscribe: () => () => {},
+  getTokenCount: () => null,
+  getTransitionFrame: () => null,
+  getFramesAvailable: () => false,
+};
+
+const CanvasFrameStoreContext = createContext<CanvasFrameStore>(EMPTY_STORE);
+
+const sameTransitionState = (
+  left: TransitionFrameState | null,
+  right: TransitionFrameState | null,
+): boolean =>
+  left === right ||
+  (left !== null &&
+    right !== null &&
+    left.firingCount === right.firingCount &&
+    left.firedInThisFrame === right.firedInThisFrame &&
+    left.timeSinceLastFiringMs === right.timeSinceLastFiringMs);
+
+/**
+ * Reads the frame source and publishes it to the canvas.
+ *
+ * This component re-renders on every frame; the canvas below it does not,
+ * because `children` arrives as an element its own parent already made.
+ */
+export const CanvasFrameStoreProvider: React.FC<React.PropsWithChildren> = ({
+  children,
+}) => {
+  const { currentViewedFrame, currentFrameReader, totalFrames } = use(
+    ExecutionFrameSourceContext,
+  );
+  const { initialMarking } = use(SimulationContext);
+  const { globalMode } = use(EditorContext);
+
+  const snapshot = useRef<FrameSnapshot>(EMPTY_SNAPSHOT);
+  const listeners = useRef(new Set<() => void>());
+  /**
+   * Read through on demand, so a frame costs the transitions actually
+   * mounted. Each entry is kept while its content holds, so a transition that
+   * did not move keeps its value and does not re-render.
+   */
+  const transitionCache = useRef(
+    new Map<string, TransitionFrameState | null>(),
+  );
+
+  const [store] = useState<CanvasFrameStore>(() => ({
+    subscribe: (listener) => {
+      listeners.current.add(listener);
+      return () => {
+        listeners.current.delete(listener);
+      };
+    },
+
+    getTokenCount: (placeId) => {
+      const {
+        viewedFrame,
+        simulateMode,
+        initialMarking: marking,
+      } = snapshot.current;
+      if (viewedFrame) {
+        return viewedFrame.places[placeId]?.tokenCount ?? null;
+      }
+      if (!simulateMode) {
+        return null;
+      }
+      const placeMarking = marking[placeId];
+      return typeof placeMarking === "number"
+        ? placeMarking
+        : (placeMarking?.length ?? 0);
+    },
+
+    getTransitionFrame: (transitionId) => {
+      const cache = transitionCache.current;
+      if (cache.has(transitionId)) {
+        return cache.get(transitionId) ?? null;
+      }
+      const state =
+        snapshot.current.reader?.getTransitionState(transitionId) ?? null;
+      cache.set(transitionId, state);
+      return state;
+    },
+
+    getFramesAvailable: () => snapshot.current.framesAvailable,
+  }));
+
+  // Publishing happens after the commit, so a subscriber re-reads a store the
+  // rest of the tree has already seen.
+  useEffect(() => {
+    snapshot.current = {
+      reader: currentFrameReader,
+      viewedFrame: currentViewedFrame,
+      initialMarking,
+      simulateMode: globalMode === "simulate",
+      framesAvailable: totalFrames > 0,
+    };
+
+    // Re-read each transition that is mounted, and keep the previous value
+    // where the transition did not move, so only what changed re-renders.
+    const cache = transitionCache.current;
+    for (const [transitionId, previous] of cache) {
+      const next = currentFrameReader?.getTransitionState(transitionId) ?? null;
+      cache.set(
+        transitionId,
+        sameTransitionState(previous, next) ? previous : next,
+      );
+    }
+
+    for (const listener of listeners.current) {
+      listener();
+    }
+  }, [
+    currentViewedFrame,
+    currentFrameReader,
+    totalFrames,
+    initialMarking,
+    globalMode,
+  ]);
+
+  return (
+    <CanvasFrameStoreContext value={store}>{children}</CanvasFrameStoreContext>
+  );
+};
+
+/** The tokens to show on one place, without re-rendering the canvas. */
+export const usePlaceTokenCount = (placeId: string): number | null => {
+  const store = use(CanvasFrameStoreContext);
+  return useSyncExternalStore(
+    store.subscribe,
+    () => store.getTokenCount(placeId),
+    () => null,
+  );
+};
+
+/** One transition's frame state, without re-rendering the canvas. */
+export const useTransitionFrame = (
+  transitionId: string,
+): TransitionFrameState | null => {
+  const store = use(CanvasFrameStoreContext);
+  return useSyncExternalStore(
+    store.subscribe,
+    () => store.getTransitionFrame(transitionId),
+    () => null,
+  );
+};
+
+/** Whether any frame exists to visualize. */
+export const useFramesAvailable = (): boolean => {
+  const store = use(CanvasFrameStoreContext);
+  return useSyncExternalStore(
+    store.subscribe,
+    store.getFramesAvailable,
+    () => false,
+  );
+};

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/canvas-frame-store.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/canvas-frame-store.tsx
@@ -36,14 +36,6 @@ type FrameSnapshot = {
   framesAvailable: boolean;
 };
 
-const EMPTY_SNAPSHOT: FrameSnapshot = {
-  reader: null,
-  viewedFrame: null,
-  initialMarking: {},
-  simulateMode: false,
-  framesAvailable: false,
-};
-
 type CanvasFrameStore = {
   subscribe: (listener: () => void) => () => void;
   /** Tokens to show on a place, or null for no badge. */
@@ -84,7 +76,15 @@ export const CanvasFrameStoreProvider: React.FC<React.PropsWithChildren> = ({
   const { initialMarking } = use(SimulationContext);
   const { globalMode } = use(EditorContext);
 
-  const snapshot = useRef<FrameSnapshot>(EMPTY_SNAPSHOT);
+  // Filled on the first render, so the first paint already carries the
+  // marking and the viewed frame rather than gaining them a frame later.
+  const snapshot = useRef<FrameSnapshot>({
+    reader: currentFrameReader,
+    viewedFrame: currentViewedFrame,
+    initialMarking,
+    simulateMode: globalMode === "simulate",
+    framesAvailable: totalFrames > 0,
+  });
   const listeners = useRef(new Set<() => void>());
   /**
    * Read through on demand, so a frame costs the transitions actually

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/canvas-scene.test.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/canvas-scene.test.ts
@@ -7,7 +7,7 @@ import {
   getArcEndpointKey,
 } from "@hashintel/petrinaut-core";
 
-import { buildCanvasFocus } from "./canvas-focus";
+import { buildNetAdjacency, resolveCanvasFocus } from "./canvas-focus";
 import { buildCanvasScene, type CanvasSceneInput } from "./canvas-scene";
 
 import type { Place, SDCPN, Transition } from "@hashintel/petrinaut-core";
@@ -63,8 +63,8 @@ const input: CanvasSceneInput = {
   draggingStateByNodeId: {},
   isSelected: () => false,
   hoveredId: null,
-  focus: buildCanvasFocus({
-    net: { ...sdcpn, componentInstances: [] },
+  focus: resolveCanvasFocus({
+    adjacency: buildNetAdjacency({ ...sdcpn, componentInstances: [] }),
     hoveredId: null,
     selectedIds: new Set(),
   }),
@@ -107,8 +107,8 @@ describe("buildCanvasScene", () => {
       ...input,
       isSelected: (id) => id === "p1",
       hoveredId: "t1",
-      focus: buildCanvasFocus({
-        net: input.net,
+      focus: resolveCanvasFocus({
+        adjacency: buildNetAdjacency(input.net),
         hoveredId: "t1",
         selectedIds: new Set(["p1"]),
       }),

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/arc.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/arc.tsx
@@ -10,6 +10,7 @@ import { type CSSProperties, use, useEffect, useRef } from "react";
 import { css } from "@hashintel/ds-helpers/css";
 
 import { UserSettingsContext } from "../../../../../../react/state/user-settings-context";
+import { useTransitionFrame } from "../../../canvas-frame-store";
 import { useFiringDelta } from "../../../hooks/use-firing-delta";
 import {
   ARC_HALO_OVERHANG,
@@ -289,7 +290,8 @@ export const Arc: React.FC<EdgeProps<ArcEdgeType>> = ({
   const readMarkerId = `read-dot-${id}`;
 
   // Track firing count delta for simulation visualization
-  const firingDelta = useFiringDelta(data?.frame?.firingCount ?? null);
+  const frame = useTransitionFrame(data?.transitionId ?? "");
+  const firingDelta = useFiringDelta(frame?.firingCount ?? null);
 
   // Ref for the main arc path to animate stroke width
   const arcPathRef = useRef<SVGPathElement | null>(null);

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/classic-place-node.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/classic-place-node.tsx
@@ -4,6 +4,10 @@ import { Icon } from "@hashintel/ds-components";
 import { css } from "@hashintel/ds-helpers/css";
 
 import { splitPascalCase } from "../../../../../lib/split-pascal-case";
+import {
+  useFramesAvailable,
+  usePlaceTokenCount,
+} from "../../../canvas-frame-store";
 import { nodeFocusStyle } from "../../../styles/focus";
 import { handleStyling } from "../../../styles/styling";
 import { placeBorderColor, placeFillColor } from "../../../styles/type-colors";
@@ -82,10 +86,10 @@ export const ClassicPlaceNode: React.FC<NodeProps<PlaceNodeType>> = ({
   isConnectable,
   selected,
 }: NodeProps<PlaceNodeType>) => {
-  // The token count and whether any frame exists ride on the node: a place
-  // that read them from the frame source would re-render on every playback
-  // frame, whether or not its own count moved.
-  const { tokenCount, framesAvailable } = data;
+  // Subscribed rather than carried on the node, so a frame re-renders this
+  // place only when its own count moves.
+  const tokenCount = usePlaceTokenCount(id);
+  const framesAvailable = useFramesAvailable();
 
   // Show the visualizer on hover for places with a visualizer during simulation.
   const showStateTooltip =

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/classic-place-node.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/classic-place-node.tsx
@@ -86,8 +86,7 @@ export const ClassicPlaceNode: React.FC<NodeProps<PlaceNodeType>> = ({
   isConnectable,
   selected,
 }: NodeProps<PlaceNodeType>) => {
-  // Subscribed rather than carried on the node, so a frame re-renders this
-  // place only when its own count moves.
+  // A frame re-renders this place only when its own count moves.
   const tokenCount = usePlaceTokenCount(id);
   const framesAvailable = useFramesAvailable();
 

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/classic-transition-node.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/classic-transition-node.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef } from "react";
 import { Icon } from "@hashintel/ds-components";
 import { css } from "@hashintel/ds-helpers/css";
 
+import { useTransitionFrame } from "../../../canvas-frame-store";
 import { useFiringDelta } from "../../../hooks/use-firing-delta";
 import { nodeFocusStyle } from "../../../styles/focus";
 import { handleStyling } from "../../../styles/styling";
@@ -130,6 +131,7 @@ function useFiringAnimation(
 }
 
 export const ClassicTransitionNode: React.FC<NodeProps<TransitionNodeType>> = ({
+  id,
   data,
   isConnectable,
   selected,
@@ -141,7 +143,8 @@ export const ClassicTransitionNode: React.FC<NodeProps<TransitionNodeType>> = ({
   const boltRef = useRef<HTMLDivElement | null>(null);
 
   // Track firing count delta for simulation visualization
-  const firingDelta = useFiringDelta(data.frame?.firingCount ?? null);
+  const frame = useTransitionFrame(id);
+  const firingDelta = useFiringDelta(frame?.firingCount ?? null);
 
   // Animate when firing occurs
   useFiringAnimation(boxRef, boltRef, firingDelta);

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/place-node.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/place-node.tsx
@@ -54,8 +54,7 @@ export const PlaceNode: React.FC<NodeProps<PlaceNodeType>> = ({
   isConnectable,
   selected,
 }: NodeProps<PlaceNodeType>) => {
-  // Subscribed rather than carried on the node, so a frame re-renders this
-  // place only when its own count moves.
+  // A frame re-renders this place only when its own count moves.
   const tokenCount = usePlaceTokenCount(id);
   const framesAvailable = useFramesAvailable();
 

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/place-node.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/place-node.tsx
@@ -1,6 +1,10 @@
 import { Icon } from "@hashintel/ds-components";
 import { css } from "@hashintel/ds-helpers/css";
 
+import {
+  useFramesAvailable,
+  usePlaceTokenCount,
+} from "../../../canvas-frame-store";
 import { nodeFocusStyle } from "../../../styles/focus";
 import { placeBorderColor, placeFillColor } from "../../../styles/type-colors";
 import {
@@ -50,10 +54,10 @@ export const PlaceNode: React.FC<NodeProps<PlaceNodeType>> = ({
   isConnectable,
   selected,
 }: NodeProps<PlaceNodeType>) => {
-  // The token count and whether any frame exists ride on the node: a place
-  // that read them from the frame source would re-render on every playback
-  // frame, whether or not its own count moved.
-  const { tokenCount, framesAvailable } = data;
+  // Subscribed rather than carried on the node, so a frame re-renders this
+  // place only when its own count moves.
+  const tokenCount = usePlaceTokenCount(id);
+  const framesAvailable = useFramesAvailable();
 
   // Show the visualizer on hover for places with a visualizer during simulation.
   const showStateTooltip =

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/react-flow-types.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/react-flow-types.ts
@@ -16,24 +16,9 @@ export type TransitionFrameState = NonNullable<
   ReturnType<SimulationFrameReader["getTransitionState"]>
 >;
 
-export type PlaceNodeData = CanvasPlaceNode & {
-  /**
-   * Tokens in the viewed frame, or the initial marking before a run. Null
-   * hides the badge. Carried on the node so a place does not subscribe to a
-   * frame source that changes on every playback frame.
-   */
-  tokenCount: number | null;
-  /** Whether any frame exists to visualize. */
-  framesAvailable: boolean;
-};
+export type PlaceNodeData = CanvasPlaceNode;
 
-export type TransitionNodeData = CanvasTransitionNode & {
-  /**
-   * State of this transition in the current simulation frame.
-   * Null when no simulation is running.
-   */
-  frame: TransitionFrameState | null;
-};
+export type TransitionNodeData = CanvasTransitionNode;
 
 export type ComponentInstanceNodeData = CanvasComponentInstanceNode;
 
@@ -51,12 +36,9 @@ export type NodeType =
   | PlaceNodeType
   | ComponentInstanceNodeType;
 
-export type ArcData = Pick<CanvasArc, "kind" | "weight" | "focus"> & {
-  /**
-   * State of the transition connected to this arc in the current simulation frame.
-   * Null when no simulation is running.
-   */
-  frame: TransitionFrameState | null;
-};
+export type ArcData = Pick<
+  CanvasArc,
+  "kind" | "weight" | "focus" | "transitionId"
+>;
 
 export type ArcEdgeType = Edge<ArcData>;

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/transition-node.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/transition-node.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef } from "react";
 import { Icon } from "@hashintel/ds-components";
 import { css } from "@hashintel/ds-helpers/css";
 
+import { useTransitionFrame } from "../../../canvas-frame-store";
 import { useFiringDelta } from "../../../hooks/use-firing-delta";
 import { nodeFocusStyle } from "../../../styles/focus";
 import {
@@ -99,6 +100,7 @@ function useFiringAnimation(
 }
 
 export const TransitionNode: React.FC<NodeProps<TransitionNodeType>> = ({
+  id,
   data,
   isConnectable,
   selected,
@@ -110,7 +112,8 @@ export const TransitionNode: React.FC<NodeProps<TransitionNodeType>> = ({
   const boltRef = useRef<HTMLDivElement | null>(null);
 
   // Track firing count delta for simulation visualization
-  const firingDelta = useFiringDelta(data.frame?.firingCount ?? null);
+  const frame = useTransitionFrame(id);
+  const firingDelta = useFiringDelta(frame?.firingCount ?? null);
 
   // Animate when firing occurs
   useFiringAnimation(boxRef, boltRef, firingDelta);

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/use-react-flow-elements.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/use-react-flow-elements.ts
@@ -1,55 +1,16 @@
 import { MarkerType } from "@xyflow/react";
-import { use } from "react";
 
-import { ExecutionFrameSourceContext } from "../../../../../../react/execution-frame/context";
-import { SimulationContext } from "../../../../../../react/simulation/context";
-import { EditorContext } from "../../../../../../react/state/editor-context";
 import { arcHaloColor } from "../../../styles/focus";
 import { useStableItems } from "../../../use-stable-items";
 import { portInHandleId, portOutHandleId } from "./port-handles";
 
-import type {
-  InitialMarking,
-  SimulationFrameReader,
-  SimulationFrameState,
-} from "../../../../../../react/simulation/context";
 import type { CanvasArc, CanvasNode, CanvasScene } from "../../../canvas-scene";
 import type { ArcEdgeType, NodeType } from "./react-flow-types";
 
 const ARC_STROKE_WIDTH = 2;
 const ARC_MARKER_SIZE = 20;
 
-/**
- * What a place shows in its badge: the viewed frame's count, or the initial
- * marking while simulate mode waits for a run. Null hides the badge.
- *
- * Read here rather than in the place component: the frame source changes on
- * every playback frame, so a place that subscribed to it would re-render on
- * every frame whether or not its own count moved.
- */
-const placeTokenCount = (
-  placeId: string,
-  frame: FrameContext,
-): number | null => {
-  if (frame.viewedFrame) {
-    return frame.viewedFrame.places[placeId]?.tokenCount ?? null;
-  }
-  if (!frame.simulateMode) {
-    return null;
-  }
-  const marking = frame.initialMarking[placeId];
-  return typeof marking === "number" ? marking : (marking?.length ?? 0);
-};
-
-type FrameContext = {
-  reader: SimulationFrameReader | null;
-  viewedFrame: SimulationFrameState | null;
-  framesAvailable: boolean;
-  initialMarking: InitialMarking;
-  simulateMode: boolean;
-};
-
-const toReactFlowNode = (node: CanvasNode, frame: FrameContext): NodeType => {
+const toReactFlowNode = (node: CanvasNode): NodeType => {
   const size = { width: node.width, height: node.height };
   const common = {
     // Only a node carrying a role is marked, so the pane can mute the rest
@@ -64,33 +25,15 @@ const toReactFlowNode = (node: CanvasNode, frame: FrameContext): NodeType => {
   };
   switch (node.kind) {
     case "place":
-      return {
-        ...common,
-        type: "place",
-        data: {
-          ...node,
-          tokenCount: placeTokenCount(node.id, frame),
-          framesAvailable: frame.framesAvailable,
-        },
-      };
+      return { ...common, type: "place", data: node };
     case "transition":
-      return {
-        ...common,
-        type: "transition",
-        data: {
-          ...node,
-          frame: frame.reader?.getTransitionState(node.id) ?? null,
-        },
-      };
+      return { ...common, type: "transition", data: node };
     case "componentInstance":
       return { ...common, type: "componentInstance", data: node };
   }
 };
 
-const toReactFlowEdge = (
-  arc: CanvasArc,
-  frameReader: SimulationFrameReader | null,
-): ArcEdgeType => {
+const toReactFlowEdge = (arc: CanvasArc): ArcEdgeType => {
   const color = arc.color;
   // The casing cannot wrap the arrowhead, so the arrowhead takes its colour:
   // the cased arc then runs into a head of the same colour rather than
@@ -123,38 +66,23 @@ const toReactFlowEdge = (
       kind: arc.kind,
       weight: arc.weight,
       focus: arc.focus,
-      frame: frameReader?.getTransitionState(arc.transitionId) ?? null,
+      transitionId: arc.transitionId,
     },
   };
 };
 
 /**
- * The scene as React Flow nodes and edges. React Flow keeps its own copy of
- * both, so these are rebuilt on every render and reconciled by id.
+ * The scene as React Flow nodes and edges. No per-frame value rides here: a
+ * place's token count and a transition's firing state reach them by
+ * subscription, so a playback frame leaves this list untouched.
  */
 export const useReactFlowElements = (
   scene: CanvasScene,
 ): { nodes: NodeType[]; edges: ArcEdgeType[] } => {
-  const { currentFrameReader, currentViewedFrame, totalFrames } = use(
-    ExecutionFrameSourceContext,
-  );
-  const { initialMarking } = use(SimulationContext);
-  const { globalMode } = use(EditorContext);
-  const frame: FrameContext = {
-    reader: currentFrameReader,
-    viewedFrame: currentViewedFrame,
-    framesAvailable: totalFrames > 0,
-    initialMarking,
-    simulateMode: globalMode === "simulate",
-  };
   // Rebuilt from the scene, then held at their previous identity where
   // nothing changed, so React Flow re-renders only what a hover touched.
   return {
-    nodes: useStableItems(
-      scene.nodes.map((node) => toReactFlowNode(node, frame)),
-    ),
-    edges: useStableItems(
-      scene.arcs.map((arc) => toReactFlowEdge(arc, currentFrameReader)),
-    ),
+    nodes: useStableItems(scene.nodes.map(toReactFlowNode)),
+    edges: useStableItems(scene.arcs.map(toReactFlowEdge)),
   };
 };

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/sdcpn-view.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/sdcpn-view.tsx
@@ -8,6 +8,7 @@ import { use, useRef } from "react";
 import { css } from "@hashintel/ds-helpers/css";
 
 import { SDCPNContext } from "../../../react/state/sdcpn-context";
+import { CanvasFrameStoreProvider } from "./canvas-frame-store";
 import { canvasRenderers, defaultCanvasRenderer } from "./canvas-renderers";
 import { CursorTooltip } from "./components/cursor-tooltip";
 import { useContainerSize } from "./hooks/util/use-container-size";
@@ -45,12 +46,19 @@ export const SDCPNView: React.FC<{
   return (
     <div ref={canvasContainer} className={canvasContainerStyle}>
       {containerSize && (
-        <Renderer
-          key={petriNetId}
-          scene={scene}
-          containerSize={containerSize}
-          viewportActions={viewportActions}
-        />
+        /*
+          The store re-renders as frames arrive; the renderer below it does
+          not, because this element is made here and handed down unchanged.
+          That is what keeps a playback frame off the canvas's render path.
+        */
+        <CanvasFrameStoreProvider>
+          <Renderer
+            key={petriNetId}
+            scene={scene}
+            containerSize={containerSize}
+            viewportActions={viewportActions}
+          />
+        </CanvasFrameStoreProvider>
       )}
       <CursorTooltip />
     </div>

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/sdcpn-view.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/sdcpn-view.tsx
@@ -46,11 +46,6 @@ export const SDCPNView: React.FC<{
   return (
     <div ref={canvasContainer} className={canvasContainerStyle}>
       {containerSize && (
-        /*
-          The store re-renders as frames arrive; the renderer below it does
-          not, because this element is made here and handed down unchanged.
-          That is what keeps a playback frame off the canvas's render path.
-        */
         <CanvasFrameStoreProvider>
           <Renderer
             key={petriNetId}

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/sdcpn-view.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/sdcpn-view.tsx
@@ -28,8 +28,9 @@ const canvasContainerStyle = css({
  * SDCPNView builds the renderer-agnostic scene for the active net and hands
  * it to the active canvas renderer. It measures the canvas container and only
  * mounts the renderer once the size is known, so the net renders centered
- * from its very first frame. Switching to another net remounts the renderer,
- * centering it on the new net.
+ * from its very first frame. Switching to another net remounts the frame
+ * store and the renderer under it, so the store holds only the new net's
+ * transitions and the renderer centers on the new net.
  */
 export const SDCPNView: React.FC<{
   viewportActions?: ViewportAction[];
@@ -46,9 +47,8 @@ export const SDCPNView: React.FC<{
   return (
     <div ref={canvasContainer} className={canvasContainerStyle}>
       {containerSize && (
-        <CanvasFrameStoreProvider>
+        <CanvasFrameStoreProvider key={petriNetId}>
           <Renderer
-            key={petriNetId}
             scene={scene}
             containerSize={containerSize}
             viewportActions={viewportActions}

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/use-canvas-scene.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/use-canvas-scene.ts
@@ -9,7 +9,7 @@ import { ActiveNetContext } from "../../../react/state/active-net-context";
 import { EditorContext } from "../../../react/state/editor-context";
 import { SDCPNContext } from "../../../react/state/sdcpn-context";
 import { UserSettingsContext } from "../../../react/state/user-settings-context";
-import { buildCanvasFocus } from "./canvas-focus";
+import { buildNetAdjacency, resolveCanvasFocus } from "./canvas-focus";
 import { buildCanvasScene, type CanvasScene } from "./canvas-scene";
 import { usePointerAtRest } from "./hooks/util/use-pointer-at-rest";
 
@@ -40,6 +40,10 @@ export const useCanvasScene = (
     setSettledHoverId(hoveredId);
   }
 
+  // Indexed on the net alone, so the compiler holds it across the renders a
+  // hover causes and only rebuilds it when the net itself changes.
+  const adjacency = buildNetAdjacency(activeNet);
+
   return buildCanvasScene({
     net: activeNet,
     sdcpn: petriNetDefinition,
@@ -50,8 +54,8 @@ export const useCanvasScene = (
     hoveredId: settledHoverId,
     // With the highlight off, the neighbourhood answers to the selection
     // alone; the hover still reaches the node it rests on.
-    focus: buildCanvasFocus({
-      net: activeNet,
+    focus: resolveCanvasFocus({
+      adjacency,
       hoveredId: highlightOnHover ? settledHoverId : null,
       selectedIds: new Set(selection.keys()),
     }),


### PR DESCRIPTION
## Summary

Before this PR, a playback frame moved one number per place and one per transition, and those numbers rode on the React Flow node data. A frame therefore rebuilt every node and arc in the net and re-rendered the lot to move a handful of values. Separately, resolving which nodes sit upstream and downstream of the focused one rebuilt the net's directed arcs and walked all of them on every render.

Per-frame values now reach the canvas by subscription, and the net's shape is indexed once. Playback on a 400-node net runs at 29 frames a second rather than 10.

| Ring net under live playback | Before | After |
| ---------------------------- | ------ | ----- |
| 400 nodes | 10 fps, 83ms median frame | 29 fps, 42ms |
| 400 nodes, worst frame | 183ms | 68ms |
| 400 nodes, fitted view, this head | 6 fps, p95 192ms | 16 fps, p95 116ms |
| 1000 nodes, fitted view, this head | 3 fps, p95 475ms | 10 fps, p95 276ms |

First two rows from the original measurement, the last two against production builds of the base and this head, all headless Chromium at 1600x900 on a ring net that fires continuously, frame intervals sampled from `requestAnimationFrame` over 5 s with `smoke-ring.mjs`.

#### Before

https://github.com/user-attachments/assets/e2f64ed5-c837-4cf9-8cf5-947cd61eb9db

#### After

https://github.com/user-attachments/assets/ab14bc58-57a1-4fc8-ad21-c505045d5a0b

## Links

- Ticket [FE-1634](https://linear.app/hash/issue/FE-1634)

## Changes

- Per-frame values live in a store, not on the node data
  > A place subscribes to its own token count, a transition and its arcs to their own firing state, so a frame re-renders only what moved.
  > Store identity never changes: the provider re-renders as frames arrive, and the canvas below it does not, because its element is made above and handed down unchanged.
- Transition state is read on demand
  > Only the transitions actually mounted are read, and each keeps its previous value while its firing count holds, so a transition that did not fire does not re-render.
- Net adjacency is indexed once
  > Every node gets its upstream, downstream, incoming and outgoing lists, and every arc the nodes it joins.
  > Resolving a focus visits only the focused items, so it costs the size of the neighbourhood rather than the size of the net, and the index rebuilds only when the net changes.
- React Flow element list carries no frame state
  > `PlaceNodeData`, `TransitionNodeData` and `ArcData` shed their per-frame fields, so a frame leaves the list untouched.

#### Review fixes

- Frame store starts fresh for each net
  > The provider is keyed on the net, so no other net's transitions are read on a frame.
- Frame store filled before the first paint
  > The snapshot starts from the provider's props, so places carry their marking on the first render.

## Known issues

- Hover costs about 205ms of script rather than 173ms
  > Every node now carries a subscription. The playback gain is worth it, but the hover path is the next thing to look at.

## Test coverage

- `canvas-focus.test.ts`:
  > The index's shape, and the focus roles resolved from it.
- Measured, 400-node net under playback:
  > Token badges show the initial marking, then move as tokens flow, and the firing animations still run.
- Existing `@hashintel/petrinaut` unit suite.
- `canvas-frame-store.test.tsx`:
  > Initial-marking fallback in simulate mode, the viewed frame's counts, and a frame re-rendering only the items whose values moved.

## How to test

- Open [Petrinaut preview](https://petrinaut-git-claude-canvas-frame-and-adjacency.stage.hash.ai) on Vercel
- Menu > Load example > Supply Chain with Disruption
- Press Play
  > Expect token counts to update on the places as it runs, and transitions to flash as they fire
- Scrub the timeline
  > Expect the counts to follow the scrubbed frame
- Rest the pointer on a node while a run is playing
  > Expect the neighbourhood highlight to behave as it does at rest


