### PR TITLE
FE-1651: Keep a notification without detail a single compact line

### DIFF
--- a/.changeset/compact-notification-toast.md
+++ b/.changeset/compact-notification-toast.md
@@ -1,0 +1,5 @@
+---
+"@hashintel/petrinaut": patch
+---
+
+A notification that carries no detail is a single centred line again, without the copy and close buttons a long error needs. An error, which stays open until it is dismissed, and any notification with detail keep them.

--- a/.changeset/compact-notification-toast.md
+++ b/.changeset/compact-notification-toast.md
@@ -1,5 +1,0 @@
----
-"@hashintel/petrinaut": patch
----
-
-A notification that carries no detail is a single centred line again, without the copy and close buttons a long error needs. An error, which stays open until it is dismissed, and any notification with detail keep them.

--- a/libs/@hashintel/petrinaut/src/react/notifications/provider.test.tsx
+++ b/libs/@hashintel/petrinaut/src/react/notifications/provider.test.tsx
@@ -74,3 +74,63 @@ test("keeps error notifications open while preserving the default for other tone
     type: "success",
   });
 });
+
+test("shows a way out only where a notification needs one", async () => {
+  const Trigger = () => {
+    const { addNotification } = use(NotificationsContext);
+
+    return (
+      <>
+        <button
+          type="button"
+          onClick={() => addNotification({ message: "Simulation complete" })}
+        >
+          Complete
+        </button>
+        <button
+          type="button"
+          onClick={() =>
+            addNotification({
+              detail: "The complete elicitor failure.",
+              message: "Assistant run failed",
+              tone: "error",
+            })
+          }
+        >
+          Error
+        </button>
+      </>
+    );
+  };
+
+  render(
+    <NotificationsProvider>
+      <Trigger />
+    </NotificationsProvider>,
+  );
+
+  // The toaster is a module singleton whose toasts outlive a test, so each
+  // notification is read from its own toast rather than from the document,
+  // under a title no other test uses.
+  const toastFor = async (title: string) =>
+    (await screen.findByText(title)).closest("[data-part='root']");
+
+  fireEvent.click(screen.getByRole("button", { name: "Complete" }));
+  fireEvent.click(screen.getByRole("button", { name: "Error" }));
+
+  const complete = await toastFor("Simulation complete");
+  expect(complete?.hasAttribute("data-detail")).toBe(false);
+  expect(
+    complete?.querySelector("[aria-label='Close notification']"),
+  ).toBeNull();
+  expect(complete?.querySelector("[aria-label='Copy details']")).toBeNull();
+
+  const failure = await toastFor("Assistant run failed");
+  expect(failure?.hasAttribute("data-detail")).toBe(true);
+  await waitFor(() =>
+    expect(
+      failure?.querySelector("[aria-label='Close notification']"),
+    ).toBeTruthy(),
+  );
+  expect(failure?.querySelector("[aria-label='Copy details']")).toBeTruthy();
+});

--- a/libs/@hashintel/petrinaut/src/react/notifications/toaster.tsx
+++ b/libs/@hashintel/petrinaut/src/react/notifications/toaster.tsx
@@ -24,7 +24,13 @@ const toastRootStyle = css({
   transition: "[translate 300ms, scale 300ms, opacity 300ms, box-shadow 300ms]",
   transitionTimingFunction: "[cubic-bezier(0.21, 1.02, 0.73, 1)]",
   display: "flex",
-  alignItems: "flex-start",
+  // A message on its own sits centred against its close button. One that
+  // carries detail grows into a column, so its title lines up with the top
+  // of the buttons beside it.
+  alignItems: "center",
+  "&[data-detail]": {
+    alignItems: "flex-start",
+  },
   gap: "2",
   minHeight: "[26px]",
   width: "[max-content]",
@@ -92,8 +98,16 @@ export const NotificationsToaster = () => (
         const detail =
           typeof toast.description === "string" ? toast.description : undefined;
 
+        // An error notification stays until it is dismissed, and one with
+        // detail is there to be read, so both offer a way out. A plain
+        // message clears itself and stays a single compact line.
+        const dismissible = detail !== undefined || toast.type === "error";
+
         return (
-          <Toast.Root className={toastRootStyle}>
+          <Toast.Root
+            className={toastRootStyle}
+            data-detail={detail === undefined ? undefined : ""}
+          >
             <div className={toastContentStyle}>
               <Toast.Title className={toastTitleStyle}>
                 {toast.title}
@@ -104,31 +118,33 @@ export const NotificationsToaster = () => (
                 </Toast.Description>
               )}
             </div>
-            <div className={toastActionsStyle}>
-              {detail && (
-                <Button
-                  aria-label="Copy details"
-                  className={toastActionStyle}
-                  iconName="copy"
-                  onClick={() => {
-                    void navigator.clipboard.writeText(detail);
-                  }}
-                  size="xs"
-                  tooltip="Copy details"
-                  variant="ghost"
-                />
-              )}
-              <Toast.CloseTrigger asChild>
-                <Button
-                  aria-label="Close notification"
-                  className={toastActionStyle}
-                  iconName="close"
-                  size="xs"
-                  tooltip="Close notification"
-                  variant="ghost"
-                />
-              </Toast.CloseTrigger>
-            </div>
+            {dismissible && (
+              <div className={toastActionsStyle}>
+                {detail && (
+                  <Button
+                    aria-label="Copy details"
+                    className={toastActionStyle}
+                    iconName="copy"
+                    onClick={() => {
+                      void navigator.clipboard.writeText(detail);
+                    }}
+                    size="xs"
+                    tooltip="Copy details"
+                    variant="ghost"
+                  />
+                )}
+                <Toast.CloseTrigger asChild>
+                  <Button
+                    aria-label="Close notification"
+                    className={toastActionStyle}
+                    iconName="close"
+                    size="xs"
+                    tooltip="Close notification"
+                    variant="ghost"
+                  />
+                </Toast.CloseTrigger>
+              </div>
+            )}
           </Toast.Root>
         );
       }}


### PR DESCRIPTION
## Summary

Before this PR, every notification carried the chrome a long error needs. #9564 gave the toaster a description column, a copy button and a close button so an AI assistant failure could be read and copied from the toast, and applied that shape to all of them. A three-second message with no detail, "Simulation complete" among them, rendered as a tall pill: title top-aligned in a column, close button beside it.

A notification without detail is a single centred line again, with no buttons, the form it had before. One that carries detail keeps the column, the copy button and the close button, and so does an error, which never dismisses itself.

## Links

- Ticket [FE-1651](https://linear.app/hash/issue/FE-1651)

## Changes

- A notification's buttons appear only where it needs a way out
  > An error stays open until dismissed and a detail is there to be read, so both keep copy and close. A plain message clears itself after three seconds.
- The toast centres its row unless it carries detail
  > `data-detail` on the toast root drives the alignment, so a title with a description still lines up with the top of the buttons beside it.

## Test coverage

- `provider.test.tsx`:
  > A message with no detail renders no close or copy button and no `data-detail`; an error with detail renders both and carries the attribute.
  > Queries read from each toast's own root, since the toaster is a module singleton whose toasts outlive a test.
- Built stylesheet:
  > Carries `align-items: center` for the toast root and `align-items: flex-start` only under `[data-detail]`.

## How to test

- Open [Petrinaut preview](https://petrinaut-git-claude-fe-1651-compact-notification-toast.stage.hash.ai) on Vercel
- Menu > Load example > any model
- Switch to Simulate
- Create an experiment with a couple of runs and wait for it to finish
  > Expect a single-line dark toast in the bottom right, no buttons, gone after three seconds
- Ask the AI assistant something while the assistant is unreachable
  > Expect the error toast to keep its wrapped title, Copy details and Close, and to stay until closed
