### PR TITLE
FE-1609: Round the Preview's floating playback bar

### DIFF
--- a/.changeset/rounded-preview-playback-bar.md
+++ b/.changeset/rounded-preview-playback-bar.md
@@ -1,0 +1,5 @@
+---
+"@hashintel/petrinaut": patch
+---
+
+The Preview's playback bar has rounded corners, matching the zoom controls and the minimap that float over the same canvas.

--- a/libs/@hashintel/petrinaut/src/ui/preview/preview-quick-simulation-controls.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/preview/preview-quick-simulation-controls.tsx
@@ -36,9 +36,12 @@ const playbackPositionStyle = css({
   interpolateSize: "[allow-keywords]",
   padding: "0.5",
   overflow: "hidden",
-  // A flat bordered box like the editor's panels: square, opaque, no shadow.
+  // An opaque bordered box with no shadow, like the editor's panels, but
+  // rounded: it floats over the canvas rather than framing the embed, and
+  // `lg` is the `md` of the controls it wraps plus the padding around them.
   borderWidth: "thin",
   borderColor: "neutral.s40",
+  borderRadius: "lg",
   backgroundColor: "neutral.s00",
   "&[data-expanded='true']": {
     width: "[calc(100% - 16px)]",


### PR DESCRIPTION
## Summary

Before this PR, the Preview's playback bar was styled after the editor's docked panels: a flat, square, opaque box. It floats over the canvas with all four sides exposed, alongside the zoom controls and the minimap, which both already carry a radius. Square corners made it the only piece of embed chrome that read as part of the frame rather than as something sitting on top of the net.

Playback bar now carries an `lg` radius, collapsed and with the timeline expanded. Nothing else floating over the embed canvas changed, because none of it was square. Editor and Review panels keep their square corners: they dock to the layout edges and share borders with their neighbours, so the flat treatment stays where it was designed for.

<img src="https://github.com/user-attachments/assets/899f95f0-ea0e-4864-b82a-0ca5a475da7e" alt="The preview's playback bar, before and after" width="820">

## Links

- Ticket [FE-1609](https://linear.app/hash/issue/FE-1609)

## Changes

- Preview playback bar gets an `lg` corner radius
  > `lg` is the `md` radius of the controls the bar wraps plus its own `0.5` padding, so the outer curve stays concentric with the buttons inside.
  > Existing `overflow: hidden` clips the expanded timeline to the same curve.

## Known issues

- Editor and Review panels stay square, which answers the ticket's open decision one way
  > A radius there would touch every docked panel and the bottom bar, and those share borders with the surfaces they sit against.

## Test coverage

- `preview-quick-simulation-controls.test.tsx`:
  > Existing render and expand-state assertions for the bar, unaffected by the radius.
- Computed-style probe in the running embed:
  > `border-radius` reads `8px` on the playback bar collapsed and expanded, against `0px` before the change.

## How to test

- Open [SIR embed](https://petrinaut-git-claude-fe-1609-round-preview-playback-bar.stage.hash.ai/embed/examples/sir-epidemic-model) on Vercel
  > Expect rounded corners on the playback bar at the bottom of the canvas
- Quick Simulation > pick a scenario
- Press Play
  > Expect the bar to expand upward, timeline clipped to the same rounded corners
- Open [SIR editor](https://petrinaut-git-claude-fe-1609-round-preview-playback-bar.stage.hash.ai/examples/sir-epidemic-model)
  > Expect bottom bar and side panels to keep square corners

