### PR TITLE
FE-778: Dim the code editor loading label and left-align it inline

### DIFF
--- a/.changeset/code-editor-loading-label.md
+++ b/.changeset/code-editor-loading-label.md
@@ -1,0 +1,5 @@
+---
+"@hashintel/petrinaut": patch
+---
+
+The code editor's loading label is dimmed, and sits at the left of an inline editor while Monaco loads instead of jumping from the centre.

--- a/.changeset/code-editor-loading-label.md
+++ b/.changeset/code-editor-loading-label.md
@@ -1,5 +1,0 @@
----
-"@hashintel/petrinaut": patch
----
-
-The code editor's loading label is dimmed, and sits at the left of an inline editor while Monaco loads instead of jumping from the centre.

--- a/libs/@hashintel/petrinaut/src/ui/monaco/code-editor.test.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/monaco/code-editor.test.tsx
@@ -1,0 +1,88 @@
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+/**
+ * @vitest-environment jsdom
+ */
+import { Suspense, useEffect, useState } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { CodeEditor } from "./code-editor";
+import { MonacoContext } from "./context";
+
+import type { MonacoContextValue } from "./context";
+import type { EditorProps } from "@monaco-editor/react";
+import type { editor } from "monaco-editor";
+
+afterEach(cleanup);
+
+// A stand-in for @monaco-editor/react's Editor: shows `loading` until the
+// test releases the mount, then reports a minimal editor instance.
+const mountGate: { release: () => void } = { release: () => {} };
+
+const FakeEditor: React.FC<EditorProps> = ({ loading, onMount }) => {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    mountGate.release = () => setMounted(true);
+  }, []);
+  useEffect(() => {
+    if (!mounted) {
+      return;
+    }
+    const model = {
+      getValue: () => "",
+      setValue: vi.fn(),
+      getLineCount: () => 1,
+      getLineMaxColumn: () => 1,
+      getFullModelRange: () => ({}),
+    };
+    const instance = {
+      getModel: () => model,
+      setPosition: vi.fn(),
+      setSelection: vi.fn(),
+      onDidChangeModelContent: vi.fn(),
+      onDidScrollChange: vi.fn(),
+      onDidFocusEditorText: vi.fn(),
+      onDidBlurEditorText: vi.fn(),
+    } as unknown as editor.IStandaloneCodeEditor;
+    onMount?.(instance, {} as never);
+  }, [mounted, onMount]);
+  return mounted ? (
+    <div data-testid="editor" />
+  ) : (
+    <div data-testid="editor-loading">{loading}</div>
+  );
+};
+
+const monacoContext: Promise<MonacoContextValue> = Promise.resolve({
+  monaco: {} as never,
+  Editor: FakeEditor,
+});
+
+describe("CodeEditor", () => {
+  it("shows the placeholder only once the editor has mounted", async () => {
+    // The inner component suspends on the Monaco module, so the render is
+    // awaited for the module to settle.
+    await act(async () => {
+      render(
+        <MonacoContext value={monacoContext}>
+          <Suspense fallback={null}>
+            <CodeEditor singleLine placeholder="Type an expression" value="" />
+          </Suspense>
+        </MonacoContext>,
+      );
+    });
+
+    // While Monaco mounts, its dimmed label has the row; the placeholder
+    // would land at the same inset and read as two labels. (The Suspense
+    // fallback shows the same label first, so wait for the editor's own.)
+    const loading = await screen.findByTestId("editor-loading");
+    expect(loading.textContent).toBe("Loading...");
+    expect(screen.queryByText("Type an expression")).toBeNull();
+
+    act(() => {
+      mountGate.release();
+    });
+    await waitFor(() => screen.getByTestId("editor"));
+    expect(screen.getByText("Type an expression")).toBeTruthy();
+    expect(screen.queryByText("Loading...")).toBeNull();
+  });
+});

--- a/libs/@hashintel/petrinaut/src/ui/monaco/code-editor.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/monaco/code-editor.tsx
@@ -88,24 +88,35 @@ const singleLineContainerStyle = cva({
   },
 });
 
+// The wait for Monaco, shown twice: as the Suspense fallback while the
+// module loads and as Monaco's own `loading` while the editor mounts.
+// Dimmed, so it reads as a wait and not as content; it fills its box
+// because Monaco centres whatever it is given.
 const loadingStyle = css({
   display: "flex",
   alignItems: "center",
   justifyContent: "center",
   gap: "2",
   height: "full",
+  width: "full",
   color: "fg.muted",
   bg: "bg.subtle",
   fontSize: "base",
+  opacity: "[0.5]",
 });
 
+// Inline editors left-align the label where the text will land, so it does
+// not jump from the centre when the editor mounts.
 const singleLineLoadingStyle = css({
   display: "flex",
   alignItems: "center",
+  justifyContent: "flex-start",
   height: "full",
-  paddingX: "2",
+  width: "full",
+  paddingLeft: "[12px]",
   color: "neutral.s80",
   fontSize: "sm",
+  opacity: "[0.5]",
 });
 
 const placeholderStyle = css({
@@ -348,6 +359,7 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
           options={options}
           height={height}
           singleLine={singleLine}
+          loading={fallback}
           {...props}
         />
       </Suspense>

--- a/libs/@hashintel/petrinaut/src/ui/monaco/code-editor.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/monaco/code-editor.tsx
@@ -184,12 +184,16 @@ const CodeEditorInner: React.FC<CodeEditorProps> = ({
   // Withholding `value` makes @monaco-editor/react skip its sync; the prop
   // resumes syncing external changes once focus leaves.
   const [editorFocused, setEditorFocused] = useState(false);
+  // Until Monaco mounts, its `loading` label sits where the placeholder
+  // would, so the placeholder waits for the mount rather than overlapping it.
+  const [editorMounted, setEditorMounted] = useState(false);
 
   const handleMount = (
     editorInstance: editor.IStandaloneCodeEditor,
     monacoInstance: Monaco,
   ) => {
     editorRef.current = editorInstance;
+    setEditorMounted(true);
 
     // With a `path`, @monaco-editor/react reuses the existing model and
     // ignores `value` — a reopened editor would show the model's stale text
@@ -313,7 +317,7 @@ const CodeEditorInner: React.FC<CodeEditorProps> = ({
 
   return (
     <>
-      {singleLine && placeholder && !value && (
+      {singleLine && placeholder && !value && editorMounted && (
         <div className={placeholderStyle}>{placeholder}</div>
       )}
       <Editor

--- a/libs/@hashintel/petrinaut/src/ui/monaco/code-editor.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/monaco/code-editor.tsx
@@ -102,7 +102,7 @@ const loadingStyle = css({
   color: "fg.muted",
   bg: "bg.subtle",
   fontSize: "base",
-  opacity: "[0.5]",
+  opacity: "[0.3]",
 });
 
 // Inline editors left-align the label where the text will land, so it does
@@ -116,7 +116,7 @@ const singleLineLoadingStyle = css({
   paddingLeft: "[12px]",
   color: "neutral.s80",
   fontSize: "sm",
-  opacity: "[0.5]",
+  opacity: "[0.3]",
 });
 
 const placeholderStyle = css({


### PR DESCRIPTION
## Summary

Before this PR, a code editor showed a full-strength "Loading..." label while Monaco loaded, centered in the box. In an inline expression cell the centered label jumped to the left once the editor mounted, and in both shapes it read as content rather than as a wait.

Both placeholders now share one dimmed element: left-aligned and vertically centered in an inline editor, centered in a block editor. Monaco's own loading state renders the same element, so the label does not change between the module load and the editor mount.

**Before**

https://github.com/user-attachments/assets/23ef0e4d-7f4d-4c98-a780-4e8a886e7be8

**After**

https://github.com/user-attachments/assets/49ab7ec0-0267-462e-bb44-16be85a6fd77

## Links

- Ticket [FE-778](https://linear.app/hash/issue/FE-778)

## Changes

- One loading element for both waits
  > `CodeEditor` passes its Suspense fallback to Monaco's `loading` prop, so the module load and the editor mount show the same label.
- Inline label sits at the left, block label stays centered
  > Both fill their box and render at 0.3 opacity.

#### Review fixes

- Placeholder waits for the editor mount
  > Monaco's loading label and the inline placeholder sat at the same inset until the editor mounted; the placeholder now renders only after `onMount`.

## Test coverage

- Existing `@hashintel/petrinaut` unit suite
- `code-editor.test.tsx`:
  > The inline placeholder is absent while a stand-in editor shows its loading label and appears once it mounts.

## How to test

- Open [Petrinaut preview](https://petrinaut-git-claude-fe-778-code-editor-loading-placeholder.stage.hash.ai) on Vercel
- Menu > Load example > SIR Epidemic Model
- Throttle the network in the developer tools
- Select a transition, open its lambda code
  > Expect a dimmed centered "Loading..." label until the editor mounts
- Viewport controls > Settings > General > Ad-hoc scenarios
- Bottom bar > diagnostics > Simulation Settings tab, open a place's count cell
  > Expect a dimmed "Loading..." label at the left of the cell until the editor mounts




