### PR TITLE
BE-838: Restore Atlas package startup after CLI gating

### DIFF
--- a/libs/@local/graph/atlas/package.json
+++ b/libs/@local/graph/atlas/package.json
@@ -8,7 +8,7 @@
     "doc:dependency-diagram": "cargo run -p hash-repo-chores -- dependency-diagram --output docs/dependency-diagram.mmd --root hash-graph-atlas --root-deps-and-dependents --link-mode non-roots --include-dev-deps --include-build-deps --logging-console-level info",
     "fix:clippy": "just clippy --fix",
     "lint:clippy": "just clippy",
-    "start": "cargo run -p hash-graph-atlas --bin hash-graph-atlas --",
+    "start": "cargo run -p hash-graph-atlas --bin hash-graph-atlas --features cli --",
     "test:integration": "cargo nextest run --package hash-graph-atlas --all-features --filterset 'kind(test)'",
     "test:miri": "cargo miri test --lib -- ::miri::",
     "test:unit": "mise run test:unit @rust/hash-graph-atlas -- --filterset 'not kind(test)'"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Restore the Atlas package's start script after the Atlas binary was gated behind the `cli` feature. Without this, callers such as benchmark setup fail before Atlas starts, including the base comparison for #9585.

## 🔗 Related links

- #9585
- [Failing benchmark run](https://github.com/hashintel/hash/actions/runs/21850366377)

## 🚫 Blocked by

- [x] Nothing

## 🔍 What does this change?

- Passes `--features cli` when the `@rust/hash-graph-atlas` start script invokes Cargo.

<details>
<summary>🏗️ Agent notes</summary>

The Atlas binary declares `required-features = ["cli"]`. The package script omitted that feature, so Cargo exited with `target requires the features: cli` and the benchmark harness later reported a healthcheck timeout.

</details>

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

None.

## 🐾 Next steps

Rerun the benchmark check on #9585 after this reaches `main` so its baseline checkout includes the repaired script.

## 🛡 What tests cover this?

- Invoked the package start script with `--help`; Cargo built and ran the Atlas CLI successfully.
- Pre-commit checks passed, including package formatting and task-dependency validation.

## ❓ How to test this?

1. Run `mise exec -- yarn workspace @rust/hash-graph-atlas start --help`.
2. Confirm Cargo builds the Atlas binary and prints its command-line help instead of reporting a missing `cli` feature.

## 📹 Demo

Not applicable; this repairs an internal start command.

Made with [Cursor](https://cursor.com)