### PR TITLE
FE-1639: Show the model's code in the Preview inspector, and make the panel resizable

### DIFF
--- a/.changeset/preview-code-view.md
+++ b/.changeset/preview-code-view.md
@@ -1,0 +1,5 @@
+---
+"@hashintel/petrinaut": patch
+---
+
+The embedded Preview's inspector links to the code behind the selected item -- a transition's rate or lambda function and its kernel, a differential equation's body -- and shows it read-only in its own view. The inspector is also resizable from its inner edge and animates open and closed.

--- a/libs/@hashintel/petrinaut/docs/preview.md
+++ b/libs/@hashintel/petrinaut/docs/preview.md
@@ -27,6 +27,15 @@ are still rendered, and simply do nothing. On a wide embed the
 inspector docks to the right of the canvas. On a narrow embed it sits under
 the canvas so the canvas remains usable.
 
+Where the selected item is driven by code, the inspector links to it: a
+transition's rate or lambda function and its transition kernel, and the
+equation body behind a differential equation or a place with dynamics. The link
+opens the code in the inspector, read-only and unhighlighted, with a back
+button to the properties. Code is selectable, so you can copy it.
+
+Drag the inspector's inner edge to resize it. It animates open and closed, so
+the canvas resizes smoothly rather than jumping by the panel's width.
+
 Use the compact net selector to move between the root net and its subnets. The
 canvas, selection, and inspector update together when you change nets.
 

--- a/libs/@hashintel/petrinaut/src/ui/preview/code-view.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/preview/code-view.tsx
@@ -1,0 +1,94 @@
+import { Button } from "@hashintel/ds-components";
+import { css } from "@hashintel/ds-helpers/css";
+
+import type { CodeViewTarget } from "../views/shared/code-view/context";
+
+const containerStyle = css({
+  display: "flex",
+  flexDirection: "column",
+  height: "full",
+  minHeight: "0",
+});
+
+const headerStyle = css({
+  display: "flex",
+  alignItems: "center",
+  gap: "1",
+  flexShrink: "0",
+  paddingX: "2",
+  paddingY: "2",
+  borderBottomWidth: "thin",
+  borderColor: "neutral.a20",
+  backgroundColor: "neutral.s00",
+});
+
+const titleStyle = css({
+  minWidth: "0",
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+  fontSize: "sm",
+  fontWeight: "semibold",
+  color: "neutral.fg.heading",
+});
+
+const codeStyle = css({
+  flex: "1",
+  minWidth: "0",
+  minHeight: "0",
+  overflow: "auto",
+  margin: "0",
+  padding: "3",
+  fontFamily: "mono",
+  fontSize: "[12px]",
+  lineHeight: "[1.6]",
+  color: "neutral.fg.body",
+  tabSize: "2",
+  // Wrapped, not scrolled sideways: the panel is narrow and a reader should
+  // not have to drag to reach the end of a comment. Indentation is preserved.
+  whiteSpace: "pre-wrap",
+  overflowWrap: "break-word",
+  // Code is the one thing in an embed a reader wants to take away, so it
+  // opts back out of the embed's blanket `user-select: none`.
+  userSelect: "text",
+});
+
+const emptyStyle = css({
+  padding: "3",
+  fontSize: "sm",
+  color: "neutral.s95",
+});
+
+/**
+ * One piece of the model's code, as it is written.
+ *
+ * Deliberately a `pre` and nothing more: no editing, no highlighting, no
+ * language tooling. The preview mounts none of that, and the point here is to
+ * let a reader see what drives the net.
+ */
+export const PreviewCodeView = ({
+  target: { title, code },
+  onBack,
+}: {
+  target: CodeViewTarget;
+  onBack: () => void;
+}) => (
+  <div className={containerStyle}>
+    <div className={headerStyle}>
+      <Button
+        size="xs"
+        variant="ghost"
+        iconName="chevronLeft"
+        aria-label="Back to properties"
+        tooltip="Back to properties"
+        onClick={onBack}
+      />
+      <span className={titleStyle}>{title}</span>
+    </div>
+    {code.trim() ? (
+      <pre className={codeStyle}>{code}</pre>
+    ) : (
+      <div className={emptyStyle}>This part of the model carries no code.</div>
+    )}
+  </div>
+);

--- a/libs/@hashintel/petrinaut/src/ui/preview/properties-panel.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/preview/properties-panel.tsx
@@ -1,30 +1,67 @@
+import { use, useState } from "react";
+
 import { css, cx } from "@hashintel/ds-helpers/css";
 
 import { usePanelTarget } from "../../react/state/use-selection";
+import { UserSettingsContext } from "../../react/state/user-settings-context";
 import { GlassPanel } from "../components/glass-panel";
 import { SelectedItemProperties } from "../views/Editor/panels/PropertiesPanel/selected-item-properties";
+import {
+  CodeViewContext,
+  type CodeViewTarget,
+} from "../views/shared/code-view/context";
+import { PreviewCodeView } from "./code-view";
+
+const DEFAULT_WIDTH = 300;
+const MIN_WIDTH = 240;
+const MAX_WIDTH = 560;
 
 // Docked beside the canvas like the editor's inspector: a flat bordered
-// column with square corners, no shadow or blur.
+// column with square corners, no shadow or blur. Its open width rides a
+// custom property so the narrow layout can animate its height from the same
+// state without a second set of inline styles.
 const previewPanelStyle = css({
   flexShrink: "0",
-  width: "[clamp(250px, 34vw, 320px)]",
+  width: "[var(--preview-panel-width)]",
   minHeight: "0",
   overflow: "hidden",
   borderLeftWidth: "thin",
   "@media (max-width: 640px)": {
     width: "auto",
-    height: "[min(40%, 240px)]",
+    height: "[var(--preview-panel-height)]",
     borderLeftWidth: "0",
     borderTopWidth: "thin",
   },
 });
 
+const animatedPanelStyle = css({
+  transition: "[width 180ms ease-in-out]",
+  "@media (max-width: 640px)": {
+    transition: "[height 180ms ease-in-out]",
+  },
+  "@media (prefers-reduced-motion: reduce)": {
+    transition: "[none]",
+  },
+  // A drag tracks the pointer, so the width it writes must not be animated.
+  "&:has([data-resizing='true'])": {
+    transition: "[none]",
+  },
+});
+
 const previewPanelContentStyle = css({
   overflowY: "auto",
-  // The inspector content is shared with the full editor and sized for it;
-  // rendering it slightly smaller keeps the embed sheet compact without
-  // forking the editor components.
+});
+
+// The inspector content is shared with the full editor and sized for it;
+// rendering it slightly smaller keeps the embed sheet compact without forking
+// the editor components.
+//
+// The zoom belongs on the scrolling box itself: the property content fills its
+// host with `flex: 1` against `height: 100%`, and a plain wrapper in between
+// has no height of its own to give it, which collapses the whole subtree.
+// Code is exempt, being monospaced at a size chosen for this view.
+const scaledContentStyle = css({
+  overflowY: "auto",
   zoom: "[0.85]",
 });
 
@@ -33,22 +70,74 @@ const previewPanelContentStyle = css({
  * a column docked to the right of the canvas at normal embed widths and a band
  * under it on narrow viewports; the entity-specific content is identical to
  * the full editor.
+ *
+ * The shell stays mounted so opening and closing it animates, and it hosts the
+ * read-only code view that the property panels link to.
  */
 export const PreviewPropertiesPanel: React.FC<{ className?: string }> = ({
   className,
 }) => {
   const panelTarget = usePanelTarget();
+  const { showAnimations } = use(UserSettingsContext);
+  const [width, setWidth] = useState(DEFAULT_WIDTH);
+  const [codeTarget, setCodeTarget] = useState<CodeViewTarget | null>(null);
 
-  if (panelTarget.kind === "none") {
-    return null;
+  const isOpen = panelTarget.kind !== "none";
+
+  /**
+   * Selecting something else leaves the code of the last selection behind, so
+   * the panel returns to properties whenever the selection changes. Adjusting
+   * during render rather than in an effect keeps the two from disagreeing for
+   * a frame.
+   */
+  const [lastPanelTarget, setLastPanelTarget] = useState(panelTarget);
+  if (lastPanelTarget !== panelTarget) {
+    setLastPanelTarget(panelTarget);
+    setCodeTarget(null);
   }
+
+  /**
+   * The content follows the selection, so a closing panel is an empty box for
+   * the length of the transition. That is what stops the canvas jumping, which
+   * is the point of animating it.
+   */
+  const content = codeTarget ? (
+    <PreviewCodeView target={codeTarget} onBack={() => setCodeTarget(null)} />
+  ) : (
+    <SelectedItemProperties />
+  );
 
   return (
     <GlassPanel
-      className={cx(previewPanelStyle, className)}
-      contentClassName={previewPanelContentStyle}
+      className={cx(
+        previewPanelStyle,
+        showAnimations && animatedPanelStyle,
+        className,
+      )}
+      contentClassName={
+        codeTarget ? previewPanelContentStyle : scaledContentStyle
+      }
+      resizable={
+        isOpen
+          ? {
+              edge: "left",
+              size: width,
+              onResize: setWidth,
+              minSize: MIN_WIDTH,
+              maxSize: MAX_WIDTH,
+            }
+          : undefined
+      }
+      style={
+        {
+          "--preview-panel-width": isOpen ? `${width}px` : "0px",
+          "--preview-panel-height": isOpen ? "min(40%, 240px)" : "0px",
+        } as React.CSSProperties
+      }
     >
-      <SelectedItemProperties />
+      <CodeViewContext value={{ open: setCodeTarget }}>
+        {content}
+      </CodeViewContext>
     </GlassPanel>
   );
 };

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/differential-equation-properties/subviews/main.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/differential-equation-properties/subviews/main.tsx
@@ -21,6 +21,7 @@ import { DraftFieldInput } from "../../../../../../components/draft-field-input"
 import { PropertyValue } from "../../../../../../components/property-value";
 import { DifferentialEquationIcon } from "../../../../../../constants/entity-icons";
 import { UI_MESSAGES } from "../../../../../../constants/ui-messages";
+import { CodeLink } from "../../../../../shared/code-view/code-link";
 import { usePetrinautPresentation } from "../../../../../shared/presentation-context";
 import { useDiffEqPropertiesContext } from "../context";
 
@@ -183,6 +184,8 @@ const DiffEqMainContent: React.FC = () => {
             </Tooltip>
           </PropertyValue>
         </Form.Field>
+
+        <CodeLink title="Equation" code={differentialEquation.code} />
 
         {presentation.showSourceCode && (
           <Suspense fallback={null}>

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/place-properties/subviews/main.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/place-properties/subviews/main.tsx
@@ -23,6 +23,7 @@ import { Section, SectionList } from "../../../../../../components/section";
 import { PlaceIcon } from "../../../../../../constants/entity-icons";
 import { UI_MESSAGES } from "../../../../../../constants/ui-messages";
 import { useDraftField } from "../../../../../../hooks/use-draft-field";
+import { CodeLink } from "../../../../../shared/code-view/code-link";
 import { usePlacePropertiesContext } from "../context";
 
 import type { SubView } from "../../../../../../components/sub-view/types";
@@ -116,6 +117,11 @@ const PlaceMainContent: React.FC = () => {
       });
     }
   };
+
+  const placeDiffEq =
+    differentialEquations.find(
+      (candidate) => candidate.id === place.differentialEquationId,
+    ) ?? null;
 
   const placeTypeName =
     types.find((candidate) => candidate.id === place.colorId)?.name ?? "None";
@@ -322,29 +328,35 @@ const PlaceMainContent: React.FC = () => {
             ) : (
               place.dynamicsEnabled && (
                 <>
-                  <Tooltip
-                    content={UI_MESSAGES.READ_ONLY_MODE}
-                    disableTooltip={!isReadOnly}
-                  >
-                    <Select
-                      required
-                      value={place.differentialEquationId ?? ""}
-                      size="sm"
-                      onChange={(differentialEquationId) => {
-                        if (differentialEquationId) {
-                          updatePlace({
-                            placeId: place.id,
-                            update: { differentialEquationId },
-                          });
-                        }
-                      }}
-                      items={availableDiffEqs.map((eq) => ({
-                        value: eq.id,
-                        text: eq.name,
-                      }))}
-                      disabled={isReadOnly}
-                    />
-                  </Tooltip>
+                  <PropertyValue text={placeDiffEq?.name}>
+                    <Tooltip
+                      content={UI_MESSAGES.READ_ONLY_MODE}
+                      disableTooltip={!isReadOnly}
+                    >
+                      <Select
+                        required
+                        value={place.differentialEquationId ?? ""}
+                        size="sm"
+                        onChange={(differentialEquationId) => {
+                          if (differentialEquationId) {
+                            updatePlace({
+                              placeId: place.id,
+                              update: { differentialEquationId },
+                            });
+                          }
+                        }}
+                        items={availableDiffEqs.map((eq) => ({
+                          value: eq.id,
+                          text: eq.name,
+                        }))}
+                        disabled={isReadOnly}
+                      />
+                    </Tooltip>
+                  </PropertyValue>
+
+                  {placeDiffEq && (
+                    <CodeLink title="Equation" code={placeDiffEq.code} />
+                  )}
 
                   {place.differentialEquationId && (
                     <div className={jumpButtonContainerStyle}>

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/transition-properties/subviews/main.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/transition-properties/subviews/main.tsx
@@ -23,6 +23,7 @@ import { DraftFieldInput } from "../../../../../../components/draft-field-input"
 import { Section, SectionList } from "../../../../../../components/section";
 import { TransitionIcon } from "../../../../../../constants/entity-icons";
 import { UI_MESSAGES } from "../../../../../../constants/ui-messages";
+import { CodeLink } from "../../../../../shared/code-view/code-link";
 import { useTransitionPropertiesContext } from "../context";
 
 import type { SubView } from "../../../../../../components/sub-view/types";
@@ -171,6 +172,19 @@ const TransitionMainContent: React.FC = () => {
           }
           disabled={isReadOnly}
           tooltip={isReadOnly ? UI_MESSAGES.READ_ONLY_MODE : undefined}
+        />
+
+        <CodeLink
+          title={
+            transition.lambdaType === "stochastic"
+              ? "Rate function"
+              : "Lambda function"
+          }
+          code={transition.lambdaCode}
+        />
+        <CodeLink
+          title="Transition kernel"
+          code={transition.transitionKernelCode}
         />
       </Form.Section>
 

--- a/libs/@hashintel/petrinaut/src/ui/views/shared/code-view/code-link.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/shared/code-view/code-link.tsx
@@ -1,0 +1,35 @@
+import { Button, Icon } from "@hashintel/ds-components";
+import { css } from "@hashintel/ds-helpers/css";
+
+import { useCodeView, type CodeViewTarget } from "./context";
+
+const containerStyle = css({
+  textAlign: "right",
+});
+
+/**
+ * Opens one piece of the model's code in the surrounding surface's code view,
+ * and renders nothing where there is no such view.
+ */
+export const CodeLink = ({ title, code }: CodeViewTarget) => {
+  const codeView = useCodeView();
+
+  if (!codeView) {
+    return null;
+  }
+
+  return (
+    <div className={containerStyle}>
+      <Button
+        variant="subtle"
+        tone="neutral"
+        size="xs"
+        prefix={<Icon name="code" size="xs" />}
+        suffix={<Icon name="arrowRight" />}
+        onClick={() => codeView.open({ title, code })}
+      >
+        {title}
+      </Button>
+    </div>
+  );
+};

--- a/libs/@hashintel/petrinaut/src/ui/views/shared/code-view/context.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/shared/code-view/context.ts
@@ -1,0 +1,24 @@
+import { createContext, use } from "react";
+
+/** One piece of the model's code, named as the reader should see it. */
+export interface CodeViewTarget {
+  /** Heads the view, e.g. "Lambda function". */
+  title: string;
+  code: string;
+}
+
+export interface CodeViewController {
+  open: (target: CodeViewTarget) => void;
+}
+
+/**
+ * The surface that can show a piece of the model's code, when there is one.
+ *
+ * A surface that authors code has editors for it already, so it provides no
+ * controller and the links to this view do not render. Presence of the
+ * controller is the whole feature test.
+ */
+export const CodeViewContext = createContext<CodeViewController | null>(null);
+
+export const useCodeView = (): CodeViewController | null =>
+  use(CodeViewContext);


### PR DESCRIPTION
## Summary

Before this PR, a reader of an embedded net could not see the code that drives it. A transition's rate or lambda function and its kernel, and the body of a differential equation, are what explain why the net behaves as it does, and the inspector that described the selected item offered none of them. The inspector also appeared and vanished the instant a selection changed, at a width the reader could not alter, so the canvas jumped by the panel's width each time and code had nowhere to grow into.

Inspector now links to the code behind the selected item and opens it in its own view, read-only, with a way back. It is resizable from its inner edge and animates open and closed. Code is the one thing in the embed that stays selectable, so a reader can copy it.

https://github.com/user-attachments/assets/f053ccd0-8d13-4e30-8cc0-dc3a286e44e0

## Links

- Ticket [FE-1639](https://linear.app/hash/issue/FE-1639)
- Docs [Embedded Preview](https://github.com/hashintel/hash/blob/claude/fe-1639-properties-panel-code-view/libs/@hashintel/petrinaut/docs/preview.md)

## Changes

#### Code view

- New `CodeViewContext`, and a `CodeLink` that renders only where a surface provides one
  > Presence of the controller is the whole feature test: the editor authors this code in Monaco already, provides no controller, and the links do not render there.
- Links from the item that owns the code
  > A transition offers its rate or lambda function and its transition kernel, a differential equation its body, and a place with dynamics the equation driving it.
- `PreviewCodeView` shows one piece of code as written
  > A `pre` and a back button. No editing, no highlighting, no language tooling, matching what the preview mounts.
  > Long lines wrap rather than scroll sideways, since the panel is narrow and indentation is preserved either way.
- Code opts out of the embed's blanket `user-select: none`

#### Inspector panel

- Panel is resizable from its inner edge, 240px to 560px
- Panel animates open and closed
  > Width rides a custom property so the narrow layout animates its height from the same state. Reduced motion and the animations setting both switch it off, and a resize drag suppresses it so the edge tracks the pointer.
- Panel stays mounted, at zero width, when nothing is selected
- Returning to properties on a selection change is adjusted during render
  > Otherwise the code of the previous selection would show for a frame against the new one's properties.

## Known issues

- Which code the panel is showing is not in the URL
  > The view is local state, so a reader cannot link someone to a kernel. The navigation contract would have to carry it.
- A closing panel is an empty box for the length of the transition
  > Content follows the selection, and the point of the animation is that the canvas resizes smoothly rather than jumping.

## Test coverage

- Existing `@hashintel/petrinaut` unit suite
- Verified in the running embed:
  > Panel measures 1px closed and 301px open, drags to 443px, the rate function and kernel open and return, and every button in the panel passes a hit test at its own coordinates.

## How to test

- Open [truck fleet embed](https://petrinaut-git-claude-fe-1639-properties-panel-code-view.stage.hash.ai/embed/examples/truck-fleet-predictive-maintenance) on Vercel
- Select the "Dispatch a truck" transition
  > Expect the panel to animate open, with **Lambda function** and **Transition kernel** links
- Click **Lambda function**
  > Expect the code, read-only, and a back button to the properties
- Select a text range in the code
  > Expect the selection to take, unlike the rest of the embed
- Drag the panel's inner edge
  > Expect the panel to resize with the pointer, no animation lag
- Select the "Conditions" place, then click **Equation**
  > Expect the differential equation's body
- Click empty canvas
  > Expect the panel to animate closed
- Open [the full editor](https://petrinaut-git-claude-fe-1639-properties-panel-code-view.stage.hash.ai/examples/truck-fleet-predictive-maintenance) and select a transition
  > Expect no code links, since the editor has its own code editors
