### PR TITLE
FE-1645: Show the prepared-fixture selector only in Brunch demo mode

### DIFF
--- a/.changeset/user-settings-provider-for-hosts.md
+++ b/.changeset/user-settings-provider-for-hosts.md
@@ -1,0 +1,5 @@
+---
+"@hashintel/petrinaut": patch
+---
+
+Hosts can mount `UserSettingsProvider` from `@hashintel/petrinaut/react` above `Petrinaut` to read and change the persisted user settings from their own components; the editor reuses that provider instead of creating its own.

--- a/apps/petrinaut-website/src/main/app/local-storage-demo/local-storage-demo-app.test.tsx
+++ b/apps/petrinaut-website/src/main/app/local-storage-demo/local-storage-demo-app.test.tsx
@@ -584,9 +584,6 @@ describe("local storage demo prepared fixture", () => {
     );
 
     expect(
-      document.querySelector('[aria-label="Prepared fixture selector"]'),
-    ).toBeNull();
-    expect(
       document.querySelector('[aria-label="Prepared fixture status"]'),
     ).toBeNull();
     const aiAssistant = editorProps.current?.aiAssistant as

--- a/apps/petrinaut-website/src/main/app/local-storage-demo/local-storage-demo-app.test.tsx
+++ b/apps/petrinaut-website/src/main/app/local-storage-demo/local-storage-demo-app.test.tsx
@@ -1,7 +1,14 @@
 /**
  * @vitest-environment jsdom
  */
-import { act, cleanup, render, waitFor } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { isValidElement, type ReactNode } from "react";
 import { afterEach, describe, expect, test, vi } from "vitest";
 
@@ -567,6 +574,35 @@ describe("local storage demo prepared fixture", () => {
     cleanup();
     editorProps.current = null;
     brunchPreviewConfig.isBrunchConfigured = true;
+  });
+
+  test("shows the fixture selector only while Brunch demo mode is on", () => {
+    seedStoredNet();
+    render(<LocalStorageDemoApp onSearchChange={() => {}} search={{}} />);
+    const selector = () =>
+      document.querySelector<HTMLElement>(
+        '[aria-label="Prepared fixture selector"]',
+      );
+
+    // Never displayed by default, even on a Brunch-configured build.
+    expect(selector()).toBeNull();
+
+    // The palette command flips the persisted setting.
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    fireEvent.click(
+      screen.getByRole("button", { name: /Toggle Brunch demo mode/ }),
+    );
+    const shown = selector();
+    expect(shown).not.toBeNull();
+    // Clear of Petrinaut's 64px top bar, so the panel is usable.
+    expect(shown!.style.position).toBe("fixed");
+    expect(shown!.style.top).toBe("80px");
+
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    fireEvent.click(
+      screen.getByRole("button", { name: /Toggle Brunch demo mode/ }),
+    );
+    expect(selector()).toBeNull();
   });
 
   test("neither advertises nor opens the fixture while Brunch is unconfigured", () => {

--- a/apps/petrinaut-website/src/main/app/local-storage-demo/local-storage-demo-app.tsx
+++ b/apps/petrinaut-website/src/main/app/local-storage-demo/local-storage-demo-app.tsx
@@ -5,7 +5,7 @@
 
 import { createFlueClient, type FlueConversationSettlement } from "@flue/sdk";
 import { castDraft, produce } from "immer";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { use, useCallback, useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 
 import {
@@ -22,6 +22,8 @@ import {
 import {
   CommandRegistryProvider,
   useCommand,
+  UserSettingsContext,
+  UserSettingsProvider,
 } from "@hashintel/petrinaut/react";
 import {
   DefaultChatTransport,
@@ -59,7 +61,10 @@ import {
   crewReservationDocumentId,
   preparedCrewReservationNet,
 } from "./prepared-crew-reservation-fixture";
-import { PreparedFixtureBanner } from "./prepared-fixture-banner";
+import {
+  PreparedFixtureBanner,
+  PreparedFixtureSelector,
+} from "./prepared-fixture-banner";
 import { resolveCrewReservationBundle } from "./resolve-crew-reservation-bundle";
 import {
   crewReservationFixtureConfiguration,
@@ -226,14 +231,16 @@ const createActiveHandle = (net: SDCPNInLocalStorage): ActiveHandle => ({
 });
 
 /**
- * The demo's own palette command, registered beside Petrinaut's: picking it
- * in the palette starts a fresh net.
+ * The demo's own palette commands, registered beside Petrinaut's: one starts
+ * a fresh net, one toggles Brunch demo mode, the persisted user setting that
+ * shows the prepared-fixture selector.
  */
 const DemoCommands = ({
   createNewNet,
 }: {
   createNewNet: (params: { petriNetDefinition: SDCPN; title: string }) => void;
 }) => {
+  const { brunchDemoMode, setBrunchDemoMode } = use(UserSettingsContext);
   useCommand({
     id: "demo.net.new",
     label: "Create a new empty net",
@@ -242,7 +249,26 @@ const DemoCommands = ({
     run: () =>
       createNewNet({ petriNetDefinition: emptySDCPN, title: "New Process" }),
   });
+  useCommand(
+    {
+      id: "demo.brunch.toggle-demo-mode",
+      label: "Toggle Brunch demo mode",
+      category: "Demo",
+      keywords: ["fixture", "prepared", "crew reservation"],
+      run: () => setBrunchDemoMode(!brunchDemoMode),
+    },
+    { when: brunchPreviewConfig.isBrunchConfigured },
+  );
   return null;
+};
+
+/**
+ * The prepared-fixture selector, shown only while Brunch demo mode is on: a
+ * demo affordance, never part of the default shell.
+ */
+const DemoModeFixtureSelector = () => {
+  const { brunchDemoMode } = use(UserSettingsContext);
+  return brunchDemoMode ? <PreparedFixtureSelector /> : null;
 };
 
 /**
@@ -684,24 +710,31 @@ export const LocalStorageDemoApp = ({
           />,
           document.body,
         )}
-      <CommandRegistryProvider>
-        <WalkthroughProvider steps={walkthroughSteps}>
-          <Petrinaut
-            aiAssistant={aiAssistant}
-            handle={activeHandle.handle}
-            existingNets={existingNets}
-            createNewNet={createNewNet}
-            loadPetriNet={loadPetriNet}
-            navigation={navigation}
-            readonly={false}
-            setTitle={setTitle}
-            title={currentNet.title}
-            viewportActions={[sentryFeedbackAction]}
-          />
-        </WalkthroughProvider>
-        <DemoCommands createNewNet={createNewNet} />
-        <CommandPalette />
-      </CommandRegistryProvider>
+      {/* The settings are mounted here, above the editor, so the demo's own
+          command and selector read the same persisted state the editor does. */}
+      <UserSettingsProvider>
+        {brunchPreviewConfig.isBrunchConfigured && !preparedFixtureIsCurrent ? (
+          <DemoModeFixtureSelector />
+        ) : null}
+        <CommandRegistryProvider>
+          <WalkthroughProvider steps={walkthroughSteps}>
+            <Petrinaut
+              aiAssistant={aiAssistant}
+              handle={activeHandle.handle}
+              existingNets={existingNets}
+              createNewNet={createNewNet}
+              loadPetriNet={loadPetriNet}
+              navigation={navigation}
+              readonly={false}
+              setTitle={setTitle}
+              title={currentNet.title}
+              viewportActions={[sentryFeedbackAction]}
+            />
+          </WalkthroughProvider>
+          <DemoCommands createNewNet={createNewNet} />
+          <CommandPalette />
+        </CommandRegistryProvider>
+      </UserSettingsProvider>
     </div>
   );
 };

--- a/apps/petrinaut-website/src/main/app/local-storage-demo/local-storage-demo-app.tsx
+++ b/apps/petrinaut-website/src/main/app/local-storage-demo/local-storage-demo-app.tsx
@@ -59,10 +59,7 @@ import {
   crewReservationDocumentId,
   preparedCrewReservationNet,
 } from "./prepared-crew-reservation-fixture";
-import {
-  PreparedFixtureBanner,
-  PreparedFixtureSelector,
-} from "./prepared-fixture-banner";
+import { PreparedFixtureBanner } from "./prepared-fixture-banner";
 import { resolveCrewReservationBundle } from "./resolve-crew-reservation-bundle";
 import {
   crewReservationFixtureConfiguration,
@@ -687,9 +684,6 @@ export const LocalStorageDemoApp = ({
           />,
           document.body,
         )}
-      {brunchPreviewConfig.isBrunchConfigured && !preparedFixtureIsCurrent && (
-        <PreparedFixtureSelector />
-      )}
       <CommandRegistryProvider>
         <WalkthroughProvider steps={walkthroughSteps}>
           <Petrinaut

--- a/apps/petrinaut-website/src/main/app/local-storage-demo/prepared-fixture-banner.test.tsx
+++ b/apps/petrinaut-website/src/main/app/local-storage-demo/prepared-fixture-banner.test.tsx
@@ -15,10 +15,7 @@ import {
   crewReservationDocumentId,
   crewReservationFixtureId,
 } from "./prepared-crew-reservation-fixture";
-import {
-  PreparedFixtureBanner,
-  PreparedFixtureSelector,
-} from "./prepared-fixture-banner";
+import { PreparedFixtureBanner } from "./prepared-fixture-banner";
 
 const settledManifest = {
   version: 1 as const,
@@ -47,14 +44,6 @@ const settledManifest = {
 } satisfies CrewReservationSettledManifest;
 
 describe("PreparedFixtureBanner", () => {
-  test("offers a stable labelled fixture selector", () => {
-    const markup = renderToStaticMarkup(<PreparedFixtureSelector />);
-
-    expect(markup).toContain("Prepared fixture selector");
-    expect(markup).toContain("Open the labelled crew-reservation fixture");
-    expect(markup).toContain("?brunch-fixture=crew-reservation-v1");
-  });
-
   test("visibly states authorship, non-claims, and automatic settlement", () => {
     const markup = renderToStaticMarkup(
       <PreparedFixtureBanner settledManifest={null} />,

--- a/apps/petrinaut-website/src/main/app/local-storage-demo/prepared-fixture-banner.test.tsx
+++ b/apps/petrinaut-website/src/main/app/local-storage-demo/prepared-fixture-banner.test.tsx
@@ -15,7 +15,10 @@ import {
   crewReservationDocumentId,
   crewReservationFixtureId,
 } from "./prepared-crew-reservation-fixture";
-import { PreparedFixtureBanner } from "./prepared-fixture-banner";
+import {
+  PreparedFixtureBanner,
+  PreparedFixtureSelector,
+} from "./prepared-fixture-banner";
 
 const settledManifest = {
   version: 1 as const,
@@ -44,6 +47,17 @@ const settledManifest = {
 } satisfies CrewReservationSettledManifest;
 
 describe("PreparedFixtureBanner", () => {
+  test("offers a stable labelled fixture selector below the top bar", () => {
+    const markup = renderToStaticMarkup(<PreparedFixtureSelector />);
+
+    expect(markup).toContain("Prepared fixture selector");
+    expect(markup).toContain("Open the labelled crew-reservation fixture");
+    expect(markup).toContain("?brunch-fixture=crew-reservation-v1");
+    // Petrinaut's top bar is 64px tall; the panel sits under it, not behind.
+    expect(markup).toContain("position:fixed");
+    expect(markup).toContain("top:80px");
+  });
+
   test("visibly states authorship, non-claims, and automatic settlement", () => {
     const markup = renderToStaticMarkup(
       <PreparedFixtureBanner settledManifest={null} />,

--- a/apps/petrinaut-website/src/main/app/local-storage-demo/prepared-fixture-banner.tsx
+++ b/apps/petrinaut-website/src/main/app/local-storage-demo/prepared-fixture-banner.tsx
@@ -1,12 +1,17 @@
 import { latestRunbookIrBlock } from "@hashintel/brunch-agent/workpiece";
 
-import { preparedCrewReservationWorkpiece } from "./prepared-crew-reservation-fixture";
+import {
+  crewReservationFixtureId,
+  crewReservationFixtureQuery,
+  preparedCrewReservationWorkpiece,
+} from "./prepared-crew-reservation-fixture";
 
 import type { CrewReservationSettledManifest } from "./crew-reservation-settled-manifest";
 import type { CrewReservationSettlementStatus } from "./use-crew-reservation-settled-manifest";
 
-// Fixed below Petrinaut's 64px top bar, so the banner never sits behind it.
-const fixtureBannerStyle = {
+// Centred below Petrinaut's 64px top bar, clear of the side panels, so the
+// panels never sit behind the bar.
+const fixturePanelStyle = {
   background: "rgba(255, 255, 255, 0.96)",
   border: "1px solid #c9d2df",
   borderRadius: 8,
@@ -17,9 +22,25 @@ const fixtureBannerStyle = {
   position: "fixed",
   top: 80,
   transform: "translateX(-50%)",
-  width: "calc(100vw - 32px)",
   zIndex: 20,
 } as const;
+
+const fixtureBannerStyle = {
+  ...fixturePanelStyle,
+  width: "calc(100vw - 32px)",
+} as const;
+
+/** The demo-mode entry point to the prepared fixture. */
+export const PreparedFixtureSelector = () => (
+  <aside aria-label="Prepared fixture selector" style={fixturePanelStyle}>
+    <strong>Prepared Brunch fixtures</strong>
+    <div>
+      <a href={`?${crewReservationFixtureQuery}=${crewReservationFixtureId}`}>
+        Open the labelled crew-reservation fixture
+      </a>
+    </div>
+  </aside>
+);
 
 export const PreparedFixtureBanner = ({
   currentWorkpiece,

--- a/apps/petrinaut-website/src/main/app/local-storage-demo/prepared-fixture-banner.tsx
+++ b/apps/petrinaut-website/src/main/app/local-storage-demo/prepared-fixture-banner.tsx
@@ -1,46 +1,25 @@
 import { latestRunbookIrBlock } from "@hashintel/brunch-agent/workpiece";
 
-import {
-  crewReservationFixtureId,
-  crewReservationFixtureQuery,
-  preparedCrewReservationWorkpiece,
-} from "./prepared-crew-reservation-fixture";
+import { preparedCrewReservationWorkpiece } from "./prepared-crew-reservation-fixture";
 
 import type { CrewReservationSettledManifest } from "./crew-reservation-settled-manifest";
 import type { CrewReservationSettlementStatus } from "./use-crew-reservation-settled-manifest";
 
-const fixturePanelStyle = {
+// Fixed below Petrinaut's 64px top bar, so the banner never sits behind it.
+const fixtureBannerStyle = {
   background: "rgba(255, 255, 255, 0.96)",
   border: "1px solid #c9d2df",
   borderRadius: 8,
   boxShadow: "0 2px 8px rgba(20, 33, 50, 0.12)",
-  left: 16,
+  left: "50%",
   maxWidth: 520,
   padding: "10px 12px",
-  position: "absolute",
-  top: 16,
-  zIndex: 20,
-} as const;
-
-const fixtureBannerStyle = {
-  ...fixturePanelStyle,
-  left: "50%",
   position: "fixed",
   top: 80,
   transform: "translateX(-50%)",
   width: "calc(100vw - 32px)",
+  zIndex: 20,
 } as const;
-
-export const PreparedFixtureSelector = () => (
-  <aside aria-label="Prepared fixture selector" style={fixturePanelStyle}>
-    <strong>Prepared Brunch fixtures</strong>
-    <div>
-      <a href={`?${crewReservationFixtureQuery}=${crewReservationFixtureId}`}>
-        Open the labelled crew-reservation fixture
-      </a>
-    </div>
-  </aside>
-);
 
 export const PreparedFixtureBanner = ({
   currentWorkpiece,

--- a/libs/@hashintel/petrinaut/src/react/index.ts
+++ b/libs/@hashintel/petrinaut/src/react/index.ts
@@ -113,6 +113,16 @@ export type {
   SimulationProviderProps,
 } from "./simulation/provider";
 
+// --- User settings ---
+// A host mounts the provider above `Petrinaut` to read and change the
+// persisted settings from its own components; the editor reuses that instance.
+export { UserSettingsContext } from "./state/user-settings-context";
+export type {
+  UserSettings,
+  UserSettingsContextValue,
+} from "./state/user-settings-context";
+export { UserSettingsProvider } from "./state/user-settings-provider";
+
 // --- Error tracker DI ---
 export { ErrorTrackerContext } from "./error-tracker-context";
 export type { ErrorTracker } from "./error-tracker-context";

--- a/libs/@hashintel/petrinaut/src/react/state/user-settings-context.ts
+++ b/libs/@hashintel/petrinaut/src/react/state/user-settings-context.ts
@@ -102,6 +102,12 @@ export type UserSettings = {
    * is unaffected either way.
    */
   enableInBrowserOptimization: boolean;
+  /**
+   * Shows a host's Brunch demo affordances, such as the demo site's
+   * prepared-fixture selector. Toggled from a palette command the host
+   * registers; the settings dialog has no control for it.
+   */
+  brunchDemoMode: boolean;
   subViewPanels: SubViewPanelsSettings;
   /** Where each document's canvas was last left, keyed by document id. */
   canvasViewports: Record<string, SavedCanvasViewport>;
@@ -133,6 +139,7 @@ export type UserSettingsActions = {
   setEnableParameterSweeps: (value: boolean) => void;
   setEnableOptimizationSurface: (value: boolean) => void;
   setEnableInBrowserOptimization: (value: boolean) => void;
+  setBrunchDemoMode: (value: boolean) => void;
   updateSubViewSection: (
     containerName: string,
     sectionId: string,
@@ -169,11 +176,16 @@ export const defaultUserSettings: UserSettings = {
   enableParameterSweeps: false,
   enableOptimizationSurface: false,
   enableInBrowserOptimization: false,
+  brunchDemoMode: false,
   subViewPanels: {},
   canvasViewports: {},
 };
 
-const DEFAULT_CONTEXT_VALUE: UserSettingsContextValue = {
+/**
+ * The value outside any provider. `UserSettingsProvider` compares against it
+ * to tell whether an ancestor already provides the settings.
+ */
+export const defaultUserSettingsContextValue: UserSettingsContextValue = {
   ...defaultUserSettings,
   setShowAnimations: () => {},
   setKeepPanelsMounted: () => {},
@@ -200,10 +212,11 @@ const DEFAULT_CONTEXT_VALUE: UserSettingsContextValue = {
   setEnableParameterSweeps: () => {},
   setEnableOptimizationSurface: () => {},
   setEnableInBrowserOptimization: () => {},
+  setBrunchDemoMode: () => {},
   updateSubViewSection: () => {},
   setCanvasViewport: () => {},
 };
 
 export const UserSettingsContext = createContext<UserSettingsContextValue>(
-  DEFAULT_CONTEXT_VALUE,
+  defaultUserSettingsContextValue,
 );

--- a/libs/@hashintel/petrinaut/src/react/state/user-settings-provider.test.tsx
+++ b/libs/@hashintel/petrinaut/src/react/state/user-settings-provider.test.tsx
@@ -3,12 +3,23 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
  * @vitest-environment jsdom
  */
 import { use } from "react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { UserSettingsContext } from "./user-settings-context";
 import { UserSettingsProvider } from "./user-settings-provider";
 
 afterEach(cleanup);
+
+// The provider persists every change, so a test's toggle would otherwise seed
+// the next test's initial state. Guarded: some Node versions expose a global
+// `localStorage` whose methods are missing.
+beforeEach(() => {
+  try {
+    localStorage.removeItem("petrinaut:user-settings");
+  } catch {
+    // No storage to reset.
+  }
+});
 
 const DemoModeProbe = ({ name }: { name: string }) => {
   const { brunchDemoMode, setBrunchDemoMode } = use(UserSettingsContext);

--- a/libs/@hashintel/petrinaut/src/react/state/user-settings-provider.test.tsx
+++ b/libs/@hashintel/petrinaut/src/react/state/user-settings-provider.test.tsx
@@ -1,0 +1,51 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+/**
+ * @vitest-environment jsdom
+ */
+import { use } from "react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { UserSettingsContext } from "./user-settings-context";
+import { UserSettingsProvider } from "./user-settings-provider";
+
+afterEach(cleanup);
+
+const DemoModeProbe = ({ name }: { name: string }) => {
+  const { brunchDemoMode, setBrunchDemoMode } = use(UserSettingsContext);
+  return (
+    <button type="button" onClick={() => setBrunchDemoMode(!brunchDemoMode)}>
+      {name}: {brunchDemoMode ? "on" : "off"}
+    </button>
+  );
+};
+
+describe("UserSettingsProvider", () => {
+  it("starts with Brunch demo mode off and toggles it", () => {
+    render(
+      <UserSettingsProvider>
+        <DemoModeProbe name="probe" />
+      </UserSettingsProvider>,
+    );
+
+    const probe = screen.getByRole("button", { name: "probe: off" });
+    fireEvent.click(probe);
+    expect(screen.getByRole("button", { name: "probe: on" })).toBe(probe);
+  });
+
+  it("reuses an ancestor provider, so a host and the editor share one state", () => {
+    // The host mounts the provider above the editor and reads the settings
+    // in its own components; the editor's own provider must not fork them.
+    render(
+      <UserSettingsProvider>
+        <DemoModeProbe name="host" />
+        <UserSettingsProvider>
+          <DemoModeProbe name="editor" />
+        </UserSettingsProvider>
+      </UserSettingsProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "editor: off" }));
+    expect(screen.getByRole("button", { name: "host: on" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "editor: on" })).toBeTruthy();
+  });
+});

--- a/libs/@hashintel/petrinaut/src/react/state/user-settings-provider.tsx
+++ b/libs/@hashintel/petrinaut/src/react/state/user-settings-provider.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from "react";
+import { use, useEffect, useState } from "react";
 
 import {
   defaultUserSettings,
+  defaultUserSettingsContextValue,
   UserSettingsContext,
 } from "./user-settings-context";
 import { rememberCanvasViewport } from "./user-settings-provider/remember-canvas-viewport";
@@ -51,7 +52,23 @@ const loadSettings = (): UserSettings => {
   return defaultUserSettings;
 };
 
+/**
+ * Provides the persisted user settings. A host may mount it above
+ * `Petrinaut` to share the settings with its own components; the editor's
+ * own instance then reuses that ancestor, so one state owns the storage key.
+ */
 export const UserSettingsProvider: React.FC<React.PropsWithChildren> = ({
+  children,
+}) => {
+  const ancestor = use(UserSettingsContext);
+  return ancestor === defaultUserSettingsContextValue ? (
+    <OwnedUserSettingsProvider>{children}</OwnedUserSettingsProvider>
+  ) : (
+    children
+  );
+};
+
+const OwnedUserSettingsProvider: React.FC<React.PropsWithChildren> = ({
   children,
 }) => {
   const [state, setState] = useState<UserSettings>(loadSettings);
@@ -129,6 +146,8 @@ export const UserSettingsProvider: React.FC<React.PropsWithChildren> = ({
     },
     setEnableInBrowserOptimization: (value: boolean) =>
       setState((prev) => ({ ...prev, enableInBrowserOptimization: value })),
+    setBrunchDemoMode: (value: boolean) =>
+      setState((prev) => ({ ...prev, brunchDemoMode: value })),
     updateSubViewSection: (
       containerName: string,
       sectionId: string,

--- a/libs/@hashintel/petrinaut/src/react/state/user-settings-provider.tsx
+++ b/libs/@hashintel/petrinaut/src/react/state/user-settings-provider.tsx
@@ -52,22 +52,6 @@ const loadSettings = (): UserSettings => {
   return defaultUserSettings;
 };
 
-/**
- * Provides the persisted user settings. A host may mount it above
- * `Petrinaut` to share the settings with its own components; the editor's
- * own instance then reuses that ancestor, so one state owns the storage key.
- */
-export const UserSettingsProvider: React.FC<React.PropsWithChildren> = ({
-  children,
-}) => {
-  const ancestor = use(UserSettingsContext);
-  return ancestor === defaultUserSettingsContextValue ? (
-    <OwnedUserSettingsProvider>{children}</OwnedUserSettingsProvider>
-  ) : (
-    children
-  );
-};
-
 const OwnedUserSettingsProvider: React.FC<React.PropsWithChildren> = ({
   children,
 }) => {
@@ -174,5 +158,21 @@ const OwnedUserSettingsProvider: React.FC<React.PropsWithChildren> = ({
 
   return (
     <UserSettingsContext value={contextValue}>{children}</UserSettingsContext>
+  );
+};
+
+/**
+ * Provides the persisted user settings. A host may mount it above
+ * `Petrinaut` to share the settings with its own components; the editor's
+ * own instance then reuses that ancestor, so one state owns the storage key.
+ */
+export const UserSettingsProvider: React.FC<React.PropsWithChildren> = ({
+  children,
+}) => {
+  const ancestor = use(UserSettingsContext);
+  return ancestor === defaultUserSettingsContextValue ? (
+    <OwnedUserSettingsProvider>{children}</OwnedUserSettingsProvider>
+  ) : (
+    children
   );
 };

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/create-experiment-drawer.test.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/SimulateView/experiments/create-experiment-drawer.test.tsx
@@ -148,6 +148,7 @@ const TestProviders = ({
     setEnableOptimizationSurface: () => {},
     setCanvasViewport: () => {},
     setEnableInBrowserOptimization: () => {},
+    setBrunchDemoMode: () => {},
     updateSubViewSection: () => {},
   };
 


### PR DESCRIPTION
## Summary

Before this PR, the demo site rendered a "Prepared Brunch fixtures" panel beside the editor whenever the Brunch AI was configured and the crew-reservation fixture was not the current net. The panel sat 16px from the top at a stacking order below Petrinaut's 64px top bar, so only its rounded bottom edge showed, as a stray box behind the model name in every mode. Its one link opens the fixture through the `brunch-fixture` query, the entry point of the Mission 6 two-tab witness.

The panel is now a demo affordance that is never displayed by default. The palette command **Toggle Brunch demo mode** flips a persisted user setting, `brunchDemoMode`, that the settings dialog does not show; while it is on, the selector sits centred below the top bar, clear of the side panels, like the fixture status banner that appears once the fixture is current. To read that setting outside the editor, the demo shell mounts Petrinaut's `UserSettingsProvider` above `Petrinaut`, and the editor reuses that instance.

**Before**

https://github.com/user-attachments/assets/1a754aa2-04b1-4996-92db-14d31441da71

**After**

https://github.com/user-attachments/assets/56f6715b-5027-4bb4-87ef-7595ecb0729e

## Links

- Ticket [FE-1645](https://linear.app/hash/issue/FE-1645)

## Changes

#### Petrinaut

- `UserSettingsProvider` reuses an ancestor provider
  > A host mounts it above `Petrinaut` and reads or changes the persisted settings from its own components; the editor's own instance then renders its children, so one state owns the storage key.
- `UserSettingsProvider`, `UserSettingsContext` and their types are exported from `@hashintel/petrinaut/react`
- `brunchDemoMode` joins the user settings
  > Off by default, persisted with the others, no control in the settings dialog.

#### Demo site

- **Toggle Brunch demo mode** joins the palette's Demo commands
  > Listed only on a Brunch-configured build; it flips `brunchDemoMode`.
- Prepared-fixture selector shows only in demo mode
  > Fixed 80px from the top and centred, the same placement as the fixture status banner, so nothing of the demo shell sits behind the top bar.

## Test coverage

- `user-settings-provider.test.tsx`:
  > Brunch demo mode starts off and toggles; a nested provider shares the ancestor's state.
- `local-storage-demo-app.test.tsx`:
  > The selector is absent by default, appears fixed at 80px after the palette command, and disappears when the command runs again.
- `prepared-fixture-banner.test.tsx`:
  > The selector's label, link and placement.

## How to test

- Open [Petrinaut preview](https://petrinaut-git-claude-fe-1645-remove-prepared-fixture-selector.stage.hash.ai) on Vercel
- Menu > Load example > any model
  > Expect no box peeking under the top bar behind the model name, in Edit and in Simulate
- Press ⌘K > Toggle Brunch demo mode
  > Expect the "Prepared Brunch fixtures" panel centred below the top bar
- Reload
  > Expect the panel still shown
- Click "Open the labelled crew-reservation fixture"
  > Expect the "Test-authored prepared fixture" banner in the same place, and no selector
- Press ⌘K > Toggle Brunch demo mode
  > Expect the selector gone once the fixture is left

