### PR TITLE
H-6800: Fix concurrent Voice provenance rollback

### DIFF
--- a/.changeset/voice-provenance-rollback.md
+++ b/.changeset/voice-provenance-rollback.md
@@ -1,0 +1,5 @@
+---
+"@hashintel/petrinaut": patch
+---
+
+Keep rejected overlapping Voice tool answers from restoring failed sibling provenance or overwriting newer message metadata.

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel.test.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel.test.tsx
@@ -36,6 +36,7 @@ import { definePetrinautAiInteractiveTool } from "../../../types/ai-interactive-
 import {
   addMappedToolOutput,
   AiAssistantPanel,
+  getVoiceToolCallIds,
   safelyAddToolOutput,
 } from "./ai-assistant-panel";
 
@@ -157,6 +158,44 @@ const textChunks = (id: string, text: string): UIMessageChunk[] => [
   { type: "text-end", id },
 ];
 
+const createPendingVoiceQuestionMessage = ({
+  id = "assistant-voice-questions",
+  metadata,
+  toolCallIds,
+}: {
+  id?: string;
+  metadata?: PetrinautAiMessage["metadata"];
+  toolCallIds: string[];
+}): PetrinautAiMessage =>
+  ({
+    id,
+    ...(metadata ? { metadata } : {}),
+    parts: toolCallIds.map((toolCallId) => ({
+      input: { question: `Question for ${toolCallId}` },
+      state: "input-available",
+      toolCallId,
+      toolName: "answerQuestion",
+      type: "dynamic-tool",
+    })),
+    role: "assistant",
+  }) as unknown as PetrinautAiMessage;
+
+const createTestMessageStore = (initialMessage: PetrinautAiMessage) => {
+  let messages = [initialMessage];
+
+  return {
+    getMessages: () => messages,
+    setMessages: (nextMessages: PetrinautAiMessage[]) => {
+      messages = nextMessages;
+    },
+    updateMessages: (
+      updater: (currentMessages: PetrinautAiMessage[]) => PetrinautAiMessage[],
+    ) => {
+      messages = updater(messages);
+    },
+  };
+};
+
 const SubmitForSecondConversation = ({
   conversationId,
   submitText,
@@ -269,6 +308,21 @@ afterEach(() => {
 });
 
 describe("AiAssistantPanel composer submissions", () => {
+  test("normalizes current and legacy voice tool origins", () => {
+    expect(
+      getVoiceToolCallIds({
+        source: "voice",
+        toolCallId: "legacy-question",
+        voiceToolCallIds: [
+          "current-question",
+          "legacy-question",
+          "current-question",
+        ],
+      }),
+    ).toEqual(["current-question", "legacy-question"]);
+    expect(getVoiceToolCallIds({ toolCallId: "legacy-question" })).toEqual([]);
+  });
+
   test("disables Clear when the host owns canonical conversation history", () => {
     const transport: PetrinautAiTransport = {
       reconnectToStream: () => Promise.resolve(null),
@@ -3457,83 +3511,39 @@ describe("AiAssistantPanel composer submissions", () => {
   });
 
   test("retains every voice tool origin on one assistant message", async () => {
-    let latestMessages = [
-      {
-        id: "assistant-voice-questions",
-        parts: [
-          {
-            input: { question: "Who approves it?" },
-            state: "input-available",
-            toolCallId: "voice-question-1",
-            toolName: "answerQuestion",
-            type: "dynamic-tool",
-          },
-          {
-            input: { question: "Who acts next?" },
-            state: "input-available",
-            toolCallId: "voice-question-2",
-            toolName: "answerQuestion",
-            type: "dynamic-tool",
-          },
-        ],
-        role: "assistant",
-      },
-    ] as unknown as PetrinautAiMessage[];
-    const updateMessages = (
-      updater: (messages: PetrinautAiMessage[]) => PetrinautAiMessage[],
-    ) => {
-      latestMessages = updater(latestMessages);
-    };
+    const messageStore = createTestMessageStore(
+      createPendingVoiceQuestionMessage({
+        toolCallIds: ["voice-question-1", "voice-question-2"],
+      }),
+    );
     const addToolOutput = vi.fn().mockResolvedValue(undefined);
 
     for (const toolCallId of ["voice-question-1", "voice-question-2"]) {
       await addMappedToolOutput({
         addToolOutput,
-        currentMessages: latestMessages,
+        currentMessages: messageStore.getMessages(),
         params: {
           output: { answer: toolCallId },
           tool: "answerQuestion",
           toolCallId,
         },
         source: "voice",
-        updateMessages,
+        updateMessages: messageStore.updateMessages,
       });
     }
 
-    expect(latestMessages[0]?.metadata).toEqual({
+    expect(messageStore.getMessages()[0]?.metadata).toEqual({
       source: "voice",
       voiceToolCallIds: ["voice-question-1", "voice-question-2"],
     });
   });
 
   test("preserves sibling voice provenance when another tool output rejects", async () => {
-    let latestMessages = [
-      {
-        id: "assistant-voice-questions",
-        parts: [
-          {
-            input: { question: "Who approves it?" },
-            state: "input-available",
-            toolCallId: "voice-question-1",
-            toolName: "answerQuestion",
-            type: "dynamic-tool",
-          },
-          {
-            input: { question: "Who acts next?" },
-            state: "input-available",
-            toolCallId: "voice-question-2",
-            toolName: "answerQuestion",
-            type: "dynamic-tool",
-          },
-        ],
-        role: "assistant",
-      },
-    ] as unknown as PetrinautAiMessage[];
-    const updateMessages = (
-      updater: (messages: PetrinautAiMessage[]) => PetrinautAiMessage[],
-    ) => {
-      latestMessages = updater(latestMessages);
-    };
+    const messageStore = createTestMessageStore(
+      createPendingVoiceQuestionMessage({
+        toolCallIds: ["voice-question-1", "voice-question-2"],
+      }),
+    );
     let rejectFirstSubmission: ((reason?: unknown) => void) | undefined;
     const addToolOutput = vi
       .fn()
@@ -3547,14 +3557,14 @@ describe("AiAssistantPanel composer submissions", () => {
 
     const firstSubmission = addMappedToolOutput({
       addToolOutput,
-      currentMessages: latestMessages,
+      currentMessages: messageStore.getMessages(),
       params: {
         output: { answer: "The shift lead" },
         tool: "answerQuestion",
         toolCallId: "voice-question-1",
       },
       source: "voice",
-      updateMessages,
+      updateMessages: messageStore.updateMessages,
     });
     const firstSubmissionRejection = expect(firstSubmission).rejects.toThrow(
       "First voice tool output rejected.",
@@ -3562,19 +3572,19 @@ describe("AiAssistantPanel composer submissions", () => {
 
     await addMappedToolOutput({
       addToolOutput,
-      currentMessages: latestMessages,
+      currentMessages: messageStore.getMessages(),
       params: {
         output: { answer: "The release manager" },
         tool: "answerQuestion",
         toolCallId: "voice-question-2",
       },
       source: "voice",
-      updateMessages,
+      updateMessages: messageStore.updateMessages,
     });
     rejectFirstSubmission?.(new Error("First voice tool output rejected."));
     await firstSubmissionRejection;
 
-    expect(latestMessages[0]?.metadata).toEqual({
+    expect(messageStore.getMessages()[0]?.metadata).toEqual({
       source: "voice",
       voiceToolCallIds: ["voice-question-2"],
     });
@@ -3583,33 +3593,11 @@ describe("AiAssistantPanel composer submissions", () => {
   test.each(["first-then-second", "second-then-first"] as const)(
     "removes both failed voice origins when overlapping outputs reject %s",
     async (rejectionOrder) => {
-      let latestMessages = [
-        {
-          id: "assistant-voice-questions",
-          parts: [
-            {
-              input: { question: "Who approves it?" },
-              state: "input-available",
-              toolCallId: "voice-question-1",
-              toolName: "answerQuestion",
-              type: "dynamic-tool",
-            },
-            {
-              input: { question: "Who acts next?" },
-              state: "input-available",
-              toolCallId: "voice-question-2",
-              toolName: "answerQuestion",
-              type: "dynamic-tool",
-            },
-          ],
-          role: "assistant",
-        },
-      ] as unknown as PetrinautAiMessage[];
-      const updateMessages = (
-        updater: (messages: PetrinautAiMessage[]) => PetrinautAiMessage[],
-      ) => {
-        latestMessages = updater(latestMessages);
-      };
+      const messageStore = createTestMessageStore(
+        createPendingVoiceQuestionMessage({
+          toolCallIds: ["voice-question-1", "voice-question-2"],
+        }),
+      );
       let rejectFirstSubmission: ((reason?: unknown) => void) | undefined;
       let rejectSecondSubmission: ((reason?: unknown) => void) | undefined;
       const addToolOutput = vi
@@ -3629,28 +3617,28 @@ describe("AiAssistantPanel composer submissions", () => {
 
       const firstSubmission = addMappedToolOutput({
         addToolOutput,
-        currentMessages: latestMessages,
+        currentMessages: messageStore.getMessages(),
         params: {
           output: { answer: "The shift lead" },
           tool: "answerQuestion",
           toolCallId: "voice-question-1",
         },
         source: "voice",
-        updateMessages,
+        updateMessages: messageStore.updateMessages,
       });
       const firstSubmissionRejection = expect(firstSubmission).rejects.toThrow(
         "First voice tool output rejected.",
       );
       const secondSubmission = addMappedToolOutput({
         addToolOutput,
-        currentMessages: latestMessages,
+        currentMessages: messageStore.getMessages(),
         params: {
           output: { answer: "The release manager" },
           tool: "answerQuestion",
           toolCallId: "voice-question-2",
         },
         source: "voice",
-        updateMessages,
+        updateMessages: messageStore.updateMessages,
       });
       const secondSubmissionRejection = expect(
         secondSubmission,
@@ -3672,93 +3660,67 @@ describe("AiAssistantPanel composer submissions", () => {
         await firstSubmissionRejection;
       }
 
-      expect(latestMessages[0]?.metadata).toBeUndefined();
+      expect(messageStore.getMessages()[0]?.metadata).toBeUndefined();
     },
   );
 
   test("preserves independent voice provenance and concurrent message updates on rejection", async () => {
-    let latestMessages = [
-      {
+    const messageStore = createTestMessageStore(
+      createPendingVoiceQuestionMessage({
         id: "assistant-voice-question",
         metadata: { source: "voice" },
-        parts: [
-          {
-            input: { question: "Who approves it?" },
-            state: "input-available",
-            toolCallId: "voice-question",
-            toolName: "answerQuestion",
-            type: "dynamic-tool",
-          },
-        ],
-        role: "assistant",
-      },
-    ] as unknown as PetrinautAiMessage[];
-    const updateMessages = (
-      updater: (messages: PetrinautAiMessage[]) => PetrinautAiMessage[],
-    ) => {
-      latestMessages = updater(latestMessages);
-    };
+        toolCallIds: ["voice-question"],
+      }),
+    );
     const addToolOutput = vi.fn().mockImplementationOnce(async () => {
-      latestMessages = latestMessages.map((message) => ({
-        ...message,
-        metadata: { ...message.metadata, stopped: true },
-        parts: [
-          ...message.parts,
-          { text: "Unrelated concurrent update", type: "text" },
-        ],
-      })) as PetrinautAiMessage[];
+      messageStore.setMessages(
+        messageStore.getMessages().map((message) => ({
+          ...message,
+          metadata: { ...message.metadata, stopped: true },
+          parts: [
+            ...message.parts,
+            { text: "Unrelated concurrent update", type: "text" },
+          ],
+        })) as PetrinautAiMessage[],
+      );
       throw new Error("Voice tool output rejected.");
     });
 
     await expect(
       addMappedToolOutput({
         addToolOutput,
-        currentMessages: latestMessages,
+        currentMessages: messageStore.getMessages(),
         params: {
           output: { answer: "The shift lead" },
           tool: "answerQuestion",
           toolCallId: "voice-question",
         },
         source: "voice",
-        updateMessages,
+        updateMessages: messageStore.updateMessages,
       }),
     ).rejects.toThrow("Voice tool output rejected.");
 
-    expect(latestMessages[0]?.metadata).toEqual({
+    expect(messageStore.getMessages()[0]?.metadata).toEqual({
       source: "voice",
       stopped: true,
     });
-    expect(latestMessages[0]?.parts).toContainEqual({
+    expect(messageStore.getMessages()[0]?.parts).toContainEqual({
       text: "Unrelated concurrent update",
       type: "text",
     });
   });
 
   test("preserves pre-existing voice attribution for a rejected tool", async () => {
-    let latestMessages = [
-      {
+    const messageStore = createTestMessageStore(
+      createPendingVoiceQuestionMessage({
         id: "assistant-voice-question",
         metadata: {
           source: "voice",
           voiceToolCallIds: ["voice-question"],
         },
-        parts: [
-          {
-            input: { question: "Who approves it?" },
-            state: "input-available",
-            toolCallId: "voice-question",
-            toolName: "answerQuestion",
-            type: "dynamic-tool",
-          },
-        ],
-        role: "assistant",
-      },
-    ] as unknown as PetrinautAiMessage[];
-    const updateMessages = (
-      updater: (messages: PetrinautAiMessage[]) => PetrinautAiMessage[],
-    ) => {
-      latestMessages = updater(latestMessages);
-    };
+        toolCallIds: ["voice-question"],
+      }),
+    );
     const addToolOutput = vi
       .fn()
       .mockRejectedValueOnce(new Error("Voice tool output rejected."));
@@ -3766,54 +3728,42 @@ describe("AiAssistantPanel composer submissions", () => {
     await expect(
       addMappedToolOutput({
         addToolOutput,
-        currentMessages: latestMessages,
+        currentMessages: messageStore.getMessages(),
         params: {
           output: { answer: "The shift lead" },
           tool: "answerQuestion",
           toolCallId: "voice-question",
         },
         source: "voice",
-        updateMessages,
+        updateMessages: messageStore.updateMessages,
       }),
     ).rejects.toThrow("Voice tool output rejected.");
 
-    expect(latestMessages[0]?.metadata).toEqual({
+    expect(messageStore.getMessages()[0]?.metadata).toEqual({
       source: "voice",
       voiceToolCallIds: ["voice-question"],
     });
   });
 
   test("rolls back failed tool provenance before a typed retry", async () => {
-    let latestMessages = [
-      {
+    const messageStore = createTestMessageStore(
+      createPendingVoiceQuestionMessage({
         id: "assistant-pending-voice-question",
-        parts: [
-          {
-            input: { question: "Who approves it?" },
-            state: "input-available",
-            toolCallId: "voice-question",
-            toolName: "answerQuestion",
-            type: "dynamic-tool",
-          },
-        ],
-        role: "assistant",
-      },
-    ] as unknown as PetrinautAiMessage[];
-    const updateMessages = (
-      updater: (messages: PetrinautAiMessage[]) => PetrinautAiMessage[],
-    ) => {
-      latestMessages = updater(latestMessages);
-    };
+        toolCallIds: ["voice-question"],
+      }),
+    );
     const addToolOutput = vi
       .fn()
       .mockImplementationOnce(async () => {
-        latestMessages = latestMessages.map((message) => ({
-          ...message,
-          parts: [
-            ...message.parts,
-            { text: "Unrelated concurrent update", type: "text" },
-          ],
-        })) as PetrinautAiMessage[];
+        messageStore.setMessages(
+          messageStore.getMessages().map((message) => ({
+            ...message,
+            parts: [
+              ...message.parts,
+              { text: "Unrelated concurrent update", type: "text" },
+            ],
+          })) as PetrinautAiMessage[],
+        );
         throw new Error("Voice tool output rejected.");
       })
       .mockResolvedValueOnce(undefined);
@@ -3826,27 +3776,27 @@ describe("AiAssistantPanel composer submissions", () => {
     await expect(
       addMappedToolOutput({
         addToolOutput,
-        currentMessages: latestMessages,
+        currentMessages: messageStore.getMessages(),
         params,
         source: "voice",
-        updateMessages,
+        updateMessages: messageStore.updateMessages,
       }),
     ).rejects.toThrow("Voice tool output rejected.");
 
-    expect(latestMessages[0]?.metadata).toBeUndefined();
-    expect(latestMessages[0]?.parts).toContainEqual({
+    expect(messageStore.getMessages()[0]?.metadata).toBeUndefined();
+    expect(messageStore.getMessages()[0]?.parts).toContainEqual({
       text: "Unrelated concurrent update",
       type: "text",
     });
 
     await addMappedToolOutput({
       addToolOutput,
-      currentMessages: latestMessages,
+      currentMessages: messageStore.getMessages(),
       params: {
         ...params,
         output: { answer: "Typed retry" },
       },
-      updateMessages,
+      updateMessages: messageStore.updateMessages,
     });
 
     expect(addToolOutput).toHaveBeenLastCalledWith({
@@ -3854,7 +3804,7 @@ describe("AiAssistantPanel composer submissions", () => {
       tool: "answerQuestion",
       toolCallId: "voice-question",
     });
-    expect(latestMessages[0]?.metadata).toBeUndefined();
+    expect(messageStore.getMessages()[0]?.metadata).toBeUndefined();
   });
 
   test("reports browser tool-output rejections through the AI SDK error state", async () => {

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel.test.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel.test.tsx
@@ -3580,6 +3580,209 @@ describe("AiAssistantPanel composer submissions", () => {
     });
   });
 
+  test.each(["first-then-second", "second-then-first"] as const)(
+    "removes both failed voice origins when overlapping outputs reject %s",
+    async (rejectionOrder) => {
+      let latestMessages = [
+        {
+          id: "assistant-voice-questions",
+          parts: [
+            {
+              input: { question: "Who approves it?" },
+              state: "input-available",
+              toolCallId: "voice-question-1",
+              toolName: "answerQuestion",
+              type: "dynamic-tool",
+            },
+            {
+              input: { question: "Who acts next?" },
+              state: "input-available",
+              toolCallId: "voice-question-2",
+              toolName: "answerQuestion",
+              type: "dynamic-tool",
+            },
+          ],
+          role: "assistant",
+        },
+      ] as unknown as PetrinautAiMessage[];
+      const updateMessages = (
+        updater: (messages: PetrinautAiMessage[]) => PetrinautAiMessage[],
+      ) => {
+        latestMessages = updater(latestMessages);
+      };
+      let rejectFirstSubmission: ((reason?: unknown) => void) | undefined;
+      let rejectSecondSubmission: ((reason?: unknown) => void) | undefined;
+      const addToolOutput = vi
+        .fn()
+        .mockImplementationOnce(
+          () =>
+            new Promise<void>((_resolve, reject) => {
+              rejectFirstSubmission = reject;
+            }),
+        )
+        .mockImplementationOnce(
+          () =>
+            new Promise<void>((_resolve, reject) => {
+              rejectSecondSubmission = reject;
+            }),
+        );
+
+      const firstSubmission = addMappedToolOutput({
+        addToolOutput,
+        currentMessages: latestMessages,
+        params: {
+          output: { answer: "The shift lead" },
+          tool: "answerQuestion",
+          toolCallId: "voice-question-1",
+        },
+        source: "voice",
+        updateMessages,
+      });
+      const firstSubmissionRejection = expect(firstSubmission).rejects.toThrow(
+        "First voice tool output rejected.",
+      );
+      const secondSubmission = addMappedToolOutput({
+        addToolOutput,
+        currentMessages: latestMessages,
+        params: {
+          output: { answer: "The release manager" },
+          tool: "answerQuestion",
+          toolCallId: "voice-question-2",
+        },
+        source: "voice",
+        updateMessages,
+      });
+      const secondSubmissionRejection = expect(
+        secondSubmission,
+      ).rejects.toThrow("Second voice tool output rejected.");
+
+      if (rejectionOrder === "first-then-second") {
+        rejectFirstSubmission?.(new Error("First voice tool output rejected."));
+        await firstSubmissionRejection;
+        rejectSecondSubmission?.(
+          new Error("Second voice tool output rejected."),
+        );
+        await secondSubmissionRejection;
+      } else {
+        rejectSecondSubmission?.(
+          new Error("Second voice tool output rejected."),
+        );
+        await secondSubmissionRejection;
+        rejectFirstSubmission?.(new Error("First voice tool output rejected."));
+        await firstSubmissionRejection;
+      }
+
+      expect(latestMessages[0]?.metadata).toBeUndefined();
+    },
+  );
+
+  test("preserves independent voice provenance and concurrent message updates on rejection", async () => {
+    let latestMessages = [
+      {
+        id: "assistant-voice-question",
+        metadata: { source: "voice" },
+        parts: [
+          {
+            input: { question: "Who approves it?" },
+            state: "input-available",
+            toolCallId: "voice-question",
+            toolName: "answerQuestion",
+            type: "dynamic-tool",
+          },
+        ],
+        role: "assistant",
+      },
+    ] as unknown as PetrinautAiMessage[];
+    const updateMessages = (
+      updater: (messages: PetrinautAiMessage[]) => PetrinautAiMessage[],
+    ) => {
+      latestMessages = updater(latestMessages);
+    };
+    const addToolOutput = vi.fn().mockImplementationOnce(async () => {
+      latestMessages = latestMessages.map((message) => ({
+        ...message,
+        metadata: { ...message.metadata, stopped: true },
+        parts: [
+          ...message.parts,
+          { text: "Unrelated concurrent update", type: "text" },
+        ],
+      })) as PetrinautAiMessage[];
+      throw new Error("Voice tool output rejected.");
+    });
+
+    await expect(
+      addMappedToolOutput({
+        addToolOutput,
+        currentMessages: latestMessages,
+        params: {
+          output: { answer: "The shift lead" },
+          tool: "answerQuestion",
+          toolCallId: "voice-question",
+        },
+        source: "voice",
+        updateMessages,
+      }),
+    ).rejects.toThrow("Voice tool output rejected.");
+
+    expect(latestMessages[0]?.metadata).toEqual({
+      source: "voice",
+      stopped: true,
+    });
+    expect(latestMessages[0]?.parts).toContainEqual({
+      text: "Unrelated concurrent update",
+      type: "text",
+    });
+  });
+
+  test("preserves pre-existing voice attribution for a rejected tool", async () => {
+    let latestMessages = [
+      {
+        id: "assistant-voice-question",
+        metadata: {
+          source: "voice",
+          voiceToolCallIds: ["voice-question"],
+        },
+        parts: [
+          {
+            input: { question: "Who approves it?" },
+            state: "input-available",
+            toolCallId: "voice-question",
+            toolName: "answerQuestion",
+            type: "dynamic-tool",
+          },
+        ],
+        role: "assistant",
+      },
+    ] as unknown as PetrinautAiMessage[];
+    const updateMessages = (
+      updater: (messages: PetrinautAiMessage[]) => PetrinautAiMessage[],
+    ) => {
+      latestMessages = updater(latestMessages);
+    };
+    const addToolOutput = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Voice tool output rejected."));
+
+    await expect(
+      addMappedToolOutput({
+        addToolOutput,
+        currentMessages: latestMessages,
+        params: {
+          output: { answer: "The shift lead" },
+          tool: "answerQuestion",
+          toolCallId: "voice-question",
+        },
+        source: "voice",
+        updateMessages,
+      }),
+    ).rejects.toThrow("Voice tool output rejected.");
+
+    expect(latestMessages[0]?.metadata).toEqual({
+      source: "voice",
+      voiceToolCallIds: ["voice-question"],
+    });
+  });
+
   test("rolls back failed tool provenance before a typed retry", async () => {
     let latestMessages = [
       {

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel.tsx
@@ -160,6 +160,18 @@ const voiceInputWithdrawn = (signal: AbortSignal | undefined): unknown =>
     "AbortError",
   );
 
+export const getVoiceToolCallIds = (
+  metadata: PetrinautAiMessage["metadata"],
+): string[] =>
+  metadata?.source === "voice"
+    ? [
+        ...new Set([
+          ...(metadata.voiceToolCallIds ?? []),
+          ...(metadata.toolCallId ? [metadata.toolCallId] : []),
+        ]),
+      ]
+    : [];
+
 const markVoiceToolOrigin = (
   messages: PetrinautAiMessage[],
   messageId: string,
@@ -168,15 +180,7 @@ const markVoiceToolOrigin = (
   messages.map((message) =>
     message.id === messageId
       ? (() => {
-          const previousToolCallIds =
-            message.metadata?.source === "voice"
-              ? [
-                  ...(message.metadata.voiceToolCallIds ?? []),
-                  ...(message.metadata.toolCallId
-                    ? [message.metadata.toolCallId]
-                    : []),
-                ]
-              : [];
+          const previousToolCallIds = getVoiceToolCallIds(message.metadata);
           const { toolCallId: _legacyToolCallId, ...previousMetadata } =
             message.metadata ?? {};
 
@@ -286,16 +290,7 @@ const beginVoiceToolSubmission = (
     submissionState = {
       pendingSubmissionCount: 0,
       preexistingSource: message.metadata?.source === "voice",
-      preexistingToolCallIds: new Set(
-        message.metadata?.source === "voice"
-          ? [
-              ...(message.metadata.voiceToolCallIds ?? []),
-              ...(message.metadata.toolCallId
-                ? [message.metadata.toolCallId]
-                : []),
-            ]
-          : [],
-      ),
+      preexistingToolCallIds: new Set(getVoiceToolCallIds(message.metadata)),
     };
     messageStates.set(message.id, submissionState);
   }
@@ -379,57 +374,54 @@ export const addMappedToolOutput = async ({
   } catch (error) {
     if (containingMessage) {
       updateMessages((latestMessages) =>
-        latestMessages.map((message) =>
-          message.id === containingMessage.id &&
-          message.metadata?.source === "voice" &&
-          (message.metadata.voiceToolCallIds?.includes(params.toolCallId) ===
-            true ||
-            message.metadata.toolCallId === params.toolCallId)
-            ? (() => {
-                const attributionAlreadyPresent =
-                  submissionState?.preexistingToolCallIds.has(
-                    params.toolCallId,
-                  ) === true;
-                const voiceToolCallIds = [
-                  ...(message.metadata.voiceToolCallIds ?? []),
-                  ...(message.metadata.toolCallId
-                    ? [message.metadata.toolCallId]
-                    : []),
-                ];
-                const remainingVoiceToolCallIds = attributionAlreadyPresent
-                  ? voiceToolCallIds
-                  : voiceToolCallIds.filter(
-                      (candidateToolCallId) =>
-                        candidateToolCallId !== params.toolCallId,
-                    );
-                if (remainingVoiceToolCallIds.length === 0) {
-                  const {
-                    source: _source,
-                    toolCallId: _legacyToolCallId,
-                    voiceToolCallIds: _voiceToolCallIds,
-                    ...unrelatedMetadata
-                  } = message.metadata;
-                  const metadata = submissionState?.preexistingSource
-                    ? { ...unrelatedMetadata, source: "voice" as const }
-                    : Object.keys(unrelatedMetadata).length > 0
-                      ? unrelatedMetadata
-                      : undefined;
+        latestMessages.map((message) => {
+          if (
+            message.id !== containingMessage.id ||
+            message.metadata?.source !== "voice"
+          ) {
+            return message;
+          }
 
-                  return { ...message, metadata };
-                }
-                const { toolCallId: _legacyToolCallId, ...metadata } =
-                  message.metadata;
+          const voiceToolCallIds = getVoiceToolCallIds(message.metadata);
+          if (!voiceToolCallIds.includes(params.toolCallId)) {
+            return message;
+          }
 
-                return {
-                  ...message,
-                  metadata: {
-                    ...metadata,
-                    voiceToolCallIds: [...new Set(remainingVoiceToolCallIds)],
-                  },
-                };
-              })()
-            : message,
-        ),
+          const attributionAlreadyPresent =
+            submissionState?.preexistingToolCallIds.has(params.toolCallId) ===
+            true;
+          const remainingVoiceToolCallIds = attributionAlreadyPresent
+            ? voiceToolCallIds
+            : voiceToolCallIds.filter(
+                (candidateToolCallId) =>
+                  candidateToolCallId !== params.toolCallId,
+              );
+          if (remainingVoiceToolCallIds.length === 0) {
+            const {
+              source: _source,
+              toolCallId: _legacyToolCallId,
+              voiceToolCallIds: _voiceToolCallIds,
+              ...unrelatedMetadata
+            } = message.metadata;
+            const metadata = submissionState?.preexistingSource
+              ? { ...unrelatedMetadata, source: "voice" as const }
+              : Object.keys(unrelatedMetadata).length > 0
+                ? unrelatedMetadata
+                : undefined;
+
+            return { ...message, metadata };
+          }
+          const { toolCallId: _legacyToolCallId, ...metadata } =
+            message.metadata;
+
+          return {
+            ...message,
+            metadata: {
+              ...metadata,
+              voiceToolCallIds: remainingVoiceToolCallIds,
+            },
+          };
+        }),
       );
     }
     throw error;

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/ai-assistant-panel.tsx
@@ -256,6 +256,83 @@ const addDynamicToolOutput = (
   return Promise.resolve(addToolOutputForDynamicTool(params));
 };
 
+type UpdatePetrinautAiMessages = (
+  updater: (messages: PetrinautAiMessage[]) => PetrinautAiMessage[],
+) => void;
+
+type VoiceToolSubmissionState = {
+  pendingSubmissionCount: number;
+  preexistingSource: boolean;
+  preexistingToolCallIds: Set<string>;
+};
+
+const voiceToolSubmissionStates = new WeakMap<
+  UpdatePetrinautAiMessages,
+  Map<string, VoiceToolSubmissionState>
+>();
+
+const beginVoiceToolSubmission = (
+  updateMessages: UpdatePetrinautAiMessages,
+  message: PetrinautAiMessage,
+): VoiceToolSubmissionState => {
+  let messageStates = voiceToolSubmissionStates.get(updateMessages);
+  if (!messageStates) {
+    messageStates = new Map();
+    voiceToolSubmissionStates.set(updateMessages, messageStates);
+  }
+
+  let submissionState = messageStates.get(message.id);
+  if (!submissionState) {
+    submissionState = {
+      pendingSubmissionCount: 0,
+      preexistingSource: message.metadata?.source === "voice",
+      preexistingToolCallIds: new Set(
+        message.metadata?.source === "voice"
+          ? [
+              ...(message.metadata.voiceToolCallIds ?? []),
+              ...(message.metadata.toolCallId
+                ? [message.metadata.toolCallId]
+                : []),
+            ]
+          : [],
+      ),
+    };
+    messageStates.set(message.id, submissionState);
+  }
+
+  submissionState.pendingSubmissionCount += 1;
+  return submissionState;
+};
+
+const finishVoiceToolSubmission = (
+  updateMessages: UpdatePetrinautAiMessages,
+  messageId: string,
+): void => {
+  const messageStates = voiceToolSubmissionStates.get(updateMessages);
+  if (!messageStates) {
+    return;
+  }
+
+  const submissionState = messageStates.get(messageId);
+  if (!submissionState) {
+    return;
+  }
+
+  const pendingSubmissionCount = submissionState.pendingSubmissionCount - 1;
+  if (pendingSubmissionCount > 0) {
+    messageStates.set(messageId, {
+      ...submissionState,
+      pendingSubmissionCount,
+    });
+    return;
+  }
+
+  messageStates.delete(messageId);
+  if (messageStates.size === 0) {
+    voiceToolSubmissionStates.delete(updateMessages);
+  }
+};
+
 export const addMappedToolOutput = async ({
   addToolOutput,
   currentMessages,
@@ -283,7 +360,9 @@ export const addMappedToolOutput = async ({
           ),
         )
       : undefined;
-  const previousMetadata = containingMessage?.metadata;
+  const submissionState = containingMessage
+    ? beginVoiceToolSubmission(updateMessages, containingMessage)
+    : undefined;
 
   if (containingMessage) {
     updateMessages((latestMessages) =>
@@ -308,11 +387,9 @@ export const addMappedToolOutput = async ({
             message.metadata.toolCallId === params.toolCallId)
             ? (() => {
                 const attributionAlreadyPresent =
-                  previousMetadata?.source === "voice" &&
-                  (previousMetadata.voiceToolCallIds?.includes(
+                  submissionState?.preexistingToolCallIds.has(
                     params.toolCallId,
-                  ) === true ||
-                    previousMetadata.toolCallId === params.toolCallId);
+                  ) === true;
                 const voiceToolCallIds = [
                   ...(message.metadata.voiceToolCallIds ?? []),
                   ...(message.metadata.toolCallId
@@ -326,7 +403,19 @@ export const addMappedToolOutput = async ({
                         candidateToolCallId !== params.toolCallId,
                     );
                 if (remainingVoiceToolCallIds.length === 0) {
-                  return { ...message, metadata: previousMetadata };
+                  const {
+                    source: _source,
+                    toolCallId: _legacyToolCallId,
+                    voiceToolCallIds: _voiceToolCallIds,
+                    ...unrelatedMetadata
+                  } = message.metadata;
+                  const metadata = submissionState?.preexistingSource
+                    ? { ...unrelatedMetadata, source: "voice" as const }
+                    : Object.keys(unrelatedMetadata).length > 0
+                      ? unrelatedMetadata
+                      : undefined;
+
+                  return { ...message, metadata };
                 }
                 const { toolCallId: _legacyToolCallId, ...metadata } =
                   message.metadata;
@@ -344,6 +433,10 @@ export const addMappedToolOutput = async ({
       );
     }
     throw error;
+  } finally {
+    if (containingMessage && submissionState) {
+      finishVoiceToolSubmission(updateMessages, containingMessage.id);
+    }
   }
 };
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Prevent overlapping rejected Voice tool answers from restoring stale provenance onto an assistant message. Each failed submission now removes only its own temporary Voice tool-call ID from the latest metadata, preserving successful siblings and unrelated concurrent updates.

## 🔗 Related links

- [H-6800 — Improve Petrinaut Voice turn-taking and answer provenance](https://linear.app/hash/issue/H-6800/improve-petrinaut-voice-turn-taking-and-answer-provenance) _(internal)_
- Donor PR [#9512](https://github.com/hashintel/hash/pull/9512)
- Original review finding: [stale Voice-ID rollback](https://github.com/hashintel/hash/pull/9512#discussion_r3924571858)
- Accepted reconciliation [#9564](https://github.com/hashintel/hash/pull/9564)

## 🚫 Blocked by

- [x] Nothing

## 🔍 What does this change?

- Coordinate overlapping Voice tool submissions against one pre-submission provenance baseline.
- Roll failed submissions back from current metadata instead of restoring a captured snapshot.
- Preserve successful sibling IDs, pre-existing attribution, independent message-level Voice source, unrelated metadata and concurrent message parts.
- Remove submission coordination state once the overlapping group settles.
- Add regressions for both dual-rejection orders and concurrent metadata updates.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] modifies an **npm**-publishable library and **I have added a changeset file**

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

Direct spoken-user attribution after hydration remains explicitly deferred. This focused fix does not restore the obsolete inline `brunch_ask` widget provenance slot.

## 🐾 Next steps

After this fix and the remaining provenance omissions are explicitly accepted, #9512 can close as a donor.

## 🛡 What tests cover this?

- Both completion orders when two overlapping Voice tool submissions reject.
- One-success/one-failure sibling preservation.
- Typed retry after rejection.
- Pre-existing and independent Voice attribution.
- Unrelated concurrent metadata and message-part preservation.
- Complete `ai-assistant-panel.test.tsx`: 62 tests.

## ❓ How to test this?

1. Run `yarn workspace @hashintel/petrinaut test:unit --run src/ui/views/Editor/panels/ai-assistant-panel.test.tsx`.
2. Run `yarn workspace @hashintel/petrinaut lint:tsc`.
3. Run `yarn workspace @hashintel/petrinaut lint:eslint`.

## 📹 Demo

Not applicable; this repairs internal provenance bookkeeping and is covered by deterministic regressions.

Made with [Cursor](https://cursor.com)