### PR TITLE
SRE-997: Make the compose files an input of the integration tests

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -74,9 +74,11 @@
       "dependsOn": ["^manifest"],
       "env": ["TEST_COVERAGE"]
     },
+    // The integration tests and benches run against the services `infra/compose` starts.
     "test:integration": {
       "dependsOn": ["^manifest"],
-      "env": ["TEST_COVERAGE"]
+      "env": ["TEST_COVERAGE"],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/infra/compose/**"]
     },
     // Smoke-tests the image `build:docker` produced. Not run in CI yet.
     // TODO(SRE-1032): run this in the deploy workflow against the image it already builds.
@@ -98,7 +100,8 @@
     },
     "bench:integration": {
       "dependsOn": ["^manifest"],
-      "cache": false
+      "cache": false,
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/infra/compose/**"]
     },
     // Linting and formatting
     "lint": {},


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The integration tests and benches run against the services `infra/compose` starts, but no task listed those files as an input, so a change to `compose.yml` or to a service configuration selected no integration test in CI.

## 🔗 Related links

- SRE-997

## 🔍 What does this change?

- The root `test:integration` and `bench:integration` declare `inputs: ["$TURBO_DEFAULT$", "$TURBO_ROOT$/infra/compose/**"]`. Every package with one of these tasks inherits it; none overrides `inputs` on them.
- Nothing else: `test:unit`, the lints and the images are unaffected, and the task documents do not change, since `infra/compose` is not a package.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

- [x] affected the execution graph, and the `turbo.json`'s have been updated to reflect this

## ⚠️ Known issues

None.

## 🐾 Next steps

None.

## 🛡 What tests cover this?

Verified with `turbo run --dry=json`: with a file added under `infra/compose/`, the resolved inputs of all eleven `test:integration` tasks and of `bench:integration` include it, no `test:unit` task's do, and each task keeps its own files as inputs.

## ❓ How to test this?

1. Check out the branch
2. Add a file under `infra/compose/` and run `.github/scripts/affected-packages.sh test:integration`; every package with integration tests is listed
3. Remove the file; the script lists none
