### PR TITLE
FE-1641: Open the Preview's Quick Simulation controls from the playback bar

### DIFF
--- a/.changeset/preview-quick-simulation-in-bar.md
+++ b/.changeset/preview-quick-simulation-in-bar.md
@@ -1,0 +1,5 @@
+---
+"@hashintel/petrinaut": patch
+---
+
+The embedded Preview opens its Quick Simulation scenario and parameter controls from the playback bar, beside Play, instead of from the top bar.

--- a/libs/@hashintel/petrinaut/docs/preview.md
+++ b/libs/@hashintel/petrinaut/docs/preview.md
@@ -41,9 +41,9 @@ canvas, selection, and inspector update together when you change nets.
 
 ## Quick Simulation
 
-Some embeds include Quick Simulation. Open **Quick Simulation** in the header
-to choose one of the model's named scenarios and adjust the parameters the
-embed makes available. The first scenario is selected when the embed does not
+Some embeds include Quick Simulation. Open it from the sliders button in the
+playback bar at the bottom of the canvas, next to Play, to choose one of the
+model's named scenarios and adjust the parameters the embed makes available. The first scenario is selected when the embed does not
 specify a valid one. There is no "No scenario" option in this surface.
 
 The selected scenario's initial marking appears on the shared canvas before a

--- a/libs/@hashintel/petrinaut/src/ui/preview/petrinaut-preview.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/preview/petrinaut-preview.tsx
@@ -43,10 +43,7 @@ import {
   type PetrinautPreviewNavigationState,
 } from "./navigation-adapter";
 import { PreviewNetNavigation } from "./preview-net-navigation";
-import {
-  PreviewSimulationConfiguration,
-  PreviewSimulationPlaybackControls,
-} from "./preview-quick-simulation-controls";
+import { PreviewSimulationPlaybackControls } from "./preview-quick-simulation-controls";
 import { PreviewPropertiesPanel } from "./properties-panel";
 import {
   createPreviewSimulationCompiler,
@@ -293,11 +290,6 @@ export const PetrinautPreview: FunctionComponent<PetrinautPreviewProps> = ({
           <span className={previewTitleStyle} title={title}>
             {title}
           </span>
-          {quickSimulation && (
-            <PreviewSimulationConfiguration
-              parameterBounds={quickSimulation.parameterBounds}
-            />
-          )}
           {fullViewUrl !== undefined && (
             <Button
               href={fullViewUrl}
@@ -318,6 +310,7 @@ export const PetrinautPreview: FunctionComponent<PetrinautPreviewProps> = ({
             {quickSimulation && (
               <PreviewSimulationPlaybackControls
                 allowedPlaybackSpeeds={playbackOptions?.allowedPlaybackSpeeds}
+                parameterBounds={quickSimulation.parameterBounds}
               />
             )}
           </div>

--- a/libs/@hashintel/petrinaut/src/ui/preview/preview-quick-simulation-controls.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/preview/preview-quick-simulation-controls.tsx
@@ -1,6 +1,6 @@
 import { use, useRef, useState } from "react";
 
-import { Button, Icon, Popover } from "@hashintel/ds-components";
+import { Icon, Popover } from "@hashintel/ds-components";
 import { css } from "@hashintel/ds-helpers/css";
 
 import { ExecutionFrameSourceContext } from "../../react/execution-frame/context";
@@ -8,6 +8,8 @@ import { SimulationContext } from "../../react/simulation/context";
 import { ActiveNetContext } from "../../react/state/active-net-context";
 import { UserSettingsContext } from "../../react/state/user-settings-context";
 import { SimulationControls } from "../views/Editor/components/BottomBar/simulation-controls";
+import { ToolbarButton } from "../views/Editor/components/BottomBar/toolbar-button";
+import { ToolbarDivider } from "../views/Editor/components/BottomBar/toolbar-divider";
 import { SimulationTimeline } from "../views/Editor/panels/BottomPanel/subviews/simulation-timeline/content";
 import { SimulationScenarioControls } from "../views/shared/simulation-scenario-controls";
 
@@ -103,13 +105,12 @@ const timelineStyle = css({
   borderColor: "neutral.bd.subtle",
 });
 
-const configurationLabelStyle = css({
-  "@media (max-width: 420px)": {
-    display: "none",
-  },
-});
-
-export const PreviewSimulationConfiguration = ({
+/**
+ * The scenario and parameters a run is configured with, opened from the
+ * playback bar: the choices and the Play button they feed are one task, and
+ * the bar is where the reader already is.
+ */
+const PreviewSimulationConfiguration = ({
   parameterBounds,
 }: Pick<PetrinautPreviewQuickSimulation, "parameterBounds">) => {
   const triggerRef = useRef<HTMLButtonElement>(null);
@@ -117,21 +118,20 @@ export const PreviewSimulationConfiguration = ({
 
   return (
     <>
-      <Button
+      <ToolbarButton
         ref={triggerRef}
-        size="xs"
-        variant="ghost"
-        prefix={<Icon name="play" size="xs" />}
-        aria-label="Configure Quick Simulation"
-        aria-expanded={open}
+        tooltip="Quick Simulation: scenario and parameters"
+        ariaLabel="Configure Quick Simulation"
+        ariaExpanded={open}
+        isSelected={open}
         onClick={() => setOpen((wasOpen) => !wasOpen)}
       >
-        <span className={configurationLabelStyle}>Quick Simulation</span>
-      </Button>
+        <Icon name="sliders" />
+      </ToolbarButton>
       {open && (
         <Popover
           triggerRef={triggerRef}
-          position="bottom-end"
+          position="top-start"
           onClose={() => setOpen(false)}
         >
           <Popover.Container className={configurationPopoverStyle}>
@@ -151,7 +151,11 @@ export const PreviewSimulationConfiguration = ({
 
 export const PreviewSimulationPlaybackControls = ({
   allowedPlaybackSpeeds,
-}: Pick<PetrinautPreviewQuickSimulation, "allowedPlaybackSpeeds">) => {
+  parameterBounds,
+}: Pick<
+  PetrinautPreviewQuickSimulation,
+  "allowedPlaybackSpeeds" | "parameterBounds"
+>) => {
   const { activeSubnetId } = use(ActiveNetContext);
   const { scenarioCompilationErrors } = use(SimulationContext);
   const { totalFrames } = use(ExecutionFrameSourceContext);
@@ -168,6 +172,8 @@ export const PreviewSimulationPlaybackControls = ({
     >
       <div className={playbackControlsScrollStyle}>
         <div className={playbackControlsRowStyle}>
+          <PreviewSimulationConfiguration parameterBounds={parameterBounds} />
+          <ToolbarDivider />
           <SimulationControls
             allowedPlaybackSpeeds={
               allowedPlaybackSpeeds?.length ? allowedPlaybackSpeeds : undefined


### PR DESCRIPTION
## Summary

Before this PR, an embed opened its Quick Simulation controls from the top bar, at the opposite end of the frame from the Play button they configure. Choosing a scenario and starting the run are one task, and the top bar was also the only chrome a reader met before pressing Play, so the embed led with configuration rather than with the net.

Controls now open from the playback bar, beside Play, behind a sliders button that reads as scenario and parameters. The menu's contents are unchanged and it opens upward from the bar. The top bar keeps the net selector, the title, and the full-view link.

https://github.com/user-attachments/assets/a32fb289-e719-4ab1-bf07-79e069953dfa

## Links

- Ticket [FE-1641](https://linear.app/hash/issue/FE-1641)
- Docs [Embedded Preview](https://github.com/hashintel/hash/blob/claude/fe-1641-quick-simulation-in-playback-bar/libs/@hashintel/petrinaut/docs/preview.md)

## Changes

- Quick Simulation opens from the playback bar
  > A `sliders` toolbar button at the left of the bar's row, ahead of a divider and the transport controls, so the transport keeps its centred position.
  > The popover opens `top-start`, upward from the bar, and the trigger reads as selected while it is up.
- Trigger left the top bar
  > The header is the net selector, the title, and the full-view link.
- Configuration component is no longer exported from the preview module
  > It has one call site, inside the bar's own controls.

## Test coverage

- Existing `@hashintel/petrinaut` unit suite
- Verified in the running embed:
  > The trigger renders inside the playback bar, the popover's lower edge sits above the bar's top, and the header carries only the title and the full-view link.

## How to test

- Open [SIR embed](https://petrinaut-git-claude-fe-1641-quick-simulation-in-playback-bar.stage.hash.ai/embed/examples/sir-epidemic-model) on Vercel
  > Expect a sliders button in the playback bar, and no Quick Simulation control in the top bar
- Click the sliders button
  > Expect the scenario and parameters menu, opening upward
- Choose another scenario, then close the menu
  > Expect the new scenario's marking on the canvas
- Press Play
  > Expect the run to start and the bar to expand into the timeline
- Narrow the window to 420px
  > Expect the button to stay reachable in the bar
