### PR TITLE
FE-1673: Pin a place's state visualizer to the canvas

### DIFF
--- a/.changeset/pin-place-state-visualizer.md
+++ b/.changeset/pin-place-state-visualizer.md
@@ -2,4 +2,4 @@
 "@hashintel/petrinaut": patch
 ---
 
-A place's state visualizer can be pinned open on the canvas, so it stays in view while the timeline is scrubbed or the initial state edited. The box also keeps the hover while the pointer is on it, so it can be reached and scrolled.
+A place's state visualizer can be pinned open on the canvas, from a pin over its top-right corner, so it stays in view while the timeline is scrubbed or the initial state edited. The box now opens whether or not a simulation has run, drawing the initial marking before one has, and keeps the hover while the pointer is on it, so it can be reached and scrolled.

--- a/.changeset/pin-place-state-visualizer.md
+++ b/.changeset/pin-place-state-visualizer.md
@@ -1,0 +1,5 @@
+---
+"@hashintel/petrinaut": patch
+---
+
+A place's state visualizer can be pinned open on the canvas, so it stays in view while the timeline is scrubbed or the initial state edited. The box also keeps the hover while the pointer is on it, so it can be reached and scrolled.

--- a/.changeset/pin-place-state-visualizer.md
+++ b/.changeset/pin-place-state-visualizer.md
@@ -2,4 +2,4 @@
 "@hashintel/petrinaut": patch
 ---
 
-A place's state visualizer can be pinned open on the canvas, from a pin over its top-right corner, so it stays in view while the timeline is scrubbed or the initial state edited. The box opens whether or not a simulation has run, drawing the initial marking before one has, grows into place from the edge facing its node, and keeps the hover while the pointer is on it so it can be reached and scrolled. Its pin is a disc of frosted glass that holds back until the box is pointed at.
+A place's state visualizer is reachable from the canvas in two steps, a button on hover and the panel on a click, and can be pinned open from a rounded glass pin in its top-right corner, so it stays in view while the timeline is scrubbed or the initial state edited. The box opens whether or not a simulation has run, drawing the initial marking before one has, grows into place from the edge facing its node, and keeps the hover while the pointer is on it. Its code compiles once and its picture is redrawn only when the frame, the marking, the parameters or the code move: on a scrub with an expensive visualizer pinned, 45 to 63 frames per second.

--- a/.changeset/pin-place-state-visualizer.md
+++ b/.changeset/pin-place-state-visualizer.md
@@ -2,4 +2,4 @@
 "@hashintel/petrinaut": patch
 ---
 
-A place's state visualizer is reachable from the canvas in two steps, a button on hover and the panel on a click, and can be pinned open from a rounded glass pin in its top-right corner, so it stays in view while the timeline is scrubbed or the initial state edited. The box opens whether or not a simulation has run, drawing the initial marking before one has, grows into place from the edge facing its node, and keeps the hover while the pointer is on it. Its code compiles once and its picture is redrawn only when the frame, the marking, the parameters or the code move: on a scrub with an expensive visualizer pinned, 45 to 63 frames per second.
+A place's state visualizer opens from a button on the hovered place, with or without a run, and can be pinned to stay in view while the timeline is scrubbed.

--- a/.changeset/pin-place-state-visualizer.md
+++ b/.changeset/pin-place-state-visualizer.md
@@ -2,4 +2,4 @@
 "@hashintel/petrinaut": patch
 ---
 
-A place's state visualizer can be pinned open on the canvas, from a pin over its top-right corner, so it stays in view while the timeline is scrubbed or the initial state edited. The box now opens whether or not a simulation has run, drawing the initial marking before one has, and keeps the hover while the pointer is on it, so it can be reached and scrolled.
+A place's state visualizer can be pinned open on the canvas, from a pin over its top-right corner, so it stays in view while the timeline is scrubbed or the initial state edited. The box opens whether or not a simulation has run, drawing the initial marking before one has, grows into place from the edge facing its node, and keeps the hover while the pointer is on it so it can be reached and scrolled. Its pin is a disc of frosted glass that holds back until the box is pointed at.

--- a/.changeset/visualizer-picture-held.md
+++ b/.changeset/visualizer-picture-held.md
@@ -1,0 +1,5 @@
+---
+"@hashintel/petrinaut": patch
+---
+
+A place's visualizer is redrawn only when the frame, the marking, the parameters or its own code move, rather than on every re-render of the surface it sits on. On a scrub with an expensive visualizer pinned to the canvas that is 45 to 63 frames per second, with the worst frame down from 92ms to 51ms.

--- a/.changeset/visualizer-picture-held.md
+++ b/.changeset/visualizer-picture-held.md
@@ -1,5 +1,0 @@
----
-"@hashintel/petrinaut": patch
----
-
-A place's visualizer is redrawn only when the frame, the marking, the parameters or its own code move, rather than on every re-render of the surface it sits on. On a scrub with an expensive visualizer pinned to the canvas that is 45 to 63 frames per second, with the worst frame down from 92ms to 51ms.

--- a/libs/@hashintel/petrinaut/docs/petri-net-extensions.md
+++ b/libs/@hashintel/petrinaut/docs/petri-net-extensions.md
@@ -109,7 +109,9 @@ export default Visualization(({ tokens, parameters }) => {
 
 The component receives `tokens` (array of token objects) and `parameters` (global parameter values). It renders in the properties panel. During simulation, it updates live as token state changes.
 
-It also appears on the canvas: point at the place and the visualizer opens beside the node, whether or not anything has run. Before a run it draws the initial marking, so a net still being built can be checked by pointing at it. A **pin** in the visualizer's top-right corner holds the box open -- faint until you point at the box, solid once pinned. A pinned box stays up with the pointer somewhere else entirely, which is what makes it possible to watch one place while scrubbing the [timeline](simulation.md#timeline) or editing the initial state. Click the pin again to release it. Pin as many places as you want to watch at once; pins last until the page is reloaded.
+It is reachable from the canvas too, in two steps. Point at the place and a small round button appears above it; click that and the visualizer opens where the button was, whether or not anything has run. Before a run it draws the initial marking, so a net still being built can be checked by pointing at it.
+
+Opening it belongs to that hover: move the pointer away and it closes, and pointing at the place again offers the button rather than the visualizer. A **pin** in the visualizer's top-right corner is what makes it stay -- faint until you point at the box, solid once pinned. A pinned box stays up with the pointer somewhere else entirely, which is what makes it possible to watch one place while scrubbing the [timeline](simulation.md#timeline) or editing the initial state. Click the pin again to release it. Pin as many places as you want to watch at once; pins last until the page is reloaded.
 
 <img width="474" height="385" alt="visauliser-preview" src="https://github.com/user-attachments/assets/303f51f3-0a53-480b-9639-52c4b77aa6e0" />
 

--- a/libs/@hashintel/petrinaut/docs/petri-net-extensions.md
+++ b/libs/@hashintel/petrinaut/docs/petri-net-extensions.md
@@ -109,6 +109,8 @@ export default Visualization(({ tokens, parameters }) => {
 
 The component receives `tokens` (array of token objects) and `parameters` (global parameter values). It renders in the properties panel. During simulation, it updates live as token state changes.
 
+It also appears on the canvas: point at the place and the visualizer opens beside the node, whether or not anything has run. Before a run it draws the initial marking, so a net still being built can be checked by pointing at it. A **pin** in the visualizer's top-right corner holds the box open -- faint until you point at the box, solid once pinned. A pinned box stays up with the pointer somewhere else entirely, which is what makes it possible to watch one place while scrubbing the [timeline](simulation.md#timeline) or editing the initial state. Click the pin again to release it. Pin as many places as you want to watch at once; pins last until the page is reloaded.
+
 <img width="474" height="385" alt="visauliser-preview" src="https://github.com/user-attachments/assets/303f51f3-0a53-480b-9639-52c4b77aa6e0" />
 
 Use the menu in the code editor header to **Load default template** for a starting point.

--- a/libs/@hashintel/petrinaut/docs/simulation.md
+++ b/libs/@hashintel/petrinaut/docs/simulation.md
@@ -149,6 +149,8 @@ Select a place during simulation to see its current token values in the properti
 
 If the place has a [visualizer](petri-net-extensions.md#visualizer) defined, it renders live in the properties panel, updating as the simulation progresses.
 
+The same visualizer also appears on the canvas: point at the place and it opens beside the node, following the run. Its **pin** holds it open -- pinned, it stays up with the pointer somewhere else entirely, so you can watch it while you scrub the timeline or change the initial state. Click the pin again to release it. Pin as many places as you want to watch at once; pins last for the session.
+
 ![visualiser](https://github.com/user-attachments/assets/9324bb5b-4912-499e-8a5d-f2bc6a7754c2)
 
 ## Locked editing

--- a/libs/@hashintel/petrinaut/docs/simulation.md
+++ b/libs/@hashintel/petrinaut/docs/simulation.md
@@ -149,7 +149,7 @@ Select a place during simulation to see its current token values in the properti
 
 If the place has a [visualizer](petri-net-extensions.md#visualizer) defined, it renders live in the properties panel, updating as the simulation progresses.
 
-The same visualizer also appears on the canvas: point at the place and it opens beside the node, following the run. Its **pin** holds it open -- pinned, it stays up with the pointer somewhere else entirely, so you can watch it while you scrub the timeline or change the initial state. Click the pin again to release it. Pin as many places as you want to watch at once; pins last for the session.
+The same visualizer also appears on the canvas when you point at the place, and its [pin](petri-net-extensions.md#visualizer) holds it open while you scrub the timeline or change the initial state.
 
 ![visualiser](https://github.com/user-attachments/assets/9324bb5b-4912-499e-8a5d-f2bc6a7754c2)
 

--- a/libs/@hashintel/petrinaut/docs/simulation.md
+++ b/libs/@hashintel/petrinaut/docs/simulation.md
@@ -149,7 +149,7 @@ Select a place during simulation to see its current token values in the properti
 
 If the place has a [visualizer](petri-net-extensions.md#visualizer) defined, it renders live in the properties panel, updating as the simulation progresses.
 
-The same visualizer also appears on the canvas when you point at the place, and its [pin](petri-net-extensions.md#visualizer) holds it open while you scrub the timeline or change the initial state.
+The same visualizer is reachable on the canvas: point at the place, click the button that appears above it, and its [pin](petri-net-extensions.md#visualizer) holds it open while you scrub the timeline or change the initial state.
 
 ![visualiser](https://github.com/user-attachments/assets/9324bb5b-4912-499e-8a5d-f2bc6a7754c2)
 

--- a/libs/@hashintel/petrinaut/src/react/hooks/use-petrinaut-commands.test.tsx
+++ b/libs/@hashintel/petrinaut/src/react/hooks/use-petrinaut-commands.test.tsx
@@ -60,6 +60,7 @@ const editorContextValue = (
   clearSelection: () => {},
   setHoveredItem: () => {},
   clearHoveredItem: () => {},
+  toggleVisualizerPin: () => {},
   setDraggingStateByNodeId: () => {},
   updateDraggingStateByNodeId: () => {},
   resetDraggingState: () => {},

--- a/libs/@hashintel/petrinaut/src/react/hooks/use-petrinaut-commands.test.tsx
+++ b/libs/@hashintel/petrinaut/src/react/hooks/use-petrinaut-commands.test.tsx
@@ -61,6 +61,7 @@ const editorContextValue = (
   setHoveredItem: () => {},
   clearHoveredItem: () => {},
   toggleVisualizerPin: () => {},
+  openPlaceVisualizer: () => {},
   setDraggingStateByNodeId: () => {},
   updateDraggingStateByNodeId: () => {},
   resetDraggingState: () => {},

--- a/libs/@hashintel/petrinaut/src/react/hooks/use-petrinaut-mutations.test.tsx
+++ b/libs/@hashintel/petrinaut/src/react/hooks/use-petrinaut-mutations.test.tsx
@@ -64,6 +64,7 @@ const editorContextValue = (
   setHoveredItem: () => {},
   clearHoveredItem: () => {},
   toggleVisualizerPin: () => {},
+  openPlaceVisualizer: () => {},
   setDraggingStateByNodeId: () => {},
   updateDraggingStateByNodeId: () => {},
   resetDraggingState: () => {},

--- a/libs/@hashintel/petrinaut/src/react/hooks/use-petrinaut-mutations.test.tsx
+++ b/libs/@hashintel/petrinaut/src/react/hooks/use-petrinaut-mutations.test.tsx
@@ -63,6 +63,7 @@ const editorContextValue = (
   clearSelection: () => {},
   setHoveredItem: () => {},
   clearHoveredItem: () => {},
+  toggleVisualizerPin: () => {},
   setDraggingStateByNodeId: () => {},
   updateDraggingStateByNodeId: () => {},
   resetDraggingState: () => {},

--- a/libs/@hashintel/petrinaut/src/react/state/editor-context.ts
+++ b/libs/@hashintel/petrinaut/src/react/state/editor-context.ts
@@ -100,6 +100,13 @@ export type EditorState = {
    * watched while the timeline is scrubbed or the initial state edited.
    */
   pinnedVisualizerPlaceIds: Set<string>;
+  /**
+   * The place whose state visualizer has been opened from the button that
+   * pointing at a place offers. It belongs to that hover: moving the pointer
+   * to another place, or off the canvas, closes it again. Pinning is what
+   * outlasts a hover.
+   */
+  openVisualizerPlaceId: string | null;
   draggingStateByNodeId: DraggingStateByNodeId;
   timelineChartType: TimelineChartType;
   /**
@@ -158,6 +165,8 @@ export type EditorActions = {
   clearHoveredItem: () => void;
   /** Pin a place's state visualizer open, or release it. */
   toggleVisualizerPin: (placeId: string) => void;
+  /** Open a place's state visualizer for the hover it is part of. */
+  openPlaceVisualizer: (placeId: string) => void;
   setDraggingStateByNodeId: (state: DraggingStateByNodeId) => void;
   updateDraggingStateByNodeId: (
     updater: (state: DraggingStateByNodeId) => DraggingStateByNodeId,
@@ -197,6 +206,7 @@ export const initialEditorState: EditorState = {
   hasSelection: false,
   hoveredItem: null,
   pinnedVisualizerPlaceIds: new Set<string>(),
+  openVisualizerPlaceId: null,
   draggingStateByNodeId: {},
   timelineChartType: "run",
   timelineView: { kind: "per-place" },
@@ -233,6 +243,7 @@ const DEFAULT_CONTEXT_VALUE: EditorContextValue = {
   setHoveredItem: () => {},
   clearHoveredItem: () => {},
   toggleVisualizerPin: () => {},
+  openPlaceVisualizer: () => {},
   setDraggingStateByNodeId: () => {},
   updateDraggingStateByNodeId: () => {},
   resetDraggingState: () => {},

--- a/libs/@hashintel/petrinaut/src/react/state/editor-context.ts
+++ b/libs/@hashintel/petrinaut/src/react/state/editor-context.ts
@@ -94,6 +94,12 @@ export type EditorState = {
   hasSelection: boolean;
   /** The item currently being hovered, if any. */
   hoveredItem: SelectionItem | null;
+  /**
+   * Places whose state visualizer is pinned open on the canvas. A pinned
+   * visualizer stays up when the pointer leaves the place, so it can be
+   * watched while the timeline is scrubbed or the initial state edited.
+   */
+  pinnedVisualizerPlaceIds: Set<string>;
   draggingStateByNodeId: DraggingStateByNodeId;
   timelineChartType: TimelineChartType;
   /**
@@ -150,6 +156,8 @@ export type EditorActions = {
   clearSelection: () => void;
   setHoveredItem: (item: SelectionItem) => void;
   clearHoveredItem: () => void;
+  /** Pin a place's state visualizer open, or release it. */
+  toggleVisualizerPin: (placeId: string) => void;
   setDraggingStateByNodeId: (state: DraggingStateByNodeId) => void;
   updateDraggingStateByNodeId: (
     updater: (state: DraggingStateByNodeId) => DraggingStateByNodeId,
@@ -188,6 +196,7 @@ export const initialEditorState: EditorState = {
   selection: new Map(),
   hasSelection: false,
   hoveredItem: null,
+  pinnedVisualizerPlaceIds: new Set<string>(),
   draggingStateByNodeId: {},
   timelineChartType: "run",
   timelineView: { kind: "per-place" },
@@ -223,6 +232,7 @@ const DEFAULT_CONTEXT_VALUE: EditorContextValue = {
   clearSelection: () => {},
   setHoveredItem: () => {},
   clearHoveredItem: () => {},
+  toggleVisualizerPin: () => {},
   setDraggingStateByNodeId: () => {},
   updateDraggingStateByNodeId: () => {},
   resetDraggingState: () => {},

--- a/libs/@hashintel/petrinaut/src/react/state/editor-provider.tsx
+++ b/libs/@hashintel/petrinaut/src/react/state/editor-provider.tsx
@@ -428,6 +428,14 @@ export const EditorProvider: React.FC<EditorProviderProps> = ({ children }) => {
       setState((prev) => ({ ...prev, hoveredItem: item })),
     clearHoveredItem: () =>
       setState((prev) => ({ ...prev, hoveredItem: null })),
+    toggleVisualizerPin: (placeId: string) =>
+      setState((prev) => {
+        const pinnedVisualizerPlaceIds = new Set(prev.pinnedVisualizerPlaceIds);
+        if (!pinnedVisualizerPlaceIds.delete(placeId)) {
+          pinnedVisualizerPlaceIds.add(placeId);
+        }
+        return { ...prev, pinnedVisualizerPlaceIds };
+      }),
     setDraggingStateByNodeId: (draggingState: DraggingStateByNodeId) =>
       setState((prev) => ({ ...prev, draggingStateByNodeId: draggingState })),
     updateDraggingStateByNodeId: (updater) =>

--- a/libs/@hashintel/petrinaut/src/react/state/editor-provider.tsx
+++ b/libs/@hashintel/petrinaut/src/react/state/editor-provider.tsx
@@ -424,10 +424,25 @@ export const EditorProvider: React.FC<EditorProviderProps> = ({ children }) => {
         return selection;
       }),
     clearSelection: () => setSelection(new Map()),
+    // An opened visualizer belongs to the hover that opened it, so both of
+    // these drop it as soon as the pointer is somewhere else.
     setHoveredItem: (item: SelectionItem) =>
-      setState((prev) => ({ ...prev, hoveredItem: item })),
+      setState((prev) => ({
+        ...prev,
+        hoveredItem: item,
+        openVisualizerPlaceId:
+          prev.openVisualizerPlaceId === item.id
+            ? prev.openVisualizerPlaceId
+            : null,
+      })),
     clearHoveredItem: () =>
-      setState((prev) => ({ ...prev, hoveredItem: null })),
+      setState((prev) => ({
+        ...prev,
+        hoveredItem: null,
+        openVisualizerPlaceId: null,
+      })),
+    openPlaceVisualizer: (placeId: string) =>
+      setState((prev) => ({ ...prev, openVisualizerPlaceId: placeId })),
     toggleVisualizerPin: (placeId: string) =>
       setState((prev) => {
         const pinnedVisualizerPlaceIds = new Set(prev.pinnedVisualizerPlaceIds);

--- a/libs/@hashintel/petrinaut/src/ui/components/pin-icon.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/components/pin-icon.tsx
@@ -1,10 +1,3 @@
-import type { SVGProps } from "react";
-
-type PinIconProps = SVGProps<SVGSVGElement> & {
-  size?: number | string;
-  title?: string;
-};
-
 /**
  * A thumbtack, for holding a floating surface open.
  *
@@ -12,18 +5,15 @@ type PinIconProps = SVGProps<SVGSVGElement> & {
  * throughout and stroked thinly: it sits over a visualizer's own artwork, so
  * it has to read as a mark rather than compete as a picture.
  */
-export const PinIcon = ({ size = 13, title, ...props }: PinIconProps) => (
+export const PinIcon = () => (
   <svg
-    aria-hidden={title === undefined ? true : undefined}
+    aria-hidden
     fill="none"
-    height={size}
-    role={title === undefined ? undefined : "img"}
+    height={13}
     viewBox="0 0 16 16"
-    width={size}
+    width={13}
     xmlns="http://www.w3.org/2000/svg"
-    {...props}
   >
-    {title && <title>{title}</title>}
     {/* Cap: a rounded bar across the head of the tack. */}
     <path
       d="M5.6 2.6H10.4"

--- a/libs/@hashintel/petrinaut/src/ui/components/pin-icon.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/components/pin-icon.tsx
@@ -8,9 +8,11 @@ type PinIconProps = SVGProps<SVGSVGElement> & {
 /**
  * A thumbtack, for holding a floating surface open.
  *
- * Drawn here rather than taken from the icon set, which has no pin.
+ * Drawn here rather than taken from the icon set, which has no pin. Rounded
+ * throughout and stroked thinly: it sits over a visualizer's own artwork, so
+ * it has to read as a mark rather than compete as a picture.
  */
-export const PinIcon = ({ size = 14, title, ...props }: PinIconProps) => (
+export const PinIcon = ({ size = 13, title, ...props }: PinIconProps) => (
   <svg
     aria-hidden={title === undefined ? true : undefined}
     fill="none"
@@ -22,12 +24,27 @@ export const PinIcon = ({ size = 14, title, ...props }: PinIconProps) => (
     {...props}
   >
     {title && <title>{title}</title>}
+    {/* Cap: a rounded bar across the head of the tack. */}
     <path
-      d="M5.5 2.5H10.5M6.5 2.5L5.5 9.5H10.5L9.5 2.5M8 9.5V13.5"
+      d="M5.6 2.6H10.4"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeWidth="1.3"
+    />
+    {/* Body: shoulders curving down to a rounded base. */}
+    <path
+      d="M6.6 2.6C6.6 5.2 6.1 7.4 5.4 8.7C5.2 9.1 5.4 9.5 5.9 9.5H10.1C10.6 9.5 10.8 9.1 10.6 8.7C9.9 7.4 9.4 5.2 9.4 2.6"
       stroke="currentColor"
       strokeLinecap="round"
       strokeLinejoin="round"
-      strokeWidth="1.4"
+      strokeWidth="1.3"
+    />
+    {/* Needle. */}
+    <path
+      d="M8 9.9V13.2"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeWidth="1.3"
     />
   </svg>
 );

--- a/libs/@hashintel/petrinaut/src/ui/components/pin-icon.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/components/pin-icon.tsx
@@ -1,0 +1,33 @@
+import type { SVGProps } from "react";
+
+type PinIconProps = SVGProps<SVGSVGElement> & {
+  size?: number | string;
+  title?: string;
+};
+
+/**
+ * A thumbtack, for holding a floating surface open.
+ *
+ * Drawn here rather than taken from the icon set, which has no pin.
+ */
+export const PinIcon = ({ size = 14, title, ...props }: PinIconProps) => (
+  <svg
+    aria-hidden={title === undefined ? true : undefined}
+    fill="none"
+    height={size}
+    role={title === undefined ? undefined : "img"}
+    viewBox="0 0 16 16"
+    width={size}
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    {title && <title>{title}</title>}
+    <path
+      d="M5.5 2.5H10.5M6.5 2.5L5.5 9.5H10.5L9.5 2.5M8 9.5V13.5"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.4"
+    />
+  </svg>
+);

--- a/libs/@hashintel/petrinaut/src/ui/lib/compile-visualizer.test.ts
+++ b/libs/@hashintel/petrinaut/src/ui/lib/compile-visualizer.test.ts
@@ -108,4 +108,22 @@ describe("compileVisualizer caching", () => {
     expect(first).toBeInstanceOf(Error);
     expect(second).toBe(first);
   });
+
+  it("evicts the visualizer used least recently, not the one made first", () => {
+    const kept = `export default Visualization(() => <p>kept</p>);`;
+    const dropped = `export default Visualization(() => <p>dropped</p>);`;
+    const first = compileVisualizer(kept);
+    compileVisualizer(dropped);
+
+    // A keystroke's worth of drafts, with the kept one looked at halfway.
+    for (let draft = 0; draft < 30; draft++) {
+      if (draft === 15) {
+        compileVisualizer(kept);
+      }
+      compileVisualizer(`export default Visualization(() => <i>${draft}</i>);`);
+    }
+
+    expect(compileVisualizer(kept)).toBe(first);
+    expect(compileVisualizer(dropped)).not.toBe(compileVisualizer(kept));
+  });
 });

--- a/libs/@hashintel/petrinaut/src/ui/lib/compile-visualizer.test.ts
+++ b/libs/@hashintel/petrinaut/src/ui/lib/compile-visualizer.test.ts
@@ -2,6 +2,15 @@ import { describe, expect, it } from "vitest";
 
 import { compileVisualizer } from "./compile-visualizer";
 
+const compileError = (code: string): unknown => {
+  try {
+    compileVisualizer(code);
+    return null;
+  } catch (error) {
+    return error;
+  }
+};
+
 const emptyProps = { tokens: [], parameters: {} };
 
 describe("compileVisualizer", () => {
@@ -93,22 +102,8 @@ describe("compileVisualizer caching", () => {
   it("keeps a failure rather than recompiling it", () => {
     const broken = `export default Visualization(() => <div />; // unbalanced`;
 
-    const first = (() => {
-      try {
-        compileVisualizer(broken);
-        return null;
-      } catch (error) {
-        return error;
-      }
-    })();
-    const second = (() => {
-      try {
-        compileVisualizer(broken);
-        return null;
-      } catch (error) {
-        return error;
-      }
-    })();
+    const first = compileError(broken);
+    const second = compileError(broken);
 
     expect(first).toBeInstanceOf(Error);
     expect(second).toBe(first);

--- a/libs/@hashintel/petrinaut/src/ui/lib/compile-visualizer.test.ts
+++ b/libs/@hashintel/petrinaut/src/ui/lib/compile-visualizer.test.ts
@@ -71,3 +71,46 @@ describe("compileVisualizer", () => {
     ).toThrow(/Failed to compile/);
   });
 });
+
+describe("compileVisualizer caching", () => {
+  it("returns the component already made for the same code", () => {
+    const code = `export default Visualization(() => <div />);`;
+
+    expect(compileVisualizer(code)).toBe(compileVisualizer(code));
+  });
+
+  it("compiles code that differs", () => {
+    const first = compileVisualizer(
+      `export default Visualization(() => <span />);`,
+    );
+    const second = compileVisualizer(
+      `export default Visualization(() => <section />);`,
+    );
+
+    expect(first).not.toBe(second);
+  });
+
+  it("keeps a failure rather than recompiling it", () => {
+    const broken = `export default Visualization(() => <div />; // unbalanced`;
+
+    const first = (() => {
+      try {
+        compileVisualizer(broken);
+        return null;
+      } catch (error) {
+        return error;
+      }
+    })();
+    const second = (() => {
+      try {
+        compileVisualizer(broken);
+        return null;
+      } catch (error) {
+        return error;
+      }
+    })();
+
+    expect(first).toBeInstanceOf(Error);
+    expect(second).toBe(first);
+  });
+});

--- a/libs/@hashintel/petrinaut/src/ui/lib/compile-visualizer.ts
+++ b/libs/@hashintel/petrinaut/src/ui/lib/compile-visualizer.ts
@@ -96,12 +96,9 @@ function compile(code: string): VisualizerComponent {
 /**
  * Compiled visualizers, kept by their source.
  *
- * A visualizer is compiled wherever it is shown, and it is shown on every
- * hover of its place on the canvas as well as in the properties panel, so the
- * same few hundred lines went through Babel again and again. Compiling is a
- * pure function of the code, so the result is kept — the failure too, since a
- * visualizer that does not compile is asked for just as often as one that
- * does.
+ * Compiling is a pure function of the code, so each source is compiled once
+ * and its result kept, the failure too: a visualizer that does not compile is
+ * asked for as often as one that does.
  *
  * Bounded, and least-recently-used first: editing the code produces an entry
  * per keystroke, so evicting by arrival would throw out the visualizers being

--- a/libs/@hashintel/petrinaut/src/ui/lib/compile-visualizer.ts
+++ b/libs/@hashintel/petrinaut/src/ui/lib/compile-visualizer.ts
@@ -10,26 +10,7 @@ type VisualizerProps = {
 
 type VisualizerComponent = (props: VisualizerProps) => ReactElement;
 
-/**
- * Compiles TypeScript/JSX visualizer code into a React component.
- * Expects a module with a default export using the Visualization constructor.
- *
- * @param code - The TypeScript/JSX module code with a default export.
- *               Should follow the pattern: `export default Visualization(({ tokens, parameters }) => { ... })`
- * @returns A compiled React component function
- *
- * @example
- * ```typescript
- * const code = `
- *   export default Visualization(({ tokens, parameters }) => {
- *     return <div>{tokens.length} satellites</div>;
- *   });
- * `;
- * const Component = compileVisualizer(code);
- * const element = <Component tokens={[]} parameters={{}} />;
- * ```
- */
-export function compileVisualizer(code: string): VisualizerComponent {
+function compile(code: string): VisualizerComponent {
   try {
     // Transform TypeScript + JSX to JavaScript
     // Using classic runtime to avoid needing react/jsx-runtime imports
@@ -110,4 +91,75 @@ export function compileVisualizer(code: string): VisualizerComponent {
 
     throw new Error(`Failed to compile visualizer code: ${errorMessage}`);
   }
+}
+
+/**
+ * Compiled visualizers, kept by their source.
+ *
+ * A visualizer is compiled wherever it is shown, and it is shown on every
+ * hover of its place on the canvas as well as in the properties panel, so the
+ * same few hundred lines went through Babel again and again. Compiling is a
+ * pure function of the code, so the result is kept — the failure too, since a
+ * visualizer that does not compile is asked for just as often as one that
+ * does.
+ *
+ * Bounded, and oldest-first: editing the code produces a new entry per
+ * keystroke, and only the latest is worth holding.
+ */
+const CACHE_LIMIT = 24;
+const compiled = new Map<
+  string,
+  { component: VisualizerComponent } | { error: unknown }
+>();
+
+/**
+ * Compiles TypeScript/JSX visualizer code into a React component.
+ * Expects a module with a default export using the Visualization constructor.
+ *
+ * The same code compiles once: repeat calls return the component already
+ * made, so a component identity is stable across renders and re-opens.
+ *
+ * @param code - The TypeScript/JSX module code with a default export.
+ *               Should follow the pattern: `export default Visualization(({ tokens, parameters }) => { ... })`
+ * @returns A compiled React component function
+ *
+ * @example
+ * ```typescript
+ * const code = `
+ *   export default Visualization(({ tokens, parameters }) => {
+ *     return <div>{tokens.length} satellites</div>;
+ *   });
+ * `;
+ * const Component = compileVisualizer(code);
+ * const element = <Component tokens={[]} parameters={{}} />;
+ * ```
+ */
+export function compileVisualizer(code: string): VisualizerComponent {
+  const cached = compiled.get(code);
+  if (cached) {
+    if ("error" in cached) {
+      throw cached.error;
+    }
+    return cached.component;
+  }
+
+  let outcome: { component: VisualizerComponent } | { error: unknown };
+  try {
+    outcome = { component: compile(code) };
+  } catch (error) {
+    outcome = { error };
+  }
+
+  compiled.set(code, outcome);
+  if (compiled.size > CACHE_LIMIT) {
+    const oldest = compiled.keys().next();
+    if (!oldest.done) {
+      compiled.delete(oldest.value);
+    }
+  }
+
+  if ("error" in outcome) {
+    throw outcome.error;
+  }
+  return outcome.component;
 }

--- a/libs/@hashintel/petrinaut/src/ui/lib/compile-visualizer.ts
+++ b/libs/@hashintel/petrinaut/src/ui/lib/compile-visualizer.ts
@@ -103,8 +103,9 @@ function compile(code: string): VisualizerComponent {
  * visualizer that does not compile is asked for just as often as one that
  * does.
  *
- * Bounded, and oldest-first: editing the code produces a new entry per
- * keystroke, and only the latest is worth holding.
+ * Bounded, and least-recently-used first: editing the code produces an entry
+ * per keystroke, so evicting by arrival would throw out the visualizers being
+ * looked at to make room for one keystroke's worth of drafts.
  */
 const CACHE_LIMIT = 24;
 const compiled = new Map<
@@ -137,6 +138,9 @@ const compiled = new Map<
 export function compileVisualizer(code: string): VisualizerComponent {
   const cached = compiled.get(code);
   if (cached) {
+    // Re-inserting makes this the newest entry, so use decides what survives.
+    compiled.delete(code);
+    compiled.set(code, cached);
     if ("error" in cached) {
       throw cached.error;
     }

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/place-properties/subviews/place-visualizer/subview.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/PropertiesPanel/place-properties/subviews/place-visualizer/subview.tsx
@@ -99,7 +99,7 @@ const PlaceVisualizerContent: React.FC = () => {
     return (
       <div className={messageStyle}>
         Enable the visualizer to define a custom token visualization for this
-        place, viewable when a simulation is running.
+        place. It renders here, and on the canvas when you point at the place.
       </div>
     );
   }

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/experiments-story-fixtures.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/experiments-story-fixtures.tsx
@@ -757,6 +757,7 @@ export function FakeEditorProvider({
       clearSelection: () => {},
       setHoveredItem: () => {},
       clearHoveredItem: () => {},
+      toggleVisualizerPin: () => {},
       setDraggingStateByNodeId: () => {},
       updateDraggingStateByNodeId: () => {},
       simulateDrawer,

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/experiments-story-fixtures.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/experiments-story-fixtures.tsx
@@ -758,6 +758,7 @@ export function FakeEditorProvider({
       setHoveredItem: () => {},
       clearHoveredItem: () => {},
       toggleVisualizerPin: () => {},
+      openPlaceVisualizer: () => {},
       setDraggingStateByNodeId: () => {},
       updateDraggingStateByNodeId: () => {},
       simulateDrawer,

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel.test.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel.test.tsx
@@ -122,6 +122,7 @@ const editorContextValue: EditorContextValue = {
   clearSelection: () => {},
   setHoveredItem: () => {},
   clearHoveredItem: () => {},
+  toggleVisualizerPin: () => {},
   setDraggingStateByNodeId: () => {},
   updateDraggingStateByNodeId: () => {},
   resetDraggingState: () => {},

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel.test.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel.test.tsx
@@ -123,6 +123,7 @@ const editorContextValue: EditorContextValue = {
   setHoveredItem: () => {},
   clearHoveredItem: () => {},
   toggleVisualizerPin: () => {},
+  openPlaceVisualizer: () => {},
   setDraggingStateByNodeId: () => {},
   updateDraggingStateByNodeId: () => {},
   resetDraggingState: () => {},

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/canvas-frame-store.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/canvas-frame-store.tsx
@@ -33,7 +33,6 @@ type FrameSnapshot = {
   viewedFrame: SimulationFrameState | null;
   initialMarking: InitialMarking;
   simulateMode: boolean;
-  framesAvailable: boolean;
 };
 
 type CanvasFrameStore = {
@@ -42,14 +41,12 @@ type CanvasFrameStore = {
   getTokenCount: (placeId: string) => number | null;
   /** A transition's state in the viewed frame, or null when no run exists. */
   getTransitionFrame: (transitionId: string) => TransitionFrameState | null;
-  getFramesAvailable: () => boolean;
 };
 
 const EMPTY_STORE: CanvasFrameStore = {
   subscribe: () => () => {},
   getTokenCount: () => null,
   getTransitionFrame: () => null,
-  getFramesAvailable: () => false,
 };
 
 const CanvasFrameStoreContext = createContext<CanvasFrameStore>(EMPTY_STORE);
@@ -70,7 +67,7 @@ const sameTransitionState = (
 export const CanvasFrameStoreProvider: React.FC<React.PropsWithChildren> = ({
   children,
 }) => {
-  const { currentViewedFrame, currentFrameReader, totalFrames } = use(
+  const { currentViewedFrame, currentFrameReader } = use(
     ExecutionFrameSourceContext,
   );
   const { initialMarking } = use(SimulationContext);
@@ -83,7 +80,6 @@ export const CanvasFrameStoreProvider: React.FC<React.PropsWithChildren> = ({
     viewedFrame: currentViewedFrame,
     initialMarking,
     simulateMode: globalMode === "simulate",
-    framesAvailable: totalFrames > 0,
   });
   const listeners = useRef(new Set<() => void>());
   /**
@@ -131,8 +127,6 @@ export const CanvasFrameStoreProvider: React.FC<React.PropsWithChildren> = ({
       cache.set(transitionId, state);
       return state;
     },
-
-    getFramesAvailable: () => snapshot.current.framesAvailable,
   }));
 
   // Publishing happens after the commit, so a subscriber re-reads a store the
@@ -143,7 +137,6 @@ export const CanvasFrameStoreProvider: React.FC<React.PropsWithChildren> = ({
       viewedFrame: currentViewedFrame,
       initialMarking,
       simulateMode: globalMode === "simulate",
-      framesAvailable: totalFrames > 0,
     };
 
     // Re-read each transition that is mounted, and keep the previous value
@@ -160,13 +153,7 @@ export const CanvasFrameStoreProvider: React.FC<React.PropsWithChildren> = ({
     for (const listener of listeners.current) {
       listener();
     }
-  }, [
-    currentViewedFrame,
-    currentFrameReader,
-    totalFrames,
-    initialMarking,
-    globalMode,
-  ]);
+  }, [currentViewedFrame, currentFrameReader, initialMarking, globalMode]);
 
   return (
     <CanvasFrameStoreContext value={store}>{children}</CanvasFrameStoreContext>
@@ -192,15 +179,5 @@ export const useTransitionFrame = (
     store.subscribe,
     () => store.getTransitionFrame(transitionId),
     () => null,
-  );
-};
-
-/** Whether any frame exists to visualize. */
-export const useFramesAvailable = (): boolean => {
-  const store = use(CanvasFrameStoreContext);
-  return useSyncExternalStore(
-    store.subscribe,
-    store.getFramesAvailable,
-    () => false,
   );
 };

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/canvas-scene.test.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/canvas-scene.test.ts
@@ -68,6 +68,7 @@ const input: CanvasSceneInput = {
     hoveredId: null,
     selectedIds: new Set(),
   }),
+  pinnedVisualizerIds: new Set(),
 };
 
 describe("buildCanvasScene", () => {
@@ -119,6 +120,30 @@ describe("buildCanvasScene", () => {
     expect(nodes.find((node) => node.id === "p2")?.focus).toBe("downstream");
     expect(arcs.find((arc) => arc.id === inputArcId)?.focus).toBe("incoming");
     expect(arcs.find((arc) => arc.id === outputArcId)?.focus).toBe("outgoing");
+  });
+
+  it("marks the hovered node even where nothing is focused", () => {
+    // The hover highlight can be turned off, which leaves the focus empty
+    // while the pointer still rests on a node — the state visualizer and the
+    // rest of the hover-driven surfaces still have to see it.
+    const { nodes } = buildCanvasScene({ ...input, hoveredId: "p1" });
+
+    expect(nodes.find((node) => node.id === "p1")?.hovered).toBe(true);
+    expect(nodes.find((node) => node.id === "p1")?.focus).toBe("none");
+  });
+
+  it("marks a place whose state visualizer is pinned", () => {
+    const { nodes } = buildCanvasScene({
+      ...input,
+      pinnedVisualizerIds: new Set(["p1"]),
+    });
+
+    expect(nodes.find((node) => node.id === "p1")).toMatchObject({
+      visualizerPinned: true,
+    });
+    expect(nodes.find((node) => node.id === "p2")).toMatchObject({
+      visualizerPinned: false,
+    });
   });
 
   it("builds one arc per input and output arc, oriented through the transition", () => {

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/canvas-scene.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/canvas-scene.ts
@@ -58,6 +58,8 @@ export type CanvasPlaceNode = CanvasNodeBase & {
   hasColorType: boolean;
   /** Whether the place defines custom visualizer code. */
   hasVisualizer: boolean;
+  /** Whether its visualizer is pinned open, so it shows without a hover. */
+  visualizerPinned: boolean;
   /** Display colour of the place's token type, when it has one. */
   typeColor: string | undefined;
 };
@@ -122,6 +124,8 @@ export type CanvasSceneInput = {
   /** The node under the pointer, once the hover has settled. */
   hoveredId: string | null;
   focus: CanvasFocus;
+  /** Places whose state visualizer is pinned open. */
+  pinnedVisualizerIds: ReadonlySet<string>;
 };
 
 const positionOf = (
@@ -143,6 +147,7 @@ export const buildCanvasScene = ({
   isSelected,
   hoveredId,
   focus,
+  pinnedVisualizerIds,
 }: CanvasSceneInput): CanvasScene => {
   const interaction = (id: string) => ({
     selected: isSelected(id),
@@ -170,6 +175,7 @@ export const buildCanvasScene = ({
         extensions.colors && extensions.dynamics && place.dynamicsEnabled,
       hasColorType: (placeType?.elements.length ?? 0) > 0,
       hasVisualizer: !!place.visualizerCode,
+      visualizerPinned: pinnedVisualizerIds.has(place.id),
       typeColor: placeType?.displayColor,
     });
   }

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/classic-place-node.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/classic-place-node.tsx
@@ -4,10 +4,7 @@ import { Icon } from "@hashintel/ds-components";
 import { css } from "@hashintel/ds-helpers/css";
 
 import { splitPascalCase } from "../../../../../lib/split-pascal-case";
-import {
-  useFramesAvailable,
-  usePlaceTokenCount,
-} from "../../../canvas-frame-store";
+import { usePlaceTokenCount } from "../../../canvas-frame-store";
 import { nodeFocusStyle } from "../../../styles/focus";
 import { handleStyling } from "../../../styles/styling";
 import { placeBorderColor, placeFillColor } from "../../../styles/type-colors";
@@ -88,14 +85,16 @@ export const ClassicPlaceNode: React.FC<NodeProps<PlaceNodeType>> = ({
 }: NodeProps<PlaceNodeType>) => {
   // A frame re-renders this place only when its own count moves.
   const tokenCount = usePlaceTokenCount(id);
-  const framesAvailable = useFramesAvailable();
 
-  // Show the visualizer on hover for places with a visualizer during
-  // simulation, and keep it up for as long as it is pinned.
+  // Show the visualizer on hover for places that define one, and keep it up
+  // for as long as it is pinned. Before a run it draws the initial marking,
+  // so a net still being built is worth pointing at too.
   const showStateTooltip =
     data.hasColorType &&
     data.hasVisualizer &&
-    framesAvailable &&
+    // Dragging the place would carry the box along over the canvas it is
+    // being dropped on, and redraw the visualizer every frame of the drag.
+    !data.dragging &&
     (data.hovered || data.visualizerPinned);
 
   // Add zero width space to labels between pascal case points as text-wrapping breakpoints

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/classic-place-node.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/classic-place-node.tsx
@@ -90,9 +90,13 @@ export const ClassicPlaceNode: React.FC<NodeProps<PlaceNodeType>> = ({
   const tokenCount = usePlaceTokenCount(id);
   const framesAvailable = useFramesAvailable();
 
-  // Show the visualizer on hover for places with a visualizer during simulation.
+  // Show the visualizer on hover for places with a visualizer during
+  // simulation, and keep it up for as long as it is pinned.
   const showStateTooltip =
-    data.hasColorType && data.hasVisualizer && framesAvailable && data.hovered;
+    data.hasColorType &&
+    data.hasVisualizer &&
+    framesAvailable &&
+    (data.hovered || data.visualizerPinned);
 
   // Add zero width space to labels between pascal case points as text-wrapping breakpoints
   const label = splitPascalCase(data.label).join("\u200B");

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/place-node.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/place-node.tsx
@@ -58,9 +58,13 @@ export const PlaceNode: React.FC<NodeProps<PlaceNodeType>> = ({
   const tokenCount = usePlaceTokenCount(id);
   const framesAvailable = useFramesAvailable();
 
-  // Show the visualizer on hover for places with a visualizer during simulation.
+  // Show the visualizer on hover for places with a visualizer during
+  // simulation, and keep it up for as long as it is pinned.
   const showStateTooltip =
-    data.hasColorType && data.hasVisualizer && framesAvailable && data.hovered;
+    data.hasColorType &&
+    data.hasVisualizer &&
+    framesAvailable &&
+    (data.hovered || data.visualizerPinned);
 
   // React Flow marks a node selected as a drag-selection is drawn, before the
   // change reaches the editor's own selection.

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/place-node.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/place-node.tsx
@@ -1,10 +1,7 @@
 import { Icon } from "@hashintel/ds-components";
 import { css } from "@hashintel/ds-helpers/css";
 
-import {
-  useFramesAvailable,
-  usePlaceTokenCount,
-} from "../../../canvas-frame-store";
+import { usePlaceTokenCount } from "../../../canvas-frame-store";
 import { nodeFocusStyle } from "../../../styles/focus";
 import { placeBorderColor, placeFillColor } from "../../../styles/type-colors";
 import {
@@ -56,14 +53,16 @@ export const PlaceNode: React.FC<NodeProps<PlaceNodeType>> = ({
 }: NodeProps<PlaceNodeType>) => {
   // A frame re-renders this place only when its own count moves.
   const tokenCount = usePlaceTokenCount(id);
-  const framesAvailable = useFramesAvailable();
 
-  // Show the visualizer on hover for places with a visualizer during
-  // simulation, and keep it up for as long as it is pinned.
+  // Show the visualizer on hover for places that define one, and keep it up
+  // for as long as it is pinned. Before a run it draws the initial marking,
+  // so a net still being built is worth pointing at too.
   const showStateTooltip =
     data.hasColorType &&
     data.hasVisualizer &&
-    framesAvailable &&
+    // Dragging the place would carry the box along over the canvas it is
+    // being dropped on, and redraw the visualizer every frame of the drag.
+    !data.dragging &&
     (data.hovered || data.visualizerPinned);
 
   // React Flow marks a node selected as a drag-selection is drawn, before the

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/place-state-tooltip.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/place-state-tooltip.tsx
@@ -5,7 +5,7 @@ import {
   useReactFlow,
   useViewport,
 } from "@xyflow/react";
-import { lazy, Suspense, use, useRef } from "react";
+import { use, useEffect, useRef, useState } from "react";
 
 import { Button } from "@hashintel/ds-components";
 import { css, cva, cx } from "@hashintel/ds-helpers/css";
@@ -17,11 +17,31 @@ import { UserSettingsContext } from "../../../../../../react/state/user-settings
 import { PinIcon } from "../../../../../components/pin-icon";
 import { usePetrinautPresentation } from "../../../../shared/presentation-context";
 
-const DeferredPlaceStateVisualization = lazy(async () => {
-  const { PlaceStateVisualization } =
-    await import("../../../../shared/place-state-visualization");
-  return { default: PlaceStateVisualization };
-});
+/**
+ * The module that draws a visualizer, loaded on demand and remembered.
+ *
+ * It carries the compiler for user code, so it stays out of the canvas's own
+ * chunk. Loaded through state rather than `lazy` and a boundary inside the
+ * box: a boundary there lets the box mount and measure itself empty, and the
+ * retry that brings the artwork in re-renders only the suspended subtree, so
+ * the size the box opens at is never corrected. Held here, the box does not
+ * exist until it has something to draw.
+ */
+type PlaceStateVisualizationComponent =
+  (typeof import("../../../../shared/place-state-visualization"))["PlaceStateVisualization"];
+
+let loadedVisualization: PlaceStateVisualizationComponent | null = null;
+let pendingVisualization: Promise<PlaceStateVisualizationComponent> | null =
+  null;
+
+const loadVisualization = () => {
+  pendingVisualization ??=
+    import("../../../../shared/place-state-visualization").then((module) => {
+      loadedVisualization = module.PlaceStateVisualization;
+      return module.PlaceStateVisualization;
+    });
+  return pendingVisualization;
+};
 
 // Gap between the node and the box, in screen pixels. Held as padding on the
 // wrapper rather than as the toolbar's offset, so the pointer can cross from
@@ -173,8 +193,33 @@ export const PlaceStateTooltip: React.FC<{ nodeId: string }> = ({ nodeId }) => {
   const { flowToScreenPosition } = useReactFlow();
   useViewport();
 
+  // Both the initial value and the setter are wrapped: a component is a
+  // function, and React would take a bare one for a lazy initialiser or a
+  // state updater and call it with no props.
+  const [PlaceStateVisualization, setPlaceStateVisualization] =
+    useState<PlaceStateVisualizationComponent | null>(
+      () => loadedVisualization,
+    );
+
+  useEffect(() => {
+    if (PlaceStateVisualization) {
+      return;
+    }
+    let cancelled = false;
+    void loadVisualization().then((component) => {
+      if (!cancelled) {
+        setPlaceStateVisualization(() => component);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [PlaceStateVisualization]);
+
   const contentRef = useRef<HTMLDivElement>(null);
-  const boxSize = useElementSize(contentRef);
+  // The border box: the flip below decides against the height the box
+  // actually occupies, padding and border included.
+  const boxSize = useElementSize(contentRef, { box: "border" });
 
   const place = petriNetDefinition.places.find((pl) => pl.id === nodeId);
   const placeType = place?.colorId
@@ -187,7 +232,8 @@ export const PlaceStateTooltip: React.FC<{ nodeId: string }> = ({ nodeId }) => {
     !placeType ||
     placeType.elements.length === 0 ||
     !place.visualizerCode ||
-    !node
+    !node ||
+    !PlaceStateVisualization
   ) {
     return null;
   }
@@ -230,12 +276,7 @@ export const PlaceStateTooltip: React.FC<{ nodeId: string }> = ({ nodeId }) => {
         onPointerLeave={clearHoveredItem}
       >
         <div ref={contentRef} className={tooltipStyle}>
-          <Suspense fallback={null}>
-            <DeferredPlaceStateVisualization
-              place={place}
-              placeType={placeType}
-            />
-          </Suspense>
+          <PlaceStateVisualization place={place} placeType={placeType} />
         </div>
         <div className={cx(pinStyle({ pinned }), PIN_CLASS)}>
           <Button

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/place-state-tooltip.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/place-state-tooltip.tsx
@@ -7,10 +7,13 @@ import {
 } from "@xyflow/react";
 import { lazy, Suspense, use, useRef } from "react";
 
+import { Button } from "@hashintel/ds-components";
 import { css } from "@hashintel/ds-helpers/css";
 
 import { useElementSize } from "../../../../../../react/hooks/use-element-size";
+import { EditorContext } from "../../../../../../react/state/editor-context";
 import { SDCPNContext } from "../../../../../../react/state/sdcpn-context";
+import { PinIcon } from "../../../../../components/pin-icon";
 import { usePetrinautPresentation } from "../../../../shared/presentation-context";
 
 const DeferredPlaceStateVisualization = lazy(async () => {
@@ -19,15 +22,23 @@ const DeferredPlaceStateVisualization = lazy(async () => {
   return { default: PlaceStateVisualization };
 });
 
-// Gap between the node and the box, in screen pixels.
+// Gap between the node and the box, in screen pixels. Held as padding on the
+// wrapper rather than as the toolbar's offset, so the pointer can cross from
+// the node to the box without passing over the canvas and ending the hover.
 const TOOLTIP_OFFSET_PX = 12;
 
 // Screen-space height of the top bar; the box flips below the node rather than
 // disappear behind it when placing it above would intrude into this zone.
 const TOP_BAR_SAFE_ZONE_PX = 72;
 
+const wrapperStyle = css({
+  display: "flex",
+});
+
 const tooltipStyle = css({
   display: "flex",
+  alignItems: "flex-start",
+  gap: "[4px]",
   maxWidth: "[90vw]",
   maxHeight: "[80vh]",
   overflow: "auto",
@@ -36,15 +47,24 @@ const tooltipStyle = css({
   border: "[1px solid {colors.neutral.bd.subtle}]",
   borderRadius: "md",
   boxShadow: "[0px 8px 24px rgba(0, 0, 0, 0.16)]",
-  pointerEvents: "none",
 });
 
 /**
- * Hover box surfacing a colored place's custom visualizer on the canvas.
+ * Box surfacing a colored place's custom visualizer on the canvas.
+ *
+ * It follows the pointer by default and closes with the hover. Pinning holds
+ * it open instead, so it can be watched while the timeline is scrubbed or the
+ * place's initial state edited.
  */
 export const PlaceStateTooltip: React.FC<{ nodeId: string }> = ({ nodeId }) => {
   const presentation = usePetrinautPresentation();
   const { petriNetDefinition } = use(SDCPNContext);
+  const {
+    pinnedVisualizerPlaceIds,
+    toggleVisualizerPin,
+    setHoveredItem,
+    clearHoveredItem,
+  } = use(EditorContext);
 
   const node = useInternalNode(nodeId);
   const { flowToScreenPosition } = useReactFlow();
@@ -69,6 +89,8 @@ export const PlaceStateTooltip: React.FC<{ nodeId: string }> = ({ nodeId }) => {
     return null;
   }
 
+  const pinned = pinnedVisualizerPlaceIds.has(nodeId);
+
   const nodeTopY = flowToScreenPosition({
     x: node.internals.positionAbsolute.x,
     y: node.internals.positionAbsolute.y,
@@ -85,21 +107,44 @@ export const PlaceStateTooltip: React.FC<{ nodeId: string }> = ({ nodeId }) => {
       nodeId={nodeId}
       isVisible
       position={placeBelow ? Position.Bottom : Position.Top}
-      offset={TOOLTIP_OFFSET_PX}
+      offset={0}
     >
       <div
-        ref={contentRef}
-        className={tooltipStyle}
-        // Hide until measured so a tall box near the top never flashes behind
-        // the top bar before the above/below decision settles.
-        style={{ opacity: boxSize ? 1 : 0 }}
+        className={wrapperStyle}
+        // The gap between node and box is the wrapper's own padding, so the
+        // pointer crosses it without touching the canvas.
+        style={{ padding: `${TOOLTIP_OFFSET_PX}px 0` }}
+        // The box counts as part of the place while the pointer is on it:
+        // without this, reaching for the pin would end the hover and take the
+        // box with it.
+        onPointerEnter={() => setHoveredItem({ type: "place", id: nodeId })}
+        onPointerLeave={clearHoveredItem}
       >
-        <Suspense fallback={null}>
-          <DeferredPlaceStateVisualization
-            place={place}
-            placeType={placeType}
+        <div
+          ref={contentRef}
+          className={tooltipStyle}
+          // Hide until measured so a tall box near the top never flashes behind
+          // the top bar before the above/below decision settles.
+          style={{ opacity: boxSize ? 1 : 0 }}
+        >
+          <Suspense fallback={null}>
+            <DeferredPlaceStateVisualization
+              place={place}
+              placeType={placeType}
+            />
+          </Suspense>
+          <Button
+            size="xxs"
+            variant="ghost"
+            prefix={<PinIcon />}
+            aria-label={
+              pinned ? "Unpin state visualizer" : "Pin state visualizer"
+            }
+            aria-pressed={pinned}
+            tooltip={pinned ? "Unpin" : "Keep open while you work"}
+            onClick={() => toggleVisualizerPin(nodeId)}
           />
-        </Suspense>
+        </div>
       </div>
     </NodeToolbar>
   );

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/place-state-tooltip.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/place-state-tooltip.tsx
@@ -71,6 +71,14 @@ const PIN_CLASS = "place-visualizer-pin";
 const wrapperStyle = css({
   display: "flex",
   position: "relative",
+  /*
+   * The box's corner radius, and the source every nested corner is measured
+   * from. A shape inset by `n` from the box curves at this radius minus `n`,
+   * which keeps the curves parallel instead of letting the tighter ones
+   * crowd inside the wider ones. Derived in CSS rather than restated, so
+   * changing this one number moves the whole set.
+   */
+  "--visualizer-radius": "[14px]",
   opacity: "[0]",
   transform: "[scale(0.96)]",
   pointerEvents: "none",
@@ -108,11 +116,17 @@ const tooltipStyle = css({
   // leave the pin hanging outside it.
   minWidth: "[38px]",
   minHeight: "[34px]",
+  /*
+   * The artwork reaches the border rather than sitting in a frame of padding.
+   * A visualizer draws its own background, square to its viewBox, and inside
+   * a padded box that square corner sat visibly within the box's rounded
+   * one. Scrolling clips to the padding box, which follows the radius, so
+   * with no padding the artwork's corners simply become the box's.
+   */
   overflow: "auto",
-  padding: "[4px]",
   backgroundColor: "neutral.s00",
   border: "[1px solid {colors.neutral.bd.subtle}]",
-  borderRadius: "md",
+  borderRadius: "[var(--visualizer-radius)]",
   boxShadow: "[0px 8px 24px rgba(0, 0, 0, 0.16)]",
 });
 
@@ -136,6 +150,11 @@ const tooltipStyle = css({
  * Anchored on the wrapper rather than inside the box, so it keeps its corner
  * while a tall visualizer scrolls underneath.
  */
+/** A further 1px inside the glass, for the glass's own border. */
+const pinButtonStyle = css({
+  borderRadius: "[calc(var(--visualizer-radius) - 9px)]",
+});
+
 const pinStyle = cva({
   base: {
     position: "absolute",
@@ -145,9 +164,8 @@ const pinStyle = cva({
     top: "[20px]",
     right: "[8px]",
     display: "flex",
-    // The button's own radius, so the disc and the ink it holds share a
-    // corner.
-    borderRadius: "md",
+    // Inset 8px from the box's corner, so it curves 8px tighter.
+    borderRadius: "[calc(var(--visualizer-radius) - 8px)]",
     // A rim of light rather than a drawn border: it reads against a dark
     // artwork and dissolves into a pale one.
     border: "[1px solid rgba(255, 255, 255, 0.5)]",
@@ -295,6 +313,7 @@ export const PlaceStateTooltip: React.FC<{ nodeId: string }> = ({ nodeId }) => {
         </div>
         <div className={cx(pinStyle({ pinned }), PIN_CLASS)}>
           <Button
+            className={pinButtonStyle}
             size="xxs"
             variant="ghost"
             prefix={<PinIcon />}

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/place-state-tooltip.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/place-state-tooltip.tsx
@@ -142,7 +142,14 @@ export const PlaceStateTooltip: React.FC<{ nodeId: string }> = ({ nodeId }) => {
             }
             aria-pressed={pinned}
             tooltip={pinned ? "Unpin" : "Keep open while you work"}
-            onClick={() => toggleVisualizerPin(nodeId)}
+            // The box is a portal but still a child of the node in the React
+            // tree, so without this a click on the pin also selects the place
+            // and opens its properties.
+            onMouseDown={(event) => event.stopPropagation()}
+            onClick={(event) => {
+              event.stopPropagation();
+              toggleVisualizerPin(nodeId);
+            }}
           />
         </div>
       </div>

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/place-state-tooltip.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/place-state-tooltip.tsx
@@ -214,10 +214,9 @@ const pinButtonStyle = css({
 const pinStyle = cva({
   base: {
     position: "absolute",
-    // 8px inside the box's top-right corner. The 12px on top clears the
-    // wrapper's own padding, which holds the gap to the node, so it has to
-    // stay in step with `TOOLTIP_OFFSET_PX`.
-    top: "[20px]",
+    // 8px inside the box's top-right corner, past the wrapper's gap to the
+    // node when that gap is on top; the wrapper sets the variable.
+    top: "[calc(8px + var(--node-gap-top, 0px))]",
     right: "[8px]",
     display: "flex",
     // Inset 8px from the box's corner, so it curves 8px tighter.
@@ -274,6 +273,7 @@ export const PlaceStateTooltip: React.FC<{ nodeId: string }> = ({ nodeId }) => {
     openVisualizerPlaceId,
     toggleVisualizerPin,
     openPlaceVisualizer,
+    hoveredItem,
     setHoveredItem,
     clearHoveredItem,
   } = use(EditorContext);
@@ -334,6 +334,14 @@ export const PlaceStateTooltip: React.FC<{ nodeId: string }> = ({ nodeId }) => {
   const showVisualizer =
     (pinned || openVisualizerPlaceId === nodeId) &&
     PlaceStateVisualization !== null;
+
+  // The button is offered while the pointer is on the place or its toolbar,
+  // not for the settled hover that mounts this component: leaving an open
+  // panel clears the hover at once, and the settled hover only follows once
+  // the pointer rests, so without this the button would pop in on the way out.
+  if (!showVisualizer && hoveredItem?.id !== nodeId) {
+    return null;
+  }
 
   const nodeTopY = flowToScreenPosition({
     x: node.internals.positionAbsolute.x,
@@ -414,9 +422,13 @@ export const PlaceStateTooltip: React.FC<{ nodeId: string }> = ({ nodeId }) => {
         data-animated={showAnimations}
         data-open={boxSize !== null}
         style={{
-          // The gap between node and box is the wrapper's own padding, so the
-          // pointer crosses it without touching the canvas.
-          padding: `${TOOLTIP_OFFSET_PX}px 0`,
+          // The gap between node and box is the wrapper's own padding, on the
+          // side facing the node only, so the pointer crosses it without
+          // touching the canvas and no dead strip sits on the far side.
+          paddingTop: placeBelow ? `${TOOLTIP_OFFSET_PX}px` : 0,
+          paddingBottom: placeBelow ? 0 : `${TOOLTIP_OFFSET_PX}px`,
+          // @ts-expect-error CSS variables work at runtime, but are not in the type system
+          "--node-gap-top": `${placeBelow ? TOOLTIP_OFFSET_PX : 0}px`,
           // Grows from whichever edge faces the node.
           transformOrigin: placeBelow ? "top center" : "bottom center",
         }}

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/place-state-tooltip.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/place-state-tooltip.tsx
@@ -150,6 +150,21 @@ const tooltipStyle = css({
  * Anchored on the wrapper rather than inside the box, so it keeps its corner
  * while a tall visualizer scrolls underneath.
  */
+/**
+ * The button that pointing at a place offers, before the visualizer itself.
+ *
+ * A place's picture is worth a panel, and a panel that opens on hover alone
+ * covers the net while somebody is only passing over it. So the hover offers
+ * this instead: one small round button, in the slot the panel will occupy, and
+ * the panel is what clicking it produces.
+ */
+const triggerStyle = css({
+  borderRadius: "full",
+  backgroundColor: "neutral.s00",
+  boxShadow: "[0 1px 4px rgba(0, 0, 0, 0.18)]",
+  borderColor: "neutral.bd.subtle",
+});
+
 /** A further 1px inside the glass, for the glass's own border. */
 const pinButtonStyle = css({
   borderRadius: "[calc(var(--visualizer-radius) - 9px)]",
@@ -217,7 +232,9 @@ export const PlaceStateTooltip: React.FC<{ nodeId: string }> = ({ nodeId }) => {
   const { showAnimations } = use(UserSettingsContext);
   const {
     pinnedVisualizerPlaceIds,
+    openVisualizerPlaceId,
     toggleVisualizerPin,
+    openPlaceVisualizer,
     setHoveredItem,
     clearHoveredItem,
   } = use(EditorContext);
@@ -265,13 +282,19 @@ export const PlaceStateTooltip: React.FC<{ nodeId: string }> = ({ nodeId }) => {
     !placeType ||
     placeType.elements.length === 0 ||
     !place.visualizerCode ||
-    !node ||
-    !PlaceStateVisualization
+    !node
   ) {
     return null;
   }
 
   const pinned = pinnedVisualizerPlaceIds.has(nodeId);
+  // Pinning outlasts the hover; opening belongs to it. Either shows the
+  // panel, and until one of them does, the hover shows the button that opens
+  // it. The module that draws a visualizer is only needed for the panel, so
+  // the button is offered while it is still loading.
+  const showVisualizer =
+    (pinned || openVisualizerPlaceId === nodeId) &&
+    PlaceStateVisualization !== null;
 
   const nodeTopY = flowToScreenPosition({
     x: node.internals.positionAbsolute.x,
@@ -283,6 +306,52 @@ export const PlaceStateTooltip: React.FC<{ nodeId: string }> = ({ nodeId }) => {
   const boxHeight = boxSize?.height ?? 0;
   const placeBelow =
     nodeTopY - TOOLTIP_OFFSET_PX - boxHeight < TOP_BAR_SAFE_ZONE_PX;
+
+  const keepHovered = {
+    // Both surfaces count as part of the place while the pointer is on them:
+    // without this, reaching for either would end the hover and take it away.
+    onPointerEnter: () => setHoveredItem({ type: "place", id: nodeId }),
+    onPointerLeave: clearHoveredItem,
+  };
+
+  if (!showVisualizer) {
+    return (
+      <NodeToolbar
+        nodeId={nodeId}
+        isVisible
+        position={placeBelow ? Position.Bottom : Position.Top}
+        offset={0}
+      >
+        <div
+          className={wrapperStyle}
+          data-animated={showAnimations}
+          data-open
+          // The gap to the node is this wrapper's own padding, so the pointer
+          // crosses it without touching the canvas.
+          style={{ padding: `${TOOLTIP_OFFSET_PX}px 0` }}
+          {...keepHovered}
+        >
+          <Button
+            className={triggerStyle}
+            size="xs"
+            variant="subtle"
+            shape="round"
+            iconName="eye"
+            aria-label="Show state visualizer"
+            tooltip="Show state visualizer"
+            // The button is a portal but still a child of the node in the
+            // React tree, so without this a click on it also selects the
+            // place and opens its properties.
+            onMouseDown={(event) => event.stopPropagation()}
+            onClick={(event) => {
+              event.stopPropagation();
+              openPlaceVisualizer(nodeId);
+            }}
+          />
+        </div>
+      </NodeToolbar>
+    );
+  }
 
   return (
     <NodeToolbar
@@ -302,11 +371,7 @@ export const PlaceStateTooltip: React.FC<{ nodeId: string }> = ({ nodeId }) => {
           // Grows from whichever edge faces the node.
           transformOrigin: placeBelow ? "top center" : "bottom center",
         }}
-        // The box counts as part of the place while the pointer is on it:
-        // without this, reaching for the pin would end the hover and take the
-        // box with it.
-        onPointerEnter={() => setHoveredItem({ type: "place", id: nodeId })}
-        onPointerLeave={clearHoveredItem}
+        {...keepHovered}
       >
         <div ref={contentRef} className={tooltipStyle}>
           <PlaceStateVisualization place={place} placeType={placeType} />

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/place-state-tooltip.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/place-state-tooltip.tsx
@@ -151,10 +151,23 @@ const pinStyle = cva({
     border: "[1px solid rgba(255, 255, 255, 0.5)]",
     boxShadow: "[0 1px 3px rgba(0, 0, 0, 0.14)]",
     backdropFilter: "[blur(8px) saturate(140%)]",
-    // Keeps the button's ink and the blur inside the disc.
-    overflow: "hidden",
-    color: "neutral.s120",
     transition: "[opacity 120ms ease, background-color 150ms ease]",
+    /*
+     * The focus ring belongs to the disc, not to the button inside it. The
+     * button draws its own at no offset, which is inside the disc's rim and
+     * indistinguishable from it, and clipping the disc to keep the button's
+     * ink round erased it altogether. Round the button instead, and ring the
+     * disc from outside.
+     */
+    "&:has(:focus-visible)": {
+      // Two tones, because the ring floats over the visualizer's artwork:
+      // the light one carries a dark picture, the dark halo beyond it carries
+      // a pale one, and neither can go missing.
+      outline: "[2px solid rgba(255, 255, 255, 0.95)]",
+      outlineOffset: "[1px]",
+      boxShadow:
+        "[0 0 0 5px rgba(0, 0, 0, 0.45), 0 1px 3px rgba(0, 0, 0, 0.14)]",
+    },
   },
   variants: {
     pinned: {
@@ -282,6 +295,9 @@ export const PlaceStateTooltip: React.FC<{ nodeId: string }> = ({ nodeId }) => {
           <Button
             size="xxs"
             variant="ghost"
+            // Round, so its hover and pressed ink stay inside the disc
+            // without the disc having to clip anything.
+            shape="round"
             prefix={<PinIcon />}
             aria-label={
               pinned ? "Unpin state visualizer" : "Pin state visualizer"

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/place-state-tooltip.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/place-state-tooltip.tsx
@@ -137,44 +137,19 @@ const tooltipStyle = css({
 });
 
 /**
- * The pin sits over the visualizer's top-right corner rather than beside it,
- * so the box stays the size of the artwork.
- *
- * A pane of frosted glass around the button, not the button's own surface: a
- * visualizer draws whatever it likes underneath — black, in the satellites
- * example — and every button variant in the system paints in translucent ink
- * meant for the app's own background, so a bare glyph disappears into the
- * artwork. Blurring what is behind it and tinting that pale gives the disc
- * the artwork's own colour while lifting it enough for a dark glyph to read
- * over anything, and leaves the button's hover and pressed ink to sit on top
- * of it as designed.
- *
- * Held back until the pointer or the keyboard reaches the box, and at full
- * strength while pinned, which is when it has to be found again to release
- * it.
- *
- * Anchored on the wrapper rather than inside the box, so it keeps its corner
- * while a tall visualizer scrolls underneath.
- */
-/**
  * The button that pointing at a place offers, before the visualizer itself.
  *
  * A place's picture is worth a panel, and a panel that opens on hover alone
  * covers the net while somebody is only passing over it. So the hover offers
- * this instead: one small round button, in the slot the panel will occupy, and
- * the panel is what clicking it produces.
- */
-/**
+ * this instead: one small round button, astride the node's edge, and the
+ * panel is what clicking it produces.
+ *
  * The white surface belongs to this wrapper, not to the button inside it.
  * Every button variant in the system paints its hover in translucent ink
  * meant for the app's own background, and that ink beats a background set on
- * the button itself: pointing at the button turned it transparent and the
- * node showed straight through. Held out here, the ink lands on an opaque
- * surface as designed.
- *
- * The button sits astride the node's edge rather than clear of it, so it
- * needs none of the panel's padding either: the pointer reaches it off the
- * node without crossing the canvas in between.
+ * the button itself, so the opaque surface lives here and the ink lands on
+ * it. Sitting astride the node's edge, the button needs none of the panel's
+ * padding: the pointer reaches it off the node without crossing the canvas.
  */
 const triggerStyle = css({
   display: "flex",
@@ -216,6 +191,26 @@ const pinButtonStyle = css({
   borderRadius: "[calc(var(--visualizer-radius) - 9px)]",
 });
 
+/**
+ * The pin sits over the visualizer's top-right corner rather than beside it,
+ * so the box stays the size of the artwork.
+ *
+ * A pane of frosted glass around the button, not the button's own surface: a
+ * visualizer draws whatever it likes underneath — black, in the satellites
+ * example — and every button variant in the system paints in translucent ink
+ * meant for the app's own background, so a bare glyph disappears into the
+ * artwork. Blurring what is behind it and tinting that pale gives the glass
+ * the artwork's own colour while lifting it enough for a dark glyph to read
+ * over anything, and leaves the button's hover and pressed ink to sit on top
+ * of it as designed.
+ *
+ * Held back until the pointer or the keyboard reaches the box, and at full
+ * strength while pinned, which is when it has to be found again to release
+ * it.
+ *
+ * Anchored on the wrapper rather than inside the box, so it keeps its corner
+ * while a tall visualizer scrolls underneath.
+ */
 const pinStyle = cva({
   base: {
     position: "absolute",
@@ -234,11 +229,9 @@ const pinStyle = cva({
     backdropFilter: "[blur(8px) saturate(140%)]",
     transition: "[opacity 120ms ease, background-color 150ms ease]",
     /*
-     * The focus ring belongs to the disc, not to the button inside it: the
-     * button draws its own at no offset, which lands on the disc's rim and is
-     * indistinguishable from it. Ringing the disc from outside also means
-     * nothing has to be clipped to keep the button's ink in, which is what
-     * erased the ring in the first place.
+     * The focus ring belongs to the glass, not to the button inside it: the
+     * button draws its own at no offset, which lands on the glass's rim and is
+     * indistinguishable from it.
      */
     "&:has(:focus-visible)": {
       // Two tones, because the ring floats over the visualizer's artwork:
@@ -358,12 +351,9 @@ export const PlaceStateTooltip: React.FC<{ nodeId: string }> = ({ nodeId }) => {
     // without this, reaching for either would end the hover and take it away.
     onPointerEnter: () => setHoveredItem({ type: "place", id: nodeId }),
     /*
-     * Leaving onto a node is not leaving. React routes enter and leave
-     * through its own tree, and the toolbar is a portal inside the node's
-     * subtree there, so coming back to the node fires this leave and no enter
-     * at all: clearing here dropped the hover, and the highlight with it, on
-     * the node the pointer had just returned to. Landing on another node is
-     * that node's business, and its own enter arrives.
+     * Leaving onto a node is not leaving: the toolbar is a portal inside the
+     * node's React subtree, so returning to the node fires this leave with no
+     * enter to follow. Another node's own enter sets the hover for it.
      */
     onPointerLeave: (event: React.PointerEvent) => {
       const landedOn = event.relatedTarget;

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/place-state-tooltip.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/place-state-tooltip.tsx
@@ -120,14 +120,14 @@ const tooltipStyle = css({
  * The pin sits over the visualizer's top-right corner rather than beside it,
  * so the box stays the size of the artwork.
  *
- * A disc of frosted glass around the button, not the button's own surface: a
+ * A pane of frosted glass around the button, not the button's own surface: a
  * visualizer draws whatever it likes underneath — black, in the satellites
  * example — and every button variant in the system paints in translucent ink
  * meant for the app's own background, so a bare glyph disappears into the
  * artwork. Blurring what is behind it and tinting that pale gives the disc
  * the artwork's own colour while lifting it enough for a dark glyph to read
  * over anything, and leaves the button's hover and pressed ink to sit on top
- * of the disc as designed.
+ * of it as designed.
  *
  * Held back until the pointer or the keyboard reaches the box, and at full
  * strength while pinned, which is when it has to be found again to release
@@ -139,13 +139,15 @@ const tooltipStyle = css({
 const pinStyle = cva({
   base: {
     position: "absolute",
-    // 5px inside the box's top-right corner. The 12px clears the wrapper's
-    // own top padding, which holds the gap to the node, so it has to stay in
-    // step with `TOOLTIP_OFFSET_PX`.
-    top: "[17px]",
-    right: "[5px]",
+    // 8px inside the box's top-right corner. The 12px on top clears the
+    // wrapper's own padding, which holds the gap to the node, so it has to
+    // stay in step with `TOOLTIP_OFFSET_PX`.
+    top: "[20px]",
+    right: "[8px]",
     display: "flex",
-    borderRadius: "full",
+    // The button's own radius, so the disc and the ink it holds share a
+    // corner.
+    borderRadius: "md",
     // A rim of light rather than a drawn border: it reads against a dark
     // artwork and dissolves into a pale one.
     border: "[1px solid rgba(255, 255, 255, 0.5)]",
@@ -153,11 +155,11 @@ const pinStyle = cva({
     backdropFilter: "[blur(8px) saturate(140%)]",
     transition: "[opacity 120ms ease, background-color 150ms ease]",
     /*
-     * The focus ring belongs to the disc, not to the button inside it. The
-     * button draws its own at no offset, which is inside the disc's rim and
-     * indistinguishable from it, and clipping the disc to keep the button's
-     * ink round erased it altogether. Round the button instead, and ring the
-     * disc from outside.
+     * The focus ring belongs to the disc, not to the button inside it: the
+     * button draws its own at no offset, which lands on the disc's rim and is
+     * indistinguishable from it. Ringing the disc from outside also means
+     * nothing has to be clipped to keep the button's ink in, which is what
+     * erased the ring in the first place.
      */
     "&:has(:focus-visible)": {
       // Two tones, because the ring floats over the visualizer's artwork:
@@ -295,9 +297,6 @@ export const PlaceStateTooltip: React.FC<{ nodeId: string }> = ({ nodeId }) => {
           <Button
             size="xxs"
             variant="ghost"
-            // Round, so its hover and pressed ink stay inside the disc
-            // without the disc having to clip anything.
-            shape="round"
             prefix={<PinIcon />}
             aria-label={
               pinned ? "Unpin state visualizer" : "Pin state visualizer"

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/place-state-tooltip.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/place-state-tooltip.tsx
@@ -53,6 +53,12 @@ const TOOLTIP_OFFSET_PX = 12;
 const TOP_BAR_SAFE_ZONE_PX = 72;
 
 /**
+ * The button's diameter. Half of it is the toolbar offset that lands its
+ * centre on the node's edge, so the two have to be stated together.
+ */
+const TRIGGER_SIZE_PX = 22;
+
+/**
  * Marks the pin, so pointing at the box anywhere can raise it. Written out
  * again in the wrapper's selector below: Panda reads these style objects
  * statically, and an interpolated key would not reach the stylesheet.
@@ -159,10 +165,25 @@ const tooltipStyle = css({
  * the panel is what clicking it produces.
  */
 const triggerStyle = css({
+  // Sized here rather than by the button's own scale, because half of it is
+  // the offset that centres it on the node's edge.
+  width: "[22px]",
+  minWidth: "[22px]",
+  height: "[22px]",
+  padding: "[0]",
   borderRadius: "full",
   backgroundColor: "neutral.s00",
   boxShadow: "[0 1px 4px rgba(0, 0, 0, 0.18)]",
   borderColor: "neutral.bd.subtle",
+});
+
+/**
+ * The button sits astride the node's edge rather than clear of it, so it
+ * needs none of the box's padding: the pointer reaches it off the node
+ * without crossing the canvas in between.
+ */
+const triggerWrapperStyle = css({
+  display: "flex",
 });
 
 /** A further 1px inside the glass, for the glass's own border. */
@@ -311,7 +332,24 @@ export const PlaceStateTooltip: React.FC<{ nodeId: string }> = ({ nodeId }) => {
     // Both surfaces count as part of the place while the pointer is on them:
     // without this, reaching for either would end the hover and take it away.
     onPointerEnter: () => setHoveredItem({ type: "place", id: nodeId }),
-    onPointerLeave: clearHoveredItem,
+    /*
+     * Leaving onto a node is not leaving. React routes enter and leave
+     * through its own tree, and the toolbar is a portal inside the node's
+     * subtree there, so coming back to the node fires this leave and no enter
+     * at all: clearing here dropped the hover, and the highlight with it, on
+     * the node the pointer had just returned to. Landing on another node is
+     * that node's business, and its own enter arrives.
+     */
+    onPointerLeave: (event: React.PointerEvent) => {
+      const landedOn = event.relatedTarget;
+      if (
+        landedOn instanceof Element &&
+        landedOn.closest(".react-flow__node") !== null
+      ) {
+        return;
+      }
+      clearHoveredItem();
+    },
   };
 
   if (!showVisualizer) {
@@ -320,17 +358,11 @@ export const PlaceStateTooltip: React.FC<{ nodeId: string }> = ({ nodeId }) => {
         nodeId={nodeId}
         isVisible
         position={placeBelow ? Position.Bottom : Position.Top}
-        offset={0}
+        // Half the button back towards the node, which puts its centre on the
+        // node's edge.
+        offset={-TRIGGER_SIZE_PX / 2}
       >
-        <div
-          className={wrapperStyle}
-          data-animated={showAnimations}
-          data-open
-          // The gap to the node is this wrapper's own padding, so the pointer
-          // crosses it without touching the canvas.
-          style={{ padding: `${TOOLTIP_OFFSET_PX}px 0` }}
-          {...keepHovered}
-        >
+        <div className={triggerWrapperStyle} {...keepHovered}>
           <Button
             className={triggerStyle}
             size="xs"

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/place-state-tooltip.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/place-state-tooltip.tsx
@@ -424,7 +424,9 @@ export const PlaceStateTooltip: React.FC<{ nodeId: string }> = ({ nodeId }) => {
         // The box is a portal but still a child of the node in the React
         // tree, so without this a press or a click anywhere on it, the
         // artwork, its scrollbar or the pin, also selects the place and opens
-        // its properties.
+        // its properties. The wrapper is only a surface for those, hence
+        // presentational: the pin inside it is the control.
+        role="presentation"
         onMouseDown={(event) => event.stopPropagation()}
         onClick={(event) => event.stopPropagation()}
       >

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/place-state-tooltip.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/place-state-tooltip.tsx
@@ -8,7 +8,7 @@ import {
 import { lazy, Suspense, use, useRef } from "react";
 
 import { Button } from "@hashintel/ds-components";
-import { css } from "@hashintel/ds-helpers/css";
+import { css, cva, cx } from "@hashintel/ds-helpers/css";
 
 import { useElementSize } from "../../../../../../react/hooks/use-element-size";
 import { EditorContext } from "../../../../../../react/state/editor-context";
@@ -31,16 +31,51 @@ const TOOLTIP_OFFSET_PX = 12;
 // disappear behind it when placing it above would intrude into this zone.
 const TOP_BAR_SAFE_ZONE_PX = 72;
 
-const wrapperStyle = css({
-  display: "flex",
+/**
+ * Marks the pin, so pointing at the box anywhere can raise it. Written out
+ * again in the wrapper's selector below: Panda reads these style objects
+ * statically, and an interpolated key would not reach the stylesheet.
+ */
+const PIN_CLASS = "place-visualizer-pin";
+
+const wrapperStyle = cva({
+  base: {
+    display: "flex",
+    position: "relative",
+    "&:hover .place-visualizer-pin": {
+      opacity: "[1]",
+    },
+    // Reaching the pin by keyboard has to bring it up too, or its focus ring
+    // arrives at a third of its strength.
+    "&:focus-within .place-visualizer-pin": {
+      opacity: "[1]",
+    },
+  },
+  variants: {
+    // Hidden until measured, so a tall box near the top never flashes behind
+    // the top bar before the above/below decision settles.
+    measured: {
+      true: {},
+      false: {
+        opacity: "[0]",
+        pointerEvents: "none",
+      },
+    },
+  },
 });
 
 const tooltipStyle = css({
   display: "flex",
+  // The visualizer keeps its own height rather than being stretched to the
+  // box, which is what lets a tall one scroll instead of squashing.
   alignItems: "flex-start",
-  gap: "[4px]",
   maxWidth: "[90vw]",
   maxHeight: "[80vh]",
+  // Enough to hold the pin, whatever the visualizer draws: one that renders
+  // nothing for an empty place would otherwise collapse to its padding and
+  // leave the pin hanging outside it.
+  minWidth: "[38px]",
+  minHeight: "[34px]",
   overflow: "auto",
   padding: "[4px]",
   backgroundColor: "neutral.s00",
@@ -50,11 +85,51 @@ const tooltipStyle = css({
 });
 
 /**
+ * The pin sits over the visualizer's top-right corner rather than beside it,
+ * so the box stays the size of the artwork. It holds back until the pointer
+ * arrives, and stays at full strength while pinned, which is when it has to
+ * be found again to release it.
+ *
+ * This is a surface of its own around the button, not the button's own: a
+ * visualizer draws whatever it likes underneath — black, in the satellites
+ * example — and every button variant in the system paints in translucent ink
+ * meant for the app's own background, so a bare glyph disappears into the
+ * artwork. An opaque chip with a border reads over anything, and leaves the
+ * button's hover and pressed ink to sit on top of it as designed.
+ *
+ * Anchored on the wrapper rather than inside the box, so it keeps its corner
+ * while a tall visualizer scrolls underneath.
+ */
+const pinStyle = cva({
+  base: {
+    position: "absolute",
+    // 5px inside the box's top-right corner. The 12px clears the wrapper's
+    // own top padding, which holds the gap to the node, so it has to stay in
+    // step with `TOOLTIP_OFFSET_PX`.
+    top: "[17px]",
+    right: "[5px]",
+    display: "flex",
+    borderRadius: "md",
+    border: "[1px solid {colors.neutral.bd.solid}]",
+    // Keeps the button's hover ink inside the rounded corners.
+    overflow: "hidden",
+    transition: "[opacity 120ms ease]",
+  },
+  variants: {
+    pinned: {
+      true: { opacity: "[1]", backgroundColor: "neutral.s20" },
+      false: { opacity: "[0.3]", backgroundColor: "neutral.s00" },
+    },
+  },
+});
+
+/**
  * Box surfacing a colored place's custom visualizer on the canvas.
  *
  * It follows the pointer by default and closes with the hover. Pinning holds
  * it open instead, so it can be watched while the timeline is scrubbed or the
- * place's initial state edited.
+ * place's initial state edited. Before a run it shows the initial marking,
+ * the same state the properties panel previews.
  */
 export const PlaceStateTooltip: React.FC<{ nodeId: string }> = ({ nodeId }) => {
   const presentation = usePetrinautPresentation();
@@ -110,7 +185,7 @@ export const PlaceStateTooltip: React.FC<{ nodeId: string }> = ({ nodeId }) => {
       offset={0}
     >
       <div
-        className={wrapperStyle}
+        className={wrapperStyle({ measured: boxSize !== null })}
         // The gap between node and box is the wrapper's own padding, so the
         // pointer crosses it without touching the canvas.
         style={{ padding: `${TOOLTIP_OFFSET_PX}px 0` }}
@@ -120,19 +195,15 @@ export const PlaceStateTooltip: React.FC<{ nodeId: string }> = ({ nodeId }) => {
         onPointerEnter={() => setHoveredItem({ type: "place", id: nodeId })}
         onPointerLeave={clearHoveredItem}
       >
-        <div
-          ref={contentRef}
-          className={tooltipStyle}
-          // Hide until measured so a tall box near the top never flashes behind
-          // the top bar before the above/below decision settles.
-          style={{ opacity: boxSize ? 1 : 0 }}
-        >
+        <div ref={contentRef} className={tooltipStyle}>
           <Suspense fallback={null}>
             <DeferredPlaceStateVisualization
               place={place}
               placeType={placeType}
             />
           </Suspense>
+        </div>
+        <div className={cx(pinStyle({ pinned }), PIN_CLASS)}>
           <Button
             size="xxs"
             variant="ghost"

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/place-state-tooltip.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/place-state-tooltip.tsx
@@ -13,6 +13,7 @@ import { css, cva, cx } from "@hashintel/ds-helpers/css";
 import { useElementSize } from "../../../../../../react/hooks/use-element-size";
 import { EditorContext } from "../../../../../../react/state/editor-context";
 import { SDCPNContext } from "../../../../../../react/state/sdcpn-context";
+import { UserSettingsContext } from "../../../../../../react/state/user-settings-context";
 import { PinIcon } from "../../../../../components/pin-icon";
 import { usePetrinautPresentation } from "../../../../shared/presentation-context";
 
@@ -38,29 +39,40 @@ const TOP_BAR_SAFE_ZONE_PX = 72;
  */
 const PIN_CLASS = "place-visualizer-pin";
 
-const wrapperStyle = cva({
-  base: {
-    display: "flex",
-    position: "relative",
-    "&:hover .place-visualizer-pin": {
-      opacity: "[1]",
-    },
-    // Reaching the pin by keyboard has to bring it up too, or its focus ring
-    // arrives at a third of its strength.
-    "&:focus-within .place-visualizer-pin": {
-      opacity: "[1]",
+/**
+ * The box grows out of the node it belongs to.
+ *
+ * It has to be measured before it can be placed, so it starts hidden either
+ * way; opening from just under full size turns that first frame into the
+ * start of a movement rather than a flash. The origin is the edge nearest the
+ * node, set by the caller, so the box appears to come from the place rather
+ * than from its own middle.
+ */
+const wrapperStyle = css({
+  display: "flex",
+  position: "relative",
+  opacity: "[0]",
+  transform: "[scale(0.96)]",
+  pointerEvents: "none",
+  "&[data-open='true']": {
+    opacity: "[1]",
+    transform: "[scale(1)]",
+    pointerEvents: "auto",
+  },
+  "&[data-animated='true']": {
+    transition:
+      "[opacity 120ms ease-out, transform 160ms cubic-bezier(0.2, 0.9, 0.25, 1)]",
+    "@media (prefers-reduced-motion: reduce)": {
+      transition: "[none]",
     },
   },
-  variants: {
-    // Hidden until measured, so a tall box near the top never flashes behind
-    // the top bar before the above/below decision settles.
-    measured: {
-      true: {},
-      false: {
-        opacity: "[0]",
-        pointerEvents: "none",
-      },
-    },
+  // Pointing anywhere at the box brings its pin forward, and so does reaching
+  // it by keyboard.
+  "&:hover .place-visualizer-pin": {
+    opacity: "[1]",
+  },
+  "&:focus-within .place-visualizer-pin": {
+    opacity: "[1]",
   },
 });
 
@@ -86,16 +98,20 @@ const tooltipStyle = css({
 
 /**
  * The pin sits over the visualizer's top-right corner rather than beside it,
- * so the box stays the size of the artwork. It holds back until the pointer
- * arrives, and stays at full strength while pinned, which is when it has to
- * be found again to release it.
+ * so the box stays the size of the artwork.
  *
- * This is a surface of its own around the button, not the button's own: a
+ * A disc of frosted glass around the button, not the button's own surface: a
  * visualizer draws whatever it likes underneath — black, in the satellites
  * example — and every button variant in the system paints in translucent ink
  * meant for the app's own background, so a bare glyph disappears into the
- * artwork. An opaque chip with a border reads over anything, and leaves the
- * button's hover and pressed ink to sit on top of it as designed.
+ * artwork. Blurring what is behind it and tinting that pale gives the disc
+ * the artwork's own colour while lifting it enough for a dark glyph to read
+ * over anything, and leaves the button's hover and pressed ink to sit on top
+ * of the disc as designed.
+ *
+ * Held back until the pointer or the keyboard reaches the box, and at full
+ * strength while pinned, which is when it has to be found again to release
+ * it.
  *
  * Anchored on the wrapper rather than inside the box, so it keeps its corner
  * while a tall visualizer scrolls underneath.
@@ -109,16 +125,27 @@ const pinStyle = cva({
     top: "[17px]",
     right: "[5px]",
     display: "flex",
-    borderRadius: "md",
-    border: "[1px solid {colors.neutral.bd.solid}]",
-    // Keeps the button's hover ink inside the rounded corners.
+    borderRadius: "full",
+    // A rim of light rather than a drawn border: it reads against a dark
+    // artwork and dissolves into a pale one.
+    border: "[1px solid rgba(255, 255, 255, 0.5)]",
+    boxShadow: "[0 1px 3px rgba(0, 0, 0, 0.14)]",
+    backdropFilter: "[blur(8px) saturate(140%)]",
+    // Keeps the button's ink and the blur inside the disc.
     overflow: "hidden",
-    transition: "[opacity 120ms ease]",
+    color: "neutral.s120",
+    transition: "[opacity 120ms ease, background-color 150ms ease]",
   },
   variants: {
     pinned: {
-      true: { opacity: "[1]", backgroundColor: "neutral.s20" },
-      false: { opacity: "[0.3]", backgroundColor: "neutral.s00" },
+      true: {
+        opacity: "[1]",
+        backgroundColor: "[rgba(255, 255, 255, 0.86)]",
+      },
+      false: {
+        opacity: "[0.72]",
+        backgroundColor: "[rgba(255, 255, 255, 0.46)]",
+      },
     },
   },
 });
@@ -134,6 +161,7 @@ const pinStyle = cva({
 export const PlaceStateTooltip: React.FC<{ nodeId: string }> = ({ nodeId }) => {
   const presentation = usePetrinautPresentation();
   const { petriNetDefinition } = use(SDCPNContext);
+  const { showAnimations } = use(UserSettingsContext);
   const {
     pinnedVisualizerPlaceIds,
     toggleVisualizerPin,
@@ -185,10 +213,16 @@ export const PlaceStateTooltip: React.FC<{ nodeId: string }> = ({ nodeId }) => {
       offset={0}
     >
       <div
-        className={wrapperStyle({ measured: boxSize !== null })}
-        // The gap between node and box is the wrapper's own padding, so the
-        // pointer crosses it without touching the canvas.
-        style={{ padding: `${TOOLTIP_OFFSET_PX}px 0` }}
+        className={wrapperStyle}
+        data-animated={showAnimations}
+        data-open={boxSize !== null}
+        style={{
+          // The gap between node and box is the wrapper's own padding, so the
+          // pointer crosses it without touching the canvas.
+          padding: `${TOOLTIP_OFFSET_PX}px 0`,
+          // Grows from whichever edge faces the node.
+          transformOrigin: placeBelow ? "top center" : "bottom center",
+        }}
         // The box counts as part of the place while the pointer is on it:
         // without this, reaching for the pin would end the hover and take the
         // box with it.

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/place-state-tooltip.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/place-state-tooltip.tsx
@@ -341,10 +341,12 @@ export const PlaceStateTooltip: React.FC<{ nodeId: string }> = ({ nodeId }) => {
   }).y;
 
   // Above-placed box grows upward from the node's top edge; flip below if its
-  // top would intrude into the top bar's zone.
-  const boxHeight = boxSize?.height ?? 0;
+  // top would intrude into the top bar's zone. Decided against what is about
+  // to show: the box's own height, or the button's once the box is closed,
+  // since the last measured box height outlives the box.
+  const shownHeight = showVisualizer ? (boxSize?.height ?? 0) : TRIGGER_SIZE_PX;
   const placeBelow =
-    nodeTopY - TOOLTIP_OFFSET_PX - boxHeight < TOP_BAR_SAFE_ZONE_PX;
+    nodeTopY - TOOLTIP_OFFSET_PX - shownHeight < TOP_BAR_SAFE_ZONE_PX;
 
   const keepHovered = {
     // Both surfaces count as part of the place while the pointer is on them:
@@ -419,6 +421,12 @@ export const PlaceStateTooltip: React.FC<{ nodeId: string }> = ({ nodeId }) => {
           transformOrigin: placeBelow ? "top center" : "bottom center",
         }}
         {...keepHovered}
+        // The box is a portal but still a child of the node in the React
+        // tree, so without this a press or a click anywhere on it, the
+        // artwork, its scrollbar or the pin, also selects the place and opens
+        // its properties.
+        onMouseDown={(event) => event.stopPropagation()}
+        onClick={(event) => event.stopPropagation()}
       >
         <div ref={contentRef} className={tooltipStyle}>
           <PlaceStateVisualization place={place} placeType={placeType} />
@@ -434,14 +442,7 @@ export const PlaceStateTooltip: React.FC<{ nodeId: string }> = ({ nodeId }) => {
             }
             aria-pressed={pinned}
             tooltip={pinned ? "Unpin" : "Keep open while you work"}
-            // The box is a portal but still a child of the node in the React
-            // tree, so without this a click on the pin also selects the place
-            // and opens its properties.
-            onMouseDown={(event) => event.stopPropagation()}
-            onClick={(event) => {
-              event.stopPropagation();
-              toggleVisualizerPin(nodeId);
-            }}
+            onClick={() => toggleVisualizerPin(nodeId)}
           />
         </div>
       </div>

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/place-state-tooltip.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/place-state-tooltip.tsx
@@ -164,26 +164,51 @@ const tooltipStyle = css({
  * this instead: one small round button, in the slot the panel will occupy, and
  * the panel is what clicking it produces.
  */
+/**
+ * The white surface belongs to this wrapper, not to the button inside it.
+ * Every button variant in the system paints its hover in translucent ink
+ * meant for the app's own background, and that ink beats a background set on
+ * the button itself: pointing at the button turned it transparent and the
+ * node showed straight through. Held out here, the ink lands on an opaque
+ * surface as designed.
+ *
+ * The button sits astride the node's edge rather than clear of it, so it
+ * needs none of the panel's padding either: the pointer reaches it off the
+ * node without crossing the canvas in between.
+ */
 const triggerStyle = css({
+  display: "flex",
   // Sized here rather than by the button's own scale, because half of it is
   // the offset that centres it on the node's edge.
   width: "[22px]",
-  minWidth: "[22px]",
   height: "[22px]",
-  padding: "[0]",
   borderRadius: "full",
   backgroundColor: "neutral.s00",
+  border: "[1px solid {colors.neutral.bd.subtle}]",
   boxShadow: "[0 1px 4px rgba(0, 0, 0, 0.18)]",
-  borderColor: "neutral.bd.subtle",
+  transition: "[background-color 120ms ease, box-shadow 120ms ease]",
+  // The response to being pointed at is the surface warming and lifting. The
+  // button's own hover ink is a fortieth of black, which over white is not a
+  // response at all.
+  _hover: {
+    backgroundColor: "neutral.s30",
+    boxShadow: "[0 2px 6px rgba(0, 0, 0, 0.22)]",
+  },
+  // As on the pin: the ring belongs out here, where nothing clips it and the
+  // button's own at no offset would be lost in the rim.
+  "&:has(:focus-visible)": {
+    outline: "[2px solid rgba(255, 255, 255, 0.95)]",
+    outlineOffset: "[1px]",
+    boxShadow: "[0 0 0 5px rgba(0, 0, 0, 0.45), 0 1px 4px rgba(0, 0, 0, 0.18)]",
+  },
 });
 
-/**
- * The button sits astride the node's edge rather than clear of it, so it
- * needs none of the box's padding: the pointer reaches it off the node
- * without crossing the canvas in between.
- */
-const triggerWrapperStyle = css({
-  display: "flex",
+/** Fills the surface, less its 1px rim. */
+const triggerButtonStyle = css({
+  width: "[20px]",
+  minWidth: "[20px]",
+  height: "[20px]",
+  padding: "[0]",
 });
 
 /** A further 1px inside the glass, for the glass's own border. */
@@ -362,11 +387,11 @@ export const PlaceStateTooltip: React.FC<{ nodeId: string }> = ({ nodeId }) => {
         // node's edge.
         offset={-TRIGGER_SIZE_PX / 2}
       >
-        <div className={triggerWrapperStyle} {...keepHovered}>
+        <div className={triggerStyle} {...keepHovered}>
           <Button
-            className={triggerStyle}
+            className={triggerButtonStyle}
             size="xs"
-            variant="subtle"
+            variant="ghost"
             shape="round"
             iconName="eye"
             aria-label="Show state visualizer"

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/use-canvas-scene.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/use-canvas-scene.ts
@@ -23,8 +23,13 @@ export const useCanvasScene = (
 ): CanvasScene => {
   const { activeNet } = use(ActiveNetContext);
   const { extensions, petriNetDefinition } = use(SDCPNContext);
-  const { draggingStateByNodeId, isSelected, selection, hoveredItem } =
-    use(EditorContext);
+  const {
+    draggingStateByNodeId,
+    isSelected,
+    selection,
+    hoveredItem,
+    pinnedVisualizerPlaceIds,
+  } = use(EditorContext);
   const { compactNodes, highlightOnHover } = use(UserSettingsContext);
 
   /*
@@ -59,5 +64,6 @@ export const useCanvasScene = (
       hoveredId: highlightOnHover ? settledHoverId : null,
       selectedIds: new Set(selection.keys()),
     }),
+    pinnedVisualizerIds: pinnedVisualizerPlaceIds,
   });
 };

--- a/libs/@hashintel/petrinaut/src/ui/views/shared/place-state-visualization.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/shared/place-state-visualization.tsx
@@ -64,26 +64,10 @@ export const PlaceStateVisualization: React.FC<
   }, [place.visualizerCode]);
 
   /*
-   * The picture, held against what it is drawn from.
-   *
-   * Rendering it runs user code, and the tokens it takes are derived fresh
-   * each time, so without this every re-render of the surface it sits on — a
-   * hover settling, a pin, a box being measured — redrew the picture too.
-   * Keeping the element lets React reuse the subtree until the frame, the
-   * marking, the parameters or the code itself move. Measured on a scrub with
-   * a 100ms picture pinned to the canvas: 45 to 63 frames per second, worst
-   * frame 92ms to 51ms.
-   *
-   * `useDeferredValue` on the frame does NOT belong on top of this, though it
-   * looks like it should. Measured the same way it took 63 down to 54-59, and
-   * on its own, without this memo, 45 down to 35: the update that moves the
-   * frame is the one that has to redraw, so there is nothing left to defer
-   * that the memo has not already skipped, and the second priority pass costs
-   * a whole extra draw. That was a scrub against a picture whose cost is in
-   * its render; a picture whose cost is in the nodes it produces pays that in
-   * the commit, which no priority can interrupt either. Somewhere the frame
-   * is not what changed — code being typed in the visualizer editor, say — a
-   * transition may still be the right tool.
+   * Rendering the picture runs user code and derives its tokens afresh, so
+   * the element is kept until the frame, the marking, the parameters or the
+   * code change; a re-render of the surface it sits on, a hover settling, a
+   * pin, a box being measured, reuses it.
    */
   const picture = useMemo(() => {
     if (!VisualizerComponent || !placeType) {

--- a/libs/@hashintel/petrinaut/src/ui/views/shared/place-state-visualization.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/shared/place-state-visualization.tsx
@@ -79,7 +79,11 @@ export const PlaceStateVisualization: React.FC<
    * on its own, without this memo, 45 down to 35: the update that moves the
    * frame is the one that has to redraw, so there is nothing left to defer
    * that the memo has not already skipped, and the second priority pass costs
-   * a whole extra draw.
+   * a whole extra draw. That was a scrub against a picture whose cost is in
+   * its render; a picture whose cost is in the nodes it produces pays that in
+   * the commit, which no priority can interrupt either. Somewhere the frame
+   * is not what changed — code being typed in the visualizer editor, say — a
+   * transition may still be the right tool.
    */
   const picture = useMemo(() => {
     if (!VisualizerComponent || !placeType) {

--- a/libs/@hashintel/petrinaut/src/ui/views/shared/place-state-visualization.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/shared/place-state-visualization.tsx
@@ -63,46 +63,86 @@ export const PlaceStateVisualization: React.FC<
     }
   }, [place.visualizerCode]);
 
+  /*
+   * The picture, held against what it is drawn from.
+   *
+   * Rendering it runs user code, and the tokens it takes are derived fresh
+   * each time, so without this every re-render of the surface it sits on — a
+   * hover settling, a pin, a box being measured — redrew the picture too.
+   * Keeping the element lets React reuse the subtree until the frame, the
+   * marking, the parameters or the code itself move. Measured on a scrub with
+   * a 100ms picture pinned to the canvas: 45 to 63 frames per second, worst
+   * frame 92ms to 51ms.
+   *
+   * `useDeferredValue` on the frame does NOT belong on top of this, though it
+   * looks like it should. Measured the same way it took 63 down to 54-59, and
+   * on its own, without this memo, 45 down to 35: the update that moves the
+   * frame is the one that has to redraw, so there is nothing left to defer
+   * that the memo has not already skipped, and the second priority pass costs
+   * a whole extra draw.
+   */
+  const picture = useMemo(() => {
+    if (!VisualizerComponent || !placeType) {
+      return null;
+    }
+
+    const tokens: TokenRecord[] = [];
+
+    if (totalFrames > 0 && currentFrameReader) {
+      tokens.push(...currentFrameReader.getPlaceTokens(place));
+    } else {
+      const marking = initialMarking[place.id];
+      if (Array.isArray(marking) && marking.length > 0) {
+        // Marking records may hold uuid values as at-rest strings; coerce them
+        // to runtime token values (uuid → bigint) as the engine would. Total
+        // per element: a stored value that no longer converts (e.g. legacy
+        // data predating a schema edit) falls back to the element's default
+        // instead of crashing the panel.
+        for (const token of marking) {
+          const coerced: TokenRecord = createUserKeyedRecord();
+          for (const element of placeType.elements) {
+            try {
+              coerced[element.name] = coerceTokenAttributeValue(
+                element,
+                getOwn(token, element.name),
+                `Initial marking for place ${place.name}`,
+              );
+            } catch {
+              coerced[element.name] = defaultTokenAttributeValue(element.type);
+            }
+          }
+          tokens.push(coerced);
+        }
+      }
+    }
+
+    return (
+      // eslint-disable-next-line react-hooks-js/static-components -- Runtime visualizer code intentionally creates a component from user input.
+      <VisualizerComponent
+        tokens={tokens}
+        parameters={mergeParameterValues(
+          parameterValues,
+          defaultParameterValues,
+        )}
+      />
+    );
+  }, [
+    VisualizerComponent,
+    defaultParameterValues,
+    initialMarking,
+    parameterValues,
+    place,
+    placeType,
+    totalFrames,
+    currentFrameReader,
+  ]);
+
   if (!place.visualizerCode) {
     return <div className={messageStyle}>No visualizer code defined</div>;
   }
 
   if (!placeType) {
     return <div className={messageStyle}>Place has no type set</div>;
-  }
-
-  const tokens: TokenRecord[] = [];
-  let parameters: Record<string, number | boolean> = {};
-
-  if (totalFrames > 0 && currentFrameReader) {
-    tokens.push(...currentFrameReader.getPlaceTokens(place));
-    parameters = mergeParameterValues(parameterValues, defaultParameterValues);
-  } else {
-    const marking = initialMarking[place.id];
-    if (Array.isArray(marking) && marking.length > 0) {
-      // Marking records may hold uuid values as at-rest strings; coerce them
-      // to runtime token values (uuid → bigint) as the engine would. Total
-      // per element: a stored value that no longer converts (e.g. legacy
-      // data predating a schema edit) falls back to the element's default
-      // instead of crashing the panel.
-      for (const token of marking) {
-        const coerced: TokenRecord = createUserKeyedRecord();
-        for (const element of placeType.elements) {
-          try {
-            coerced[element.name] = coerceTokenAttributeValue(
-              element,
-              getOwn(token, element.name),
-              `Initial marking for place ${place.name}`,
-            );
-          } catch {
-            coerced[element.name] = defaultTokenAttributeValue(element.type);
-          }
-        }
-        tokens.push(coerced);
-      }
-    }
-
-    parameters = mergeParameterValues(parameterValues, defaultParameterValues);
   }
 
   if (!VisualizerComponent) {
@@ -113,10 +153,5 @@ export const PlaceStateVisualization: React.FC<
     );
   }
 
-  return (
-    <VisualizerErrorBoundary>
-      {/* eslint-disable-next-line react-hooks-js/static-components -- Runtime visualizer code intentionally creates a component from user input. */}
-      <VisualizerComponent tokens={tokens} parameters={parameters} />
-    </VisualizerErrorBoundary>
-  );
+  return <VisualizerErrorBoundary>{picture}</VisualizerErrorBoundary>;
 };


### PR DESCRIPTION
## Summary

Before this PR, a place's state visualizer opened as a tooltip the moment the pointer rested on the place, covered the net while somebody was only passing over it, vanished as soon as the pointer left, and needed a run before it would draw anything. Watching one place's state while scrubbing the timeline or editing the initial marking was not possible.

The visualizer is now reachable from the canvas in two steps, a button on hover and the panel on a click, and gains a pin so it stays in view while the timeline is scrubbed. It opens whether or not anything has run, drawing the initial marking before one has. Its code compiles once and its picture is redrawn only when the frame, the marking, the parameters or the code move.

| Scrub, 1000 nodes, a 100ms visualizer pinned | Before | After |
| -------------------------------------------- | ------ | ----- |
| Frame rate                                   | 45 fps | 63 fps |
| Worst frame                                  | 92ms   | 51ms  |

Measured against the built website in headless Chromium, frame intervals sampled from `requestAnimationFrame` over a scrub of the timeline.

https://github.com/user-attachments/assets/84ac2512-942b-49c2-ba33-e9bc413f4b86

## Links

- Ticket [FE-1673](https://linear.app/hash/issue/FE-1673)
- Docs [Petri net extensions](https://github.com/hashintel/hash/blob/claude/canvas-firing-visibility-and-pin/libs/%40hashintel/petrinaut/docs/petri-net-extensions.md)
- Docs [Simulation](https://github.com/hashintel/hash/blob/claude/canvas-firing-visibility-and-pin/libs/%40hashintel/petrinaut/docs/simulation.md)

## Changes

- Pointing at a place offers a button, and clicking it opens the visualizer
  > A panel that opens on the hover alone covers the net while somebody is only passing over it.
  > The button sits astride the node's top edge, an opaque white disc that darkens a step under the pointer, and the panel opens above it.
  > Opening belongs to that hover: one place id, dropped as soon as the pointer moves to another place or off the canvas, so coming back offers the button again. Clicking it does not pin.
- Pin holds the visualizer open
  > Pinned places live on the editor state and reach the node through the scene, so a pin re-renders one node.
  > Several places can be pinned at once; pins last until the page is reloaded.
- Panel opens with no run, drawing the initial marking
  > A place could not be pinned while the net was still being built, which is when watching one place's state against its initial marking is most useful.
  > The properties panel already previewed that state, so the two now agree. Frames availability leaves the canvas frame store with the gate that read it.
- Hovering is carried on the scene in its own right, not read off the focus
  > `Highlight on hover` switches the focus off, which took the state visualizer with it.
  > `CanvasFocus` loses its `hoveredId`, which nothing outside the focus model read.
- Pin is a rounded square of frosted glass, 8px inside the visualizer's top-right corner
  > It blurs and tints what the visualizer draws behind it, so it takes the artwork's own colour and still lifts it enough for the glyph to read over a pale picture and a black one alike.
  > Held back at a little under three quarters until the pointer or the keyboard reaches the box, full strength while pinned. Verified legible over the satellites example's black sky and the disruption example's pale blue.
  > Its focus ring belongs to the glass and is drawn in two tones, a light ring inside a dark halo, because it floats over artwork of any colour.
- Box grows into place rather than appearing
  > 120ms of opacity and 160ms of scale from 0.96, out of the edge facing its node, on the measurement the box already waits for.
  > Held still where the **Animations** setting is off or the reader prefers reduced motion.
- Box does not exist until it has artwork to draw
  > The module that draws a visualizer is held in state rather than behind a boundary inside the box.
  > A boundary inside the box let it mount and open on an empty 38x34 rectangle.
  > Hoisting the boundary left the box invisible, because the retry re-renders only the suspended subtree and never the measurement.
- Box keeps the hover while the pointer is on it
  > Reaching for the pin used to end the hover and take the box with it. The gap between node and box is the wrapper's own padding, so the pointer crosses it without touching the canvas.
  > The box has always been scrollable and could never be scrolled.
- Dragging a place leaves its box behind
  > Otherwise the box rides over the canvas the node is being dropped on, redrawing the visualizer every frame of the drag.
- Visualizer compiles once for its code
  > Compiling happens wherever a visualizer is shown, and the box now shows it on every hover, so the same code went through Babel again and again.
  > Results and failures are kept by source, bounded to 24 entries and evicted least-recently-used, so a typing burst in the editor cannot push out the visualizers being looked at.
- Visualizer is redrawn only when what it draws moves
  > Rendering one runs user code, and its tokens were derived fresh every render, so a hover settling, a pin, or a box being measured redrew the picture. It is now held against the frame, the marking, the parameters and its own code.
  > `useDeferredValue` on the frame does not belong on top of that, and the comment says so: it measured 63 down to 54-59 with the picture held, and 45 down to 35 without it, because the update that moves the frame is the one that has to redraw.

#### Review fixes

- Press or click anywhere on the box stays off the place
  > The wrapper stops `mousedown` and `click`, so the artwork, its scrollbar and the pin no longer select the place.
- Trigger's flip is decided by its own height
  > The last measured box height outlives the box, so a button following an unpinned panel is placed for its own size.
- Button offered only while the live hover is on the place or its toolbar
  > Leaving an open panel closes it outright instead of showing the button for the rest of the gesture.
- Gap padded on the node-facing side alone
  > No dead strip on the far side of the box takes a click; the pin's inset follows the gap.

## Test coverage

- `canvas-scene.test.ts`:
  > A hovered node with no focus, and a pinned place.
- `compile-visualizer.test.ts`:
  > One component per source, a fresh compile for code that differs, a kept failure, and the entry in use surviving a burst of drafts.
- Playwright, against the built website:
  > Pin reachable from a hover, holding through a scrub, and releasing on a second click.
- Playwright, the two steps:
  > Button on hover and no panel, the button surviving being reached across the gap, the panel on the click and not pinned by it, closing when the hover leaves, the button offered again on return, and a second place offering its own button while one panel is pinned.
- Playwright, with nothing run:
  > Panel open after the click, pin held back on the node and full on the panel or under keyboard focus, pin inside the panel's corner, pinning without selecting the place, and the panel gone mid-drag and back after the drop.
- Playwright, the opening:
  > Opacity and transform sampled from the hover: 0 and scale 0.96 to 1 and scale 1 over about 120ms, origin settling on the edge facing the node, and no transition at all with the Animations setting off or under reduced motion.
- Playwright, the scrub A/B:
  > Frame intervals over a scrub with an expensive visualizer pinned, run against builds with and without the held picture and with and without a deferred frame.
- Existing `@hashintel/petrinaut` unit suite.

## How to test

- Open [Petrinaut preview](https://petrinaut-git-claude-canvas-firing-visibility-and-pin.stage.hash.ai) on Vercel
- Menu > Load example > Supply Chain with Disruption
- Point at InboundShipments, before running anything
  > Expect a small round button on the place's top edge, and no panel
- Click it
  > Expect the visualizer to open above the place, drawing the initial marking, with a faint pin in its top-right corner
- Move the pointer away
  > Expect the panel to close
- Move the pointer back onto the place
  > Expect the button offered again rather than the panel
- Click the button
- Move the pointer onto the panel
  > Expect the pin to come up to full strength
- Click the pin
- Drag the place somewhere else
  > Expect the panel to go while the place moves, and to come back where it lands
- Press Play
- Press Pause
- Drag along the timeline chart
  > Expect the pinned panel to follow the scrubbed frame
- Click the pin again
- Move the pointer away
  > Expect the panel to close



