### PR TITLE
FE-1637: Show read-only property values as text instead of disabled inputs

### DIFF
--- a/.changeset/readonly-property-values-as-text.md
+++ b/.changeset/readonly-property-values-as-text.md
@@ -1,0 +1,5 @@
+---
+"@hashintel/petrinaut": patch
+---
+
+The properties panel shows the values of a read-only net as text instead of as disabled inputs. Names, descriptions, and single-value fields read at full contrast, and their labels no longer grey out.

--- a/.changeset/readonly-property-values-as-text.md
+++ b/.changeset/readonly-property-values-as-text.md
@@ -2,4 +2,4 @@
 "@hashintel/petrinaut": patch
 ---
 
-The properties panel shows the values of a read-only net as text instead of as disabled inputs. Names, descriptions, and single-value fields read at full contrast, and their labels no longer grey out.
+The properties panel shows a read-only net's names, descriptions, and the single-value fields of places, arcs, differential equations and component instances as text instead of as disabled inputs. They read at full contrast, and their labels no longer grey out. Toggles, checkboxes and the list editors keep their controls.

--- a/libs/@hashintel/petrinaut/docs/preview.md
+++ b/libs/@hashintel/petrinaut/docs/preview.md
@@ -21,8 +21,9 @@ looking at.
 
 Select a place, transition, arc, or other supported item to inspect it. The
 preview presents the same property information as Petrinaut's inspector,
-without source editing or other authoring controls. Values you cannot change
-are shown as text rather than as filled-in fields. On a wide embed the
+without source editing or other authoring controls. A field's name, description and
+type are shown as text rather than as filled-in fields; the remaining controls
+are still rendered, and simply do nothing. On a wide embed the
 inspector docks to the right of the canvas. On a narrow embed it sits under
 the canvas so the canvas remains usable.
 

--- a/libs/@hashintel/petrinaut/docs/preview.md
+++ b/libs/@hashintel/petrinaut/docs/preview.md
@@ -21,7 +21,8 @@ looking at.
 
 Select a place, transition, arc, or other supported item to inspect it. The
 preview presents the same property information as Petrinaut's inspector,
-without source editing or other authoring controls. On a wide embed the
+without source editing or other authoring controls. Values you cannot change
+are shown as text rather than as filled-in fields. On a wide embed the
 inspector docks to the right of the canvas. On a narrow embed it sits under
 the canvas so the canvas remains usable.
 

--- a/libs/@hashintel/petrinaut/src/ui/components/description-field.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/components/description-field.tsx
@@ -3,7 +3,9 @@ import { useLayoutEffect, useRef } from "react";
 import { Form, TextArea, Tooltip } from "@hashintel/ds-components";
 import { css } from "@hashintel/ds-helpers/css";
 
+import { useIsReadOnly } from "../../react/state/use-is-read-only";
 import { useDraftField } from "../hooks/use-draft-field";
+import { PropertyValue } from "./property-value";
 
 interface DescriptionTextAreaProps {
   /** Stable identifier of the entity owning this field; switching it discards stale drafts. */
@@ -54,22 +56,24 @@ export const DescriptionTextArea: React.FC<DescriptionTextAreaProps> = ({
   }, [sourceId]);
 
   return (
-    <Tooltip content={tooltip ?? ""} disableTooltip={!tooltip}>
-      <TextArea
-        inputRef={textAreaRef}
-        className={textAreaStyle}
-        size="sm"
-        rows={1}
-        value={field.value}
-        onChange={field.setValue}
-        onBlur={() => {
-          if (field.value !== canonicalValue) {
-            onCommit(field.value === "" ? undefined : field.value);
-          }
-        }}
-        disabled={disabled}
-      />
-    </Tooltip>
+    <PropertyValue text={sourceValue} emptyText="No description">
+      <Tooltip content={tooltip ?? ""} disableTooltip={!tooltip}>
+        <TextArea
+          inputRef={textAreaRef}
+          className={textAreaStyle}
+          size="sm"
+          rows={1}
+          value={field.value}
+          onChange={field.setValue}
+          onBlur={() => {
+            if (field.value !== canonicalValue) {
+              onCommit(field.value === "" ? undefined : field.value);
+            }
+          }}
+          disabled={disabled}
+        />
+      </Tooltip>
+    </PropertyValue>
   );
 };
 
@@ -79,8 +83,16 @@ export const DescriptionTextArea: React.FC<DescriptionTextAreaProps> = ({
 export const DescriptionField: React.FC<DescriptionTextAreaProps> = ({
   disabled = false,
   ...textAreaProps
-}) => (
-  <Form.Field label="Description" size="sm" disabled={disabled}>
-    <DescriptionTextArea {...textAreaProps} disabled={disabled} />
-  </Form.Field>
-);
+}) => {
+  const isReadOnly = useIsReadOnly();
+
+  return (
+    <Form.Field
+      label="Description"
+      size="sm"
+      disabled={disabled && !isReadOnly}
+    >
+      <DescriptionTextArea {...textAreaProps} disabled={disabled} />
+    </Form.Field>
+  );
+};

--- a/libs/@hashintel/petrinaut/src/ui/components/description-field.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/components/description-field.tsx
@@ -40,6 +40,7 @@ export const DescriptionTextArea: React.FC<DescriptionTextAreaProps> = ({
   const canonicalValue = sourceValue ?? "";
   const field = useDraftField({ sourceId, sourceValue: canonicalValue });
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
+  const isReadOnly = useIsReadOnly();
 
   useLayoutEffect(() => {
     const textArea = textAreaRef.current;
@@ -53,7 +54,9 @@ export const DescriptionTextArea: React.FC<DescriptionTextAreaProps> = ({
     const borderHeight = box.offsetHeight - box.clientHeight;
     const contentHeight = textArea.scrollHeight + borderHeight;
     box.style.height = `${Math.min(Math.max(contentHeight, minHeight), initialMaxHeight)}px`;
-  }, [sourceId]);
+    // A read-only net renders the value as text instead, so the box is
+    // remounted when editing resumes and has to be measured again.
+  }, [sourceId, isReadOnly]);
 
   return (
     <PropertyValue text={sourceValue} emptyText="No description">

--- a/libs/@hashintel/petrinaut/src/ui/components/draft-field-input.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/components/draft-field-input.tsx
@@ -62,7 +62,9 @@ export const DraftFieldInput: React.FC<DraftFieldInputProps> = ({
       // A read-only field is not a disabled one: its label describes a value
       // the reader can read, so it keeps full contrast.
       disabled={disabled && !isReadOnly}
-      errors={field.error ? [field.error] : undefined}
+      // The error belongs to a draft the reader cannot see; showing it beside
+      // the canonical value would contradict the value itself.
+      errors={!isReadOnly && field.error ? [field.error] : undefined}
     >
       <PropertyValue text={sourceValue}>
         <Tooltip content={tooltip ?? ""} disableTooltip={!tooltip}>

--- a/libs/@hashintel/petrinaut/src/ui/components/draft-field-input.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/components/draft-field-input.tsx
@@ -1,7 +1,9 @@
 import { Form, TextInput, Tooltip } from "@hashintel/ds-components";
 import { css } from "@hashintel/ds-helpers/css";
 
+import { useIsReadOnly } from "../../react/state/use-is-read-only";
 import { useDraftField } from "../hooks/use-draft-field";
+import { PropertyValue } from "./property-value";
 
 type ValidationResult =
   | { valid: true; name: string }
@@ -50,43 +52,48 @@ export const DraftFieldInput: React.FC<DraftFieldInputProps> = ({
   tooltip,
 }) => {
   const field = useDraftField({ sourceId, sourceValue });
+  const isReadOnly = useIsReadOnly();
 
   return (
     <Form.Field
       label={label}
       labelTooltip={labelTooltip}
       size="sm"
-      disabled={disabled}
+      // A read-only field is not a disabled one: its label describes a value
+      // the reader can read, so it keeps full contrast.
+      disabled={disabled && !isReadOnly}
       errors={field.error ? [field.error] : undefined}
     >
-      <Tooltip content={tooltip ?? ""} disableTooltip={!tooltip}>
-        <TextInput
-          value={field.value}
-          size="sm"
-          className={monospace ? monospaceInputStyle : undefined}
-          onChange={(value) => {
-            field.setValue(value);
-            if (field.error) {
+      <PropertyValue text={sourceValue}>
+        <Tooltip content={tooltip ?? ""} disableTooltip={!tooltip}>
+          <TextInput
+            value={field.value}
+            size="sm"
+            className={monospace ? monospaceInputStyle : undefined}
+            onChange={(value) => {
+              field.setValue(value);
+              if (field.error) {
+                field.setError(null);
+              }
+            }}
+            onBlur={() => {
+              const result = validate(field.value);
+
+              if (!result.valid) {
+                field.setError(result.error);
+                return;
+              }
+
               field.setError(null);
-            }
-          }}
-          onBlur={() => {
-            const result = validate(field.value);
-
-            if (!result.valid) {
-              field.setError(result.error);
-              return;
-            }
-
-            field.setError(null);
-            if (result.name !== sourceValue) {
-              onCommit(result.name);
-            }
-          }}
-          disabled={disabled}
-          invalid={!!field.error}
-        />
-      </Tooltip>
+              if (result.name !== sourceValue) {
+                onCommit(result.name);
+              }
+            }}
+            disabled={disabled}
+            invalid={!!field.error}
+          />
+        </Tooltip>
+      </PropertyValue>
     </Form.Field>
   );
 };

--- a/libs/@hashintel/petrinaut/src/ui/components/property-value.test.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/components/property-value.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { PropertyValue } from "./property-value";
+
+const isReadOnly = vi.hoisted(() => ({ current: false }));
+
+vi.mock("../../react/state/use-is-read-only", () => ({
+  useIsReadOnly: () => isReadOnly.current,
+}));
+
+afterEach(cleanup);
+
+describe("PropertyValue", () => {
+  it("renders the editing control while the net is editable", () => {
+    isReadOnly.current = false;
+    render(
+      <PropertyValue text="Susceptible">
+        <input defaultValue="Susceptible" />
+      </PropertyValue>,
+    );
+
+    expect(screen.getByRole("textbox")).toBeDefined();
+  });
+
+  it("renders the value as text once the net is read-only", () => {
+    isReadOnly.current = true;
+    render(
+      <PropertyValue text="Susceptible">
+        <input defaultValue="Susceptible" />
+      </PropertyValue>,
+    );
+
+    expect(screen.queryByRole("textbox")).toBeNull();
+    expect(screen.getByText("Susceptible")).toBeDefined();
+  });
+
+  it.each([undefined, null, "   "])(
+    "stands in for a value the net does not carry (%s)",
+    (text) => {
+      isReadOnly.current = true;
+      render(
+        <PropertyValue text={text} emptyText="No description">
+          <input />
+        </PropertyValue>,
+      );
+
+      expect(screen.getByText("No description")).toBeDefined();
+    },
+  );
+});

--- a/libs/@hashintel/petrinaut/src/ui/components/property-value.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/components/property-value.tsx
@@ -50,10 +50,10 @@ export const PropertyValue = ({
     return children;
   }
 
-  const value = text?.trim();
-
-  return value ? (
-    <div className={valueStyle}>{value}</div>
+  // Trimmed only to decide whether anything is there: the value renders as
+  // authored, because `pre-wrap` is here to keep the author's own formatting.
+  return text?.trim() ? (
+    <div className={valueStyle}>{text}</div>
   ) : (
     <div className={emptyValueStyle}>{emptyText}</div>
   );

--- a/libs/@hashintel/petrinaut/src/ui/components/property-value.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/components/property-value.tsx
@@ -1,0 +1,60 @@
+import { type ReactNode } from "react";
+
+import { css } from "@hashintel/ds-helpers/css";
+
+import { useIsReadOnly } from "../../react/state/use-is-read-only";
+
+const valueStyle = css({
+  fontSize: "sm",
+  lineHeight: "[1.45]",
+  color: "neutral.fg.body",
+  // Descriptions carry the line breaks their author typed.
+  whiteSpace: "pre-wrap",
+  overflowWrap: "anywhere",
+});
+
+const emptyValueStyle = css({
+  fontSize: "sm",
+  lineHeight: "[1.45]",
+  color: "neutral.s95",
+});
+
+export interface PropertyValueProps {
+  /**
+   * The value as the reader should see it. `undefined` and a blank string
+   * both render {@link PropertyValueProps.emptyText}.
+   */
+  text: string | undefined | null;
+  /** Stands in for a value the net does not carry. */
+  emptyText?: string;
+  /** The control that edits this value while the net is editable. */
+  children: ReactNode;
+}
+
+/**
+ * One property's value: the control that edits it on an editable net, and the
+ * value as text on a read-only one.
+ *
+ * A disabled input reads as something to click that refuses to respond, and
+ * greys the value down while doing it. The same value as text reads as what it
+ * is, a fact about the net.
+ */
+export const PropertyValue = ({
+  text,
+  emptyText = "None",
+  children,
+}: PropertyValueProps) => {
+  const isReadOnly = useIsReadOnly();
+
+  if (!isReadOnly) {
+    return children;
+  }
+
+  const value = text?.trim();
+
+  return value ? (
+    <div className={valueStyle}>{value}</div>
+  ) : (
+    <div className={emptyValueStyle}>{emptyText}</div>
+  );
+};

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/arc-properties/main.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/arc-properties/main.tsx
@@ -21,6 +21,7 @@ import {
 
 import { EditorContext } from "../../../../../../react/state/editor-context";
 import { useIsReadOnly } from "../../../../../../react/state/use-is-read-only";
+import { PropertyValue } from "../../../../../components/property-value";
 import { VerticalSubViewsContainer } from "../../../../../components/sub-view/vertical/vertical-sub-views-container";
 import { UI_MESSAGES } from "../../../../../constants/ui-messages";
 
@@ -35,6 +36,12 @@ const containerStyle = css({
   height: "[100%]",
   minHeight: "[0]",
 });
+
+const arcTypeLabels: Record<InputArc["type"], string> = {
+  standard: "Standard",
+  read: "Read",
+  inhibitor: "Inhibitor",
+};
 
 const readOnlyFieldStyle = css({
   fontSize: "sm",
@@ -94,49 +101,52 @@ const ArcMainContent: React.FC = () => {
         <div className={readOnlyFieldStyle}>{targetName}</div>
       </Form.Field>
       {arcDirection === "input" && (
-        <Form.Field label="Type" size="sm" disabled={isReadOnly}>
-          <Tooltip
-            content={UI_MESSAGES.READ_ONLY_MODE}
-            disableTooltip={!isReadOnly}
-          >
-            <Select
-              required
-              value={type}
-              size="sm"
-              onChange={(nextType: InputArc["type"]) => {
-                updateArcType({
-                  transitionId,
-                  endpoint,
-                  type: nextType,
-                });
-              }}
-              items={[
-                { value: "standard" as const, text: "Standard" },
-                { value: "read" as const, text: "Read" },
-                { value: "inhibitor" as const, text: "Inhibitor" },
-              ]}
-              disabled={isReadOnly}
-            />
-          </Tooltip>
+        <Form.Field label="Type" size="sm">
+          <PropertyValue text={arcTypeLabels[type]}>
+            <Tooltip
+              content={UI_MESSAGES.READ_ONLY_MODE}
+              disableTooltip={!isReadOnly}
+            >
+              <Select
+                required
+                value={type}
+                size="sm"
+                onChange={(nextType: InputArc["type"]) => {
+                  updateArcType({
+                    transitionId,
+                    endpoint,
+                    type: nextType,
+                  });
+                }}
+                items={Object.entries(arcTypeLabels).map(([value, text]) => ({
+                  value: value as InputArc["type"],
+                  text,
+                }))}
+                disabled={isReadOnly}
+              />
+            </Tooltip>
+          </PropertyValue>
         </Form.Field>
       )}
-      <Form.Field label="Weight" size="sm" disabled={isReadOnly}>
-        <NumberInput
-          size="sm"
-          min={1}
-          value={weight}
-          onChange={(nextWeight) => {
-            if (nextWeight !== null && nextWeight > 0) {
-              updateArcWeight({
-                transitionId,
-                arcDirection,
-                endpoint,
-                weight: nextWeight,
-              });
-            }
-          }}
-          disabled={isReadOnly}
-        />
+      <Form.Field label="Weight" size="sm">
+        <PropertyValue text={String(weight)}>
+          <NumberInput
+            size="sm"
+            min={1}
+            value={weight}
+            onChange={(nextWeight) => {
+              if (nextWeight !== null && nextWeight > 0) {
+                updateArcWeight({
+                  transitionId,
+                  arcDirection,
+                  endpoint,
+                  weight: nextWeight,
+                });
+              }
+            }}
+            disabled={isReadOnly}
+          />
+        </PropertyValue>
       </Form.Field>
     </Form.Section>
   );

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/component-instance-properties/subviews/main.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/component-instance-properties/subviews/main.tsx
@@ -81,7 +81,9 @@ const ComponentInstanceMainContent: React.FC = () => {
         <Form.Field
           label="Name"
           size="sm"
-          errors={nameField.error ? [nameField.error] : undefined}
+          errors={
+            !isDisabled && nameField.error ? [nameField.error] : undefined
+          }
         >
           <PropertyValue text={instance.name}>
             <Tooltip

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/component-instance-properties/subviews/main.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/component-instance-properties/subviews/main.tsx
@@ -11,6 +11,7 @@ import { validateEntityName } from "@hashintel/petrinaut-core";
 import { usePetrinautMutations } from "../../../../../../../react";
 import { useIsReadOnly } from "../../../../../../../react/state/use-is-read-only";
 import { DescriptionField } from "../../../../../../components/description-field";
+import { PropertyValue } from "../../../../../../components/property-value";
 import { Section, SectionList } from "../../../../../../components/section";
 import { UI_MESSAGES } from "../../../../../../constants/ui-messages";
 import { useDraftField } from "../../../../../../hooks/use-draft-field";
@@ -80,22 +81,26 @@ const ComponentInstanceMainContent: React.FC = () => {
         <Form.Field
           label="Name"
           size="sm"
-          disabled={isDisabled}
           errors={nameField.error ? [nameField.error] : undefined}
         >
-          <Tooltip content={readOnlyTooltip ?? ""} disableTooltip={!isDisabled}>
-            <TextInput
-              value={nameField.value}
-              size="sm"
-              onChange={(name) => {
-                nameField.setValue(name);
-                if (nameField.error) nameField.setError(null);
-              }}
-              onBlur={handleNameBlur}
-              disabled={isDisabled}
-              invalid={!!nameField.error}
-            />
-          </Tooltip>
+          <PropertyValue text={instance.name}>
+            <Tooltip
+              content={readOnlyTooltip ?? ""}
+              disableTooltip={!isDisabled}
+            >
+              <TextInput
+                value={nameField.value}
+                size="sm"
+                onChange={(name) => {
+                  nameField.setValue(name);
+                  if (nameField.error) nameField.setError(null);
+                }}
+                onBlur={handleNameBlur}
+                disabled={isDisabled}
+                invalid={!!nameField.error}
+              />
+            </Tooltip>
+          </PropertyValue>
         </Form.Field>
 
         <DescriptionField

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/differential-equation-properties/subviews/main.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/differential-equation-properties/subviews/main.tsx
@@ -18,6 +18,7 @@ import {
 
 import { useIsReadOnly } from "../../../../../../../react/state/use-is-read-only";
 import { DraftFieldInput } from "../../../../../../components/draft-field-input";
+import { PropertyValue } from "../../../../../../components/property-value";
 import { DifferentialEquationIcon } from "../../../../../../constants/entity-icons";
 import { UI_MESSAGES } from "../../../../../../constants/ui-messages";
 import { usePetrinautPresentation } from "../../../../../shared/presentation-context";
@@ -139,40 +140,48 @@ const DiffEqMainContent: React.FC = () => {
           tooltip={isReadOnly ? UI_MESSAGES.READ_ONLY_MODE : undefined}
         />
 
-        <Form.Field label="Associated Type" size="sm" disabled={isReadOnly}>
-          <Tooltip
-            content={UI_MESSAGES.READ_ONLY_MODE}
-            disableTooltip={!isReadOnly}
+        <Form.Field label="Associated Type" size="sm">
+          <PropertyValue
+            text={
+              types.find(
+                (candidate) => candidate.id === differentialEquation.colorId,
+              )?.name
+            }
           >
-            <Select
-              required
-              value={differentialEquation.colorId ?? ""}
-              onChange={(colorId) => {
-                if (colorId) {
-                  handleTypeChange(colorId);
-                }
-              }}
-              items={types.map((type) => ({
-                value: type.id,
-                text: type.name,
-              }))}
-              placeholder="Select a type"
-              size="sm"
-              disabled={isReadOnly}
-              renderItem={(value) => {
-                const type = types.find((tp) => tp.id === value);
-                return (
-                  <div className={arcStyle}>
-                    <div
-                      className={colorDotStyle}
-                      style={{ backgroundColor: type?.displayColor }}
-                    />
-                    {type?.name ?? value}
-                  </div>
-                );
-              }}
-            />
-          </Tooltip>
+            <Tooltip
+              content={UI_MESSAGES.READ_ONLY_MODE}
+              disableTooltip={!isReadOnly}
+            >
+              <Select
+                required
+                value={differentialEquation.colorId ?? ""}
+                onChange={(colorId) => {
+                  if (colorId) {
+                    handleTypeChange(colorId);
+                  }
+                }}
+                items={types.map((type) => ({
+                  value: type.id,
+                  text: type.name,
+                }))}
+                placeholder="Select a type"
+                size="sm"
+                disabled={isReadOnly}
+                renderItem={(value) => {
+                  const type = types.find((tp) => tp.id === value);
+                  return (
+                    <div className={arcStyle}>
+                      <div
+                        className={colorDotStyle}
+                        style={{ backgroundColor: type?.displayColor }}
+                      />
+                      {type?.name ?? value}
+                    </div>
+                  );
+                }}
+              />
+            </Tooltip>
+          </PropertyValue>
         </Form.Field>
 
         {presentation.showSourceCode && (

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/place-properties/subviews/main.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/place-properties/subviews/main.tsx
@@ -18,6 +18,7 @@ import { ActiveNetContext } from "../../../../../../../react/state/active-net-co
 import { EditorContext } from "../../../../../../../react/state/editor-context";
 import { SDCPNContext } from "../../../../../../../react/state/sdcpn-context";
 import { DescriptionTextArea } from "../../../../../../components/description-field";
+import { PropertyValue } from "../../../../../../components/property-value";
 import { Section, SectionList } from "../../../../../../components/section";
 import { PlaceIcon } from "../../../../../../constants/entity-icons";
 import { UI_MESSAGES } from "../../../../../../constants/ui-messages";
@@ -116,6 +117,9 @@ const PlaceMainContent: React.FC = () => {
     }
   };
 
+  const placeTypeName =
+    types.find((candidate) => candidate.id === place.colorId)?.name ?? "None";
+
   // Filter differential equations by place type
   const availableDiffEqs = place.colorId
     ? differentialEquations.filter((eq) => eq.colorId === place.colorId)
@@ -125,29 +129,31 @@ const PlaceMainContent: React.FC = () => {
     <div ref={rootDivRef}>
       <SectionList>
         <Section title="Name">
-          <Tooltip
-            content={UI_MESSAGES.READ_ONLY_MODE}
-            disableTooltip={!isReadOnly}
-          >
-            <TextInput
-              size="sm"
-              inputRef={nameInputRef}
-              value={nameField.value}
-              onChange={(name) => {
-                nameField.setValue(name);
-                if (nameField.error) {
-                  nameField.setError(null);
-                }
-              }}
-              onFocus={() => setIsNameInputFocused(true)}
-              onBlur={() => {
-                setIsNameInputFocused(false);
-                handleNameBlur();
-              }}
-              disabled={isReadOnly}
-              invalid={!!nameField.error}
-            />
-          </Tooltip>
+          <PropertyValue text={place.name}>
+            <Tooltip
+              content={UI_MESSAGES.READ_ONLY_MODE}
+              disableTooltip={!isReadOnly}
+            >
+              <TextInput
+                size="sm"
+                inputRef={nameInputRef}
+                value={nameField.value}
+                onChange={(name) => {
+                  nameField.setValue(name);
+                  if (nameField.error) {
+                    nameField.setError(null);
+                  }
+                }}
+                onFocus={() => setIsNameInputFocused(true)}
+                onBlur={() => {
+                  setIsNameInputFocused(false);
+                  handleNameBlur();
+                }}
+                disabled={isReadOnly}
+                invalid={!!nameField.error}
+              />
+            </Tooltip>
+          </PropertyValue>
           {nameField.error && (
             <div className={errorMessageStyle}>{nameField.error}</div>
           )}
@@ -177,51 +183,53 @@ const PlaceMainContent: React.FC = () => {
                 : ""
             } Tokens in places don't have to carry data, but they need one to enable dynamics (token data changing over time when in a place).`}
           >
-            <Tooltip
-              content={UI_MESSAGES.READ_ONLY_MODE}
-              disableTooltip={!isReadOnly}
-            >
-              <Select
-                required
-                size="sm"
-                value={place.colorId ?? ""}
-                onChange={(colorId) => {
-                  const nextColorId = colorId === "" ? null : colorId;
-                  updatePlace({
-                    placeId: place.id,
-                    update: {
-                      colorId: nextColorId,
-                      dynamicsEnabled:
-                        nextColorId === null && place.dynamicsEnabled
-                          ? false
-                          : place.dynamicsEnabled,
-                    },
-                  });
-                }}
-                items={[
-                  { value: "", text: "None" },
-                  ...types.map((type) => ({
-                    value: type.id,
-                    text: type.name,
-                  })),
-                ]}
-                renderItem={(value) => {
-                  const type = types.find((tp) => tp.id === value);
-                  return (
-                    <div className={arcStyle}>
-                      {type?.displayColor && (
-                        <div
-                          className={typeColorDotStyle}
-                          style={{ backgroundColor: type.displayColor }}
-                        />
-                      )}
-                      {type?.name ?? "None"}
-                    </div>
-                  );
-                }}
-                disabled={isReadOnly}
-              />
-            </Tooltip>
+            <PropertyValue text={placeTypeName}>
+              <Tooltip
+                content={UI_MESSAGES.READ_ONLY_MODE}
+                disableTooltip={!isReadOnly}
+              >
+                <Select
+                  required
+                  size="sm"
+                  value={place.colorId ?? ""}
+                  onChange={(colorId) => {
+                    const nextColorId = colorId === "" ? null : colorId;
+                    updatePlace({
+                      placeId: place.id,
+                      update: {
+                        colorId: nextColorId,
+                        dynamicsEnabled:
+                          nextColorId === null && place.dynamicsEnabled
+                            ? false
+                            : place.dynamicsEnabled,
+                      },
+                    });
+                  }}
+                  items={[
+                    { value: "", text: "None" },
+                    ...types.map((type) => ({
+                      value: type.id,
+                      text: type.name,
+                    })),
+                  ]}
+                  renderItem={(value) => {
+                    const type = types.find((tp) => tp.id === value);
+                    return (
+                      <div className={arcStyle}>
+                        {type?.displayColor && (
+                          <div
+                            className={typeColorDotStyle}
+                            style={{ backgroundColor: type.displayColor }}
+                          />
+                        )}
+                        {type?.name ?? "None"}
+                      </div>
+                    );
+                  }}
+                  disabled={isReadOnly}
+                />
+              </Tooltip>
+            </PropertyValue>
 
             {place.colorId && (
               <div className={jumpButtonContainerStyle}>

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/place-properties/subviews/main.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/place-properties/subviews/main.tsx
@@ -154,7 +154,7 @@ const PlaceMainContent: React.FC = () => {
               />
             </Tooltip>
           </PropertyValue>
-          {nameField.error && (
+          {!isReadOnly && nameField.error && (
             <div className={errorMessageStyle}>{nameField.error}</div>
           )}
         </Section>


### PR DESCRIPTION
## Summary

Before this PR, a read-only net still rendered every property value in the control that edits it, greyed out. A name arrived as a disabled text box, a description as a disabled textarea, and the field labels dimmed along with them, so the values a reader came for were the lowest-contrast text on the panel. Two fields in the arc panel already sidestepped this and printed their value as text.

The properties panel now renders read-only values the way those two arc fields do: the value as text, at full contrast, under a label that no longer greys out. This reaches the embedded Preview, the website's full example view, and the editor whenever the net is read-only, which includes Simulate mode and any live simulation.

<img src="https://github.com/user-attachments/assets/69bc3379-91f1-4e3e-b8da-a3d9a699f7fc" alt="A place's properties on a read-only net, before and after" width="900">

## Links

- Ticket [FE-1637](https://linear.app/hash/issue/FE-1637)
- Docs [Embedded Preview](https://github.com/hashintel/hash/blob/claude/fe-1637-readonly-values-as-text/libs/@hashintel/petrinaut/docs/preview.md)

## Changes

#### Shared

- New `PropertyValue`, wrapping one field's editing control
  > Renders its children on an editable net and the value as text on a read-only one, reading the same `useIsReadOnly` every panel already consults.
  > A missing or blank value renders a caller-chosen stand-in, defaulting to "None".
- `DraftFieldInput` and the description field render through it
  > That covers the name and description of transitions, types, parameters, differential equations, places, and component instances in one place.
- Read-only labels keep full contrast
  > `Form.Field` no longer receives `disabled` when the only reason was the net being read-only. A read-only field is not a disabled one.

#### Panels

- Place name, accepted token type, arc type, arc weight, differential-equation type, and component-instance name read as text
  > Arc type labels now come from one map shared with the select's options, so the two cannot name a type differently.
- Toggles and checkboxes are unchanged
  > A checkbox already shows its value by being ticked, so it reads correctly without a text form.

## Known issues

- Complex editors keep their controls on a read-only net
  > The type-element list, the initial-state grid, and the arc tables are structures rather than single values, and each needs its own read-only presentation.

## Test coverage

- `property-value.test.tsx`:
  > Control on an editable net, text on a read-only one, and the stand-in for undefined, null, and blank values.
- Existing `@hashintel/petrinaut` unit suite
- Verified in the running embed:
  > Selecting a place leaves no text input in the panel, and name, description, and token type render as text.

## How to test

- Open [SIR embed](https://petrinaut-git-claude-fe-1637-readonly-values-as-text.stage.hash.ai/embed/examples/sir-epidemic-model) on Vercel
- Select the Infected place
  > Expect name and description as text, labels at full contrast, no input boxes
- Select an arc
  > Expect Type and Weight as text
- Open [SIR full view](https://petrinaut-git-claude-fe-1637-readonly-values-as-text.stage.hash.ai/examples/sir-epidemic-model) and select a transition
  > Expect name and description as text
- Switch to Simulate in the full view and select a place
  > Expect the same text presentation, since the net is read-only there

