### PR TITLE
SRE-1047: Carry crate changes into the images through the manifest chain

### DIFF
--- a/.claude/hooks/docs/task-dependencies.json
+++ b/.claude/hooks/docs/task-dependencies.json
@@ -5,15 +5,29 @@
     "@local/tsconfig"
   ],
   "tasks": {
-    "fix:eslint": [
-      "@local/eslint#build"
-    ],
-    "lint:eslint": [
-      "@local/eslint#build"
-    ],
-    "lint:tsc": [
-      "@local/eslint#build"
-    ],
-    "test:unit": []
+    "fix:eslint": {
+      "dependsOn": [
+        "@local/eslint#build"
+      ]
+    },
+    "lint:eslint": {
+      "dependsOn": [
+        "@local/eslint#build"
+      ],
+      "env": [
+        "CHECK_TEMPORARILY_DISABLED_RULES"
+      ]
+    },
+    "lint:tsc": {
+      "dependsOn": [
+        "@local/eslint#build"
+      ]
+    },
+    "test:unit": {
+      "dependsOn": [],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/apps/brunch-agent/docs/task-dependencies.json
+++ b/apps/brunch-agent/docs/task-dependencies.json
@@ -9,77 +9,126 @@
     "@local/hash-backend-utils"
   ],
   "tasks": {
-    "build": [
-      "@hashintel/brunch-agent#build",
-      "@hashintel/brunch-agent-binding-flue#build",
-      "@hashintel/brunch-agent-plugin-sdcpn#build",
-      "@hashintel/brunch-agent-transport-aisdk#build",
-      "@hashintel/petrinaut-core#build",
-      "@local/hash-backend-utils#build"
-    ],
-    "build:docker": [],
-    "dev": [
-      "@hashintel/brunch-agent#build",
-      "@hashintel/brunch-agent-binding-flue#build",
-      "@hashintel/brunch-agent-plugin-sdcpn#build",
-      "@hashintel/brunch-agent-transport-aisdk#build",
-      "@hashintel/petrinaut-core#build",
-      "@local/hash-backend-utils#build"
-    ],
-    "fix:eslint": [
-      "@hashintel/brunch-agent#build",
-      "@hashintel/brunch-agent-binding-flue#build",
-      "@hashintel/brunch-agent-plugin-sdcpn#build",
-      "@hashintel/brunch-agent-transport-aisdk#build",
-      "@hashintel/petrinaut-core#build",
-      "@local/eslint#build",
-      "@local/hash-backend-utils#build"
-    ],
-    "lint:eslint": [
-      "@hashintel/brunch-agent#build",
-      "@hashintel/brunch-agent-binding-flue#build",
-      "@hashintel/brunch-agent-plugin-sdcpn#build",
-      "@hashintel/brunch-agent-transport-aisdk#build",
-      "@hashintel/petrinaut-core#build",
-      "@local/eslint#build",
-      "@local/hash-backend-utils#build"
-    ],
-    "lint:tsc": [
-      "@hashintel/brunch-agent#build",
-      "@hashintel/brunch-agent-binding-flue#build",
-      "@hashintel/brunch-agent-plugin-sdcpn#build",
-      "@hashintel/brunch-agent-transport-aisdk#build",
-      "@hashintel/petrinaut-core#build",
-      "@local/hash-backend-utils#build"
-    ],
-    "petrinaut:dev": [
-      "@hashintel/brunch-agent#build",
-      "@hashintel/brunch-agent-binding-flue#build",
-      "@hashintel/brunch-agent-plugin-sdcpn#build",
-      "@hashintel/brunch-agent-transport-aisdk#build",
-      "@hashintel/petrinaut-core#build",
-      "@local/hash-backend-utils#build"
-    ],
-    "start": [
-      "build"
-    ],
-    "start:healthcheck": [],
-    "start:test": [
-      "build"
-    ],
-    "start:test:healthcheck": [],
-    "test:docker": [
-      "build:docker"
-    ],
-    "test:integration": [],
-    "test:unit": [
-      "@hashintel/brunch-agent#build",
-      "@hashintel/brunch-agent-binding-flue#build",
-      "@hashintel/brunch-agent-plugin-sdcpn#build",
-      "@hashintel/brunch-agent-transport-aisdk#build",
-      "@hashintel/petrinaut-core#build",
-      "@local/hash-backend-utils#build",
-      "build"
-    ]
+    "build": {
+      "dependsOn": [
+        "@hashintel/brunch-agent#build",
+        "@hashintel/brunch-agent-binding-flue#build",
+        "@hashintel/brunch-agent-plugin-sdcpn#build",
+        "@hashintel/brunch-agent-transport-aisdk#build",
+        "@hashintel/petrinaut-core#build",
+        "@local/hash-backend-utils#build"
+      ]
+    },
+    "build:docker": {
+      "dependsOn": [],
+      "cache": false
+    },
+    "dev": {
+      "dependsOn": [
+        "@hashintel/brunch-agent#build",
+        "@hashintel/brunch-agent-binding-flue#build",
+        "@hashintel/brunch-agent-plugin-sdcpn#build",
+        "@hashintel/brunch-agent-transport-aisdk#build",
+        "@hashintel/petrinaut-core#build",
+        "@local/hash-backend-utils#build"
+      ],
+      "cache": false,
+      "persistent": true
+    },
+    "fix:eslint": {
+      "dependsOn": [
+        "@hashintel/brunch-agent#build",
+        "@hashintel/brunch-agent-binding-flue#build",
+        "@hashintel/brunch-agent-plugin-sdcpn#build",
+        "@hashintel/brunch-agent-transport-aisdk#build",
+        "@hashintel/petrinaut-core#build",
+        "@local/eslint#build",
+        "@local/hash-backend-utils#build"
+      ]
+    },
+    "lint:eslint": {
+      "dependsOn": [
+        "@hashintel/brunch-agent#build",
+        "@hashintel/brunch-agent-binding-flue#build",
+        "@hashintel/brunch-agent-plugin-sdcpn#build",
+        "@hashintel/brunch-agent-transport-aisdk#build",
+        "@hashintel/petrinaut-core#build",
+        "@local/eslint#build",
+        "@local/hash-backend-utils#build"
+      ],
+      "env": [
+        "CHECK_TEMPORARILY_DISABLED_RULES"
+      ]
+    },
+    "lint:tsc": {
+      "dependsOn": [
+        "@hashintel/brunch-agent#build",
+        "@hashintel/brunch-agent-binding-flue#build",
+        "@hashintel/brunch-agent-plugin-sdcpn#build",
+        "@hashintel/brunch-agent-transport-aisdk#build",
+        "@hashintel/petrinaut-core#build",
+        "@local/hash-backend-utils#build"
+      ]
+    },
+    "petrinaut:dev": {
+      "dependsOn": [
+        "@hashintel/brunch-agent#build",
+        "@hashintel/brunch-agent-binding-flue#build",
+        "@hashintel/brunch-agent-plugin-sdcpn#build",
+        "@hashintel/brunch-agent-transport-aisdk#build",
+        "@hashintel/petrinaut-core#build",
+        "@local/hash-backend-utils#build"
+      ],
+      "cache": false,
+      "persistent": true
+    },
+    "start": {
+      "dependsOn": [
+        "build"
+      ],
+      "cache": false,
+      "persistent": true
+    },
+    "start:healthcheck": {
+      "dependsOn": [],
+      "cache": false
+    },
+    "start:test": {
+      "dependsOn": [
+        "build"
+      ],
+      "cache": false,
+      "persistent": true
+    },
+    "start:test:healthcheck": {
+      "dependsOn": [],
+      "cache": false
+    },
+    "test:docker": {
+      "dependsOn": [
+        "build:docker"
+      ],
+      "cache": false
+    },
+    "test:integration": {
+      "dependsOn": [],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    },
+    "test:unit": {
+      "dependsOn": [
+        "@hashintel/brunch-agent#build",
+        "@hashintel/brunch-agent-binding-flue#build",
+        "@hashintel/brunch-agent-plugin-sdcpn#build",
+        "@hashintel/brunch-agent-transport-aisdk#build",
+        "@hashintel/petrinaut-core#build",
+        "@local/hash-backend-utils#build",
+        "build"
+      ],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/apps/hash-ai-worker-ts/docs/task-dependencies.json
+++ b/apps/hash-ai-worker-ts/docs/task-dependencies.json
@@ -15,91 +15,130 @@
     "@local/tsconfig"
   ],
   "tasks": {
-    "build": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@local/advanced-types#build",
-      "@local/eslint#build",
-      "@local/hash-backend-utils#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-isomorphic-utils#build",
-      "@local/internal-api-client#build",
-      "@local/status#build"
-    ],
-    "build:docker": [],
-    "dev": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@local/advanced-types#build",
-      "@local/eslint#build",
-      "@local/hash-backend-utils#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-isomorphic-utils#build",
-      "@local/internal-api-client#build",
-      "@local/status#build"
-    ],
-    "fix:eslint": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@local/advanced-types#build",
-      "@local/eslint#build",
-      "@local/hash-backend-utils#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-isomorphic-utils#build",
-      "@local/internal-api-client#build",
-      "@local/status#build"
-    ],
-    "lint:eslint": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@local/advanced-types#build",
-      "@local/eslint#build",
-      "@local/hash-backend-utils#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-isomorphic-utils#build",
-      "@local/internal-api-client#build",
-      "@local/status#build"
-    ],
-    "lint:tsc": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@local/advanced-types#build",
-      "@local/eslint#build",
-      "@local/hash-backend-utils#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-isomorphic-utils#build",
-      "@local/internal-api-client#build",
-      "@local/status#build"
-    ],
-    "sentry:sourcemaps": [
-      "build"
-    ],
-    "start": [
-      "@apps/hash-graph#start:healthcheck",
-      "build"
-    ],
-    "start:healthcheck": [],
-    "start:test": [
-      "@apps/hash-graph#start:test:healthcheck",
-      "build"
-    ],
-    "start:test:healthcheck": [],
-    "test:unit": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@local/advanced-types#build",
-      "@local/eslint#build",
-      "@local/hash-backend-utils#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-isomorphic-utils#build",
-      "@local/internal-api-client#build",
-      "@local/status#build"
-    ]
+    "build": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@local/advanced-types#build",
+        "@local/eslint#build",
+        "@local/hash-backend-utils#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-isomorphic-utils#build",
+        "@local/internal-api-client#build",
+        "@local/status#build"
+      ]
+    },
+    "build:docker": {
+      "dependsOn": [],
+      "cache": false
+    },
+    "dev": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@local/advanced-types#build",
+        "@local/eslint#build",
+        "@local/hash-backend-utils#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-isomorphic-utils#build",
+        "@local/internal-api-client#build",
+        "@local/status#build"
+      ],
+      "cache": false,
+      "persistent": true
+    },
+    "fix:eslint": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@local/advanced-types#build",
+        "@local/eslint#build",
+        "@local/hash-backend-utils#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-isomorphic-utils#build",
+        "@local/internal-api-client#build",
+        "@local/status#build"
+      ]
+    },
+    "lint:eslint": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@local/advanced-types#build",
+        "@local/eslint#build",
+        "@local/hash-backend-utils#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-isomorphic-utils#build",
+        "@local/internal-api-client#build",
+        "@local/status#build"
+      ],
+      "env": [
+        "CHECK_TEMPORARILY_DISABLED_RULES"
+      ]
+    },
+    "lint:tsc": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@local/advanced-types#build",
+        "@local/eslint#build",
+        "@local/hash-backend-utils#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-isomorphic-utils#build",
+        "@local/internal-api-client#build",
+        "@local/status#build"
+      ]
+    },
+    "sentry:sourcemaps": {
+      "dependsOn": [
+        "build"
+      ]
+    },
+    "start": {
+      "dependsOn": [
+        "@apps/hash-graph#start:healthcheck",
+        "build"
+      ],
+      "cache": false,
+      "persistent": true
+    },
+    "start:healthcheck": {
+      "dependsOn": [],
+      "cache": false
+    },
+    "start:test": {
+      "dependsOn": [
+        "@apps/hash-graph#start:test:healthcheck",
+        "build"
+      ],
+      "cache": false,
+      "persistent": true
+    },
+    "start:test:healthcheck": {
+      "dependsOn": [],
+      "cache": false
+    },
+    "test:unit": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@local/advanced-types#build",
+        "@local/eslint#build",
+        "@local/hash-backend-utils#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-isomorphic-utils#build",
+        "@local/internal-api-client#build",
+        "@local/status#build"
+      ],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/apps/hash-ai-worker-ts/turbo.json
+++ b/apps/hash-ai-worker-ts/turbo.json
@@ -5,9 +5,6 @@
       "outputs": ["./dist/**"],
       "dependsOn": ["^build"]
     },
-    "build:docker": {
-      "dependsOn": ["^manifest"]
-    },
     "dev": {
       "dependsOn": ["^build"]
     },

--- a/apps/hash-api/docs/task-dependencies.json
+++ b/apps/hash-api/docs/task-dependencies.json
@@ -20,147 +20,190 @@
     "@local/tsconfig"
   ],
   "tasks": {
-    "build:docker": [],
-    "codegen": [
-      "@hashintel/petrinaut-core#build",
-      "@local/hash-isomorphic-utils#build",
-      "@local/petrinaut-optimizer-client#build"
-    ],
-    "dev": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@hashintel/petrinaut-core#build",
-      "@local/advanced-types#build",
-      "@local/eslint#build",
-      "@local/harpc-client#build",
-      "@local/hash-backend-utils#build",
-      "@local/hash-graph-authorization#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-graph-store#build",
-      "@local/hash-isomorphic-utils#build",
-      "@local/internal-api-client#build",
-      "@local/petrinaut-optimizer-client#build",
-      "@local/status#build",
-      "codegen"
-    ],
-    "fix:eslint": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@hashintel/petrinaut-core#build",
-      "@local/advanced-types#build",
-      "@local/eslint#build",
-      "@local/harpc-client#build",
-      "@local/hash-backend-utils#build",
-      "@local/hash-graph-authorization#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-graph-store#build",
-      "@local/hash-isomorphic-utils#build",
-      "@local/internal-api-client#build",
-      "@local/petrinaut-optimizer-client#build",
-      "@local/status#build",
-      "codegen"
-    ],
-    "lint:eslint": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@hashintel/petrinaut-core#build",
-      "@local/advanced-types#build",
-      "@local/eslint#build",
-      "@local/harpc-client#build",
-      "@local/hash-backend-utils#build",
-      "@local/hash-graph-authorization#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-graph-store#build",
-      "@local/hash-isomorphic-utils#build",
-      "@local/internal-api-client#build",
-      "@local/petrinaut-optimizer-client#build",
-      "@local/status#build",
-      "codegen"
-    ],
-    "lint:tsc": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@hashintel/petrinaut-core#build",
-      "@local/advanced-types#build",
-      "@local/eslint#build",
-      "@local/harpc-client#build",
-      "@local/hash-backend-utils#build",
-      "@local/hash-graph-authorization#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-graph-store#build",
-      "@local/hash-isomorphic-utils#build",
-      "@local/internal-api-client#build",
-      "@local/petrinaut-optimizer-client#build",
-      "@local/status#build",
-      "codegen"
-    ],
-    "start": [
-      "start:migrate"
-    ],
-    "start:healthcheck": [],
-    "start:migrate": [
-      "@apps/hash-graph#start:healthcheck",
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@hashintel/petrinaut-core#build",
-      "@local/advanced-types#build",
-      "@local/eslint#build",
-      "@local/harpc-client#build",
-      "@local/hash-backend-utils#build",
-      "@local/hash-graph-authorization#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-graph-store#build",
-      "@local/hash-isomorphic-utils#build",
-      "@local/internal-api-client#build",
-      "@local/petrinaut-optimizer-client#build",
-      "@local/status#build",
-      "codegen"
-    ],
-    "start:test": [
-      "start:test:migrate"
-    ],
-    "start:test:healthcheck": [],
-    "start:test:migrate": [
-      "@apps/hash-graph#start:test:healthcheck",
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@hashintel/petrinaut-core#build",
-      "@local/advanced-types#build",
-      "@local/eslint#build",
-      "@local/harpc-client#build",
-      "@local/hash-backend-utils#build",
-      "@local/hash-graph-authorization#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-graph-store#build",
-      "@local/hash-isomorphic-utils#build",
-      "@local/internal-api-client#build",
-      "@local/petrinaut-optimizer-client#build",
-      "@local/status#build",
-      "codegen"
-    ],
-    "test:unit": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@hashintel/petrinaut-core#build",
-      "@local/advanced-types#build",
-      "@local/eslint#build",
-      "@local/harpc-client#build",
-      "@local/hash-backend-utils#build",
-      "@local/hash-graph-authorization#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-graph-store#build",
-      "@local/hash-isomorphic-utils#build",
-      "@local/internal-api-client#build",
-      "@local/petrinaut-optimizer-client#build",
-      "@local/status#build",
-      "codegen"
-    ]
+    "build:docker": {
+      "dependsOn": [],
+      "cache": false
+    },
+    "codegen": {
+      "dependsOn": [
+        "@hashintel/petrinaut-core#build",
+        "@local/hash-isomorphic-utils#build",
+        "@local/petrinaut-optimizer-client#build"
+      ]
+    },
+    "dev": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@hashintel/petrinaut-core#build",
+        "@local/advanced-types#build",
+        "@local/eslint#build",
+        "@local/harpc-client#build",
+        "@local/hash-backend-utils#build",
+        "@local/hash-graph-authorization#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-graph-store#build",
+        "@local/hash-isomorphic-utils#build",
+        "@local/internal-api-client#build",
+        "@local/petrinaut-optimizer-client#build",
+        "@local/status#build",
+        "codegen"
+      ],
+      "cache": false,
+      "persistent": true
+    },
+    "fix:eslint": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@hashintel/petrinaut-core#build",
+        "@local/advanced-types#build",
+        "@local/eslint#build",
+        "@local/harpc-client#build",
+        "@local/hash-backend-utils#build",
+        "@local/hash-graph-authorization#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-graph-store#build",
+        "@local/hash-isomorphic-utils#build",
+        "@local/internal-api-client#build",
+        "@local/petrinaut-optimizer-client#build",
+        "@local/status#build",
+        "codegen"
+      ]
+    },
+    "lint:eslint": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@hashintel/petrinaut-core#build",
+        "@local/advanced-types#build",
+        "@local/eslint#build",
+        "@local/harpc-client#build",
+        "@local/hash-backend-utils#build",
+        "@local/hash-graph-authorization#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-graph-store#build",
+        "@local/hash-isomorphic-utils#build",
+        "@local/internal-api-client#build",
+        "@local/petrinaut-optimizer-client#build",
+        "@local/status#build",
+        "codegen"
+      ],
+      "env": [
+        "CHECK_TEMPORARILY_DISABLED_RULES"
+      ]
+    },
+    "lint:tsc": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@hashintel/petrinaut-core#build",
+        "@local/advanced-types#build",
+        "@local/eslint#build",
+        "@local/harpc-client#build",
+        "@local/hash-backend-utils#build",
+        "@local/hash-graph-authorization#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-graph-store#build",
+        "@local/hash-isomorphic-utils#build",
+        "@local/internal-api-client#build",
+        "@local/petrinaut-optimizer-client#build",
+        "@local/status#build",
+        "codegen"
+      ]
+    },
+    "start": {
+      "dependsOn": [
+        "start:migrate"
+      ],
+      "cache": false,
+      "persistent": true
+    },
+    "start:healthcheck": {
+      "dependsOn": [],
+      "cache": false
+    },
+    "start:migrate": {
+      "dependsOn": [
+        "@apps/hash-graph#start:healthcheck",
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@hashintel/petrinaut-core#build",
+        "@local/advanced-types#build",
+        "@local/eslint#build",
+        "@local/harpc-client#build",
+        "@local/hash-backend-utils#build",
+        "@local/hash-graph-authorization#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-graph-store#build",
+        "@local/hash-isomorphic-utils#build",
+        "@local/internal-api-client#build",
+        "@local/petrinaut-optimizer-client#build",
+        "@local/status#build",
+        "codegen"
+      ],
+      "cache": false
+    },
+    "start:test": {
+      "dependsOn": [
+        "start:test:migrate"
+      ],
+      "cache": false,
+      "persistent": true
+    },
+    "start:test:healthcheck": {
+      "dependsOn": [],
+      "cache": false
+    },
+    "start:test:migrate": {
+      "dependsOn": [
+        "@apps/hash-graph#start:test:healthcheck",
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@hashintel/petrinaut-core#build",
+        "@local/advanced-types#build",
+        "@local/eslint#build",
+        "@local/harpc-client#build",
+        "@local/hash-backend-utils#build",
+        "@local/hash-graph-authorization#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-graph-store#build",
+        "@local/hash-isomorphic-utils#build",
+        "@local/internal-api-client#build",
+        "@local/petrinaut-optimizer-client#build",
+        "@local/status#build",
+        "codegen"
+      ],
+      "cache": false
+    },
+    "test:unit": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@hashintel/petrinaut-core#build",
+        "@local/advanced-types#build",
+        "@local/eslint#build",
+        "@local/harpc-client#build",
+        "@local/hash-backend-utils#build",
+        "@local/hash-graph-authorization#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-graph-store#build",
+        "@local/hash-isomorphic-utils#build",
+        "@local/internal-api-client#build",
+        "@local/petrinaut-optimizer-client#build",
+        "@local/status#build",
+        "codegen"
+      ],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/apps/hash-api/turbo.json
+++ b/apps/hash-api/turbo.json
@@ -17,11 +17,6 @@
     "build": {
       "dependsOn": ["codegen", "^build"]
     },
-    // The image copies the repository and generates and builds inside it, so the host
-    // only contributes sources.
-    "build:docker": {
-      "dependsOn": ["^manifest"]
-    },
     "dev": {
       "dependsOn": ["codegen", "^build"]
     },

--- a/apps/hash-frontend/docs/task-dependencies.json
+++ b/apps/hash-frontend/docs/task-dependencies.json
@@ -21,111 +21,151 @@
     "@local/tsconfig"
   ],
   "tasks": {
-    "build": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@hashintel/ds-components#build",
-      "@hashintel/petrinaut#build",
-      "@hashintel/petrinaut-core#build",
-      "@local/advanced-types#build",
-      "@local/eslint#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-graph-store#build",
-      "@local/hash-isomorphic-utils#build",
-      "@local/status#build",
-      "codegen"
-    ],
-    "build:docker": [],
-    "codegen": [
-      "@hashintel/ds-components#build",
-      "@hashintel/petrinaut#build",
-      "@local/hash-isomorphic-utils#build"
-    ],
-    "dev": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@hashintel/ds-components#build",
-      "@hashintel/petrinaut#build",
-      "@hashintel/petrinaut-core#build",
-      "@local/advanced-types#build",
-      "@local/eslint#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-graph-store#build",
-      "@local/hash-isomorphic-utils#build",
-      "@local/status#build",
-      "codegen"
-    ],
-    "fix:eslint": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@hashintel/ds-components#build",
-      "@hashintel/petrinaut#build",
-      "@hashintel/petrinaut-core#build",
-      "@local/advanced-types#build",
-      "@local/eslint#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-graph-store#build",
-      "@local/hash-isomorphic-utils#build",
-      "@local/status#build",
-      "codegen"
-    ],
-    "lint:eslint": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@hashintel/ds-components#build",
-      "@hashintel/petrinaut#build",
-      "@hashintel/petrinaut-core#build",
-      "@local/advanced-types#build",
-      "@local/eslint#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-graph-store#build",
-      "@local/hash-isomorphic-utils#build",
-      "@local/status#build",
-      "codegen"
-    ],
-    "lint:tsc": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@hashintel/ds-components#build",
-      "@hashintel/petrinaut#build",
-      "@hashintel/petrinaut-core#build",
-      "@local/advanced-types#build",
-      "@local/eslint#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-graph-store#build",
-      "@local/hash-isomorphic-utils#build",
-      "@local/status#build",
-      "codegen"
-    ],
-    "start": [
-      "@apps/hash-api#start:healthcheck",
-      "build"
-    ],
-    "start:healthcheck": [],
-    "start:test": [
-      "@apps/hash-api#start:test:healthcheck",
-      "build"
-    ],
-    "start:test:healthcheck": [],
-    "test:unit": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@hashintel/ds-components#build",
-      "@hashintel/petrinaut#build",
-      "@hashintel/petrinaut-core#build",
-      "@local/advanced-types#build",
-      "@local/eslint#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-graph-store#build",
-      "@local/hash-isomorphic-utils#build",
-      "@local/status#build",
-      "codegen"
-    ]
+    "build": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@hashintel/ds-components#build",
+        "@hashintel/petrinaut#build",
+        "@hashintel/petrinaut-core#build",
+        "@local/advanced-types#build",
+        "@local/eslint#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-graph-store#build",
+        "@local/hash-isomorphic-utils#build",
+        "@local/status#build",
+        "codegen"
+      ],
+      "cache": false
+    },
+    "build:docker": {
+      "dependsOn": [],
+      "cache": false
+    },
+    "codegen": {
+      "dependsOn": [
+        "@hashintel/ds-components#build",
+        "@hashintel/petrinaut#build",
+        "@local/hash-isomorphic-utils#build"
+      ]
+    },
+    "dev": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@hashintel/ds-components#build",
+        "@hashintel/petrinaut#build",
+        "@hashintel/petrinaut-core#build",
+        "@local/advanced-types#build",
+        "@local/eslint#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-graph-store#build",
+        "@local/hash-isomorphic-utils#build",
+        "@local/status#build",
+        "codegen"
+      ],
+      "cache": false,
+      "persistent": true
+    },
+    "fix:eslint": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@hashintel/ds-components#build",
+        "@hashintel/petrinaut#build",
+        "@hashintel/petrinaut-core#build",
+        "@local/advanced-types#build",
+        "@local/eslint#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-graph-store#build",
+        "@local/hash-isomorphic-utils#build",
+        "@local/status#build",
+        "codegen"
+      ]
+    },
+    "lint:eslint": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@hashintel/ds-components#build",
+        "@hashintel/petrinaut#build",
+        "@hashintel/petrinaut-core#build",
+        "@local/advanced-types#build",
+        "@local/eslint#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-graph-store#build",
+        "@local/hash-isomorphic-utils#build",
+        "@local/status#build",
+        "codegen"
+      ],
+      "env": [
+        "CHECK_TEMPORARILY_DISABLED_RULES"
+      ]
+    },
+    "lint:tsc": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@hashintel/ds-components#build",
+        "@hashintel/petrinaut#build",
+        "@hashintel/petrinaut-core#build",
+        "@local/advanced-types#build",
+        "@local/eslint#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-graph-store#build",
+        "@local/hash-isomorphic-utils#build",
+        "@local/status#build",
+        "codegen"
+      ]
+    },
+    "start": {
+      "dependsOn": [
+        "@apps/hash-api#start:healthcheck",
+        "build"
+      ],
+      "cache": false,
+      "persistent": true
+    },
+    "start:healthcheck": {
+      "dependsOn": [],
+      "cache": false
+    },
+    "start:test": {
+      "dependsOn": [
+        "@apps/hash-api#start:test:healthcheck",
+        "build"
+      ],
+      "cache": false,
+      "persistent": true
+    },
+    "start:test:healthcheck": {
+      "dependsOn": [],
+      "cache": false
+    },
+    "test:unit": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@hashintel/ds-components#build",
+        "@hashintel/petrinaut#build",
+        "@hashintel/petrinaut-core#build",
+        "@local/advanced-types#build",
+        "@local/eslint#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-graph-store#build",
+        "@local/hash-isomorphic-utils#build",
+        "@local/status#build",
+        "codegen"
+      ],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/apps/hash-frontend/turbo.json
+++ b/apps/hash-frontend/turbo.json
@@ -17,11 +17,6 @@
       "cache": false,
       "dependsOn": ["^build", "codegen"]
     },
-    // The image copies the repository and generates and builds inside it, so the host
-    // only contributes sources.
-    "build:docker": {
-      "dependsOn": ["^manifest"]
-    },
     "dev": {
       "dependsOn": ["codegen", "^build"]
     },

--- a/apps/hash-graph/docs/task-dependencies.json
+++ b/apps/hash-graph/docs/task-dependencies.json
@@ -17,32 +17,76 @@
     "@rust/hash-temporal-client"
   ],
   "tasks": {
-    "build:docker": [],
-    "compile": [],
-    "compile:release": [],
-    "doc:dependency-diagram": [
-      "@rust/hash-repo-chores#build"
-    ],
-    "fix:clippy": [],
-    "lint:clippy": [],
-    "start": [
-      "start:migrate"
-    ],
-    "start:healthcheck": [
-      "compile:release"
-    ],
-    "start:migrate": [
-      "compile:release"
-    ],
-    "start:test": [
-      "start:test:migrate"
-    ],
-    "start:test:healthcheck": [
-      "compile"
-    ],
-    "start:test:migrate": [
-      "compile"
-    ],
-    "test:unit": []
+    "build:docker": {
+      "dependsOn": [],
+      "cache": false
+    },
+    "compile": {
+      "dependsOn": [],
+      "cache": false
+    },
+    "compile:release": {
+      "dependsOn": [],
+      "cache": false
+    },
+    "doc:dependency-diagram": {
+      "dependsOn": [
+        "@rust/hash-repo-chores#build"
+      ],
+      "cache": false
+    },
+    "fix:clippy": {
+      "dependsOn": []
+    },
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    },
+    "start": {
+      "dependsOn": [
+        "start:migrate"
+      ],
+      "cache": false,
+      "persistent": true
+    },
+    "start:healthcheck": {
+      "dependsOn": [
+        "compile:release"
+      ],
+      "cache": false
+    },
+    "start:migrate": {
+      "dependsOn": [
+        "compile:release"
+      ],
+      "cache": false
+    },
+    "start:test": {
+      "dependsOn": [
+        "start:test:migrate"
+      ],
+      "cache": false,
+      "persistent": true
+    },
+    "start:test:healthcheck": {
+      "dependsOn": [
+        "compile"
+      ],
+      "cache": false
+    },
+    "start:test:migrate": {
+      "dependsOn": [
+        "compile"
+      ],
+      "cache": false
+    },
+    "test:unit": {
+      "dependsOn": [],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/apps/hash-integration-worker/docs/task-dependencies.json
+++ b/apps/hash-integration-worker/docs/task-dependencies.json
@@ -12,69 +12,103 @@
     "@local/tsconfig"
   ],
   "tasks": {
-    "build": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@local/eslint#build",
-      "@local/hash-backend-utils#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-isomorphic-utils#build",
-      "@local/status#build"
-    ],
-    "build:docker": [],
-    "dev": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@local/eslint#build",
-      "@local/hash-backend-utils#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-isomorphic-utils#build",
-      "@local/status#build"
-    ],
-    "fix:eslint": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@local/eslint#build",
-      "@local/hash-backend-utils#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-isomorphic-utils#build",
-      "@local/status#build"
-    ],
-    "lint:eslint": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@local/eslint#build",
-      "@local/hash-backend-utils#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-isomorphic-utils#build",
-      "@local/status#build"
-    ],
-    "lint:tsc": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@local/eslint#build",
-      "@local/hash-backend-utils#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-isomorphic-utils#build",
-      "@local/status#build"
-    ],
-    "sentry:sourcemaps": [
-      "build"
-    ],
-    "start": [
-      "@apps/hash-graph#start:healthcheck",
-      "build"
-    ],
-    "start:healthcheck": [],
-    "start:test": [
-      "@apps/hash-graph#start:test:healthcheck",
-      "build"
-    ],
-    "start:test:healthcheck": []
+    "build": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@local/eslint#build",
+        "@local/hash-backend-utils#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-isomorphic-utils#build",
+        "@local/status#build"
+      ]
+    },
+    "build:docker": {
+      "dependsOn": [],
+      "cache": false
+    },
+    "dev": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@local/eslint#build",
+        "@local/hash-backend-utils#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-isomorphic-utils#build",
+        "@local/status#build"
+      ],
+      "cache": false,
+      "persistent": true
+    },
+    "fix:eslint": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@local/eslint#build",
+        "@local/hash-backend-utils#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-isomorphic-utils#build",
+        "@local/status#build"
+      ]
+    },
+    "lint:eslint": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@local/eslint#build",
+        "@local/hash-backend-utils#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-isomorphic-utils#build",
+        "@local/status#build"
+      ],
+      "env": [
+        "CHECK_TEMPORARILY_DISABLED_RULES"
+      ]
+    },
+    "lint:tsc": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@local/eslint#build",
+        "@local/hash-backend-utils#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-isomorphic-utils#build",
+        "@local/status#build"
+      ]
+    },
+    "sentry:sourcemaps": {
+      "dependsOn": [
+        "build"
+      ]
+    },
+    "start": {
+      "dependsOn": [
+        "@apps/hash-graph#start:healthcheck",
+        "build"
+      ],
+      "cache": false,
+      "persistent": true
+    },
+    "start:healthcheck": {
+      "dependsOn": [],
+      "cache": false
+    },
+    "start:test": {
+      "dependsOn": [
+        "@apps/hash-graph#start:test:healthcheck",
+        "build"
+      ],
+      "cache": false,
+      "persistent": true
+    },
+    "start:test:healthcheck": {
+      "dependsOn": [],
+      "cache": false
+    }
   }
 }

--- a/apps/hash-integration-worker/turbo.json
+++ b/apps/hash-integration-worker/turbo.json
@@ -5,9 +5,6 @@
       "outputs": ["./dist/**"],
       "dependsOn": ["^build"]
     },
-    "build:docker": {
-      "dependsOn": ["^manifest"]
-    },
     "dev": {
       "dependsOn": ["^build"]
     },

--- a/apps/petrinaut-docs/docs/task-dependencies.json
+++ b/apps/petrinaut-docs/docs/task-dependencies.json
@@ -4,17 +4,33 @@
     "@local/petrinaut-arch-docs"
   ],
   "tasks": {
-    "build": [
-      "sync:bundle"
-    ],
-    "dev": [
-      "sync:bundle"
-    ],
-    "lint:tsc": [
-      "sync:bundle"
-    ],
-    "sync:bundle": [
-      "@local/petrinaut-arch-docs#doc:architecture"
-    ]
+    "build": {
+      "dependsOn": [
+        "sync:bundle"
+      ],
+      "cache": false
+    },
+    "dev": {
+      "dependsOn": [
+        "sync:bundle"
+      ],
+      "cache": false,
+      "persistent": true,
+      "env": [
+        "PORT"
+      ]
+    },
+    "lint:tsc": {
+      "dependsOn": [
+        "sync:bundle"
+      ],
+      "cache": false
+    },
+    "sync:bundle": {
+      "dependsOn": [
+        "@local/petrinaut-arch-docs#doc:architecture"
+      ],
+      "cache": false
+    }
   }
 }

--- a/apps/petrinaut-opt/docs/task-dependencies.json
+++ b/apps/petrinaut-opt/docs/task-dependencies.json
@@ -5,18 +5,33 @@
     "@local/petrinaut-python"
   ],
   "tasks": {
-    "codegen": [
-      "@local/petrinaut-python#codegen"
-    ],
-    "lint:ruff": [],
-    "lint:types": [
-      "@local/petrinaut-python#codegen"
-    ],
-    "start": [
-      "@local/petrinaut-python#codegen"
-    ],
-    "test:unit": [
-      "codegen"
-    ]
+    "codegen": {
+      "dependsOn": [
+        "@local/petrinaut-python#codegen"
+      ]
+    },
+    "lint:ruff": {
+      "dependsOn": []
+    },
+    "lint:types": {
+      "dependsOn": [
+        "@local/petrinaut-python#codegen"
+      ]
+    },
+    "start": {
+      "dependsOn": [
+        "@local/petrinaut-python#codegen"
+      ],
+      "cache": false,
+      "persistent": true
+    },
+    "test:unit": {
+      "dependsOn": [
+        "codegen"
+      ],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/apps/petrinaut-website/docs/task-dependencies.json
+++ b/apps/petrinaut-website/docs/task-dependencies.json
@@ -10,74 +10,103 @@
     "@local/petrinaut-optimizer-client"
   ],
   "tasks": {
-    "build": [
-      "@hashintel/brunch-agent#build",
-      "@hashintel/brunch-agent-transport-aisdk#build",
-      "@hashintel/ds-components#build",
-      "@hashintel/petrinaut#build",
-      "@hashintel/petrinaut-core#build",
-      "@local/petrinaut-optimizer-client#build",
-      "codegen",
-      "examples:generate"
-    ],
-    "codegen": [],
-    "dev": [
-      "@hashintel/brunch-agent#build",
-      "@hashintel/brunch-agent-transport-aisdk#build",
-      "@hashintel/ds-components#build",
-      "@hashintel/petrinaut#build",
-      "@hashintel/petrinaut-core#build",
-      "@local/petrinaut-optimizer-client#build",
-      "codegen",
-      "examples:generate"
-    ],
-    "examples:generate": [
-      "@hashintel/brunch-agent#build",
-      "@hashintel/brunch-agent-transport-aisdk#build",
-      "@hashintel/ds-components#build",
-      "@hashintel/petrinaut#build",
-      "@hashintel/petrinaut-core#build",
-      "@local/petrinaut-optimizer-client#build"
-    ],
-    "fix:eslint": [
-      "@hashintel/brunch-agent#build",
-      "@hashintel/brunch-agent-transport-aisdk#build",
-      "@hashintel/ds-components#build",
-      "@hashintel/petrinaut#build",
-      "@hashintel/petrinaut-core#build",
-      "@local/eslint#build",
-      "@local/petrinaut-optimizer-client#build",
-      "codegen"
-    ],
-    "lint:eslint": [
-      "@hashintel/brunch-agent#build",
-      "@hashintel/brunch-agent-transport-aisdk#build",
-      "@hashintel/ds-components#build",
-      "@hashintel/petrinaut#build",
-      "@hashintel/petrinaut-core#build",
-      "@local/eslint#build",
-      "@local/petrinaut-optimizer-client#build",
-      "codegen"
-    ],
-    "lint:tsc": [
-      "@hashintel/brunch-agent#build",
-      "@hashintel/brunch-agent-transport-aisdk#build",
-      "@hashintel/ds-components#build",
-      "@hashintel/petrinaut#build",
-      "@hashintel/petrinaut-core#build",
-      "@local/petrinaut-optimizer-client#build",
-      "codegen",
-      "examples:generate"
-    ],
-    "test:unit": [
-      "@hashintel/brunch-agent#build",
-      "@hashintel/brunch-agent-transport-aisdk#build",
-      "@hashintel/ds-components#build",
-      "@hashintel/petrinaut#build",
-      "@hashintel/petrinaut-core#build",
-      "@local/petrinaut-optimizer-client#build",
-      "codegen",
-      "examples:generate"
-    ]
+    "build": {
+      "dependsOn": [
+        "@hashintel/brunch-agent#build",
+        "@hashintel/brunch-agent-transport-aisdk#build",
+        "@hashintel/ds-components#build",
+        "@hashintel/petrinaut#build",
+        "@hashintel/petrinaut-core#build",
+        "@local/petrinaut-optimizer-client#build",
+        "codegen",
+        "examples:generate"
+      ],
+      "env": [
+        "SENTRY_DSN",
+        "VITE_PETRINAUT_OPT_PROVIDER",
+        "VITE_VERCEL_ENV"
+      ]
+    },
+    "codegen": {
+      "dependsOn": []
+    },
+    "dev": {
+      "dependsOn": [
+        "@hashintel/brunch-agent#build",
+        "@hashintel/brunch-agent-transport-aisdk#build",
+        "@hashintel/ds-components#build",
+        "@hashintel/petrinaut#build",
+        "@hashintel/petrinaut-core#build",
+        "@local/petrinaut-optimizer-client#build",
+        "codegen",
+        "examples:generate"
+      ],
+      "cache": false,
+      "persistent": true
+    },
+    "examples:generate": {
+      "dependsOn": [
+        "@hashintel/brunch-agent#build",
+        "@hashintel/brunch-agent-transport-aisdk#build",
+        "@hashintel/ds-components#build",
+        "@hashintel/petrinaut#build",
+        "@hashintel/petrinaut-core#build",
+        "@local/petrinaut-optimizer-client#build"
+      ]
+    },
+    "fix:eslint": {
+      "dependsOn": [
+        "@hashintel/brunch-agent#build",
+        "@hashintel/brunch-agent-transport-aisdk#build",
+        "@hashintel/ds-components#build",
+        "@hashintel/petrinaut#build",
+        "@hashintel/petrinaut-core#build",
+        "@local/eslint#build",
+        "@local/petrinaut-optimizer-client#build",
+        "codegen"
+      ]
+    },
+    "lint:eslint": {
+      "dependsOn": [
+        "@hashintel/brunch-agent#build",
+        "@hashintel/brunch-agent-transport-aisdk#build",
+        "@hashintel/ds-components#build",
+        "@hashintel/petrinaut#build",
+        "@hashintel/petrinaut-core#build",
+        "@local/eslint#build",
+        "@local/petrinaut-optimizer-client#build",
+        "codegen"
+      ],
+      "env": [
+        "CHECK_TEMPORARILY_DISABLED_RULES"
+      ]
+    },
+    "lint:tsc": {
+      "dependsOn": [
+        "@hashintel/brunch-agent#build",
+        "@hashintel/brunch-agent-transport-aisdk#build",
+        "@hashintel/ds-components#build",
+        "@hashintel/petrinaut#build",
+        "@hashintel/petrinaut-core#build",
+        "@local/petrinaut-optimizer-client#build",
+        "codegen",
+        "examples:generate"
+      ]
+    },
+    "test:unit": {
+      "dependsOn": [
+        "@hashintel/brunch-agent#build",
+        "@hashintel/brunch-agent-transport-aisdk#build",
+        "@hashintel/ds-components#build",
+        "@hashintel/petrinaut#build",
+        "@hashintel/petrinaut-core#build",
+        "@local/petrinaut-optimizer-client#build",
+        "codegen",
+        "examples:generate"
+      ],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/apps/plugin-browser/docs/task-dependencies.json
+++ b/apps/plugin-browser/docs/task-dependencies.json
@@ -13,85 +13,106 @@
     "@local/status"
   ],
   "tasks": {
-    "build": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@local/advanced-types#build",
-      "@local/eslint#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-isomorphic-utils#build",
-      "@local/status#build",
-      "codegen"
-    ],
-    "build:firefox": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@local/advanced-types#build",
-      "@local/eslint#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-isomorphic-utils#build",
-      "@local/status#build",
-      "codegen"
-    ],
-    "build:test": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@local/advanced-types#build",
-      "@local/eslint#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-isomorphic-utils#build",
-      "@local/status#build",
-      "codegen"
-    ],
-    "codegen": [
-      "@local/hash-isomorphic-utils#build"
-    ],
-    "dev": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@local/advanced-types#build",
-      "@local/eslint#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-isomorphic-utils#build",
-      "@local/status#build",
-      "codegen"
-    ],
-    "fix:eslint": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@local/advanced-types#build",
-      "@local/eslint#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-isomorphic-utils#build",
-      "@local/status#build",
-      "codegen"
-    ],
-    "lint:eslint": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@local/advanced-types#build",
-      "@local/eslint#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-isomorphic-utils#build",
-      "@local/status#build",
-      "codegen"
-    ],
-    "lint:tsc": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@local/advanced-types#build",
-      "@local/eslint#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-isomorphic-utils#build",
-      "@local/status#build",
-      "codegen"
-    ]
+    "build": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@local/advanced-types#build",
+        "@local/eslint#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-isomorphic-utils#build",
+        "@local/status#build",
+        "codegen"
+      ]
+    },
+    "build:firefox": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@local/advanced-types#build",
+        "@local/eslint#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-isomorphic-utils#build",
+        "@local/status#build",
+        "codegen"
+      ]
+    },
+    "build:test": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@local/advanced-types#build",
+        "@local/eslint#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-isomorphic-utils#build",
+        "@local/status#build",
+        "codegen"
+      ]
+    },
+    "codegen": {
+      "dependsOn": [
+        "@local/hash-isomorphic-utils#build"
+      ]
+    },
+    "dev": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@local/advanced-types#build",
+        "@local/eslint#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-isomorphic-utils#build",
+        "@local/status#build",
+        "codegen"
+      ],
+      "cache": false,
+      "persistent": true
+    },
+    "fix:eslint": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@local/advanced-types#build",
+        "@local/eslint#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-isomorphic-utils#build",
+        "@local/status#build",
+        "codegen"
+      ]
+    },
+    "lint:eslint": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@local/advanced-types#build",
+        "@local/eslint#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-isomorphic-utils#build",
+        "@local/status#build",
+        "codegen"
+      ],
+      "env": [
+        "CHECK_TEMPORARILY_DISABLED_RULES"
+      ]
+    },
+    "lint:tsc": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@local/advanced-types#build",
+        "@local/eslint#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-isomorphic-utils#build",
+        "@local/status#build",
+        "codegen"
+      ]
+    }
   }
 }

--- a/libs/@blockprotocol/graph/docs/task-dependencies.json
+++ b/libs/@blockprotocol/graph/docs/task-dependencies.json
@@ -6,21 +6,32 @@
     "@local/tsconfig"
   ],
   "tasks": {
-    "build": [
-      "@blockprotocol/type-system#build",
-      "@local/eslint#build"
-    ],
-    "fix:eslint": [
-      "@blockprotocol/type-system#build",
-      "@local/eslint#build"
-    ],
-    "lint:eslint": [
-      "@blockprotocol/type-system#build",
-      "@local/eslint#build"
-    ],
-    "lint:tsc": [
-      "@blockprotocol/type-system#build",
-      "@local/eslint#build"
-    ]
+    "build": {
+      "dependsOn": [
+        "@blockprotocol/type-system#build",
+        "@local/eslint#build"
+      ]
+    },
+    "fix:eslint": {
+      "dependsOn": [
+        "@blockprotocol/type-system#build",
+        "@local/eslint#build"
+      ]
+    },
+    "lint:eslint": {
+      "dependsOn": [
+        "@blockprotocol/type-system#build",
+        "@local/eslint#build"
+      ],
+      "env": [
+        "CHECK_TEMPORARILY_DISABLED_RULES"
+      ]
+    },
+    "lint:tsc": {
+      "dependsOn": [
+        "@blockprotocol/type-system#build",
+        "@local/eslint#build"
+      ]
+    }
   }
 }

--- a/libs/@blockprotocol/type-system/rust/docs/task-dependencies.json
+++ b/libs/@blockprotocol/type-system/rust/docs/task-dependencies.json
@@ -7,13 +7,32 @@
     "@rust/hash-graph-temporal-versioning"
   ],
   "tasks": {
-    "build:types": [],
-    "build:wasm": [],
-    "doc:dependency-diagram": [
-      "@rust/hash-repo-chores#build"
-    ],
-    "fix:clippy": [],
-    "lint:clippy": [],
-    "test:unit": []
+    "build:types": {
+      "dependsOn": []
+    },
+    "build:wasm": {
+      "dependsOn": []
+    },
+    "doc:dependency-diagram": {
+      "dependsOn": [
+        "@rust/hash-repo-chores#build"
+      ],
+      "cache": false
+    },
+    "fix:clippy": {
+      "dependsOn": []
+    },
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    },
+    "test:unit": {
+      "dependsOn": [],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@blockprotocol/type-system/typescript/docs/task-dependencies.json
+++ b/libs/@blockprotocol/type-system/typescript/docs/task-dependencies.json
@@ -6,32 +6,50 @@
     "@local/tsconfig"
   ],
   "tasks": {
-    "build": [
-      "@local/hash-codec#build",
-      "codegen"
-    ],
-    "codegen": [
-      "@blockprotocol/type-system-rs#build:types",
-      "@blockprotocol/type-system-rs#build:wasm"
-    ],
-    "fix:eslint": [
-      "@local/eslint#build",
-      "@local/hash-codec#build",
-      "codegen"
-    ],
-    "lint:eslint": [
-      "@local/eslint#build",
-      "@local/hash-codec#build",
-      "codegen"
-    ],
-    "lint:tsc": [
-      "@local/eslint#build",
-      "@local/hash-codec#build",
-      "codegen"
-    ],
-    "test:unit": [
-      "@local/hash-codec#build",
-      "codegen"
-    ]
+    "build": {
+      "dependsOn": [
+        "@local/hash-codec#build",
+        "codegen"
+      ]
+    },
+    "codegen": {
+      "dependsOn": [
+        "@blockprotocol/type-system-rs#build:types",
+        "@blockprotocol/type-system-rs#build:wasm"
+      ]
+    },
+    "fix:eslint": {
+      "dependsOn": [
+        "@local/eslint#build",
+        "@local/hash-codec#build",
+        "codegen"
+      ]
+    },
+    "lint:eslint": {
+      "dependsOn": [
+        "@local/eslint#build",
+        "@local/hash-codec#build",
+        "codegen"
+      ],
+      "env": [
+        "CHECK_TEMPORARILY_DISABLED_RULES"
+      ]
+    },
+    "lint:tsc": {
+      "dependsOn": [
+        "@local/eslint#build",
+        "@local/hash-codec#build",
+        "codegen"
+      ]
+    },
+    "test:unit": {
+      "dependsOn": [
+        "@local/hash-codec#build",
+        "codegen"
+      ],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@blockprotocol/type-system/typescript/turbo.json
+++ b/libs/@blockprotocol/type-system/typescript/turbo.json
@@ -1,6 +1,9 @@
 {
   "extends": ["//"],
   "tasks": {
+    "manifest": {
+      "dependsOn": ["^manifest", "@blockprotocol/type-system-rs#manifest"]
+    },
     "codegen": {
       "dependsOn": [
         "@blockprotocol/type-system-rs#build:types",

--- a/libs/@hashintel/block-design-system/docs/task-dependencies.json
+++ b/libs/@hashintel/block-design-system/docs/task-dependencies.json
@@ -8,20 +8,29 @@
     "@local/tsconfig"
   ],
   "tasks": {
-    "fix:eslint": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@local/eslint#build"
-    ],
-    "lint:eslint": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@local/eslint#build"
-    ],
-    "lint:tsc": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@local/eslint#build"
-    ]
+    "fix:eslint": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@local/eslint#build"
+      ]
+    },
+    "lint:eslint": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@local/eslint#build"
+      ],
+      "env": [
+        "CHECK_TEMPORARILY_DISABLED_RULES"
+      ]
+    },
+    "lint:tsc": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@local/eslint#build"
+      ]
+    }
   }
 }

--- a/libs/@hashintel/brunch-agent/packages/binding-flue/docs/task-dependencies.json
+++ b/libs/@hashintel/brunch-agent/packages/binding-flue/docs/task-dependencies.json
@@ -4,22 +4,38 @@
     "@hashintel/brunch-agent"
   ],
   "tasks": {
-    "build": [
-      "@hashintel/brunch-agent#build"
-    ],
-    "fix:eslint": [
-      "@hashintel/brunch-agent#build",
-      "@local/eslint#build"
-    ],
-    "lint:eslint": [
-      "@hashintel/brunch-agent#build",
-      "@local/eslint#build"
-    ],
-    "lint:tsc": [
-      "@hashintel/brunch-agent#build"
-    ],
-    "test:unit": [
-      "@hashintel/brunch-agent#build"
-    ]
+    "build": {
+      "dependsOn": [
+        "@hashintel/brunch-agent#build"
+      ]
+    },
+    "fix:eslint": {
+      "dependsOn": [
+        "@hashintel/brunch-agent#build",
+        "@local/eslint#build"
+      ]
+    },
+    "lint:eslint": {
+      "dependsOn": [
+        "@hashintel/brunch-agent#build",
+        "@local/eslint#build"
+      ],
+      "env": [
+        "CHECK_TEMPORARILY_DISABLED_RULES"
+      ]
+    },
+    "lint:tsc": {
+      "dependsOn": [
+        "@hashintel/brunch-agent#build"
+      ]
+    },
+    "test:unit": {
+      "dependsOn": [
+        "@hashintel/brunch-agent#build"
+      ],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@hashintel/brunch-agent/packages/core/docs/task-dependencies.json
+++ b/libs/@hashintel/brunch-agent/packages/core/docs/task-dependencies.json
@@ -2,15 +2,34 @@
   "package": "@hashintel/brunch-agent",
   "dependencies": [],
   "tasks": {
-    "build": [],
-    "fix:eslint": [
-      "@local/eslint#build"
-    ],
-    "linear:graph": [],
-    "lint:eslint": [
-      "@local/eslint#build"
-    ],
-    "lint:tsc": [],
-    "test:unit": []
+    "build": {
+      "dependsOn": []
+    },
+    "fix:eslint": {
+      "dependsOn": [
+        "@local/eslint#build"
+      ]
+    },
+    "linear:graph": {
+      "dependsOn": [],
+      "cache": false
+    },
+    "lint:eslint": {
+      "dependsOn": [
+        "@local/eslint#build"
+      ],
+      "env": [
+        "CHECK_TEMPORARILY_DISABLED_RULES"
+      ]
+    },
+    "lint:tsc": {
+      "dependsOn": []
+    },
+    "test:unit": {
+      "dependsOn": [],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@hashintel/brunch-agent/packages/plugin-dafny/docs/task-dependencies.json
+++ b/libs/@hashintel/brunch-agent/packages/plugin-dafny/docs/task-dependencies.json
@@ -4,22 +4,38 @@
     "@hashintel/brunch-agent"
   ],
   "tasks": {
-    "build": [
-      "@hashintel/brunch-agent#build"
-    ],
-    "fix:eslint": [
-      "@hashintel/brunch-agent#build",
-      "@local/eslint#build"
-    ],
-    "lint:eslint": [
-      "@hashintel/brunch-agent#build",
-      "@local/eslint#build"
-    ],
-    "lint:tsc": [
-      "@hashintel/brunch-agent#build"
-    ],
-    "test:unit": [
-      "@hashintel/brunch-agent#build"
-    ]
+    "build": {
+      "dependsOn": [
+        "@hashintel/brunch-agent#build"
+      ]
+    },
+    "fix:eslint": {
+      "dependsOn": [
+        "@hashintel/brunch-agent#build",
+        "@local/eslint#build"
+      ]
+    },
+    "lint:eslint": {
+      "dependsOn": [
+        "@hashintel/brunch-agent#build",
+        "@local/eslint#build"
+      ],
+      "env": [
+        "CHECK_TEMPORARILY_DISABLED_RULES"
+      ]
+    },
+    "lint:tsc": {
+      "dependsOn": [
+        "@hashintel/brunch-agent#build"
+      ]
+    },
+    "test:unit": {
+      "dependsOn": [
+        "@hashintel/brunch-agent#build"
+      ],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@hashintel/brunch-agent/packages/plugin-gherkin/docs/task-dependencies.json
+++ b/libs/@hashintel/brunch-agent/packages/plugin-gherkin/docs/task-dependencies.json
@@ -4,22 +4,38 @@
     "@hashintel/brunch-agent"
   ],
   "tasks": {
-    "build": [
-      "@hashintel/brunch-agent#build"
-    ],
-    "fix:eslint": [
-      "@hashintel/brunch-agent#build",
-      "@local/eslint#build"
-    ],
-    "lint:eslint": [
-      "@hashintel/brunch-agent#build",
-      "@local/eslint#build"
-    ],
-    "lint:tsc": [
-      "@hashintel/brunch-agent#build"
-    ],
-    "test:unit": [
-      "@hashintel/brunch-agent#build"
-    ]
+    "build": {
+      "dependsOn": [
+        "@hashintel/brunch-agent#build"
+      ]
+    },
+    "fix:eslint": {
+      "dependsOn": [
+        "@hashintel/brunch-agent#build",
+        "@local/eslint#build"
+      ]
+    },
+    "lint:eslint": {
+      "dependsOn": [
+        "@hashintel/brunch-agent#build",
+        "@local/eslint#build"
+      ],
+      "env": [
+        "CHECK_TEMPORARILY_DISABLED_RULES"
+      ]
+    },
+    "lint:tsc": {
+      "dependsOn": [
+        "@hashintel/brunch-agent#build"
+      ]
+    },
+    "test:unit": {
+      "dependsOn": [
+        "@hashintel/brunch-agent#build"
+      ],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@hashintel/brunch-agent/packages/plugin-sdcpn/docs/task-dependencies.json
+++ b/libs/@hashintel/brunch-agent/packages/plugin-sdcpn/docs/task-dependencies.json
@@ -5,27 +5,43 @@
     "@hashintel/petrinaut-core"
   ],
   "tasks": {
-    "build": [
-      "@hashintel/brunch-agent#build",
-      "@hashintel/petrinaut-core#build"
-    ],
-    "fix:eslint": [
-      "@hashintel/brunch-agent#build",
-      "@hashintel/petrinaut-core#build",
-      "@local/eslint#build"
-    ],
-    "lint:eslint": [
-      "@hashintel/brunch-agent#build",
-      "@hashintel/petrinaut-core#build",
-      "@local/eslint#build"
-    ],
-    "lint:tsc": [
-      "@hashintel/brunch-agent#build",
-      "@hashintel/petrinaut-core#build"
-    ],
-    "test:unit": [
-      "@hashintel/brunch-agent#build",
-      "@hashintel/petrinaut-core#build"
-    ]
+    "build": {
+      "dependsOn": [
+        "@hashintel/brunch-agent#build",
+        "@hashintel/petrinaut-core#build"
+      ]
+    },
+    "fix:eslint": {
+      "dependsOn": [
+        "@hashintel/brunch-agent#build",
+        "@hashintel/petrinaut-core#build",
+        "@local/eslint#build"
+      ]
+    },
+    "lint:eslint": {
+      "dependsOn": [
+        "@hashintel/brunch-agent#build",
+        "@hashintel/petrinaut-core#build",
+        "@local/eslint#build"
+      ],
+      "env": [
+        "CHECK_TEMPORARILY_DISABLED_RULES"
+      ]
+    },
+    "lint:tsc": {
+      "dependsOn": [
+        "@hashintel/brunch-agent#build",
+        "@hashintel/petrinaut-core#build"
+      ]
+    },
+    "test:unit": {
+      "dependsOn": [
+        "@hashintel/brunch-agent#build",
+        "@hashintel/petrinaut-core#build"
+      ],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@hashintel/brunch-agent/packages/transport-aisdk/docs/task-dependencies.json
+++ b/libs/@hashintel/brunch-agent/packages/transport-aisdk/docs/task-dependencies.json
@@ -2,14 +2,30 @@
   "package": "@hashintel/brunch-agent-transport-aisdk",
   "dependencies": [],
   "tasks": {
-    "build": [],
-    "fix:eslint": [
-      "@local/eslint#build"
-    ],
-    "lint:eslint": [
-      "@local/eslint#build"
-    ],
-    "lint:tsc": [],
-    "test:unit": []
+    "build": {
+      "dependsOn": []
+    },
+    "fix:eslint": {
+      "dependsOn": [
+        "@local/eslint#build"
+      ]
+    },
+    "lint:eslint": {
+      "dependsOn": [
+        "@local/eslint#build"
+      ],
+      "env": [
+        "CHECK_TEMPORARILY_DISABLED_RULES"
+      ]
+    },
+    "lint:tsc": {
+      "dependsOn": []
+    },
+    "test:unit": {
+      "dependsOn": [],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@hashintel/design-system/docs/task-dependencies.json
+++ b/libs/@hashintel/design-system/docs/task-dependencies.json
@@ -6,17 +6,26 @@
     "@local/tsconfig"
   ],
   "tasks": {
-    "fix:eslint": [
-      "@blockprotocol/type-system#build",
-      "@local/eslint#build"
-    ],
-    "lint:eslint": [
-      "@blockprotocol/type-system#build",
-      "@local/eslint#build"
-    ],
-    "lint:tsc": [
-      "@blockprotocol/type-system#build",
-      "@local/eslint#build"
-    ]
+    "fix:eslint": {
+      "dependsOn": [
+        "@blockprotocol/type-system#build",
+        "@local/eslint#build"
+      ]
+    },
+    "lint:eslint": {
+      "dependsOn": [
+        "@blockprotocol/type-system#build",
+        "@local/eslint#build"
+      ],
+      "env": [
+        "CHECK_TEMPORARILY_DISABLED_RULES"
+      ]
+    },
+    "lint:tsc": {
+      "dependsOn": [
+        "@blockprotocol/type-system#build",
+        "@local/eslint#build"
+      ]
+    }
   }
 }

--- a/libs/@hashintel/ds-components/docs/task-dependencies.json
+++ b/libs/@hashintel/ds-components/docs/task-dependencies.json
@@ -6,59 +6,101 @@
     "@local/tsconfig"
   ],
   "tasks": {
-    "build": [
-      "@local/eslint#build",
-      "codegen"
-    ],
-    "build:buildinfo": [
-      "codegen"
-    ],
-    "build:ladle": [
-      "@local/eslint#build",
-      "codegen"
-    ],
-    "build:lib": [
-      "@local/eslint#build",
-      "codegen"
-    ],
-    "codegen": [],
-    "dev": [
-      "@local/eslint#build",
-      "codegen"
-    ],
-    "dev:ladle": [
-      "@local/eslint#build",
-      "codegen"
-    ],
-    "fix": [
-      "codegen"
-    ],
-    "fix:eslint": [
-      "@local/eslint#build",
-      "codegen"
-    ],
-    "lint": [
-      "codegen"
-    ],
-    "lint:eslint": [
-      "@local/eslint#build",
-      "codegen"
-    ],
-    "lint:tsc": [
-      "@local/eslint#build",
-      "codegen"
-    ],
-    "preview:ladle": [
-      "build:ladle"
-    ],
-    "test:snapshots": [
-      "build:ladle"
-    ],
-    "test:snapshots:update": [
-      "build:ladle"
-    ],
-    "test:unit": [
-      "build:buildinfo"
-    ]
+    "build": {
+      "dependsOn": [
+        "@local/eslint#build",
+        "codegen"
+      ]
+    },
+    "build:buildinfo": {
+      "dependsOn": [
+        "codegen"
+      ]
+    },
+    "build:ladle": {
+      "dependsOn": [
+        "@local/eslint#build",
+        "codegen"
+      ]
+    },
+    "build:lib": {
+      "dependsOn": [
+        "@local/eslint#build",
+        "codegen"
+      ]
+    },
+    "codegen": {
+      "dependsOn": []
+    },
+    "dev": {
+      "dependsOn": [
+        "@local/eslint#build",
+        "codegen"
+      ],
+      "cache": false,
+      "persistent": true
+    },
+    "dev:ladle": {
+      "dependsOn": [
+        "@local/eslint#build",
+        "codegen"
+      ],
+      "cache": false,
+      "persistent": true
+    },
+    "fix": {
+      "dependsOn": [
+        "codegen"
+      ]
+    },
+    "fix:eslint": {
+      "dependsOn": [
+        "@local/eslint#build",
+        "codegen"
+      ]
+    },
+    "lint": {
+      "dependsOn": [
+        "codegen"
+      ]
+    },
+    "lint:eslint": {
+      "dependsOn": [
+        "@local/eslint#build",
+        "codegen"
+      ],
+      "env": [
+        "CHECK_TEMPORARILY_DISABLED_RULES"
+      ]
+    },
+    "lint:tsc": {
+      "dependsOn": [
+        "@local/eslint#build",
+        "codegen"
+      ]
+    },
+    "preview:ladle": {
+      "dependsOn": [
+        "build:ladle"
+      ]
+    },
+    "test:snapshots": {
+      "dependsOn": [
+        "build:ladle"
+      ]
+    },
+    "test:snapshots:update": {
+      "dependsOn": [
+        "build:ladle"
+      ]
+    },
+    "test:unit": {
+      "dependsOn": [
+        "build:buildinfo"
+      ],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@hashintel/ds-helpers/docs/task-dependencies.json
+++ b/libs/@hashintel/ds-helpers/docs/task-dependencies.json
@@ -2,8 +2,10 @@
   "package": "@hashintel/ds-helpers",
   "dependencies": [],
   "tasks": {
-    "codegen": [
-      "@hashintel/ds-components#codegen"
-    ]
+    "codegen": {
+      "dependsOn": [
+        "@hashintel/ds-components#codegen"
+      ]
+    }
   }
 }

--- a/libs/@hashintel/petrinaut-cli/docs/task-dependencies.json
+++ b/libs/@hashintel/petrinaut-cli/docs/task-dependencies.json
@@ -4,30 +4,49 @@
     "@hashintel/petrinaut-core"
   ],
   "tasks": {
-    "build": [
-      "@hashintel/petrinaut-core#build"
-    ],
-    "codegen": [
-      "@hashintel/petrinaut-core#build"
-    ],
-    "fix:eslint": [
-      "@hashintel/petrinaut-core#build",
-      "@local/eslint#build",
-      "codegen"
-    ],
-    "lint:eslint": [
-      "@hashintel/petrinaut-core#build",
-      "@local/eslint#build",
-      "codegen"
-    ],
-    "lint:tsc": [
-      "@hashintel/petrinaut-core#build",
-      "codegen"
-    ],
-    "test:unit": [
-      "@hashintel/petrinaut-core#build",
-      "build",
-      "codegen"
-    ]
+    "build": {
+      "dependsOn": [
+        "@hashintel/petrinaut-core#build"
+      ],
+      "cache": false
+    },
+    "codegen": {
+      "dependsOn": [
+        "@hashintel/petrinaut-core#build"
+      ]
+    },
+    "fix:eslint": {
+      "dependsOn": [
+        "@hashintel/petrinaut-core#build",
+        "@local/eslint#build",
+        "codegen"
+      ]
+    },
+    "lint:eslint": {
+      "dependsOn": [
+        "@hashintel/petrinaut-core#build",
+        "@local/eslint#build",
+        "codegen"
+      ],
+      "env": [
+        "CHECK_TEMPORARILY_DISABLED_RULES"
+      ]
+    },
+    "lint:tsc": {
+      "dependsOn": [
+        "@hashintel/petrinaut-core#build",
+        "codegen"
+      ]
+    },
+    "test:unit": {
+      "dependsOn": [
+        "@hashintel/petrinaut-core#build",
+        "build",
+        "codegen"
+      ],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@hashintel/petrinaut-core/docs/task-dependencies.json
+++ b/libs/@hashintel/petrinaut-core/docs/task-dependencies.json
@@ -4,14 +4,31 @@
     "@local/petrinaut-optimizer-core"
   ],
   "tasks": {
-    "build": [],
-    "fix:eslint": [
-      "@local/eslint#build"
-    ],
-    "lint:eslint": [
-      "@local/eslint#build"
-    ],
-    "lint:tsc": [],
-    "test:unit": []
+    "build": {
+      "dependsOn": [],
+      "cache": false
+    },
+    "fix:eslint": {
+      "dependsOn": [
+        "@local/eslint#build"
+      ]
+    },
+    "lint:eslint": {
+      "dependsOn": [
+        "@local/eslint#build"
+      ],
+      "env": [
+        "CHECK_TEMPORARILY_DISABLED_RULES"
+      ]
+    },
+    "lint:tsc": {
+      "dependsOn": []
+    },
+    "test:unit": {
+      "dependsOn": [],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@hashintel/petrinaut/docs/task-dependencies.json
+++ b/libs/@hashintel/petrinaut/docs/task-dependencies.json
@@ -8,43 +8,64 @@
     "@local/petrinaut-optimizer-client"
   ],
   "tasks": {
-    "build": [
-      "@hashintel/ds-components#build",
-      "@hashintel/petrinaut-core#build",
-      "@hashintel/refractive#build",
-      "@local/petrinaut-optimizer-client#build"
-    ],
-    "dev": [
-      "@hashintel/ds-components#build",
-      "@hashintel/petrinaut-core#build",
-      "@hashintel/refractive#build",
-      "@local/petrinaut-optimizer-client#build"
-    ],
-    "fix:eslint": [
-      "@hashintel/ds-components#build",
-      "@hashintel/petrinaut-core#build",
-      "@hashintel/refractive#build",
-      "@local/eslint#build",
-      "@local/petrinaut-optimizer-client#build"
-    ],
-    "lint:eslint": [
-      "@hashintel/ds-components#build",
-      "@hashintel/petrinaut-core#build",
-      "@hashintel/refractive#build",
-      "@local/eslint#build",
-      "@local/petrinaut-optimizer-client#build"
-    ],
-    "lint:tsc": [
-      "@hashintel/ds-components#build",
-      "@hashintel/petrinaut-core#build",
-      "@hashintel/refractive#build",
-      "@local/petrinaut-optimizer-client#build"
-    ],
-    "test:unit": [
-      "@hashintel/ds-components#build",
-      "@hashintel/petrinaut-core#build",
-      "@hashintel/refractive#build",
-      "@local/petrinaut-optimizer-client#build"
-    ]
+    "build": {
+      "dependsOn": [
+        "@hashintel/ds-components#build",
+        "@hashintel/petrinaut-core#build",
+        "@hashintel/refractive#build",
+        "@local/petrinaut-optimizer-client#build"
+      ],
+      "cache": false
+    },
+    "dev": {
+      "dependsOn": [
+        "@hashintel/ds-components#build",
+        "@hashintel/petrinaut-core#build",
+        "@hashintel/refractive#build",
+        "@local/petrinaut-optimizer-client#build"
+      ],
+      "cache": false,
+      "persistent": true
+    },
+    "fix:eslint": {
+      "dependsOn": [
+        "@hashintel/ds-components#build",
+        "@hashintel/petrinaut-core#build",
+        "@hashintel/refractive#build",
+        "@local/eslint#build",
+        "@local/petrinaut-optimizer-client#build"
+      ]
+    },
+    "lint:eslint": {
+      "dependsOn": [
+        "@hashintel/ds-components#build",
+        "@hashintel/petrinaut-core#build",
+        "@hashintel/refractive#build",
+        "@local/eslint#build",
+        "@local/petrinaut-optimizer-client#build"
+      ],
+      "env": [
+        "CHECK_TEMPORARILY_DISABLED_RULES"
+      ]
+    },
+    "lint:tsc": {
+      "dependsOn": [
+        "@hashintel/ds-components#build",
+        "@hashintel/petrinaut-core#build",
+        "@hashintel/refractive#build",
+        "@local/petrinaut-optimizer-client#build"
+      ]
+    },
+    "test:unit": {
+      "dependsOn": [
+        "@hashintel/ds-components#build",
+        "@hashintel/petrinaut-core#build",
+        "@hashintel/refractive#build",
+        "@local/petrinaut-optimizer-client#build"
+      ],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@hashintel/query-editor/docs/task-dependencies.json
+++ b/libs/@hashintel/query-editor/docs/task-dependencies.json
@@ -7,20 +7,29 @@
     "@local/eslint"
   ],
   "tasks": {
-    "fix:eslint": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@local/eslint#build"
-    ],
-    "lint:eslint": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@local/eslint#build"
-    ],
-    "lint:tsc": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@local/eslint#build"
-    ]
+    "fix:eslint": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@local/eslint#build"
+      ]
+    },
+    "lint:eslint": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@local/eslint#build"
+      ],
+      "env": [
+        "CHECK_TEMPORARILY_DISABLED_RULES"
+      ]
+    },
+    "lint:tsc": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@local/eslint#build"
+      ]
+    }
   }
 }

--- a/libs/@hashintel/refractive/docs/task-dependencies.json
+++ b/libs/@hashintel/refractive/docs/task-dependencies.json
@@ -2,14 +2,29 @@
   "package": "@hashintel/refractive",
   "dependencies": [],
   "tasks": {
-    "build": [],
-    "dev": [],
-    "fix:eslint": [
-      "@local/eslint#build"
-    ],
-    "lint:eslint": [
-      "@local/eslint#build"
-    ],
-    "lint:tsc": []
+    "build": {
+      "dependsOn": []
+    },
+    "dev": {
+      "dependsOn": [],
+      "cache": false,
+      "persistent": true
+    },
+    "fix:eslint": {
+      "dependsOn": [
+        "@local/eslint#build"
+      ]
+    },
+    "lint:eslint": {
+      "dependsOn": [
+        "@local/eslint#build"
+      ],
+      "env": [
+        "CHECK_TEMPORARILY_DISABLED_RULES"
+      ]
+    },
+    "lint:tsc": {
+      "dependsOn": []
+    }
   }
 }

--- a/libs/@hashintel/type-editor/docs/task-dependencies.json
+++ b/libs/@hashintel/type-editor/docs/task-dependencies.json
@@ -8,23 +8,32 @@
     "@local/hash-isomorphic-utils"
   ],
   "tasks": {
-    "fix:eslint": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@local/eslint#build",
-      "@local/hash-isomorphic-utils#build"
-    ],
-    "lint:eslint": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@local/eslint#build",
-      "@local/hash-isomorphic-utils#build"
-    ],
-    "lint:tsc": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@local/eslint#build",
-      "@local/hash-isomorphic-utils#build"
-    ]
+    "fix:eslint": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@local/eslint#build",
+        "@local/hash-isomorphic-utils#build"
+      ]
+    },
+    "lint:eslint": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@local/eslint#build",
+        "@local/hash-isomorphic-utils#build"
+      ],
+      "env": [
+        "CHECK_TEMPORARILY_DISABLED_RULES"
+      ]
+    },
+    "lint:tsc": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@local/eslint#build",
+        "@local/hash-isomorphic-utils#build"
+      ]
+    }
   }
 }

--- a/libs/@local/advanced-types/docs/task-dependencies.json
+++ b/libs/@local/advanced-types/docs/task-dependencies.json
@@ -5,15 +5,26 @@
     "@local/tsconfig"
   ],
   "tasks": {
-    "build": [],
-    "fix:eslint": [
-      "@local/eslint#build"
-    ],
-    "lint:eslint": [
-      "@local/eslint#build"
-    ],
-    "lint:tsc": [
-      "@local/eslint#build"
-    ]
+    "build": {
+      "dependsOn": []
+    },
+    "fix:eslint": {
+      "dependsOn": [
+        "@local/eslint#build"
+      ]
+    },
+    "lint:eslint": {
+      "dependsOn": [
+        "@local/eslint#build"
+      ],
+      "env": [
+        "CHECK_TEMPORARILY_DISABLED_RULES"
+      ]
+    },
+    "lint:tsc": {
+      "dependsOn": [
+        "@local/eslint#build"
+      ]
+    }
   }
 }

--- a/libs/@local/codec/rust/docs/task-dependencies.json
+++ b/libs/@local/codec/rust/docs/task-dependencies.json
@@ -7,12 +7,29 @@
     "@rust/hash-codegen"
   ],
   "tasks": {
-    "build:types": [],
-    "doc:dependency-diagram": [
-      "@rust/hash-repo-chores#build"
-    ],
-    "fix:clippy": [],
-    "lint:clippy": [],
-    "test:unit": []
+    "build:types": {
+      "dependsOn": []
+    },
+    "doc:dependency-diagram": {
+      "dependsOn": [
+        "@rust/hash-repo-chores#build"
+      ],
+      "cache": false
+    },
+    "fix:clippy": {
+      "dependsOn": []
+    },
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    },
+    "test:unit": {
+      "dependsOn": [],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@local/codec/typescript/docs/task-dependencies.json
+++ b/libs/@local/codec/typescript/docs/task-dependencies.json
@@ -4,14 +4,20 @@
     "@local/tsconfig"
   ],
   "tasks": {
-    "build": [
-      "codegen"
-    ],
-    "codegen": [
-      "@rust/hash-codec#build:types"
-    ],
-    "lint:tsc": [
-      "codegen"
-    ]
+    "build": {
+      "dependsOn": [
+        "codegen"
+      ]
+    },
+    "codegen": {
+      "dependsOn": [
+        "@rust/hash-codec#build:types"
+      ]
+    },
+    "lint:tsc": {
+      "dependsOn": [
+        "codegen"
+      ]
+    }
   }
 }

--- a/libs/@local/codec/typescript/turbo.json
+++ b/libs/@local/codec/typescript/turbo.json
@@ -1,6 +1,9 @@
 {
   "extends": ["//"],
   "tasks": {
+    "manifest": {
+      "dependsOn": ["^manifest", "@rust/hash-codec#manifest"]
+    },
     "codegen": {
       "dependsOn": ["@rust/hash-codec#build:types"],
       "inputs": [

--- a/libs/@local/codegen/docs/task-dependencies.json
+++ b/libs/@local/codegen/docs/task-dependencies.json
@@ -2,11 +2,26 @@
   "package": "@rust/hash-codegen",
   "dependencies": [],
   "tasks": {
-    "doc:dependency-diagram": [
-      "@rust/hash-repo-chores#build"
-    ],
-    "fix:clippy": [],
-    "lint:clippy": [],
-    "test:unit": []
+    "doc:dependency-diagram": {
+      "dependsOn": [
+        "@rust/hash-repo-chores#build"
+      ],
+      "cache": false
+    },
+    "fix:clippy": {
+      "dependsOn": []
+    },
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    },
+    "test:unit": {
+      "dependsOn": [],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@local/config/docs/task-dependencies.json
+++ b/libs/@local/config/docs/task-dependencies.json
@@ -4,11 +4,26 @@
     "@rust/error-stack"
   ],
   "tasks": {
-    "doc:dependency-diagram": [
-      "@rust/hash-repo-chores#build"
-    ],
-    "fix:clippy": [],
-    "lint:clippy": [],
-    "test:unit": []
+    "doc:dependency-diagram": {
+      "dependsOn": [
+        "@rust/hash-repo-chores#build"
+      ],
+      "cache": false
+    },
+    "fix:clippy": {
+      "dependsOn": []
+    },
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    },
+    "test:unit": {
+      "dependsOn": [],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@local/effect-dns/core/docs/task-dependencies.json
+++ b/libs/@local/effect-dns/core/docs/task-dependencies.json
@@ -5,15 +5,26 @@
     "@local/tsconfig"
   ],
   "tasks": {
-    "build": [],
-    "fix:eslint": [
-      "@local/eslint#build"
-    ],
-    "lint:eslint": [
-      "@local/eslint#build"
-    ],
-    "lint:tsc": [
-      "@local/eslint#build"
-    ]
+    "build": {
+      "dependsOn": []
+    },
+    "fix:eslint": {
+      "dependsOn": [
+        "@local/eslint#build"
+      ]
+    },
+    "lint:eslint": {
+      "dependsOn": [
+        "@local/eslint#build"
+      ],
+      "env": [
+        "CHECK_TEMPORARILY_DISABLED_RULES"
+      ]
+    },
+    "lint:tsc": {
+      "dependsOn": [
+        "@local/eslint#build"
+      ]
+    }
   }
 }

--- a/libs/@local/effect-dns/hickory/rust/docs/task-dependencies.json
+++ b/libs/@local/effect-dns/hickory/rust/docs/task-dependencies.json
@@ -2,10 +2,20 @@
   "package": "@rust/effect-dns-hickory",
   "dependencies": [],
   "tasks": {
-    "doc:dependency-diagram": [
-      "@rust/hash-repo-chores#build"
-    ],
-    "fix:clippy": [],
-    "lint:clippy": []
+    "doc:dependency-diagram": {
+      "dependsOn": [
+        "@rust/hash-repo-chores#build"
+      ],
+      "cache": false
+    },
+    "fix:clippy": {
+      "dependsOn": []
+    },
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    }
   }
 }

--- a/libs/@local/effect-dns/hickory/typescript/docs/task-dependencies.json
+++ b/libs/@local/effect-dns/hickory/typescript/docs/task-dependencies.json
@@ -5,20 +5,36 @@
     "@local/tsconfig"
   ],
   "tasks": {
-    "build": [
-      "@local/eslint#build"
-    ],
-    "fix:eslint": [
-      "@local/eslint#build"
-    ],
-    "lint:eslint": [
-      "build"
-    ],
-    "lint:tsc": [
-      "build"
-    ],
-    "test:unit": [
-      "build"
-    ]
+    "build": {
+      "dependsOn": [
+        "@local/eslint#build"
+      ]
+    },
+    "fix:eslint": {
+      "dependsOn": [
+        "@local/eslint#build"
+      ]
+    },
+    "lint:eslint": {
+      "dependsOn": [
+        "build"
+      ],
+      "env": [
+        "CHECK_TEMPORARILY_DISABLED_RULES"
+      ]
+    },
+    "lint:tsc": {
+      "dependsOn": [
+        "build"
+      ]
+    },
+    "test:unit": {
+      "dependsOn": [
+        "build"
+      ],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@local/effect-dns/hickory/typescript/turbo.json
+++ b/libs/@local/effect-dns/hickory/typescript/turbo.json
@@ -2,6 +2,9 @@
   "$schema": "https://turborepo.org/schema.json",
   "extends": ["//"],
   "tasks": {
+    "manifest": {
+      "dependsOn": ["^manifest", "@rust/effect-dns-hickory#manifest"]
+    },
     "build": {
       "dependsOn": ["^build", "@rust/effect-dns-hickory#manifest"],
       "inputs": [

--- a/libs/@local/eslint/docs/task-dependencies.json
+++ b/libs/@local/eslint/docs/task-dependencies.json
@@ -4,12 +4,21 @@
     "@local/tsconfig"
   ],
   "tasks": {
-    "build": [],
-    "fix:eslint": [
-      "build"
-    ],
-    "lint:eslint": [
-      "build"
-    ]
+    "build": {
+      "dependsOn": []
+    },
+    "fix:eslint": {
+      "dependsOn": [
+        "build"
+      ]
+    },
+    "lint:eslint": {
+      "dependsOn": [
+        "build"
+      ],
+      "env": [
+        "CHECK_TEMPORARILY_DISABLED_RULES"
+      ]
+    }
   }
 }

--- a/libs/@local/graph/api/docs/task-dependencies.json
+++ b/libs/@local/graph/api/docs/task-dependencies.json
@@ -31,12 +31,29 @@
     "@rust/hashql-syntax-jexpr"
   ],
   "tasks": {
-    "build:openapi": [],
-    "doc:dependency-diagram": [
-      "@rust/hash-repo-chores#build"
-    ],
-    "fix:clippy": [],
-    "lint:clippy": [],
-    "test:unit": []
+    "build:openapi": {
+      "dependsOn": []
+    },
+    "doc:dependency-diagram": {
+      "dependsOn": [
+        "@rust/hash-repo-chores#build"
+      ],
+      "cache": false
+    },
+    "fix:clippy": {
+      "dependsOn": []
+    },
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    },
+    "test:unit": {
+      "dependsOn": [],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@local/graph/atlas/docs/task-dependencies.json
+++ b/libs/@local/graph/atlas/docs/task-dependencies.json
@@ -16,14 +16,39 @@
     "@rust/hashql-core"
   ],
   "tasks": {
-    "build:docker": [],
-    "doc:dependency-diagram": [
-      "@rust/hash-repo-chores#build"
-    ],
-    "fix:clippy": [],
-    "lint:clippy": [],
-    "test:integration": [],
-    "test:miri": [],
-    "test:unit": []
+    "build:docker": {
+      "dependsOn": [],
+      "cache": false
+    },
+    "doc:dependency-diagram": {
+      "dependsOn": [
+        "@rust/hash-repo-chores#build"
+      ],
+      "cache": false
+    },
+    "fix:clippy": {
+      "dependsOn": []
+    },
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    },
+    "test:integration": {
+      "dependsOn": [],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    },
+    "test:miri": {
+      "dependsOn": []
+    },
+    "test:unit": {
+      "dependsOn": [],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@local/graph/atlas/turbo.json
+++ b/libs/@local/graph/atlas/turbo.json
@@ -1,8 +1,0 @@
-{
-  "extends": ["//"],
-  "tasks": {
-    "build:docker": {
-      "dependsOn": ["^manifest"]
-    }
-  }
-}

--- a/libs/@local/graph/authentication/docs/task-dependencies.json
+++ b/libs/@local/graph/authentication/docs/task-dependencies.json
@@ -8,12 +8,32 @@
     "@rust/hash-middleware"
   ],
   "tasks": {
-    "doc:dependency-diagram": [
-      "@rust/hash-repo-chores#build"
-    ],
-    "fix:clippy": [],
-    "lint:clippy": [],
-    "test:integration": [],
-    "test:unit": []
+    "doc:dependency-diagram": {
+      "dependsOn": [
+        "@rust/hash-repo-chores#build"
+      ],
+      "cache": false
+    },
+    "fix:clippy": {
+      "dependsOn": []
+    },
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    },
+    "test:integration": {
+      "dependsOn": [],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    },
+    "test:unit": {
+      "dependsOn": [],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@local/graph/authorization/rust/docs/task-dependencies.json
+++ b/libs/@local/graph/authorization/rust/docs/task-dependencies.json
@@ -7,13 +7,35 @@
     "@rust/hash-codegen"
   ],
   "tasks": {
-    "build:types": [],
-    "doc:dependency-diagram": [
-      "@rust/hash-repo-chores#build"
-    ],
-    "fix:clippy": [],
-    "lint:clippy": [],
-    "test:integration": [],
-    "test:unit": []
+    "build:types": {
+      "dependsOn": []
+    },
+    "doc:dependency-diagram": {
+      "dependsOn": [
+        "@rust/hash-repo-chores#build"
+      ],
+      "cache": false
+    },
+    "fix:clippy": {
+      "dependsOn": []
+    },
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    },
+    "test:integration": {
+      "dependsOn": [],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    },
+    "test:unit": {
+      "dependsOn": [],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@local/graph/authorization/typescript/docs/task-dependencies.json
+++ b/libs/@local/graph/authorization/typescript/docs/task-dependencies.json
@@ -5,16 +5,22 @@
     "@local/tsconfig"
   ],
   "tasks": {
-    "build": [
-      "@blockprotocol/type-system#build",
-      "codegen"
-    ],
-    "codegen": [
-      "@rust/hash-graph-authorization#build:types"
-    ],
-    "lint:tsc": [
-      "@blockprotocol/type-system#build",
-      "codegen"
-    ]
+    "build": {
+      "dependsOn": [
+        "@blockprotocol/type-system#build",
+        "codegen"
+      ]
+    },
+    "codegen": {
+      "dependsOn": [
+        "@rust/hash-graph-authorization#build:types"
+      ]
+    },
+    "lint:tsc": {
+      "dependsOn": [
+        "@blockprotocol/type-system#build",
+        "codegen"
+      ]
+    }
   }
 }

--- a/libs/@local/graph/authorization/typescript/turbo.json
+++ b/libs/@local/graph/authorization/typescript/turbo.json
@@ -1,6 +1,9 @@
 {
   "extends": ["//"],
   "tasks": {
+    "manifest": {
+      "dependsOn": ["^manifest", "@rust/hash-graph-authorization#manifest"]
+    },
     "codegen": {
       "dependsOn": ["@rust/hash-graph-authorization#build:types"],
       "inputs": [

--- a/libs/@local/graph/client/typescript/docs/task-dependencies.json
+++ b/libs/@local/graph/client/typescript/docs/task-dependencies.json
@@ -4,9 +4,13 @@
     "@local/tsconfig"
   ],
   "tasks": {
-    "build": [
-      "codegen"
-    ],
-    "codegen": []
+    "build": {
+      "dependsOn": [
+        "codegen"
+      ]
+    },
+    "codegen": {
+      "dependsOn": []
+    }
   }
 }

--- a/libs/@local/graph/client/typescript/turbo.json
+++ b/libs/@local/graph/client/typescript/turbo.json
@@ -1,6 +1,9 @@
 {
   "extends": ["//"],
   "tasks": {
+    "manifest": {
+      "dependsOn": ["^manifest", "@rust/hash-graph-api#manifest"]
+    },
     "build": {
       "dependsOn": ["codegen", "^manifest"],
       "outputs": ["./dist/**"]

--- a/libs/@local/graph/embeddings/docs/task-dependencies.json
+++ b/libs/@local/graph/embeddings/docs/task-dependencies.json
@@ -6,14 +6,37 @@
     "@rust/hash-graph-types"
   ],
   "tasks": {
-    "build:codspeed": [],
-    "doc:dependency-diagram": [
-      "@rust/hash-repo-chores#build"
-    ],
-    "fix:clippy": [],
-    "lint:clippy": [],
-    "test:codspeed": [],
-    "test:miri": [],
-    "test:unit": []
+    "build:codspeed": {
+      "dependsOn": [],
+      "cache": false
+    },
+    "doc:dependency-diagram": {
+      "dependsOn": [
+        "@rust/hash-repo-chores#build"
+      ],
+      "cache": false
+    },
+    "fix:clippy": {
+      "dependsOn": []
+    },
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    },
+    "test:codspeed": {
+      "dependsOn": [],
+      "cache": false
+    },
+    "test:miri": {
+      "dependsOn": []
+    },
+    "test:unit": {
+      "dependsOn": [],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@local/graph/migrations-macros/docs/task-dependencies.json
+++ b/libs/@local/graph/migrations-macros/docs/task-dependencies.json
@@ -2,10 +2,20 @@
   "package": "@rust/hash-graph-migrations-macros",
   "dependencies": [],
   "tasks": {
-    "doc:dependency-diagram": [
-      "@rust/hash-repo-chores#build"
-    ],
-    "fix:clippy": [],
-    "lint:clippy": []
+    "doc:dependency-diagram": {
+      "dependsOn": [
+        "@rust/hash-repo-chores#build"
+      ],
+      "cache": false
+    },
+    "fix:clippy": {
+      "dependsOn": []
+    },
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    }
   }
 }

--- a/libs/@local/graph/migrations/docs/task-dependencies.json
+++ b/libs/@local/graph/migrations/docs/task-dependencies.json
@@ -6,12 +6,28 @@
     "@rust/hash-telemetry"
   ],
   "tasks": {
-    "doc:dependency-diagram": [
-      "@rust/hash-repo-chores#build"
-    ],
-    "fix:clippy": [],
-    "lint:clippy": [],
-    "start:migrate:down": [],
-    "start:migrate:up": []
+    "doc:dependency-diagram": {
+      "dependsOn": [
+        "@rust/hash-repo-chores#build"
+      ],
+      "cache": false
+    },
+    "fix:clippy": {
+      "dependsOn": []
+    },
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    },
+    "start:migrate:down": {
+      "dependsOn": [],
+      "cache": false
+    },
+    "start:migrate:up": {
+      "dependsOn": [],
+      "cache": false
+    }
   }
 }

--- a/libs/@local/graph/postgres-store/docs/task-dependencies.json
+++ b/libs/@local/graph/postgres-store/docs/task-dependencies.json
@@ -17,14 +17,34 @@
     "@rust/hash-temporal-client"
   ],
   "tasks": {
-    "doc:dependency-diagram": [
-      "@rust/hash-repo-chores#build"
-    ],
-    "fix:clippy": [],
-    "lint:clippy": [],
-    "test:integration": [
-      "@rust/hash-graph-migrations#start:migrate:up"
-    ],
-    "test:unit": []
+    "doc:dependency-diagram": {
+      "dependsOn": [
+        "@rust/hash-repo-chores#build"
+      ],
+      "cache": false
+    },
+    "fix:clippy": {
+      "dependsOn": []
+    },
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    },
+    "test:integration": {
+      "dependsOn": [
+        "@rust/hash-graph-migrations#start:migrate:up"
+      ],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    },
+    "test:unit": {
+      "dependsOn": [],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@local/graph/sdk/typescript/docs/task-dependencies.json
+++ b/libs/@local/graph/sdk/typescript/docs/task-dependencies.json
@@ -12,55 +12,71 @@
     "@local/tsconfig"
   ],
   "tasks": {
-    "build": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@local/advanced-types#build",
-      "@local/eslint#build",
-      "@local/harpc-client#build",
-      "@local/hash-graph-authorization#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-store#build"
-    ],
-    "fix:eslint": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@local/advanced-types#build",
-      "@local/eslint#build",
-      "@local/harpc-client#build",
-      "@local/hash-graph-authorization#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-store#build"
-    ],
-    "lint:eslint": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@local/advanced-types#build",
-      "@local/eslint#build",
-      "@local/harpc-client#build",
-      "@local/hash-graph-authorization#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-store#build"
-    ],
-    "lint:tsc": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@local/advanced-types#build",
-      "@local/eslint#build",
-      "@local/harpc-client#build",
-      "@local/hash-graph-authorization#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-store#build"
-    ],
-    "test:unit": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@local/advanced-types#build",
-      "@local/eslint#build",
-      "@local/harpc-client#build",
-      "@local/hash-graph-authorization#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-store#build"
-    ]
+    "build": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@local/advanced-types#build",
+        "@local/eslint#build",
+        "@local/harpc-client#build",
+        "@local/hash-graph-authorization#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-store#build"
+      ]
+    },
+    "fix:eslint": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@local/advanced-types#build",
+        "@local/eslint#build",
+        "@local/harpc-client#build",
+        "@local/hash-graph-authorization#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-store#build"
+      ]
+    },
+    "lint:eslint": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@local/advanced-types#build",
+        "@local/eslint#build",
+        "@local/harpc-client#build",
+        "@local/hash-graph-authorization#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-store#build"
+      ],
+      "env": [
+        "CHECK_TEMPORARILY_DISABLED_RULES"
+      ]
+    },
+    "lint:tsc": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@local/advanced-types#build",
+        "@local/eslint#build",
+        "@local/harpc-client#build",
+        "@local/hash-graph-authorization#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-store#build"
+      ]
+    },
+    "test:unit": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@local/advanced-types#build",
+        "@local/eslint#build",
+        "@local/harpc-client#build",
+        "@local/hash-graph-authorization#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-store#build"
+      ],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@local/graph/store/rust/docs/task-dependencies.json
+++ b/libs/@local/graph/store/rust/docs/task-dependencies.json
@@ -11,12 +11,29 @@
     "@rust/hash-temporal-client"
   ],
   "tasks": {
-    "build:types": [],
-    "doc:dependency-diagram": [
-      "@rust/hash-repo-chores#build"
-    ],
-    "fix:clippy": [],
-    "lint:clippy": [],
-    "test:unit": []
+    "build:types": {
+      "dependsOn": []
+    },
+    "doc:dependency-diagram": {
+      "dependsOn": [
+        "@rust/hash-repo-chores#build"
+      ],
+      "cache": false
+    },
+    "fix:clippy": {
+      "dependsOn": []
+    },
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    },
+    "test:unit": {
+      "dependsOn": [],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@local/graph/store/typescript/docs/task-dependencies.json
+++ b/libs/@local/graph/store/typescript/docs/task-dependencies.json
@@ -6,18 +6,24 @@
     "@local/tsconfig"
   ],
   "tasks": {
-    "build": [
-      "@blockprotocol/type-system#build",
-      "@local/hash-graph-authorization#build",
-      "codegen"
-    ],
-    "codegen": [
-      "@rust/hash-graph-store#build:types"
-    ],
-    "lint:tsc": [
-      "@blockprotocol/type-system#build",
-      "@local/hash-graph-authorization#build",
-      "codegen"
-    ]
+    "build": {
+      "dependsOn": [
+        "@blockprotocol/type-system#build",
+        "@local/hash-graph-authorization#build",
+        "codegen"
+      ]
+    },
+    "codegen": {
+      "dependsOn": [
+        "@rust/hash-graph-store#build:types"
+      ]
+    },
+    "lint:tsc": {
+      "dependsOn": [
+        "@blockprotocol/type-system#build",
+        "@local/hash-graph-authorization#build",
+        "codegen"
+      ]
+    }
   }
 }

--- a/libs/@local/graph/store/typescript/turbo.json
+++ b/libs/@local/graph/store/typescript/turbo.json
@@ -1,6 +1,9 @@
 {
   "extends": ["//"],
   "tasks": {
+    "manifest": {
+      "dependsOn": ["^manifest", "@rust/hash-graph-store#manifest"]
+    },
     "codegen": {
       "dependsOn": ["@rust/hash-graph-store#build:types"],
       "inputs": [

--- a/libs/@local/graph/temporal-versioning/docs/task-dependencies.json
+++ b/libs/@local/graph/temporal-versioning/docs/task-dependencies.json
@@ -4,11 +4,26 @@
     "@rust/hash-codec"
   ],
   "tasks": {
-    "doc:dependency-diagram": [
-      "@rust/hash-repo-chores#build"
-    ],
-    "fix:clippy": [],
-    "lint:clippy": [],
-    "test:unit": []
+    "doc:dependency-diagram": {
+      "dependsOn": [
+        "@rust/hash-repo-chores#build"
+      ],
+      "cache": false
+    },
+    "fix:clippy": {
+      "dependsOn": []
+    },
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    },
+    "test:unit": {
+      "dependsOn": [],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@local/graph/type-fetcher/docs/task-dependencies.json
+++ b/libs/@local/graph/type-fetcher/docs/task-dependencies.json
@@ -10,10 +10,20 @@
     "@rust/hash-temporal-client"
   ],
   "tasks": {
-    "doc:dependency-diagram": [
-      "@rust/hash-repo-chores#build"
-    ],
-    "fix:clippy": [],
-    "lint:clippy": []
+    "doc:dependency-diagram": {
+      "dependsOn": [
+        "@rust/hash-repo-chores#build"
+      ],
+      "cache": false
+    },
+    "fix:clippy": {
+      "dependsOn": []
+    },
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    }
   }
 }

--- a/libs/@local/graph/types/docs/task-dependencies.json
+++ b/libs/@local/graph/types/docs/task-dependencies.json
@@ -7,11 +7,26 @@
     "@rust/hash-graph-temporal-versioning"
   ],
   "tasks": {
-    "doc:dependency-diagram": [
-      "@rust/hash-repo-chores#build"
-    ],
-    "fix:clippy": [],
-    "lint:clippy": [],
-    "test:unit": []
+    "doc:dependency-diagram": {
+      "dependsOn": [
+        "@rust/hash-repo-chores#build"
+      ],
+      "cache": false
+    },
+    "fix:clippy": {
+      "dependsOn": []
+    },
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    },
+    "test:unit": {
+      "dependsOn": [],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@local/graph/validation/docs/task-dependencies.json
+++ b/libs/@local/graph/validation/docs/task-dependencies.json
@@ -9,11 +9,26 @@
     "@rust/hash-graph-types"
   ],
   "tasks": {
-    "doc:dependency-diagram": [
-      "@rust/hash-repo-chores#build"
-    ],
-    "fix:clippy": [],
-    "lint:clippy": [],
-    "test:unit": []
+    "doc:dependency-diagram": {
+      "dependsOn": [
+        "@rust/hash-repo-chores#build"
+      ],
+      "cache": false
+    },
+    "fix:clippy": {
+      "dependsOn": []
+    },
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    },
+    "test:unit": {
+      "dependsOn": [],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@local/harpc/client/rust/docs/task-dependencies.json
+++ b/libs/@local/harpc/client/rust/docs/task-dependencies.json
@@ -9,10 +9,20 @@
     "@rust/harpc-types"
   ],
   "tasks": {
-    "doc:dependency-diagram": [
-      "@rust/hash-repo-chores#build"
-    ],
-    "fix:clippy": [],
-    "lint:clippy": []
+    "doc:dependency-diagram": {
+      "dependsOn": [
+        "@rust/hash-repo-chores#build"
+      ],
+      "cache": false
+    },
+    "fix:clippy": {
+      "dependsOn": []
+    },
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    }
   }
 }

--- a/libs/@local/harpc/client/typescript/docs/task-dependencies.json
+++ b/libs/@local/harpc/client/typescript/docs/task-dependencies.json
@@ -5,18 +5,34 @@
     "@local/tsconfig"
   ],
   "tasks": {
-    "build": [],
-    "fix:eslint": [
-      "@local/eslint#build"
-    ],
-    "lint:eslint": [
-      "@local/eslint#build"
-    ],
-    "lint:tsc": [
-      "@local/eslint#build"
-    ],
-    "test:unit": [
-      "@rust/harpc-wire-protocol#build:cli"
-    ]
+    "build": {
+      "dependsOn": []
+    },
+    "fix:eslint": {
+      "dependsOn": [
+        "@local/eslint#build"
+      ]
+    },
+    "lint:eslint": {
+      "dependsOn": [
+        "@local/eslint#build"
+      ],
+      "env": [
+        "CHECK_TEMPORARILY_DISABLED_RULES"
+      ]
+    },
+    "lint:tsc": {
+      "dependsOn": [
+        "@local/eslint#build"
+      ]
+    },
+    "test:unit": {
+      "dependsOn": [
+        "@rust/harpc-wire-protocol#build:cli"
+      ],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@local/harpc/codec/docs/task-dependencies.json
+++ b/libs/@local/harpc/codec/docs/task-dependencies.json
@@ -5,11 +5,26 @@
     "@rust/harpc-types"
   ],
   "tasks": {
-    "doc:dependency-diagram": [
-      "@rust/hash-repo-chores#build"
-    ],
-    "fix:clippy": [],
-    "lint:clippy": [],
-    "test:unit": []
+    "doc:dependency-diagram": {
+      "dependsOn": [
+        "@rust/hash-repo-chores#build"
+      ],
+      "cache": false
+    },
+    "fix:clippy": {
+      "dependsOn": []
+    },
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    },
+    "test:unit": {
+      "dependsOn": [],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@local/harpc/net/docs/task-dependencies.json
+++ b/libs/@local/harpc/net/docs/task-dependencies.json
@@ -8,11 +8,26 @@
     "@rust/hash-codec"
   ],
   "tasks": {
-    "doc:dependency-diagram": [
-      "@rust/hash-repo-chores#build"
-    ],
-    "fix:clippy": [],
-    "lint:clippy": [],
-    "test:unit": []
+    "doc:dependency-diagram": {
+      "dependsOn": [
+        "@rust/hash-repo-chores#build"
+      ],
+      "cache": false
+    },
+    "fix:clippy": {
+      "dependsOn": []
+    },
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    },
+    "test:unit": {
+      "dependsOn": [],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@local/harpc/server/docs/task-dependencies.json
+++ b/libs/@local/harpc/server/docs/task-dependencies.json
@@ -11,10 +11,20 @@
     "@rust/harpc-types"
   ],
   "tasks": {
-    "doc:dependency-diagram": [
-      "@rust/hash-repo-chores#build"
-    ],
-    "fix:clippy": [],
-    "lint:clippy": []
+    "doc:dependency-diagram": {
+      "dependsOn": [
+        "@rust/hash-repo-chores#build"
+      ],
+      "cache": false
+    },
+    "fix:clippy": {
+      "dependsOn": []
+    },
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    }
   }
 }

--- a/libs/@local/harpc/system/docs/task-dependencies.json
+++ b/libs/@local/harpc/system/docs/task-dependencies.json
@@ -5,10 +5,20 @@
     "@rust/harpc-types"
   ],
   "tasks": {
-    "doc:dependency-diagram": [
-      "@rust/hash-repo-chores#build"
-    ],
-    "fix:clippy": [],
-    "lint:clippy": []
+    "doc:dependency-diagram": {
+      "dependsOn": [
+        "@rust/hash-repo-chores#build"
+      ],
+      "cache": false
+    },
+    "fix:clippy": {
+      "dependsOn": []
+    },
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    }
   }
 }

--- a/libs/@local/harpc/tower/docs/task-dependencies.json
+++ b/libs/@local/harpc/tower/docs/task-dependencies.json
@@ -7,11 +7,26 @@
     "@rust/harpc-types"
   ],
   "tasks": {
-    "doc:dependency-diagram": [
-      "@rust/hash-repo-chores#build"
-    ],
-    "fix:clippy": [],
-    "lint:clippy": [],
-    "test:unit": []
+    "doc:dependency-diagram": {
+      "dependsOn": [
+        "@rust/hash-repo-chores#build"
+      ],
+      "cache": false
+    },
+    "fix:clippy": {
+      "dependsOn": []
+    },
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    },
+    "test:unit": {
+      "dependsOn": [],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@local/harpc/types/docs/task-dependencies.json
+++ b/libs/@local/harpc/types/docs/task-dependencies.json
@@ -2,11 +2,26 @@
   "package": "@rust/harpc-types",
   "dependencies": [],
   "tasks": {
-    "doc:dependency-diagram": [
-      "@rust/hash-repo-chores#build"
-    ],
-    "fix:clippy": [],
-    "lint:clippy": [],
-    "test:unit": []
+    "doc:dependency-diagram": {
+      "dependsOn": [
+        "@rust/hash-repo-chores#build"
+      ],
+      "cache": false
+    },
+    "fix:clippy": {
+      "dependsOn": []
+    },
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    },
+    "test:unit": {
+      "dependsOn": [],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@local/harpc/wire-protocol/docs/task-dependencies.json
+++ b/libs/@local/harpc/wire-protocol/docs/task-dependencies.json
@@ -5,13 +5,32 @@
     "@rust/harpc-types"
   ],
   "tasks": {
-    "build:cli": [],
-    "doc:dependency-diagram": [
-      "@rust/hash-repo-chores#build"
-    ],
-    "fix:clippy": [],
-    "lint:clippy": [],
-    "test:miri": [],
-    "test:unit": []
+    "build:cli": {
+      "dependsOn": []
+    },
+    "doc:dependency-diagram": {
+      "dependsOn": [
+        "@rust/hash-repo-chores#build"
+      ],
+      "cache": false
+    },
+    "fix:clippy": {
+      "dependsOn": []
+    },
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    },
+    "test:miri": {
+      "dependsOn": []
+    },
+    "test:unit": {
+      "dependsOn": [],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@local/hash-backend-utils/docs/task-dependencies.json
+++ b/libs/@local/hash-backend-utils/docs/task-dependencies.json
@@ -13,60 +13,76 @@
     "@local/tsconfig"
   ],
   "tasks": {
-    "build": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@local/advanced-types#build",
-      "@local/eslint#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-isomorphic-utils#build",
-      "@local/internal-api-client#build",
-      "@local/status#build"
-    ],
-    "fix:eslint": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@local/advanced-types#build",
-      "@local/eslint#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-isomorphic-utils#build",
-      "@local/internal-api-client#build",
-      "@local/status#build"
-    ],
-    "lint:eslint": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@local/advanced-types#build",
-      "@local/eslint#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-isomorphic-utils#build",
-      "@local/internal-api-client#build",
-      "@local/status#build"
-    ],
-    "lint:tsc": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@local/advanced-types#build",
-      "@local/eslint#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-isomorphic-utils#build",
-      "@local/internal-api-client#build",
-      "@local/status#build"
-    ],
-    "test:unit": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@local/advanced-types#build",
-      "@local/eslint#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-isomorphic-utils#build",
-      "@local/internal-api-client#build",
-      "@local/status#build"
-    ]
+    "build": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@local/advanced-types#build",
+        "@local/eslint#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-isomorphic-utils#build",
+        "@local/internal-api-client#build",
+        "@local/status#build"
+      ]
+    },
+    "fix:eslint": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@local/advanced-types#build",
+        "@local/eslint#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-isomorphic-utils#build",
+        "@local/internal-api-client#build",
+        "@local/status#build"
+      ]
+    },
+    "lint:eslint": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@local/advanced-types#build",
+        "@local/eslint#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-isomorphic-utils#build",
+        "@local/internal-api-client#build",
+        "@local/status#build"
+      ],
+      "env": [
+        "CHECK_TEMPORARILY_DISABLED_RULES"
+      ]
+    },
+    "lint:tsc": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@local/advanced-types#build",
+        "@local/eslint#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-isomorphic-utils#build",
+        "@local/internal-api-client#build",
+        "@local/status#build"
+      ]
+    },
+    "test:unit": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@local/advanced-types#build",
+        "@local/eslint#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-isomorphic-utils#build",
+        "@local/internal-api-client#build",
+        "@local/status#build"
+      ],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@local/hash-isomorphic-utils/docs/task-dependencies.json
+++ b/libs/@local/hash-isomorphic-utils/docs/task-dependencies.json
@@ -12,61 +12,79 @@
     "@local/tsconfig"
   ],
   "tasks": {
-    "build": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@local/advanced-types#build",
-      "@local/eslint#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-graph-store#build",
-      "@local/status#build",
-      "codegen"
-    ],
-    "codegen": [],
-    "fix:eslint": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@local/advanced-types#build",
-      "@local/eslint#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-graph-store#build",
-      "@local/status#build",
-      "codegen"
-    ],
-    "lint:eslint": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@local/advanced-types#build",
-      "@local/eslint#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-graph-store#build",
-      "@local/status#build",
-      "codegen"
-    ],
-    "lint:tsc": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@local/advanced-types#build",
-      "@local/eslint#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-graph-store#build",
-      "@local/status#build",
-      "codegen"
-    ],
-    "test:unit": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@local/advanced-types#build",
-      "@local/eslint#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-graph-store#build",
-      "@local/status#build",
-      "codegen"
-    ]
+    "build": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@local/advanced-types#build",
+        "@local/eslint#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-graph-store#build",
+        "@local/status#build",
+        "codegen"
+      ]
+    },
+    "codegen": {
+      "dependsOn": []
+    },
+    "fix:eslint": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@local/advanced-types#build",
+        "@local/eslint#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-graph-store#build",
+        "@local/status#build",
+        "codegen"
+      ]
+    },
+    "lint:eslint": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@local/advanced-types#build",
+        "@local/eslint#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-graph-store#build",
+        "@local/status#build",
+        "codegen"
+      ],
+      "env": [
+        "CHECK_TEMPORARILY_DISABLED_RULES"
+      ]
+    },
+    "lint:tsc": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@local/advanced-types#build",
+        "@local/eslint#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-graph-store#build",
+        "@local/status#build",
+        "codegen"
+      ]
+    },
+    "test:unit": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@local/advanced-types#build",
+        "@local/eslint#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-graph-store#build",
+        "@local/status#build",
+        "codegen"
+      ],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@local/hashql/ast/docs/task-dependencies.json
+++ b/libs/@local/hashql/ast/docs/task-dependencies.json
@@ -5,11 +5,26 @@
     "@rust/hashql-diagnostics"
   ],
   "tasks": {
-    "doc:dependency-diagram": [
-      "@rust/hash-repo-chores#build"
-    ],
-    "fix:clippy": [],
-    "lint:clippy": [],
-    "test:unit": []
+    "doc:dependency-diagram": {
+      "dependsOn": [
+        "@rust/hash-repo-chores#build"
+      ],
+      "cache": false
+    },
+    "fix:clippy": {
+      "dependsOn": []
+    },
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    },
+    "test:unit": {
+      "dependsOn": [],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@local/hashql/compiletest/docs/task-dependencies.json
+++ b/libs/@local/hashql/compiletest/docs/task-dependencies.json
@@ -11,11 +11,26 @@
     "@rust/hashql-syntax-jexpr"
   ],
   "tasks": {
-    "doc:dependency-diagram": [
-      "@rust/hash-repo-chores#build"
-    ],
-    "fix:clippy": [],
-    "lint:clippy": [],
-    "test:unit": []
+    "doc:dependency-diagram": {
+      "dependsOn": [
+        "@rust/hash-repo-chores#build"
+      ],
+      "cache": false
+    },
+    "fix:clippy": {
+      "dependsOn": []
+    },
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    },
+    "test:unit": {
+      "dependsOn": [],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@local/hashql/core/docs/task-dependencies.json
+++ b/libs/@local/hashql/core/docs/task-dependencies.json
@@ -7,14 +7,37 @@
     "@rust/hashql-macros"
   ],
   "tasks": {
-    "build:codspeed": [],
-    "doc:dependency-diagram": [
-      "@rust/hash-repo-chores#build"
-    ],
-    "fix:clippy": [],
-    "lint:clippy": [],
-    "test:codspeed": [],
-    "test:miri": [],
-    "test:unit": []
+    "build:codspeed": {
+      "dependsOn": [],
+      "cache": false
+    },
+    "doc:dependency-diagram": {
+      "dependsOn": [
+        "@rust/hash-repo-chores#build"
+      ],
+      "cache": false
+    },
+    "fix:clippy": {
+      "dependsOn": []
+    },
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    },
+    "test:codspeed": {
+      "dependsOn": [],
+      "cache": false
+    },
+    "test:miri": {
+      "dependsOn": []
+    },
+    "test:unit": {
+      "dependsOn": [],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@local/hashql/diagnostics/docs/task-dependencies.json
+++ b/libs/@local/hashql/diagnostics/docs/task-dependencies.json
@@ -2,11 +2,26 @@
   "package": "@rust/hashql-diagnostics",
   "dependencies": [],
   "tasks": {
-    "doc:dependency-diagram": [
-      "@rust/hash-repo-chores#build"
-    ],
-    "fix:clippy": [],
-    "lint:clippy": [],
-    "test:unit": []
+    "doc:dependency-diagram": {
+      "dependsOn": [
+        "@rust/hash-repo-chores#build"
+      ],
+      "cache": false
+    },
+    "fix:clippy": {
+      "dependsOn": []
+    },
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    },
+    "test:unit": {
+      "dependsOn": [],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@local/hashql/eval/docs/task-dependencies.json
+++ b/libs/@local/hashql/eval/docs/task-dependencies.json
@@ -13,11 +13,26 @@
     "@rust/hashql-mir"
   ],
   "tasks": {
-    "doc:dependency-diagram": [
-      "@rust/hash-repo-chores#build"
-    ],
-    "fix:clippy": [],
-    "lint:clippy": [],
-    "test:unit": []
+    "doc:dependency-diagram": {
+      "dependsOn": [
+        "@rust/hash-repo-chores#build"
+      ],
+      "cache": false
+    },
+    "fix:clippy": {
+      "dependsOn": []
+    },
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    },
+    "test:unit": {
+      "dependsOn": [],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@local/hashql/hir/docs/task-dependencies.json
+++ b/libs/@local/hashql/hir/docs/task-dependencies.json
@@ -6,11 +6,26 @@
     "@rust/hashql-diagnostics"
   ],
   "tasks": {
-    "doc:dependency-diagram": [
-      "@rust/hash-repo-chores#build"
-    ],
-    "fix:clippy": [],
-    "lint:clippy": [],
-    "test:unit": []
+    "doc:dependency-diagram": {
+      "dependsOn": [
+        "@rust/hash-repo-chores#build"
+      ],
+      "cache": false
+    },
+    "fix:clippy": {
+      "dependsOn": []
+    },
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    },
+    "test:unit": {
+      "dependsOn": [],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@local/hashql/macros/docs/task-dependencies.json
+++ b/libs/@local/hashql/macros/docs/task-dependencies.json
@@ -2,7 +2,14 @@
   "package": "@rust/hashql-macros",
   "dependencies": [],
   "tasks": {
-    "fix:clippy": [],
-    "lint:clippy": []
+    "fix:clippy": {
+      "dependsOn": []
+    },
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    }
   }
 }

--- a/libs/@local/hashql/mir/docs/task-dependencies.json
+++ b/libs/@local/hashql/mir/docs/task-dependencies.json
@@ -6,14 +6,37 @@
     "@rust/hashql-hir"
   ],
   "tasks": {
-    "build:codspeed": [],
-    "doc:dependency-diagram": [
-      "@rust/hash-repo-chores#build"
-    ],
-    "fix:clippy": [],
-    "lint:clippy": [],
-    "test:codspeed": [],
-    "test:miri": [],
-    "test:unit": []
+    "build:codspeed": {
+      "dependsOn": [],
+      "cache": false
+    },
+    "doc:dependency-diagram": {
+      "dependsOn": [
+        "@rust/hash-repo-chores#build"
+      ],
+      "cache": false
+    },
+    "fix:clippy": {
+      "dependsOn": []
+    },
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    },
+    "test:codspeed": {
+      "dependsOn": [],
+      "cache": false
+    },
+    "test:miri": {
+      "dependsOn": []
+    },
+    "test:unit": {
+      "dependsOn": [],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@local/hashql/syntax-jexpr/docs/task-dependencies.json
+++ b/libs/@local/hashql/syntax-jexpr/docs/task-dependencies.json
@@ -6,11 +6,26 @@
     "@rust/hashql-diagnostics"
   ],
   "tasks": {
-    "doc:dependency-diagram": [
-      "@rust/hash-repo-chores#build"
-    ],
-    "fix:clippy": [],
-    "lint:clippy": [],
-    "test:unit": []
+    "doc:dependency-diagram": {
+      "dependsOn": [
+        "@rust/hash-repo-chores#build"
+      ],
+      "cache": false
+    },
+    "fix:clippy": {
+      "dependsOn": []
+    },
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    },
+    "test:unit": {
+      "dependsOn": [],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@local/internal-api-client/typescript/docs/task-dependencies.json
+++ b/libs/@local/internal-api-client/typescript/docs/task-dependencies.json
@@ -2,6 +2,8 @@
   "package": "@local/internal-api-client",
   "dependencies": [],
   "tasks": {
-    "build": []
+    "build": {
+      "dependsOn": []
+    }
   }
 }

--- a/libs/@local/middleware/docs/task-dependencies.json
+++ b/libs/@local/middleware/docs/task-dependencies.json
@@ -5,11 +5,26 @@
     "@rust/error-stack"
   ],
   "tasks": {
-    "doc:dependency-diagram": [
-      "@rust/hash-repo-chores#build"
-    ],
-    "fix:clippy": [],
-    "lint:clippy": [],
-    "test:unit": []
+    "doc:dependency-diagram": {
+      "dependsOn": [
+        "@rust/hash-repo-chores#build"
+      ],
+      "cache": false
+    },
+    "fix:clippy": {
+      "dependsOn": []
+    },
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    },
+    "test:unit": {
+      "dependsOn": [],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@local/petrinaut-arch-docs/docs/task-dependencies.json
+++ b/libs/@local/petrinaut-arch-docs/docs/task-dependencies.json
@@ -11,28 +11,60 @@
     "@local/tsconfig"
   ],
   "tasks": {
-    "doc:architecture": [],
-    "fix:eslint": [
-      "@apps/petrinaut-website#build",
-      "@hashintel/petrinaut#build",
-      "@hashintel/petrinaut-cli#build",
-      "@hashintel/petrinaut-core#build",
-      "@local/eslint#build"
-    ],
-    "lint:arch-docs": [],
-    "lint:eslint": [
-      "@apps/petrinaut-website#build",
-      "@hashintel/petrinaut#build",
-      "@hashintel/petrinaut-cli#build",
-      "@hashintel/petrinaut-core#build",
-      "@local/eslint#build"
-    ],
-    "lint:tsc": [
-      "@apps/petrinaut-website#build",
-      "@hashintel/petrinaut#build",
-      "@hashintel/petrinaut-cli#build",
-      "@hashintel/petrinaut-core#build"
-    ],
-    "test:unit": []
+    "doc:architecture": {
+      "dependsOn": [],
+      "cache": false,
+      "env": [
+        "GITHUB_HEAD_REF",
+        "GITHUB_REF_NAME",
+        "GITHUB_SHA",
+        "PETRINAUT_ARCH_DOCS_CACHE_DIR",
+        "PETRINAUT_ARCH_DOCS_DIFF_BASE",
+        "PETRINAUT_ARCH_DOCS_SOURCE_REF",
+        "VERCEL_GIT_COMMIT_REF",
+        "VERCEL_GIT_COMMIT_SHA",
+        "VERCEL_GIT_REPO_OWNER",
+        "VERCEL_GIT_REPO_SLUG"
+      ]
+    },
+    "fix:eslint": {
+      "dependsOn": [
+        "@apps/petrinaut-website#build",
+        "@hashintel/petrinaut#build",
+        "@hashintel/petrinaut-cli#build",
+        "@hashintel/petrinaut-core#build",
+        "@local/eslint#build"
+      ]
+    },
+    "lint:arch-docs": {
+      "dependsOn": [],
+      "cache": false
+    },
+    "lint:eslint": {
+      "dependsOn": [
+        "@apps/petrinaut-website#build",
+        "@hashintel/petrinaut#build",
+        "@hashintel/petrinaut-cli#build",
+        "@hashintel/petrinaut-core#build",
+        "@local/eslint#build"
+      ],
+      "env": [
+        "CHECK_TEMPORARILY_DISABLED_RULES"
+      ]
+    },
+    "lint:tsc": {
+      "dependsOn": [
+        "@apps/petrinaut-website#build",
+        "@hashintel/petrinaut#build",
+        "@hashintel/petrinaut-cli#build",
+        "@hashintel/petrinaut-core#build"
+      ]
+    },
+    "test:unit": {
+      "dependsOn": [],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@local/petrinaut-optimizer-client/docs/task-dependencies.json
+++ b/libs/@local/petrinaut-optimizer-client/docs/task-dependencies.json
@@ -6,18 +6,29 @@
     "@local/tsconfig"
   ],
   "tasks": {
-    "build": [
-      "@hashintel/petrinaut-core#build",
-      "codegen"
-    ],
-    "codegen": [],
-    "lint:tsc": [
-      "@hashintel/petrinaut-core#build",
-      "codegen"
-    ],
-    "test:unit": [
-      "@hashintel/petrinaut-core#build",
-      "codegen"
-    ]
+    "build": {
+      "dependsOn": [
+        "@hashintel/petrinaut-core#build",
+        "codegen"
+      ]
+    },
+    "codegen": {
+      "dependsOn": []
+    },
+    "lint:tsc": {
+      "dependsOn": [
+        "@hashintel/petrinaut-core#build",
+        "codegen"
+      ]
+    },
+    "test:unit": {
+      "dependsOn": [
+        "@hashintel/petrinaut-core#build",
+        "codegen"
+      ],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@local/petrinaut-optimizer-core/docs/task-dependencies.json
+++ b/libs/@local/petrinaut-optimizer-core/docs/task-dependencies.json
@@ -2,8 +2,17 @@
   "package": "@local/petrinaut-optimizer-core",
   "dependencies": [],
   "tasks": {
-    "lint:ruff": [],
-    "lint:types": [],
-    "test:unit": []
+    "lint:ruff": {
+      "dependsOn": []
+    },
+    "lint:types": {
+      "dependsOn": []
+    },
+    "test:unit": {
+      "dependsOn": [],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@local/petrinaut-python/docs/task-dependencies.json
+++ b/libs/@local/petrinaut-python/docs/task-dependencies.json
@@ -4,15 +4,26 @@
     "@hashintel/petrinaut-cli"
   ],
   "tasks": {
-    "codegen": [
-      "@hashintel/petrinaut-cli#codegen"
-    ],
-    "lint:ruff": [],
-    "lint:types": [
-      "codegen"
-    ],
-    "test:unit": [
-      "codegen"
-    ]
+    "codegen": {
+      "dependsOn": [
+        "@hashintel/petrinaut-cli#codegen"
+      ]
+    },
+    "lint:ruff": {
+      "dependsOn": []
+    },
+    "lint:types": {
+      "dependsOn": [
+        "codegen"
+      ]
+    },
+    "test:unit": {
+      "dependsOn": [
+        "codegen"
+      ],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@local/repo-chores/node/docs/task-dependencies.json
+++ b/libs/@local/repo-chores/node/docs/task-dependencies.json
@@ -7,25 +7,39 @@
     "@local/tsconfig"
   ],
   "tasks": {
-    "fix:eslint": [
-      "@local/eslint#build",
-      "@local/hash-backend-utils#build",
-      "@local/hash-isomorphic-utils#build"
-    ],
-    "lint:eslint": [
-      "@local/eslint#build",
-      "@local/hash-backend-utils#build",
-      "@local/hash-isomorphic-utils#build"
-    ],
-    "lint:tsc": [
-      "@local/eslint#build",
-      "@local/hash-backend-utils#build",
-      "@local/hash-isomorphic-utils#build"
-    ],
-    "test:unit": [
-      "@local/eslint#build",
-      "@local/hash-backend-utils#build",
-      "@local/hash-isomorphic-utils#build"
-    ]
+    "fix:eslint": {
+      "dependsOn": [
+        "@local/eslint#build",
+        "@local/hash-backend-utils#build",
+        "@local/hash-isomorphic-utils#build"
+      ]
+    },
+    "lint:eslint": {
+      "dependsOn": [
+        "@local/eslint#build",
+        "@local/hash-backend-utils#build",
+        "@local/hash-isomorphic-utils#build"
+      ],
+      "env": [
+        "CHECK_TEMPORARILY_DISABLED_RULES"
+      ]
+    },
+    "lint:tsc": {
+      "dependsOn": [
+        "@local/eslint#build",
+        "@local/hash-backend-utils#build",
+        "@local/hash-isomorphic-utils#build"
+      ]
+    },
+    "test:unit": {
+      "dependsOn": [
+        "@local/eslint#build",
+        "@local/hash-backend-utils#build",
+        "@local/hash-isomorphic-utils#build"
+      ],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/@local/repo-chores/rust/docs/task-dependencies.json
+++ b/libs/@local/repo-chores/rust/docs/task-dependencies.json
@@ -5,17 +5,36 @@
     "@rust/hash-telemetry"
   ],
   "tasks": {
-    "analyze-benchmarks": [
-      "build"
-    ],
-    "build": [],
-    "doc:dependency-diagram": [
-      "build"
-    ],
-    "fix:clippy": [],
-    "lint:clippy": [],
-    "upload-benchmarks": [
-      "build"
-    ]
+    "analyze-benchmarks": {
+      "dependsOn": [
+        "build"
+      ],
+      "cache": false
+    },
+    "build": {
+      "dependsOn": [],
+      "cache": false
+    },
+    "doc:dependency-diagram": {
+      "dependsOn": [
+        "build"
+      ],
+      "cache": false
+    },
+    "fix:clippy": {
+      "dependsOn": []
+    },
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    },
+    "upload-benchmarks": {
+      "dependsOn": [
+        "build"
+      ],
+      "cache": false
+    }
   }
 }

--- a/libs/@local/repo-chores/rust/src/task_dependencies/mod.rs
+++ b/libs/@local/repo-chores/rust/src/task_dependencies/mod.rs
@@ -1,7 +1,9 @@
 //! Generation of the checked-in `task-dependencies.json` files.
 //!
 //! One document per package records the package's direct dependencies and, per task, the
-//! tasks turbo runs before it. A task of the package itself is listed by its bare name, a
+//! tasks turbo runs before it, whether turbo caches it, whether it keeps running, and the
+//! environment variables in its hash — the definition turbo arrives at after merging the root
+//! and the package `turbo.json`. A task of the package itself is listed by its bare name, a
 //! task of another package by its id.
 //!
 //! Only tasks turbo reports a command for are recorded: a task without a command never
@@ -92,6 +94,14 @@ struct QueryResponse<T> {
     errors: Vec<serde_json::Value>,
 }
 
+/// The task definition turbo arrives at after merging the root and the package `turbo.json`.
+#[derive(Debug, serde::Deserialize)]
+struct ResolvedTaskDefinition {
+    cache: bool,
+    persistent: bool,
+    env: Vec<String>,
+}
+
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct DryRunTask {
@@ -100,6 +110,7 @@ struct DryRunTask {
     package: String,
     command: String,
     dependencies: Vec<String>,
+    resolved_task_definition: ResolvedTaskDefinition,
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -107,11 +118,40 @@ struct DryRun {
     tasks: Vec<DryRunTask>,
 }
 
+/// A task as turbo resolves it, with the fields at turbo's defaults left out.
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Task {
+    depends_on: BTreeSet<String>,
+    #[serde(skip_serializing_if = "is_true")]
+    cache: bool,
+    #[serde(skip_serializing_if = "is_false")]
+    persistent: bool,
+    #[serde(skip_serializing_if = "BTreeSet::is_empty")]
+    env: BTreeSet<String>,
+}
+
+#[expect(
+    clippy::trivially_copy_pass_by_ref,
+    reason = "`skip_serializing_if` passes the field by reference"
+)]
+const fn is_true(value: &bool) -> bool {
+    *value
+}
+
+#[expect(
+    clippy::trivially_copy_pass_by_ref,
+    reason = "`skip_serializing_if` passes the field by reference"
+)]
+const fn is_false(value: &bool) -> bool {
+    !*value
+}
+
 #[derive(Debug, serde::Serialize)]
 struct Document {
     package: String,
     dependencies: BTreeSet<String>,
-    tasks: BTreeMap<String, BTreeSet<String>>,
+    tasks: BTreeMap<String, Task>,
 }
 
 /// Runs `command`, attaching the error output of a failed invocation.
@@ -388,10 +428,15 @@ fn documents(
 
         document.tasks.insert(
             task.task.clone(),
-            executed_dependencies(&task.dependencies, &by_id)?
-                .into_iter()
-                .map(|id| local_name(&task.package, id))
-                .collect(),
+            Task {
+                depends_on: executed_dependencies(&task.dependencies, &by_id)?
+                    .into_iter()
+                    .map(|id| local_name(&task.package, id))
+                    .collect(),
+                cache: task.resolved_task_definition.cache,
+                persistent: task.resolved_task_definition.persistent,
+                env: task.resolved_task_definition.env.iter().cloned().collect(),
+            },
         );
     }
 

--- a/libs/@local/status/rust/docs/task-dependencies.json
+++ b/libs/@local/status/rust/docs/task-dependencies.json
@@ -4,10 +4,20 @@
     "@local/status"
   ],
   "tasks": {
-    "doc:dependency-diagram": [
-      "@rust/hash-repo-chores#build"
-    ],
-    "fix:clippy": [],
-    "lint:clippy": []
+    "doc:dependency-diagram": {
+      "dependsOn": [
+        "@rust/hash-repo-chores#build"
+      ],
+      "cache": false
+    },
+    "fix:clippy": {
+      "dependsOn": []
+    },
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    }
   }
 }

--- a/libs/@local/status/typescript/docs/task-dependencies.json
+++ b/libs/@local/status/typescript/docs/task-dependencies.json
@@ -5,15 +5,26 @@
     "@local/tsconfig"
   ],
   "tasks": {
-    "build": [],
-    "fix:eslint": [
-      "@local/eslint#build"
-    ],
-    "lint:eslint": [
-      "@local/eslint#build"
-    ],
-    "lint:tsc": [
-      "@local/eslint#build"
-    ]
+    "build": {
+      "dependsOn": []
+    },
+    "fix:eslint": {
+      "dependsOn": [
+        "@local/eslint#build"
+      ]
+    },
+    "lint:eslint": {
+      "dependsOn": [
+        "@local/eslint#build"
+      ],
+      "env": [
+        "CHECK_TEMPORARILY_DISABLED_RULES"
+      ]
+    },
+    "lint:tsc": {
+      "dependsOn": [
+        "@local/eslint#build"
+      ]
+    }
   }
 }

--- a/libs/@local/telemetry/docs/task-dependencies.json
+++ b/libs/@local/telemetry/docs/task-dependencies.json
@@ -4,10 +4,20 @@
     "@rust/error-stack"
   ],
   "tasks": {
-    "doc:dependency-diagram": [
-      "@rust/hash-repo-chores#build"
-    ],
-    "fix:clippy": [],
-    "lint:clippy": []
+    "doc:dependency-diagram": {
+      "dependsOn": [
+        "@rust/hash-repo-chores#build"
+      ],
+      "cache": false
+    },
+    "fix:clippy": {
+      "dependsOn": []
+    },
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    }
   }
 }

--- a/libs/@local/temporal-client/docs/task-dependencies.json
+++ b/libs/@local/temporal-client/docs/task-dependencies.json
@@ -5,11 +5,26 @@
     "@rust/error-stack"
   ],
   "tasks": {
-    "doc:dependency-diagram": [
-      "@rust/hash-repo-chores#build"
-    ],
-    "fix:clippy": [],
-    "lint:clippy": [],
-    "test:integration": []
+    "doc:dependency-diagram": {
+      "dependsOn": [
+        "@rust/hash-repo-chores#build"
+      ],
+      "cache": false
+    },
+    "fix:clippy": {
+      "dependsOn": []
+    },
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    },
+    "test:integration": {
+      "dependsOn": [],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/antsi/docs/task-dependencies.json
+++ b/libs/antsi/docs/task-dependencies.json
@@ -2,8 +2,20 @@
   "package": "@rust/antsi",
   "dependencies": [],
   "tasks": {
-    "fix:clippy": [],
-    "lint:clippy": [],
-    "test:unit": []
+    "fix:clippy": {
+      "dependsOn": []
+    },
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    },
+    "test:unit": {
+      "dependsOn": [],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/darwin-kperf/codegen/docs/task-dependencies.json
+++ b/libs/darwin-kperf/codegen/docs/task-dependencies.json
@@ -2,6 +2,11 @@
   "package": "@rust/darwin-kperf-codegen",
   "dependencies": [],
   "tasks": {
-    "lint:clippy": []
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    }
   }
 }

--- a/libs/darwin-kperf/criterion/docs/task-dependencies.json
+++ b/libs/darwin-kperf/criterion/docs/task-dependencies.json
@@ -5,6 +5,11 @@
     "@rust/darwin-kperf-events"
   ],
   "tasks": {
-    "lint:clippy": []
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    }
   }
 }

--- a/libs/darwin-kperf/docs/task-dependencies.json
+++ b/libs/darwin-kperf/docs/task-dependencies.json
@@ -5,6 +5,11 @@
     "@rust/darwin-kperf-sys"
   ],
   "tasks": {
-    "lint:clippy": []
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    }
   }
 }

--- a/libs/darwin-kperf/events/docs/task-dependencies.json
+++ b/libs/darwin-kperf/events/docs/task-dependencies.json
@@ -2,6 +2,11 @@
   "package": "@rust/darwin-kperf-events",
   "dependencies": [],
   "tasks": {
-    "lint:clippy": []
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    }
   }
 }

--- a/libs/darwin-kperf/sys/docs/task-dependencies.json
+++ b/libs/darwin-kperf/sys/docs/task-dependencies.json
@@ -2,6 +2,11 @@
   "package": "@rust/darwin-kperf-sys",
   "dependencies": [],
   "tasks": {
-    "lint:clippy": []
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    }
   }
 }

--- a/libs/error-stack/docs/task-dependencies.json
+++ b/libs/error-stack/docs/task-dependencies.json
@@ -4,9 +4,23 @@
     "@rust/error-stack-macros"
   ],
   "tasks": {
-    "fix:clippy": [],
-    "lint:clippy": [],
-    "test:miri": [],
-    "test:unit": []
+    "fix:clippy": {
+      "dependsOn": []
+    },
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    },
+    "test:miri": {
+      "dependsOn": []
+    },
+    "test:unit": {
+      "dependsOn": [],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/libs/error-stack/macros/docs/task-dependencies.json
+++ b/libs/error-stack/macros/docs/task-dependencies.json
@@ -2,7 +2,14 @@
   "package": "@rust/error-stack-macros",
   "dependencies": [],
   "tasks": {
-    "fix:clippy": [],
-    "lint:clippy": []
+    "fix:clippy": {
+      "dependsOn": []
+    },
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    }
   }
 }

--- a/tests/graph/benches/docs/task-dependencies.json
+++ b/tests/graph/benches/docs/task-dependencies.json
@@ -15,13 +15,28 @@
     "@rust/hash-telemetry"
   ],
   "tasks": {
-    "bench:integration": [
-      "@apps/hash-graph#start:healthcheck"
-    ],
-    "fix:clippy": [],
-    "lint:clippy": [],
-    "test:integration": [
-      "@apps/hash-graph#start:test:healthcheck"
-    ]
+    "bench:integration": {
+      "dependsOn": [
+        "@apps/hash-graph#start:healthcheck"
+      ],
+      "cache": false
+    },
+    "fix:clippy": {
+      "dependsOn": []
+    },
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    },
+    "test:integration": {
+      "dependsOn": [
+        "@apps/hash-graph#start:test:healthcheck"
+      ],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/tests/graph/http/docs/task-dependencies.json
+++ b/tests/graph/http/docs/task-dependencies.json
@@ -4,8 +4,13 @@
     "@apps/hash-graph"
   ],
   "tasks": {
-    "test:integration": [
-      "@apps/hash-graph#start:test:healthcheck"
-    ]
+    "test:integration": {
+      "dependsOn": [
+        "@apps/hash-graph#start:test:healthcheck"
+      ],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/tests/graph/integration/docs/task-dependencies.json
+++ b/tests/graph/integration/docs/task-dependencies.json
@@ -15,8 +15,20 @@
     "@rust/hash-telemetry"
   ],
   "tasks": {
-    "fix:clippy": [],
-    "lint:clippy": [],
-    "test:integration": []
+    "fix:clippy": {
+      "dependsOn": []
+    },
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    },
+    "test:integration": {
+      "dependsOn": [],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/tests/graph/test-data/rust/docs/task-dependencies.json
+++ b/tests/graph/test-data/rust/docs/task-dependencies.json
@@ -7,11 +7,26 @@
     "@rust/hash-graph-store"
   ],
   "tasks": {
-    "doc:dependency-diagram": [
-      "@rust/hash-repo-chores#build"
-    ],
-    "fix:clippy": [],
-    "lint:clippy": [],
-    "test:unit": []
+    "doc:dependency-diagram": {
+      "dependsOn": [
+        "@rust/hash-repo-chores#build"
+      ],
+      "cache": false
+    },
+    "fix:clippy": {
+      "dependsOn": []
+    },
+    "lint:clippy": {
+      "dependsOn": [],
+      "env": [
+        "GITHUB_EVENT_NAME"
+      ]
+    },
+    "test:unit": {
+      "dependsOn": [],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/tests/hash-backend-integration/docs/task-dependencies.json
+++ b/tests/hash-backend-integration/docs/task-dependencies.json
@@ -19,96 +19,112 @@
     "@local/tsconfig"
   ],
   "tasks": {
-    "codegen": [
-      "@local/hash-isomorphic-utils#build"
-    ],
-    "fix:eslint": [
-      "@apps/hash-ai-worker-ts#build",
-      "@apps/hash-api#codegen",
-      "@apps/hash-integration-worker#build",
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@hashintel/petrinaut-core#build",
-      "@local/advanced-types#build",
-      "@local/eslint#build",
-      "@local/harpc-client#build",
-      "@local/hash-backend-utils#build",
-      "@local/hash-graph-authorization#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-graph-store#build",
-      "@local/hash-isomorphic-utils#build",
-      "@local/internal-api-client#build",
-      "@local/petrinaut-optimizer-client#build",
-      "@local/status#build",
-      "codegen"
-    ],
-    "lint:eslint": [
-      "@apps/hash-ai-worker-ts#build",
-      "@apps/hash-api#codegen",
-      "@apps/hash-integration-worker#build",
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@hashintel/petrinaut-core#build",
-      "@local/advanced-types#build",
-      "@local/eslint#build",
-      "@local/harpc-client#build",
-      "@local/hash-backend-utils#build",
-      "@local/hash-graph-authorization#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-graph-store#build",
-      "@local/hash-isomorphic-utils#build",
-      "@local/internal-api-client#build",
-      "@local/petrinaut-optimizer-client#build",
-      "@local/status#build",
-      "codegen"
-    ],
-    "lint:tsc": [
-      "@apps/hash-ai-worker-ts#build",
-      "@apps/hash-api#codegen",
-      "@apps/hash-integration-worker#build",
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@hashintel/petrinaut-core#build",
-      "@local/advanced-types#build",
-      "@local/eslint#build",
-      "@local/harpc-client#build",
-      "@local/hash-backend-utils#build",
-      "@local/hash-graph-authorization#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-graph-store#build",
-      "@local/hash-isomorphic-utils#build",
-      "@local/internal-api-client#build",
-      "@local/petrinaut-optimizer-client#build",
-      "@local/status#build",
-      "codegen"
-    ],
-    "test:integration": [
-      "@apps/hash-ai-worker-ts#build",
-      "@apps/hash-ai-worker-ts#start:test:healthcheck",
-      "@apps/hash-api#codegen",
-      "@apps/hash-api#start:test:healthcheck",
-      "@apps/hash-graph#start:test:healthcheck",
-      "@apps/hash-integration-worker#build",
-      "@apps/hash-integration-worker#start:test:healthcheck",
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@hashintel/petrinaut-core#build",
-      "@local/advanced-types#build",
-      "@local/eslint#build",
-      "@local/harpc-client#build",
-      "@local/hash-backend-utils#build",
-      "@local/hash-graph-authorization#build",
-      "@local/hash-graph-client#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-graph-store#build",
-      "@local/hash-isomorphic-utils#build",
-      "@local/internal-api-client#build",
-      "@local/petrinaut-optimizer-client#build",
-      "@local/status#build",
-      "codegen"
-    ]
+    "codegen": {
+      "dependsOn": [
+        "@local/hash-isomorphic-utils#build"
+      ]
+    },
+    "fix:eslint": {
+      "dependsOn": [
+        "@apps/hash-ai-worker-ts#build",
+        "@apps/hash-api#codegen",
+        "@apps/hash-integration-worker#build",
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@hashintel/petrinaut-core#build",
+        "@local/advanced-types#build",
+        "@local/eslint#build",
+        "@local/harpc-client#build",
+        "@local/hash-backend-utils#build",
+        "@local/hash-graph-authorization#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-graph-store#build",
+        "@local/hash-isomorphic-utils#build",
+        "@local/internal-api-client#build",
+        "@local/petrinaut-optimizer-client#build",
+        "@local/status#build",
+        "codegen"
+      ]
+    },
+    "lint:eslint": {
+      "dependsOn": [
+        "@apps/hash-ai-worker-ts#build",
+        "@apps/hash-api#codegen",
+        "@apps/hash-integration-worker#build",
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@hashintel/petrinaut-core#build",
+        "@local/advanced-types#build",
+        "@local/eslint#build",
+        "@local/harpc-client#build",
+        "@local/hash-backend-utils#build",
+        "@local/hash-graph-authorization#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-graph-store#build",
+        "@local/hash-isomorphic-utils#build",
+        "@local/internal-api-client#build",
+        "@local/petrinaut-optimizer-client#build",
+        "@local/status#build",
+        "codegen"
+      ],
+      "env": [
+        "CHECK_TEMPORARILY_DISABLED_RULES"
+      ]
+    },
+    "lint:tsc": {
+      "dependsOn": [
+        "@apps/hash-ai-worker-ts#build",
+        "@apps/hash-api#codegen",
+        "@apps/hash-integration-worker#build",
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@hashintel/petrinaut-core#build",
+        "@local/advanced-types#build",
+        "@local/eslint#build",
+        "@local/harpc-client#build",
+        "@local/hash-backend-utils#build",
+        "@local/hash-graph-authorization#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-graph-store#build",
+        "@local/hash-isomorphic-utils#build",
+        "@local/internal-api-client#build",
+        "@local/petrinaut-optimizer-client#build",
+        "@local/status#build",
+        "codegen"
+      ]
+    },
+    "test:integration": {
+      "dependsOn": [
+        "@apps/hash-ai-worker-ts#build",
+        "@apps/hash-ai-worker-ts#start:test:healthcheck",
+        "@apps/hash-api#codegen",
+        "@apps/hash-api#start:test:healthcheck",
+        "@apps/hash-graph#start:test:healthcheck",
+        "@apps/hash-integration-worker#build",
+        "@apps/hash-integration-worker#start:test:healthcheck",
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@hashintel/petrinaut-core#build",
+        "@local/advanced-types#build",
+        "@local/eslint#build",
+        "@local/harpc-client#build",
+        "@local/hash-backend-utils#build",
+        "@local/hash-graph-authorization#build",
+        "@local/hash-graph-client#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-graph-store#build",
+        "@local/hash-isomorphic-utils#build",
+        "@local/internal-api-client#build",
+        "@local/petrinaut-optimizer-client#build",
+        "@local/status#build",
+        "codegen"
+      ],
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/tests/hash-playwright/docs/task-dependencies.json
+++ b/tests/hash-playwright/docs/task-dependencies.json
@@ -13,37 +13,54 @@
     "@local/tsconfig"
   ],
   "tasks": {
-    "codegen": [
-      "@local/hash-isomorphic-utils#build"
-    ],
-    "fix:eslint": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@local/eslint#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-isomorphic-utils#build",
-      "codegen"
-    ],
-    "lint:eslint": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@local/eslint#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-isomorphic-utils#build",
-      "codegen"
-    ],
-    "lint:tsc": [
-      "@blockprotocol/graph#build",
-      "@blockprotocol/type-system#build",
-      "@local/hash-graph-sdk#build",
-      "@local/hash-isomorphic-utils#build",
-      "codegen"
-    ],
-    "test:integration": [
-      "@apps/hash-api#start:test:healthcheck",
-      "@apps/hash-frontend#start:test:healthcheck",
-      "@apps/plugin-browser#build:test",
-      "codegen"
-    ]
+    "codegen": {
+      "dependsOn": [
+        "@local/hash-isomorphic-utils#build"
+      ]
+    },
+    "fix:eslint": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@local/eslint#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-isomorphic-utils#build",
+        "codegen"
+      ]
+    },
+    "lint:eslint": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@local/eslint#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-isomorphic-utils#build",
+        "codegen"
+      ],
+      "env": [
+        "CHECK_TEMPORARILY_DISABLED_RULES"
+      ]
+    },
+    "lint:tsc": {
+      "dependsOn": [
+        "@blockprotocol/graph#build",
+        "@blockprotocol/type-system#build",
+        "@local/hash-graph-sdk#build",
+        "@local/hash-isomorphic-utils#build",
+        "codegen"
+      ]
+    },
+    "test:integration": {
+      "dependsOn": [
+        "@apps/hash-api#start:test:healthcheck",
+        "@apps/hash-frontend#start:test:healthcheck",
+        "@apps/plugin-browser#build:test",
+        "codegen"
+      ],
+      "cache": false,
+      "env": [
+        "TEST_COVERAGE"
+      ]
+    }
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,8 @@
     // A task nothing implements, so depending on it runs nothing. Its hash still covers the
     // package's inputs, and the chain over `^manifest` carries those of every transitive
     // dependency, which is what a task needs from a crate it reads sources from rather than
-    // artifacts.
+    // artifacts. A package that reads a crate the package graph does not reach adds the
+    // crate's `manifest` to its own, so the chain continues into the crate.
     "manifest": {
       "dependsOn": ["^manifest"]
     },
@@ -31,8 +32,11 @@
       "dependsOn": ["//#sync:turborepo"]
     },
     "build": {},
+    // An image copies the repository and generates and builds inside it, so the host
+    // contributes only sources.
     "build:docker": {
-      "cache": false
+      "cache": false,
+      "dependsOn": ["^manifest"]
     },
     "build:codspeed": {
       "cache": false,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

`deploy.yml` selects the images to build through `affectedTasks(tasks: ["build:docker"])`, which follows the package graph and the task edges. Six TypeScript packages consume a Rust crate only through a task edge on `codegen`, so the `manifest` chain behind `build:docker → ^manifest` stopped at them: a change to the Graph API spec or to `type-system-rs` did not select the frontend image, although the image regenerates the client and the WASM from them inside.

## 🔗 Related links

- SRE-1047
- SRE-989 — introduced `manifest`
- SRE-1039 — the layer this is stacked on
- SRE-984 — crates become native and lose their `package.json`, so a crate edge stays a task edge

## 🔍 What does this change?

- `hash-graph-client`, `hash-codec`, `hash-graph-authorization`, `hash-graph-store`, `type-system` and `effect-dns-hickory` declare `"manifest": { "dependsOn": ["^manifest", "@rust/<crate>#manifest"] }`, so the chain continues into the crate. Their `codegen` edges stay: they invalidate the generated code and order its execution.
- The root `build:docker` depends on `^manifest`; the overrides in `hash-api`, `hash-frontend`, `hash-ai-worker-ts`, `hash-integration-worker` and `hash-graph-atlas` go, and `brunch-agent` and `hash-graph` get the edge as well.
- The task documents do not change: `manifest` runs nothing, and `build:docker` still executes nothing before it.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] affected the execution graph, and the `turbo.json`'s have been updated to reflect this

## ⚠️ Known issues

None.

## 🐾 Next steps

None.

## 🛡 What tests cover this?

Measured with `affectedTasks(base: "HEAD", tasks: ["build:docker"])` and a probe file: a change under `libs/@local/graph/api/openapi/models`, in `@rust/hash-graph-api`, in `@blockprotocol/type-system-rs` or in `@rust/hash-codec` now selects `@apps/hash-frontend#build:docker`; before, none of them did. The checked-in task documents are unchanged and regenerated in CI.

## ❓ How to test this?

1. Check out the branch
2. Add a file under `libs/@local/graph/api/openapi/models/`
3. Run `turbo query 'query { affectedTasks(base: "HEAD", tasks: ["build:docker"]) { items { name package { name } } } }'`; `@apps/hash-frontend` is among the `build:docker` items
