### PR TITLE
FE-1678: Estimate parameter importance during browser optimization and show it in the study view

### DIFF
--- a/.changeset/optimization-importance-events.md
+++ b/.changeset/optimization-importance-events.md
@@ -1,5 +1,0 @@
----
-"@hashintel/petrinaut-core": patch
----
-
-The browser optimizer estimates PED-ANOVA parameter importances: the `complete` event carries an optional `importances` block, and so does every trial event at a cadence once the study is past its floor. A study whose estimate cannot be computed completes without the block.

--- a/.changeset/optimization-importance-events.md
+++ b/.changeset/optimization-importance-events.md
@@ -1,0 +1,5 @@
+---
+"@hashintel/petrinaut-core": patch
+---
+
+The browser optimizer estimates PED-ANOVA parameter importances: the `complete` event carries an optional `importances` block, and so does every trial event at a cadence once the study is past its floor. A study whose estimate cannot be computed completes without the block.

--- a/.changeset/optimization-parameter-importance.md
+++ b/.changeset/optimization-parameter-importance.md
@@ -1,5 +1,0 @@
----
-"@hashintel/petrinaut": patch
----
-
-A study run in the browser shows a Sensitivity analysis card: the optimizer's PED-ANOVA importance per optimized parameter as a bar, faded below a floor of 50 or 100 completed steps, with a signed correlation column computed from the steps.

--- a/.changeset/optimization-parameter-importance.md
+++ b/.changeset/optimization-parameter-importance.md
@@ -1,0 +1,5 @@
+---
+"@hashintel/petrinaut": patch
+---
+
+A study run in the browser shows a Parameter importance card: the optimizer's PED-ANOVA share per optimized parameter as a bar, faded below a floor of 50 or 100 completed steps, with a signed correlation column computed from the steps.

--- a/.changeset/optimization-parameter-importance.md
+++ b/.changeset/optimization-parameter-importance.md
@@ -2,4 +2,4 @@
 "@hashintel/petrinaut": patch
 ---
 
-A study run in the browser shows a Parameter importance card: the optimizer's PED-ANOVA share per optimized parameter as a bar, faded below a floor of 50 or 100 completed steps, with a signed correlation column computed from the steps.
+A study run in the browser shows a Sensitivity analysis card: the optimizer's PED-ANOVA importance per optimized parameter as a bar, faded below a floor of 50 or 100 completed steps, with a signed correlation column computed from the steps.

--- a/libs/@hashintel/petrinaut-core/src/index.ts
+++ b/libs/@hashintel/petrinaut-core/src/index.ts
@@ -143,6 +143,7 @@ export type {
   PetrinautOptimizationStudy,
   PetrinautOptimizationTrialConstraints,
   PetrinautOptimizationTrialEvent,
+  PetrinautOptimizationImportances,
   PetrinautOptimizationConstraintPolicy,
   PetrinautIntegerOptimizationDomain,
 } from "./optimization";

--- a/libs/@hashintel/petrinaut-core/src/optimization/browser/browser-optimization.test.ts
+++ b/libs/@hashintel/petrinaut-core/src/optimization/browser/browser-optimization.test.ts
@@ -194,6 +194,7 @@ describe("createBrowserOptimization", () => {
       "petrinaut_optimizer_core/description.py",
       "petrinaut_optimizer_core/study.py",
       "petrinaut_optimizer_core/ask_tell.py",
+      "petrinaut_optimizer_core/importance.py",
       "petrinaut_optimizer_core/pyodide_entry.py",
     ]);
     expect(context.worker.sentOfType("start")).toHaveLength(0);
@@ -383,6 +384,52 @@ describe("createBrowserOptimization", () => {
     // A trial the channel reported nothing for carries no constraints.
     expect(events[3]).toMatchObject({ type: "trial", trial: 2 });
     expect(events[3]).not.toHaveProperty("constraints");
+  });
+
+  it("copies the worker's importances onto the trial and complete events, and finishes without them", async () => {
+    const importances = {
+      values: { rate: 0.7, count: 0.2, enabled: 0.1 },
+      completedTrials: 50,
+    };
+    const context = setUp();
+    const runId = await startRun(context);
+
+    context.worker.emit({ type: "trial", runId, event: completedTrial });
+    context.worker.emit({
+      type: "trial",
+      runId,
+      event: { ...completedTrial, trial: 1, importances },
+    });
+    context.worker.emit({
+      type: "complete",
+      runId,
+      summary: { ...summary, importances },
+    });
+
+    const events = await collectEvents(
+      context.capability.attachOptimizationRun(runId),
+    );
+    expect(events[1]).not.toHaveProperty("importances");
+    expect(events[2]).toMatchObject({ type: "trial", trial: 1, importances });
+    expect(events[3]).toMatchObject({ type: "complete", importances });
+
+    const plain = setUp();
+    const plainRun = await startRun(plain);
+    plain.worker.emit({
+      type: "trial",
+      runId: plainRun,
+      event: completedTrial,
+    });
+    plain.worker.emit({ type: "complete", runId: plainRun, summary });
+    const plainEvents = await collectEvents(
+      plain.capability.attachOptimizationRun(plainRun),
+    );
+    expect(plainEvents.map((event) => event.type)).toEqual([
+      "started",
+      "trial",
+      "complete",
+    ]);
+    expect(plainEvents[2]).not.toHaveProperty("importances");
   });
 
   it("cancels a running study through the worker and ends with the cancelled error code", async () => {

--- a/libs/@hashintel/petrinaut-core/src/optimization/browser/browser-optimization.ts
+++ b/libs/@hashintel/petrinaut-core/src/optimization/browser/browser-optimization.ts
@@ -349,6 +349,7 @@ const connectBrowserOptimization = (options: {
           state: event.state,
           best: event.best,
           ...(constraints ? { constraints } : {}),
+          ...(event.importances ? { importances: event.importances } : {}),
         });
         return;
       }
@@ -365,6 +366,9 @@ const connectBrowserOptimization = (options: {
               prunedTrials: summary.prunedTrials,
               failedTrials: summary.failedTrials,
               best: summary.best,
+              ...(summary.importances
+                ? { importances: summary.importances }
+                : {}),
             },
             "finished-resumable",
           );

--- a/libs/@hashintel/petrinaut-core/src/optimization/browser/messages.ts
+++ b/libs/@hashintel/petrinaut-core/src/optimization/browser/messages.ts
@@ -11,6 +11,12 @@ export type OptimizerBestTrial = {
   objective: number;
 };
 
+/** PED-ANOVA importances over the completed trials, normalised to sum to 1. */
+export type OptimizerImportances = {
+  values: Record<string, number>;
+  completedTrials: number;
+};
+
 /** One finished Optuna trial, as the Python study reports it. */
 export type OptimizerTrialPayload = {
   trial: number;
@@ -18,6 +24,8 @@ export type OptimizerTrialPayload = {
   objective: number | null;
   state: "complete" | "pruned" | "failed";
   best: OptimizerBestTrial | null;
+  /** Set at the importance cadence once the study is past its floor. */
+  importances?: OptimizerImportances;
 };
 
 /** Counts over the whole study so far, across every segment it ran. */
@@ -29,6 +37,8 @@ export type OptimizerStudySummary = {
   best: OptimizerBestTrial | null;
   /** Set when the segment stopped early because the run was cancelled. */
   cancelled?: boolean;
+  /** The final estimate, when the study could make one. */
+  importances?: OptimizerImportances;
 };
 
 export type OptimizerInitMessage = {

--- a/libs/@hashintel/petrinaut-core/src/optimization/browser/python-sources.ts
+++ b/libs/@hashintel/petrinaut-core/src/optimization/browser/python-sources.ts
@@ -1,6 +1,7 @@
 import initSource from "@local/petrinaut-optimizer-core/python/__init__.py?raw";
 import askTellSource from "@local/petrinaut-optimizer-core/python/ask_tell.py?raw";
 import descriptionSource from "@local/petrinaut-optimizer-core/python/description.py?raw";
+import importanceSource from "@local/petrinaut-optimizer-core/python/importance.py?raw";
 import pyodideEntrySource from "@local/petrinaut-optimizer-core/python/pyodide_entry.py?raw";
 import studySource from "@local/petrinaut-optimizer-core/python/study.py?raw";
 
@@ -10,5 +11,6 @@ export const optimizerPythonSources: Readonly<Record<string, string>> = {
   "petrinaut_optimizer_core/description.py": descriptionSource,
   "petrinaut_optimizer_core/study.py": studySource,
   "petrinaut_optimizer_core/ask_tell.py": askTellSource,
+  "petrinaut_optimizer_core/importance.py": importanceSource,
   "petrinaut_optimizer_core/pyodide_entry.py": pyodideEntrySource,
 };

--- a/libs/@hashintel/petrinaut-core/src/optimization/browser/worker/study-runner.pyodide.test.ts
+++ b/libs/@hashintel/petrinaut-core/src/optimization/browser/worker/study-runner.pyodide.test.ts
@@ -224,13 +224,19 @@ describe("createOptimizerStudyRunner", () => {
         expect(event.best?.objective).toBeCloseTo(bestSoFar, 9);
       }
 
-      expect(summary).toEqual({
+      // PED-ANOVA runs under Pyodide on numpy alone; the study's final
+      // estimate rides the summary, and its shares sum to one.
+      const { importances, ...counts } = summary;
+      expect(counts).toEqual({
         requestedTrials: 30,
         completedTrials: 29,
         prunedTrials: 1,
         failedTrials: 0,
         best: run.trials.at(-1)?.best,
       });
+      expect(importances?.completedTrials).toBe(29);
+      const shares = Object.values(importances?.values ?? {});
+      expect(shares.reduce((sum, share) => sum + share, 0)).toBeCloseTo(1, 6);
     },
     loadTimeout,
   );
@@ -310,13 +316,15 @@ describe("createOptimizerStudyRunner", () => {
 
       expect(resumed.trialNumbers).toEqual([5, 6]);
       expect(resumed.trials.map((event) => event.trial)).toEqual([5, 6]);
-      expect(summary).toEqual({
+      const { importances, ...counts } = summary;
+      expect(counts).toEqual({
         requestedTrials: 6,
         completedTrials: 6,
         prunedTrials: 0,
         failedTrials: 0,
         best: resumed.trials.at(-1)?.best,
       });
+      expect(importances?.completedTrials).toBe(6);
     },
     loadTimeout,
   );

--- a/libs/@hashintel/petrinaut-core/src/optimization/browser/worker/study-runner.ts
+++ b/libs/@hashintel/petrinaut-core/src/optimization/browser/worker/study-runner.ts
@@ -3,6 +3,7 @@
  */
 import { micropipRequirements } from "../pyodide-config";
 import { isPyProxyLike } from "./pyodide-like";
+import { asImportances } from "./study-runner/as-importances";
 
 import type {
   OptimizationScalar,
@@ -11,6 +12,7 @@ import type {
 } from "../../index";
 import type {
   OptimizerBestTrial,
+  OptimizerImportances,
   OptimizerStudySummary,
   OptimizerTrialPayload,
 } from "../messages";
@@ -136,6 +138,13 @@ const asBest = (value: unknown): OptimizerBestTrial | null => {
   };
 };
 
+const withImportances = (
+  value: unknown,
+): { importances?: OptimizerImportances } => {
+  const importances = asImportances(value);
+  return importances === undefined ? {} : { importances };
+};
+
 const asTrialState = (value: unknown): OptimizerTrialPayload["state"] => {
   if (value === "complete" || value === "pruned" || value === "failed") {
     return value;
@@ -155,6 +164,7 @@ const normalizeTrialPayload = (value: unknown): OptimizerTrialPayload => {
         : asNumber(objective, "trial objective"),
     state: asTrialState(record.state),
     best: asBest(record.best),
+    ...withImportances(record.importances),
   };
 };
 
@@ -167,6 +177,7 @@ const normalizeSummary = (value: unknown): OptimizerStudySummary => {
     failedTrials: asNumber(record.failedTrials, "failed trial count"),
     best: asBest(record.best),
     ...(record.cancelled === true ? { cancelled: true } : {}),
+    ...withImportances(record.importances),
   };
 };
 

--- a/libs/@hashintel/petrinaut-core/src/optimization/browser/worker/study-runner/as-importances.test.ts
+++ b/libs/@hashintel/petrinaut-core/src/optimization/browser/worker/study-runner/as-importances.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { asImportances } from "./as-importances";
+
+describe("asImportances", () => {
+  it("keeps a well-formed block", () => {
+    expect(
+      asImportances({
+        values: { rate: 0.75, count: 0.25 },
+        completedTrials: 50,
+      }),
+    ).toEqual({ values: { rate: 0.75, count: 0.25 }, completedTrials: 50 });
+  });
+
+  it("drops anything malformed rather than throwing", () => {
+    expect(asImportances(undefined)).toBeUndefined();
+    expect(asImportances(null)).toBeUndefined();
+    expect(asImportances([])).toBeUndefined();
+    expect(asImportances({ values: {}, completedTrials: 0 })).toBeUndefined();
+    expect(asImportances({ values: {}, completedTrials: 1.5 })).toBeUndefined();
+    expect(asImportances({ values: [], completedTrials: 3 })).toBeUndefined();
+    expect(
+      asImportances({ values: { rate: "0.5" }, completedTrials: 3 }),
+    ).toBeUndefined();
+    expect(
+      asImportances({ values: { rate: 1.5 }, completedTrials: 3 }),
+    ).toBeUndefined();
+    expect(
+      asImportances({ values: { rate: Number.NaN }, completedTrials: 3 }),
+    ).toBeUndefined();
+  });
+});

--- a/libs/@hashintel/petrinaut-core/src/optimization/browser/worker/study-runner/as-importances.ts
+++ b/libs/@hashintel/petrinaut-core/src/optimization/browser/worker/study-runner/as-importances.ts
@@ -1,0 +1,32 @@
+import type { OptimizerImportances } from "../../messages";
+
+/**
+ * The importances block when it is well formed, else nothing: an estimate is
+ * a garnish on the event, never a reason to fail the study.
+ */
+export const asImportances = (
+  value: unknown,
+): OptimizerImportances | undefined => {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return undefined;
+  }
+  const { values, completedTrials } = value as Record<string, unknown>;
+  if (
+    typeof values !== "object" ||
+    values === null ||
+    Array.isArray(values) ||
+    typeof completedTrials !== "number" ||
+    !Number.isInteger(completedTrials) ||
+    completedTrials < 1
+  ) {
+    return undefined;
+  }
+  const shares: Record<string, number> = {};
+  for (const [identifier, share] of Object.entries(values)) {
+    if (typeof share !== "number" || !(share >= 0 && share <= 1)) {
+      return undefined;
+    }
+    shares[identifier] = share;
+  }
+  return { values: shares, completedTrials };
+};

--- a/libs/@hashintel/petrinaut-core/src/optimization/index.ts
+++ b/libs/@hashintel/petrinaut-core/src/optimization/index.ts
@@ -652,6 +652,15 @@ export const petrinautOptimizationTrialConstraintsSchema = z
     description: "Constraint results of one trial, browser runtime only.",
   });
 
+/** PED-ANOVA importances, normalised to sum to 1, keyed by optimized parameter identifier. */
+export const petrinautOptimizationImportancesSchema = z
+  .strictObject({
+    values: z.record(z.string(), z.number().min(0).max(1)),
+    /** Completed trials the estimate was fitted on. */
+    completedTrials: z.number().int().positive(),
+  })
+  .meta({ description: "Parameter importances, browser runtime only." });
+
 export const petrinautOptimizationTrialEventSchema = z
   .strictObject({
     type: z.literal("trial"),
@@ -662,6 +671,8 @@ export const petrinautOptimizationTrialEventSchema = z
     best: optimizationBestSchema.nullable(),
     /** Present on the trials of a study evaluated in the browser with constraints declared. */
     constraints: petrinautOptimizationTrialConstraintsSchema.optional(),
+    /** Present at the importance cadence on the trials of a study evaluated in the browser. */
+    importances: petrinautOptimizationImportancesSchema.optional(),
     seq: optimizationEventSeqSchema,
   })
   .meta({ description: "One completed Optuna trial and the running best." });
@@ -683,6 +694,8 @@ export const petrinautOptimizationCompleteEventSchema = z
     failedTrials: z.number().int().nonnegative(),
     best: optimizationBestSchema.nullable(),
     resumable: optimizationResumableSchema,
+    /** The final estimate of a study evaluated in the browser, when one could be made. */
+    importances: petrinautOptimizationImportancesSchema.optional(),
     seq: optimizationEventSeqSchema,
   })
   .meta({ description: "The final optimization summary." });
@@ -776,6 +789,9 @@ export type PetrinautOptimizationStateConstraintResult = z.infer<
 >;
 export type PetrinautOptimizationTrialConstraints = z.infer<
   typeof petrinautOptimizationTrialConstraintsSchema
+>;
+export type PetrinautOptimizationImportances = z.infer<
+  typeof petrinautOptimizationImportancesSchema
 >;
 
 /**

--- a/libs/@hashintel/petrinaut-core/src/optimization/optimization.test.ts
+++ b/libs/@hashintel/petrinaut-core/src/optimization/optimization.test.ts
@@ -517,6 +517,33 @@ describe("petrinautOptimizationEventSchema", () => {
     expect(zeroRuns.success).toBe(false);
   });
 
+  it("accepts importances on the trial and complete events, and rejects shares outside [0, 1]", () => {
+    const importances = {
+      values: { rate: 0.75, count: 0.25 },
+      completedTrials: 50,
+    };
+    expect(
+      petrinautOptimizationEventSchema.safeParse({ ...events[1], importances })
+        .success,
+    ).toBe(true);
+    expect(
+      petrinautOptimizationEventSchema.safeParse({ ...events[2], importances })
+        .success,
+    ).toBe(true);
+    expect(
+      petrinautOptimizationEventSchema.safeParse({
+        ...events[2],
+        importances: { values: { rate: 1.5 }, completedTrials: 50 },
+      }).success,
+    ).toBe(false);
+    expect(
+      petrinautOptimizationEventSchema.safeParse({
+        ...events[2],
+        importances: { values: { rate: 1 }, completedTrials: 0 },
+      }).success,
+    ).toBe(false);
+  });
+
   it("rejects negative or fractional sequence numbers", () => {
     const negative = petrinautOptimizationEventSchema.safeParse({
       type: "started",

--- a/libs/@hashintel/petrinaut/docs/optimization.md
+++ b/libs/@hashintel/petrinaut/docs/optimization.md
@@ -258,9 +258,12 @@ view on a laptop screen while the study streams:
   **Correlation** column beside the bars gives each parameter's signed
   correlation with the objective over the completed steps (`+0.34`, `−0.12`),
   computed from the steps themselves, so it is there from the third completed
-  step whatever the floor. Before the first estimate the rows show a dash. The
-  card only appears for a study run in the browser; a study on the service has
-  no sensitivity analysis yet.
+  step whatever the floor. Before the first estimate the rows show a dash. A
+  study that optimizes a single parameter has nothing to rank it against: its
+  line says **PED-ANOVA ranks two or more parameters**, the card is never
+  muted, and only the correlation column carries information. The card only
+  appears for a study run in the browser; a study on the service has no
+  sensitivity analysis yet.
 - The steps table fills whatever height is left, the best step starred and
   tinted. It shows a row or two on a laptop screen and a page of them on a
   taller one; the strip's step count and best value stay in view either way.

--- a/libs/@hashintel/petrinaut/docs/optimization.md
+++ b/libs/@hashintel/petrinaut/docs/optimization.md
@@ -239,6 +239,22 @@ view on a laptop screen while the study streams:
   headline sits in the summary band as **Steps clear**. Infeasible draws are
   hollow grey rings on the surface and grey rows in the steps table, and the
   best step so far is never one of them.
+- The **Parameter importance** card, last in the row, ranks the optimized
+  parameters by how much of the objective's variance each one explains, with
+  a bar and a percentage per parameter. The estimate is Optuna's PED-ANOVA,
+  computed by the optimizer running in your browser once the study is over,
+  and again every few steps while a long study runs (every tenth step, or
+  every twentieth of the requested steps when that is more) once it is past
+  the floor. The line under the title says how many completed steps the
+  estimate is fitted on. Below the floor, 50 completed steps for a study of
+  under 100 steps and 100 otherwise, the card is muted, the bars fade and the
+  line says **below the 50-step floor, treat as a hint**: a confident ranking
+  over a handful of steps would mislead. A **Correlation** column beside the
+  bars gives each parameter's signed correlation with the objective over the
+  completed steps (`+0.34`, `−0.12`), computed from the steps themselves, so
+  it is there from the third completed step whatever the floor. Before the
+  first estimate the rows show a dash. The card only appears for a study run
+  in the browser; a study on the service reports no importance yet.
 - The steps table fills whatever height is left, the best step starred and
   tinted. It shows a row or two on a laptop screen and a page of them on a
   taller one; the strip's step count and best value stay in view either way.

--- a/libs/@hashintel/petrinaut/docs/optimization.md
+++ b/libs/@hashintel/petrinaut/docs/optimization.md
@@ -239,22 +239,23 @@ view on a laptop screen while the study streams:
   headline sits in the summary band as **Steps clear**. Infeasible draws are
   hollow grey rings on the surface and grey rows in the steps table, and the
   best step so far is never one of them.
-- The **Parameter importance** card, last in the row, ranks the optimized
+- The **Sensitivity analysis** card, last in the row, ranks the optimized
   parameters by how much of the objective's variance each one explains, with
-  a bar and a percentage per parameter. The estimate is Optuna's PED-ANOVA,
-  computed by the optimizer running in your browser once the study is over,
-  and again every few steps while a long study runs (every tenth step, or
-  every twentieth of the requested steps when that is more) once it is past
-  the floor. The line under the title says how many completed steps the
-  estimate is fitted on. Below the floor, 50 completed steps for a study of
-  under 100 steps and 100 otherwise, the card is muted, the bars fade and the
-  line says **below the 50-step floor, treat as a hint**: a confident ranking
-  over a handful of steps would mislead. A **Correlation** column beside the
-  bars gives each parameter's signed correlation with the objective over the
-  completed steps (`+0.34`, `−0.12`), computed from the steps themselves, so
-  it is there from the third completed step whatever the floor. Before the
-  first estimate the rows show a dash. The card only appears for a study run
-  in the browser; a study on the service reports no importance yet.
+  a bar and a **Share** percentage per parameter. The estimate is Optuna's
+  PED-ANOVA, computed by the optimizer running in your browser once the study
+  is over, and again every few steps while a long study runs (every tenth
+  step, or every twentieth of the requested steps when that is more) once it
+  is past the floor. The line under the title names the statistic and says
+  how many completed steps it is fitted on. Below the floor, 50 completed
+  steps for a study of under 100 steps and 100 otherwise, the card is muted,
+  the bars fade and the line says **below the 50-step floor, treat as a
+  hint**: a confident ranking over a handful of steps would mislead. A
+  **Correlation** column beside the bars gives each parameter's signed
+  correlation with the objective over the completed steps (`+0.34`, `−0.12`),
+  computed from the steps themselves, so it is there from the third completed
+  step whatever the floor. Before the first estimate the rows show a dash. The
+  card only appears for a study run in the browser; a study on the service has
+  no sensitivity analysis yet.
 - The steps table fills whatever height is left, the best step starred and
   tinted. It shows a row or two on a laptop screen and a page of them on a
   taller one; the strip's step count and best value stay in view either way.

--- a/libs/@hashintel/petrinaut/docs/optimization.md
+++ b/libs/@hashintel/petrinaut/docs/optimization.md
@@ -240,12 +240,16 @@ view on a laptop screen while the study streams:
   hollow grey rings on the surface and grey rows in the steps table, and the
   best step so far is never one of them.
 - The **Sensitivity analysis** card, last in the row, ranks the optimized
-  parameters by how much of the objective's variance each one explains, with
+  parameters by how much each one matters for reaching the best steps, with
   a bar and a **Share** percentage per parameter. The estimate is Optuna's
-  PED-ANOVA, computed by the optimizer running in your browser once the study
-  is over, and again every few steps while a long study runs (every tenth
-  step, or every twentieth of the requested steps when that is more) once it
-  is past the floor. The line under the title names the statistic and says
+  PED-ANOVA: it takes the best tenth of the completed steps and measures how
+  concentrated each parameter's values are there relative to its whole range,
+  a relative importance that sums to 100% rather than a share of the
+  objective's variance. It is computed by the optimizer running in your
+  browser once the study is over, and again every few steps while a long
+  study runs (every tenth step, or every twentieth of the requested steps
+  when that is more) once it is past the floor. The line under the title
+  names the statistic and says
   how many completed steps it is fitted on. Below the floor, 50 completed
   steps for a study of under 100 steps and 100 otherwise, the card is muted,
   the bars fade and the line says **below the N-step floor, treat as a

--- a/libs/@hashintel/petrinaut/docs/optimization.md
+++ b/libs/@hashintel/petrinaut/docs/optimization.md
@@ -248,8 +248,9 @@ view on a laptop screen while the study streams:
   is past the floor. The line under the title names the statistic and says
   how many completed steps it is fitted on. Below the floor, 50 completed
   steps for a study of under 100 steps and 100 otherwise, the card is muted,
-  the bars fade and the line says **below the 50-step floor, treat as a
-  hint**: a confident ranking over a handful of steps would mislead. A
+  the bars fade and the line says **below the N-step floor, treat as a
+  hint**, N being the floor just named: a confident ranking over a handful of
+  steps would mislead. A
   **Correlation** column beside the bars gives each parameter's signed
   correlation with the objective over the completed steps (`+0.34`, `−0.12`),
   computed from the steps themselves, so it is there from the third completed

--- a/libs/@hashintel/petrinaut/src/react/optimizations/context.ts
+++ b/libs/@hashintel/petrinaut/src/react/optimizations/context.ts
@@ -46,9 +46,10 @@ export type OptimizationBest = NonNullable<
 >;
 
 /**
- * PED-ANOVA importances as the optimizer last reported them: a share of the
- * objective's variance per optimized parameter, summing to 1, and the
- * completed trials the estimate was fitted on.
+ * PED-ANOVA importances as the optimizer last reported them: a share of
+ * relative importance per optimized parameter (how concentrated its values
+ * are among the best steps relative to its whole range), summing to 1, and
+ * the completed trials the estimate was fitted on.
  */
 export type OptimizationImportance = PetrinautOptimizationImportances;
 

--- a/libs/@hashintel/petrinaut/src/react/optimizations/context.ts
+++ b/libs/@hashintel/petrinaut/src/react/optimizations/context.ts
@@ -6,6 +6,7 @@ import type { OptimizationSurfaceAxis } from "./surface-grid";
 import type {
   MonteCarloUserDefinedMetricFrame,
   PetrinautOptimizationEvent,
+  PetrinautOptimizationImportances,
   PetrinautOptimizationInput,
   PetrinautOptimizationTrialEvent,
 } from "@hashintel/petrinaut-core";
@@ -43,6 +44,13 @@ export type OptimizationConnectionState = "streaming" | "reconnecting";
 export type OptimizationBest = NonNullable<
   Extract<PetrinautOptimizationEvent, { type: "complete" }>["best"]
 >;
+
+/**
+ * PED-ANOVA importances as the optimizer last reported them: a share of the
+ * objective's variance per optimized parameter, summing to 1, and the
+ * completed trials the estimate was fitted on.
+ */
+export type OptimizationImportance = PetrinautOptimizationImportances;
 
 /** The most runs a study's navigated point is refined to. */
 export const POINT_REFINEMENT_MAX_RUNS = 100;
@@ -169,6 +177,11 @@ export type OptimizationRecord = {
   failedTrials: number;
   trials: readonly PetrinautOptimizationTrialEvent[];
   best: OptimizationBest | null;
+  /**
+   * The latest importance estimate received on a trial or the complete
+   * event; null until the first, and always for a study run on the service.
+   */
+  importance: OptimizationImportance | null;
   /**
    * The backend the study's trials run on: the one asked for, until the
    * first trial that ran elsewhere reports where. `cpu` for a remote study.

--- a/libs/@hashintel/petrinaut/src/react/optimizations/provider.test.tsx
+++ b/libs/@hashintel/petrinaut/src/react/optimizations/provider.test.tsx
@@ -388,6 +388,66 @@ describe("OptimizationsProvider", () => {
     });
   });
 
+  it("keeps the latest importance estimate a trial or the complete event carried", async () => {
+    const first = { values: { infected_ratio: 1 }, completedTrials: 50 };
+    const last = { values: { infected_ratio: 1 }, completedTrials: 60 };
+    const trial = {
+      type: "trial",
+      trial: 0,
+      parameters: { infected_ratio: 0.1 },
+      objective: 1,
+      state: "complete",
+      best: null,
+    } as const;
+    const capability: PetrinautOptimization = {
+      createOptimizationRun: () => Promise.resolve({ runId: "run-importance" }),
+      async *attachOptimizationRun() {
+        yield { ...trial, seq: 1 };
+        yield { ...trial, trial: 1, importances: first, seq: 2 };
+        yield { ...trial, trial: 2, seq: 3 };
+        yield {
+          type: "complete",
+          requestedTrials: 3,
+          completedTrials: 3,
+          prunedTrials: 0,
+          failedTrials: 0,
+          best: null,
+          importances: last,
+          seq: 4,
+        };
+      },
+      cancelOptimizationRun: () => Promise.resolve(),
+    };
+    let latest: OptimizationsContextValue | null = null;
+
+    render(
+      <PetrinautOptimizationContext value={capability}>
+        <PetrinautNavigationProvider>
+          <OptimizationsProvider>
+            <CaptureContext
+              onValue={(value) => {
+                latest = value;
+              }}
+            />
+          </OptimizationsProvider>
+        </PetrinautNavigationProvider>
+      </PetrinautOptimizationContext>,
+    );
+
+    await act(async () => {
+      await latest!.createOptimization(input);
+    });
+    await waitFor(() =>
+      expect(latest!.optimizations[0]?.status).toBe("complete"),
+    );
+
+    expect(latest!.optimizations[0]?.importance).toEqual(last);
+    expect(latest!.optimizations[0]?.trials[1]?.importances).toEqual(first);
+    expect(latest!.optimizations[0]?.trials[2]).not.toHaveProperty(
+      "importances",
+    );
+  });
+
   it("retries a failed optimization from its original input", async () => {
     let call = 0;
     const capability: PetrinautOptimization = {

--- a/libs/@hashintel/petrinaut/src/react/optimizations/provider.tsx
+++ b/libs/@hashintel/petrinaut/src/react/optimizations/provider.tsx
@@ -303,6 +303,7 @@ const createOptimizationRecord = (
   failedTrials: 0,
   trials: [],
   best: null,
+  importance: null,
   computeBackend: "cpu",
   axes: buildOptimizationSurfaceAxes(input),
   connected: null,
@@ -561,6 +562,7 @@ export const OptimizationsProvider = ({ children }: PropsWithChildren) => {
               current.best,
               event,
             ),
+            importance: event.importances ?? current.importance,
           }));
           studiesRef.current.get(optimizationId)?.trialReported(event);
           break;
@@ -579,6 +581,7 @@ export const OptimizationsProvider = ({ children }: PropsWithChildren) => {
                 // running best stay authoritative.
                 requestedTrials: event.requestedTrials,
                 best: event.best ?? current.best,
+                importance: event.importances ?? current.importance,
               },
               () => ({ resumable: resumable(event) }),
             ),

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/optimizations-story-fixtures.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/optimizations-story-fixtures.ts
@@ -797,16 +797,13 @@ const FAKE_STUDIES: Record<
 
 export function useFakeConnectedStudy({
   running,
-  constrained = false,
-  study = constrained ? "constrained" : "base",
+  study = "base",
   importance = false,
   fallbackReason = null,
   refinementError = null,
 }: {
   running: boolean;
-  /** Use the study with two constraints and constraint results on its trials. */
-  constrained?: boolean;
-  /** The fake study to mount; `constrained` picks the constrained one when unset. */
+  /** The fake study to mount. */
   study?: FakeStudyKind;
   /** Attach the PED-ANOVA estimate the optimizer would report once the study is over. */
   importance?: boolean;

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/optimizations-story-fixtures.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/optimizations-story-fixtures.ts
@@ -28,6 +28,7 @@ import type { SweepCellSnapshot } from "../../../../../../react/experiments/swee
 import type {
   ConnectedStudyState,
   OptimizationBest,
+  OptimizationImportance,
   OptimizationNavigation,
   OptimizationRecord,
   OptimizationsContextValue,
@@ -124,6 +125,7 @@ export const optimizedBindingSets = {
  */
 export function makeOptimizationInput(
   optimized: Record<string, PetrinautOptimizationParameterBinding>,
+  { trials = 30 }: { trials?: number } = {},
 ): PetrinautOptimizationInput {
   const definition = supplyChainProfit.petriNetDefinition;
   const scenario = definition.scenarios?.find(
@@ -159,7 +161,7 @@ export function makeOptimizationInput(
     scenario: { id: scenario.id, parameterBindings },
     objective: { metricId: "metric_profit", direction: "maximize" },
     execution: { seed: 1_234, dt: 1, maxTime: 365 },
-    study: { trials: 30, sampler: "tpe" },
+    study: { trials, sampler: "tpe" },
   });
 }
 
@@ -297,6 +299,8 @@ export function makeOptimizationRecord(options: {
   computeBackend?: ExperimentComputeBackend;
   /** The local state of a connected study; a remote study has none. */
   connected?: ConnectedStudyState | null;
+  /** The latest importance estimate the study reported; none by default. */
+  importance?: OptimizationImportance | null;
 }): OptimizationRecord {
   const {
     input,
@@ -305,6 +309,7 @@ export function makeOptimizationRecord(options: {
     status = "running",
     computeBackend = "cpu",
     connected = null,
+    importance = null,
   } = options;
   return {
     id: "optimization-story-1",
@@ -324,6 +329,7 @@ export function makeOptimizationRecord(options: {
     failedTrials: trials.filter((trial) => trial.state === "failed").length,
     trials,
     best,
+    importance,
     computeBackend,
     axes: buildOptimizationSurfaceAxes(input),
     connected,
@@ -541,6 +547,56 @@ export const fakeStudyInput = makeOptimizationInput(
 );
 export const fakeStudyTrials = makeTrials(fakeStudyInput, 30);
 
+/** The same study asked for 60 steps: past the 50-step importance floor once it lands. */
+export const fakeLongStudyInput = makeOptimizationInput(
+  optimizedBindingSets.logScale,
+  { trials: 60 },
+);
+export const fakeLongStudyTrials = makeTrials(fakeLongStudyInput, 60);
+
+/**
+ * How much of the synthetic objective's variance each parameter moves, by
+ * hand: the bump over production rate and selling price dominates, marketing
+ * spend's logarithm adds little, and a batch size only shifts a penalty.
+ */
+const SYNTHETIC_IMPORTANCE_WEIGHTS: Record<string, number> = {
+  production_rate: 0.55,
+  selling_price: 0.32,
+  marketing_spend: 0.09,
+  batch_size: 0.04,
+};
+
+/**
+ * The PED-ANOVA block the optimizer would attach after `trials` landed:
+ * shares over the study's optimized parameters, normalised to sum to 1,
+ * fitted on the completed steps among them.
+ */
+export function makeImportance(
+  input: PetrinautOptimizationInput,
+  trials: readonly PetrinautOptimizationTrialEvent[],
+): OptimizationImportance {
+  const identifiers = Object.entries(input.scenario.parameterBindings)
+    .filter(([, binding]) => binding.kind === "optimize")
+    .map(([identifier]) => identifier);
+  const total = identifiers.reduce(
+    (sum, identifier) =>
+      sum + (SYNTHETIC_IMPORTANCE_WEIGHTS[identifier] ?? 0.05),
+    0,
+  );
+  return {
+    values: Object.fromEntries(
+      identifiers.map((identifier) => [
+        identifier,
+        (SYNTHETIC_IMPORTANCE_WEIGHTS[identifier] ?? 0.05) / total,
+      ]),
+    ),
+    completedTrials: Math.max(
+      1,
+      trials.filter((trial) => trial.state === "complete").length,
+    ),
+  };
+}
+
 const hirSpan = { start: 0, length: 0 };
 const hirNumber = (id: number, value: number): HirExpr => ({
   kind: "numberLit",
@@ -721,21 +777,44 @@ const REFINEMENT_LADDER = [8, 25, 100];
  * batches after every move. Returns the record and the context value the
  * story mounts.
  */
+/** Which fake study the connected stories mount. */
+export type FakeStudyKind = "base" | "constrained" | "long";
+
+const FAKE_STUDIES: Record<
+  FakeStudyKind,
+  {
+    input: PetrinautOptimizationInput;
+    trials: ReturnType<typeof makeTrials>;
+  }
+> = {
+  base: { input: fakeStudyInput, trials: fakeStudyTrials },
+  constrained: {
+    input: fakeConstrainedStudyInput,
+    trials: fakeConstrainedStudyTrials,
+  },
+  long: { input: fakeLongStudyInput, trials: fakeLongStudyTrials },
+};
+
 export function useFakeConnectedStudy({
   running,
   constrained = false,
+  study = constrained ? "constrained" : "base",
+  importance = false,
   fallbackReason = null,
   refinementError = null,
 }: {
   running: boolean;
   /** Use the study with two constraints and constraint results on its trials. */
   constrained?: boolean;
+  /** The fake study to mount; `constrained` picks the constrained one when unset. */
+  study?: FakeStudyKind;
+  /** Attach the PED-ANOVA estimate the optimizer would report once the study is over. */
+  importance?: boolean;
   fallbackReason?: string | null;
   /** Set to have every navigated point fail with this reason instead of refining. */
   refinementError?: string | null;
 }): { optimization: OptimizationRecord; value: OptimizationsContextValue } {
-  const input = constrained ? fakeConstrainedStudyInput : fakeStudyInput;
-  const allTrials = constrained ? fakeConstrainedStudyTrials : fakeStudyTrials;
+  const { input, trials: allTrials } = FAKE_STUDIES[study];
   const clock = useFakeStudyClock({
     steps: running ? allTrials.trials.length : 0,
     ticksPerStep: 8,
@@ -804,6 +883,7 @@ export function useFakeConnectedStudy({
     trials,
     best: trials.at(-1)?.best ?? null,
     status: inFlight ? "running" : "complete",
+    importance: importance && !inFlight ? makeImportance(input, trials) : null,
     connected: makeConnectedStudyState(input, {
       navigation,
       selection,

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view.tsx
@@ -294,7 +294,7 @@ const RemoteStudyBody = ({
  * A study evaluated in this browser: the header and the summary, the
  * parameter controls with their state line, the chart cards (the surface, the
  * objective at the point, the objective by step, Constraints when the study
- * declares any, and Parameter importance), and the steps filling what is
+ * declares any, and Sensitivity analysis), and the steps filling what is
  * left. The navigation drives the surface and the objective's timeline,
  * following each step while the study runs.
  */

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view.tsx
@@ -36,6 +36,7 @@ import {
   OBJECTIVE_PLOT_HEIGHT,
   OptimizationMetrics,
 } from "./study-view/optimization-metrics";
+import { ParameterImportancePanel } from "./study-view/parameter-importance-panel";
 import { StepsTable } from "./study-view/steps-table";
 import { type StudyPhase, studyPhase } from "./study-view/study-phase";
 import { StudySummaryBand } from "./study-view/study-summary-strip";
@@ -291,8 +292,9 @@ const RemoteStudyBody = ({
 
 /**
  * A study evaluated in this browser: the header and the summary, the
- * parameter controls with their state line, the three chart cards (a fourth,
- * Constraints, when the study declares any), and the steps filling what is
+ * parameter controls with their state line, the chart cards (the surface, the
+ * objective at the point, the objective by step, Constraints when the study
+ * declares any, and Parameter importance), and the steps filling what is
  * left. The navigation drives the surface and the objective's timeline,
  * following each step while the study runs.
  */
@@ -354,6 +356,12 @@ const ConnectedStudyBody = ({
               plotHeight={OBJECTIVE_PLOT_HEIGHT}
             />
           ) : null}
+          {/* Only a study evaluated here receives importances; a remote study
+            has no panel rather than an empty one. */}
+          <ParameterImportancePanel
+            optimization={optimization}
+            plotHeight={OBJECTIVE_PLOT_HEIGHT}
+          />
         </div>
         <div className={connectedStepsStyle}>
           <StepsTable

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/importance-view.test.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/importance-view.test.ts
@@ -185,7 +185,7 @@ describe("importanceRows", () => {
 });
 
 describe("the card's copy", () => {
-  it("leads with the count, names the floor only below it, and ends with PED-ANOVA's question", () => {
+  it("names the statistic and the count, the floor only below it, and ends with the question the bars answer", () => {
     const rows: never[] = [];
     expect(
       describeImportance({
@@ -197,7 +197,7 @@ describe("the card's copy", () => {
         barScale: 0.5,
       }),
     ).toBe(
-      "estimated from 54 completed steps · PED-ANOVA: how much of the objective's variance each parameter explains",
+      "PED-ANOVA importance estimated from 54 completed steps · how much of the objective's variance each parameter explains",
     );
     expect(
       describeImportance({
@@ -209,7 +209,7 @@ describe("the card's copy", () => {
         barScale: 1,
       }),
     ).toBe(
-      "estimated from 27 completed steps · below the 50-step floor, treat as a hint · PED-ANOVA: how much of the objective's variance each parameter explains",
+      "PED-ANOVA importance estimated from 27 completed steps · below the 50-step floor, treat as a hint · how much of the objective's variance each parameter explains",
     );
     expect(
       describeImportance({
@@ -220,7 +220,7 @@ describe("the card's copy", () => {
         belowFloor: true,
         barScale: 1,
       }),
-    ).toContain("estimated from 1 completed step ·");
+    ).toContain("importance estimated from 1 completed step ·");
     expect(
       describeImportance({
         rows,
@@ -231,7 +231,7 @@ describe("the card's copy", () => {
         barScale: 1,
       }),
     ).toMatch(
-      /^no estimate yet · 12 completed steps · below the 50-step floor/u,
+      /^no PED-ANOVA importance yet · 12 completed steps · below the 50-step floor/u,
     );
   });
 

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/importance-view.test.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/importance-view.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  makeOptimizationInput,
+  makeOptimizationRecord,
+  makeTrials,
+  optimizedBindingSets,
+} from "../optimizations-story-fixtures";
+import {
+  describeImportance,
+  formatCorrelation,
+  formatImportance,
+  importanceFloor,
+  importanceRows,
+  optimizedParameterIdentifiers,
+  pearsonCorrelations,
+} from "./importance-view";
+
+import type { PetrinautOptimizationTrialEvent } from "@hashintel/petrinaut-core";
+
+const trialAt = (
+  trial: number,
+  parameters: Record<string, number | boolean>,
+  objective: number | null,
+): PetrinautOptimizationTrialEvent => ({
+  type: "trial",
+  trial,
+  parameters,
+  objective,
+  state: objective === null ? "pruned" : "complete",
+  best: null,
+});
+
+describe("importanceFloor", () => {
+  it("is 100 for a study of 100 steps or more, else 50", () => {
+    expect(importanceFloor(30)).toBe(50);
+    expect(importanceFloor(99)).toBe(50);
+    expect(importanceFloor(100)).toBe(100);
+    expect(importanceFloor(400)).toBe(100);
+  });
+});
+
+describe("optimizedParameterIdentifiers", () => {
+  it("lists numeric and boolean optimized parameters in binding order, never fixed ones", () => {
+    const input = {
+      scenario: {
+        id: "scenario",
+        parameterBindings: {
+          batch_size: { kind: "fixed", value: 220 },
+          ...optimizedBindingSets.base,
+          express_shipping: { kind: "optimize", domain: { kind: "boolean" } },
+        },
+      },
+    } satisfies Parameters<typeof optimizedParameterIdentifiers>[0];
+
+    expect(optimizedParameterIdentifiers(input)).toEqual([
+      "production_rate",
+      "selling_price",
+      "express_shipping",
+    ]);
+  });
+});
+
+describe("pearsonCorrelations", () => {
+  it("is ±1 within 1e-9 on a linear objective, with booleans as 0 and 1", () => {
+    const trials = [0.1, 0.4, 0.7, 0.9].map((rate, index) =>
+      trialAt(
+        index,
+        { rate, enabled: index % 2 === 0, fixed: 3 },
+        10 - 4 * rate,
+      ),
+    );
+
+    const correlations = pearsonCorrelations(trials, [
+      "rate",
+      "enabled",
+      "fixed",
+    ]);
+
+    expect(correlations.rate).toBeCloseTo(-1, 9);
+    expect(correlations.enabled).not.toBeNull();
+    expect(Math.abs(correlations.enabled!)).toBeLessThan(1);
+    expect(correlations.fixed).toBeNull();
+  });
+
+  it("is null under three completed steps and leaves pruned steps out", () => {
+    const two = [trialAt(0, { rate: 0.1 }, 1), trialAt(1, { rate: 0.2 }, 2)];
+    expect(pearsonCorrelations(two, ["rate"]).rate).toBeNull();
+
+    const withPruned = [...two, trialAt(2, { rate: 0.3 }, null)];
+    expect(pearsonCorrelations(withPruned, ["rate"]).rate).toBeNull();
+
+    const three = [...two, trialAt(2, { rate: 0.3 }, 3)];
+    expect(pearsonCorrelations(three, ["rate"]).rate).toBeCloseTo(1, 9);
+  });
+});
+
+describe("importanceRows", () => {
+  const input = makeOptimizationInput(optimizedBindingSets.logScale);
+  const { trials } = makeTrials(input, 30);
+
+  it("sorts by importance then identifier and scales the bars to the largest share above the floor", () => {
+    const view = importanceRows(
+      makeOptimizationRecord({
+        input: { ...input, study: { ...input.study, trials: 60 } },
+        trials,
+        importance: {
+          values: {
+            production_rate: 0.5,
+            selling_price: 0.3,
+            marketing_spend: 0.2,
+          },
+          completedTrials: 54,
+        },
+      }),
+    );
+
+    expect(view.rows.map((row) => row.identifier)).toEqual([
+      "production_rate",
+      "selling_price",
+      "marketing_spend",
+    ]);
+    expect(view.rows.every((row) => row.correlation !== null)).toBe(true);
+    expect(view).toMatchObject({
+      effectiveCount: 54,
+      floor: 50,
+      belowFloor: false,
+      barScale: 0.5,
+    });
+  });
+
+  it("fades below the floor: the estimate's own count, the whole unit as the scale", () => {
+    const view = importanceRows(
+      makeOptimizationRecord({
+        input,
+        trials,
+        importance: {
+          values: {
+            production_rate: 0.3,
+            selling_price: 0.5,
+            marketing_spend: 0.2,
+          },
+          completedTrials: 27,
+        },
+      }),
+    );
+
+    expect(view.rows[0]?.identifier).toBe("selling_price");
+    expect(view).toMatchObject({
+      effectiveCount: 27,
+      floor: 50,
+      belowFloor: true,
+      barScale: 1,
+    });
+  });
+
+  it("counts the completed steps itself while no estimate arrived, keeping identifier order and the correlations", () => {
+    const view = importanceRows(makeOptimizationRecord({ input, trials }));
+
+    expect(view.rows.map((row) => row.identifier)).toEqual([
+      "marketing_spend",
+      "production_rate",
+      "selling_price",
+    ]);
+    expect(view.rows.every((row) => row.importance === null)).toBe(true);
+    expect(view.rows.every((row) => row.correlation !== null)).toBe(true);
+    expect(view.effectiveCount).toBe(
+      trials.filter((trial) => trial.state === "complete").length,
+    );
+    expect(view.belowFloor).toBe(true);
+  });
+
+  it("gives an empty study dashed rows and no correlations", () => {
+    const view = importanceRows(makeOptimizationRecord({ input }));
+
+    expect(view.rows).toHaveLength(3);
+    expect(
+      view.rows.every(
+        (row) => row.importance === null && row.correlation === null,
+      ),
+    ).toBe(true);
+    expect(view.effectiveCount).toBe(0);
+  });
+});
+
+describe("the card's copy", () => {
+  it("leads with the count, names the floor only below it, and ends with PED-ANOVA's question", () => {
+    const rows: never[] = [];
+    expect(
+      describeImportance({
+        rows,
+        effectiveCount: 54,
+        floor: 50,
+        belowFloor: false,
+        barScale: 0.5,
+      }),
+    ).toBe(
+      "estimated from 54 completed steps · PED-ANOVA: how much of the objective's variance each parameter explains",
+    );
+    expect(
+      describeImportance({
+        rows,
+        effectiveCount: 27,
+        floor: 50,
+        belowFloor: true,
+        barScale: 1,
+      }),
+    ).toBe(
+      "estimated from 27 completed steps · below the 50-step floor, treat as a hint · PED-ANOVA: how much of the objective's variance each parameter explains",
+    );
+    expect(
+      describeImportance({
+        rows,
+        effectiveCount: 1,
+        floor: 50,
+        belowFloor: true,
+        barScale: 1,
+      }),
+    ).toContain("estimated from 1 completed step ·");
+  });
+
+  it("prints a share as a whole percentage and a correlation with its sign", () => {
+    expect(formatImportance(0.5)).toBe("50%");
+    expect(formatImportance(0.004)).toBe("0%");
+    expect(formatCorrelation(0.834)).toBe("+0.83");
+    expect(formatCorrelation(-0.125)).toBe("−0.13");
+    expect(formatCorrelation(0)).toBe("+0.00");
+  });
+});

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/importance-view.test.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/importance-view.test.ts
@@ -167,6 +167,7 @@ describe("importanceRows", () => {
     expect(view.effectiveCount).toBe(
       trials.filter((trial) => trial.state === "complete").length,
     );
+    expect(view.estimated).toBe(false);
     expect(view.belowFloor).toBe(true);
   });
 
@@ -189,6 +190,7 @@ describe("the card's copy", () => {
     expect(
       describeImportance({
         rows,
+        estimated: true,
         effectiveCount: 54,
         floor: 50,
         belowFloor: false,
@@ -200,6 +202,7 @@ describe("the card's copy", () => {
     expect(
       describeImportance({
         rows,
+        estimated: true,
         effectiveCount: 27,
         floor: 50,
         belowFloor: true,
@@ -211,12 +214,25 @@ describe("the card's copy", () => {
     expect(
       describeImportance({
         rows,
+        estimated: true,
         effectiveCount: 1,
         floor: 50,
         belowFloor: true,
         barScale: 1,
       }),
     ).toContain("estimated from 1 completed step ·");
+    expect(
+      describeImportance({
+        rows,
+        estimated: false,
+        effectiveCount: 12,
+        floor: 50,
+        belowFloor: true,
+        barScale: 1,
+      }),
+    ).toMatch(
+      /^no estimate yet · 12 completed steps · below the 50-step floor/u,
+    );
   });
 
   it("prints a share as a whole percentage and a correlation with its sign", () => {

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/importance-view.test.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/importance-view.test.ts
@@ -95,6 +95,14 @@ describe("pearsonCorrelations", () => {
   });
 });
 
+/** A study moving one parameter: valid to create, but nothing for PED-ANOVA to rank it against. */
+const singleOptimizedBinding = {
+  production_rate: {
+    kind: "optimize",
+    domain: { kind: "continuous", minimum: 50, maximum: 400, scale: "linear" },
+  },
+} satisfies Parameters<typeof makeOptimizationInput>[0];
+
 describe("importanceRows", () => {
   const input = makeOptimizationInput(optimizedBindingSets.logScale);
   const { trials } = makeTrials(input, 30);
@@ -182,6 +190,37 @@ describe("importanceRows", () => {
     ).toBe(true);
     expect(view.effectiveCount).toBe(0);
   });
+
+  it("calls a study with one optimized parameter unrankable, never below the floor, and keeps its correlation", () => {
+    const singleParameterInput = makeOptimizationInput(singleOptimizedBinding);
+    const singleParameterTrials = makeTrials(singleParameterInput, 30).trials;
+    const completedCount = singleParameterTrials.filter(
+      (trial) => trial.state === "complete",
+    ).length;
+
+    const view = importanceRows(
+      makeOptimizationRecord({
+        input: singleParameterInput,
+        trials: singleParameterTrials,
+        importance: null,
+      }),
+    );
+
+    expect(completedCount).toBeLessThan(view.floor);
+    expect(view).toMatchObject({
+      rankable: false,
+      estimated: false,
+      effectiveCount: completedCount,
+      belowFloor: false,
+      barScale: 1,
+    });
+    expect(view.rows).toHaveLength(1);
+    expect(view.rows[0]?.importance).toBeNull();
+    expect(view.rows[0]?.correlation).not.toBeNull();
+    expect(describeImportance(view)).toBe(
+      `PED-ANOVA ranks two or more parameters · ${completedCount} completed steps · correlation only`,
+    );
+  });
 });
 
 describe("the card's copy", () => {
@@ -190,6 +229,7 @@ describe("the card's copy", () => {
     expect(
       describeImportance({
         rows,
+        rankable: true,
         estimated: true,
         effectiveCount: 54,
         floor: 50,
@@ -202,6 +242,7 @@ describe("the card's copy", () => {
     expect(
       describeImportance({
         rows,
+        rankable: true,
         estimated: true,
         effectiveCount: 27,
         floor: 50,
@@ -214,6 +255,7 @@ describe("the card's copy", () => {
     expect(
       describeImportance({
         rows,
+        rankable: true,
         estimated: true,
         effectiveCount: 1,
         floor: 50,
@@ -224,6 +266,7 @@ describe("the card's copy", () => {
     expect(
       describeImportance({
         rows,
+        rankable: true,
         estimated: false,
         effectiveCount: 12,
         floor: 50,

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/importance-view.test.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/importance-view.test.ts
@@ -197,7 +197,7 @@ describe("the card's copy", () => {
         barScale: 0.5,
       }),
     ).toBe(
-      "PED-ANOVA importance estimated from 54 completed steps · how much of the objective's variance each parameter explains",
+      "PED-ANOVA importance estimated from 54 completed steps · how much each parameter matters for reaching the best steps",
     );
     expect(
       describeImportance({
@@ -209,7 +209,7 @@ describe("the card's copy", () => {
         barScale: 1,
       }),
     ).toBe(
-      "PED-ANOVA importance estimated from 27 completed steps · below the 50-step floor, treat as a hint · how much of the objective's variance each parameter explains",
+      "PED-ANOVA importance estimated from 27 completed steps · below the 50-step floor, treat as a hint · how much each parameter matters for reaching the best steps",
     );
     expect(
       describeImportance({

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/importance-view.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/importance-view.ts
@@ -28,6 +28,8 @@ export type ImportanceRow = {
 export type ImportanceView = {
   /** Sorted by importance, largest first, then by identifier. */
   rows: readonly ImportanceRow[];
+  /** Whether PED-ANOVA can rank the study at all: it needs two or more optimized parameters. */
+  rankable: boolean;
   /** Whether an estimate has been received at all. */
   estimated: boolean;
   /** Completed steps the estimate is fitted on, or completed so far while none was received. */
@@ -150,13 +152,16 @@ export const importanceRows = (
   ).length;
   const effectiveCount = importance?.completedTrials ?? completedCount;
   const floor = importanceFloor(requestedTrials);
-  const belowFloor = effectiveCount < floor;
+  // The same rule as the optimizer core: one parameter has nothing to rank against.
+  const rankable = identifiers.length >= 2;
+  const belowFloor = rankable && effectiveCount < floor;
   const largest = rows.reduce(
     (max, row) => Math.max(max, row.importance ?? 0),
     0,
   );
   return {
     rows,
+    rankable,
     estimated: importance !== null,
     effectiveCount,
     floor,
@@ -168,10 +173,15 @@ export const importanceRows = (
 /**
  * The line under the card's title: the statistic and the count first, so
  * they survive a narrow card's clipping. Before the first estimate the line
- * says so rather than claiming an estimate over the steps completed so far.
+ * says so rather than claiming an estimate over the steps completed so far;
+ * a study with one optimized parameter never gets one, so its line says why
+ * and points at the correlation column.
  */
 export const describeImportance = (view: ImportanceView): string => {
   const steps = `${view.effectiveCount} completed ${view.effectiveCount === 1 ? "step" : "steps"}`;
+  if (!view.rankable) {
+    return `PED-ANOVA ranks two or more parameters · ${steps} · correlation only`;
+  }
   const count = view.estimated
     ? `PED-ANOVA importance estimated from ${steps}`
     : `no PED-ANOVA importance yet · ${steps}`;

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/importance-view.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/importance-view.ts
@@ -28,6 +28,8 @@ export type ImportanceRow = {
 export type ImportanceView = {
   /** Sorted by importance, largest first, then by identifier. */
   rows: readonly ImportanceRow[];
+  /** Whether an estimate has been received at all. */
+  estimated: boolean;
   /** Completed steps the estimate is fitted on, or completed so far while none was received. */
   effectiveCount: number;
   floor: number;
@@ -155,6 +157,7 @@ export const importanceRows = (
   );
   return {
     rows,
+    estimated: importance !== null,
     effectiveCount,
     floor,
     belowFloor,
@@ -162,9 +165,16 @@ export const importanceRows = (
   };
 };
 
-/** The line under the card's title: the count first, so it survives a narrow card's clipping. */
+/**
+ * The line under the card's title: the count first, so it survives a narrow
+ * card's clipping. Before the first estimate the line says so rather than
+ * claiming an estimate over the steps completed so far.
+ */
 export const describeImportance = (view: ImportanceView): string => {
-  const count = `estimated from ${view.effectiveCount} completed ${view.effectiveCount === 1 ? "step" : "steps"}`;
+  const steps = `${view.effectiveCount} completed ${view.effectiveCount === 1 ? "step" : "steps"}`;
+  const count = view.estimated
+    ? `estimated from ${steps}`
+    : `no estimate yet · ${steps}`;
   const floor = view.belowFloor
     ? ` · below the ${view.floor}-step floor, treat as a hint`
     : "";

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/importance-view.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/importance-view.ts
@@ -19,7 +19,7 @@ const MIN_CORRELATION_TRIALS = 3;
 
 export type ImportanceRow = {
   identifier: string;
-  /** PED-ANOVA share of the objective's variance; null while none was received. */
+  /** PED-ANOVA share of relative importance for reaching the best steps; null while none was received. */
   importance: number | null;
   /** Signed Pearson correlation of the parameter with the objective over the completed steps. */
   correlation: number | null;
@@ -178,7 +178,7 @@ export const describeImportance = (view: ImportanceView): string => {
   const floor = view.belowFloor
     ? ` · below the ${view.floor}-step floor, treat as a hint`
     : "";
-  return `${count}${floor} · how much of the objective's variance each parameter explains`;
+  return `${count}${floor} · how much each parameter matters for reaching the best steps`;
 };
 
 /** A share as the bar prints it: a whole percentage. */

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/importance-view.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/importance-view.ts
@@ -1,5 +1,5 @@
 /**
- * The Parameter importance card's data: one row per optimized parameter with
+ * The Sensitivity analysis card's data: one row per optimized parameter with
  * the PED-ANOVA share the optimizer last reported and a signed Pearson
  * correlation computed here from the completed steps, plus the floor under
  * which the estimate is only a hint. Pure, so the fade rule and the maths are
@@ -166,19 +166,19 @@ export const importanceRows = (
 };
 
 /**
- * The line under the card's title: the count first, so it survives a narrow
- * card's clipping. Before the first estimate the line says so rather than
- * claiming an estimate over the steps completed so far.
+ * The line under the card's title: the statistic and the count first, so
+ * they survive a narrow card's clipping. Before the first estimate the line
+ * says so rather than claiming an estimate over the steps completed so far.
  */
 export const describeImportance = (view: ImportanceView): string => {
   const steps = `${view.effectiveCount} completed ${view.effectiveCount === 1 ? "step" : "steps"}`;
   const count = view.estimated
-    ? `estimated from ${steps}`
-    : `no estimate yet · ${steps}`;
+    ? `PED-ANOVA importance estimated from ${steps}`
+    : `no PED-ANOVA importance yet · ${steps}`;
   const floor = view.belowFloor
     ? ` · below the ${view.floor}-step floor, treat as a hint`
     : "";
-  return `${count}${floor} · PED-ANOVA: how much of the objective's variance each parameter explains`;
+  return `${count}${floor} · how much of the objective's variance each parameter explains`;
 };
 
 /** A share as the bar prints it: a whole percentage. */

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/importance-view.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/importance-view.ts
@@ -1,0 +1,182 @@
+/**
+ * The Parameter importance card's data: one row per optimized parameter with
+ * the PED-ANOVA share the optimizer last reported and a signed Pearson
+ * correlation computed here from the completed steps, plus the floor under
+ * which the estimate is only a hint. Pure, so the fade rule and the maths are
+ * tested without the DOM.
+ */
+import type { OptimizationRecord } from "../../../../../../../react/optimizations/context";
+import type {
+  PetrinautOptimizationInput,
+  PetrinautOptimizationTrialEvent,
+} from "@hashintel/petrinaut-core";
+
+/** A study requesting this many steps or more earns the higher floor. */
+const LONG_STUDY_TRIALS = 100;
+
+/** Pearson needs this many completed steps before it says anything. */
+const MIN_CORRELATION_TRIALS = 3;
+
+export type ImportanceRow = {
+  identifier: string;
+  /** PED-ANOVA share of the objective's variance; null while none was received. */
+  importance: number | null;
+  /** Signed Pearson correlation of the parameter with the objective over the completed steps. */
+  correlation: number | null;
+};
+
+export type ImportanceView = {
+  /** Sorted by importance, largest first, then by identifier. */
+  rows: readonly ImportanceRow[];
+  /** Completed steps the estimate is fitted on, or completed so far while none was received. */
+  effectiveCount: number;
+  floor: number;
+  belowFloor: boolean;
+  /**
+   * What a full-width bar stands for. The largest share above the floor;
+   * the whole unit below it, so faded bars never set the scale.
+   */
+  barScale: number;
+};
+
+/** The completed-step count from which the estimate is worth trusting; matches the optimizer core. */
+export const importanceFloor = (requestedTrials: number): number =>
+  requestedTrials >= LONG_STUDY_TRIALS ? LONG_STUDY_TRIALS : 50;
+
+/** Every parameter the study lets the optimizer move, numeric and boolean, in binding order. */
+export const optimizedParameterIdentifiers = (
+  input: Pick<PetrinautOptimizationInput, "scenario">,
+): string[] =>
+  Object.entries(input.scenario.parameterBindings)
+    .filter(([, binding]) => binding.kind === "optimize")
+    .map(([identifier]) => identifier);
+
+const asNumber = (value: number | boolean | undefined): number | null =>
+  typeof value === "boolean" ? (value ? 1 : 0) : (value ?? null);
+
+const pearson = (
+  pairs: readonly (readonly [number, number])[],
+): number | null => {
+  if (pairs.length < MIN_CORRELATION_TRIALS) {
+    return null;
+  }
+  let sumX = 0;
+  let sumY = 0;
+  for (const [x, y] of pairs) {
+    sumX += x;
+    sumY += y;
+  }
+  const meanX = sumX / pairs.length;
+  const meanY = sumY / pairs.length;
+  let covariance = 0;
+  let varianceX = 0;
+  let varianceY = 0;
+  for (const [x, y] of pairs) {
+    covariance += (x - meanX) * (y - meanY);
+    varianceX += (x - meanX) ** 2;
+    varianceY += (y - meanY) ** 2;
+  }
+  if (varianceX === 0 || varianceY === 0) {
+    return null;
+  }
+  return covariance / Math.sqrt(varianceX * varianceY);
+};
+
+/**
+ * The signed Pearson correlation of each parameter with the objective over
+ * the completed steps, booleans as 0 and 1. Null under three completed steps
+ * and when either side has no variance.
+ */
+export const pearsonCorrelations = (
+  trials: readonly PetrinautOptimizationTrialEvent[],
+  identifiers: readonly string[],
+): Record<string, number | null> => {
+  const completed = trials.filter(
+    (trial) => trial.state === "complete" && trial.objective !== null,
+  );
+  const correlations: Record<string, number | null> = {};
+  for (const identifier of identifiers) {
+    const pairs: (readonly [number, number])[] = [];
+    for (const trial of completed) {
+      const value = asNumber(trial.parameters[identifier]);
+      if (value !== null && trial.objective !== null) {
+        pairs.push([value, trial.objective]);
+      }
+    }
+    correlations[identifier] = pearson(pairs);
+  }
+  return correlations;
+};
+
+const byImportanceThenIdentifier = (
+  left: ImportanceRow,
+  right: ImportanceRow,
+): number => {
+  if (left.importance !== right.importance) {
+    if (left.importance === null) {
+      return 1;
+    }
+    if (right.importance === null) {
+      return -1;
+    }
+    return right.importance - left.importance;
+  }
+  return left.identifier.localeCompare(right.identifier);
+};
+
+/** The card's rows and its fade verdict, derived from the record alone. */
+export const importanceRows = (
+  optimization: Pick<
+    OptimizationRecord,
+    "trials" | "importance" | "input" | "requestedTrials"
+  >,
+): ImportanceView => {
+  const { trials, importance, input, requestedTrials } = optimization;
+  const identifiers = optimizedParameterIdentifiers(input);
+  const correlations = pearsonCorrelations(trials, identifiers);
+  const rows = identifiers
+    .map(
+      (identifier): ImportanceRow => ({
+        identifier,
+        importance: importance?.values[identifier] ?? null,
+        correlation: correlations[identifier] ?? null,
+      }),
+    )
+    .sort(byImportanceThenIdentifier);
+  const completedCount = trials.filter(
+    (trial) => trial.state === "complete",
+  ).length;
+  const effectiveCount = importance?.completedTrials ?? completedCount;
+  const floor = importanceFloor(requestedTrials);
+  const belowFloor = effectiveCount < floor;
+  const largest = rows.reduce(
+    (max, row) => Math.max(max, row.importance ?? 0),
+    0,
+  );
+  return {
+    rows,
+    effectiveCount,
+    floor,
+    belowFloor,
+    barScale: belowFloor || largest === 0 ? 1 : largest,
+  };
+};
+
+/** The line under the card's title: the count first, so it survives a narrow card's clipping. */
+export const describeImportance = (view: ImportanceView): string => {
+  const count = `estimated from ${view.effectiveCount} completed ${view.effectiveCount === 1 ? "step" : "steps"}`;
+  const floor = view.belowFloor
+    ? ` · below the ${view.floor}-step floor, treat as a hint`
+    : "";
+  return `${count}${floor} · PED-ANOVA: how much of the objective's variance each parameter explains`;
+};
+
+/** A share as the bar prints it: a whole percentage. */
+export const formatImportance = (importance: number): string =>
+  `${Math.round(importance * 100)}%`;
+
+/** A correlation with its sign always shown, a true minus sign for the negative side. */
+export const formatCorrelation = (correlation: number): string => {
+  const magnitude = Math.abs(correlation).toFixed(2);
+  return correlation < 0 ? `−${magnitude}` : `+${magnitude}`;
+};

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/parameter-importance-panel.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/parameter-importance-panel.tsx
@@ -118,7 +118,7 @@ const correlationStyle = css({
 });
 
 const HELP =
-  "PED-ANOVA compares the parameter values of the best steps with those of every step: the parameter whose values differ most between the two explains most of the objective's variance. Shares sum to 100%. Correlation is the signed Pearson correlation of each parameter with the objective over the completed steps, computed from the steps themselves, so it is available from the third completed step. Below the floor the estimate is faded: treat it as a hint.";
+  "PED-ANOVA looks at the best tenth of the completed steps and measures how far each parameter's values there are concentrated relative to its whole range: the parameter whose good values are the most concentrated matters most for reaching top results. Shares are relative and sum to 100%. Correlation is the signed Pearson correlation of each parameter with the objective over the completed steps, computed from the steps themselves, so it is available from the third completed step. Below the floor the estimate is faded: treat it as a hint.";
 
 export const ParameterImportancePanel = ({
   optimization,

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/parameter-importance-panel.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/parameter-importance-panel.tsx
@@ -1,5 +1,5 @@
 /**
- * The Parameter importance card: one row per optimized parameter with a bar
+ * The Sensitivity analysis card: one row per optimized parameter with a bar
  * for the PED-ANOVA share the optimizer last reported and a column for the
  * signed correlation computed here from the steps. Below the study's floor the
  * card is muted and the bars fade, so a confident chart never sits on a
@@ -132,7 +132,7 @@ export const ParameterImportancePanel = ({
 
   return (
     <ChartCard
-      title="Parameter importance"
+      title="Sensitivity analysis"
       subtitle={describeImportance(view)}
       help={HELP}
       bodyHeight={plotHeight}
@@ -145,7 +145,7 @@ export const ParameterImportancePanel = ({
       >
         <div className={cx(columnsStyle, headerRowStyle)}>
           <span className={headerCellStyle}>Parameter</span>
-          <span className={headerCellStyle}>Importance</span>
+          <span className={headerCellStyle}>Share</span>
           <span className={headerCellStyle} data-align="right">
             Correlation
           </span>

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/parameter-importance-panel.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/study-view/parameter-importance-panel.tsx
@@ -1,0 +1,192 @@
+/**
+ * The Parameter importance card: one row per optimized parameter with a bar
+ * for the PED-ANOVA share the optimizer last reported and a column for the
+ * signed correlation computed here from the steps. Below the study's floor the
+ * card is muted and the bars fade, so a confident chart never sits on a
+ * handful of steps; the correlation column stays legible in both states.
+ */
+import { css, cx } from "@hashintel/ds-helpers/css";
+
+import { ChartCard } from "../../shared/chart-card";
+import {
+  describeImportance,
+  formatCorrelation,
+  formatImportance,
+  importanceRows,
+} from "./importance-view";
+
+import type { OptimizationRecord } from "../../../../../../../react/optimizations/context";
+
+const bodyStyle = css({
+  display: "flex",
+  flexDirection: "column",
+  gap: "1",
+  height: "full",
+  minHeight: "[0]",
+  fontVariantNumeric: "tabular-nums",
+});
+
+const columnsStyle = css({
+  display: "grid",
+  gridTemplateColumns: "minmax(0, 9rem) minmax(0, 1fr) 4.5rem",
+  alignItems: "center",
+  columnGap: "3",
+});
+
+const headerRowStyle = css({
+  paddingBottom: "1",
+  borderBottomWidth: "[1px]",
+  borderBottomStyle: "solid",
+  borderBottomColor: "neutral.bd.subtle",
+});
+
+const headerCellStyle = css({
+  fontSize: "xs",
+  fontWeight: "medium",
+  color: "neutral.s80",
+  whiteSpace: "nowrap",
+  "&[data-align='right']": { textAlign: "right" },
+});
+
+const rowsStyle = css({
+  display: "flex",
+  flexDirection: "column",
+  overflowY: "auto",
+  scrollbarWidth: "[thin]",
+  minHeight: "[0]",
+});
+
+// Every row is exactly this tall, so a card never changes shape as
+// estimates land or the sort order changes.
+const rowStyle = css({
+  height: "[30px]",
+  flexShrink: "0",
+});
+
+const nameStyle = css({
+  fontSize: "xs",
+  fontWeight: "medium",
+  fontFamily: "mono",
+  color: "neutral.s110",
+  minWidth: "[0]",
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+  "[data-estimated='false'] &": { color: "neutral.s70" },
+});
+
+const barCellStyle = css({
+  display: "flex",
+  alignItems: "center",
+  gap: "2",
+  minWidth: "[0]",
+});
+
+const barTrackStyle = css({
+  position: "relative",
+  flex: "[1]",
+  height: "[8px]",
+  backgroundColor: "neutral.s20",
+  borderRadius: "full",
+  overflow: "hidden",
+});
+
+const barFillStyle = css({
+  display: "block",
+  height: "full",
+  borderRadius: "full",
+  backgroundColor: "blue.s100",
+  transition: "[width 160ms ease-out]",
+  "[data-below-floor='true'] &": { opacity: "[0.25]" },
+});
+
+const barValueStyle = css({
+  fontSize: "xs",
+  color: "neutral.s100",
+  minWidth: "[2.5rem]",
+  textAlign: "right",
+  whiteSpace: "nowrap",
+  "[data-estimated='false'] &": { color: "neutral.s70" },
+});
+
+const correlationStyle = css({
+  fontSize: "xs",
+  color: "neutral.s90",
+  textAlign: "right",
+  whiteSpace: "nowrap",
+  "&[data-known='false']": { color: "neutral.s70" },
+});
+
+const HELP =
+  "PED-ANOVA compares the parameter values of the best steps with those of every step: the parameter whose values differ most between the two explains most of the objective's variance. Shares sum to 100%. Correlation is the signed Pearson correlation of each parameter with the objective over the completed steps, computed from the steps themselves, so it is available from the third completed step. Below the floor the estimate is faded: treat it as a hint.";
+
+export const ParameterImportancePanel = ({
+  optimization,
+  plotHeight,
+}: {
+  optimization: OptimizationRecord;
+  /** The body's height in pixels; the card is exactly as tall as its neighbours. */
+  plotHeight: number;
+}) => {
+  const view = importanceRows(optimization);
+
+  return (
+    <ChartCard
+      title="Parameter importance"
+      subtitle={describeImportance(view)}
+      help={HELP}
+      bodyHeight={plotHeight}
+      tone={view.belowFloor ? "muted" : "default"}
+    >
+      <div
+        className={bodyStyle}
+        data-importance-panel
+        data-below-floor={view.belowFloor}
+      >
+        <div className={cx(columnsStyle, headerRowStyle)}>
+          <span className={headerCellStyle}>Parameter</span>
+          <span className={headerCellStyle}>Importance</span>
+          <span className={headerCellStyle} data-align="right">
+            Correlation
+          </span>
+        </div>
+        <div className={rowsStyle}>
+          {view.rows.map((row) => (
+            <div
+              key={row.identifier}
+              className={cx(columnsStyle, rowStyle)}
+              data-importance-row={row.identifier}
+              data-estimated={row.importance !== null}
+            >
+              <span className={nameStyle}>{row.identifier}</span>
+              <span className={barCellStyle}>
+                <span className={barTrackStyle}>
+                  <span
+                    className={barFillStyle}
+                    data-importance-bar
+                    style={{
+                      width: `${((row.importance ?? 0) / view.barScale) * 100}%`,
+                    }}
+                  />
+                </span>
+                <span className={barValueStyle}>
+                  {row.importance === null
+                    ? "—"
+                    : formatImportance(row.importance)}
+                </span>
+              </span>
+              <span
+                className={correlationStyle}
+                data-known={row.correlation !== null}
+              >
+                {row.correlation === null
+                  ? "—"
+                  : formatCorrelation(row.correlation)}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </ChartCard>
+  );
+};

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/view-optimization-drawer.stories.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/view-optimization-drawer.stories.tsx
@@ -83,12 +83,12 @@ export const ConnectedWithConstraintsRunning: Story = {
 };
 
 export const ConnectedWithImportance: Story = {
-  name: "Connected study with importance",
+  name: "Connected study with sensitivity analysis",
   parameters: {
     docs: {
       description: {
         story:
-          "A complete 60-step study, past the 50-step floor, with the PED-ANOVA estimate the optimizer attached at the end: the Parameter importance card ranks the three optimized parameters with a bar each, the line under the title says how many completed steps the estimate is fitted on, and the Correlation column gives each parameter's signed Pearson correlation with the objective, computed from the steps.",
+          "A complete 60-step study, past the 50-step floor, with the PED-ANOVA estimate the optimizer attached at the end: the Sensitivity analysis card ranks the three optimized parameters with a bar each, the line under the title says how many completed steps the estimate is fitted on, and the Correlation column gives each parameter's signed Pearson correlation with the objective, computed from the steps.",
       },
     },
   },
@@ -96,7 +96,7 @@ export const ConnectedWithImportance: Story = {
 };
 
 export const ConnectedBelowImportanceFloor: Story = {
-  name: "Connected study below the importance floor",
+  name: "Connected study below the sensitivity analysis floor",
   parameters: {
     docs: {
       description: {

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/view-optimization-drawer.stories.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/view-optimization-drawer.stories.tsx
@@ -32,8 +32,6 @@ type Story = StoryObj<typeof meta>;
 const FakeConnectedStudy = (props: {
   /** Lands one step every 1.2 s and follows the next; else shows the complete study. */
   running: boolean;
-  /** The study with a parameter and a state constraint, results on every step. */
-  constrained?: boolean;
   /** Which fake study to mount; the 60-step one is past the importance floor. */
   study?: FakeStudyKind;
   /** The complete study with the optimizer's PED-ANOVA estimate attached. */
@@ -74,12 +72,12 @@ export const ConnectedWithConstraints: Story = {
       },
     },
   },
-  render: () => <FakeConnectedStudy running={false} constrained />,
+  render: () => <FakeConnectedStudy running={false} study="constrained" />,
 };
 
 export const ConnectedWithConstraintsRunning: Story = {
   name: "Connected study with constraints, following steps",
-  render: () => <FakeConnectedStudy running constrained />,
+  render: () => <FakeConnectedStudy running study="constrained" />,
 };
 
 export const ConnectedWithImportance: Story = {

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/view-optimization-drawer.stories.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/view-optimization-drawer.stories.tsx
@@ -11,6 +11,7 @@ import { FakeExperimentsProvider } from "../experiments/experiments-story-fixtur
 import {
   fakeStudyInput,
   fakeStudyTrials,
+  type FakeStudyKind,
   makeOptimizationRecord,
   makeOptimizationsContextValue,
   useFakeConnectedStudy,
@@ -33,6 +34,10 @@ const FakeConnectedStudy = (props: {
   running: boolean;
   /** The study with a parameter and a state constraint, results on every step. */
   constrained?: boolean;
+  /** Which fake study to mount; the 60-step one is past the importance floor. */
+  study?: FakeStudyKind;
+  /** The complete study with the optimizer's PED-ANOVA estimate attached. */
+  importance?: boolean;
   fallbackReason?: string | null;
   refinementError?: string | null;
 }) => {
@@ -75,6 +80,32 @@ export const ConnectedWithConstraints: Story = {
 export const ConnectedWithConstraintsRunning: Story = {
   name: "Connected study with constraints, following steps",
   render: () => <FakeConnectedStudy running constrained />,
+};
+
+export const ConnectedWithImportance: Story = {
+  name: "Connected study with importance",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "A complete 60-step study, past the 50-step floor, with the PED-ANOVA estimate the optimizer attached at the end: the Parameter importance card ranks the three optimized parameters with a bar each, the line under the title says how many completed steps the estimate is fitted on, and the Correlation column gives each parameter's signed Pearson correlation with the objective, computed from the steps.",
+      },
+    },
+  },
+  render: () => <FakeConnectedStudy running={false} study="long" importance />,
+};
+
+export const ConnectedBelowImportanceFloor: Story = {
+  name: "Connected study below the importance floor",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The complete 30-step study with an estimate: under the 50-step floor the card is muted, the bars fade to a quarter and stop setting the scale, and the line under the title says so. The Correlation column is as legible as above the floor.",
+      },
+    },
+  },
+  render: () => <FakeConnectedStudy running={false} importance />,
 };
 
 export const ConnectedRefinementFailed: Story = {

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/view-optimization-drawer.test.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/view-optimization-drawer.test.tsx
@@ -15,7 +15,10 @@ import { UserSettingsContext } from "../../../../../../react/state/user-settings
 import {
   fakeConstrainedStudyInput,
   fakeConstrainedStudyTrials,
+  fakeLongStudyInput,
+  fakeLongStudyTrials,
   makeConnectedStudyState,
+  makeImportance,
   makeOptimizationInput,
   makeOptimizationRecord,
   makeOptimizationsContextValue,
@@ -631,5 +634,102 @@ describe("ViewOptimizationDrawer for a connected study with constraints", () => 
     expect(screen.queryByText("Constraints")).toBeNull();
     expect(screen.queryByText("Steps clear")).toBeNull();
     expect(screen.queryByText("Runs passed")).toBeNull();
+  });
+});
+
+describe("ViewOptimizationDrawer's Parameter importance card", () => {
+  const settledLong = makeOptimizationRecord({
+    input: fakeLongStudyInput,
+    trials: fakeLongStudyTrials.trials,
+    best: fakeLongStudyTrials.best,
+    status: "complete",
+    importance: makeImportance(fakeLongStudyInput, fakeLongStudyTrials.trials),
+    connected: makeConnectedStudyState(fakeLongStudyInput, {
+      resumable: true,
+    }),
+  });
+
+  const importanceCard = () =>
+    screen
+      .getByText("Parameter importance")
+      .closest<HTMLElement>("[data-chart-card]")!;
+
+  it("ranks the optimized parameters with a bar each above the floor, the count in the subtitle and a Correlation column", () => {
+    renderDrawer(settledLong);
+
+    const card = importanceCard();
+    expect(card.getAttribute("data-tone")).toBe("default");
+    expect(
+      card.querySelector("[data-chart-card-subtitle]")?.textContent,
+    ).toMatch(/^estimated from \d+ completed steps · PED-ANOVA/u);
+    expect(card.textContent).not.toContain("floor");
+    const rows = card.querySelectorAll<HTMLElement>("[data-importance-row]");
+    expect([...rows].map((row) => row.dataset.importanceRow)).toEqual([
+      "production_rate",
+      "selling_price",
+      "marketing_spend",
+    ]);
+    const widths = [
+      ...card.querySelectorAll<HTMLElement>("[data-importance-bar]"),
+    ].map((bar) => Number.parseFloat(bar.style.width));
+    expect(widths[0]).toBe(100);
+    expect(widths.every((width) => width > 0)).toBe(true);
+    expect(card.textContent).toContain("Correlation");
+    expect(card.textContent).toMatch(/[+−]\d\.\d\d/u);
+  });
+
+  it("mutes the card and fades the bars below the floor, and says so in the subtitle", () => {
+    renderDrawer(
+      makeOptimizationRecord({
+        input,
+        trials,
+        best,
+        status: "complete",
+        importance: makeImportance(input, trials),
+        connected: makeConnectedStudyState(input, { resumable: true }),
+      }),
+    );
+
+    const card = importanceCard();
+    expect(card.getAttribute("data-tone")).toBe("muted");
+    expect(
+      card.querySelector("[data-chart-card-subtitle]")?.textContent,
+    ).toContain("below the 50-step floor, treat as a hint");
+    expect(
+      card
+        .querySelector("[data-importance-panel]")
+        ?.getAttribute("data-below-floor"),
+    ).toBe("true");
+    // Faded bars do not set the scale: the largest bar is its raw share, not full width.
+    const widths = [
+      ...card.querySelectorAll<HTMLElement>("[data-importance-bar]"),
+    ].map((bar) => Number.parseFloat(bar.style.width));
+    expect(Math.max(...widths)).toBeLessThan(100);
+  });
+
+  it("shows dashed rows and the correlations while no estimate has arrived, and nothing for a remote study", () => {
+    renderDrawer(
+      makeOptimizationRecord({
+        input,
+        trials,
+        best,
+        status: "running",
+        connected: makeConnectedStudyState(input),
+      }),
+    );
+
+    const card = importanceCard();
+    const rows = card.querySelectorAll<HTMLElement>("[data-importance-row]");
+    expect(rows).toHaveLength(2);
+    expect([...rows].every((row) => row.dataset.estimated === "false")).toBe(
+      true,
+    );
+    expect(card.textContent).toMatch(/[+−]\d\.\d\d/u);
+    cleanup();
+
+    renderDrawer(
+      makeOptimizationRecord({ input, trials, best, status: "complete" }),
+    );
+    expect(screen.queryByText("Parameter importance")).toBeNull();
   });
 });

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/view-optimization-drawer.test.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/view-optimization-drawer.test.tsx
@@ -662,7 +662,7 @@ describe("ViewOptimizationDrawer's Sensitivity analysis card", () => {
     expect(
       card.querySelector("[data-chart-card-subtitle]")?.textContent,
     ).toMatch(
-      /^PED-ANOVA importance estimated from \d+ completed steps · how much/u,
+      /^PED-ANOVA importance estimated from \d+ completed steps · how much each parameter matters for reaching the best steps$/u,
     );
     expect(card.textContent).not.toContain("floor");
     const rows = card.querySelectorAll<HTMLElement>("[data-importance-row]");

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/view-optimization-drawer.test.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/view-optimization-drawer.test.tsx
@@ -734,4 +734,41 @@ describe("ViewOptimizationDrawer's Sensitivity analysis card", () => {
     );
     expect(screen.queryByText("Sensitivity analysis")).toBeNull();
   });
+
+  it("tells a one-parameter study that PED-ANOVA ranks two or more parameters, unmuted, with the correlation column", () => {
+    const singleParameterInput = makeOptimizationInput({
+      production_rate: {
+        kind: "optimize",
+        domain: {
+          kind: "continuous",
+          minimum: 50,
+          maximum: 400,
+          scale: "linear",
+        },
+      },
+    });
+    const singleParameter = makeTrials(singleParameterInput, 30);
+    renderDrawer(
+      makeOptimizationRecord({
+        input: singleParameterInput,
+        trials: singleParameter.trials,
+        best: singleParameter.best,
+        status: "complete",
+        connected: makeConnectedStudyState(singleParameterInput, {
+          resumable: true,
+        }),
+      }),
+    );
+
+    const card = importanceCard();
+    expect(card.getAttribute("data-tone")).toBe("default");
+    expect(
+      card.querySelector("[data-chart-card-subtitle]")?.textContent,
+    ).toMatch(
+      /^PED-ANOVA ranks two or more parameters · \d+ completed steps · correlation only$/u,
+    );
+    expect(card.textContent).not.toContain("floor");
+    expect(card.querySelectorAll("[data-importance-row]")).toHaveLength(1);
+    expect(card.textContent).toMatch(/[+−]\d\.\d\d/u);
+  });
 });

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/view-optimization-drawer.test.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/optimizations/view-optimization-drawer.test.tsx
@@ -637,7 +637,7 @@ describe("ViewOptimizationDrawer for a connected study with constraints", () => 
   });
 });
 
-describe("ViewOptimizationDrawer's Parameter importance card", () => {
+describe("ViewOptimizationDrawer's Sensitivity analysis card", () => {
   const settledLong = makeOptimizationRecord({
     input: fakeLongStudyInput,
     trials: fakeLongStudyTrials.trials,
@@ -651,7 +651,7 @@ describe("ViewOptimizationDrawer's Parameter importance card", () => {
 
   const importanceCard = () =>
     screen
-      .getByText("Parameter importance")
+      .getByText("Sensitivity analysis")
       .closest<HTMLElement>("[data-chart-card]")!;
 
   it("ranks the optimized parameters with a bar each above the floor, the count in the subtitle and a Correlation column", () => {
@@ -661,7 +661,9 @@ describe("ViewOptimizationDrawer's Parameter importance card", () => {
     expect(card.getAttribute("data-tone")).toBe("default");
     expect(
       card.querySelector("[data-chart-card-subtitle]")?.textContent,
-    ).toMatch(/^estimated from \d+ completed steps · PED-ANOVA/u);
+    ).toMatch(
+      /^PED-ANOVA importance estimated from \d+ completed steps · how much/u,
+    );
     expect(card.textContent).not.toContain("floor");
     const rows = card.querySelectorAll<HTMLElement>("[data-importance-row]");
     expect([...rows].map((row) => row.dataset.importanceRow)).toEqual([
@@ -730,6 +732,6 @@ describe("ViewOptimizationDrawer's Parameter importance card", () => {
     renderDrawer(
       makeOptimizationRecord({ input, trials, best, status: "complete" }),
     );
-    expect(screen.queryByText("Parameter importance")).toBeNull();
+    expect(screen.queryByText("Sensitivity analysis")).toBeNull();
   });
 });

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/shared/chart-card.stories.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/shared/chart-card.stories.tsx
@@ -208,7 +208,7 @@ export const Muted: Story = {
   render: () => (
     <div style={{ width: 480 }}>
       <ChartCard
-        title="Parameter importance"
+        title="Sensitivity analysis"
         subtitle="fitted on 12 completed steps · below the 100-step floor"
         tone="muted"
         actions={placeholderMenu}

--- a/libs/@local/petrinaut-arch-docs/content/ui/optimizations-tab.mdx
+++ b/libs/@local/petrinaut-arch-docs/content/ui/optimizations-tab.mdx
@@ -90,7 +90,7 @@ prunes an infeasible draw before any simulation and runs state constraints as
 `auxiliaryMetrics` on the detached objective request, 0/1 indicators
 aggregated with `min` over each run's frames.
 
-Parameter importance travels the other way. The optimizer core's
+Sensitivity analysis travels the other way. The optimizer core's
 `importance.py` estimates PED-ANOVA importances (the one Optuna evaluator that
 needs numpy alone) and `pyodide_entry.py` attaches them to the summary and, at
 `importance_cadence` past `importance_floor`, to trial events; the worker's
@@ -98,7 +98,8 @@ needs numpy alone) and `pyodide_entry.py` attaches them to the summary and, at
 browser capability copies the block onto the `trial` and `complete` log events
 as `importances`. `OptimizationsProvider` keeps the latest on
 `record.importance`. `ParameterImportancePanel`
-(`study-view/parameter-importance-panel.tsx`) renders it from the pure
+(`study-view/parameter-importance-panel.tsx`), the **Sensitivity analysis**
+card, renders it from the pure
 `importance-view.ts`: rows sorted by share, a signed Pearson correlation per
 parameter computed from `record.trials`, and the fade rule (`tone="muted"`,
 bars at a quarter opacity that no longer set the scale) below

--- a/libs/@local/petrinaut-arch-docs/content/ui/optimizations-tab.mdx
+++ b/libs/@local/petrinaut-arch-docs/content/ui/optimizations-tab.mdx
@@ -90,6 +90,20 @@ prunes an infeasible draw before any simulation and runs state constraints as
 `auxiliaryMetrics` on the detached objective request, 0/1 indicators
 aggregated with `min` over each run's frames.
 
+Parameter importance travels the other way. The optimizer core's
+`importance.py` estimates PED-ANOVA importances (the one Optuna evaluator that
+needs numpy alone) and `pyodide_entry.py` attaches them to the summary and, at
+`importance_cadence` past `importance_floor`, to trial events; the worker's
+`asImportances` drops a malformed block rather than failing the study, and the
+browser capability copies the block onto the `trial` and `complete` log events
+as `importances`. `OptimizationsProvider` keeps the latest on
+`record.importance`. `ParameterImportancePanel`
+(`study-view/parameter-importance-panel.tsx`) renders it from the pure
+`importance-view.ts`: rows sorted by share, a signed Pearson correlation per
+parameter computed from `record.trials`, and the fade rule (`tone="muted"`,
+bars at a quarter opacity that no longer set the scale) below
+`importanceFloor(requestedTrials)`. A remote study has no panel.
+
 The remote body continues with a collapsible **Best parameters** grid, the
 objective by step, the experimental **Surface** section when the
 **Optimization surface** setting is on and the study has two or more numeric
@@ -116,7 +130,9 @@ in view while the study streams:
   `objectiveAtPointTitle`: **Objective at the step in flight** while a live
   study is followed, **Objective at the selected point** otherwise. The
   drawer's grid wraps to two rows and gives a lone last card the whole row;
-  the full view's grid holds all three in one row.
+  the full view's grid holds three in one row. `ConstraintSummaryCard` follows
+  when the study declares constraints, and `ParameterImportancePanel` is
+  always last.
 - `StepsTable` filling the remaining height, the best step starred and tinted
   (`bestTrial`); the remote body passes `bestTrial={null}`.
 

--- a/libs/@local/petrinaut-optimizer-core/src/petrinaut_optimizer_core/__init__.py
+++ b/libs/@local/petrinaut-optimizer-core/src/petrinaut_optimizer_core/__init__.py
@@ -20,6 +20,7 @@ from .description import (
     StudyDescription,
     parse_description,
 )
+from .importance import importance_cadence, importance_floor, parameter_importances
 from .study import Scalar, create_study, suggest
 
 __all__ = [
@@ -31,6 +32,9 @@ __all__ = [
     "Scalar",
     "StudyDescription",
     "create_study",
+    "importance_cadence",
+    "importance_floor",
+    "parameter_importances",
     "parse_description",
     "run_study",
     "suggest",

--- a/libs/@local/petrinaut-optimizer-core/src/petrinaut_optimizer_core/importance.py
+++ b/libs/@local/petrinaut-optimizer-core/src/petrinaut_optimizer_core/importance.py
@@ -1,0 +1,67 @@
+"""PED-ANOVA parameter importances, the one evaluator that runs without sklearn.
+
+Optuna's default evaluator (fANOVA) and its mean-decrease-impurity evaluator
+both build random forests with scikit-learn, which is neither in the service
+venv nor shipped into Pyodide. PED-ANOVA needs numpy alone.
+"""
+
+from __future__ import annotations
+
+import math
+import warnings
+
+import optuna
+from optuna.exceptions import ExperimentalWarning
+from optuna.importance import PedAnovaImportanceEvaluator, get_param_importances
+from optuna.trial import TrialState
+
+# Below this many completed trials the estimate is a hint at best; the host
+# fades it. The floor rises with the study so a long study earns its confidence.
+LONG_STUDY_TRIALS = 100
+
+
+def importance_cadence(requested_trials: int) -> int:
+    """How many completed trials pass between one importance estimate and the next."""
+    return max(10, requested_trials // 20)
+
+
+def importance_floor(requested_trials: int) -> int:
+    """The completed-trial count from which the estimate is worth streaming."""
+    return LONG_STUDY_TRIALS if requested_trials >= LONG_STUDY_TRIALS else 50
+
+
+def completed_trials(study: optuna.Study) -> int:
+    return len(study.get_trials(deepcopy=False, states=(TrialState.COMPLETE,)))
+
+
+def _estimate(study: optuna.Study) -> dict[str, float] | None:
+    completed = study.get_trials(deepcopy=False, states=(TrialState.COMPLETE,))
+    if len(completed) < 2:
+        return None
+    parameters = {name for trial in completed for name in trial.distributions}
+    if len(parameters) < 2:
+        return None
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", ExperimentalWarning)
+        importances = get_param_importances(
+            study, evaluator=PedAnovaImportanceEvaluator(evaluate_on_local=False)
+        )
+    values = {name: float(value) for name, value in importances.items()}
+    if any(not math.isfinite(value) or value < 0 for value in values.values()):
+        return None
+    return values
+
+
+def parameter_importances(study: optuna.Study) -> dict[str, float] | None:
+    """Normalised importances over the completed trials, or None when they cannot be estimated.
+
+    Uses `PedAnovaImportanceEvaluator(evaluate_on_local=False)` and no
+    `target`: a target callable forces lower-is-better and returns a confident
+    wrong ranking for a maximised objective. None on fewer than two completed
+    trials, on a single optimized parameter, and on any exception the
+    evaluator raises, so a study never fails for its summary.
+    """
+    try:
+        return _estimate(study)
+    except Exception:
+        return None

--- a/libs/@local/petrinaut-optimizer-core/src/petrinaut_optimizer_core/pyodide_entry.py
+++ b/libs/@local/petrinaut-optimizer-core/src/petrinaut_optimizer_core/pyodide_entry.py
@@ -20,6 +20,12 @@ from optuna.exceptions import ExperimentalWarning
 
 from .ask_tell import run_study, told_trials
 from .description import MAX_STUDY_TRIALS, StudyDescription, parse_description
+from .importance import (
+    completed_trials,
+    importance_cadence,
+    importance_floor,
+    parameter_importances,
+)
 from .study import Scalar, create_study
 
 
@@ -55,6 +61,42 @@ def _positive_integer(value: object, name: str) -> int:
     if isinstance(value, bool) or not isinstance(value, int) or value < 1:
         raise ValueError(f"optimization {name} must be a positive integer")
     return value
+
+
+def importances_of(study: optuna.Study) -> dict[str, Any] | None:
+    """The `importances` block for an event, or None when the estimate is unavailable."""
+    values = parameter_importances(study)
+    if values is None:
+        return None
+    return {"values": values, "completedTrials": completed_trials(study)}
+
+
+def attach_importances(study: optuna.Study, event: dict[str, Any]) -> None:
+    importances = importances_of(study)
+    if importances is not None:
+        event["importances"] = importances
+
+
+def with_importances_at_cadence(
+    study: optuna.Study, requested: int, on_trial: Callable[[dict[str, Any]], object]
+) -> Callable[[dict[str, Any]], object]:
+    """Wrap `on_trial` so every `importance_cadence` completed trials past the floor carry an estimate.
+
+    The count is the study's own, so a continued study keeps the rhythm it had.
+    The estimate never raises, and a trial it is unavailable for goes out
+    without the key; the study never fails for its importances.
+    """
+    floor = importance_floor(requested)
+    cadence = importance_cadence(requested)
+
+    def report(event: dict[str, Any]) -> object:
+        if event.get("state") == "complete":
+            completed = completed_trials(study)
+            if completed >= floor and (completed - floor) % cadence == 0:
+                attach_importances(study, event)
+        return on_trial(event)
+
+    return report
 
 
 def create_browser_study(description_json: str, parallelism: int = 1) -> StudyHandle:
@@ -115,11 +157,12 @@ def run_browser_study(
                 handle.description,
                 trials=trials,
                 evaluate=evaluate_trial,
-                on_trial=on_trial,
+                on_trial=with_importances_at_cadence(study, handle.requested, on_trial),
                 is_cancelled=lambda: bool(is_cancelled()),
                 parallelism=handle.parallelism,
             )
             summary["requestedTrials"] = handle.requested
+            attach_importances(study, summary)
             return summary
         finally:
             handle.running = False

--- a/libs/@local/petrinaut-optimizer-core/tests/test_importance.py
+++ b/libs/@local/petrinaut-optimizer-core/tests/test_importance.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import optuna
+import pytest
+from optuna.samplers import RandomSampler
+
+from petrinaut_optimizer_core import importance
+from petrinaut_optimizer_core.importance import (
+    importance_cadence,
+    importance_floor,
+    parameter_importances,
+)
+
+
+def weighted_sum(trial: optuna.Trial) -> float:
+    return 5 * trial.suggest_float("a", 0, 1) + trial.suggest_float("b", 0, 1)
+
+
+@pytest.mark.parametrize("direction", ["minimize", "maximize"])
+def test_ranks_the_heavier_parameter_first_in_either_direction(
+    direction: str,
+) -> None:
+    study = optuna.create_study(direction=direction, sampler=RandomSampler(seed=0))
+    study.optimize(weighted_sum, n_trials=40)
+
+    importances = parameter_importances(study)
+
+    assert importances is not None
+    assert set(importances) == {"a", "b"}
+    assert importances["a"] > importances["b"]
+    assert sum(importances.values()) == pytest.approx(1.0)
+
+
+def test_pruned_trials_are_left_out_and_booleans_take_part() -> None:
+    def objective(trial: optuna.Trial) -> float:
+        rate = trial.suggest_float("rate", 0.1, 2.0, log=True)
+        enabled = trial.suggest_categorical("enabled", [False, True])
+        if trial.number % 9 == 8:
+            raise optuna.TrialPruned
+        return rate + int(enabled)
+
+    study = optuna.create_study(sampler=RandomSampler(seed=1))
+    study.optimize(objective, n_trials=45)
+
+    importances = parameter_importances(study)
+
+    assert importances is not None
+    assert set(importances) == {"rate", "enabled"}
+
+
+def test_none_without_two_completed_trials() -> None:
+    assert parameter_importances(optuna.create_study()) is None
+
+    study = optuna.create_study(sampler=RandomSampler(seed=0))
+    study.optimize(weighted_sum, n_trials=1)
+    assert parameter_importances(study) is None
+
+
+def test_none_for_a_single_parameter() -> None:
+    study = optuna.create_study(sampler=RandomSampler(seed=0))
+    study.optimize(lambda trial: trial.suggest_float("a", 0, 1), n_trials=10)
+
+    assert parameter_importances(study) is None
+
+
+def test_an_evaluator_failure_yields_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    study = optuna.create_study(sampler=RandomSampler(seed=0))
+    study.optimize(weighted_sum, n_trials=10)
+
+    def explode(*_args: object, **_kwargs: object) -> dict[str, float]:
+        raise RuntimeError("numpy went away")
+
+    monkeypatch.setattr(importance, "get_param_importances", explode)
+
+    assert parameter_importances(study) is None
+
+
+def test_the_cadence_and_the_floor_follow_the_requested_trials() -> None:
+    assert importance_cadence(30) == 10
+    assert importance_cadence(200) == 10
+    assert importance_cadence(400) == 20
+    assert importance_floor(30) == 50
+    assert importance_floor(99) == 50
+    assert importance_floor(100) == 100
+    assert importance_floor(1_000) == 100

--- a/libs/@local/petrinaut-optimizer-core/tests/test_pyodide_entry.py
+++ b/libs/@local/petrinaut-optimizer-core/tests/test_pyodide_entry.py
@@ -67,6 +67,9 @@ def test_runs_a_study_from_json_with_javascript_style_callbacks(
     assert len(evaluated) == 3
     assert [event["trial"] for event in events] == [0, 1, 2]
     assert all(isinstance(event, dict) for event in events)
+    # Three completed trials over three parameters are enough for an estimate;
+    # the host fades it below the floor.
+    assert summary.pop("importances")["completedTrials"] == 3
     assert summary == {
         "requestedTrials": 3,
         "completedTrials": 3,
@@ -110,6 +113,8 @@ def test_a_stopped_study_continues_from_the_trials_it_holds(
     assert stopped["completedTrials"] == 1
     assert stopped["failedTrials"] == 0
     assert [event["trial"] for event in events] == [0, 2, 3]
+    assert "importances" not in stopped, "one completed trial supports no estimate"
+    assert resumed.pop("importances")["completedTrials"] == 3
     assert resumed == {
         "requestedTrials": 3,
         "completedTrials": 3,
@@ -163,6 +168,7 @@ def test_a_failed_segment_leaves_the_study_resumable_without_over_counting(
     )
 
     assert [event["trial"] for event in events] == [0, 2, 3]
+    assert resumed.pop("importances")["completedTrials"] == 3
     assert resumed == {
         "requestedTrials": 3,
         "completedTrials": 3,
@@ -283,3 +289,67 @@ def test_rejects_an_outcome_that_is_not_an_object(
                 handle, 3, evaluate_to_a_number, ignore_event, never_cancelled
             )
         )
+
+
+def test_importances_ride_the_trials_at_the_cadence_past_the_floor_and_the_summary(
+    optimization_description: dict[str, Any],
+) -> None:
+    optimization_description["study"]["trials"] = 60
+    handle = create_browser_study(json.dumps(optimization_description))
+    events: list[dict[str, Any]] = []
+
+    summary = asyncio.run(
+        run_browser_study(handle, 60, evaluate, events.append, never_cancelled)
+    )
+
+    carrying = [event["trial"] for event in events if "importances" in event]
+    assert carrying == [49, 59], (
+        "the 50th and 60th completed trials, floor 50, cadence 10"
+    )
+    for event in events:
+        if "importances" in event:
+            block = event["importances"]
+            assert set(block["values"]) == {"rate", "count", "enabled"}
+            assert block["completedTrials"] == event["trial"] + 1
+            assert sum(block["values"].values()) == pytest.approx(1.0)
+    assert summary["importances"]["completedTrials"] == 60
+    assert set(summary["importances"]["values"]) == {"rate", "count", "enabled"}
+
+
+def test_a_short_study_streams_no_importances_but_its_summary_still_estimates(
+    optimization_description: dict[str, Any],
+) -> None:
+    optimization_description["study"]["trials"] = 20
+    handle = create_browser_study(json.dumps(optimization_description))
+    events: list[dict[str, Any]] = []
+
+    summary = asyncio.run(
+        run_browser_study(handle, 20, evaluate, events.append, never_cancelled)
+    )
+
+    assert all("importances" not in event for event in events)
+    assert summary["importances"]["completedTrials"] == 20
+
+
+def test_a_study_whose_importances_cannot_be_estimated_still_completes(
+    optimization_description: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from petrinaut_optimizer_core import importance, pyodide_entry
+
+    def explode(*_args: object, **_kwargs: object) -> dict[str, float]:
+        raise RuntimeError("numpy went away")
+
+    monkeypatch.setattr(importance, "get_param_importances", explode)
+    optimization_description["study"]["trials"] = 60
+    handle = create_browser_study(json.dumps(optimization_description))
+    events: list[dict[str, Any]] = []
+
+    summary = asyncio.run(
+        run_browser_study(handle, 60, evaluate, events.append, never_cancelled)
+    )
+
+    assert pyodide_entry.importances_of(handle.study) is None  # type: ignore[arg-type]
+    assert all("importances" not in event for event in events)
+    assert "importances" not in summary
+    assert summary["completedTrials"] == 60


### PR DESCRIPTION
> [!IMPORTANT]
> **Experimental**
> Behind the **In-browser optimization** feature flag.

## Summary

A study run in the browser reports how much each optimized parameter matters for reaching the best steps. The Pyodide worker computes Optuna's PED-ANOVA importances on the study's summary and, once the study is past a floor of completed steps, on every trial at a cadence. The events carry the block to the record and the study view shows a Sensitivity analysis card: one bar per optimized parameter with its PED-ANOVA importance as a share, and a signed Pearson correlation computed from the steps.

Below the floor, 100 completed steps for a study of 100 or more requested steps and 50 otherwise, the card is muted, its bars are faded and the subtitle says to treat the estimate as a hint. The correlation column is valid below the floor and stays. Studies on the optimization service carry no estimate and get no card.

https://github.com/user-attachments/assets/d54f9c2c-7814-4a03-a3e0-09c667c47f05

## Links

- Ticket [FE-1678](https://linear.app/hash/issue/FE-1678)
- Docs [The Optimizations tab](https://petrinaut-docs-git-claude-opt-proto-importance.stage.hash.ai/architecture/ui/views/editor/optimizations/optimizations-tab)
- Docs [Optimization › In the browser](https://github.com/hashintel/hash/blob/claude/opt-proto-importance/libs/@hashintel/petrinaut/docs/optimization.md#in-the-browser)
- Reference [Optuna PedAnovaImportanceEvaluator](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.importance.PedAnovaImportanceEvaluator.html)

## Changes

#### Python

- `importance.py` computes `parameter_importances(study)` with `PedAnovaImportanceEvaluator(evaluate_on_local=False)`
  > None under two completed trials, for one parameter, and on any exception. `importance_cadence` is `max(10, requested // 20)` and `importance_floor` is 100 for 100 or more requested trials, else 50.
- `pyodide_entry.py` attaches the block
  > `with_importances_at_cadence` wraps `on_trial` so a complete trial at the cadence past the floor carries `importances: { values, completedTrials }`. `attach_importances` puts the final estimate on every summary with two or more completed trials.

#### Core events and browser runtime

- Optional `importances` on the trial and complete events
  > `petrinautOptimizationImportancesSchema` holds shares in [0, 1] keyed by identifier and a positive `completedTrials`. `PetrinautOptimizationImportances` is exported from the package index.
- `asImportances` normalises the worker's block
  > A malformed block drops the field and never throws. `study-runner.ts` reads it into the trial payload and the summary.
- Browser capability copies the block onto the trial and complete log events
  > A summary without it still finishes the run. `python-sources.ts` writes `importance.py` into Pyodide.

#### Study view

- `record.importance` on the optimizations context
  > Replaced by every trial or complete event that carries a block.
- `importance-view.ts` derives the rows
  > `optimizedParameterIdentifiers` lists numeric and boolean parameters in binding order. `pearsonCorrelations` treats booleans as 0 and 1 and is null under three completed steps or at zero variance.
  > `importanceRows` sorts by share then identifier and gives `effectiveCount`, `belowFloor` and `barScale`.
  > Interim shape, revised in a later change: rows in binding order with no sort, identifiers from `partitionParameterBindings(...).optimized`, `effectiveCount` from `record.completedTrials`.
- Sensitivity analysis card, last in a connected study's card grid in both layouts
  > Columns Parameter, Share and Correlation, a `blue.s100` bar with its percentage per row, a help tooltip naming PED-ANOVA's question.
  > Subtitle names the statistic: "PED-ANOVA importance estimated from N completed steps".
  > Below the floor the card takes `tone="muted"` and the bars sit at 0.25 opacity.
  > Before the first estimate the rows are dashed and the subtitle reads "no PED-ANOVA importance yet".
- Fixtures and stories for a long study
  > `fakeLongStudyInput` and `fakeLongStudyTrials` with 60 steps, `makeImportance`, and the stories `Connected study with sensitivity analysis` and `Connected study below the sensitivity analysis floor`.
  > `useFakeConnectedStudy` takes `study: FakeStudyKind` to pick the fixture study, with no `constrained` boolean.

#### Review fixes

- Card titled Sensitivity analysis in every view, story name, test and the bullet's bold lead in the guide
  > Subtitle keeps the statistic's name, PED-ANOVA importance. Code identifiers are unchanged.
- Help text, subtitle, doc comments and guide describe PED-ANOVA as the concentration of good parameter values
  > Copy called the estimate a share of the objective's variance against every step, which is what fANOVA computes.
  > `evaluate_on_local=False` measures how concentrated each parameter's values are among the best tenth of steps relative to its whole range, a relative share summing to 100%.
  > Subtitle now ends "how much each parameter matters for reaching the best steps", pinned by `importance-view.test.ts` and the subtitle regex in `view-optimization-drawer.test.tsx`.
- One-parameter study's Sensitivity analysis card says PED-ANOVA ranks two or more parameters
  > A study may optimize one parameter and PED-ANOVA returns None below two, so the record's `importance` was never set and the card read "no PED-ANOVA importance yet" after the run ended.
  > `ImportanceView.rankable` is false under two optimized parameters; such a card is never muted and its subtitle ends "correlation only".
  > `importance-view.test.ts` and `view-optimization-drawer.test.tsx` pin the one-parameter case and the guide's In the browser section states the rule.

## Test coverage

- `test_importance.py`, `test_pyodide_entry.py`:
  > The evaluator's ranking on a linear objective in both directions, None under the minimum trials, the cadence and floor rules, the block on trials at the cadence and on the summary.
- `optimization.test.ts`, `as-importances.test.ts`, `browser-optimization.test.ts`:
  > Shares outside [0, 1] rejected, a malformed block dropped, the block copied onto the trial and complete events and a run finishing without one.
- `study-runner.pyodide.test.ts`:
  > The real Pyodide runtime's summary carries `importances` with its `completedTrials`.
- `provider.test.tsx`, `importance-view.test.ts`:
  > The latest estimate kept on the record; the floor, the identifiers, the correlations, the row order, the fade below the floor and the copy.
- `view-optimization-drawer.test.tsx`:
  > The card above the floor, muted below it, dashed while no estimate arrived, and absent for a remote study.

## How to test

#### In the browser

- Open [Petrinaut preview](https://petrinaut-git-claude-opt-proto-importance.stage.hash.ai) on Vercel
- Viewport controls > Settings > Simulation > In-browser optimization
- Load example > Supply Chain Profit
- Simulate > Optimizations > Create
- Select metric `Profit`, direction Maximize, tick Optimize production_rate and Optimize batch_size, set Optimization steps to 60, Run
- Open the study row
  > Expect a Sensitivity analysis card last in the grid, dashed rows, subtitle reading "no PED-ANOVA importance yet"
- Wait for 50 completed steps
  > Expect a bar per parameter, subtitle reading "PED-ANOVA importance estimated from 50 completed steps", a signed correlation per row

#### Python

- Run `cd libs/@local/petrinaut-optimizer-core && uv run pytest -q`
  > Expect every test to pass



