### PR TITLE
FE-1677: Enforce optimization constraints and show their verdicts in the study view

### DIFF
--- a/.changeset/optimization-constraint-margins.md
+++ b/.changeset/optimization-constraint-margins.md
@@ -2,4 +2,4 @@
 "@hashintel/petrinaut-core": patch
 ---
 
-Constraints become evaluable: `constraintMargin` and `evaluateParameterConstraints` give a parameter constraint's signed slack at a point (`margin >= 0` means satisfied), `compileStateConstraintIndicator` compiles a state constraint as a 0/1 metric, and a user-defined metric's per-run values honour its time aggregation. The manifest accepts an optional `constraintPolicy` (alpha, default 0.05) and the browser runtime's trial events carry an optional `constraints` block with per-constraint margins and per-run pass counts.
+Add constraint margin and state-indicator evaluators, an optional manifest constraintPolicy, and aggregateTime support in getRunValues.

--- a/.changeset/optimization-constraint-margins.md
+++ b/.changeset/optimization-constraint-margins.md
@@ -1,0 +1,5 @@
+---
+"@hashintel/petrinaut-core": patch
+---
+
+Constraints become evaluable: `constraintMargin` and `evaluateParameterConstraints` give a parameter constraint's signed slack at a point (`margin >= 0` means satisfied), `compileStateConstraintIndicator` compiles a state constraint as a 0/1 metric, and a user-defined metric's per-run values honour its time aggregation. The manifest accepts an optional `constraintPolicy` (alpha, default 0.05) and the browser runtime's trial events carry an optional `constraints` block with per-constraint margins and per-run pass counts.

--- a/.changeset/optimization-constraint-verdicts.md
+++ b/.changeset/optimization-constraint-verdicts.md
@@ -1,0 +1,5 @@
+---
+"@hashintel/petrinaut": patch
+---
+
+A study with constraints run in the browser now evaluates them: a step whose parameters break a parameter constraint is pruned before it runs and greyed as infeasible everywhere a step is drawn, every run reports whether each state constraint held throughout, and the study view shows a Constraints card, a Steps clear stat and a Runs passed column, every rate as a raw fraction beside its percentage. The create drawer gains a Pass threshold setting (95 percent by default). The objective is unchanged by any verdict.

--- a/.changeset/optimization-constraint-verdicts.md
+++ b/.changeset/optimization-constraint-verdicts.md
@@ -1,5 +1,0 @@
----
-"@hashintel/petrinaut": patch
----
-
-A study with constraints run in the browser now evaluates them: a step whose parameters break a parameter constraint is pruned before it runs and greyed as infeasible everywhere a step is drawn, every run reports whether each state constraint held throughout, and the study view shows a Constraints card, a Steps clear stat and a Runs passed column, every rate as a raw fraction beside its percentage. The create drawer gains a Pass threshold setting (95 percent by default). The objective is unchanged by any verdict.

--- a/libs/@hashintel/petrinaut-core/src/constraint/constraint.ts
+++ b/libs/@hashintel/petrinaut-core/src/constraint/constraint.ts
@@ -147,3 +147,8 @@ export function constraintsInSpace<S extends ConstraintSpace>(
       constraint.space === space,
   );
 }
+
+/** How a constraint is named wherever it is reported: its display name, else its id. */
+export const constraintLabel = (
+  constraint: Pick<Constraint, "id" | "name">,
+): string => constraint.name ?? constraint.id;

--- a/libs/@hashintel/petrinaut-core/src/constraint/constraint.ts
+++ b/libs/@hashintel/petrinaut-core/src/constraint/constraint.ts
@@ -14,8 +14,10 @@
  *   boolean. It is observed while a run goes.
  *
  * A constraint belongs to whatever carries it (today the optimization
- * manifest); this module owns the shape, not the placement. Nothing enforces
- * constraints yet: they are declared, validated, and evaluable.
+ * manifest); this module owns the shape, not the placement. `margin.ts`
+ * evaluates a parameter constraint's signed slack at one point, and
+ * `indicator-metric.ts` compiles a state constraint as a 0/1 metric the
+ * simulation observes per run. Both report; neither changes an objective.
  *
  * @layerRoot core.constraints
  * @role Boolean conditions over the parameter space or the simulation state, authored as TypeScript, carried as HIR, and shaped once for every consumer

--- a/libs/@hashintel/petrinaut-core/src/constraint/indicator-metric.test.ts
+++ b/libs/@hashintel/petrinaut-core/src/constraint/indicator-metric.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+
+import { instantiateHirMetric } from "../hir/instantiate";
+import { lowerTypeScriptToHir } from "../hir/lower-typescript";
+import { StringPool } from "../simulation/engine/string-pool";
+import {
+  compileStateConstraintIndicator,
+  wrapHirAsIndicator,
+} from "./indicator-metric";
+import { lowerConstraint } from "./lower";
+
+import type { HirFunction } from "../hir/hir";
+import type { SDCPN } from "../types/sdcpn";
+import type { StateConstraint } from "./constraint";
+
+const sdcpn: SDCPN = {
+  places: [
+    {
+      id: "place-queue",
+      name: "Queue",
+      colorId: null,
+      dynamicsEnabled: false,
+      differentialEquationId: null,
+      x: 0,
+      y: 0,
+    },
+    {
+      id: "place-done",
+      name: "Done",
+      colorId: null,
+      dynamicsEnabled: false,
+      differentialEquationId: null,
+      x: 0,
+      y: 0,
+    },
+  ],
+  transitions: [],
+  types: [],
+  parameters: [],
+  differentialEquations: [],
+};
+
+const lowerState = (code: string): StateConstraint => {
+  const result = lowerConstraint(
+    { space: "state", id: "queue-cap", code },
+    { netParameters: [], scenarioParameters: [], sdcpn },
+  );
+  if (!result.ok || result.constraint.space !== "state") {
+    throw new Error(result.ok ? "wrong space" : result.diagnostics[0]?.message);
+  }
+  return result.constraint;
+};
+
+/** Runs an emitted indicator against a frame holding only place counts. */
+const evaluateAt = (
+  artifact: NonNullable<ReturnType<typeof compileStateConstraintIndicator>>,
+  countsByName: Record<string, number>,
+): number => {
+  const frameOrder = ["Done", "Queue"];
+  const placeIndices = new Int32Array(
+    artifact.placeNames.map((name) => frameOrder.indexOf(name)),
+  );
+  const metric = instantiateHirMetric(
+    artifact.source,
+    {},
+    placeIndices,
+    new StringPool(),
+  );
+  const placeCounts = new Uint32Array(
+    frameOrder.map((name) => countsByName[name] ?? 0),
+  );
+  return metric(
+    new Float64Array(0),
+    new BigUint64Array(0),
+    new Uint8Array(0),
+    placeCounts,
+    new Uint32Array(frameOrder.length),
+  );
+};
+
+describe("wrapHirAsIndicator", () => {
+  it("wraps the body as `body ? 1 : 0` with fresh node ids", () => {
+    const lowered = lowerTypeScriptToHir("return true;", "metric");
+    if (!lowered.ok) {
+      throw new Error(lowered.diagnostics[0]?.message);
+    }
+    const fn: HirFunction = lowered.fn;
+    const wrapped = wrapHirAsIndicator(fn);
+    expect(wrapped.params).toEqual(fn.params);
+    expect(wrapped.body).toMatchObject({
+      kind: "cond",
+      condition: fn.body,
+      thenBranch: { kind: "numberLit", value: 1 },
+      elseBranch: { kind: "numberLit", value: 0 },
+    });
+    const ids = new Set<number>();
+    const collect = (node: { id: number }) => ids.add(node.id);
+    collect(wrapped.body);
+    if (wrapped.body.kind === "cond") {
+      collect(wrapped.body.thenBranch);
+      collect(wrapped.body.elseBranch);
+      collect(wrapped.body.condition);
+    }
+    expect(ids.size).toBe(4);
+  });
+});
+
+describe("compileStateConstraintIndicator", () => {
+  it("emits a program that reads 1 where the condition holds and 0 where it fails", () => {
+    const artifact = compileStateConstraintIndicator(
+      lowerState("return state.places.Queue.count <= 10;"),
+      sdcpn,
+    );
+    expect(artifact).not.toBeNull();
+    expect(evaluateAt(artifact!, { Queue: 4 })).toBe(1);
+    expect(evaluateAt(artifact!, { Queue: 10 })).toBe(1);
+    expect(evaluateAt(artifact!, { Queue: 11 })).toBe(0);
+  });
+
+  it("compiles compound conditions over several places", () => {
+    const artifact = compileStateConstraintIndicator(
+      lowerState(
+        "return state.places.Queue.count < 5 && state.places.Done.count > 0;",
+      ),
+      sdcpn,
+    );
+    expect(artifact).not.toBeNull();
+    expect(evaluateAt(artifact!, { Queue: 2, Done: 1 })).toBe(1);
+    expect(evaluateAt(artifact!, { Queue: 2, Done: 0 })).toBe(0);
+    expect(evaluateAt(artifact!, { Queue: 7, Done: 3 })).toBe(0);
+  });
+});

--- a/libs/@hashintel/petrinaut-core/src/constraint/indicator-metric.ts
+++ b/libs/@hashintel/petrinaut-core/src/constraint/indicator-metric.ts
@@ -1,0 +1,80 @@
+/**
+ * A state constraint as a metric the simulation can observe: its boolean
+ * body wrapped as `condition ? 1 : 0` and emitted as a buffer metric
+ * program, so every run reports 1 on a frame where the condition held and 0
+ * where it did not. Aggregated with `min` over a run's frames, that is the
+ * "always" quantifier: 1 exactly when the condition held on every sampled
+ * frame.
+ *
+ * The emitter imports no TypeScript compiler, so this runs on the main
+ * thread; the authoring side type-checked the body already.
+ */
+import {
+  DEFAULT_PETRINAUT_EXTENSIONS,
+  type PetrinautExtensionSettings,
+  sanitizeSDCPNForExtensions,
+} from "../extensions";
+import { emitBufferMetricJs } from "../hir/emit-buffer-js";
+import { walkHir } from "../hir/hir";
+import { buildMetricContext } from "../hir/surface-context";
+
+import type { HirExpr, HirFunction, HirNumberLit } from "../hir/hir";
+import type { HirMetricArtifact } from "../hir/instantiate";
+import type { SDCPN } from "../types/sdcpn";
+import type { StateConstraint } from "./constraint";
+
+const maxNodeId = (expr: HirExpr): number => {
+  let max = -1;
+  walkHir(expr, (node) => {
+    max = Math.max(max, node.id);
+  });
+  return max;
+};
+
+/** The function's body wrapped as `body ? 1 : 0`, node ids kept unique. */
+export const wrapHirAsIndicator = (fn: HirFunction): HirFunction => {
+  const firstFreshId = maxNodeId(fn.body) + 1;
+  const { span } = fn.body;
+  const literal = (id: number, value: 0 | 1): HirNumberLit => ({
+    kind: "numberLit",
+    id,
+    span,
+    value,
+    raw: String(value),
+  });
+  return {
+    ...fn,
+    body: {
+      kind: "cond",
+      id: firstFreshId,
+      span,
+      condition: fn.body,
+      thenBranch: literal(firstFreshId + 1, 1),
+      elseBranch: literal(firstFreshId + 2, 0),
+    },
+  };
+};
+
+/**
+ * The constraint's indicator as a metric artifact over `sdcpn`, or null when
+ * the emitter declines the body (the same shapes `compileHirArtifacts`
+ * reports as not compilable).
+ */
+export const compileStateConstraintIndicator = (
+  constraint: StateConstraint,
+  sdcpn: SDCPN,
+  extensions: PetrinautExtensionSettings = DEFAULT_PETRINAUT_EXTENSIONS,
+): HirMetricArtifact | null => {
+  const context = buildMetricContext(
+    sanitizeSDCPNForExtensions(sdcpn, extensions),
+    extensions,
+    "boolean",
+  );
+  const program = emitBufferMetricJs(
+    wrapHirAsIndicator(constraint.hir),
+    context,
+  );
+  return program === null
+    ? null
+    : { source: program.source, placeNames: program.placeNames };
+};

--- a/libs/@hashintel/petrinaut-core/src/constraint/margin.test.ts
+++ b/libs/@hashintel/petrinaut-core/src/constraint/margin.test.ts
@@ -2,11 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { HirInterpretError } from "../hir/interpret";
 import { lowerTypeScriptToHir } from "../hir/lower-typescript";
-import {
-  constraintMargin,
-  evaluateParameterConstraints,
-  marginForOptuna,
-} from "./margin";
+import { constraintMargin, evaluateParameterConstraints } from "./margin";
 
 import type { HirFunction } from "../hir/hir";
 import type { ParameterConstraint } from "./constraint";
@@ -97,14 +93,6 @@ describe("constraintMargin", () => {
 
   it("throws where interpretation would", () => {
     expect(() => margin("scenario.unknown < 3")).toThrow(HirInterpretError);
-  });
-});
-
-describe("marginForOptuna", () => {
-  it("negates once so a satisfied margin reads as non-positive", () => {
-    expect(marginForOptuna(4)).toBe(-4);
-    expect(marginForOptuna(-2)).toBe(2);
-    expect(marginForOptuna(0)).toBe(-0);
   });
 });
 

--- a/libs/@hashintel/petrinaut-core/src/constraint/margin.test.ts
+++ b/libs/@hashintel/petrinaut-core/src/constraint/margin.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+
+import { HirInterpretError } from "../hir/interpret";
+import { lowerTypeScriptToHir } from "../hir/lower-typescript";
+import {
+  constraintMargin,
+  evaluateParameterConstraints,
+  marginForOptuna,
+} from "./margin";
+
+import type { HirFunction } from "../hir/hir";
+import type { ParameterConstraint } from "./constraint";
+
+const lower = (code: string): HirFunction => {
+  const result = lowerTypeScriptToHir(code, "scenario-expression");
+  if (!result.ok) {
+    throw new Error(result.diagnostics[0]?.message);
+  }
+  return result.fn;
+};
+
+const bindings = {
+  parameters: { rate: 1.5, enabled: true },
+  scenario: { min_load: 2, max_load: 8, flag: false },
+};
+
+const margin = (code: string): number =>
+  constraintMargin(lower(code), bindings);
+
+describe("constraintMargin", () => {
+  it("gives a comparison its signed slack", () => {
+    expect(margin("scenario.min_load <= scenario.max_load")).toBe(6);
+    expect(margin("scenario.min_load < 10")).toBe(8);
+    expect(margin("scenario.min_load >= 5")).toBe(-3);
+    expect(margin("scenario.max_load > 3")).toBe(5);
+    expect(margin("scenario.min_load == 2")).toBe(0);
+    expect(margin("scenario.min_load == 5")).toBe(-3);
+    expect(margin("scenario.min_load != 5")).toBe(3);
+  });
+
+  it("reports a strict comparison at exact equality as failed by its sign", () => {
+    expect(margin("scenario.min_load < 2")).toBeLessThan(0);
+    expect(margin("scenario.min_load > 2")).toBeLessThan(0);
+    expect(margin("scenario.min_load != 2")).toBeLessThan(0);
+    expect(margin("scenario.min_load <= 2")).toBe(0);
+  });
+
+  it("takes the minimum over && and the maximum over ||", () => {
+    expect(margin("scenario.min_load < 10 && scenario.max_load < 10")).toBe(2);
+    expect(margin("scenario.min_load < 10 && scenario.max_load < 5")).toBe(-3);
+    expect(margin("scenario.min_load > 10 || scenario.max_load < 10")).toBe(2);
+    expect(margin("scenario.min_load > 10 || scenario.max_load > 10")).toBe(-2);
+  });
+
+  it("flips the sign under !", () => {
+    expect(margin("!(scenario.min_load < 10)")).toBe(-8);
+    expect(margin("!(scenario.min_load > 10)")).toBe(8);
+  });
+
+  it("gives a bare boolean one unit on the side of its verdict", () => {
+    expect(margin("true")).toBe(1);
+    expect(margin("false")).toBe(-1);
+    expect(margin("parameters.enabled")).toBe(1);
+    expect(margin("scenario.flag")).toBe(-1);
+    expect(margin("parameters.enabled == scenario.flag")).toBe(-1);
+    expect(margin("parameters.enabled != scenario.flag")).toBe(1);
+  });
+
+  it("takes the chosen branch of a conditional", () => {
+    expect(
+      margin(
+        "parameters.enabled ? scenario.min_load < 10 : scenario.min_load > 10",
+      ),
+    ).toBe(8);
+    expect(
+      margin("scenario.flag ? scenario.min_load < 10 : scenario.min_load > 10"),
+    ).toBe(-8);
+  });
+
+  it("evaluates through math calls and arithmetic", () => {
+    expect(margin("Math.max(scenario.min_load, 3) * 2 <= 10")).toBe(4);
+    expect(margin("Math.abs(scenario.min_load - scenario.max_load) < 5")).toBe(
+      -1,
+    );
+  });
+
+  it("scopes let bindings", () => {
+    const fn = lowerTypeScriptToHir(
+      "const gap = scenario.max_load - scenario.min_load; return gap >= 4;",
+      "scenario-code",
+    );
+    if (!fn.ok) {
+      throw new Error(fn.diagnostics[0]?.message);
+    }
+    expect(constraintMargin(fn.fn, bindings)).toBe(2);
+  });
+
+  it("throws where interpretation would", () => {
+    expect(() => margin("scenario.unknown < 3")).toThrow(HirInterpretError);
+  });
+});
+
+describe("marginForOptuna", () => {
+  it("negates once so a satisfied margin reads as non-positive", () => {
+    expect(marginForOptuna(4)).toBe(-4);
+    expect(marginForOptuna(-2)).toBe(2);
+    expect(marginForOptuna(0)).toBe(-0);
+  });
+});
+
+describe("evaluateParameterConstraints", () => {
+  it("returns one margin per constraint in the list's order", () => {
+    const constraints: ParameterConstraint[] = [
+      {
+        space: "parameters",
+        id: "order",
+        code: "scenario.min_load < scenario.max_load",
+        hir: {
+          ...lower("scenario.min_load < scenario.max_load"),
+          surface: "scenario-expression",
+        },
+      },
+      {
+        space: "parameters",
+        id: "cap",
+        code: "scenario.max_load <= 5",
+        hir: {
+          ...lower("scenario.max_load <= 5"),
+          surface: "scenario-expression",
+        },
+      },
+    ];
+    expect(evaluateParameterConstraints(constraints, bindings)).toEqual([
+      { constraintId: "order", margin: 6 },
+      { constraintId: "cap", margin: -3 },
+    ]);
+  });
+});

--- a/libs/@hashintel/petrinaut-core/src/constraint/margin.test.ts
+++ b/libs/@hashintel/petrinaut-core/src/constraint/margin.test.ts
@@ -53,6 +53,14 @@ describe("constraintMargin", () => {
     expect(margin("!(scenario.min_load > 10)")).toBe(8);
   });
 
+  it("fails a negated comparison that holds exactly at its boundary", () => {
+    expect(margin("!(scenario.min_load <= 2)")).toBeLessThan(0);
+    expect(margin("!(scenario.min_load >= 2)")).toBeLessThan(0);
+    expect(margin("!(scenario.min_load == 2)")).toBeLessThan(0);
+    expect(margin("!(scenario.min_load < 2)")).toBeGreaterThan(0);
+    expect(margin("!!(scenario.min_load <= 2)")).toBeGreaterThan(0);
+  });
+
   it("gives a bare boolean one unit on the side of its verdict", () => {
     expect(margin("true")).toBe(1);
     expect(margin("false")).toBe(-1);

--- a/libs/@hashintel/petrinaut-core/src/constraint/margin.ts
+++ b/libs/@hashintel/petrinaut-core/src/constraint/margin.ts
@@ -1,8 +1,7 @@
 /**
  * The signed margin of a constraint: how far its condition holds or fails at
  * one point of the parameter space. `margin >= 0` means satisfied, and every
- * consumer reads the sign that way; a sampler that wants the opposite
- * convention negates through `marginForOptuna`, in one place.
+ * consumer reads the sign that way.
  */
 import {
   HirInterpretError,
@@ -13,9 +12,6 @@ import {
 
 import type { HirBinaryOp, HirExpr, HirFunction, Span } from "../hir/hir";
 import type { ParameterConstraint } from "./constraint";
-
-/** Negated exactly once, here, for a sampler that reads `<= 0` as feasible. Unused until a margin reaches Optuna. */
-export const marginForOptuna = (margin: number): number => -margin;
 
 export type ParameterConstraintResult = {
   constraintId: string;

--- a/libs/@hashintel/petrinaut-core/src/constraint/margin.ts
+++ b/libs/@hashintel/petrinaut-core/src/constraint/margin.ts
@@ -1,0 +1,196 @@
+/**
+ * The signed margin of a constraint: how far its condition holds or fails at
+ * one point of the parameter space. `margin >= 0` means satisfied, and every
+ * consumer reads the sign that way; a sampler that wants the opposite
+ * convention negates through `marginForOptuna`, in one place.
+ */
+import {
+  HirInterpretError,
+  type HirInterpretBindings,
+  interpretHirExpr,
+  type HirValue,
+} from "../hir/interpret";
+
+import type { HirBinaryOp, HirExpr, HirFunction, Span } from "../hir/hir";
+import type { ParameterConstraint } from "./constraint";
+
+/** Negated exactly once, here, for a sampler that reads `<= 0` as feasible. Unused until a margin reaches Optuna. */
+export const marginForOptuna = (margin: number): number => -margin;
+
+export type ParameterConstraintResult = {
+  constraintId: string;
+  margin: number;
+};
+
+/**
+ * A strict comparison at exact equality has zero slack yet fails, so its
+ * margin cannot be the slack: the sign carries the verdict, so it is the
+ * smallest negative number instead.
+ */
+const BOUNDARY_FAILURE = -Number.MIN_VALUE;
+
+type Locals = ReadonlyMap<string, HirValue>;
+
+const COMPARISONS = new Set<HirBinaryOp>(["<", "<=", ">", ">=", "==", "!="]);
+
+const truthy = (value: HirValue): boolean => Boolean(value);
+
+const numeric = (value: HirValue, span: Span, what: string): number => {
+  if (typeof value === "number") {
+    return value;
+  }
+  if (typeof value === "boolean") {
+    return value ? 1 : 0;
+  }
+  throw new HirInterpretError(`${what} must be a number.`, span);
+};
+
+/** The verdict of `left <op> right` under the interpreter's own rules. */
+const comparisonHolds = (
+  op: HirBinaryOp,
+  left: HirValue,
+  right: HirValue,
+  leftSpan: Span,
+  rightSpan: Span,
+): boolean => {
+  if (op === "==") {
+    return left === right;
+  }
+  if (op === "!=") {
+    return left !== right;
+  }
+  const leftNumber = numeric(left, leftSpan, `\`${op}\` operands`);
+  const rightNumber = numeric(right, rightSpan, `\`${op}\` operands`);
+  switch (op) {
+    case "<":
+      return leftNumber < rightNumber;
+    case "<=":
+      return leftNumber <= rightNumber;
+    case ">":
+      return leftNumber > rightNumber;
+    default:
+      return leftNumber >= rightNumber;
+  }
+};
+
+/**
+ * The slack of a comparison: for `a <= b` and `a < b` it is `b - a`, for
+ * `a >= b` and `a > b` it is `a - b`, `==` gives `-|a - b|` and `!=` gives
+ * `|a - b|`. Operands that are not numbers (two booleans compared with `==`)
+ * have no distance, so their slack is one unit either way.
+ */
+const comparisonSlack = (
+  op: HirBinaryOp,
+  left: HirValue,
+  right: HirValue,
+  holds: boolean,
+): number => {
+  if (typeof left !== "number" || typeof right !== "number") {
+    if (typeof left === "boolean" && typeof right === "boolean") {
+      const distance = Math.abs(Number(left) - Number(right));
+      return op === "!=" ? distance : -distance;
+    }
+    return holds ? 1 : -1;
+  }
+  switch (op) {
+    case "<":
+    case "<=":
+      return right - left;
+    case ">":
+    case ">=":
+      return left - right;
+    case "==":
+      return -Math.abs(left - right);
+    default:
+      return Math.abs(left - right);
+  }
+};
+
+const marginOf = (
+  expr: HirExpr,
+  locals: Locals,
+  bindings: HirInterpretBindings,
+): number => {
+  switch (expr.kind) {
+    case "boolLit":
+      return expr.value ? 1 : -1;
+    case "unary":
+      if (expr.op === "!") {
+        return -marginOf(expr.operand, locals, bindings);
+      }
+      break;
+    case "binary": {
+      if (expr.op === "&&") {
+        return Math.min(
+          marginOf(expr.left, locals, bindings),
+          marginOf(expr.right, locals, bindings),
+        );
+      }
+      if (expr.op === "||") {
+        return Math.max(
+          marginOf(expr.left, locals, bindings),
+          marginOf(expr.right, locals, bindings),
+        );
+      }
+      if (!COMPARISONS.has(expr.op)) {
+        break;
+      }
+      const left = interpretHirExpr(expr.left, locals, bindings);
+      const right = interpretHirExpr(expr.right, locals, bindings);
+      const holds = comparisonHolds(
+        expr.op,
+        left,
+        right,
+        expr.left.span,
+        expr.right.span,
+      );
+      // `+ 0` folds a `-0` slack (an `==` that holds exactly) into `0`.
+      const slack = comparisonSlack(expr.op, left, right, holds) + 0;
+      if (holds) {
+        return Math.max(slack, 0);
+      }
+      return slack < 0 ? slack : BOUNDARY_FAILURE;
+    }
+    case "cond":
+      return truthy(interpretHirExpr(expr.condition, locals, bindings))
+        ? marginOf(expr.thenBranch, locals, bindings)
+        : marginOf(expr.elseBranch, locals, bindings);
+    case "let": {
+      const scoped = new Map(locals);
+      for (const binding of expr.bindings) {
+        scoped.set(
+          binding.name,
+          interpretHirExpr(binding.value, scoped, bindings),
+        );
+      }
+      return marginOf(expr.body, scoped, bindings);
+    }
+    default:
+      break;
+  }
+  // A bare boolean (a reference, a call, a field) has no boundary to
+  // measure: one unit on the side the verdict falls.
+  return truthy(interpretHirExpr(expr, locals, bindings)) ? 1 : -1;
+};
+
+/**
+ * The signed slack of a boolean HIR function at `bindings`: comparisons give
+ * their slack, `&&` the minimum of its sides, `||` the maximum, `!` flips
+ * the sign, a `cond` takes its chosen branch, a `let` scopes its bindings,
+ * and a bare boolean is +1 or -1. `margin >= 0` exactly when the condition
+ * holds. Throws `HirInterpretError` where interpretation would.
+ */
+export const constraintMargin = (
+  fn: HirFunction,
+  bindings: HirInterpretBindings,
+): number => marginOf(fn.body, new Map(), bindings);
+
+/** Every parameter constraint's margin at one point, in the list's order. */
+export const evaluateParameterConstraints = (
+  constraints: readonly ParameterConstraint[],
+  bindings: HirInterpretBindings,
+): ParameterConstraintResult[] =>
+  constraints.map((constraint) => ({
+    constraintId: constraint.id,
+    margin: constraintMargin(constraint.hir, bindings),
+  }));

--- a/libs/@hashintel/petrinaut-core/src/constraint/margin.ts
+++ b/libs/@hashintel/petrinaut-core/src/constraint/margin.ts
@@ -112,7 +112,10 @@ const marginOf = (
       return expr.value ? 1 : -1;
     case "unary":
       if (expr.op === "!") {
-        return -marginOf(expr.operand, locals, bindings);
+        // A zero margin means the operand holds exactly at its boundary, so
+        // its negation fails there (`0 === -0` catches both signs of zero).
+        const inner = marginOf(expr.operand, locals, bindings);
+        return inner === 0 ? BOUNDARY_FAILURE : -inner;
       }
       break;
     case "binary": {
@@ -172,9 +175,10 @@ const marginOf = (
 /**
  * The signed slack of a boolean HIR function at `bindings`: comparisons give
  * their slack, `&&` the minimum of its sides, `||` the maximum, `!` flips
- * the sign, a `cond` takes its chosen branch, a `let` scopes its bindings,
- * and a bare boolean is +1 or -1. `margin >= 0` exactly when the condition
- * holds. Throws `HirInterpretError` where interpretation would.
+ * the sign (a zero margin becomes the boundary failure), a `cond` takes its
+ * chosen branch, a `let` scopes its bindings, and a bare boolean is +1 or
+ * -1. `margin >= 0` exactly when the condition holds. Throws
+ * `HirInterpretError` where interpretation would.
  */
 export const constraintMargin = (
   fn: HirFunction,

--- a/libs/@hashintel/petrinaut-core/src/hir/interpret.ts
+++ b/libs/@hashintel/petrinaut-core/src/hir/interpret.ts
@@ -41,7 +41,7 @@ export class HirInterpretError extends Error {
   }
 }
 
-type Env = Map<string, HirValue>;
+type Env = ReadonlyMap<string, HirValue>;
 
 const CONSTANT_VALUES = {
   PI: Math.PI,
@@ -343,6 +343,19 @@ function evalExpr(
         expr.span,
       );
   }
+}
+
+/**
+ * Evaluates one expression under `locals` (the enclosing `let` and callback
+ * bindings) and the ambient bindings. Analyses that walk the tree themselves,
+ * such as a constraint's margin, evaluate their operands through this.
+ */
+export function interpretHirExpr(
+  expr: HirExpr,
+  locals: ReadonlyMap<string, HirValue>,
+  bindings: HirInterpretBindings,
+): HirValue {
+  return evalExpr(expr, locals, bindings);
 }
 
 /**

--- a/libs/@hashintel/petrinaut-core/src/index.ts
+++ b/libs/@hashintel/petrinaut-core/src/index.ts
@@ -451,6 +451,7 @@ export type {
 export {
   CONSTRAINT_SPACES,
   CONSTRAINT_SURFACES,
+  constraintLabel,
   constraintListSchema,
   constraintSchema,
   constraintSpaceSchema,

--- a/libs/@hashintel/petrinaut-core/src/index.ts
+++ b/libs/@hashintel/petrinaut-core/src/index.ts
@@ -464,6 +464,17 @@ export type {
   ParameterConstraint,
   StateConstraint,
 } from "./constraint/constraint";
+export {
+  compileStateConstraintIndicator,
+  wrapHirAsIndicator,
+} from "./constraint/indicator-metric";
+export {
+  constraintMargin,
+  evaluateParameterConstraints,
+  marginForOptuna,
+  type ParameterConstraintResult,
+} from "./constraint/margin";
+export type { HirInterpretBindings } from "./hir/interpret";
 // Type-only: lowering itself stays in ./hir (worker/Node).
 export type {
   ConstraintSource,

--- a/libs/@hashintel/petrinaut-core/src/index.ts
+++ b/libs/@hashintel/petrinaut-core/src/index.ts
@@ -141,7 +141,9 @@ export type {
   PetrinautOptimizationDescribeParameter,
   PetrinautOptimizationDescribeResult,
   PetrinautOptimizationStudy,
+  PetrinautOptimizationTrialConstraints,
   PetrinautOptimizationTrialEvent,
+  PetrinautOptimizationConstraintPolicy,
   PetrinautIntegerOptimizationDomain,
 } from "./optimization";
 export { createPetrinautActions } from "./actions";

--- a/libs/@hashintel/petrinaut-core/src/index.ts
+++ b/libs/@hashintel/petrinaut-core/src/index.ts
@@ -474,7 +474,6 @@ export {
 export {
   constraintMargin,
   evaluateParameterConstraints,
-  marginForOptuna,
   type ParameterConstraintResult,
 } from "./constraint/margin";
 export type { HirInterpretBindings } from "./hir/interpret";

--- a/libs/@hashintel/petrinaut-core/src/optimization/browser/browser-optimization.test.ts
+++ b/libs/@hashintel/petrinaut-core/src/optimization/browser/browser-optimization.test.ts
@@ -314,6 +314,77 @@ describe("createBrowserOptimization", () => {
     expect(events[2]).toMatchObject({ type: "complete", prunedTrials: 1 });
   });
 
+  it("carries the channel's constraint results on the trial event and forgets them once reported", async () => {
+    const constraints = {
+      parameters: [{ constraintId: "order", margin: 0.5 }],
+      state: [{ constraintId: "queue", runsPassed: 2, runsTotal: 3 }],
+    };
+    const context = setUp({
+      evaluateTrial: async (request) =>
+        request.trial === 0
+          ? { kind: "objective", objective: 1, constraints }
+          : {
+              kind: "pruned",
+              reason: "Infeasible: order",
+              constraints: {
+                parameters: [{ constraintId: "order", margin: -2 }],
+                state: [],
+                infeasible: "order",
+              },
+            },
+    });
+    const runId = await startRun(context);
+
+    for (const trial of [0, 1]) {
+      context.worker.emit({
+        type: "evaluate",
+        runId,
+        requestId: trial + 1,
+        trial,
+        suggestedValues: { rate: 0.5, count: 6, enabled: true },
+      });
+    }
+    await flush();
+    expect(
+      context.worker.sentOfType("evaluated").map(({ outcome }) => outcome),
+    ).toEqual([
+      { kind: "objective", objective: 1, constraints },
+      expect.objectContaining({ kind: "pruned", reason: "Infeasible: order" }),
+    ]);
+
+    context.worker.emit({ type: "trial", runId, event: completedTrial });
+    context.worker.emit({
+      type: "trial",
+      runId,
+      event: {
+        ...completedTrial,
+        trial: 1,
+        objective: null,
+        state: "pruned",
+      },
+    });
+    context.worker.emit({
+      type: "trial",
+      runId,
+      event: { ...completedTrial, trial: 2 },
+    });
+    context.worker.emit({ type: "complete", runId, summary });
+
+    const events = await collectEvents(
+      context.capability.attachOptimizationRun(runId),
+    );
+    expect(events[1]).toMatchObject({ type: "trial", trial: 0, constraints });
+    expect(events[2]).toMatchObject({
+      type: "trial",
+      trial: 1,
+      state: "pruned",
+      constraints: { infeasible: "order", state: [] },
+    });
+    // A trial the channel reported nothing for carries no constraints.
+    expect(events[3]).toMatchObject({ type: "trial", trial: 2 });
+    expect(events[3]).not.toHaveProperty("constraints");
+  });
+
   it("cancels a running study through the worker and ends with the cancelled error code", async () => {
     const context = setUp({
       evaluateTrial: (request) =>

--- a/libs/@hashintel/petrinaut-core/src/optimization/browser/browser-optimization.ts
+++ b/libs/@hashintel/petrinaut-core/src/optimization/browser/browser-optimization.ts
@@ -34,6 +34,7 @@ import type {
   PetrinautOptimizationChannel,
   PetrinautOptimizationEvent,
   PetrinautOptimizationManifest,
+  PetrinautOptimizationTrialConstraints,
 } from "../index";
 import type {
   OptimizerEvaluateMessage,
@@ -60,6 +61,12 @@ type RunRecord = {
   readonly manifest: PetrinautOptimizationManifest;
   readonly seeds: readonly number[];
   readonly log: OptimizationRunLog;
+  /**
+   * What the channel reported for each trial's constraints, kept from the
+   * evaluation until the worker reports the trial, whose event carries it.
+   * The worker and the Python study never see these.
+   */
+  readonly trialConstraints: Map<number, PetrinautOptimizationTrialConstraints>;
   status: RunStatus;
   /** The segment the worker runs when it takes this run. */
   command: OptimizerStartMessage | OptimizerExtendMessage;
@@ -214,6 +221,7 @@ const connectBrowserOptimization = (options: {
     // A failure can leave the host evaluating trials whose outcomes no one
     // will read; a completed or stopped segment has nothing left in flight.
     run.controller.abort();
+    run.trialConstraints.clear();
     const queuedAt = queue.indexOf(run);
     if (queuedAt !== -1) {
       queue.splice(queuedAt, 1);
@@ -299,6 +307,9 @@ const connectBrowserOptimization = (options: {
         signal: controller.signal,
       });
       if (segmentIsCurrent()) {
+        if (outcome.constraints) {
+          run.trialConstraints.set(message.trial, outcome.constraints);
+        }
         post({ type: "evaluated", requestId: message.requestId, outcome });
       }
     } catch (error) {
@@ -324,14 +335,20 @@ const connectBrowserOptimization = (options: {
         return;
       case "trial": {
         const run = activeRunFor(message.runId);
+        if (!run) {
+          return;
+        }
         const { event } = message;
-        run?.log.append({
+        const constraints = run.trialConstraints.get(event.trial);
+        run.trialConstraints.delete(event.trial);
+        run.log.append({
           type: "trial",
           trial: event.trial,
           parameters: event.parameters,
           objective: event.state === "complete" ? event.objective : null,
           state: event.state,
           best: event.best,
+          ...(constraints ? { constraints } : {}),
         });
         return;
       }
@@ -451,6 +468,7 @@ const connectBrowserOptimization = (options: {
           manifest.execution.seedsPerTrial ?? 1,
         ),
         log: createOptimizationRunLog(),
+        trialConstraints: new Map(),
         status: "queued",
         command: {
           type: "start",

--- a/libs/@hashintel/petrinaut-core/src/optimization/describe.test.ts
+++ b/libs/@hashintel/petrinaut-core/src/optimization/describe.test.ts
@@ -4,6 +4,7 @@ import { createOptimizationManifest } from "../shared/optimization-manifest.fixt
 import {
   deriveOptimizationTrialSeeds,
   describeOptimization,
+  resolveTrialScenarioBindings,
   resolveTrialScenarioParameterValues,
 } from "./describe";
 
@@ -136,5 +137,48 @@ describe("resolveTrialScenarioParameterValues", () => {
         enabled: true,
       }),
     ).toThrow('Optimization parameter "rate" must be numeric');
+  });
+});
+
+describe("resolveTrialScenarioBindings", () => {
+  const manifest = createOptimizationManifest();
+
+  it("binds a boolean parameter's 0/1 as the boolean the scenario compiler reads, and every other value as it is", () => {
+    expect(
+      resolveTrialScenarioBindings(manifest, {
+        rate: 1.5,
+        count: 6,
+        enabled: 1,
+        share: 0.25,
+      }),
+    ).toEqual({ rate: 1.5, count: 6, enabled: true, share: 0.25 });
+    expect(
+      resolveTrialScenarioBindings(manifest, {
+        rate: 1.5,
+        count: 6,
+        enabled: 0,
+        share: 0.25,
+      }).enabled,
+    ).toBe(false);
+  });
+
+  it("decodes the values a trial resolved, and reads a parameter the values lack at its default", () => {
+    const values = resolveTrialScenarioParameterValues(manifest, {
+      rate: 0.1,
+      count: 10,
+      enabled: true,
+    });
+    expect(resolveTrialScenarioBindings(manifest, values)).toEqual({
+      rate: 0.1,
+      count: 10,
+      enabled: true,
+      share: 0.25,
+    });
+    expect(resolveTrialScenarioBindings(manifest, {})).toEqual({
+      rate: 0.5,
+      count: 10,
+      enabled: true,
+      share: 0.25,
+    });
   });
 });

--- a/libs/@hashintel/petrinaut-core/src/optimization/describe.ts
+++ b/libs/@hashintel/petrinaut-core/src/optimization/describe.ts
@@ -1,4 +1,6 @@
+import { decodeScenarioParameterValue } from "../simulation/authoring/scenario/scenario-parameter-value";
 import { deriveRunSeed } from "../simulation/monte-carlo/run-state";
+import { createUserKeyedRecord, getOwn } from "../validation/record-keys";
 
 import type { Scenario } from "../types/sdcpn";
 import type {
@@ -188,4 +190,27 @@ export const resolveTrialScenarioParameterValues = (
       typeof value === "boolean" ? (value ? 1 : 0) : value;
   }
   return scenarioParameterValues;
+};
+
+/**
+ * Every scenario parameter's value for one trial as a constraint's
+ * `scenario.*` binds it: the trial's 0/1 transport decoded by each
+ * parameter's type, so a boolean parameter reads `true`/`false` as the
+ * scenario compiler binds it. A parameter the values lack reads its default,
+ * as the compiler would simulate it.
+ */
+export const resolveTrialScenarioBindings = (
+  manifest: PetrinautOptimizationManifest,
+  scenarioParameterValues: Readonly<Record<string, number>>,
+): Record<string, number | boolean> => {
+  const scenario = getOptimizationScenario(manifest);
+  const bindings = createUserKeyedRecord<number | boolean>();
+  for (const parameter of scenario.scenarioParameters) {
+    bindings[parameter.identifier] = decodeScenarioParameterValue(
+      parameter,
+      getOwn(scenarioParameterValues, parameter.identifier) ??
+        parameter.default,
+    );
+  }
+  return bindings;
 };

--- a/libs/@hashintel/petrinaut-core/src/optimization/index.ts
+++ b/libs/@hashintel/petrinaut-core/src/optimization/index.ts
@@ -235,6 +235,16 @@ function validateScenarioParameterDefault(
   }
 }
 
+/** The pass threshold as one experiment-level setting; `1 - alpha` of a step's runs must hold for the step to pass a state constraint. */
+export const DEFAULT_OPTIMIZATION_CONSTRAINT_ALPHA = 0.05;
+
+export const petrinautOptimizationConstraintPolicySchema = z
+  .strictObject({ alpha: z.number().gt(0).lt(1) })
+  .meta({
+    description:
+      "The pass threshold for a step: a state constraint passes the step when at least 1 - alpha of its runs held. Default 0.05.",
+  });
+
 export const petrinautOptimizationManifestSchema = z
   .strictObject({
     kind: z.literal("petrinaut-optimization"),
@@ -245,8 +255,9 @@ export const petrinautOptimizationManifestSchema = z
     objective: petrinautOptimizationObjectiveSchema,
     constraints: constraintListSchema.optional().meta({
       description:
-        'Optional boolean conditions over the parameter space (`space: "parameters"`) and the simulation state (`space: "state"`). Absent means unconstrained; nothing enforces them yet.',
+        'Optional boolean conditions over the parameter space (`space: "parameters"`) and the simulation state (`space: "state"`). Absent means unconstrained. The browser runtime evaluates parameter constraints before each trial simulates and observes state constraints on every run; the results are reported, never enforced on the objective.',
     }),
+    constraintPolicy: petrinautOptimizationConstraintPolicySchema.optional(),
     execution: petrinautOptimizationExecutionSchema,
     study: petrinautOptimizationStudySchema,
   })
@@ -612,6 +623,35 @@ export const petrinautOptimizationStartedEventSchema = z
   })
   .meta({ description: "The optimizer accepted and started the study." });
 
+/** One parameter constraint's signed slack at the trial's values. `margin >= 0` means satisfied. */
+export const petrinautOptimizationParameterConstraintResultSchema =
+  z.strictObject({
+    constraintId: z.string().min(1),
+    margin: z.number(),
+  });
+
+/** One state constraint's per-run verdicts within the trial: how many runs it held on, over how many ran. */
+export const petrinautOptimizationStateConstraintResultSchema = z.strictObject({
+  constraintId: z.string().min(1),
+  runsPassed: z.number().int().nonnegative(),
+  runsTotal: z.number().int().positive(),
+});
+
+export const petrinautOptimizationTrialConstraintsSchema = z
+  .strictObject({
+    parameters: z.array(petrinautOptimizationParameterConstraintResultSchema),
+    state: z.array(petrinautOptimizationStateConstraintResultSchema),
+    /**
+     * The parameter constraint the draw broke, when the trial was pruned for
+     * it before any simulation ran. Set exactly on those trials. `state` is
+     * empty on them: nothing simulated, so nothing was observed.
+     */
+    infeasible: z.string().min(1).optional(),
+  })
+  .meta({
+    description: "Constraint results of one trial, browser runtime only.",
+  });
+
 export const petrinautOptimizationTrialEventSchema = z
   .strictObject({
     type: z.literal("trial"),
@@ -620,6 +660,8 @@ export const petrinautOptimizationTrialEventSchema = z
     objective: z.number().nullable(),
     state: z.enum(["complete", "pruned", "failed"]),
     best: optimizationBestSchema.nullable(),
+    /** Present on the trials of a study evaluated in the browser with constraints declared. */
+    constraints: petrinautOptimizationTrialConstraintsSchema.optional(),
     seq: optimizationEventSeqSchema,
   })
   .meta({ description: "One completed Optuna trial and the running best." });
@@ -723,6 +765,18 @@ export type PetrinautOptimizationEvent = z.infer<
 export type PetrinautOptimizationTrialEvent = z.infer<
   typeof petrinautOptimizationTrialEventSchema
 >;
+export type PetrinautOptimizationConstraintPolicy = z.infer<
+  typeof petrinautOptimizationConstraintPolicySchema
+>;
+export type PetrinautOptimizationParameterConstraintResult = z.infer<
+  typeof petrinautOptimizationParameterConstraintResultSchema
+>;
+export type PetrinautOptimizationStateConstraintResult = z.infer<
+  typeof petrinautOptimizationStateConstraintResultSchema
+>;
+export type PetrinautOptimizationTrialConstraints = z.infer<
+  typeof petrinautOptimizationTrialConstraintsSchema
+>;
 
 /**
  * Host-provided optimization capability for Petrinaut: the self-contained
@@ -794,11 +848,15 @@ export type PetrinautOptimizationTrialOutcome =
       readonly kind: "objective";
       /** The mean of the per-seed objectives; finite. */
       readonly objective: number;
+      /** What the trial's constraints reported, when the study declares any. */
+      readonly constraints?: PetrinautOptimizationTrialConstraints;
     }
   | {
       /** The host could not run the trial; Optuna records it as pruned. */
       readonly kind: "pruned";
       readonly reason: string;
+      /** Set when the trial was pruned for an infeasible draw, naming it. */
+      readonly constraints?: PetrinautOptimizationTrialConstraints;
     };
 
 /**

--- a/libs/@hashintel/petrinaut-core/src/optimization/index.ts
+++ b/libs/@hashintel/petrinaut-core/src/optimization/index.ts
@@ -832,6 +832,8 @@ export type PetrinautOptimizationTrialRequest = {
   /**
    * Every scenario parameter's value for this trial: fixed bindings merged
    * with the suggestions, booleans as 0/1 as the scenario compiler expects.
+   * `resolveTrialScenarioBindings` decodes them for a constraint's
+   * `scenario.*`.
    */
   readonly scenarioParameterValues: Readonly<Record<string, number>>;
   /**
@@ -945,5 +947,6 @@ export const isConnectedOptimization = (
 export {
   deriveOptimizationTrialSeeds,
   describeOptimization,
+  resolveTrialScenarioBindings,
   resolveTrialScenarioParameterValues,
 } from "./describe";

--- a/libs/@hashintel/petrinaut-core/src/optimization/optimization.test.ts
+++ b/libs/@hashintel/petrinaut-core/src/optimization/optimization.test.ts
@@ -332,6 +332,21 @@ describe("petrinautOptimizationManifestSchema", () => {
     expect(stepped.success).toBe(false);
   });
 
+  it("accepts a constraint policy with alpha strictly between 0 and 1", () => {
+    const withPolicy = petrinautOptimizationManifestSchema.safeParse({
+      ...validManifest,
+      constraintPolicy: { alpha: 0.1 },
+    });
+    expect(withPolicy.success).toBe(true);
+    for (const alpha of [0, 1, -0.1]) {
+      const invalid = petrinautOptimizationManifestSchema.safeParse({
+        ...validManifest,
+        constraintPolicy: { alpha },
+      });
+      expect(invalid.success).toBe(false);
+    }
+  });
+
   it("requires at least one optimized parameter", () => {
     const parsed = petrinautOptimizationManifestSchema.safeParse({
       ...validManifest,
@@ -467,6 +482,39 @@ describe("petrinautOptimizationEventSchema", () => {
         expect(withSeq.data.seq).toBe(index + 1);
       }
     }
+  });
+
+  it("accepts a trial event carrying constraint results, and rejects malformed ones", () => {
+    const trial = events[1];
+    const withConstraints = petrinautOptimizationEventSchema.safeParse({
+      ...trial,
+      constraints: {
+        parameters: [{ constraintId: "order", margin: -0.5 }],
+        state: [{ constraintId: "queue", runsPassed: 52, runsTotal: 60 }],
+      },
+    });
+    expect(withConstraints.success).toBe(true);
+
+    const infeasible = petrinautOptimizationEventSchema.safeParse({
+      ...trial,
+      objective: null,
+      state: "pruned",
+      constraints: {
+        parameters: [{ constraintId: "order", margin: -0.5 }],
+        state: [],
+        infeasible: "order",
+      },
+    });
+    expect(infeasible.success).toBe(true);
+
+    const zeroRuns = petrinautOptimizationEventSchema.safeParse({
+      ...trial,
+      constraints: {
+        parameters: [],
+        state: [{ constraintId: "queue", runsPassed: 0, runsTotal: 0 }],
+      },
+    });
+    expect(zeroRuns.success).toBe(false);
   });
 
   it("rejects negative or fractional sequence numbers", () => {

--- a/libs/@hashintel/petrinaut-core/src/simulation/authoring/scenario/compile-scenario.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/authoring/scenario/compile-scenario.ts
@@ -13,6 +13,7 @@ import {
   interpretPreparedItem,
   prepareScenarioItem,
 } from "./compile-scenario/prepared-items";
+import { decodeScenarioParameterValue } from "./scenario-parameter-value";
 
 import type { HirInterpretBindings, HirValue } from "../../../hir/interpret";
 import type { ScenarioHir } from "../../../hir/scenario";
@@ -256,11 +257,13 @@ export const prepareScenarioCompiler = (
           itemId: sp.identifier,
           message: `Scenario parameter "${sp.identifier}" must be a finite number.`,
         });
-        scenarioObj[sp.identifier] =
-          sp.type === "boolean" ? sp.default !== 0 : sp.default;
+        scenarioObj[sp.identifier] = decodeScenarioParameterValue(
+          sp,
+          sp.default,
+        );
         continue;
       }
-      scenarioObj[sp.identifier] = sp.type === "boolean" ? value !== 0 : value;
+      scenarioObj[sp.identifier] = decodeScenarioParameterValue(sp, value);
     }
 
     const parameters: NetParameterValues = Object.assign(

--- a/libs/@hashintel/petrinaut-core/src/simulation/authoring/scenario/scenario-parameter-value.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/authoring/scenario/scenario-parameter-value.ts
@@ -1,0 +1,12 @@
+import type { ScenarioParameter } from "../../../types/sdcpn";
+
+/**
+ * A scenario parameter's value as `scenario.<identifier>` reads it. Values
+ * travel as numbers, a boolean parameter's as 0/1: it binds as
+ * `false`/`true`, every other type binds its number as it is. The scenario
+ * compiler and a constraint over the scenario apply this one rule.
+ */
+export const decodeScenarioParameterValue = (
+  parameter: Pick<ScenarioParameter, "type">,
+  value: number,
+): number | boolean => (parameter.type === "boolean" ? value !== 0 : value);

--- a/libs/@hashintel/petrinaut-core/src/simulation/monte-carlo/metrics/types.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/monte-carlo/metrics/types.ts
@@ -248,12 +248,16 @@ export type MonteCarloUserDefinedMetric = MonteCarloFrameMetric & {
   readonly frames: readonly MonteCarloUserDefinedMetricFrame[];
   getLatestFrame: () => MonteCarloUserDefinedMetricFrame | null;
   /**
-   * Latest sampled value per run index.
+   * One value per run index: the latest sampled value, or, when
+   * `aggregateTime` is configured, the run's samples aggregated over time so
+   * far (`min` over a 0/1 indicator reads 1 exactly when the condition held
+   * on every sampled frame of that run).
    *
    * A run keeps its frozen state once it completes, so after the experiment
-   * finishes each entry holds the run's final-frame value — what a single-run
+   * finishes each entry holds the run's final value — what a single-run
    * evaluation of the same metric would report. Optimization replicates read
-   * their per-seed objectives from this.
+   * their per-seed objectives from this, and state constraints their
+   * per-run verdicts.
    */
   getRunValues: () => ReadonlyMap<number, number>;
   clear: () => void;

--- a/libs/@hashintel/petrinaut-core/src/simulation/monte-carlo/metrics/user-defined.test.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/monte-carlo/metrics/user-defined.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+
+import { createMonteCarloUserDefinedMetric } from "./user-defined";
+
+import type { SimulationFrameReader } from "../../api";
+import type {
+  MonteCarloFrameMetricContext,
+  MonteCarloUserDefinedMetricConfig,
+} from "./types";
+
+/** A frame context over `runs`: run index to the value the metric reads. */
+const frameContext = (
+  frameNumber: number,
+  runs: Readonly<Record<number, number>>,
+): MonteCarloFrameMetricContext => ({
+  frameNumber,
+  time: frameNumber,
+  runCount: Object.keys(runs).length,
+  activeRunCount: Object.keys(runs).length,
+  completedRunCount: 0,
+  erroredRunCount: 0,
+  placeIds: [],
+  placeNames: [],
+  forEachActiveRunPlaceCounts: () => {},
+  forEachRunFrame: (visitor) => {
+    for (const [runIndex, value] of Object.entries(runs)) {
+      visitor({
+        runIndex: Number(runIndex),
+        status: "running",
+        // The measure below reads the value straight off this stub.
+        frame: { value } as unknown as SimulationFrameReader,
+      });
+    }
+  },
+});
+
+const metric = (config: Partial<MonteCarloUserDefinedMetricConfig> = {}) =>
+  createMonteCarloUserDefinedMetric({
+    id: "indicator",
+    measure: ({ frame }) => (frame as unknown as { value: number }).value,
+    sampleRuns: "all",
+    ...config,
+  });
+
+describe("createMonteCarloUserDefinedMetric getRunValues", () => {
+  it("reports each run's latest sample without a time aggregation", () => {
+    const indicator = metric();
+    indicator.observeFrame(frameContext(0, { 0: 1, 1: 1 }));
+    indicator.observeFrame(frameContext(1, { 0: 0, 1: 1 }));
+    indicator.observeFrame(frameContext(2, { 0: 1, 1: 1 }));
+    expect([...indicator.getRunValues()]).toEqual([
+      [0, 1],
+      [1, 1],
+    ]);
+  });
+
+  it("reports each run's minimum over its frames with aggregateTime min: a run that dipped once reads 0", () => {
+    const indicator = metric({ aggregateTime: "min" });
+    indicator.observeFrame(frameContext(0, { 0: 1, 1: 1 }));
+    indicator.observeFrame(frameContext(1, { 0: 0, 1: 1 }));
+    indicator.observeFrame(frameContext(2, { 0: 1, 1: 1 }));
+    expect([...indicator.getRunValues()]).toEqual([
+      [0, 0],
+      [1, 1],
+    ]);
+    // The frame value stays the mean over runs of the per-frame samples,
+    // folded over time by the same aggregation.
+    expect(indicator.getLatestFrame()).toMatchObject({
+      outputType: "scalar",
+      frameValue: 1,
+      timeValue: 0.5,
+    });
+  });
+
+  it("aggregates each run over time for distribution output too", () => {
+    const indicator = metric({
+      aggregateTime: "max",
+      runOutput: { type: "distribution", binning: "exact" },
+    });
+    indicator.observeFrame(frameContext(0, { 0: 2, 1: 5 }));
+    indicator.observeFrame(frameContext(1, { 0: 7, 1: 1 }));
+    expect([...indicator.getRunValues()]).toEqual([
+      [0, 7],
+      [1, 5],
+    ]);
+    expect(indicator.getLatestFrame()).toMatchObject({
+      outputType: "distribution",
+      bins: [
+        [5, 1],
+        [7, 1],
+      ],
+    });
+  });
+
+  it("clears the per-run aggregates with the rest", () => {
+    const indicator = metric({ aggregateTime: "min" });
+    indicator.observeFrame(frameContext(0, { 0: 0 }));
+    indicator.clear();
+    expect(indicator.getRunValues().size).toBe(0);
+    indicator.observeFrame(frameContext(0, { 0: 1 }));
+    expect([...indicator.getRunValues()]).toEqual([[0, 1]]);
+  });
+});

--- a/libs/@hashintel/petrinaut-core/src/simulation/monte-carlo/metrics/user-defined.ts
+++ b/libs/@hashintel/petrinaut-core/src/simulation/monte-carlo/metrics/user-defined.ts
@@ -74,6 +74,8 @@ export function createMonteCarloUserDefinedMetric(
     MonteCarloMetricNumericAccumulatorState
   >();
   const latestRunValues = new Map<number, number>();
+  /** Each run's value aggregated over its frames so far; only with a time aggregation. */
+  const runTimeValues = new Map<number, number>();
 
   return {
     id: config.id,
@@ -82,13 +84,14 @@ export function createMonteCarloUserDefinedMetric(
       return frames;
     },
     getLatestFrame: () => frames.at(-1) ?? null,
-    getRunValues: () => latestRunValues,
+    getRunValues: () => (runTimeAccumulator ? runTimeValues : latestRunValues),
     clear: () => {
       frames.length = 0;
       scalarFrameCountState = frameCountAccumulator.empty();
       scalarTimeState = scalarTimeAccumulator?.empty() ?? null;
       runTimeStatesByRunIndex.clear();
       latestRunValues.clear();
+      runTimeValues.clear();
     },
     observeFrame: (context) => {
       const runSamples: { runIndex: number; value: number }[] = [];
@@ -114,6 +117,21 @@ export function createMonteCarloUserDefinedMetric(
       for (const { runIndex, value } of runSamples) {
         latestRunValues.set(runIndex, value);
       }
+      // Each run's time aggregate is folded whatever the output shape: a
+      // distribution bins it per frame, and `getRunValues` reports it as the
+      // run's value once a time aggregation is configured.
+      if (runTimeAccumulator) {
+        for (const { runIndex, value } of runSamples) {
+          const state =
+            runTimeStatesByRunIndex.get(runIndex) ?? runTimeAccumulator.empty();
+          const next = runTimeAccumulator.add(state, value);
+          runTimeStatesByRunIndex.set(runIndex, next);
+          const timeValue = runTimeAccumulator.read(next);
+          if (timeValue !== null) {
+            runTimeValues.set(runIndex, timeValue);
+          }
+        }
+      }
 
       const runValues = runSamples.map(({ value }) => value);
 
@@ -124,16 +142,6 @@ export function createMonteCarloUserDefinedMetric(
         let timeSampleCount = runValues.length;
 
         if (runTimeAccumulator) {
-          for (const { runIndex, value } of runSamples) {
-            const state =
-              runTimeStatesByRunIndex.get(runIndex) ??
-              runTimeAccumulator.empty();
-            runTimeStatesByRunIndex.set(
-              runIndex,
-              runTimeAccumulator.add(state, value),
-            );
-          }
-
           distributionValues = runSamples.flatMap(({ runIndex }) => {
             const state = runTimeStatesByRunIndex.get(runIndex);
             if (!state) {

--- a/libs/@hashintel/petrinaut/docs/optimization.md
+++ b/libs/@hashintel/petrinaut/docs/optimization.md
@@ -84,12 +84,28 @@ the saved scenario keeps its values.
 
 ## Constraints
 
-The **Constraints** section of the create-optimization drawer records boolean conditions with the study. They are carried in the study's manifest and readable by every consumer (the Python tooling included), but **nothing enforces them yet** -- they do not prune trials or stop runs. Two kinds:
+The **Constraints** section of the create-optimization drawer records boolean
+conditions with the study. They are carried in the study's manifest and
+readable by every consumer (the Python tooling included). A study run in the
+browser (see [Running in the browser](#running-in-the-browser)) evaluates them
+and reports what it finds; the objective is never changed by them, and no run
+is excluded from it. Two kinds:
 
-- **Parameter constraints** -- one-line expressions over the study's parameters (`scenario.*` for scenario parameters, `parameters.*` for net parameters) that must produce a boolean, for example `scenario.min_load < scenario.max_load`. In a later iteration these will let the optimizer avoid infeasible parameter combinations.
-- **State constraints** -- small code bodies that read the simulation `state` exactly like a [metric](experiments.md#metrics) and `return` a boolean, for example `return state.places.Queue.count <= 10;`. In a later iteration these will measure how close a run comes to leaving the safe region, not just whether it did.
+- **Parameter constraints** -- one-line expressions over the study's parameters (`scenario.*` for scenario parameters, `parameters.*` for net parameters) that must produce a boolean, for example `scenario.min_load < scenario.max_load`. Before each step runs, the browser checks them at the step's values. A step whose values break one is **infeasible**: it costs one step and no simulation, it is reported as pruned with the constraint named, and it is drawn grey everywhere a step is drawn.
+- **State constraints** -- small code bodies that read the simulation `state` exactly like a [metric](experiments.md#metrics) and `return` a boolean, for example `return state.places.Queue.count <= 10;`. Every run of a step reports whether the condition held at every sampled time: a run **passed** when it did and **failed** otherwise.
+
+A step's verdict comes from its runs. The **Pass threshold**, one setting for
+the whole study shown under the constraint rows once a row exists, is the share
+of a step's runs that must pass (95 percent by default, an alpha of 0.05). A
+step is **clear** when every state constraint held on at least that share of
+its runs and **limited** when one fell short. Every rate in the results is
+printed as its raw fraction beside the percentage, `52 / 60 · 87%`, so the run
+count behind a percentage is always in view.
 
 Add a condition with its **Add ... constraint** button, edit it in place, and remove it with **Remove**. Each editor checks as you type: type errors, unknown names and a result that is not a boolean are underlined, and the message appears under the row. Typing `scenario.`, `parameters.` or `state.places.` offers completions, and hovering a name shows its type. **Run** stays disabled, with the first failing row named in the footer, until every constraint compiles; the constraints are compiled once more when you press Run. Empty rows are ignored.
+
+A study run on the optimization service carries its constraints but reports
+no verdicts yet.
 
 ## Watching results
 
@@ -134,7 +150,11 @@ The line under the title counts the completed steps.
 The steps table sits at the bottom, newest steps first, each with its
 parameters, objective value and a state mark (complete, pruned or failed). It
 scrolls on its own, and a long study shows its newest 200 steps while the
-strip keeps the totals and the best.
+strip keeps the totals and the best. A study with
+[constraints](#constraints) run in the browser adds a **Runs passed** column
+(`52 / 60 · 87%`, the constraint with the fewest passing runs when there are
+several; hover the mark for the rest) and greys the rows of infeasible steps,
+their mark reading **Infeasible:** and the constraint's name.
 
 Once a study is over, whether it finished, was stopped, or failed, its
 charts show the results: the objective by step and the surface keep their
@@ -209,6 +229,16 @@ view on a laptop screen while the study streams:
   in flight and the study's history are read together. In the drawer, the
   three cards wrap to two rows when the drawer is not wide enough for all
   three; the full view shows them in one row.
+- A study with [constraints](#constraints) adds a **Constraints** card as the
+  fourth. Its headline is the steps **clear** across the study over the steps
+  that simulated, `14 / 20 · 70%`, with the infeasible draws counted in the
+  line under the title beside the pass threshold. Beneath it, one line gives
+  the latest step's verdict (clear, limited or infeasible) with the runs that
+  passed its tightest constraint, and one bar per state constraint shows the
+  share of steps it passed, with a dashed mark at the threshold. The same
+  headline sits in the summary band as **Steps clear**. Infeasible draws are
+  grey dots on the Objective by step chart and hollow grey rings on the
+  surface, and the best step so far is never one of them.
 - The steps table fills whatever height is left, the best step starred and
   tinted. It shows a row or two on a laptop screen and a page of them on a
   taller one; the strip's step count and best value stay in view either way.

--- a/libs/@hashintel/petrinaut/docs/optimization.md
+++ b/libs/@hashintel/petrinaut/docs/optimization.md
@@ -91,7 +91,7 @@ browser (see [Running in the browser](#running-in-the-browser)) evaluates them
 and reports what it finds; the objective is never changed by them, and no run
 is excluded from it. Two kinds:
 
-- **Parameter constraints** -- one-line expressions over the study's parameters (`scenario.*` for scenario parameters, `parameters.*` for net parameters) that must produce a boolean, for example `scenario.min_load < scenario.max_load`. Before each step runs, the browser checks them at the step's values. A step whose values break one is **infeasible**: it costs one step and no simulation, it is reported as pruned with the constraint named, and it is drawn grey everywhere a step is drawn.
+- **Parameter constraints** -- one-line expressions over the study's parameters (`scenario.*` for scenario parameters, `parameters.*` for net parameters) that must produce a boolean, for example `scenario.min_load < scenario.max_load`. Before each step runs, the browser checks them at the step's values. A step whose values break one is **infeasible**: it costs one step and no simulation, it is reported as pruned with the constraint named, and it is greyed in the steps table and drawn as a hollow ring on the surface.
 - **State constraints** -- small code bodies that read the simulation `state` exactly like a [metric](experiments.md#metrics) and `return` a boolean, for example `return state.places.Queue.count <= 10;`. Every run of a step reports whether the condition held at every sampled time: a run **passed** when it did and **failed** otherwise.
 
 A step's verdict comes from its runs. The **Pass threshold**, one setting for
@@ -153,7 +153,7 @@ scrolls on its own, and a long study shows its newest 200 steps while the
 strip keeps the totals and the best. A study with
 [constraints](#constraints) run in the browser adds a **Runs passed** column
 (`52 / 60 · 87%`, the constraint with the fewest passing runs when there are
-several; hover the mark for the rest) and greys the rows of infeasible steps,
+several) and greys the rows of infeasible steps,
 their mark reading **Infeasible:** and the constraint's name.
 
 Once a study is over, whether it finished, was stopped, or failed, its
@@ -237,8 +237,8 @@ view on a laptop screen while the study streams:
   passed its tightest constraint, and one bar per state constraint shows the
   share of steps it passed, with a dashed mark at the threshold. The same
   headline sits in the summary band as **Steps clear**. Infeasible draws are
-  grey dots on the Objective by step chart and hollow grey rings on the
-  surface, and the best step so far is never one of them.
+  hollow grey rings on the surface and grey rows in the steps table, and the
+  best step so far is never one of them.
 - The steps table fills whatever height is left, the best step starred and
   tinted. It shows a row or two on a laptop screen and a page of them on a
   taller one; the strip's step count and best value stay in view either way.

--- a/libs/@hashintel/petrinaut/src/react/experiments/context.ts
+++ b/libs/@hashintel/petrinaut/src/react/experiments/context.ts
@@ -13,10 +13,12 @@ import type {
 export type { SweepBatchStatus } from "./sweep-session";
 import type {
   AdHocScenarioState,
+  HirMetricArtifact,
   SDCPN,
   MonteCarloExpressionMetricSpec,
   MonteCarloMetricSpec,
   MonteCarloUserDefinedMetricFrame,
+  MonteCarloUserDefinedMetricTimeAggregation,
   MonteCarloWorkerProgress,
   ReadableStore,
 } from "@hashintel/petrinaut-core";
@@ -248,6 +250,18 @@ export type ExperimentsContextValue = {
   ) => DetachedObjectiveRun;
 };
 
+/**
+ * A metric a batch observes beside its objective, already compiled: the
+ * request carries no code to lower. Each run's value, aggregated over time
+ * as asked, lands in the batch's `runResults` under `id`.
+ */
+export type DetachedObjectiveAuxiliaryMetric = {
+  id: string;
+  label: string;
+  artifact: HirMetricArtifact;
+  aggregateTime: MonteCarloUserDefinedMetricTimeAggregation;
+};
+
 /** One local compute batch for an optimization study's objective. */
 export type DetachedObjectiveRequest = {
   /** Compile-cache identity; one study keeps one compiled snapshot. */
@@ -259,6 +273,8 @@ export type DetachedObjectiveRequest = {
   scenarioParameterValues: Readonly<Record<string, number | boolean>>;
   /** The study's objective metric, evaluated as an expression metric. */
   metric: { id: string; label: string; code: string };
+  /** Metrics observed beside the objective; none by default. */
+  auxiliaryMetrics?: readonly DetachedObjectiveAuxiliaryMetric[];
   seed: number;
   runCount: number;
   dt: number;

--- a/libs/@hashintel/petrinaut/src/react/experiments/context.ts
+++ b/libs/@hashintel/petrinaut/src/react/experiments/context.ts
@@ -248,6 +248,15 @@ export type ExperimentsContextValue = {
   runDetachedObjective: (
     request: DetachedObjectiveRunRequest,
   ) => DetachedObjectiveRun;
+  /**
+   * The net parameter values a study's batch simulates with at one
+   * parameter point: the scenario's overrides applied to the net's defaults,
+   * from the same compiled snapshot the batches use. Rejects when the
+   * scenario does not compile there.
+   */
+  resolveDetachedObjectiveParameters: (
+    request: DetachedObjectiveParametersRequest,
+  ) => Promise<Readonly<Record<string, number | boolean>>>;
 };
 
 /**
@@ -280,6 +289,16 @@ export type DetachedObjectiveRequest = {
   dt: number;
   maxTime: number;
 };
+
+/** One parameter point of a study, for resolving the net parameters its batch would run with. */
+export type DetachedObjectiveParametersRequest = Pick<
+  DetachedObjectiveRequest,
+  | "cacheKey"
+  | "definition"
+  | "scenarioId"
+  | "scenarioParameterValues"
+  | "metric"
+>;
 
 export type DetachedObjectiveRunRequest = DetachedObjectiveRequest & {
   /**
@@ -359,6 +378,8 @@ const DEFAULT_CONTEXT_VALUE: ExperimentsContextValue = {
     }),
     cancel: () => {},
   }),
+  resolveDetachedObjectiveParameters: () =>
+    Promise.reject(new Error("Experiments are unavailable")),
 };
 
 export const ExperimentsContext = createContext<ExperimentsContextValue>(
@@ -381,6 +402,7 @@ export type ExperimentsActionsValue = Pick<
   | "sampleSurfaceCells"
   | "sampleDetachedObjective"
   | "runDetachedObjective"
+  | "resolveDetachedObjectiveParameters"
 >;
 
 export const ExperimentsActionsContext = createContext<ExperimentsActionsValue>(

--- a/libs/@hashintel/petrinaut/src/react/experiments/provider.tsx
+++ b/libs/@hashintel/petrinaut/src/react/experiments/provider.tsx
@@ -676,11 +676,16 @@ export const ExperimentsProvider: React.FC<ExperimentsProviderProps> = ({
     (request) => getDetachedObjectiveSampler().sample(request);
   const runDetachedObjective: ExperimentsContextValue["runDetachedObjective"] =
     (request) => getDetachedObjectiveSampler().run(request);
+  const resolveDetachedObjectiveParameters: ExperimentsContextValue["resolveDetachedObjectiveParameters"] =
+    (request) => getDetachedObjectiveSampler().resolveParameters(request);
 
   const stableSampleDetachedObjective = useStableCallback(
     sampleDetachedObjective,
   );
   const stableRunDetachedObjective = useStableCallback(runDetachedObjective);
+  const stableResolveDetachedObjectiveParameters = useStableCallback(
+    resolveDetachedObjectiveParameters,
+  );
 
   // Every callback is identity-stable, so this object never changes and
   // actions-only consumers sit out the per-publish re-render storm.
@@ -693,6 +698,8 @@ export const ExperimentsProvider: React.FC<ExperimentsProviderProps> = ({
     sampleSurfaceCells: stableSampleSurfaceCells,
     sampleDetachedObjective: stableSampleDetachedObjective,
     runDetachedObjective: stableRunDetachedObjective,
+    resolveDetachedObjectiveParameters:
+      stableResolveDetachedObjectiveParameters,
   }));
 
   const contextValue: ExperimentsContextValue = {

--- a/libs/@hashintel/petrinaut/src/react/experiments/provider/detached-objective.test.ts
+++ b/libs/@hashintel/petrinaut/src/react/experiments/provider/detached-objective.test.ts
@@ -633,6 +633,36 @@ describe("createDetachedObjectiveSampler().run", () => {
   });
 });
 
+describe("createDetachedObjectiveSampler().resolveParameters", () => {
+  it("resolves the net parameters a batch runs with, the scenario's overrides applied, and names a point that does not compile", async () => {
+    const cpu = createFakeBackend(WORKER_POOL_BACKEND_ID);
+    const { sampler } = createSampler({ cpu });
+    const {
+      runSeeds: _runSeeds,
+      computeBackend: _backend,
+      ...request
+    } = runRequest();
+
+    // The seasonal flu scenario overrides the net's infection rate of 3.
+    await expect(sampler.resolveParameters(request)).resolves.toEqual({
+      infection_rate: 1.5,
+      recovery_rate: 0.8,
+    });
+    await expect(
+      sampler.resolveParameters({
+        ...request,
+        scenarioParameterValues: {
+          population: Number.NaN,
+          infected_ratio: 0.05,
+        },
+      }),
+    ).rejects.toThrow(
+      /^Scenario parameter "population" must be a finite number\./,
+    );
+    expect(cpu.requests).toHaveLength(0);
+  });
+});
+
 describe("createDetachedObjectiveSampler().sample", () => {
   it("runs the sample on the CPU pool in the surface queue and resolves the finished snapshot", async () => {
     const cpu = createFakeBackend(WORKER_POOL_BACKEND_ID);

--- a/libs/@hashintel/petrinaut/src/react/experiments/provider/detached-objective.test.ts
+++ b/libs/@hashintel/petrinaut/src/react/experiments/provider/detached-objective.test.ts
@@ -316,6 +316,39 @@ describe("createDetachedObjectiveSampler().run", () => {
     expect(fake.handle.dispose).toHaveBeenCalled();
   });
 
+  it("appends one scalar spec per auxiliary metric, precompiled, with its time aggregation", async () => {
+    const cpu = createFakeBackend(WORKER_POOL_BACKEND_ID);
+    const { sampler } = createSampler({ cpu });
+    const artifact = { source: "() => 1", placeNames: [] };
+
+    const run = sampler.run(
+      runRequest({
+        auxiliaryMetrics: [
+          {
+            id: "queue-cap",
+            label: "Queue cap",
+            artifact,
+            aggregateTime: "min",
+          },
+        ],
+      }),
+    );
+    await vi.waitFor(() => expect(cpu.handles).toHaveLength(1));
+    expect(cpu.requests[0]?.metricSpecs).toHaveLength(2);
+    expect(cpu.requests[0]?.metricSpecs[1]).toEqual({
+      kind: "expression",
+      id: "queue-cap",
+      label: "Queue cap",
+      code: "",
+      sampleRuns: "all",
+      runOutput: { type: "scalar", aggregateRuns: "mean" },
+      aggregateTime: "min",
+      artifact,
+    });
+    completeWith(cpu.handles[0]!, 0.25);
+    await run.completion;
+  });
+
   it("names why a batch failed: errored runs, a terminal error, every backend refusing, a study that does not compile", async () => {
     const cpu = createFakeBackend(WORKER_POOL_BACKEND_ID);
     const { sampler } = createSampler({ cpu });

--- a/libs/@hashintel/petrinaut/src/react/experiments/provider/detached-objective.ts
+++ b/libs/@hashintel/petrinaut/src/react/experiments/provider/detached-objective.ts
@@ -241,6 +241,19 @@ export const createDetachedObjectiveSampler = ({
           runOutput: { type: "distribution" },
           artifact: metricArtifact,
         },
+        // `code` is display-only on a spec; execution uses the artifact.
+        ...(request.auxiliaryMetrics ?? []).map(
+          (auxiliary): ExperimentRequest["metricSpecs"][number] => ({
+            kind: "expression",
+            id: auxiliary.id,
+            label: auxiliary.label,
+            code: "",
+            sampleRuns: "all",
+            runOutput: { type: "scalar", aggregateRuns: "mean" },
+            aggregateTime: auxiliary.aggregateTime,
+            artifact: auxiliary.artifact,
+          }),
+        ),
       ],
       hirArtifacts: artifacts,
       ...(options.runSeeds === undefined

--- a/libs/@hashintel/petrinaut/src/react/experiments/provider/detached-objective.ts
+++ b/libs/@hashintel/petrinaut/src/react/experiments/provider/detached-objective.ts
@@ -3,6 +3,7 @@ import {
   createReadableStore,
   DEFAULT_PETRINAUT_EXTENSIONS,
   getOwn,
+  prepareScenarioCompiler,
   runExperimentToCompletion,
   type MonteCarloExperiment,
   type MonteCarloUserDefinedMetricFrame,
@@ -21,6 +22,7 @@ import { instantiateOnBackend } from "./shared/instantiate-on-backend";
 
 import type { LanguageClientContextValue } from "../../lsp/context";
 import type {
+  DetachedObjectiveParametersRequest,
   DetachedObjectiveRequest,
   DetachedObjectiveRun,
   DetachedObjectiveRunOutcome,
@@ -74,6 +76,15 @@ export type DetachedObjectiveSampler = {
    * error, or the count of errored runs.
    */
   run: (request: DetachedObjectiveRunRequest) => DetachedObjectiveRun;
+  /**
+   * The net parameter values a batch at `request`'s point simulates with:
+   * the scenario's overrides applied to the net's defaults, compiled from
+   * the study's cached snapshot. Rejects when the scenario does not compile
+   * there.
+   */
+  resolveParameters: (
+    request: DetachedObjectiveParametersRequest,
+  ) => Promise<Readonly<Record<string, number | boolean>>>;
   /** Cancels every run in flight and releases the backends runs chose. */
   dispose: () => void;
 };
@@ -106,7 +117,7 @@ const failedOutcome = (reason: string): DetachedObjectiveRunOutcome => ({
  */
 const compileStudy = async (
   languageClient: LanguageClient,
-  request: DetachedObjectiveRequest,
+  request: DetachedObjectiveParametersRequest,
   includeHir: boolean,
 ): Promise<CompiledStudy> => {
   const scenario = (request.definition.scenarios ?? []).find(
@@ -178,7 +189,7 @@ export const createDetachedObjectiveSampler = ({
   const runShards = Math.max(1, Math.floor(shardCount / 3));
 
   const compiledFor = (
-    request: DetachedObjectiveRequest,
+    request: DetachedObjectiveParametersRequest,
     includeHir: boolean,
   ): Promise<CompiledStudy> => {
     const key = `${request.cacheKey}|${includeHir ? "hir" : "flat"}`;
@@ -261,6 +272,27 @@ export const createDetachedObjectiveSampler = ({
         : { runs: options.runSeeds.map((seed) => ({ seed })) }),
     };
   };
+
+  const resolveParameters: DetachedObjectiveSampler["resolveParameters"] =
+    async (request) => {
+      const { scenario, scenarioHir } = await compiledFor(request, false);
+      const compiled = prepareScenarioCompiler(
+        scenario,
+        scenarioHir,
+        request.definition.parameters,
+        request.definition.places,
+        request.definition.types,
+      ).compileParameterNumbers(
+        numericScenarioValues(request.scenarioParameterValues),
+      );
+      if (!compiled.ok) {
+        throw new Error(
+          compiled.errors.map((error) => error.message).join("; ") ||
+            `Scenario "${scenario.name}" did not compile at this point`,
+        );
+      }
+      return compiled.parameters;
+    };
 
   /** A run's handle on the backend its study settled on. */
   const instantiateOnChosen = async (
@@ -534,6 +566,7 @@ export const createDetachedObjectiveSampler = ({
         : null;
     },
     run,
+    resolveParameters,
     dispose: () => {
       for (const controller of runsInFlight) {
         controller.abort();

--- a/libs/@hashintel/petrinaut/src/react/optimizations/channel/create-optimization-channel.test.ts
+++ b/libs/@hashintel/petrinaut/src/react/optimizations/channel/create-optimization-channel.test.ts
@@ -16,6 +16,7 @@ import {
   sirNetConstrainedOptimizationInput,
   sirOptimizationInput,
   sirOptimizationMetric,
+  sirSwitchConstrainedOptimizationInput,
 } from "../sir-optimization-input.fixtures";
 import {
   createOptimizationChannel,
@@ -280,6 +281,54 @@ describe("createOptimizationChannel", () => {
       constraints: { parameters: [{ constraintId: "rate-cap" }], state: [] },
     });
     expect(settled.constraints?.parameters[0]?.margin).toBeCloseTo(1);
+  });
+
+  it("binds a boolean scenario parameter by its type: a constraint over the switch holds for a true draw and prunes a false one", async () => {
+    const { fake, channel } = setup();
+    const at = (isolation: boolean) => {
+      const suggestedValues = { infected_ratio: 0.05, isolation };
+      return trialRequest({
+        manifest: sirSwitchConstrainedOptimizationInput,
+        suggestedValues,
+        scenarioParameterValues: resolveTrialScenarioParameterValues(
+          sirSwitchConstrainedOptimizationInput,
+          suggestedValues,
+        ),
+      });
+    };
+
+    const infeasible = await channel.evaluateTrial(at(false));
+    expect(infeasible).toMatchObject({
+      kind: "pruned",
+      reason: "Infeasible: Isolation on",
+      constraints: { infeasible: "isolation-on" },
+    });
+    expect(infeasible.constraints?.parameters[0]?.margin).toBe(-1);
+    expect(fake.runs).toHaveLength(0);
+
+    const feasible = channel.evaluateTrial(at(true));
+    await vi.waitFor(() => expect(fake.runs).toHaveLength(1));
+    // The batch still compiles the scenario from the 0/1 transport.
+    expect(fake.runs[0]?.request.scenarioParameterValues).toEqual({
+      population: 1_000,
+      infected_ratio: 0.05,
+      isolation: 1,
+    });
+    fake.runs[0]!.settle(
+      completedRunResult({
+        metricId,
+        frames: [distributionFrame(metricId, 180, [[0.3, 1]])],
+        runValues: [0.3],
+      }),
+    );
+    await expect(feasible).resolves.toMatchObject({
+      kind: "objective",
+      objective: 0.3,
+      constraints: {
+        parameters: [{ constraintId: "isolation-on", margin: 0 }],
+        state: [],
+      },
+    });
   });
 
   it("prunes a trial as failed to resolve when the scenario does not compile at its values", async () => {

--- a/libs/@hashintel/petrinaut/src/react/optimizations/channel/create-optimization-channel.test.ts
+++ b/libs/@hashintel/petrinaut/src/react/optimizations/channel/create-optimization-channel.test.ts
@@ -12,6 +12,7 @@ import {
   failedRunOutcome,
 } from "../fake-detached-objective-runs.fixtures";
 import {
+  sirConstrainedOptimizationInput,
   sirOptimizationInput,
   sirOptimizationMetric,
 } from "../sir-optimization-input.fixtures";
@@ -177,6 +178,100 @@ describe("createOptimizationChannel", () => {
       objective: 0.3,
     });
     expect(study.trialStarted).not.toHaveBeenCalled();
+  });
+
+  it("prunes an infeasible draw before any simulation, naming the constraint it broke", async () => {
+    const { fake, study, channel } = setup();
+    const suggestedValues = { infected_ratio: 0.15 };
+
+    const outcome = await channel.evaluateTrial(
+      trialRequest({
+        manifest: sirConstrainedOptimizationInput,
+        suggestedValues,
+        scenarioParameterValues: resolveTrialScenarioParameterValues(
+          sirConstrainedOptimizationInput,
+          suggestedValues,
+        ),
+      }),
+    );
+    expect(outcome).toMatchObject({
+      kind: "pruned",
+      reason: "Infeasible: Ratio under a tenth",
+      constraints: {
+        parameters: [{ constraintId: "ratio-cap" }],
+        state: [],
+        infeasible: "ratio-cap",
+      },
+    });
+    expect(outcome.constraints?.parameters[0]?.margin).toBeCloseTo(-0.05);
+    expect(fake.runs).toHaveLength(0);
+    expect(study.trialStarted).not.toHaveBeenCalled();
+  });
+
+  it("runs the state constraints as auxiliary metrics and reports their per-run verdicts with the plain mean objective", async () => {
+    const { fake, channel } = setup();
+    const outcome = channel.evaluateTrial(
+      trialRequest({ manifest: sirConstrainedOptimizationInput }),
+    );
+    const request = fake.runs[0]?.request;
+    expect(request?.auxiliaryMetrics).toHaveLength(1);
+    expect(request?.auxiliaryMetrics?.[0]).toMatchObject({
+      id: "infected-cap",
+      aggregateTime: "min",
+    });
+
+    fake.runs[0]!.settle({
+      ...completedRunResult({
+        metricId,
+        frames: [distributionFrame(metricId, 180, [[0.25, 3]])],
+        runValues: [0.5, 0.25, 0],
+      }),
+      runResults: new Map([
+        [0, { [metricId]: 0.5, "infected-cap": 1 }],
+        [1, { [metricId]: 0.25, "infected-cap": 0 }],
+        [2, { [metricId]: 0, "infected-cap": 1 }],
+      ]),
+    });
+    const settled = await outcome;
+    expect(settled).toMatchObject({
+      kind: "objective",
+      objective: 0.25,
+      constraints: {
+        parameters: [{ constraintId: "ratio-cap" }],
+        state: [{ constraintId: "infected-cap", runsPassed: 2, runsTotal: 3 }],
+      },
+    });
+    expect(settled.constraints?.parameters[0]?.margin).toBeCloseTo(0.05);
+
+    // The indicators are emitted once per run id.
+    const second = channel.evaluateTrial(
+      trialRequest({ manifest: sirConstrainedOptimizationInput, trial: 1 }),
+    );
+    expect(fake.runs[1]?.request.auxiliaryMetrics?.[0]?.artifact).toBe(
+      request?.auxiliaryMetrics?.[0]?.artifact,
+    );
+    fake.runs[1]!.settle(failedRunOutcome("2 of 3 runs failed"));
+    await expect(second).resolves.toEqual({
+      kind: "pruned",
+      reason: "2 of 3 runs failed",
+    });
+  });
+
+  it("attaches no constraints and runs no auxiliary metrics for a study without any", async () => {
+    const { fake, channel } = setup();
+    const outcome = channel.evaluateTrial(trialRequest());
+    expect(fake.runs[0]?.request.auxiliaryMetrics).toBeUndefined();
+    fake.runs[0]!.settle(
+      completedRunResult({
+        metricId,
+        frames: [distributionFrame(metricId, 180, [[0.3, 1]])],
+        runValues: [0.3],
+      }),
+    );
+    await expect(outcome).resolves.toEqual({
+      kind: "objective",
+      objective: 0.3,
+    });
   });
 
   it("never throws: a failing run request becomes a pruned trial, and dispose cancels runs in flight", async () => {

--- a/libs/@hashintel/petrinaut/src/react/optimizations/channel/create-optimization-channel.test.ts
+++ b/libs/@hashintel/petrinaut/src/react/optimizations/channel/create-optimization-channel.test.ts
@@ -13,6 +13,7 @@ import {
 } from "../fake-detached-objective-runs.fixtures";
 import {
   sirConstrainedOptimizationInput,
+  sirNetConstrainedOptimizationInput,
   sirOptimizationInput,
   sirOptimizationMetric,
 } from "../sir-optimization-input.fixtures";
@@ -20,6 +21,8 @@ import {
   createOptimizationChannel,
   type OptimizationChannelStudy,
 } from "./create-optimization-channel";
+
+import type { DetachedObjectiveParametersRequest } from "../../experiments/context";
 
 const metricId = sirOptimizationMetric.id;
 
@@ -42,6 +45,21 @@ const trialRequest = (
   };
 };
 
+/**
+ * Stands in for the sampler's scenario compile: the net's infection rate at
+ * twenty times the trial's infected ratio, as the overriding fixture
+ * scenario resolves it, and the recovery rate at the scenario's constant.
+ */
+const fakeResolveParameters = vi.fn(
+  (request: DetachedObjectiveParametersRequest) => {
+    const ratio = request.scenarioParameterValues.infected_ratio;
+    return Promise.resolve({
+      infection_rate: typeof ratio === "number" ? ratio * 20 : 3,
+      recovery_rate: 0.8,
+    });
+  },
+);
+
 const setup = () => {
   const fake = createFakeDetachedObjectiveRuns();
   const study: OptimizationChannelStudy = {
@@ -50,8 +68,10 @@ const setup = () => {
     trialStarted: vi.fn(),
     trialSettled: vi.fn(),
   };
+  fakeResolveParameters.mockClear();
   const channel = createOptimizationChannel({
     runDetachedObjective: fake.runDetachedObjective,
+    resolveDetachedObjectiveParameters: fakeResolveParameters,
     resolveStudy: (runId) => (runId === "run-1" ? study : null),
   });
   return { fake, study, channel };
@@ -208,11 +228,82 @@ describe("createOptimizationChannel", () => {
     expect(study.trialStarted).not.toHaveBeenCalled();
   });
 
+  it("checks a constraint over a net parameter at the value the study's scenario resolves for the trial", async () => {
+    const { fake, channel } = setup();
+    const at = (ratio: number) => {
+      const suggestedValues = { infected_ratio: ratio };
+      return trialRequest({
+        manifest: sirNetConstrainedOptimizationInput,
+        suggestedValues,
+        scenarioParameterValues: resolveTrialScenarioParameterValues(
+          sirNetConstrainedOptimizationInput,
+          suggestedValues,
+        ),
+      });
+    };
+
+    // Rate 3 at a ratio of 0.15: the draw is pruned without a batch.
+    const infeasible = await channel.evaluateTrial(at(0.15));
+    expect(infeasible).toMatchObject({
+      kind: "pruned",
+      reason: "Infeasible: Infection rate under two",
+      constraints: { infeasible: "rate-cap" },
+    });
+    expect(infeasible.constraints?.parameters[0]?.margin).toBeCloseTo(-1);
+    expect(fakeResolveParameters).toHaveBeenCalledWith({
+      cacheKey: "run-1",
+      definition: sirNetConstrainedOptimizationInput.model.definition,
+      scenarioId: sirNetConstrainedOptimizationInput.scenario.id,
+      scenarioParameterValues: { population: 1_000, infected_ratio: 0.15 },
+      metric: {
+        id: metricId,
+        label: sirOptimizationMetric.name,
+        code: sirOptimizationMetric.code,
+      },
+    });
+    expect(fake.runs).toHaveLength(0);
+
+    // Rate 1 at a ratio of 0.05: the batch runs, the margin riding along.
+    const feasible = channel.evaluateTrial(at(0.05));
+    await vi.waitFor(() => expect(fake.runs).toHaveLength(1));
+    fake.runs[0]!.settle(
+      completedRunResult({
+        metricId,
+        frames: [distributionFrame(metricId, 180, [[0.3, 1]])],
+        runValues: [0.3],
+      }),
+    );
+    const settled = await feasible;
+    expect(settled).toMatchObject({
+      kind: "objective",
+      objective: 0.3,
+      constraints: { parameters: [{ constraintId: "rate-cap" }], state: [] },
+    });
+    expect(settled.constraints?.parameters[0]?.margin).toBeCloseTo(1);
+  });
+
+  it("prunes a trial as failed to resolve when the scenario does not compile at its values", async () => {
+    const { fake, channel } = setup();
+    fakeResolveParameters.mockRejectedValueOnce(
+      new Error('Scenario parameter "population" must be a finite number.'),
+    );
+    await expect(
+      channel.evaluateTrial(
+        trialRequest({ manifest: sirNetConstrainedOptimizationInput }),
+      ),
+    ).resolves.toEqual({
+      kind: "pruned",
+      reason: 'Scenario parameter "population" must be a finite number.',
+    });
+    expect(fake.runs).toHaveLength(0);
+  });
+
   it("runs the state constraints as auxiliary metrics and reports their per-run verdicts with the plain mean objective", async () => {
     const { fake, channel } = setup();
     const outcome = channel.evaluateTrial(
       trialRequest({ manifest: sirConstrainedOptimizationInput }),
     );
+    await vi.waitFor(() => expect(fake.runs).toHaveLength(1));
     const request = fake.runs[0]?.request;
     expect(request?.auxiliaryMetrics).toHaveLength(1);
     expect(request?.auxiliaryMetrics?.[0]).toMatchObject({
@@ -247,6 +338,7 @@ describe("createOptimizationChannel", () => {
     const second = channel.evaluateTrial(
       trialRequest({ manifest: sirConstrainedOptimizationInput, trial: 1 }),
     );
+    await vi.waitFor(() => expect(fake.runs).toHaveLength(2));
     expect(fake.runs[1]?.request.auxiliaryMetrics?.[0]?.artifact).toBe(
       request?.auxiliaryMetrics?.[0]?.artifact,
     );
@@ -279,6 +371,7 @@ describe("createOptimizationChannel", () => {
       runDetachedObjective: () => {
         throw new Error("no compute");
       },
+      resolveDetachedObjectiveParameters: fakeResolveParameters,
       resolveStudy: () => null,
     });
     await expect(throwing.evaluateTrial(trialRequest())).resolves.toEqual({

--- a/libs/@hashintel/petrinaut/src/react/optimizations/channel/create-optimization-channel.ts
+++ b/libs/@hashintel/petrinaut/src/react/optimizations/channel/create-optimization-channel.ts
@@ -2,6 +2,8 @@
  * @layerRoot react.optimizations.channel
  * @role Evaluates optimizer trials as detached objective runs on the experiments backend
  */
+import { resolveTrialScenarioBindings } from "@hashintel/petrinaut-core/optimization";
+
 import { errorMessage } from "../../experiments/shared/error-message";
 import { constraintNameIn } from "../constraint-rates";
 import {
@@ -121,7 +123,9 @@ export const createOptimizationChannel = ({
       indicators = indicatorsFor(request);
       if (hasParameterConstraints(request.manifest)) {
         // `parameters.*` reads what the batch would simulate with: the
-        // scenario's overrides resolved at this trial's values.
+        // scenario's overrides resolved at this trial's values. `scenario.*`
+        // reads those values as the compiler binds them, a boolean parameter
+        // as a boolean.
         const parameters = await resolveDetachedObjectiveParameters({
           cacheKey,
           definition: request.manifest.model.definition,
@@ -131,7 +135,10 @@ export const createOptimizationChannel = ({
         });
         parameterOutcome = parameterConstraintOutcome(request.manifest, {
           parameters,
-          scenario: request.scenarioParameterValues,
+          scenario: resolveTrialScenarioBindings(
+            request.manifest,
+            request.scenarioParameterValues,
+          ),
         });
       }
     } catch (error) {

--- a/libs/@hashintel/petrinaut/src/react/optimizations/channel/create-optimization-channel.ts
+++ b/libs/@hashintel/petrinaut/src/react/optimizations/channel/create-optimization-channel.ts
@@ -3,8 +3,10 @@
  * @role Evaluates optimizer trials as detached objective runs on the experiments backend
  */
 import { errorMessage } from "../../experiments/shared/error-message";
+import { constraintNameIn } from "../constraint-rates";
 import {
-  constraintNameIn,
+  hasParameterConstraints,
+  type ParameterConstraintOutcome,
   parameterConstraintOutcome,
   stateConstraintMetrics,
   stateConstraintResults,
@@ -52,18 +54,21 @@ export type OptimizationChannel = PetrinautOptimizationChannel & {
  * The channel a connected optimizer evaluates its trials through. Each trial
  * becomes one detached objective run compiled once per optimizer run id and
  * queued on its own, so trials the optimizer keeps in flight together
- * overlap. A study's parameter constraints are checked at the trial's values
- * first: a draw that breaks one is pruned before anything simulates, naming
- * the constraint. Its state constraints run beside the objective as 0/1
- * metrics, and their per-run verdicts ride on the outcome; the objective
- * stays the mean over every run. The channel never throws: whatever stops a
- * trial reaches Optuna as a pruned trial carrying the reason.
+ * overlap. A study's parameter constraints are checked first, at the trial's
+ * values and the net parameter values they resolve to: a draw that breaks
+ * one is pruned before anything simulates, naming the constraint. Its state
+ * constraints run beside the objective as 0/1 metrics, and their per-run
+ * verdicts ride on the outcome; the objective stays the mean over every run.
+ * The channel never throws: whatever stops a trial reaches Optuna as a pruned
+ * trial carrying the reason.
  */
 export const createOptimizationChannel = ({
   runDetachedObjective,
+  resolveDetachedObjectiveParameters,
   resolveStudy,
 }: {
   runDetachedObjective: ExperimentsActionsValue["runDetachedObjective"];
+  resolveDetachedObjectiveParameters: ExperimentsActionsValue["resolveDetachedObjectiveParameters"];
   /**
    * The study behind a run id, or null for a run the provider does not
    * know, whose trials run on the CPU with nobody watching.
@@ -108,16 +113,32 @@ export const createOptimizationChannel = ({
       return prunedTrialOutcome("cancelled");
     }
 
-    let parameterOutcome: ReturnType<typeof parameterConstraintOutcome>;
+    const study = resolveStudy(request.runId);
+    const cacheKey = study?.cacheKey ?? request.runId;
+    let parameterOutcome: ParameterConstraintOutcome | null = null;
     let indicators: DetachedObjectiveAuxiliaryMetric[];
     try {
-      parameterOutcome = parameterConstraintOutcome(
-        request.manifest,
-        request.scenarioParameterValues,
-      );
       indicators = indicatorsFor(request);
+      if (hasParameterConstraints(request.manifest)) {
+        // `parameters.*` reads what the batch would simulate with: the
+        // scenario's overrides resolved at this trial's values.
+        const parameters = await resolveDetachedObjectiveParameters({
+          cacheKey,
+          definition: request.manifest.model.definition,
+          scenarioId: request.manifest.scenario.id,
+          scenarioParameterValues: request.scenarioParameterValues,
+          metric: { id: metric.id, label: metric.name, code: metric.code },
+        });
+        parameterOutcome = parameterConstraintOutcome(request.manifest, {
+          parameters,
+          scenario: request.scenarioParameterValues,
+        });
+      }
     } catch (error) {
       return prunedTrialOutcome(errorMessage(error));
+    }
+    if (isCancelled()) {
+      return prunedTrialOutcome("cancelled");
     }
     if (
       parameterOutcome?.infeasible !== undefined &&
@@ -141,9 +162,8 @@ export const createOptimizationChannel = ({
     let run: DetachedObjectiveRun | null = null;
     let outcome: DetachedObjectiveRunOutcome;
     try {
-      const study = resolveStudy(request.runId);
       run = runDetachedObjective({
-        cacheKey: study?.cacheKey ?? request.runId,
+        cacheKey,
         // Trials in flight at once each take a queue of their own; the
         // compiled study is shared through the cache key.
         queueKey: `${request.runId}:trial:${request.trial}`,

--- a/libs/@hashintel/petrinaut/src/react/optimizations/channel/create-optimization-channel.ts
+++ b/libs/@hashintel/petrinaut/src/react/optimizations/channel/create-optimization-channel.ts
@@ -4,11 +4,18 @@
  */
 import { errorMessage } from "../../experiments/shared/error-message";
 import {
+  constraintNameIn,
+  parameterConstraintOutcome,
+  stateConstraintMetrics,
+  stateConstraintResults,
+} from "./create-optimization-channel/trial-constraints";
+import {
   prunedTrialOutcome,
   trialOutcome,
 } from "./create-optimization-channel/trial-outcome";
 
 import type {
+  DetachedObjectiveAuxiliaryMetric,
   DetachedObjectiveRun,
   DetachedObjectiveRunOutcome,
   ExperimentComputeBackend,
@@ -17,6 +24,7 @@ import type {
 import type {
   OptimizationScalar,
   PetrinautOptimizationChannel,
+  PetrinautOptimizationTrialRequest,
 } from "@hashintel/petrinaut-core/optimization";
 
 /**
@@ -44,8 +52,12 @@ export type OptimizationChannel = PetrinautOptimizationChannel & {
  * The channel a connected optimizer evaluates its trials through. Each trial
  * becomes one detached objective run compiled once per optimizer run id and
  * queued on its own, so trials the optimizer keeps in flight together
- * overlap. The channel never throws: whatever stops a trial reaches Optuna
- * as a pruned trial carrying the reason.
+ * overlap. A study's parameter constraints are checked at the trial's values
+ * first: a draw that breaks one is pruned before anything simulates, naming
+ * the constraint. Its state constraints run beside the objective as 0/1
+ * metrics, and their per-run verdicts ride on the outcome; the objective
+ * stays the mean over every run. The channel never throws: whatever stops a
+ * trial reaches Optuna as a pruned trial carrying the reason.
  */
 export const createOptimizationChannel = ({
   runDetachedObjective,
@@ -59,6 +71,20 @@ export const createOptimizationChannel = ({
   resolveStudy: (runId: string) => OptimizationChannelStudy | null;
 }): OptimizationChannel => {
   const runsInFlight = new Set<DetachedObjectiveRun>();
+  /** The state constraints' indicators, emitted once per optimizer run id. */
+  const indicatorsByRun = new Map<string, DetachedObjectiveAuxiliaryMetric[]>();
+
+  const indicatorsFor = (
+    request: PetrinautOptimizationTrialRequest,
+  ): DetachedObjectiveAuxiliaryMetric[] => {
+    const cached = indicatorsByRun.get(request.runId);
+    if (cached) {
+      return cached;
+    }
+    const indicators = stateConstraintMetrics(request.manifest);
+    indicatorsByRun.set(request.runId, indicators);
+    return indicators;
+  };
 
   const evaluateTrial: PetrinautOptimizationChannel["evaluateTrial"] = async (
     request,
@@ -82,6 +108,33 @@ export const createOptimizationChannel = ({
       return prunedTrialOutcome("cancelled");
     }
 
+    let parameterOutcome: ReturnType<typeof parameterConstraintOutcome>;
+    let indicators: DetachedObjectiveAuxiliaryMetric[];
+    try {
+      parameterOutcome = parameterConstraintOutcome(
+        request.manifest,
+        request.scenarioParameterValues,
+      );
+      indicators = indicatorsFor(request);
+    } catch (error) {
+      return prunedTrialOutcome(errorMessage(error));
+    }
+    if (
+      parameterOutcome?.infeasible !== undefined &&
+      parameterOutcome.infeasible !== null
+    ) {
+      // An infeasible draw costs one trial and no simulation: nothing
+      // starts, so no batch appears in the study's activity.
+      const { infeasible } = parameterOutcome;
+      return prunedTrialOutcome(
+        `Infeasible: ${constraintNameIn(request.manifest, infeasible)}`,
+        { parameters: parameterOutcome.results, state: [], infeasible },
+      );
+    }
+    const parameterResults = parameterOutcome?.results ?? [];
+    const declaresConstraints =
+      parameterResults.length > 0 || indicators.length > 0;
+
     const controller = new AbortController();
     const forwardAbort = () => controller.abort();
     request.signal.addEventListener("abort", forwardAbort, { once: true });
@@ -98,6 +151,7 @@ export const createOptimizationChannel = ({
         scenarioId: request.manifest.scenario.id,
         scenarioParameterValues: request.scenarioParameterValues,
         metric: { id: metric.id, label: metric.name, code: metric.code },
+        ...(indicators.length > 0 ? { auxiliaryMetrics: indicators } : {}),
         seed: firstSeed,
         runCount: request.seeds.length,
         runSeeds: request.seeds,
@@ -123,7 +177,14 @@ export const createOptimizationChannel = ({
       }
       request.signal.removeEventListener("abort", forwardAbort);
     }
-    return trialOutcome(outcome, metric.id);
+    return trialOutcome(outcome, metric.id, (result) =>
+      declaresConstraints
+        ? {
+            parameters: parameterResults,
+            state: stateConstraintResults(request.manifest, result.runResults),
+          }
+        : undefined,
+    );
   };
 
   return {
@@ -133,6 +194,7 @@ export const createOptimizationChannel = ({
         run.cancel();
       }
       runsInFlight.clear();
+      indicatorsByRun.clear();
     },
   };
 };

--- a/libs/@hashintel/petrinaut/src/react/optimizations/channel/create-optimization-channel/trial-constraints.test.ts
+++ b/libs/@hashintel/petrinaut/src/react/optimizations/channel/create-optimization-channel/trial-constraints.test.ts
@@ -1,30 +1,82 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  type HirInterpretBindings,
+  prepareScenarioCompiler,
+} from "@hashintel/petrinaut-core";
+import { lowerScenarioToHir } from "@hashintel/petrinaut-core/hir";
+
+import {
   sirConstrainedOptimizationInput,
+  sirNetConstrainedOptimizationInput,
   sirOptimizationInput,
+  sirOverridingOptimizationScenario,
 } from "../../sir-optimization-input.fixtures";
 import {
-  constraintNameIn,
+  hasParameterConstraints,
   parameterConstraintOutcome,
   stateConstraintMetrics,
   stateConstraintResults,
 } from "./trial-constraints";
 
+import type { PetrinautOptimizationManifest } from "@hashintel/petrinaut-core/optimization";
+
+/** The bindings the channel evaluates at: the net values resolved through the study's scenario at the trial's values. */
+const bindingsAt = (
+  manifest: PetrinautOptimizationManifest,
+  scenario: Readonly<Record<string, number>>,
+): HirInterpretBindings => {
+  const studyScenario = manifest.model.definition.scenarios?.find(
+    (candidate) => candidate.id === manifest.scenario.id,
+  );
+  if (!studyScenario) {
+    throw new Error("The study's scenario is missing");
+  }
+  const compiled = prepareScenarioCompiler(
+    studyScenario,
+    lowerScenarioToHir(studyScenario),
+    manifest.model.definition.parameters,
+  ).compileParameterNumbers(scenario);
+  if (!compiled.ok) {
+    throw new Error(compiled.errors[0]?.message ?? "scenario");
+  }
+  return { parameters: compiled.parameters, scenario };
+};
+
+describe("hasParameterConstraints", () => {
+  it("is true only for a study with a parameter constraint", () => {
+    expect(hasParameterConstraints(sirOptimizationInput)).toBe(false);
+    expect(hasParameterConstraints(sirConstrainedOptimizationInput)).toBe(true);
+    expect(
+      hasParameterConstraints({
+        constraints: sirConstrainedOptimizationInput.constraints?.filter(
+          (constraint) => constraint.space === "state",
+        ),
+      }),
+    ).toBe(false);
+  });
+});
+
 describe("parameterConstraintOutcome", () => {
   it("is null for a study without parameter constraints", () => {
     expect(
-      parameterConstraintOutcome(sirOptimizationInput, {
-        population: 1_000,
-        infected_ratio: 0.05,
-      }),
+      parameterConstraintOutcome(
+        sirOptimizationInput,
+        bindingsAt(sirOptimizationInput, {
+          population: 1_000,
+          infected_ratio: 0.05,
+        }),
+      ),
     ).toBeNull();
   });
 
   it("reports each margin and names the first constraint a draw breaks", () => {
     const feasible = parameterConstraintOutcome(
       sirConstrainedOptimizationInput,
-      { population: 1_000, infected_ratio: 0.05 },
+      bindingsAt(sirConstrainedOptimizationInput, {
+        population: 1_000,
+        infected_ratio: 0.05,
+      }),
     );
     expect(feasible).toMatchObject({
       results: [{ constraintId: "ratio-cap" }],
@@ -34,7 +86,10 @@ describe("parameterConstraintOutcome", () => {
 
     const infeasible = parameterConstraintOutcome(
       sirConstrainedOptimizationInput,
-      { population: 1_000, infected_ratio: 0.15 },
+      bindingsAt(sirConstrainedOptimizationInput, {
+        population: 1_000,
+        infected_ratio: 0.15,
+      }),
     );
     expect(infeasible).toMatchObject({
       results: [{ constraintId: "ratio-cap" }],
@@ -42,16 +97,39 @@ describe("parameterConstraintOutcome", () => {
     });
     expect(infeasible?.results[0]?.margin).toBeCloseTo(-0.05);
   });
-});
 
-describe("constraintNameIn", () => {
-  it("prefers the authored name and falls back to the id", () => {
-    expect(constraintNameIn(sirConstrainedOptimizationInput, "ratio-cap")).toBe(
-      "Ratio under a tenth",
+  it("reads a net parameter at the value the scenario's override resolves it to at the trial's values", () => {
+    expect(sirOverridingOptimizationScenario.parameterOverrides).toMatchObject({
+      param__infection_rate: "scenario.infected_ratio * 20",
+    });
+
+    // 0.05 * 20 = 1: under the cap, although the net's default of 3 is not.
+    const feasible = parameterConstraintOutcome(
+      sirNetConstrainedOptimizationInput,
+      bindingsAt(sirNetConstrainedOptimizationInput, {
+        population: 1_000,
+        infected_ratio: 0.05,
+      }),
     );
-    expect(constraintNameIn(sirConstrainedOptimizationInput, "other")).toBe(
-      "other",
+    expect(feasible).toMatchObject({
+      results: [{ constraintId: "rate-cap" }],
+      infeasible: null,
+    });
+    expect(feasible?.results[0]?.margin).toBeCloseTo(1);
+
+    // 0.15 * 20 = 3: over the cap, so the draw is pruned.
+    const infeasible = parameterConstraintOutcome(
+      sirNetConstrainedOptimizationInput,
+      bindingsAt(sirNetConstrainedOptimizationInput, {
+        population: 1_000,
+        infected_ratio: 0.15,
+      }),
     );
+    expect(infeasible).toMatchObject({
+      results: [{ constraintId: "rate-cap" }],
+      infeasible: "rate-cap",
+    });
+    expect(infeasible?.results[0]?.margin).toBeCloseTo(-1);
   });
 });
 

--- a/libs/@hashintel/petrinaut/src/react/optimizations/channel/create-optimization-channel/trial-constraints.test.ts
+++ b/libs/@hashintel/petrinaut/src/react/optimizations/channel/create-optimization-channel/trial-constraints.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  sirConstrainedOptimizationInput,
+  sirOptimizationInput,
+} from "../../sir-optimization-input.fixtures";
+import {
+  constraintNameIn,
+  parameterConstraintOutcome,
+  stateConstraintMetrics,
+  stateConstraintResults,
+} from "./trial-constraints";
+
+describe("parameterConstraintOutcome", () => {
+  it("is null for a study without parameter constraints", () => {
+    expect(
+      parameterConstraintOutcome(sirOptimizationInput, {
+        population: 1_000,
+        infected_ratio: 0.05,
+      }),
+    ).toBeNull();
+  });
+
+  it("reports each margin and names the first constraint a draw breaks", () => {
+    const feasible = parameterConstraintOutcome(
+      sirConstrainedOptimizationInput,
+      { population: 1_000, infected_ratio: 0.05 },
+    );
+    expect(feasible).toMatchObject({
+      results: [{ constraintId: "ratio-cap" }],
+      infeasible: null,
+    });
+    expect(feasible?.results[0]?.margin).toBeCloseTo(0.05);
+
+    const infeasible = parameterConstraintOutcome(
+      sirConstrainedOptimizationInput,
+      { population: 1_000, infected_ratio: 0.15 },
+    );
+    expect(infeasible).toMatchObject({
+      results: [{ constraintId: "ratio-cap" }],
+      infeasible: "ratio-cap",
+    });
+    expect(infeasible?.results[0]?.margin).toBeCloseTo(-0.05);
+  });
+});
+
+describe("constraintNameIn", () => {
+  it("prefers the authored name and falls back to the id", () => {
+    expect(constraintNameIn(sirConstrainedOptimizationInput, "ratio-cap")).toBe(
+      "Ratio under a tenth",
+    );
+    expect(constraintNameIn(sirConstrainedOptimizationInput, "other")).toBe(
+      "other",
+    );
+  });
+});
+
+describe("stateConstraintMetrics", () => {
+  it("is empty without state constraints and compiles one min-aggregated indicator per state constraint", () => {
+    expect(stateConstraintMetrics(sirOptimizationInput)).toEqual([]);
+    const metrics = stateConstraintMetrics(sirConstrainedOptimizationInput);
+    expect(metrics).toHaveLength(1);
+    expect(metrics[0]).toMatchObject({
+      id: "infected-cap",
+      label: "Infected under 900",
+      aggregateTime: "min",
+    });
+    expect(metrics[0]?.artifact.placeNames).toEqual(["Infected"]);
+    expect(metrics[0]?.artifact.source).toContain("? 1 : 0");
+  });
+});
+
+describe("stateConstraintResults", () => {
+  it("counts the runs each constraint held on, a missing value counting as failed", () => {
+    const runResults = new Map<number, Readonly<Record<string, number>>>([
+      [0, { "infected-cap": 1, objective: 0.2 }],
+      [1, { "infected-cap": 0, objective: 0.4 }],
+      [2, { objective: 0.3 }],
+      [3, { "infected-cap": 1, objective: 0.1 }],
+    ]);
+    expect(
+      stateConstraintResults(sirConstrainedOptimizationInput, runResults),
+    ).toEqual([{ constraintId: "infected-cap", runsPassed: 2, runsTotal: 4 }]);
+  });
+
+  it("reports nothing when the batch has no run axis", () => {
+    expect(
+      stateConstraintResults(sirConstrainedOptimizationInput, new Map()),
+    ).toEqual([]);
+  });
+});

--- a/libs/@hashintel/petrinaut/src/react/optimizations/channel/create-optimization-channel/trial-constraints.ts
+++ b/libs/@hashintel/petrinaut/src/react/optimizations/channel/create-optimization-channel/trial-constraints.ts
@@ -39,8 +39,9 @@ export const hasParameterConstraints = (
  * The parameter constraints' margins at the trial's point, with `parameters`
  * bound to the net parameter values the trial simulates with (the scenario's
  * overrides applied at the trial's values) and `scenario` to the trial's
- * values (booleans as 0/1). Null when the manifest has no parameter
- * constraints. Throws where interpretation would.
+ * values decoded by each scenario parameter's type, as the scenario compiler
+ * binds them. Null when the manifest has no parameter constraints. Throws
+ * where interpretation would.
  */
 export const parameterConstraintOutcome = (
   manifest: PetrinautOptimizationManifest,

--- a/libs/@hashintel/petrinaut/src/react/optimizations/channel/create-optimization-channel/trial-constraints.ts
+++ b/libs/@hashintel/petrinaut/src/react/optimizations/channel/create-optimization-channel/trial-constraints.ts
@@ -1,0 +1,125 @@
+/**
+ * A trial's constraints as the channel evaluates them: the parameter
+ * constraints at the trial's values before anything simulates, and the state
+ * constraints as 0/1 metrics whose per-run verdicts come back with the
+ * batch. Everything here reports; the objective is never changed by it.
+ */
+import {
+  compileStateConstraintIndicator,
+  constraintLabel,
+  constraintsInSpace,
+  deriveDefaultParameterValues,
+  evaluateParameterConstraints,
+  getOwn,
+  type ParameterConstraintResult,
+} from "@hashintel/petrinaut-core";
+
+import type {
+  DetachedObjectiveAuxiliaryMetric,
+  DetachedObjectiveRunResult,
+} from "../../../experiments/context";
+import type {
+  PetrinautOptimizationManifest,
+  PetrinautOptimizationTrialConstraints,
+} from "@hashintel/petrinaut-core/optimization";
+
+export type ParameterConstraintOutcome = {
+  results: ParameterConstraintResult[];
+  /** The first constraint the draw broke, or null when every one holds. */
+  infeasible: string | null;
+};
+
+/**
+ * The parameter constraints' margins at the trial's values, with `parameters`
+ * bound to the net's defaults and `scenario` to the trial's values (booleans
+ * as 0/1). Null when the manifest has no parameter constraints. Throws
+ * where interpretation would.
+ */
+export const parameterConstraintOutcome = (
+  manifest: PetrinautOptimizationManifest,
+  scenarioParameterValues: Readonly<Record<string, number>>,
+): ParameterConstraintOutcome | null => {
+  const constraints = constraintsInSpace(
+    manifest.constraints ?? [],
+    "parameters",
+  );
+  if (constraints.length === 0) {
+    return null;
+  }
+  const results = evaluateParameterConstraints(constraints, {
+    parameters: deriveDefaultParameterValues(
+      manifest.model.definition.parameters,
+    ),
+    scenario: scenarioParameterValues,
+  });
+  const broken = results.find((result) => result.margin < 0);
+  return { results, infeasible: broken?.constraintId ?? null };
+};
+
+/** The name a report gives constraint `constraintId`, or the id when the manifest does not know it. */
+export const constraintNameIn = (
+  manifest: Pick<PetrinautOptimizationManifest, "constraints">,
+  constraintId: string,
+): string => {
+  const constraint = manifest.constraints?.find(
+    (candidate) => candidate.id === constraintId,
+  );
+  return constraint ? constraintLabel(constraint) : constraintId;
+};
+
+/**
+ * The auxiliary metrics a trial runs for its state constraints, one 0/1
+ * indicator per constraint aggregated with `min` over each run's frames:
+ * the "always" quantifier. Empty without any. Throws, naming the
+ * constraint, when the emitter declines a body.
+ */
+export const stateConstraintMetrics = (
+  manifest: PetrinautOptimizationManifest,
+): DetachedObjectiveAuxiliaryMetric[] =>
+  constraintsInSpace(manifest.constraints ?? [], "state").map((constraint) => {
+    const artifact = compileStateConstraintIndicator(
+      constraint,
+      manifest.model.definition,
+    );
+    if (artifact === null) {
+      throw new Error(
+        `State constraint "${constraintLabel(constraint)}" cannot be compiled as a metric`,
+      );
+    }
+    return {
+      id: constraint.id,
+      label: constraintLabel(constraint),
+      artifact,
+      aggregateTime: "min",
+    };
+  });
+
+/**
+ * Per-constraint `runsPassed` over `runsTotal` from the batch's run axis. A
+ * run whose value is missing counts as failed. Empty when the batch reports
+ * no run axis: nothing was observed per run.
+ */
+export const stateConstraintResults = (
+  manifest: PetrinautOptimizationManifest,
+  runResults: DetachedObjectiveRunResult["runResults"],
+): PetrinautOptimizationTrialConstraints["state"] => {
+  if (runResults.size === 0) {
+    return [];
+  }
+  return constraintsInSpace(manifest.constraints ?? [], "state").map(
+    (constraint) => {
+      let runsPassed = 0;
+      for (const values of runResults.values()) {
+        const value = getOwn(values, constraint.id);
+        if (value !== undefined && value >= 0.5) {
+          runsPassed += 1;
+        }
+      }
+      return {
+        constraintId: constraint.id,
+        runsPassed,
+        runsTotal: runResults.size,
+      };
+    },
+  );
+};

--- a/libs/@hashintel/petrinaut/src/react/optimizations/channel/create-optimization-channel/trial-constraints.ts
+++ b/libs/@hashintel/petrinaut/src/react/optimizations/channel/create-optimization-channel/trial-constraints.ts
@@ -8,9 +8,9 @@ import {
   compileStateConstraintIndicator,
   constraintLabel,
   constraintsInSpace,
-  deriveDefaultParameterValues,
   evaluateParameterConstraints,
   getOwn,
+  type HirInterpretBindings,
   type ParameterConstraintResult,
 } from "@hashintel/petrinaut-core";
 
@@ -29,15 +29,22 @@ export type ParameterConstraintOutcome = {
   infeasible: string | null;
 };
 
+/** Whether the study declares a parameter constraint, so a trial has resolved net values to check. */
+export const hasParameterConstraints = (
+  manifest: Pick<PetrinautOptimizationManifest, "constraints">,
+): boolean =>
+  constraintsInSpace(manifest.constraints ?? [], "parameters").length > 0;
+
 /**
- * The parameter constraints' margins at the trial's values, with `parameters`
- * bound to the net's defaults and `scenario` to the trial's values (booleans
- * as 0/1). Null when the manifest has no parameter constraints. Throws
- * where interpretation would.
+ * The parameter constraints' margins at the trial's point, with `parameters`
+ * bound to the net parameter values the trial simulates with (the scenario's
+ * overrides applied at the trial's values) and `scenario` to the trial's
+ * values (booleans as 0/1). Null when the manifest has no parameter
+ * constraints. Throws where interpretation would.
  */
 export const parameterConstraintOutcome = (
   manifest: PetrinautOptimizationManifest,
-  scenarioParameterValues: Readonly<Record<string, number>>,
+  bindings: HirInterpretBindings,
 ): ParameterConstraintOutcome | null => {
   const constraints = constraintsInSpace(
     manifest.constraints ?? [],
@@ -46,25 +53,9 @@ export const parameterConstraintOutcome = (
   if (constraints.length === 0) {
     return null;
   }
-  const results = evaluateParameterConstraints(constraints, {
-    parameters: deriveDefaultParameterValues(
-      manifest.model.definition.parameters,
-    ),
-    scenario: scenarioParameterValues,
-  });
+  const results = evaluateParameterConstraints(constraints, bindings);
   const broken = results.find((result) => result.margin < 0);
   return { results, infeasible: broken?.constraintId ?? null };
-};
-
-/** The name a report gives constraint `constraintId`, or the id when the manifest does not know it. */
-export const constraintNameIn = (
-  manifest: Pick<PetrinautOptimizationManifest, "constraints">,
-  constraintId: string,
-): string => {
-  const constraint = manifest.constraints?.find(
-    (candidate) => candidate.id === constraintId,
-  );
-  return constraint ? constraintLabel(constraint) : constraintId;
 };
 
 /**

--- a/libs/@hashintel/petrinaut/src/react/optimizations/channel/create-optimization-channel/trial-outcome.ts
+++ b/libs/@hashintel/petrinaut/src/react/optimizations/channel/create-optimization-channel/trial-outcome.ts
@@ -6,11 +6,19 @@ import type {
   DetachedObjectiveRunOutcome,
   DetachedObjectiveRunResult,
 } from "../../../experiments/context";
-import type { PetrinautOptimizationTrialOutcome } from "@hashintel/petrinaut-core/optimization";
+import type {
+  PetrinautOptimizationTrialConstraints,
+  PetrinautOptimizationTrialOutcome,
+} from "@hashintel/petrinaut-core/optimization";
 
 export const prunedTrialOutcome = (
   reason: string,
-): PetrinautOptimizationTrialOutcome => ({ kind: "pruned", reason });
+  constraints?: PetrinautOptimizationTrialConstraints,
+): PetrinautOptimizationTrialOutcome => ({
+  kind: "pruned",
+  reason,
+  ...(constraints ? { constraints } : {}),
+});
 
 /**
  * The mean of the per-run finals the CPU backend reports. Null when the
@@ -37,24 +45,35 @@ const runResultsMean = (
 /**
  * A settled trial batch as Optuna receives it. A batch that did not complete
  * prunes the trial with the batch's own reason. The objective is the mean of
- * the per-run objectives, as the optimizer service reports it; where the
- * backend reports no run axis it is the metric's last sampled frame, which
- * a distribution frame reduces to the mean of its bins.
+ * the per-run objectives over every run, whatever the constraints reported,
+ * as the optimizer service reports it; where the backend reports no run axis
+ * it is the metric's last sampled frame, which a distribution frame reduces
+ * to the mean of its bins. `constraintsOf` reads the batch's constraint
+ * results, which ride along on the outcome.
  */
 export const trialOutcome = (
   outcome: DetachedObjectiveRunOutcome,
   metricId: string,
+  constraintsOf?: (
+    result: DetachedObjectiveRunResult,
+  ) => PetrinautOptimizationTrialConstraints | undefined,
 ): PetrinautOptimizationTrialOutcome => {
   if (!outcome.ok) {
     return prunedTrialOutcome(outcome.reason);
   }
+  const constraints = constraintsOf?.(outcome);
   const objective =
     runResultsMean(outcome, metricId) ??
     sweepCellObjective(outcome.metricFrames, metricId);
   if (objective === null || !Number.isFinite(objective)) {
     return prunedTrialOutcome(
       `The objective metric "${metricId}" did not produce a finite value`,
+      constraints,
     );
   }
-  return { kind: "objective", objective };
+  return {
+    kind: "objective",
+    objective,
+    ...(constraints ? { constraints } : {}),
+  };
 };

--- a/libs/@hashintel/petrinaut/src/react/optimizations/constraint-rates.test.ts
+++ b/libs/@hashintel/petrinaut/src/react/optimizations/constraint-rates.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  bindingStepRate,
+  constraintAlpha,
+  formatRate,
+  passThresholdPercent,
+  stepConstraintRates,
+  stepVerdict,
+  studyConstraintRates,
+} from "./constraint-rates";
+
+import type {
+  PetrinautOptimizationTrialConstraints,
+  PetrinautOptimizationTrialEvent,
+} from "@hashintel/petrinaut-core/optimization";
+
+const trial = (
+  index: number,
+  constraints?: PetrinautOptimizationTrialConstraints,
+  state: PetrinautOptimizationTrialEvent["state"] = "complete",
+): PetrinautOptimizationTrialEvent => ({
+  type: "trial",
+  trial: index,
+  parameters: {},
+  objective: state === "complete" ? 1 : null,
+  state,
+  best: null,
+  ...(constraints ? { constraints } : {}),
+});
+
+const queue = (runsPassed: number, runsTotal = 60) => ({
+  constraintId: "queue",
+  runsPassed,
+  runsTotal,
+});
+const stock = (runsPassed: number, runsTotal = 60) => ({
+  constraintId: "stock",
+  runsPassed,
+  runsTotal,
+});
+
+describe("constraintAlpha", () => {
+  it("defaults to 0.05 and reads the manifest's policy otherwise", () => {
+    expect(constraintAlpha({})).toBe(0.05);
+    expect(constraintAlpha({ constraintPolicy: { alpha: 0.2 } })).toBe(0.2);
+    expect(passThresholdPercent(0.05)).toBe(95);
+    expect(passThresholdPercent(0.2)).toBe(80);
+  });
+});
+
+describe("stepConstraintRates and stepVerdict", () => {
+  it("passes a constraint at or above 1 - alpha of its runs, exactly at the threshold included", () => {
+    const rates = stepConstraintRates(
+      trial(0, { parameters: [], state: [queue(57), stock(56)] }),
+      0.05,
+    );
+    expect(rates).toEqual([
+      { constraintId: "queue", runsPassed: 57, runsTotal: 60, passed: true },
+      { constraintId: "stock", runsPassed: 56, runsTotal: 60, passed: false },
+    ]);
+  });
+
+  it("reads one word per step", () => {
+    expect(stepVerdict(trial(0), 0.05)).toBe("unconstrained");
+    expect(
+      stepVerdict(
+        trial(1, { parameters: [], state: [queue(60), stock(58)] }),
+        0.05,
+      ),
+    ).toBe("clear");
+    expect(
+      stepVerdict(trial(2, { parameters: [], state: [queue(52)] }), 0.05),
+    ).toBe("limited");
+    expect(
+      stepVerdict(
+        trial(
+          3,
+          {
+            parameters: [{ constraintId: "order", margin: -1 }],
+            state: [],
+            infeasible: "order",
+          },
+          "pruned",
+        ),
+        0.05,
+      ),
+    ).toBe("infeasible");
+    // Parameter constraints alone, all satisfied: the step is clear.
+    expect(
+      stepVerdict(
+        trial(4, {
+          parameters: [{ constraintId: "order", margin: 2 }],
+          state: [],
+        }),
+        0.05,
+      ),
+    ).toBe("clear");
+  });
+
+  it("names the binding constraint: the lowest pass rate in the step", () => {
+    expect(
+      bindingStepRate(
+        trial(0, { parameters: [], state: [queue(59), stock(52)] }),
+        0.05,
+      ),
+    ).toMatchObject({ constraintId: "stock", runsPassed: 52 });
+    expect(bindingStepRate(trial(1), 0.05)).toBeNull();
+    expect(
+      bindingStepRate(trial(2, { parameters: [], state: [] }), 0.05),
+    ).toBeNull();
+  });
+});
+
+describe("studyConstraintRates", () => {
+  it("counts clear steps over simulated ones, infeasible draws apart, and the same per constraint", () => {
+    const trials = [
+      trial(0, { parameters: [], state: [queue(60), stock(60)] }),
+      trial(1, { parameters: [], state: [queue(52), stock(60)] }),
+      trial(2, { parameters: [], state: [], infeasible: "order" }, "pruned"),
+      trial(3, { parameters: [], state: [queue(58), stock(50)] }),
+      // A batch that failed observed nothing per run and counts nowhere.
+      trial(4, { parameters: [], state: [] }, "pruned"),
+      trial(5, { parameters: [], state: [queue(60), stock(57)] }),
+    ];
+    expect(studyConstraintRates(trials, 0.05)).toEqual({
+      stepsClear: 2,
+      stepsSimulated: 4,
+      infeasibleDraws: 1,
+      perConstraint: [
+        { constraintId: "queue", stepsPassed: 3, stepsSimulated: 4 },
+        { constraintId: "stock", stepsPassed: 3, stepsSimulated: 4 },
+      ],
+    });
+  });
+
+  it("is empty for a study without constraints", () => {
+    expect(studyConstraintRates([trial(0), trial(1)], 0.05)).toEqual({
+      stepsClear: 0,
+      stepsSimulated: 0,
+      infeasibleDraws: 0,
+      perConstraint: [],
+    });
+  });
+
+  it("follows the alpha it is given", () => {
+    const trials = [trial(0, { parameters: [], state: [queue(52)] })];
+    expect(studyConstraintRates(trials, 0.05).stepsClear).toBe(0);
+    expect(studyConstraintRates(trials, 0.2).stepsClear).toBe(1);
+  });
+});
+
+describe("formatRate", () => {
+  it("prints the fraction with the percentage beside it", () => {
+    expect(formatRate(52, 60)).toBe("52 / 60 · 87%");
+    expect(formatRate(14, 20)).toBe("14 / 20 · 70%");
+    expect(formatRate(0, 0)).toBe("0 / 0");
+  });
+});

--- a/libs/@hashintel/petrinaut/src/react/optimizations/constraint-rates.test.ts
+++ b/libs/@hashintel/petrinaut/src/react/optimizations/constraint-rates.test.ts
@@ -3,12 +3,14 @@ import { describe, expect, it } from "vitest";
 import {
   bindingStepRate,
   constraintAlpha,
+  constraintNameIn,
   formatRate,
   passThresholdPercent,
   stepConstraintRates,
   stepVerdict,
   studyConstraintRates,
 } from "./constraint-rates";
+import { sirConstrainedOptimizationInput } from "./sir-optimization-input.fixtures";
 
 import type {
   PetrinautOptimizationTrialConstraints,
@@ -155,5 +157,16 @@ describe("formatRate", () => {
     expect(formatRate(52, 60)).toBe("52 / 60 · 87%");
     expect(formatRate(14, 20)).toBe("14 / 20 · 70%");
     expect(formatRate(0, 0)).toBe("0 / 0");
+  });
+});
+
+describe("constraintNameIn", () => {
+  it("prefers the authored name and falls back to the id", () => {
+    expect(constraintNameIn(sirConstrainedOptimizationInput, "ratio-cap")).toBe(
+      "Ratio under a tenth",
+    );
+    expect(constraintNameIn(sirConstrainedOptimizationInput, "other")).toBe(
+      "other",
+    );
   });
 });

--- a/libs/@hashintel/petrinaut/src/react/optimizations/constraint-rates.ts
+++ b/libs/@hashintel/petrinaut/src/react/optimizations/constraint-rates.ts
@@ -1,0 +1,167 @@
+/**
+ * Constraint verdicts read off a study's trial events, derived per render and
+ * never stored: a run passes or fails a constraint, a constraint has a pass
+ * rate within a step, a step is clear, limited or infeasible, and across the
+ * study some share of the steps are clear. One word per level, and every
+ * percentage printed beside the fraction it came from.
+ */
+import { DEFAULT_OPTIMIZATION_CONSTRAINT_ALPHA } from "@hashintel/petrinaut-core/optimization";
+
+import type {
+  PetrinautOptimizationManifest,
+  PetrinautOptimizationTrialEvent,
+} from "@hashintel/petrinaut-core/optimization";
+
+/** The study's pass threshold: a step passes a state constraint when at least `1 - alpha` of its runs held. */
+export const constraintAlpha = (
+  manifest: Pick<PetrinautOptimizationManifest, "constraintPolicy">,
+): number =>
+  manifest.constraintPolicy?.alpha ?? DEFAULT_OPTIMIZATION_CONSTRAINT_ALPHA;
+
+/** The threshold in percent, as the settings show it: 95 for alpha 0.05. */
+export const passThresholdPercent = (alpha: number): number =>
+  Math.round((1 - alpha) * 1000) / 10;
+
+/** Per-run verdicts within one step: passed over total, and the step's verdict against alpha. */
+export type StepConstraintRate = {
+  constraintId: string;
+  runsPassed: number;
+  runsTotal: number;
+  passed: boolean;
+};
+
+export type StepVerdict = "clear" | "limited" | "infeasible" | "unconstrained";
+
+// A hair of slack so 57 / 60 against alpha 0.05 reads as exactly 95%.
+const RATE_TOLERANCE = 1e-9;
+
+const meetsThreshold = (
+  runsPassed: number,
+  runsTotal: number,
+  alpha: number,
+): boolean =>
+  runsTotal > 0 && runsPassed / runsTotal + RATE_TOLERANCE >= 1 - alpha;
+
+export const stepConstraintRates = (
+  trial: Pick<PetrinautOptimizationTrialEvent, "constraints">,
+  alpha: number,
+): StepConstraintRate[] =>
+  (trial.constraints?.state ?? []).map((result) => ({
+    constraintId: result.constraintId,
+    runsPassed: result.runsPassed,
+    runsTotal: result.runsTotal,
+    passed: meetsThreshold(result.runsPassed, result.runsTotal, alpha),
+  }));
+
+/**
+ * The step's one-word verdict: `infeasible` when its draw broke a parameter
+ * constraint, `limited` when a state constraint fell under the threshold,
+ * `clear` otherwise, and `unconstrained` for a step that reported nothing.
+ */
+export const stepVerdict = (
+  trial: Pick<PetrinautOptimizationTrialEvent, "constraints">,
+  alpha: number,
+): StepVerdict => {
+  if (!trial.constraints) {
+    return "unconstrained";
+  }
+  if (trial.constraints.infeasible !== undefined) {
+    return "infeasible";
+  }
+  return stepConstraintRates(trial, alpha).every((rate) => rate.passed)
+    ? "clear"
+    : "limited";
+};
+
+/**
+ * The step's lowest pass rate among its state constraints: the binding one,
+ * which the steps table prints. Null when the step observed none.
+ */
+export const bindingStepRate = (
+  trial: Pick<PetrinautOptimizationTrialEvent, "constraints">,
+  alpha: number,
+): StepConstraintRate | null => {
+  let binding: StepConstraintRate | null = null;
+  for (const rate of stepConstraintRates(trial, alpha)) {
+    if (
+      binding === null ||
+      rate.runsPassed / rate.runsTotal < binding.runsPassed / binding.runsTotal
+    ) {
+      binding = rate;
+    }
+  }
+  return binding;
+};
+
+/** Across the study: steps whose every state constraint passed, over steps that simulated; plus the same per constraint. */
+export type StudyConstraintRates = {
+  stepsClear: number;
+  stepsSimulated: number;
+  infeasibleDraws: number;
+  perConstraint: {
+    constraintId: string;
+    stepsPassed: number;
+    stepsSimulated: number;
+  }[];
+};
+
+/**
+ * Derived from the trials alone, so it survives a resume and never drifts
+ * from what the table shows. A step simulated when its draw was feasible and
+ * its batch completed; a pruned batch observed nothing and counts nowhere.
+ */
+export const studyConstraintRates = (
+  trials: readonly PetrinautOptimizationTrialEvent[],
+  alpha: number,
+): StudyConstraintRates => {
+  const perConstraint = new Map<
+    string,
+    { stepsPassed: number; stepsSimulated: number }
+  >();
+  let stepsClear = 0;
+  let stepsSimulated = 0;
+  let infeasibleDraws = 0;
+  for (const trial of trials) {
+    const verdict = stepVerdict(trial, alpha);
+    if (verdict === "unconstrained") {
+      continue;
+    }
+    if (verdict === "infeasible") {
+      infeasibleDraws += 1;
+      continue;
+    }
+    if (trial.state !== "complete") {
+      continue;
+    }
+    stepsSimulated += 1;
+    if (verdict === "clear") {
+      stepsClear += 1;
+    }
+    for (const rate of stepConstraintRates(trial, alpha)) {
+      const entry = perConstraint.get(rate.constraintId) ?? {
+        stepsPassed: 0,
+        stepsSimulated: 0,
+      };
+      entry.stepsSimulated += 1;
+      if (rate.passed) {
+        entry.stepsPassed += 1;
+      }
+      perConstraint.set(rate.constraintId, entry);
+    }
+  }
+  return {
+    stepsClear,
+    stepsSimulated,
+    infeasibleDraws,
+    perConstraint: [...perConstraint].map(([constraintId, entry]) => ({
+      constraintId,
+      ...entry,
+    })),
+  };
+};
+
+/** "52 / 60 · 87%": the fraction first, the percentage beside it; no percentage over nothing. */
+export const formatRate = (passed: number, total: number): string =>
+  total > 0
+    ? `${passed} / ${total} · ${Math.round((passed / total) * 100)}%`
+    : `${passed} / ${total}`;

--- a/libs/@hashintel/petrinaut/src/react/optimizations/constraint-rates.ts
+++ b/libs/@hashintel/petrinaut/src/react/optimizations/constraint-rates.ts
@@ -5,6 +5,7 @@
  * study some share of the steps are clear. One word per level, and every
  * percentage printed beside the fraction it came from.
  */
+import { constraintLabel } from "@hashintel/petrinaut-core";
 import { DEFAULT_OPTIMIZATION_CONSTRAINT_ALPHA } from "@hashintel/petrinaut-core/optimization";
 
 import type {
@@ -17,6 +18,17 @@ export const constraintAlpha = (
   manifest: Pick<PetrinautOptimizationManifest, "constraintPolicy">,
 ): number =>
   manifest.constraintPolicy?.alpha ?? DEFAULT_OPTIMIZATION_CONSTRAINT_ALPHA;
+
+/** The name a report gives constraint `constraintId`, or the id when the manifest does not know it. */
+export const constraintNameIn = (
+  manifest: Pick<PetrinautOptimizationManifest, "constraints">,
+  constraintId: string,
+): string => {
+  const constraint = manifest.constraints?.find(
+    (candidate) => candidate.id === constraintId,
+  );
+  return constraint ? constraintLabel(constraint) : constraintId;
+};
 
 /** The threshold in percent, as the settings show it: 95 for alpha 0.05. */
 export const passThresholdPercent = (alpha: number): number =>

--- a/libs/@hashintel/petrinaut/src/react/optimizations/provider.tsx
+++ b/libs/@hashintel/petrinaut/src/react/optimizations/provider.tsx
@@ -339,6 +339,8 @@ const connectOptimizationSource = (
   const channel = createOptimizationChannel({
     runDetachedObjective: (request) =>
       experimentsActions.current.runDetachedObjective(request),
+    resolveDetachedObjectiveParameters: (request) =>
+      experimentsActions.current.resolveDetachedObjectiveParameters(request),
     resolveStudy,
   });
   const capability = source.connect(channel);

--- a/libs/@hashintel/petrinaut/src/react/optimizations/provider/connected-study.ts
+++ b/libs/@hashintel/petrinaut/src/react/optimizations/provider/connected-study.ts
@@ -32,6 +32,7 @@ import type {
 } from "../context";
 import type { OptimizationSurfaceAxis } from "../surface-grid";
 import type {
+  MonteCarloUserDefinedMetricFrame,
   PetrinautOptimizationInput,
   PetrinautOptimizationTrialEvent,
 } from "@hashintel/petrinaut-core";
@@ -149,6 +150,12 @@ export const createConnectedStudy = ({
       `The study has no metric "${input.objective.metricId}" to optimize`,
     );
   }
+  // A trial's batch also runs the study's state constraints as metrics; the
+  // selection stream describes the objective alone.
+  const objectiveFrames = (
+    frames: readonly MonteCarloUserDefinedMetricFrame[],
+  ): readonly MonteCarloUserDefinedMetricFrame[] =>
+    frames.filter((frame) => frame.metricId === metric.id);
 
   let navigation: OptimizationNavigation = {
     positions: Object.fromEntries(
@@ -304,7 +311,7 @@ export const createConnectedStudy = ({
     const mirror = () => {
       selection = {
         key,
-        metricFrames: run.frames.get(),
+        metricFrames: objectiveFrames(run.frames.get()),
         runsCompleted: run.progress.get()?.completedRuns ?? 0,
         runTarget: null,
         computing: true,
@@ -412,7 +419,7 @@ export const createConnectedStudy = ({
       selection = outcome.ok
         ? {
             key: `trial:${trial}`,
-            metricFrames: outcome.metricFrames,
+            metricFrames: objectiveFrames(outcome.metricFrames),
             runsCompleted: outcome.runsCompleted,
             runTarget: null,
             computing: false,

--- a/libs/@hashintel/petrinaut/src/react/optimizations/sir-optimization-input.fixtures.ts
+++ b/libs/@hashintel/petrinaut/src/react/optimizations/sir-optimization-input.fixtures.ts
@@ -1,5 +1,10 @@
-import { petrinautOptimizationInputSchema } from "@hashintel/petrinaut-core";
+import {
+  type Constraint,
+  type ConstraintSource,
+  petrinautOptimizationInputSchema,
+} from "@hashintel/petrinaut-core";
 import { sirModel } from "@hashintel/petrinaut-core/examples";
+import { lowerConstraint } from "@hashintel/petrinaut-core/hir";
 
 const scenario = sirModel.petriNetDefinition.scenarios?.find(
   (candidate) => candidate.id === "scenario__seasonal_flu",
@@ -49,3 +54,38 @@ export const sirOptimizationInput = petrinautOptimizationInputSchema.parse({
   execution: { seed: 1, dt: 1, maxTime: 180 },
   study: { trials: 2, sampler: "tpe" },
 });
+
+const lowerSirConstraint = (source: ConstraintSource): Constraint => {
+  const lowered = lowerConstraint(source, {
+    netParameters: sirModel.petriNetDefinition.parameters,
+    scenarioParameters: scenario.scenarioParameters,
+    sdcpn: sirModel.petriNetDefinition,
+  });
+  if (!lowered.ok) {
+    throw new Error(lowered.diagnostics[0]?.message ?? "constraint");
+  }
+  return lowered.constraint;
+};
+
+/** One parameter constraint and one state constraint over the SIR study. */
+export const sirOptimizationConstraints: Constraint[] = [
+  lowerSirConstraint({
+    space: "parameters",
+    id: "ratio-cap",
+    name: "Ratio under a tenth",
+    code: "scenario.infected_ratio <= 0.1",
+  }),
+  lowerSirConstraint({
+    space: "state",
+    id: "infected-cap",
+    name: "Infected under 900",
+    code: "return state.places.Infected.count <= 900;",
+  }),
+];
+
+/** The SIR study with both constraints declared and the default policy. */
+export const sirConstrainedOptimizationInput =
+  petrinautOptimizationInputSchema.parse({
+    ...sirOptimizationInput,
+    constraints: sirOptimizationConstraints,
+  });

--- a/libs/@hashintel/petrinaut/src/react/optimizations/sir-optimization-input.fixtures.ts
+++ b/libs/@hashintel/petrinaut/src/react/optimizations/sir-optimization-input.fixtures.ts
@@ -2,6 +2,7 @@ import {
   type Constraint,
   type ConstraintSource,
   petrinautOptimizationInputSchema,
+  type Scenario,
 } from "@hashintel/petrinaut-core";
 import { sirModel } from "@hashintel/petrinaut-core/examples";
 import { lowerConstraint } from "@hashintel/petrinaut-core/hir";
@@ -88,4 +89,39 @@ export const sirConstrainedOptimizationInput =
   petrinautOptimizationInputSchema.parse({
     ...sirOptimizationInput,
     constraints: sirOptimizationConstraints,
+  });
+
+/** The seasonal flu scenario with the net's infection rate rebound to twenty times the infected ratio. */
+export const sirOverridingOptimizationScenario: Scenario = {
+  ...scenario,
+  parameterOverrides: {
+    ...scenario.parameterOverrides,
+    param__infection_rate: "scenario.infected_ratio * 20",
+  },
+};
+
+/**
+ * The SIR study on the overriding scenario with one constraint over the net
+ * parameter: `parameters.infection_rate <= 2` holds at an infected ratio of
+ * 0.05 (rate 1) and breaks at 0.15 (rate 3), while the net's default of 3
+ * would break it at every draw.
+ */
+export const sirNetConstrainedOptimizationInput =
+  petrinautOptimizationInputSchema.parse({
+    ...sirOptimizationInput,
+    model: {
+      ...sirOptimizationInput.model,
+      definition: {
+        ...sirOptimizationInput.model.definition,
+        scenarios: [sirOverridingOptimizationScenario],
+      },
+    },
+    constraints: [
+      lowerSirConstraint({
+        space: "parameters",
+        id: "rate-cap",
+        name: "Infection rate under two",
+        code: "parameters.infection_rate <= 2",
+      }),
+    ],
   });

--- a/libs/@hashintel/petrinaut/src/react/optimizations/sir-optimization-input.fixtures.ts
+++ b/libs/@hashintel/petrinaut/src/react/optimizations/sir-optimization-input.fixtures.ts
@@ -56,10 +56,13 @@ export const sirOptimizationInput = petrinautOptimizationInputSchema.parse({
   study: { trials: 2, sampler: "tpe" },
 });
 
-const lowerSirConstraint = (source: ConstraintSource): Constraint => {
+const lowerSirConstraint = (
+  source: ConstraintSource,
+  overScenario: Scenario = scenario,
+): Constraint => {
   const lowered = lowerConstraint(source, {
     netParameters: sirModel.petriNetDefinition.parameters,
-    scenarioParameters: scenario.scenarioParameters,
+    scenarioParameters: overScenario.scenarioParameters,
     sdcpn: sirModel.petriNetDefinition,
   });
   if (!lowered.ok) {
@@ -123,5 +126,49 @@ export const sirNetConstrainedOptimizationInput =
         name: "Infection rate under two",
         code: "parameters.infection_rate <= 2",
       }),
+    ],
+  });
+
+/** The seasonal flu scenario with an `isolation` switch beside its numeric parameters. */
+export const sirSwitchedOptimizationScenario: Scenario = {
+  ...scenario,
+  scenarioParameters: [
+    ...scenario.scenarioParameters,
+    { type: "boolean", identifier: "isolation", default: 0 },
+  ],
+};
+
+/**
+ * The SIR study on the switched scenario, optimizing the switch under one
+ * constraint that requires it on: `scenario.isolation == true` holds for a
+ * true draw and breaks for a false one.
+ */
+export const sirSwitchConstrainedOptimizationInput =
+  petrinautOptimizationInputSchema.parse({
+    ...sirOptimizationInput,
+    model: {
+      ...sirOptimizationInput.model,
+      definition: {
+        ...sirOptimizationInput.model.definition,
+        scenarios: [sirSwitchedOptimizationScenario],
+      },
+    },
+    scenario: {
+      ...sirOptimizationInput.scenario,
+      parameterBindings: {
+        ...sirOptimizationInput.scenario.parameterBindings,
+        isolation: { kind: "optimize", domain: { kind: "boolean" } },
+      },
+    },
+    constraints: [
+      lowerSirConstraint(
+        {
+          space: "parameters",
+          id: "isolation-on",
+          name: "Isolation on",
+          code: "scenario.isolation == true",
+        },
+        sirSwitchedOptimizationScenario,
+      ),
     ],
   });

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/create-experiment-drawer.test.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/create-experiment-drawer.test.tsx
@@ -186,6 +186,7 @@ const TestProviders = ({
               }),
               cancel: () => {},
             }),
+            resolveDetachedObjectiveParameters: () => Promise.resolve({}),
           }}
         >
           <SDCPNContext value={sdcpnContextValue}>

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/experiments-story-fixtures.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/experiments-story-fixtures.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import {
   createReadableStore,
   DEFAULT_PETRINAUT_EXTENSIONS,
+  deriveDefaultParameterValues,
 } from "@hashintel/petrinaut-core";
 import { sirModel } from "@hashintel/petrinaut-core/examples";
 
@@ -696,6 +697,10 @@ export function FakeExperimentsProvider({
       });
     },
     runDetachedObjective: fakeRunDetachedObjective,
+    resolveDetachedObjectiveParameters: (request) =>
+      Promise.resolve(
+        deriveDefaultParameterValues(request.definition.parameters),
+      ),
     ...overrides,
   }));
 

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/create-optimization-drawer.test.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/create-optimization-drawer.test.tsx
@@ -790,6 +790,45 @@ describe("CreateOptimizationDrawer", () => {
       code: "scenario.infected_ratio < 0.9",
       hir: { surface: "scenario-expression" },
     });
+    // The default threshold is the schema's default: no policy is written.
+    expect(submittedInput.constraintPolicy).toBeUndefined();
+  });
+
+  it("writes a changed pass threshold to the manifest as alpha", async () => {
+    const languageClient = makeSuccessfulLanguageClient();
+    const createOptimization = vi.fn(
+      async (_input: PetrinautOptimizationInput) => "optimization-threshold",
+    );
+    const savedMetric = sirSdcpnContextValue.petriNetDefinition.metrics?.[0];
+    openConfiguration({ createOptimization, languageClient });
+
+    fireEvent.change(
+      screen.getByRole("combobox", { name: "Select a metric" }),
+      {
+        target: { value: `${MODEL_METRIC_VALUE_PREFIX}${savedMetric!.id}` },
+      },
+    );
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: "Optimize infected_ratio" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Maximize" }));
+    // The threshold field appears with the first constraint row.
+    expect(screen.queryByLabelText("Pass threshold (percent)")).toBeNull();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Add parameter constraint" }),
+    );
+    fireEvent.change(screen.getByRole("textbox", { name: "Metric code" }), {
+      target: { value: "scenario.infected_ratio < 0.9" },
+    });
+    fireEvent.change(screen.getByLabelText("Pass threshold (percent)"), {
+      target: { value: "90" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Run/ }));
+    await waitFor(() => expect(createOptimization).toHaveBeenCalledOnce());
+    expect(createOptimization.mock.calls[0]![0].constraintPolicy).toEqual({
+      alpha: 0.1,
+    });
   });
 
   it("runs one language session per constraint row, keyed by the row", () => {

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/create-optimization-drawer.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/create-optimization-drawer.tsx
@@ -81,6 +81,7 @@ import type {
   AdHocSynthesisError,
   Constraint,
   Metric,
+  PetrinautOptimizationConstraintPolicy,
   PetrinautOptimizationInput,
   PetrinautOptimizationParameterBinding,
   Scenario,
@@ -203,6 +204,16 @@ const directionOptions = [
 
 const OPTIMIZATION_SAMPLER = "tpe" as const;
 const DEFAULT_SEEDS_PER_TRIAL = 1;
+/** The pass threshold in percent, the complement of the default alpha 0.05. */
+const DEFAULT_PASS_THRESHOLD_PERCENT = 95;
+
+/** The manifest's constraint policy for a pass threshold in percent; none at the default. */
+export const constraintPolicyFor = (
+  passThresholdPercent: number,
+): PetrinautOptimizationConstraintPolicy | undefined =>
+  passThresholdPercent === DEFAULT_PASS_THRESHOLD_PERCENT
+    ? undefined
+    : { alpha: Math.round((100 - passThresholdPercent) * 1000) / 100_000 };
 const DEFAULT_PARALLELISM = 1;
 const AD_HOC_SCENARIO_VALUE = "__adhoc__";
 const AD_HOC_SCENARIO_LABEL = "No scenario";
@@ -531,6 +542,7 @@ export function buildPetrinautOptimizationInput({
   dt,
   maxTime,
   constraints,
+  constraintPolicy,
 }: {
   name: string;
   title: string;
@@ -545,6 +557,7 @@ export function buildPetrinautOptimizationInput({
   dt: number;
   maxTime: number;
   constraints?: Constraint[];
+  constraintPolicy?: PetrinautOptimizationConstraintPolicy;
 }): PetrinautOptimizationInput {
   // Keyed by scenario parameter identifiers from the net definition: no
   // prototype.
@@ -605,6 +618,7 @@ export function buildPetrinautOptimizationInput({
     scenario: { id: scenario.id, parameterBindings },
     objective: { metricId: metric.id, direction },
     ...(constraints ? { constraints } : {}),
+    ...(constraints && constraintPolicy ? { constraintPolicy } : {}),
     execution: { seed, dt, maxTime, seedsPerTrial },
     study: { trials: optimizationSteps, sampler: OPTIMIZATION_SAMPLER },
   });
@@ -630,6 +644,7 @@ export function buildAdHocPetrinautOptimizationInput({
   dt,
   maxTime,
   constraints,
+  constraintPolicy,
 }: {
   name: string;
   title: string;
@@ -644,6 +659,7 @@ export function buildAdHocPetrinautOptimizationInput({
   dt: number;
   maxTime: number;
   constraints?: Constraint[];
+  constraintPolicy?: PetrinautOptimizationConstraintPolicy;
 }): PetrinautOptimizationInput {
   return petrinautOptimizationInputSchema.parse({
     kind: "petrinaut-optimization",
@@ -660,6 +676,7 @@ export function buildAdHocPetrinautOptimizationInput({
     scenario: { id: scenario.id, parameterBindings },
     objective: { metricId: metric.id, direction },
     ...(constraints ? { constraints } : {}),
+    ...(constraints && constraintPolicy ? { constraintPolicy } : {}),
     execution: { seed, dt, maxTime, seedsPerTrial },
     study: { trials: optimizationSteps, sampler: OPTIMIZATION_SAMPLER },
   });
@@ -711,15 +728,19 @@ export const CreateOptimizationDrawer = ({
   const [maxTime, setMaxTime] = useState<number | null>(180);
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  // Boolean conditions embedded in the manifest as source + lowered HIR.
-  // Declarative for now: carried and readable (Python included), not
-  // enforced by the study.
+  // Boolean conditions embedded in the manifest as source + lowered HIR. The
+  // browser runtime checks parameter constraints before each step runs and
+  // observes state constraints on every run; results are reported, never
+  // enforced on the objective.
   const [parameterConstraintDrafts, setParameterConstraintDrafts] = useState<
     ConstraintDraft[]
   >([]);
   const [stateConstraintDrafts, setStateConstraintDrafts] = useState<
     ConstraintDraft[]
   >([]);
+  const [passThresholdPercent, setPassThresholdPercent] = useState<
+    number | null
+  >(DEFAULT_PASS_THRESHOLD_PERCENT);
 
   const isAdHoc =
     enableAdHocScenarios && selectedScenarioId === AD_HOC_SCENARIO_VALUE;
@@ -830,6 +851,7 @@ export const CreateOptimizationDrawer = ({
     setIsSubmitting(false);
     setParameterConstraintDrafts([]);
     setStateConstraintDrafts([]);
+    setPassThresholdPercent(DEFAULT_PASS_THRESHOLD_PERCENT);
   };
 
   const resetState = () => {
@@ -966,6 +988,9 @@ export const CreateOptimizationDrawer = ({
       }
       const manifestConstraints =
         constraints.length > 0 ? constraints : undefined;
+      const constraintPolicy = constraintPolicyFor(
+        passThresholdPercent ?? DEFAULT_PASS_THRESHOLD_PERCENT,
+      );
 
       const input = adHocBindings
         ? buildAdHocPetrinautOptimizationInput({
@@ -982,6 +1007,7 @@ export const CreateOptimizationDrawer = ({
             dt,
             maxTime,
             constraints: manifestConstraints,
+            constraintPolicy,
           })
         : buildPetrinautOptimizationInput({
             name,
@@ -997,6 +1023,7 @@ export const CreateOptimizationDrawer = ({
             dt,
             maxTime,
             constraints: manifestConstraints,
+            constraintPolicy,
           });
       await createOptimization(input, { computeBackend, parallelism });
       resetState();
@@ -1380,14 +1407,15 @@ export const CreateOptimizationDrawer = ({
 
               <Section
                 title="Constraints"
-                tooltip="Boolean conditions carried with the study. They are recorded in the manifest and readable by every consumer; nothing enforces them yet."
+                tooltip="Boolean conditions carried with the study. In the browser, a step whose parameters break a parameter constraint is pruned before it runs, and every run reports whether each state constraint held throughout. The results are reported; the objective counts every run."
                 collapsible
                 defaultOpen
               >
                 <span className={hintStyle}>
                   Parameter constraints are expressions over the study's
                   parameters (scenario.*, parameters.*), e.g. scenario.min_load
-                  &lt; scenario.max_load.
+                  &lt; scenario.max_load. A step that breaks one is skipped
+                  before it runs.
                 </span>
                 <ConstraintDraftList
                   space="parameters"
@@ -1398,7 +1426,8 @@ export const CreateOptimizationDrawer = ({
                 <span className={hintStyle}>
                   State constraints read the simulation state like a metric body
                   and must return a boolean, e.g. return
-                  state.places.Queue.count &lt;= 10;
+                  state.places.Queue.count &lt;= 10; A run passes when the
+                  condition holds at every sampled time.
                 </span>
                 <ConstraintDraftList
                   space="state"
@@ -1406,6 +1435,27 @@ export const CreateOptimizationDrawer = ({
                   onChange={setStateConstraintDrafts}
                   scenarioParameters={constraintScenarioParameters}
                 />
+                {parameterConstraintDrafts.length +
+                  stateConstraintDrafts.length >
+                0 ? (
+                  <Form.Row>
+                    <Form.Field
+                      label="Pass threshold"
+                      labelTooltip="A step passes a state constraint when at least this share of its runs held it; below, the step is reported as limited. One setting for every constraint, shown beside every rate as a raw fraction."
+                      size="sm"
+                    >
+                      <NumberInput
+                        size="sm"
+                        min={1}
+                        max={99.9}
+                        step="any"
+                        value={passThresholdPercent}
+                        onChange={setPassThresholdPercent}
+                        aria-label="Pass threshold (percent)"
+                      />
+                    </Form.Field>
+                  </Form.Row>
+                ) : null}
               </Section>
 
               <Section title="Objective" collapsible defaultOpen>

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/optimization-surface/surface-plot.test.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/optimization-surface/surface-plot.test.tsx
@@ -187,6 +187,28 @@ describe("trialSurfaceField", () => {
     );
   });
 
+  it("mutes an infeasible draw among rings as among dots", () => {
+    const infeasible: PetrinautOptimizationTrialEvent = {
+      ...trial(3, { production_rate: 400, selling_price: 20 }, null),
+      constraints: {
+        parameters: [{ constraintId: "rate-cap", margin: -50 }],
+        state: [],
+        infeasible: "rate-cap",
+      },
+    };
+    for (const mark of ["dot", "ring"] as const) {
+      const field = trialSurfaceField({
+        trials: [...trials, infeasible],
+        best,
+        xAxis,
+        yAxis,
+        mark,
+      });
+      expect(field.markers.at(-1)).toEqual({ x: 10, y: 0, kind: "muted" });
+      expect(field.values.has(contourSurfaceKey(10, 0))).toBe(false);
+    }
+  });
+
   it("skips a trial without a numeric value on a shown axis", () => {
     const field = trialSurfaceField({
       trials: [trial(0, { production_rate: 225 }, 4)],

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/optimization-surface/surface-plot.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/optimization-surface/surface-plot.tsx
@@ -84,7 +84,8 @@ export type TrialSurfaceMark = "ring" | "dot";
  * sample of the field and a mark — a ring over a field computed elsewhere, a
  * filled dot when the trials are the field's only samples — the best
  * emphasized. A trial without one — pruned or failed — is no sample; among
- * dots it is a muted ring, among rings it is absent.
+ * dots it is a muted ring, among rings it is absent. A trial whose draw broke
+ * a parameter constraint is a muted ring in both, wherever it lands.
  */
 export const trialSurfaceField = ({
   trials,
@@ -115,6 +116,10 @@ export const trialSurfaceField = ({
       yAxis,
       optimizationAxisPositionFor(yAxis, yValue),
     );
+    if (trial.constraints?.infeasible !== undefined) {
+      markers.push({ x, y, kind: "muted" });
+      continue;
+    }
     if (trial.objective === null) {
       if (mark === "dot") {
         markers.push({ x, y, kind: "muted" });

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/optimizations-story-fixtures.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/optimizations-story-fixtures.ts
@@ -559,13 +559,13 @@ const hirField = (id: number, target: HirExpr, field: string): HirExpr => ({
 });
 
 /** The rate cap the stories' parameter constraint imposes on `production_rate`. */
-export const FAKE_RATE_CAP = 350;
+export const FAKE_RATE_CAP = 320;
 /** The runs each step of the constrained study runs; the state rates are fractions of it. */
 export const FAKE_CONSTRAINED_RUNS = 60;
 
 /**
  * The stories' two constraints, hand-lowered so the fixtures need no
- * TypeScript compiler: `scenario.production_rate <= 350` over the parameter
+ * TypeScript compiler: `scenario.production_rate <= 320` over the parameter
  * space, and `return state.places.FinishedGoods.count <= 500;` over the
  * state.
  */
@@ -573,7 +573,7 @@ export const fakeStudyConstraints: Constraint[] = [
   {
     space: "parameters",
     id: "rate-cap",
-    name: "Production rate under 350",
+    name: "Production rate under 320",
     code: `scenario.production_rate <= ${FAKE_RATE_CAP}`,
     hir: {
       hirVersion: 1,

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/optimizations-story-fixtures.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/optimizations-story-fixtures.ts
@@ -35,11 +35,13 @@ import type {
   OptimizationStatus,
 } from "../../../../../../react/optimizations/context";
 import type {
+  Constraint,
   MonteCarloUserDefinedMetricFrame,
   PetrinautOptimizationInput,
   PetrinautOptimizationParameterBinding,
   PetrinautOptimizationTrialEvent,
 } from "@hashintel/petrinaut-core";
+import type { HirExpr } from "@hashintel/petrinaut-core/hir";
 
 /**
  * A smooth profit-like surface over the supply-chain scenario's parameters:
@@ -539,6 +541,175 @@ export const fakeStudyInput = makeOptimizationInput(
 );
 export const fakeStudyTrials = makeTrials(fakeStudyInput, 30);
 
+const hirSpan = { start: 0, length: 0 };
+const hirNumber = (id: number, value: number): HirExpr => ({
+  kind: "numberLit",
+  id,
+  span: hirSpan,
+  value,
+  raw: String(value),
+});
+const hirField = (id: number, target: HirExpr, field: string): HirExpr => ({
+  kind: "fieldAccess",
+  id,
+  span: hirSpan,
+  target,
+  field,
+  fieldSpan: hirSpan,
+});
+
+/** The rate cap the stories' parameter constraint imposes on `production_rate`. */
+export const FAKE_RATE_CAP = 350;
+/** The runs each step of the constrained study runs; the state rates are fractions of it. */
+export const FAKE_CONSTRAINED_RUNS = 60;
+
+/**
+ * The stories' two constraints, hand-lowered so the fixtures need no
+ * TypeScript compiler: `scenario.production_rate <= 350` over the parameter
+ * space, and `return state.places.FinishedGoods.count <= 500;` over the
+ * state.
+ */
+export const fakeStudyConstraints: Constraint[] = [
+  {
+    space: "parameters",
+    id: "rate-cap",
+    name: "Production rate under 350",
+    code: `scenario.production_rate <= ${FAKE_RATE_CAP}`,
+    hir: {
+      hirVersion: 1,
+      surface: "scenario-expression",
+      params: [],
+      span: hirSpan,
+      body: {
+        kind: "binary",
+        id: 0,
+        span: hirSpan,
+        op: "<=",
+        left: {
+          kind: "scenarioRef",
+          id: 1,
+          span: hirSpan,
+          name: "production_rate",
+        },
+        right: hirNumber(2, FAKE_RATE_CAP),
+      },
+    },
+  },
+  {
+    space: "state",
+    id: "stock-cap",
+    name: "Finished goods under 500",
+    code: "return state.places.FinishedGoods.count <= 500;",
+    hir: {
+      hirVersion: 1,
+      surface: "metric",
+      params: [{ name: "state", span: hirSpan }],
+      span: hirSpan,
+      body: {
+        kind: "binary",
+        id: 0,
+        span: hirSpan,
+        op: "<=",
+        left: hirField(
+          1,
+          hirField(
+            2,
+            hirField(
+              3,
+              { kind: "localRef", id: 4, span: hirSpan, name: "state" },
+              "places",
+            ),
+            "FinishedGoods",
+          ),
+          "count",
+        ),
+        right: hirNumber(5, 500),
+      },
+    },
+  },
+];
+
+/** The shared study with both constraints declared and sixty runs per step. */
+export const fakeConstrainedStudyInput: PetrinautOptimizationInput =
+  petrinautOptimizationInputSchema.parse({
+    ...fakeStudyInput,
+    constraints: fakeStudyConstraints,
+    execution: {
+      ...fakeStudyInput.execution,
+      seedsPerTrial: FAKE_CONSTRAINED_RUNS,
+    },
+  });
+
+/**
+ * The shared trials with constraint results: a draw over the rate cap is
+ * pruned as infeasible before it runs, every third simulated step holds the
+ * stock cap on 50 of its 60 runs (limited at the default threshold), the
+ * rest on 58 or more. The running best skips the infeasible draws.
+ */
+export function makeConstrainedTrials(
+  input: PetrinautOptimizationInput,
+  count: number,
+): {
+  trials: PetrinautOptimizationTrialEvent[];
+  best: OptimizationBest | null;
+} {
+  const trials: PetrinautOptimizationTrialEvent[] = [];
+  let best: OptimizationBest | null = null;
+  for (const trial of makeTrials(input, count).trials) {
+    const rate = trial.parameters.production_rate;
+    const margin =
+      typeof rate === "number" ? FAKE_RATE_CAP - rate : FAKE_RATE_CAP;
+    const parameters = [{ constraintId: "rate-cap", margin }];
+    if (margin < 0) {
+      trials.push({
+        ...trial,
+        objective: null,
+        state: "pruned",
+        best,
+        constraints: { parameters, state: [], infeasible: "rate-cap" },
+      });
+      continue;
+    }
+    if (
+      trial.objective !== null &&
+      (best === null || trial.objective > best.objective)
+    ) {
+      best = {
+        trial: trial.trial,
+        parameters: trial.parameters,
+        objective: trial.objective,
+      };
+    }
+    const runsPassed =
+      trial.trial % 3 === 2
+        ? 50
+        : FAKE_CONSTRAINED_RUNS - (trial.trial % 2 === 0 ? 0 : 2);
+    trials.push({
+      ...trial,
+      best,
+      constraints: {
+        parameters,
+        state:
+          trial.state === "complete"
+            ? [
+                {
+                  constraintId: "stock-cap",
+                  runsPassed,
+                  runsTotal: FAKE_CONSTRAINED_RUNS,
+                },
+              ]
+            : [],
+      },
+    });
+  }
+  return { trials, best };
+}
+
+export const fakeConstrainedStudyTrials = makeConstrainedTrials(
+  fakeConstrainedStudyInput,
+  30,
+);
+
 /** The refinement ladder a navigated point climbs in the stories, one rung per 900 ms. */
 const REFINEMENT_LADDER = [8, 25, 100];
 
@@ -552,16 +723,19 @@ const REFINEMENT_LADDER = [8, 25, 100];
  */
 export function useFakeConnectedStudy({
   running,
+  constrained = false,
   fallbackReason = null,
   refinementError = null,
 }: {
   running: boolean;
+  /** Use the study with two constraints and constraint results on its trials. */
+  constrained?: boolean;
   fallbackReason?: string | null;
   /** Set to have every navigated point fail with this reason instead of refining. */
   refinementError?: string | null;
 }): { optimization: OptimizationRecord; value: OptimizationsContextValue } {
-  const input = fakeStudyInput;
-  const allTrials = fakeStudyTrials;
+  const input = constrained ? fakeConstrainedStudyInput : fakeStudyInput;
+  const allTrials = constrained ? fakeConstrainedStudyTrials : fakeStudyTrials;
   const clock = useFakeStudyClock({
     steps: running ? allTrials.trials.length : 0,
     ticksPerStep: 8,

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view.tsx
@@ -25,6 +25,7 @@ import {
   NavigatedOptimizationSurface,
   OptimizationSurface,
 } from "./optimization-surface";
+import { ConstraintSummaryCard } from "./study-view/constraint-summary";
 import {
   ContinueControl,
   remainingOptimizationSteps,
@@ -290,9 +291,10 @@ const RemoteStudyBody = ({
 
 /**
  * A study evaluated in this browser: the header and the summary, the
- * parameter controls with their state line, the three chart cards, and the
- * steps filling what is left. The navigation drives the surface and the
- * objective's timeline, following each step while the study runs.
+ * parameter controls with their state line, the three chart cards (a fourth,
+ * Constraints, when the study declares any), and the steps filling what is
+ * left. The navigation drives the surface and the objective's timeline,
+ * following each step while the study runs.
  */
 const ConnectedStudyBody = ({
   optimization,
@@ -345,6 +347,13 @@ const ConnectedStudyBody = ({
             optimization={optimization}
             plotHeight={OBJECTIVE_PLOT_HEIGHT}
           />
+          {(optimization.input.constraints ?? []).length > 0 ? (
+            <ConstraintSummaryCard
+              optimization={optimization}
+              selection={connected.selection}
+              plotHeight={OBJECTIVE_PLOT_HEIGHT}
+            />
+          ) : null}
         </div>
         <div className={connectedStepsStyle}>
           <StepsTable

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/constraint-summary.test.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/constraint-summary.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  fakeConstrainedStudyInput,
+  fakeConstrainedStudyTrials,
+} from "../optimizations-story-fixtures";
+import { describeStep } from "./constraint-summary";
+
+import type { PetrinautOptimizationTrialEvent } from "@hashintel/petrinaut-core";
+
+const optimization = { input: fakeConstrainedStudyInput };
+
+const trial = (
+  overrides: Partial<PetrinautOptimizationTrialEvent>,
+): PetrinautOptimizationTrialEvent => ({
+  ...fakeConstrainedStudyTrials.trials[0]!,
+  trial: 2,
+  state: "complete",
+  ...overrides,
+});
+
+describe("describeStep", () => {
+  it("gives a parameter-only complete step its verdict alone, with nothing to add", () => {
+    expect(
+      describeStep(
+        optimization,
+        trial({
+          constraints: {
+            parameters: [{ constraintId: "rate-cap", margin: 1 }],
+            state: [],
+          },
+        }),
+        0.05,
+      ),
+    ).toEqual({ verdict: "Step 3: clear", detail: "" });
+  });
+
+  it("appends the state a step that did not complete ended in", () => {
+    expect(
+      describeStep(
+        optimization,
+        trial({
+          state: "failed",
+          objective: null,
+          constraints: { parameters: [], state: [] },
+        }),
+        0.05,
+      ),
+    ).toEqual({ verdict: "Step 3: clear", detail: " · failed" });
+  });
+
+  it("names the binding constraint with its pass rate", () => {
+    expect(
+      describeStep(
+        optimization,
+        trial({
+          constraints: {
+            parameters: [],
+            state: [
+              { constraintId: "stock-cap", runsPassed: 51, runsTotal: 60 },
+            ],
+          },
+        }),
+        0.05,
+      ),
+    ).toEqual({
+      verdict: "Step 3: limited",
+      detail: " · 51 / 60 runs passed · 85% · Finished goods under 500",
+    });
+  });
+
+  it("names the constraint an infeasible draw broke", () => {
+    expect(
+      describeStep(
+        optimization,
+        trial({
+          state: "pruned",
+          objective: null,
+          constraints: {
+            parameters: [{ constraintId: "rate-cap", margin: -4 }],
+            state: [],
+            infeasible: "rate-cap",
+          },
+        }),
+        0.05,
+      ),
+    ).toEqual({
+      verdict: "Step 3: infeasible",
+      detail: " · Production rate under 320",
+    });
+  });
+});

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/constraint-summary.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/constraint-summary.tsx
@@ -11,6 +11,7 @@ import { constraintLabel } from "@hashintel/petrinaut-core";
 import {
   bindingStepRate,
   constraintAlpha,
+  constraintNameIn,
   formatRate,
   passThresholdPercent,
   type StepVerdict,
@@ -174,22 +175,16 @@ export const describeStep = (
   alpha: number,
 ): string => {
   const verdict = stepVerdict(trial, alpha);
-  const constraints = optimization.input.constraints ?? [];
-  const nameOf = (constraintId: string): string => {
-    const constraint = constraints.find(
-      (candidate) => candidate.id === constraintId,
-    );
-    return constraint ? constraintLabel(constraint) : constraintId;
-  };
+  const { input } = optimization;
   const head = `Step ${trial.trial + 1}: ${VERDICT_WORD[verdict]}`;
   if (verdict === "infeasible") {
-    return `${head} · ${nameOf(trial.constraints?.infeasible ?? "")}`;
+    return `${head} · ${constraintNameIn(input, trial.constraints?.infeasible ?? "")}`;
   }
   const binding = bindingStepRate(trial, alpha);
   if (binding === null) {
     return trial.state === "complete" ? head : `${head} · ${trial.state}`;
   }
-  return `${head} · ${formatRate(binding.runsPassed, binding.runsTotal).replace(" · ", " runs passed · ")} · ${nameOf(binding.constraintId)}`;
+  return `${head} · ${formatRate(binding.runsPassed, binding.runsTotal).replace(" · ", " runs passed · ")} · ${constraintNameIn(input, binding.constraintId)}`;
 };
 
 export const ConstraintSummaryCard = ({
@@ -291,12 +286,6 @@ export const ConstraintSummaryCard = ({
                 ? "constraint is"
                 : "constraints are"}{" "}
               checked before each step runs.
-            </span>
-          ) : null}
-          {input.study.sampler === "random" ? (
-            <span className={noteStyle}>
-              The random sampler ignores constraints; results are still
-              reported.
             </span>
           ) : null}
         </div>

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/constraint-summary.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/constraint-summary.tsx
@@ -1,0 +1,306 @@
+import { css } from "@hashintel/ds-helpers/css";
+/**
+ * The study's constraints in one card: how many steps are clear across the
+ * study as the headline, the latest step's own verdict beneath it, and one
+ * bar per constraint with its pass rate over the steps that simulated. Every
+ * percentage is printed beside the fraction it came from, and every row is
+ * reserved so the card never changes shape as steps land.
+ */
+import { constraintLabel } from "@hashintel/petrinaut-core";
+
+import {
+  bindingStepRate,
+  constraintAlpha,
+  formatRate,
+  passThresholdPercent,
+  type StepVerdict,
+  stepVerdict,
+  studyConstraintRates,
+} from "../../../../../../../react/optimizations/constraint-rates";
+import { followedTrial } from "../../../../../../../react/optimizations/context";
+import { ChartCard } from "../../shared/chart-card";
+
+import type {
+  ConnectedStudyState,
+  OptimizationRecord,
+} from "../../../../../../../react/optimizations/context";
+
+const bodyStyle = css({
+  display: "flex",
+  flexDirection: "column",
+  gap: "3",
+  height: "full",
+  minHeight: "[0]",
+  fontVariantNumeric: "tabular-nums",
+});
+
+const headlineStyle = css({
+  display: "flex",
+  flexDirection: "column",
+  gap: "[2px]",
+});
+
+const headlineValueStyle = css({
+  fontSize: "2xl",
+  fontWeight: "semibold",
+  color: "neutral.s120",
+  lineHeight: "[1.1]",
+});
+
+const headlineLabelStyle = css({
+  fontSize: "xs",
+  color: "neutral.s80",
+});
+
+// One line, always present, so the rows beneath never move as steps land.
+const stepLineStyle = css({
+  fontSize: "xs",
+  color: "neutral.s100",
+  minHeight: "[18px]",
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+});
+
+const verdictStyle = css({
+  fontWeight: "semibold",
+  "&[data-verdict='clear']": { color: "green.s100" },
+  "&[data-verdict='limited']": { color: "orange.s100" },
+  "&[data-verdict='infeasible']": { color: "neutral.s70" },
+});
+
+const breakdownStyle = css({
+  display: "flex",
+  flexDirection: "column",
+  gap: "2",
+  overflowY: "auto",
+  scrollbarWidth: "[thin]",
+  minHeight: "[0]",
+});
+
+const rowStyle = css({
+  display: "grid",
+  gridTemplateColumns: "minmax(0, 1fr) 7.5rem",
+  alignItems: "center",
+  columnGap: "3",
+  rowGap: "[3px]",
+});
+
+const rowNameStyle = css({
+  fontSize: "xs",
+  fontWeight: "medium",
+  color: "neutral.s110",
+  minWidth: "[0]",
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+});
+
+const rowRateStyle = css({
+  fontSize: "xs",
+  color: "neutral.s90",
+  textAlign: "right",
+  whiteSpace: "nowrap",
+});
+
+const barTrackStyle = css({
+  position: "relative",
+  gridColumn: "[1 / -1]",
+  height: "[6px]",
+  backgroundColor: "neutral.s30",
+  borderRadius: "full",
+  overflow: "hidden",
+});
+
+const barFillStyle = css({
+  height: "full",
+  borderRadius: "full",
+  backgroundColor: "green.s90",
+  transition: "[width 160ms ease-out]",
+  "&[data-below='true']": { backgroundColor: "orange.s80" },
+});
+
+// The dashed mark on every bar: a step counts as limited when the constraint
+// held on fewer than this share of its runs.
+const thresholdMarkStyle = css({
+  position: "absolute",
+  top: "[0]",
+  bottom: "[0]",
+  width: "[0]",
+  borderLeftWidth: "[1px]",
+  borderLeftStyle: "dashed",
+  borderLeftColor: "neutral.s100",
+});
+
+const noteStyle = css({
+  fontSize: "xs",
+  color: "neutral.s80",
+});
+
+const VERDICT_WORD: Record<StepVerdict, string> = {
+  clear: "clear",
+  limited: "limited",
+  infeasible: "infeasible",
+  unconstrained: "unconstrained",
+};
+
+/**
+ * The step the card describes beneath the headline: the followed step once
+ * its event landed, else the latest reported step. Null before any step.
+ */
+export const describedStep = (
+  trials: OptimizationRecord["trials"],
+  selection: ConnectedStudyState["selection"],
+): OptimizationRecord["trials"][number] | null => {
+  const followed = selection === null ? null : followedTrial(selection.key);
+  const followedEvent =
+    followed === null
+      ? undefined
+      : trials.find((trial) => trial.trial === followed);
+  if (followedEvent) {
+    return followedEvent;
+  }
+  return trials.reduce<OptimizationRecord["trials"][number] | null>(
+    (latest, trial) =>
+      latest === null || trial.trial > latest.trial ? trial : latest,
+    null,
+  );
+};
+
+/** "Step 12: limited · 51 / 60 runs passed · Queue under 10", or the infeasible draw's constraint. */
+export const describeStep = (
+  optimization: Pick<OptimizationRecord, "input">,
+  trial: OptimizationRecord["trials"][number],
+  alpha: number,
+): string => {
+  const verdict = stepVerdict(trial, alpha);
+  const constraints = optimization.input.constraints ?? [];
+  const nameOf = (constraintId: string): string => {
+    const constraint = constraints.find(
+      (candidate) => candidate.id === constraintId,
+    );
+    return constraint ? constraintLabel(constraint) : constraintId;
+  };
+  const head = `Step ${trial.trial + 1}: ${VERDICT_WORD[verdict]}`;
+  if (verdict === "infeasible") {
+    return `${head} · ${nameOf(trial.constraints?.infeasible ?? "")}`;
+  }
+  const binding = bindingStepRate(trial, alpha);
+  if (binding === null) {
+    return trial.state === "complete" ? head : `${head} · ${trial.state}`;
+  }
+  return `${head} · ${formatRate(binding.runsPassed, binding.runsTotal).replace(" · ", " runs passed · ")} · ${nameOf(binding.constraintId)}`;
+};
+
+export const ConstraintSummaryCard = ({
+  optimization,
+  selection,
+  plotHeight,
+}: {
+  optimization: OptimizationRecord;
+  selection: ConnectedStudyState["selection"];
+  /** The body's height in pixels; the card is exactly as tall as its neighbours. */
+  plotHeight: number;
+}) => {
+  const { input, trials } = optimization;
+  const alpha = constraintAlpha(input);
+  const threshold = passThresholdPercent(alpha);
+  const rates = studyConstraintRates(trials, alpha);
+  const constraints = input.constraints ?? [];
+  const stateConstraints = constraints.filter(
+    (constraint) => constraint.space === "state",
+  );
+  const step = describedStep(trials, selection);
+  const infeasibleNote =
+    rates.infeasibleDraws === 0
+      ? ""
+      : ` · ${rates.infeasibleDraws} infeasible ${rates.infeasibleDraws === 1 ? "draw" : "draws"}`;
+
+  return (
+    <ChartCard
+      title="Constraints"
+      subtitle={`pass threshold ${threshold}% (alpha ${alpha})${infeasibleNote}`}
+      help="A run passes a state constraint when the condition held on every sampled frame. A step is clear when every state constraint held on at least the threshold share of its runs, limited otherwise, and infeasible when its parameters broke a parameter constraint before anything ran. The objective counts every run whatever the verdicts; nothing is excluded."
+      bodyHeight={plotHeight}
+    >
+      <div className={bodyStyle} data-constraint-summary>
+        <div className={headlineStyle}>
+          <span className={headlineValueStyle}>
+            {formatRate(rates.stepsClear, rates.stepsSimulated)}
+          </span>
+          <span className={headlineLabelStyle}>
+            steps clear across the study
+          </span>
+        </div>
+        <span className={stepLineStyle}>
+          {step === null ? (
+            "No step reported yet"
+          ) : (
+            <>
+              <span
+                className={verdictStyle}
+                data-verdict={stepVerdict(step, alpha)}
+              >
+                {describeStep(optimization, step, alpha).split(" · ")[0]}
+              </span>
+              {describeStep(optimization, step, alpha).slice(
+                describeStep(optimization, step, alpha).indexOf(" · "),
+              )}
+            </>
+          )}
+        </span>
+        <div className={breakdownStyle}>
+          {stateConstraints.map((constraint) => {
+            const entry = rates.perConstraint.find(
+              (candidate) => candidate.constraintId === constraint.id,
+            );
+            const passed = entry?.stepsPassed ?? 0;
+            const simulated = entry?.stepsSimulated ?? 0;
+            const share = simulated === 0 ? 0 : passed / simulated;
+            return (
+              <div
+                key={constraint.id}
+                className={rowStyle}
+                data-constraint-row={constraint.id}
+              >
+                <span className={rowNameStyle}>
+                  {constraintLabel(constraint)}
+                </span>
+                <span className={rowRateStyle}>
+                  {formatRate(passed, simulated)} steps
+                </span>
+                <div className={barTrackStyle}>
+                  <div
+                    className={barFillStyle}
+                    data-below={simulated > 0 && share < 1 - alpha}
+                    style={{ width: `${share * 100}%` }}
+                  />
+                  <div
+                    className={thresholdMarkStyle}
+                    style={{ left: `${threshold}%` }}
+                    title={`Step counted as limited below ${threshold}% of runs`}
+                  />
+                </div>
+              </div>
+            );
+          })}
+          {constraints.length > stateConstraints.length ? (
+            <span className={noteStyle}>
+              {constraints.length - stateConstraints.length} parameter{" "}
+              {constraints.length - stateConstraints.length === 1
+                ? "constraint is"
+                : "constraints are"}{" "}
+              checked before each step runs.
+            </span>
+          ) : null}
+          {input.study.sampler === "random" ? (
+            <span className={noteStyle}>
+              The random sampler ignores constraints; results are still
+              reported.
+            </span>
+          ) : null}
+        </div>
+      </div>
+    </ChartCard>
+  );
+};

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/constraint-summary.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/constraint-summary.tsx
@@ -168,23 +168,40 @@ export const describedStep = (
   );
 };
 
+/** The step line in two parts: the verdict head the card colours, and the detail tail after it. */
+export type StepLine = {
+  /** "Step 12: limited" */
+  verdict: string;
+  /** " · 51 / 60 runs passed · Queue under 10", the infeasible draw's constraint, or "" when there is nothing to add. */
+  detail: string;
+};
+
 /** "Step 12: limited · 51 / 60 runs passed · Queue under 10", or the infeasible draw's constraint. */
 export const describeStep = (
   optimization: Pick<OptimizationRecord, "input">,
   trial: OptimizationRecord["trials"][number],
   alpha: number,
-): string => {
+): StepLine => {
   const verdict = stepVerdict(trial, alpha);
   const { input } = optimization;
   const head = `Step ${trial.trial + 1}: ${VERDICT_WORD[verdict]}`;
   if (verdict === "infeasible") {
-    return `${head} · ${constraintNameIn(input, trial.constraints?.infeasible ?? "")}`;
+    return {
+      verdict: head,
+      detail: ` · ${constraintNameIn(input, trial.constraints?.infeasible ?? "")}`,
+    };
   }
   const binding = bindingStepRate(trial, alpha);
   if (binding === null) {
-    return trial.state === "complete" ? head : `${head} · ${trial.state}`;
+    return {
+      verdict: head,
+      detail: trial.state === "complete" ? "" : ` · ${trial.state}`,
+    };
   }
-  return `${head} · ${formatRate(binding.runsPassed, binding.runsTotal).replace(" · ", " runs passed · ")} · ${constraintNameIn(input, binding.constraintId)}`;
+  return {
+    verdict: head,
+    detail: ` · ${formatRate(binding.runsPassed, binding.runsTotal).replace(" · ", " runs passed · ")} · ${constraintNameIn(input, binding.constraintId)}`,
+  };
 };
 
 export const ConstraintSummaryCard = ({
@@ -206,6 +223,7 @@ export const ConstraintSummaryCard = ({
     (constraint) => constraint.space === "state",
   );
   const step = describedStep(trials, selection);
+  const line = step === null ? null : describeStep(optimization, step, alpha);
   const infeasibleNote =
     rates.infeasibleDraws === 0
       ? ""
@@ -228,7 +246,7 @@ export const ConstraintSummaryCard = ({
           </span>
         </div>
         <span className={stepLineStyle}>
-          {step === null ? (
+          {step === null || line === null ? (
             "No step reported yet"
           ) : (
             <>
@@ -236,11 +254,9 @@ export const ConstraintSummaryCard = ({
                 className={verdictStyle}
                 data-verdict={stepVerdict(step, alpha)}
               >
-                {describeStep(optimization, step, alpha).split(" · ")[0]}
+                {line.verdict}
               </span>
-              {describeStep(optimization, step, alpha).slice(
-                describeStep(optimization, step, alpha).indexOf(" · "),
-              )}
+              {line.detail}
             </>
           )}
         </span>

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/objective-history-chart.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/objective-history-chart.tsx
@@ -20,8 +20,6 @@ import type { OptimizationRecord } from "../../../../../../../react/optimization
 
 const UPlot = uPlot;
 
-/** Optuna's grey for a step whose parameters broke a constraint. */
-export const INFEASIBLE_STEP_COLOR = "#cccccc";
 const STEP_COLOR = "#9ca3af";
 const BEST_COLOR = "#2563eb";
 
@@ -57,11 +55,9 @@ const tickFormat = new Intl.NumberFormat("en-US", {
 const chartOptions = ({
   width,
   height,
-  infeasibleColor,
 }: {
   width: number;
   height: number;
-  infeasibleColor: string;
 }): uPlot.Options => ({
   width,
   height,
@@ -133,30 +129,16 @@ const chartOptions = ({
       paths: UPlot.paths.stepped?.({ align: 1 }),
       points: { show: false },
     },
-    {
-      label: "infeasible step",
-      stroke: infeasibleColor,
-      paths: () => null,
-      points: {
-        show: true,
-        size: 6,
-        fill: infeasibleColor,
-        stroke: infeasibleColor,
-      },
-    },
   ],
 });
 
 export const ObjectiveHistoryChart = ({
   optimization,
   plotHeight,
-  infeasibleColor = INFEASIBLE_STEP_COLOR,
 }: {
   optimization: Pick<OptimizationRecord, "trials" | "input">;
   /** The plot's height in pixels; the component is exactly this tall. */
   plotHeight: number;
-  /** Colour for a step whose parameters broke a constraint. */
-  infeasibleColor?: string;
 }) => {
   const chartRootRef = useRef<HTMLDivElement>(null);
   const size = useElementSize(chartRootRef, { debounce: 50 });
@@ -174,8 +156,8 @@ export const ObjectiveHistoryChart = ({
       return;
     }
     const plot = new UPlot(
-      chartOptions({ width, height: plotHeight, infeasibleColor }),
-      [[], [], [], []] as uPlot.AlignedData,
+      chartOptions({ width, height: plotHeight }),
+      [[], [], []] as uPlot.AlignedData,
       root,
     );
     plotRef.current = plot;
@@ -183,7 +165,7 @@ export const ObjectiveHistoryChart = ({
       plotRef.current = null;
       plot.destroy();
     };
-  }, [infeasibleColor, plotHeight, width]);
+  }, [plotHeight, width]);
 
   // The data is applied in its own effect so a new step redraws the plot
   // without recreating it, and a freshly created plot picks it up too.
@@ -209,11 +191,9 @@ export const ObjectiveHistoryChart = ({
 export const ObjectiveHistoryCard = ({
   optimization,
   plotHeight,
-  infeasibleColor,
 }: {
   optimization: Pick<OptimizationRecord, "trials" | "input" | "best">;
   plotHeight: number;
-  infeasibleColor?: string;
 }) => {
   const { input } = optimization;
   const metric = input.model.definition.metrics?.find(
@@ -233,7 +213,6 @@ export const ObjectiveHistoryCard = ({
       <ObjectiveHistoryChart
         optimization={optimization}
         plotHeight={plotHeight}
-        infeasibleColor={infeasibleColor}
       />
     </ChartCard>
   );

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/objective-history-data.test.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/objective-history-data.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildObjectiveHistory,
   toObjectiveHistoryData,
+  trialFeasibility,
 } from "./objective-history-data";
 
 import type { PetrinautOptimizationTrialEvent } from "@hashintel/petrinaut-core";
@@ -104,6 +105,49 @@ describe("toObjectiveHistoryData", () => {
       [3, null, null],
       [3, 3, 3],
       [null, null, 5],
+    ]);
+  });
+});
+
+describe("trialFeasibility", () => {
+  it("reads infeasible off a pruned draw's constraints, feasible off a step that simulated, unknown without results", () => {
+    expect(trialFeasibility(trial(0, 3))).toBe("unknown");
+    expect(
+      trialFeasibility({
+        ...trial(1, null, "pruned"),
+        constraints: {
+          parameters: [{ constraintId: "order", margin: -1 }],
+          state: [],
+          infeasible: "order",
+        },
+      }),
+    ).toBe("infeasible");
+    // A limited step keeps its colour: nothing is excluded from the objective.
+    expect(
+      trialFeasibility({
+        ...trial(2, 5),
+        constraints: {
+          parameters: [],
+          state: [{ constraintId: "queue", runsPassed: 40, runsTotal: 60 }],
+        },
+      }),
+    ).toBe("feasible");
+  });
+
+  it("is what buildObjectiveHistory reads by default", () => {
+    const points = buildObjectiveHistory(
+      [
+        trial(0, 3),
+        {
+          ...trial(1, null, "pruned"),
+          constraints: { parameters: [], state: [], infeasible: "order" },
+        },
+      ],
+      "maximize",
+    );
+    expect(points.map((point) => point.feasibility)).toEqual([
+      "unknown",
+      "infeasible",
     ]);
   });
 });

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/objective-history-data.test.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/objective-history-data.test.ts
@@ -75,36 +75,16 @@ describe("buildObjectiveHistory", () => {
   });
 });
 
-describe("buildObjectiveHistory with feasibility", () => {
-  it("never lets an infeasible step become the best so far", () => {
-    const points = buildObjectiveHistory(
-      [trial(0, 3), trial(1, 9), trial(2, 5)],
-      "maximize",
-      (candidate) => (candidate.trial === 1 ? "infeasible" : "feasible"),
-    );
-    expect(points.map((point) => point.bestSoFar)).toEqual([3, 3, 5]);
-    expect(points.map((point) => point.feasibility)).toEqual([
-      "feasible",
-      "infeasible",
-      "feasible",
-    ]);
-    // The infeasible step keeps its own objective for the chart to draw.
-    expect(points[1]?.objective).toBe(9);
-  });
-});
-
 describe("toObjectiveHistoryData", () => {
-  it("aligns steps, objectives and the best so far, with infeasible steps in their own series", () => {
+  it("aligns steps, objectives and the best so far", () => {
     const points = buildObjectiveHistory(
       [trial(0, 3), trial(1, null, "pruned"), trial(2, 5)],
       "maximize",
-      (candidate) => (candidate.trial === 2 ? "infeasible" : "unknown"),
     );
     expect(toObjectiveHistoryData(points)).toEqual([
       [1, 2, 3],
-      [3, null, null],
-      [3, 3, 3],
-      [null, null, 5],
+      [3, null, 5],
+      [3, 3, 5],
     ]);
   });
 });

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/objective-history-data.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/objective-history-data.ts
@@ -14,8 +14,7 @@ export type ObjectiveDirection =
 
 /**
  * Whether the step's parameters satisfied the study's constraints. `unknown`
- * for a trial event carrying no constraint results; the chart draws an
- * infeasible step in its muted colour.
+ * for a trial event carrying no constraint results.
  */
 export type ObjectiveFeasibility = "feasible" | "infeasible" | "unknown";
 
@@ -51,24 +50,20 @@ const isBetter = (
 ): boolean => (direction === "maximize" ? candidate > best : candidate < best);
 
 /**
- * `feasibilityOf` reads a trial's constraint verdict, `trialFeasibility` by
- * default. An infeasible step never becomes the best so far, the way
- * Optuna's history substitutes infinity for it before accumulating, so the
- * word "best" never sits on a configuration that broke a constraint.
+ * An infeasible step never becomes the best so far, the way Optuna's history
+ * substitutes infinity for it before accumulating, so the word "best" never
+ * sits on a configuration that broke a constraint.
  */
 export const buildObjectiveHistory = (
   trials: readonly PetrinautOptimizationTrialEvent[],
   direction: ObjectiveDirection,
-  feasibilityOf: (
-    trial: PetrinautOptimizationTrialEvent,
-  ) => ObjectiveFeasibility = trialFeasibility,
 ): ObjectiveHistoryPoint[] => {
   // Parallel steps report out of order; the history reads in step order.
   const ordered = trials.toSorted((left, right) => left.trial - right.trial);
   let best: number | null = null;
   return ordered.map((trial) => {
     const objective = trial.state === "complete" ? trial.objective : null;
-    const feasibility = feasibilityOf(trial);
+    const feasibility = trialFeasibility(trial);
     if (
       objective !== null &&
       feasibility !== "infeasible" &&
@@ -80,21 +75,11 @@ export const buildObjectiveHistory = (
   });
 };
 
-/**
- * uPlot aligned data: `[steps, objectives, bestSoFar, infeasibleObjectives]`.
- * A step's objective sits in the second series when it is feasible or of
- * unknown feasibility and in the fourth when infeasible, so the chart can
- * colour the two apart without a per-point style.
- */
+/** uPlot aligned data: `[steps, objectives, bestSoFar]`. */
 export const toObjectiveHistoryData = (
   points: readonly ObjectiveHistoryPoint[],
 ): uPlot.AlignedData => [
   points.map((point) => point.step),
-  points.map((point) =>
-    point.feasibility === "infeasible" ? null : point.objective,
-  ),
+  points.map((point) => point.objective),
   points.map((point) => point.bestSoFar),
-  points.map((point) =>
-    point.feasibility === "infeasible" ? point.objective : null,
-  ),
 ];

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/objective-history-data.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/objective-history-data.ts
@@ -14,10 +14,25 @@ export type ObjectiveDirection =
 
 /**
  * Whether the step's parameters satisfied the study's constraints. `unknown`
- * until a trial event carries constraint results; the chart then draws an
+ * for a trial event carrying no constraint results; the chart draws an
  * infeasible step in its muted colour.
  */
 export type ObjectiveFeasibility = "feasible" | "infeasible" | "unknown";
+
+/**
+ * A step's feasibility from its constraint results: infeasible when its draw
+ * broke a parameter constraint. A step whose state constraints fell short is
+ * limited, not infeasible: its objective counts like any other, so it keeps
+ * its colour and can be the best so far.
+ */
+export const trialFeasibility = (
+  trial: Pick<PetrinautOptimizationTrialEvent, "constraints">,
+): ObjectiveFeasibility => {
+  if (!trial.constraints) {
+    return "unknown";
+  }
+  return trial.constraints.infeasible === undefined ? "feasible" : "infeasible";
+};
 
 export type ObjectiveHistoryPoint = {
   /** The step number as the table shows it: the trial index plus one. */
@@ -36,18 +51,17 @@ const isBetter = (
 ): boolean => (direction === "maximize" ? candidate > best : candidate < best);
 
 /**
- * `feasibilityOf` reads a trial's constraint verdict; until trial events
- * carry one, every step is of unknown feasibility. An infeasible step never
- * becomes the best so far, the way Optuna's history substitutes infinity
- * for it before accumulating, so the word "best" never sits on a
- * configuration that broke a constraint.
+ * `feasibilityOf` reads a trial's constraint verdict, `trialFeasibility` by
+ * default. An infeasible step never becomes the best so far, the way
+ * Optuna's history substitutes infinity for it before accumulating, so the
+ * word "best" never sits on a configuration that broke a constraint.
  */
 export const buildObjectiveHistory = (
   trials: readonly PetrinautOptimizationTrialEvent[],
   direction: ObjectiveDirection,
   feasibilityOf: (
     trial: PetrinautOptimizationTrialEvent,
-  ) => ObjectiveFeasibility = () => "unknown",
+  ) => ObjectiveFeasibility = trialFeasibility,
 ): ObjectiveHistoryPoint[] => {
   // Parallel steps report out of order; the history reads in step order.
   const ordered = trials.toSorted((left, right) => left.trial - right.trial);

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/steps-table.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/steps-table.tsx
@@ -1,5 +1,6 @@
 import { Icon } from "@hashintel/ds-components";
 import { css } from "@hashintel/ds-helpers/css";
+
 /**
  * The study's steps, newest first: number, parameters, objective, the runs
  * passed when the study has constraints, and a state mark. The best step
@@ -7,11 +8,10 @@ import { css } from "@hashintel/ds-helpers/css";
  * parameter constraint is greyed, its mark naming the constraint. A long
  * study shows its latest steps only, so the table stays light.
  */
-import { constraintLabel } from "@hashintel/petrinaut-core";
-
 import {
   bindingStepRate,
   constraintAlpha,
+  constraintNameIn,
   formatRate,
 } from "../../../../../../../react/optimizations/constraint-rates";
 import { Table, type TableColumn } from "../../../../../../components/table";
@@ -91,13 +91,9 @@ const infeasibleConstraint = (
   trial: Step,
 ): string | null => {
   const constraintId = trial.constraints?.infeasible;
-  if (constraintId === undefined) {
-    return null;
-  }
-  const constraint = input.constraints?.find(
-    (candidate) => candidate.id === constraintId,
-  );
-  return constraint ? constraintLabel(constraint) : constraintId;
+  return constraintId === undefined
+    ? null
+    : constraintNameIn(input, constraintId);
 };
 
 const renderStepState = (state: StepState, infeasible: string | null) => {

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/steps-table.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/steps-table.tsx
@@ -1,11 +1,19 @@
-/**
- * The study's steps, newest first: number, parameters, objective and a state
- * mark. The best step carries a star and the table's selected-row tint. A
- * long study shows its latest steps only, so the table stays light.
- */
 import { Icon } from "@hashintel/ds-components";
 import { css } from "@hashintel/ds-helpers/css";
+/**
+ * The study's steps, newest first: number, parameters, objective, the runs
+ * passed when the study has constraints, and a state mark. The best step
+ * carries a star and the table's selected-row tint; a step whose draw broke a
+ * parameter constraint is greyed, its mark naming the constraint. A long
+ * study shows its latest steps only, so the table stays light.
+ */
+import { constraintLabel } from "@hashintel/petrinaut-core";
 
+import {
+  bindingStepRate,
+  constraintAlpha,
+  formatRate,
+} from "../../../../../../../react/optimizations/constraint-rates";
 import { Table, type TableColumn } from "../../../../../../components/table";
 import { formatNumber, formatParameters } from "../../shared/format-value";
 
@@ -13,6 +21,9 @@ import type { OptimizationRecord } from "../../../../../../../react/optimization
 
 type Step = OptimizationRecord["trials"][number];
 type StepState = Step["state"];
+
+/** Optuna's grey for a step whose parameters broke a constraint. */
+const INFEASIBLE_MARK_COLOR = "#cccccc";
 
 const stepHintStyle = css({
   fontSize: "xs",
@@ -47,10 +58,25 @@ const stepStateStyle = css({
   "&[data-state='failed']": {
     backgroundColor: "red.s90",
   },
+  "&[data-state='infeasible']": {
+    backgroundColor: `[${INFEASIBLE_MARK_COLOR}]`,
+  },
   "& svg": {
     width: "[9px]",
     height: "[9px]",
   },
+});
+
+// The table's own cell text, in the grey of an infeasible draw.
+const infeasibleTextStyle = css({
+  minWidth: "[0]",
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+  fontSize: "sm",
+  fontWeight: "medium",
+  lineHeight: "[18px]",
+  color: "neutral.s70",
 });
 
 const stepStatePresentation = {
@@ -59,13 +85,31 @@ const stepStatePresentation = {
   failed: { label: "Failed", icon: "close" },
 } as const satisfies Record<StepState, { label: string; icon: string }>;
 
-const renderStepState = (state: StepState) => {
-  const { label, icon } = stepStatePresentation[state];
+/** The parameter constraint a step's draw broke, named, or null for a feasible draw. */
+const infeasibleConstraint = (
+  input: OptimizationRecord["input"],
+  trial: Step,
+): string | null => {
+  const constraintId = trial.constraints?.infeasible;
+  if (constraintId === undefined) {
+    return null;
+  }
+  const constraint = input.constraints?.find(
+    (candidate) => candidate.id === constraintId,
+  );
+  return constraint ? constraintLabel(constraint) : constraintId;
+};
+
+const renderStepState = (state: StepState, infeasible: string | null) => {
+  const { label, icon } =
+    infeasible === null
+      ? stepStatePresentation[state]
+      : { label: `Infeasible: ${infeasible}`, icon: "filter" as const };
 
   return (
     <span
       className={stepStateStyle}
-      data-state={state}
+      data-state={infeasible === null ? state : "infeasible"}
       role="img"
       aria-label={label}
       title={label}
@@ -75,45 +119,79 @@ const renderStepState = (state: StepState) => {
   );
 };
 
+/** A cell's text: the table styles a plain string; an infeasible draw's row is greyed. */
+const cellText = (text: string, infeasible: boolean) =>
+  infeasible ? <span className={infeasibleTextStyle}>{text}</span> : text;
+
 const stepColumns = (
+  input: OptimizationRecord["input"],
   bestTrial: number | null,
-): readonly TableColumn<Step>[] => [
-  {
-    id: "trial",
-    header: "Step",
-    width: 70,
-    render: (trial) =>
-      trial.trial === bestTrial ? (
-        <span className={stepNumberStyle} title="Best step">
-          <Icon name="star" size="xxs" />
-          {trial.trial + 1}
-        </span>
-      ) : (
-        trial.trial + 1
-      ),
-  },
-  {
-    id: "parameters",
-    header: "Parameters",
-    minWidth: 260,
-    flex: "1 1 260px",
-    tone: "subtle",
-    render: (trial) => formatParameters(trial.parameters),
-  },
-  {
-    id: "objective",
-    header: "Objective",
-    width: 120,
-    render: (trial) =>
-      trial.objective === null ? "—" : formatNumber(trial.objective),
-  },
-  {
-    id: "state",
-    header: null,
-    width: 18,
-    render: (trial) => renderStepState(trial.state),
-  },
-];
+): readonly TableColumn<Step>[] => {
+  const constrained = (input.constraints ?? []).length > 0;
+  const alpha = constraintAlpha(input);
+  const isInfeasible = (trial: Step) =>
+    infeasibleConstraint(input, trial) !== null;
+  return [
+    {
+      id: "trial",
+      header: "Step",
+      width: 70,
+      render: (trial) =>
+        trial.trial === bestTrial ? (
+          <span className={stepNumberStyle} title="Best step">
+            <Icon name="star" size="xxs" />
+            {trial.trial + 1}
+          </span>
+        ) : (
+          cellText(String(trial.trial + 1), isInfeasible(trial))
+        ),
+    },
+    {
+      id: "parameters",
+      header: "Parameters",
+      minWidth: 260,
+      flex: "1 1 260px",
+      tone: "subtle",
+      render: (trial) =>
+        cellText(formatParameters(trial.parameters), isInfeasible(trial)),
+    },
+    {
+      id: "objective",
+      header: "Objective",
+      width: 120,
+      render: (trial) =>
+        cellText(
+          trial.objective === null ? "—" : formatNumber(trial.objective),
+          isInfeasible(trial),
+        ),
+    },
+    ...(constrained
+      ? [
+          {
+            id: "runsPassed",
+            header: "Runs passed",
+            width: 120,
+            render: (trial: Step) => {
+              const binding = bindingStepRate(trial, alpha);
+              return cellText(
+                binding === null
+                  ? "—"
+                  : formatRate(binding.runsPassed, binding.runsTotal),
+                isInfeasible(trial),
+              );
+            },
+          } satisfies TableColumn<Step>,
+        ]
+      : []),
+    {
+      id: "state",
+      header: null,
+      width: 18,
+      render: (trial) =>
+        renderStepState(trial.state, infeasibleConstraint(input, trial)),
+    },
+  ];
+};
 
 /** The latest steps only: the table stays light on a long study. */
 const DISPLAYED_STEPS = 200;
@@ -140,7 +218,7 @@ export const StepsTable = ({
       ) : null}
       <div className={className}>
         <Table
-          columns={stepColumns(bestTrial)}
+          columns={stepColumns(optimization.input, bestTrial)}
           emptyLabel="No steps completed yet"
           getRowId={(trial) => String(trial.trial)}
           rows={displayedSteps}

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/study-summary-strip.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/study-summary-strip.tsx
@@ -5,12 +5,18 @@
  * study, then status, steps finished over requested and the best value so
  * far in a strip, with the steps bar beneath and the error when there is
  * one. A connected study adds the followed step's runs under the steps bar,
- * the "N computing" chip and the fallback note. The band has no title of
- * its own: it is the drawer's header continued, not a section.
+ * the "N computing" chip and the fallback note. A study with constraints
+ * adds the steps clear across the study to the strip. The band has no title
+ * of its own: it is the drawer's header continued, not a section.
  */
 import { Tooltip } from "@hashintel/ds-components";
 import { css } from "@hashintel/ds-helpers/css";
 
+import {
+  constraintAlpha,
+  formatRate,
+  studyConstraintRates,
+} from "../../../../../../../react/optimizations/constraint-rates";
 import { ComputeActivity } from "../../shared/compute-activity";
 import { ComputeBackendBadge } from "../../shared/compute-backend-badge";
 import { formatNumber, formatParameters } from "../../shared/format-value";
@@ -101,6 +107,13 @@ export const StudySummaryBand = ({
   const { connected } = optimization;
   const status = describeOptimizationStatus(optimization);
   const fallbackReason = connected?.computeBackendFallbackReason ?? null;
+  const constrained = (optimization.input.constraints ?? []).length > 0;
+  const rates = constrained
+    ? studyConstraintRates(
+        optimization.trials,
+        constraintAlpha(optimization.input),
+      )
+    : null;
 
   return (
     <div className={bandStyle} data-study-band>
@@ -137,6 +150,19 @@ export const StudySummaryBand = ({
         >
           {describeStepProgress(optimization)}
         </SummaryStat>
+        {rates === null ? null : (
+          <SummaryStat
+            label="Steps clear"
+            minChars={
+              formatRate(
+                optimization.requestedTrials,
+                optimization.requestedTrials,
+              ).length
+            }
+          >
+            {formatRate(rates.stepsClear, rates.stepsSimulated)}
+          </SummaryStat>
+        )}
         <SummaryStat label="Best step so far" minChars={8}>
           {optimization.best ? (
             <Tooltip

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/view-optimization-drawer.stories.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/view-optimization-drawer.stories.tsx
@@ -31,6 +31,8 @@ type Story = StoryObj<typeof meta>;
 const FakeConnectedStudy = (props: {
   /** Lands one step every 1.2 s and follows the next; else shows the complete study. */
   running: boolean;
+  /** The study with a parameter and a state constraint, results on every step. */
+  constrained?: boolean;
   fallbackReason?: string | null;
   refinementError?: string | null;
 }) => {
@@ -55,6 +57,24 @@ export const ConnectedRunning: Story = {
 export const ConnectedComplete: Story = {
   name: "Connected study, complete",
   render: () => <FakeConnectedStudy running={false} />,
+};
+
+export const ConnectedWithConstraints: Story = {
+  name: "Connected study with constraints",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The complete study with a parameter constraint (production rate under 350) and a state constraint (finished goods under 500): the Constraints card with the steps clear across the study and one bar per state constraint, a Steps clear stat in the strip, a Runs passed column in the steps table, and the draws that broke the rate cap greyed as infeasible everywhere a step is drawn.",
+      },
+    },
+  },
+  render: () => <FakeConnectedStudy running={false} constrained />,
+};
+
+export const ConnectedWithConstraintsRunning: Story = {
+  name: "Connected study with constraints, following steps",
+  render: () => <FakeConnectedStudy running constrained />,
 };
 
 export const ConnectedRefinementFailed: Story = {

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/view-optimization-drawer.stories.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/view-optimization-drawer.stories.tsx
@@ -65,7 +65,7 @@ export const ConnectedWithConstraints: Story = {
     docs: {
       description: {
         story:
-          "The complete study with a parameter constraint (production rate under 350) and a state constraint (finished goods under 500): the Constraints card with the steps clear across the study and one bar per state constraint, a Steps clear stat in the strip, a Runs passed column in the steps table, and the draws that broke the rate cap greyed as infeasible everywhere a step is drawn.",
+          "The complete study with a parameter constraint (production rate under 320) and a state constraint (finished goods under 500): the Constraints card with the steps clear across the study and one bar per state constraint, a Steps clear stat in the strip, a Runs passed column in the steps table, and the draws that broke the rate cap greyed as infeasible everywhere a step is drawn.",
       },
     },
   },

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/view-optimization-drawer.test.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/view-optimization-drawer.test.tsx
@@ -576,7 +576,7 @@ describe("ViewOptimizationDrawer for a connected study with constraints", () => 
     expect(infeasible.length).toBeGreaterThan(0);
     expect(infeasible[0]?.getAttribute("data-state")).toBe("infeasible");
     expect(infeasible[0]?.getAttribute("title")).toBe(
-      "Infeasible: Production rate under 350",
+      "Infeasible: Production rate under 320",
     );
   });
 

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/view-optimization-drawer.test.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/view-optimization-drawer.test.tsx
@@ -13,6 +13,8 @@ import {
 } from "../../../../../../react/optimizations/context";
 import { UserSettingsContext } from "../../../../../../react/state/user-settings-context";
 import {
+  fakeConstrainedStudyInput,
+  fakeConstrainedStudyTrials,
   makeConnectedStudyState,
   makeOptimizationInput,
   makeOptimizationRecord,
@@ -516,5 +518,81 @@ describe("ViewOptimizationDrawer for a connected study", () => {
 
     expect(screen.queryByLabelText("Follow steps")).toBeNull();
     expect(screen.getByText("100 runs")).toBeTruthy();
+  });
+});
+
+describe("ViewOptimizationDrawer for a connected study with constraints", () => {
+  const constrainedInput = fakeConstrainedStudyInput;
+  const constrainedTrials = fakeConstrainedStudyTrials.trials;
+  const navigation = navigationAtTrial(
+    constrainedInput,
+    constrainedTrials.at(-1)!,
+    false,
+  );
+  const settled = makeOptimizationRecord({
+    input: constrainedInput,
+    trials: constrainedTrials,
+    best: fakeConstrainedStudyTrials.best,
+    status: "complete",
+    connected: makeConnectedStudyState(constrainedInput, {
+      navigation,
+      resumable: true,
+      selection: makeSelectionStream({
+        input: constrainedInput,
+        navigation,
+        runsCompleted: 100,
+      }),
+    }),
+  });
+
+  it("adds the Constraints card with the steps clear, the latest step's verdict and one bar per state constraint", () => {
+    renderDrawer(settled);
+
+    const card = screen
+      .getByText("Constraints")
+      .closest<HTMLElement>("[data-chart-card]")!;
+    expect(card.textContent).toContain("pass threshold 95% (alpha 0.05)");
+    expect(card.textContent).toMatch(
+      /\d+ \/ \d+ · \d+%steps clear across the study/u,
+    );
+    expect(card.textContent).toMatch(/infeasible draws?/u);
+    expect(card.textContent).toMatch(/Step 30: (clear|limited|infeasible)/u);
+    expect(card.querySelectorAll("[data-constraint-row]")).toHaveLength(1);
+    expect(card.textContent).toContain("Finished goods under 500");
+    expect(card.textContent).toContain(
+      "1 parameter constraint is checked before each step runs.",
+    );
+  });
+
+  it("puts the steps clear in the strip and a Runs passed column in the table, greying the infeasible draws", () => {
+    renderDrawer(settled);
+
+    expect(screen.getByText("Steps clear")).toBeTruthy();
+    expect(screen.getByText("Runs passed")).toBeTruthy();
+    expect(screen.getAllByText(/^\d+ \/ 60 · \d+%$/u).length).toBeGreaterThan(
+      0,
+    );
+    const infeasible = screen.getAllByTitle(/^Infeasible: /u);
+    expect(infeasible.length).toBeGreaterThan(0);
+    expect(infeasible[0]?.getAttribute("data-state")).toBe("infeasible");
+    expect(infeasible[0]?.getAttribute("title")).toBe(
+      "Infeasible: Production rate under 350",
+    );
+  });
+
+  it("shows none of it for a study without constraints", () => {
+    renderDrawer(
+      makeOptimizationRecord({
+        input,
+        trials,
+        best,
+        status: "complete",
+        connected: makeConnectedStudyState(input, { resumable: true }),
+      }),
+    );
+
+    expect(screen.queryByText("Constraints")).toBeNull();
+    expect(screen.queryByText("Steps clear")).toBeNull();
+    expect(screen.queryByText("Runs passed")).toBeNull();
   });
 });

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/view-optimization-drawer.test.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/view-optimization-drawer.test.tsx
@@ -580,6 +580,43 @@ describe("ViewOptimizationDrawer for a connected study with constraints", () => 
     );
   });
 
+  it("ends the step line at the verdict for a parameter-only study whose step completed", () => {
+    const parameterOnlyInput = {
+      ...constrainedInput,
+      constraints: constrainedInput.constraints?.filter(
+        (constraint) => constraint.space === "parameters",
+      ),
+    };
+    const parameterOnlyTrials = constrainedTrials.map((trial) => ({
+      ...trial,
+      state: "complete" as const,
+      objective: trial.objective ?? 1,
+      constraints: {
+        parameters: [{ constraintId: "rate-cap", margin: 1 }],
+        state: [],
+      },
+    }));
+    renderDrawer(
+      makeOptimizationRecord({
+        input: parameterOnlyInput,
+        trials: parameterOnlyTrials,
+        best: fakeConstrainedStudyTrials.best,
+        status: "complete",
+        connected: makeConnectedStudyState(parameterOnlyInput, {
+          navigation,
+          resumable: true,
+        }),
+      }),
+    );
+
+    const card = screen
+      .getByText("Constraints")
+      .closest<HTMLElement>("[data-chart-card]")!;
+    expect(card.textContent).toContain("Step 30: clear");
+    expect(card.textContent).not.toContain("clearr");
+    expect(card.querySelectorAll("[data-constraint-row]")).toHaveLength(0);
+  });
+
   it("shows none of it for a study without constraints", () => {
     renderDrawer(
       makeOptimizationRecord({

--- a/libs/@local/petrinaut-arch-docs/content/ui/optimizations-tab.mdx
+++ b/libs/@local/petrinaut-arch-docs/content/ui/optimizations-tab.mdx
@@ -71,9 +71,24 @@ objective by step: `buildObjectiveHistory` (`study-view/objective-history-data.t
 orders the trials by step and threads the best so far through the completed
 ones, `toObjectiveHistoryData` lays them out as uPlot aligned data
 (`[steps, objectives, bestSoFar, infeasibleObjectives]`), and the chart draws
-the objectives as dots and the best as a stepped line. `feasibility` is
-`unknown` on every point until trial events carry constraint results; an
-`infeasible` point moves to the fourth series and draws in `infeasibleColor`.
+the objectives as dots and the best as a stepped line. `trialFeasibility`
+reads a point's feasibility off the trial event's `constraints`: `unknown`
+without results, `infeasible` for a draw pruned by a parameter constraint;
+an `infeasible` point moves to the fourth series and draws in
+`infeasibleColor`, and never becomes the best so far.
+
+A study with constraints reports them through
+`react/optimizations/constraint-rates.ts`, derived per render from
+`record.trials`: `stepVerdict` (clear, limited, infeasible), `bindingStepRate`
+(the step's lowest pass rate) and `studyConstraintRates` (steps clear over
+steps simulated, per constraint too). `ConstraintSummaryCard`
+(`study-view/constraint-summary.tsx`) is the fourth chart card of a connected
+body, `StudySummaryBand` gains a **Steps clear** stat, and `StepsTable` a
+**Runs passed** column with an `infeasible` state tone. The channel
+(`react/optimizations/channel/create-optimization-channel/trial-constraints.ts`)
+prunes an infeasible draw before any simulation and runs state constraints as
+`auxiliaryMetrics` on the detached objective request, 0/1 indicators
+aggregated with `min` over each run's frames.
 
 The remote body continues with a collapsible **Best parameters** grid, the
 objective by step, the experimental **Surface** section when the


### PR DESCRIPTION
> [!IMPORTANT]
> **Experimental**
> Behind the **In-browser optimization** feature flag.

## Summary

Before this PR, a study recorded its constraints and nothing evaluated them. Every draw the optimizer proposed was simulated, every run counted the same, and the study view had no word on feasibility.

This PR evaluates constraints for a study run in the browser. A parameter constraint is checked before a step simulates, at the trial's values and the net parameter values its scenario resolves them to: a negative margin prunes the step as infeasible with the constraint named, and the step draws grey in the steps table and as a hollow ring on the surface. A state constraint compiles to a 0/1 indicator metric whose minimum over time says whether a run held it throughout, and the trial event carries runs passed over runs total per constraint. The study view gains a Constraints card, a Steps clear stat and a Runs passed column, every rate printed as a raw fraction beside its percentage, and the create drawer gains a Pass threshold. The objective stays the plain mean over every run; verdicts sit beside it and exclude nothing.

https://github.com/user-attachments/assets/ba85d9fa-d333-498b-bb98-4416cb45a45c

## Links

- Ticket [FE-1677](https://linear.app/hash/issue/FE-1677)
- Docs [The Optimizations tab](https://petrinaut-docs-git-claude-opt-proto-constraints.stage.hash.ai/architecture/ui/views/editor/optimizations/optimizations-tab)
- Docs [Optimization › Constraints](https://github.com/hashintel/hash/blob/claude/opt-proto-constraints/libs/@hashintel/petrinaut/docs/optimization.md#constraints)

## Changes

#### Core

- `constraintMargin` walks a constraint's HIR and gives its signed slack at a point
  > Comparison slack, minimum over `&&`, maximum over `||`, a flipped sign under `!`, the chosen branch of a conditional, scoped `let`, one unit for a bare boolean. `margin >= 0` means satisfied.
  > A zero margin under `!` becomes the boundary failure, so a negated non-strict comparison fails at exact equality.
  > A strict comparison at exact equality returns `-Number.MIN_VALUE`, so the sign is the verdict for integer parameters too.
  > `evaluateParameterConstraints` gives one margin per constraint.
- `compileStateConstraintIndicator` compiles a state constraint as a `body ? 1 : 0` metric
  > Emitted through `emitBufferMetricJs` with no TypeScript compiler, so it runs on the main thread. `interpretHirExpr` is exported for the margin walk.
- HIR interpreter binds locals through a `ReadonlyMap` `Env`
- `getRunValues` honours `aggregateTime` for scalar output
  > `min` over a 0/1 indicator is the "held throughout" quantifier.
- Manifest `constraintPolicy` and trial event `constraints`
  > `constraintPolicy.alpha` strictly between 0 and 1, default 0.05. The trial event carries parameter margins, per-constraint runs passed over runs total, and an optional `infeasible` name. Both trial outcome variants carry the block.
  > The manifest's `constraints` description says the browser runtime evaluates them and reports the results, never enforced on the objective.
- Browser capability merges the channel's results into the trial event
  > Kept per trial on the run record and cleared when the segment ends. The worker and the Python core see nothing of them.

#### Channel

- Parameter constraints checked first, at the trial's resolved net values
  > `parameters.*` is bound to the net parameter values the scenario resolves at the trial's values, overrides applied, through `resolveDetachedObjectiveParameters` on the experiments actions.
  > A negative margin returns `pruned` with `Infeasible: <name>` before `runDetachedObjective` and before `trialStarted`, so no batch appears in the activity list.
- State constraints run as auxiliary metrics of the objective batch
  > `auxiliaryMetrics` on the detached objective request are appended as precompiled scalar expression specs with their `aggregateTime`. Indicators are compiled once per run id and dropped on dispose.
- `trialOutcome` attaches `{ parameters, state }` beside the plain mean
  > A missing run value counts as failed. A constraint the emitter declines throws with its name and the trial is pruned with that reason.
- Followed step's selection stream carries the objective's frames only
  > The batch streams the indicator frames too.

#### Study view

- Constraints card, fourth in a connected study's card row
  > Headline "N / M · P%" over steps clear across the study, subtitle with the pass threshold, alpha and the infeasible draw count, one reserved line for the latest step's verdict, one bar per state constraint with the threshold marked, a note counting parameter constraints.
- Steps clear stat in the summary strip and a Runs passed column in the steps table
  > The column shows the binding constraint's fraction, the lowest pass rate in the step. An infeasible draw's mark is grey, titled "Infeasible: <name>", with greyed row text.
- Infeasible draws are muted rings on the surface and never the best so far
  > `trialFeasibility` reads `constraints.infeasible`; the objective history skips an infeasible draw when accumulating the best so far.
- Pass threshold in the create drawer
  > A percent input under the constraint rows, default 95, shown once a constraint row exists. `constraintPolicyFor` writes `{ alpha }` only when the threshold differs from the default.
- Constraints tooltip and hints in the create drawer say what the browser does with each kind
  > A step that breaks a parameter constraint is skipped before it runs; a run passes a state constraint when the condition holds at every sampled time.
- `constraint-rates.ts` derives every rate from the trials in render
  > `stepVerdict` reads clear, limited, infeasible or unconstrained. `formatRate` prints "52 / 60 · 87%". Nothing is stored.
  > `constraintNameIn` names a constraint for the channel, the card and the table.
- Fixtures and stories for a constrained study
  > `fakeStudyConstraints`, `fakeConstrainedStudyInput`, `makeConstrainedTrials`, and `sirConstrainedOptimizationInput` lowered with the real `lowerConstraint`. Stories `Connected study with constraints` and `Connected study with constraints, following steps`.

#### Review fixes

- `!` fails a constraint whose operand holds exactly at its boundary
  > Negating a zero margin gave `-0`, which reads as satisfied, so `!(x <= y)`, `!(x >= y)` and `!(x == y)` passed at equality.
  > The unary case now maps a zero operand margin to the boundary failure, and `margin.test.ts` pins the three negated cases failing and `!(x < 2)` and `!!(x <= 2)` passing.
- `describeStep` returns the step line as a verdict head and a detail tail
  > The card split the joined string on ` · ` and sliced from `indexOf`, so a parameter-only complete step with no separator rendered "Step N: clearr".
  > The card renders the two parts once, and `constraint-summary.test.ts` and a drawer render test pin the plain "Step N: clear".
- Channel binds `scenario.*` by each scenario parameter's type, a boolean parameter as a boolean
  > It bound the trial's 0/1 transport while `==` compares by identity, so `scenario.flag == true` held for no draw.
  > `decodeScenarioParameterValue` in core is the one rule the scenario compiler and the new `resolveTrialScenarioBindings` apply.
  > `describe.test.ts` pins the decode, and a channel test on a switched SIR scenario expects `scenario.isolation == true` feasible for a true draw and `Infeasible` for a false one.

## Known issues

- Studies on the optimization service report no verdicts
  > The card is mounted for connected studies only.
- Real Pyodide run with a constraint not exercised in this PR
  > The channel and capability tests run constraints lowered from the SIR model and the story carries results through the UI.

## Next steps

- Per-constraint pass rate over steps as a line chart with the threshold marked
- Margins to Optuna
- `AutoStudy` harness `constraints` list for the real Pyodide story

## Test coverage

- `margin.test.ts`, `indicator-metric.test.ts`:
  > Slack per operator, the sign at exact equality, a negated comparison failing at its boundary, `let` scopes, the interpreter's errors, and a compiled indicator that reads 1 then 0 on a two-place net.
- `user-defined.test.ts`, `optimization.test.ts`, `browser-optimization.test.ts`:
  > Per-run minimum over frames, the policy's alpha bounds, the trial event's constraints block, and the capability carrying the channel's results.
- `trial-constraints.test.ts`, `create-optimization-channel.test.ts`, `detached-objective.test.ts`:
  > A pruned infeasible draw before any simulation, a `parameters.*` constraint read at the value the scenario's override resolves, resolved net parameters with the overrides applied, state constraints as auxiliary metrics with per-run verdicts, nothing attached without constraints, auxiliary specs precompiled with their aggregation.
- `constraint-rates.test.ts`, `objective-history-data.test.ts`, `surface-plot.test.tsx`:
  > The threshold rule at equality, the binding constraint, the constraint name lookup, study rates with infeasible draws apart, feasibility read off the constraints block, a muted ring for an infeasible draw.
- `create-optimization-drawer.test.tsx`, `view-optimization-drawer.test.tsx`:
  > A changed threshold written as alpha, the Constraints card, the Steps clear stat, the Runs passed column, greyed marks, a parameter-only study's step line ending at its verdict, and none of it without constraints.
- `constraint-summary.test.ts`:
  > The step line's verdict and detail parts for a parameter-only complete step, a failed step, a binding state constraint and an infeasible draw.
- `describe.test.ts`:
  > A boolean parameter's 0/1 read as the boolean the scenario compiler binds, every other value as it is, and a parameter the values lack read at its default.

## How to test

- Open [Petrinaut preview](https://petrinaut-git-claude-opt-proto-constraints.stage.hash.ai) on Vercel
- Viewport controls > Settings > Simulation > In-browser optimization
- Load example > Supply Chain Profit
- Simulate > Optimizations > Create
- Select metric `Profit`, direction Maximize, tick Optimize production_rate
- Constraints > Add parameter constraint, type `parameters.production_rate <= 320`
- Constraints > Add state constraint, type `return state.places.FinishedGoods.count <= 500;`
  > Expect a Pass threshold field under the rows reading 95
- Run, then open the study row
  > Expect a Constraints card with the steps clear headline and one bar for the state constraint
  > Expect a Steps clear stat in the summary and a Runs passed column in the steps table
- Wait for a draw above 320
  > Expect its row greyed with a mark titled Infeasible and a muted ring on the surface



