### PR TITLE
FE-1638: Show elapsed and total time in the playback readout

### DIFF
--- a/.changeset/playback-time-readout.md
+++ b/.changeset/playback-time-readout.md
@@ -2,4 +2,4 @@
 "@hashintel/petrinaut": patch
 ---
 
-The playback readout shows elapsed and total simulated time instead of the frame index and frame count, in both the editor's toolbar and the embedded Preview's bar. Times print at the precision the run's time step carries.
+The playback readout shows elapsed and total simulated time instead of the frame index and frame count, in both the editor's toolbar and the embedded Preview's bar. Times print at the precision the run's time step carries, stacked over two lines. The scrubber sizes itself to the space the bar has instead of a fixed width.

--- a/.changeset/playback-time-readout.md
+++ b/.changeset/playback-time-readout.md
@@ -1,0 +1,5 @@
+---
+"@hashintel/petrinaut": patch
+---
+
+The playback readout shows elapsed and total simulated time instead of the frame index and frame count, in both the editor's toolbar and the embedded Preview's bar. Times print at the precision the run's time step carries.

--- a/libs/@hashintel/petrinaut/docs/preview.md
+++ b/libs/@hashintel/petrinaut/docs/preview.md
@@ -41,7 +41,7 @@ The selected scenario's initial marking appears on the shared canvas before a
 run starts. Press **Play** in the compact bar at the bottom to start the run;
 the preview never starts it automatically. The same bar lets you pause, reset,
 choose from the playback speeds allowed by the embed, and scrub through the
-frames that have been produced.
+run. It reads out the elapsed time and the run's total time.
 
 As soon as frames arrive, the compact bar expands upward to show a small
 timeline. The timeline follows playback, lets you hover to inspect a series,

--- a/libs/@hashintel/petrinaut/docs/simulation.md
+++ b/libs/@hashintel/petrinaut/docs/simulation.md
@@ -90,16 +90,17 @@ A transition blocked only because its output place is at [capacity](drawing-a-ne
 
 The bottom toolbar provides playback controls:
 
-| Control          | Description                         |
-| ---------------- | ----------------------------------- |
-| **Play**         | Start or resume playback.           |
-| **Pause**        | Pause at the current frame.         |
-| **Stop / Reset** | Stop playback and reset to frame 0. |
+| Control          | Description                               |
+| ---------------- | ----------------------------------------- |
+| **Play**         | Start or resume playback.                 |
+| **Pause**        | Pause at the current point in the run.    |
+| **Stop / Reset** | Stop playback and reset to the run start. |
 
-The frame counter shows the current frame number, total frames, and elapsed simulation time.
+The time readout shows the elapsed simulation time and the run's total
+simulated time, at the precision the run's time step carries.
 
 Playback widens the toolbar, so in a narrow window it keeps Play and folds the
-scrubber, the frame counter and the playback settings away until you point at
+scrubber, the time readout and the playback settings away until you point at
 it.
 
 <img width="717" height="62" alt="simulation-toolbar" src="https://github.com/user-attachments/assets/fc39afbe-8603-4be5-88b1-83d5b09d5367" />

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/components/BottomBar/playback-time.test.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/components/BottomBar/playback-time.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { formatPlaybackTimes, playbackTimes } from "./playback-time";
+
+describe("playbackTimes", () => {
+  it("places the first frame at the start of the run", () => {
+    expect(
+      playbackTimes({ frameIndex: 0, totalFrames: 100, dt: 0.01 }),
+    ).toEqual({ elapsed: 0, total: 0.99 });
+  });
+
+  it("ends the run on its last produced frame", () => {
+    const { elapsed, total } = playbackTimes({
+      frameIndex: 99,
+      totalFrames: 100,
+      dt: 0.01,
+    });
+
+    expect(elapsed).toBeCloseTo(0.99);
+    expect(elapsed).toBeCloseTo(total);
+  });
+
+  it("reports no total before a frame exists", () => {
+    expect(playbackTimes({ frameIndex: 0, totalFrames: 0, dt: 0.01 })).toEqual({
+      elapsed: 0,
+      total: 0,
+    });
+  });
+});
+
+describe("formatPlaybackTimes", () => {
+  it.each([
+    { dt: 0.5, elapsed: "1.5", total: "4.5s" },
+    { dt: 0.01, elapsed: "1.50", total: "4.50s" },
+    { dt: 0.001, elapsed: "1.500", total: "4.500s" },
+  ])("prints a run of step $dt at its own precision", ({ dt, ...expected }) => {
+    expect(formatPlaybackTimes({ elapsed: 1.5, total: 4.5 }, dt)).toEqual(
+      expected,
+    );
+  });
+
+  it("falls back to milliseconds for a step it cannot read", () => {
+    expect(formatPlaybackTimes({ elapsed: 0, total: 0 }, 0)).toEqual({
+      elapsed: "0.000",
+      total: "0.000s",
+    });
+  });
+});

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/components/BottomBar/playback-time.test.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/components/BottomBar/playback-time.test.ts
@@ -30,13 +30,49 @@ describe("playbackTimes", () => {
 
 describe("formatPlaybackTimes", () => {
   it.each([
-    { dt: 0.5, elapsed: "1.5", total: "4.5s" },
-    { dt: 0.01, elapsed: "1.50", total: "4.50s" },
-    { dt: 0.001, elapsed: "1.500", total: "4.500s" },
-  ])("prints a run of step $dt at its own precision", ({ dt, ...expected }) => {
-    expect(formatPlaybackTimes({ elapsed: 1.5, total: 4.5 }, dt)).toEqual(
-      expected,
-    );
+    {
+      dt: 1,
+      times: { elapsed: 2, total: 5 },
+      printed: { elapsed: "2", total: "5s" },
+    },
+    {
+      dt: 0.5,
+      times: { elapsed: 1.5, total: 4.5 },
+      printed: { elapsed: "1.5", total: "4.5s" },
+    },
+    // Not a power of ten: bucketing by magnitude printed "1.8" for 1.75.
+    {
+      dt: 0.25,
+      times: { elapsed: 1.75, total: 4.75 },
+      printed: { elapsed: "1.75", total: "4.75s" },
+    },
+    {
+      dt: 0.01,
+      times: { elapsed: 1.75, total: 4.75 },
+      printed: { elapsed: "1.75", total: "4.75s" },
+    },
+    {
+      dt: 0.025,
+      times: { elapsed: 1.75, total: 4.75 },
+      printed: { elapsed: "1.750", total: "4.750s" },
+    },
+    {
+      dt: 0.001,
+      times: { elapsed: 1.75, total: 4.75 },
+      printed: { elapsed: "1.750", total: "4.750s" },
+    },
+  ])(
+    "prints a run of step $dt at its own precision",
+    ({ dt, times, printed }) => {
+      expect(formatPlaybackTimes(times, dt)).toEqual(printed);
+    },
+  );
+
+  it("never prints more than milliseconds, however fine the step", () => {
+    // A step of 0.0025 carries four decimals; the readout stops at three.
+    expect(
+      formatPlaybackTimes({ elapsed: 0.005, total: 0.01 }, 0.0025),
+    ).toEqual({ elapsed: "0.005", total: "0.010s" });
   });
 
   it("falls back to milliseconds for a step it cannot read", () => {

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/components/BottomBar/playback-time.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/components/BottomBar/playback-time.ts
@@ -26,21 +26,30 @@ export const playbackTimes = ({
   total: Math.max(0, totalFrames - 1) * dt,
 });
 
+/** Most decimals a readout will print, whatever the step needs. */
+const MAX_DECIMALS = 3;
+
 /**
  * Decimals worth printing for a run of this step size: every time in the run
- * is a multiple of `dt`, so more digits than the step carries are always zero.
+ * is a multiple of `dt`, so more digits than the step itself carries are
+ * always zero.
+ *
+ * Read off the step rather than from its magnitude. A step of 0.25 carries two
+ * decimals while a step of 0.5 carries one, so bucketing by powers of ten
+ * rounds a time the run actually visited into one it never did.
  */
 const decimalsForStep = (dt: number): number => {
   if (!Number.isFinite(dt) || dt <= 0) {
-    return 3;
+    return MAX_DECIMALS;
   }
-  if (dt >= 0.1) {
-    return 1;
+
+  for (let decimals = 0; decimals < MAX_DECIMALS; decimals += 1) {
+    if (Number(dt.toFixed(decimals)) === dt) {
+      return decimals;
+    }
   }
-  if (dt >= 0.01) {
-    return 2;
-  }
-  return 3;
+
+  return MAX_DECIMALS;
 };
 
 /** `elapsed / total` for one run, in seconds, at the run's own precision. */

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/components/BottomBar/playback-time.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/components/BottomBar/playback-time.ts
@@ -1,0 +1,56 @@
+/**
+ * The playback readout's numbers: where the run has reached, and how far it
+ * goes. Both are derived from the frame the viewer is on, because a frame is
+ * how a run is stored, and neither is shown as a frame, because time is how a
+ * run is read.
+ */
+
+export interface PlaybackTimes {
+  /** Seconds from the start of the run to the frame on screen. */
+  elapsed: number;
+  /** Seconds from the start of the run to its last produced frame. */
+  total: number;
+}
+
+export const playbackTimes = ({
+  frameIndex,
+  totalFrames,
+  dt,
+}: {
+  frameIndex: number;
+  totalFrames: number;
+  dt: number;
+}): PlaybackTimes => ({
+  elapsed: frameIndex * dt,
+  // The first frame sits at t=0, so a run of n frames ends at (n - 1) steps.
+  total: Math.max(0, totalFrames - 1) * dt,
+});
+
+/**
+ * Decimals worth printing for a run of this step size: every time in the run
+ * is a multiple of `dt`, so more digits than the step carries are always zero.
+ */
+const decimalsForStep = (dt: number): number => {
+  if (!Number.isFinite(dt) || dt <= 0) {
+    return 3;
+  }
+  if (dt >= 0.1) {
+    return 1;
+  }
+  if (dt >= 0.01) {
+    return 2;
+  }
+  return 3;
+};
+
+/** `elapsed / total` for one run, in seconds, at the run's own precision. */
+export const formatPlaybackTimes = (
+  { elapsed, total }: PlaybackTimes,
+  dt: number,
+): { elapsed: string; total: string } => {
+  const decimals = decimalsForStep(dt);
+  return {
+    elapsed: elapsed.toFixed(decimals),
+    total: `${total.toFixed(decimals)}s`,
+  };
+};

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/components/BottomBar/simulation-controls.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/components/BottomBar/simulation-controls.tsx
@@ -54,9 +54,11 @@ const sliderStyle = cva({
   base: {
     // Sized to the space available rather than to a fixed 300px: `clamp`
     // tracks the viewport continuously, so a window or iframe resize slides
-    // the scrubber's width with it instead of stepping at a breakpoint, and
-    // `flex` lets it take any slack the row has left over once the bar is
-    // wider than its content.
+    // the scrubber's width with it instead of stepping at a breakpoint.
+    //
+    // The flexing applies to the embed's expanded bar, whose row is held to
+    // the bar's full width and so has slack to give. The editor's toolbar
+    // group is sized to its content, where there is none to take.
     width: "[clamp(140px, 24vw, 420px)]",
     flex: "[1 1 auto]",
     minWidth: "[96px]",
@@ -248,6 +250,7 @@ export const SimulationControls: React.FC<SimulationControlsProps> = ({
         {hasSimulation && (
           <>
             <div
+              role="timer"
               aria-label={`Elapsed ${times.elapsed} of ${times.total}`}
               className={timeReadoutStyle({
                 compact: presentation.compactControls,

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/components/BottomBar/simulation-controls.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/components/BottomBar/simulation-controls.tsx
@@ -15,23 +15,26 @@ import { ToolbarDivider } from "./toolbar-divider";
 
 import type { PlaybackSpeed } from "../../../../../react/playback/context";
 
-// One line, wide enough for the longest run either bar will show, so the
-// controls either side of it hold still while the numbers count up.
+// Elapsed over total, stacked, so the readout costs the bar a column of
+// digits rather than a row of them. Wide enough for the longest run either bar
+// will show, so the controls either side hold still while the numbers run.
 const timeReadoutStyle = cva({
   base: {
     display: "flex",
-    alignItems: "baseline",
+    flexDirection: "column",
+    alignItems: "center",
     justifyContent: "center",
-    gap: "[3px]",
-    width: "[104px]",
-    lineHeight: "[1]",
+    flexShrink: "0",
+    width: "[58px]",
+    lineHeight: "[1.15]",
     fontVariantNumeric: "tabular-nums",
+    letterSpacing: "[-0.2px]",
     overflow: "hidden",
     whiteSpace: "nowrap",
   },
   variants: {
     compact: {
-      true: { width: "[96px]" },
+      true: { width: "[54px]" },
     },
   },
 });
@@ -40,18 +43,24 @@ const elapsedTimeStyle = css({
   fontSize: "[11px]",
   fontWeight: "medium",
   color: "neutral.s110",
-  letterSpacing: "[-0.2px]",
 });
 
 const totalTimeStyle = css({
-  fontSize: "[11px]",
+  fontSize: "[9px]",
   color: "neutral.s95",
-  letterSpacing: "[-0.2px]",
 });
 
 const sliderStyle = cva({
   base: {
-    width: "[300px]",
+    // Sized to the space available rather than to a fixed 300px: `clamp`
+    // tracks the viewport continuously, so a window or iframe resize slides
+    // the scrubber's width with it instead of stepping at a breakpoint, and
+    // `flex` lets it take any slack the row has left over once the bar is
+    // wider than its content.
+    width: "[clamp(140px, 24vw, 420px)]",
+    flex: "[1 1 auto]",
+    minWidth: "[96px]",
+    maxWidth: "[100%]",
     height: "[4px]",
     appearance: "none",
     background: "neutral.s30",
@@ -82,9 +91,8 @@ const sliderStyle = cva({
   variants: {
     compact: {
       true: {
-        width: "[clamp(96px, 30vw, 220px)]",
-        flex: "[1 1 160px]",
-        minWidth: "[96px]",
+        width: "[clamp(96px, 34vw, 360px)]",
+        minWidth: "[72px]",
       },
     },
   },

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/components/BottomBar/simulation-controls.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/components/BottomBar/simulation-controls.tsx
@@ -9,43 +9,44 @@ import { EditorContext } from "../../../../../react/state/editor-context";
 import { usePetrinautPresentation } from "../../../shared/presentation-context";
 import { CollapsibleGroup } from "./collapsible-group";
 import { PlaybackSettingsMenu } from "./playback-settings-menu";
+import { formatPlaybackTimes, playbackTimes } from "./playback-time";
 import { ToolbarButton } from "./toolbar-button";
 import { ToolbarDivider } from "./toolbar-divider";
 
 import type { PlaybackSpeed } from "../../../../../react/playback/context";
 
-const frameInfoStyle = cva({
+// One line, wide enough for the longest run either bar will show, so the
+// controls either side of it hold still while the numbers count up.
+const timeReadoutStyle = cva({
   base: {
     display: "flex",
-    flexDirection: "column",
-    alignItems: "center",
-    fontSize: "[10px]",
-    color: "neutral.s105",
-    fontWeight: "medium",
+    alignItems: "baseline",
+    justifyContent: "center",
+    gap: "[3px]",
+    width: "[104px]",
     lineHeight: "[1]",
-    width: "[90px]",
     fontVariantNumeric: "tabular-nums",
     overflow: "hidden",
     whiteSpace: "nowrap",
   },
   variants: {
     compact: {
-      true: { width: "[64px]" },
+      true: { width: "[96px]" },
     },
   },
 });
 
 const elapsedTimeStyle = css({
-  fontSize: "[9px]",
-  color: "neutral.s100",
-  marginTop: "[2px]",
+  fontSize: "[11px]",
+  fontWeight: "medium",
+  color: "neutral.s110",
+  letterSpacing: "[-0.2px]",
 });
 
-const frameIndexStyle = css({
+const totalTimeStyle = css({
   fontSize: "[11px]",
-  color: "neutral.s100",
+  color: "neutral.s95",
   letterSpacing: "[-0.2px]",
-  marginTop: "[1px]",
 });
 
 const sliderStyle = cva({
@@ -127,7 +128,14 @@ export const SimulationControls: React.FC<SimulationControlsProps> = ({
   const isSimulationErrored = simulationState === "Error";
   const isPlaybackPlaying = playbackState === "Playing";
   const frameIndex = currentFrameIndex;
-  const elapsedTime = currentViewedFrame ? frameIndex * dt : 0;
+  const times = formatPlaybackTimes(
+    playbackTimes({
+      frameIndex: currentViewedFrame ? frameIndex : 0,
+      totalFrames,
+      dt,
+    }),
+    dt,
+  );
 
   // Disable play button when at the last frame and simulation is complete or errored
   const isAtLastFrame = totalFrames > 0 && frameIndex >= totalFrames - 1;
@@ -232,15 +240,13 @@ export const SimulationControls: React.FC<SimulationControlsProps> = ({
         {hasSimulation && (
           <>
             <div
-              className={frameInfoStyle({
+              aria-label={`Elapsed ${times.elapsed} of ${times.total}`}
+              className={timeReadoutStyle({
                 compact: presentation.compactControls,
               })}
             >
-              {!presentation.compactControls && <div>Frame</div>}
-              <div className={frameIndexStyle}>
-                {frameIndex + 1} / {totalFrames}
-              </div>
-              <div className={elapsedTimeStyle}>{elapsedTime.toFixed(3)}s</div>
+              <span className={elapsedTimeStyle}>{times.elapsed}</span>
+              <span className={totalTimeStyle}>/ {times.total}</span>
             </div>
 
             <input


### PR DESCRIPTION
## Summary

Before this PR, the playback readout led with the frame index and count, over the elapsed time in a smaller, lighter size. A frame index is an artefact of how a run is stored: nothing a reader can act on, and on a long run it is four digits of noise wider than the numbers that matter. The screenshot on the ticket shows "4539 / 4611" over "45.380s".

Readout now shows elapsed time over total time and nothing else, in both the editor's toolbar and the embedded Preview's bar. Times print at the precision the run's own time step carries, so a run stepped at 0.01 reads 3.07 over 3.70s rather than padding three decimals it does not have. The scrubber beside it sizes itself to the space the bar has, in place of a fixed 300px.

https://github.com/user-attachments/assets/7cd031f7-3e7d-483d-9bc5-bf8fab44fbea

## Links

- Ticket [FE-1638](https://linear.app/hash/issue/FE-1638)
- Docs [Simulation](https://github.com/hashintel/hash/blob/claude/fe-1638-playback-time-readout/libs/@hashintel/petrinaut/docs/simulation.md)
- Docs [Embedded Preview](https://github.com/hashintel/hash/blob/claude/fe-1638-playback-time-readout/libs/@hashintel/petrinaut/docs/preview.md)

## Changes

- Playback readout is elapsed time over total time, stacked over two lines
  > Elapsed carries the emphasis, the total sits under it in lighter grey.
  > The frame index, the frame count, and the "Frame" label are gone.
- Scrubber sizes itself to the space the bar has
  > `clamp(140px, 24vw, 420px)` with `flex: 1 1 auto`: `clamp` tracks the viewport continuously, so a resize slides its width instead of stepping at a breakpoint, and flex takes any slack the row has left over.
  > Inside an embed `vw` is the iframe's own width, so a host resizing its frame resizes the scrubber with it.
- New `playback-time.ts` derives and formats both numbers
  > `playbackTimes` puts the first frame at t=0, so a run of n frames ends at (n - 1) steps.
  > `formatPlaybackTimes` prints the decimals the step itself carries, found by asking which fixed-point rendering round-trips, and capped at milliseconds.
  > Bucketing by magnitude instead printed "1.8" for a true 1.75 on a run stepped at 0.25.
- Readout carries an accessible label
  > `Elapsed 3.07 of 3.70s`, since the visible text is two spans of digits.
- Fixed width holds the controls either side still
  > 58px, 54px on the compact embed bar, with tabular figures, so nothing shifts as the numbers count up.

## Test coverage

- `playback-time.test.ts`:
  > Frame-to-time mapping at the start and end of a run, the empty run, and the printed precision for each step size.
  > Steps of 0.25 and 0.025 pin the case that magnitude bucketing rounded into a time the run never visited.
- Existing `@hashintel/petrinaut` unit suite
- Verified in both surfaces:
  > The embed bar reads `3.07 / 3.70s` and the editor toolbar `3.45 / 4.00s`, with no "Frame" text left in either page.

## How to test

- Open [SIR embed](https://petrinaut-git-claude-fe-1638-playback-time-readout.stage.hash.ai/embed/examples/sir-epidemic-model) on Vercel
- Press Play
  > Expect elapsed over total time, no frame numbers
- Drag the scrubber
  > Expect the elapsed number to follow the pointer, the total to hold
- Open [SIR full view](https://petrinaut-git-claude-fe-1638-playback-time-readout.stage.hash.ai/examples/sir-epidemic-model) and press Play in the bottom toolbar
  > Expect the same readout
- Narrow the window while the run plays
  > Expect the scrubber to shrink with it, the readout to hold its width
- Narrow the window until the toolbar folds
  > Expect Play to stay, the readout to fold away with the scrubber



