### PR TITLE
FE-1633: Start the Storybook preview in CI mode

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -4,7 +4,7 @@
     {
       "name": "@hashintel/petrinaut (storybook)",
       "runtimeExecutable": "yarn",
-      "runtimeArgs": ["workspace", "@hashintel/petrinaut", "dev"],
+      "runtimeArgs": ["workspace", "@hashintel/petrinaut", "dev", "--ci"],
       "port": 6006,
       "autoPort": true
     },


### PR DESCRIPTION
> [!IMPORTANT]
> Dev tooling, nothing user-facing.

## Summary

Before this PR, the `@hashintel/petrinaut (storybook)` preview task started Storybook the way a developer starts it at a terminal. Storybook opened the OS default browser on every launch, and a taken port stopped it at a confirmation prompt. A Claude Code session shows the page in its own Browser pane, so the extra tab is noise, and the prompt has no terminal to answer it.

The preview task now passes `--ci`, Storybook's mode for a launcher that is not a person. No browser opens and no prompt waits. A developer's `yarn workspace @hashintel/petrinaut dev` at a terminal is unaffected.

## Links

- Ticket [FE-1633](https://linear.app/hash/issue/FE-1633)
- Reference [Storybook CLI options › dev](https://storybook.js.org/docs/api/cli-options#dev)

## Changes

- Storybook preview task passes `--ci`
  > `scripts/dev.sh` forwards every argument it does not consume to `storybook dev`, so only `.claude/launch.json` changes.
  > `--ci` disables both the browser and the port prompt, where `--no-open` would disable the browser alone.

## Test coverage

- Manual, `yarn workspace @hashintel/petrinaut dev --ci --smoke-test`:
  > Storybook builds, starts and exits with no browser tab opened, which shows the flag reaches it through `dev.sh`.

## How to test

- Start the Storybook preview task from a Claude Code session
  > Expect Storybook in the Browser pane and no new tab in the OS browser
- `yarn workspace @hashintel/petrinaut dev`
  > Expect Storybook to open a browser tab
