### PR TITLE
FE-1611/FE-1636: Replace the Preview's view-only badge with a full-view link, and stop its text being selectable

### DIFF
--- a/.changeset/preview-full-view-link.md
+++ b/.changeset/preview-full-view-link.md
@@ -2,4 +2,4 @@
 "@hashintel/petrinaut": patch
 ---
 
-`PetrinautPreview` takes a `fullViewUrl`, and offers it in the header as a **Full view** link that opens in a new tab. The link replaces the "View only" badge, and text in the preview is no longer selectable.
+`PetrinautPreview` takes a `fullViewUrl`, and offers it in the header as a **Full view** link that opens in a new tab. The link replaces the "View only" badge, and text in the preview is no longer selectable, apart from a field that still takes typing.

--- a/.changeset/preview-full-view-link.md
+++ b/.changeset/preview-full-view-link.md
@@ -1,0 +1,5 @@
+---
+"@hashintel/petrinaut": patch
+---
+
+`PetrinautPreview` takes a `fullViewUrl`, and offers it in the header as a **Full view** link that opens in a new tab. The link replaces the "View only" badge, and text in the preview is no longer selectable.

--- a/.changeset/rounded-preview-playback-bar.md
+++ b/.changeset/rounded-preview-playback-bar.md
@@ -1,0 +1,5 @@
+---
+"@hashintel/petrinaut": patch
+---
+
+The Preview's playback bar has rounded corners, matching the zoom controls and the minimap that float over the same canvas.

--- a/apps/petrinaut-website/README.md
+++ b/apps/petrinaut-website/README.md
@@ -41,7 +41,11 @@ Canonical example pages live below `/examples`. The JSON oEmbed endpoint at
 third-party framing. Every page also sends `upgrade-insecure-requests`: the deployed Brunch agent runs behind a proxy,
 sees plain HTTP and returns `http://` stream URLs, which an HTTPS page would otherwise block as mixed
 content. The returned iframe is sandboxed with
-`allow-scripts allow-same-origin` and does not send a referrer.
+`allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox`
+and does not send a referrer. The popup permissions are what let the preview's
+**Full view** link open the model in a new tab: a sandbox without them drops
+the navigation, and without `allow-popups-to-escape-sandbox` the full page
+would inherit the embed's sandbox.
 
 Because this is a client-rendered SPA, a static `index.html` discovery link
 cannot include the current example URL. `FullExamplePage` adds the standard

--- a/apps/petrinaut-website/api/oembed.ts
+++ b/apps/petrinaut-website/api/oembed.ts
@@ -235,7 +235,7 @@ const respond = async (request: Request): Promise<Response> => {
     provider_url: PETRINAUT_DEMO_ORIGIN,
     width,
     height,
-    html: `<iframe src="${escapeHtmlAttribute(embedUrl.href)}" title="${escapeHtmlAttribute(catalogEntry.title)}" width="${width}" height="${height}" style="border:0" loading="lazy" sandbox="allow-scripts allow-same-origin" referrerpolicy="no-referrer" allowfullscreen></iframe>`,
+    html: `<iframe src="${escapeHtmlAttribute(embedUrl.href)}" title="${escapeHtmlAttribute(catalogEntry.title)}" width="${width}" height="${height}" style="border:0" loading="lazy" sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox" referrerpolicy="no-referrer" allowfullscreen></iframe>`,
   };
 
   return jsonResponse(response, { cacheable: true });

--- a/apps/petrinaut-website/src/examples/embedded-example-page.tsx
+++ b/apps/petrinaut-website/src/examples/embedded-example-page.tsx
@@ -2,6 +2,7 @@ import { lazy, Suspense, type FunctionComponent } from "react";
 
 import { css } from "@hashintel/ds-helpers/css";
 
+import { canonicalSearchString } from "./example-search";
 import { previewSearchToNavigationState } from "./navigation-search";
 
 import type { GeneratedExampleRuntime, LoadedExample } from "./catalog";
@@ -61,6 +62,14 @@ export const EmbeddedExamplePage: FunctionComponent<
     parameterBounds: example.catalog.parameterBounds,
   };
 
+  // Root-relative, so it resolves against this site inside a host's iframe,
+  // and carrying the reader's location so the full page opens on the scenario
+  // and the item they were looking at.
+  const query = canonicalSearchString(search);
+  const fullViewUrl = `/examples/${example.catalog.slug}${
+    query ? `?${query}` : ""
+  }`;
+
   return (
     <main className={pageStyle}>
       <Suspense
@@ -69,6 +78,7 @@ export const EmbeddedExamplePage: FunctionComponent<
         <LazyPetrinautPreview
           definition={example.definition}
           documentId={`example:${example.catalog.slug}`}
+          fullViewUrl={fullViewUrl}
           navigation={navigation}
           quickSimulation={quickSimulation}
           title={example.catalog.title}

--- a/apps/petrinaut-website/src/examples/oembed-endpoint.test.ts
+++ b/apps/petrinaut-website/src/examples/oembed-endpoint.test.ts
@@ -55,7 +55,7 @@ describe("Petrinaut oEmbed endpoint", () => {
       provider_url: "https://demo.petrinaut.org",
       width: 800,
       height: 450,
-      html: '<iframe src="https://demo.petrinaut.org/embed/examples/gases-1-pn" title="Gases 1 — One Customer" width="800" height="450" style="border:0" loading="lazy" sandbox="allow-scripts allow-same-origin" referrerpolicy="no-referrer" allowfullscreen></iframe>',
+      html: '<iframe src="https://demo.petrinaut.org/embed/examples/gases-1-pn" title="Gases 1 — One Customer" width="800" height="450" style="border:0" loading="lazy" sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox" referrerpolicy="no-referrer" allowfullscreen></iframe>',
     });
   });
 
@@ -78,7 +78,7 @@ describe("Petrinaut oEmbed endpoint", () => {
 
     expect(response.status).toBe(200);
     expect(body.html).toBe(
-      '<iframe src="https://demo.petrinaut.org/embed/examples/gases-2-spn?itemId=transition-1&amp;itemType=transition&amp;mode=simulate&amp;scenario=scenario-1&amp;subnet=subnet-1" title="Gases 2 — Shared Tanker" width="800" height="450" style="border:0" loading="lazy" sandbox="allow-scripts allow-same-origin" referrerpolicy="no-referrer" allowfullscreen></iframe>',
+      '<iframe src="https://demo.petrinaut.org/embed/examples/gases-2-spn?itemId=transition-1&amp;itemType=transition&amp;mode=simulate&amp;scenario=scenario-1&amp;subnet=subnet-1" title="Gases 2 — Shared Tanker" width="800" height="450" style="border:0" loading="lazy" sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox" referrerpolicy="no-referrer" allowfullscreen></iframe>',
     );
   });
 

--- a/libs/@hashintel/petrinaut/docs/preview.md
+++ b/libs/@hashintel/petrinaut/docs/preview.md
@@ -10,6 +10,13 @@ both surfaces. You can pan and zoom the canvas, fit the net into view, and use
 the minimap. You cannot move, connect, add, delete, or otherwise edit net
 elements.
 
+Text in the preview is not selectable, so dragging across the canvas always
+pans or selects rather than highlighting a label.
+
+When the embed supplies a full-size location for the model, **Full view** in
+the header opens it in a new tab, on the scenario and the item you were
+looking at.
+
 ## Inspecting a net
 
 Select a place, transition, arc, or other supported item to inspect it. The

--- a/libs/@hashintel/petrinaut/src/ui/preview/petrinaut-preview.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/preview/petrinaut-preview.tsx
@@ -17,7 +17,7 @@ import {
   type FunctionComponent,
 } from "react";
 
-import { PortalContainerContext } from "@hashintel/ds-components";
+import { Button, Icon, PortalContainerContext } from "@hashintel/ds-components";
 import { css, cx } from "@hashintel/ds-helpers/css";
 import {
   createJsonDocHandle,
@@ -71,6 +71,12 @@ const previewRootStyle = css({
   overflow: "hidden",
   backgroundColor: "neutral.s25",
   color: "neutral.fg.body",
+  // A drag on an embed pans the canvas or draws a selection box, so a text
+  // highlight is always accidental. Fields that still take typing keep theirs.
+  userSelect: "none",
+  "& :is(input, textarea)": {
+    userSelect: "text",
+  },
 });
 
 // The editor's top bar at embed height: the same flat 1px outline, padding
@@ -103,19 +109,9 @@ const previewTitleStyle = css({
   color: "neutral.fg.heading",
 });
 
-const previewBadgeStyle = css({
-  display: "flex",
-  alignItems: "center",
-  gap: "1",
-  flexShrink: "0",
-  paddingX: "1.5",
-  paddingY: "0.5",
-  backgroundColor: "neutral.s15",
-  color: "neutral.s90",
-  fontSize: "[10px]",
-  fontWeight: "semibold",
-  textTransform: "uppercase",
-  letterSpacing: "[0.4px]",
+// The link keeps its icon at every width; the word goes first when the header
+// runs short of room, the way the Quick Simulation label does.
+const fullViewLabelStyle = css({
   "@media (max-width: 480px)": {
     display: "none",
   },
@@ -148,6 +144,12 @@ export type PetrinautPreviewProps = {
   documentId?: string;
   title?: string;
   /**
+   * Where the same model can be read at full size. Given one, Preview offers a
+   * link to it in the header, opened in a new tab so an embed on someone
+   * else's page never navigates the page around it.
+   */
+  fullViewUrl?: string;
+  /**
    * Optional host-owned navigation. The host may project this state into any
    * router; Preview itself does not depend on a router implementation.
    */
@@ -172,6 +174,7 @@ export type PetrinautPreviewProps = {
 export const PetrinautPreview: FunctionComponent<PetrinautPreviewProps> = ({
   definition,
   documentId,
+  fullViewUrl,
   navigation,
   quickSimulation,
   title = "Petrinaut model",
@@ -291,7 +294,19 @@ export const PetrinautPreview: FunctionComponent<PetrinautPreviewProps> = ({
               parameterBounds={quickSimulation.parameterBounds}
             />
           )}
-          <span className={previewBadgeStyle}>View only</span>
+          {fullViewUrl !== undefined && (
+            <Button
+              href={fullViewUrl}
+              target="_blank"
+              size="xs"
+              variant="ghost"
+              suffix={<Icon name="externalLink" size="xs" />}
+              tooltip="Open this model at full size in a new tab"
+              aria-label="Open full view"
+            >
+              <span className={fullViewLabelStyle}>Full view</span>
+            </Button>
+          )}
         </header>
         <main className={previewMainStyle}>
           <div className={previewCanvasStyle}>

--- a/libs/@hashintel/petrinaut/src/ui/preview/petrinaut-preview.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/preview/petrinaut-preview.tsx
@@ -72,9 +72,13 @@ const previewRootStyle = css({
   backgroundColor: "neutral.s25",
   color: "neutral.fg.body",
   // A drag on an embed pans the canvas or draws a selection box, so a text
-  // highlight is always accidental. Fields that still take typing keep theirs.
+  // highlight is always accidental. A field that still takes typing keeps its
+  // own selection; a disabled one carries a value to read, not to edit.
+  //
+  // Blink ignores `user-select` inside a form control either way, so this
+  // governs only the engines that honour it.
   userSelect: "none",
-  "& :is(input, textarea)": {
+  "& :is(input, textarea):enabled": {
     userSelect: "text",
   },
 });

--- a/libs/@hashintel/petrinaut/src/ui/preview/preview-quick-simulation-controls.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/preview/preview-quick-simulation-controls.tsx
@@ -36,9 +36,12 @@ const playbackPositionStyle = css({
   interpolateSize: "[allow-keywords]",
   padding: "0.5",
   overflow: "hidden",
-  // A flat bordered box like the editor's panels: square, opaque, no shadow.
+  // An opaque bordered box with no shadow, like the editor's panels, but
+  // rounded: it floats over the canvas rather than framing the embed, and
+  // `lg` is the `md` of the controls it wraps plus the padding around them.
   borderWidth: "thin",
   borderColor: "neutral.s40",
+  borderRadius: "lg",
   backgroundColor: "neutral.s00",
   "&[data-expanded='true']": {
     width: "[calc(100% - 16px)]",

--- a/libs/@local/petrinaut-arch-docs/content/website/oembed.mdx
+++ b/libs/@local/petrinaut-arch-docs/content/website/oembed.mdx
@@ -42,9 +42,14 @@ Framing policy is HTTP, not JavaScript. `vercel.json` sends
 and marks that path `X-Robots-Tag: noindex` so it is not indexed alongside the
 canonical page.
 
-The iframe carries `sandbox="allow-scripts allow-same-origin"`. Both tokens are
-required: without `allow-same-origin` the framed document runs with an opaque
-origin, its module scripts fail CORS, and the embed renders blank.
+The iframe carries
+`sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"`.
+The first two tokens are required to render at all: without `allow-same-origin`
+the framed document runs with an opaque origin, its module scripts fail CORS,
+and the embed renders blank. The popup tokens are what let the preview's **Full
+view** link reach a new tab -- a sandbox without `allow-popups` drops the
+navigation silently, and without `allow-popups-to-escape-sandbox` the full page
+would inherit the embed's sandbox instead of running as itself.
 
 ## Embedding an example in your site
 
@@ -66,7 +71,7 @@ curl "https://demo.petrinaut.org/api/oembed?url=https%3A%2F%2Fdemo.petrinaut.org
   height="450"
   style="border: 0"
   loading="lazy"
-  sandbox="allow-scripts allow-same-origin"
+  sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"
   referrerpolicy="no-referrer"
   allowfullscreen
 ></iframe>


### PR DESCRIPTION
## Summary

Before this PR, the top-right corner of an embedded net carried a "VIEW ONLY" badge. It told the reader what they could not do, in the one corner of the frame with room for something they can do, and the embed offered no way through to the full model. Dragging across the embed also highlighted labels and panel text, which a viewer never wants: a drag there pans the canvas or draws a selection box.

`PetrinautPreview` takes a `fullViewUrl` and renders it in the badge's place as a **Full view** link that opens in a new tab. The website's embed passes the model's own page, carrying the scenario and the selected item, so the full page opens where the reader was. Text in the preview is no longer selectable, and a field that still takes typing keeps its own selection.

https://github.com/user-attachments/assets/1a3ca685-2cd2-4b10-bce8-d5d5f63eacf7

## Links

- Ticket [FE-1611](https://linear.app/hash/issue/FE-1611)
- Ticket [FE-1636](https://linear.app/hash/issue/FE-1636)
- Docs [Embedded Preview](https://github.com/hashintel/hash/blob/claude/fe-1611-embed-open-in-full-view/libs/@hashintel/petrinaut/docs/preview.md)

## Changes

#### Preview

- New `fullViewUrl` prop, rendered as a **Full view** link in the header
  > Absent prop renders nothing, so a host that has no full-size page keeps the header it has.
  > The link is an anchor with `target="_blank"`, so an embed on someone else's page never navigates the page around it.
- "VIEW ONLY" badge removed
- Text in the embed is not selectable
  > `user-select: none` on the embed root, with an enabled `input` or `textarea` put back to `text` so a field that still takes typing stays usable.
  > Blink ignores `user-select` inside a form control, so in Chromium a field's text selects either way; the rule governs the engines that honour it.
- Label hides under 480px, icon and tooltip carry the link
  > Matches how the Quick Simulation label already folds. An explicit `aria-label` names the link at every width.

#### Website

- Embed page passes the model's full page as `fullViewUrl`
  > Root-relative, so it resolves against the site inside a host's iframe.
  > The reader's canonical search string rides along, so scenario and selection survive the jump.

## Test coverage

- Existing `@hashintel/petrinaut` and `@apps/petrinaut-website` unit suites
- Verified in the running embed:
  > Link resolves to `/examples/<slug>?scenario=<id>`, opens the full page on that scenario, and the embed root computes `user-select: none`.

## How to test

- Open [SIR embed](https://petrinaut-git-claude-fe-1611-embed-open-in-full-view.stage.hash.ai/embed/examples/sir-epidemic-model) on Vercel
  > Expect **Full view** in the top-right, no "VIEW ONLY" badge
- Drag across the canvas and across the net's labels
  > Expect no text highlight
- Select a place, then Quick Simulation > pick another scenario
- Click **Full view**
  > Expect a new tab on the full page, same scenario, same place selected
- Narrow the window under 480px
  > Expect the link to keep its icon and drop the word

