### PR TITLE
FE-1671: Animate a firing only where it can be seen

### DIFF
--- a/.changeset/canvas-firing-animation-budget.md
+++ b/.changeset/canvas-firing-animation-budget.md
@@ -1,0 +1,5 @@
+---
+"@hashintel/petrinaut": patch
+---
+
+A firing only animates where it can be seen: nodes and arcs off the side of the canvas, or drawn at a zoom small enough that a node is a few pixels across, skip the flash. On a thousand-node net a scrub goes from 13 to 44 frames per second and playback from 16 to 39.

--- a/.changeset/canvas-firing-animation-budget.md
+++ b/.changeset/canvas-firing-animation-budget.md
@@ -2,4 +2,4 @@
 "@hashintel/petrinaut": patch
 ---
 
-A firing only animates where it can be seen: nodes and arcs off the side of the canvas, or drawn at a zoom small enough that a node is a few pixels across, skip the flash. On a thousand-node net a scrub goes from 13 to 44 frames per second and playback from 16 to 39.
+Firing animations run only on the transitions and arcs in view, and not at all when the canvas is zoomed out far enough that a node is a few pixels across.

--- a/libs/@hashintel/petrinaut/docs/simulation.md
+++ b/libs/@hashintel/petrinaut/docs/simulation.md
@@ -76,6 +76,12 @@ Each simulation step proceeds in two phases:
 
 Simulation time advances by `dt` each frame.
 
+## What a firing looks like
+
+A transition that fires flashes yellow, shows a lightning bolt, and thickens the arcs it moved tokens along, by an amount that grows with how many fired at once.
+
+Firings you cannot see are not animated: a node off the side of the canvas, or a net zoomed out far enough that a node is only a few pixels across. Token counts, arcs and the timeline are unaffected -- only the flash is skipped, which is what keeps a large net moving at speed. Zoom in and the firings you are looking at animate as usual.
+
 ## Deadlock
 
 If no transition fires in a step **and** no transition is structurally enabled (regardless of lambda values), the simulation reports **deadlock** and stops (a "Simulation Complete" message is shown).

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/arc.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/arc.tsx
@@ -10,7 +10,6 @@ import { type CSSProperties, use, useEffect, useRef } from "react";
 
 import { css } from "@hashintel/ds-helpers/css";
 
-import { useLatest } from "../../../../../../react/hooks/use-latest";
 import { UserSettingsContext } from "../../../../../../react/state/user-settings-context";
 import { useTransitionFrame } from "../../../canvas-frame-store";
 import { useFiringDelta } from "../../../hooks/use-firing-delta";
@@ -53,19 +52,11 @@ function useFiringAnimation(
   pathRef: React.RefObject<SVGPathElement | null>,
   firingDelta: number | null,
   weight: number,
-  endpoints: {
-    sourceX: number;
-    sourceY: number;
-    targetX: number;
-    targetY: number;
-  },
 ): void {
   const animationStateRef = useRef<AnimationState | null>(null);
   // The viewport is read when a firing lands rather than subscribed to, so a
   // pan or a zoom does not re-render every arc on the canvas.
   const store = useStoreApi();
-  // Held in a ref so a node drag during a firing does not restart it.
-  const endpointsRef = useLatest(endpoints);
 
   useEffect(() => {
     // Only start a new animation when there's an actual firing (delta > 0)
@@ -73,9 +64,18 @@ function useFiringAnimation(
       return;
     }
 
-    const { sourceX, sourceY, targetX, targetY } = endpointsRef.current;
+    // The box the drawn path occupies, in flow units: a curve can sweep well
+    // past its endpoints, so where it is drawn is what decides, whichever
+    // rendering made it.
+    const box = pathRef.current.getBBox();
     if (
-      !arcFiringIsVisible(store.getState(), sourceX, sourceY, targetX, targetY)
+      !arcFiringIsVisible(
+        store.getState(),
+        box.x,
+        box.y,
+        box.x + box.width,
+        box.y + box.height,
+      )
     ) {
       return;
     }
@@ -131,7 +131,7 @@ function useFiringAnimation(
         animationStateRef.current = null;
       }
     };
-  }, [firingDelta, pathRef, weight, endpointsRef, store]);
+  }, [firingDelta, pathRef, weight, store]);
 
   // Cancel animation on unmount
   useEffect(() => {
@@ -318,12 +318,7 @@ export const Arc: React.FC<EdgeProps<ArcEdgeType>> = ({
   const arcPathRef = useRef<SVGPathElement | null>(null);
 
   // Animate stroke width when firing delta changes (scaled by arc weight)
-  useFiringAnimation(arcPathRef, firingDelta, data?.weight ?? 1, {
-    sourceX,
-    sourceY,
-    targetX,
-    targetY,
-  });
+  useFiringAnimation(arcPathRef, firingDelta, data?.weight ?? 1);
 
   // Compute path based on arc rendering setting.
   const [arcPath, labelX, labelY] =

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/arc.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/arc.tsx
@@ -4,11 +4,13 @@ import {
   getBezierPath,
   getSmoothStepPath,
   type Position,
+  useStoreApi,
 } from "@xyflow/react";
 import { type CSSProperties, use, useEffect, useRef } from "react";
 
 import { css } from "@hashintel/ds-helpers/css";
 
+import { useLatest } from "../../../../../../react/hooks/use-latest";
 import { UserSettingsContext } from "../../../../../../react/state/user-settings-context";
 import { useTransitionFrame } from "../../../canvas-frame-store";
 import { useFiringDelta } from "../../../hooks/use-firing-delta";
@@ -17,6 +19,7 @@ import {
   ARC_WHITE_OVERHANG,
   arcHaloColor,
 } from "../../../styles/focus";
+import { arcFiringIsVisible } from "./firing-animation-visibility";
 
 import type { ArcData, ArcEdgeType } from "./react-flow-types";
 
@@ -50,12 +53,29 @@ function useFiringAnimation(
   pathRef: React.RefObject<SVGPathElement | null>,
   firingDelta: number | null,
   weight: number,
+  endpoints: {
+    sourceX: number;
+    sourceY: number;
+    targetX: number;
+    targetY: number;
+  },
 ): void {
   const animationStateRef = useRef<AnimationState | null>(null);
+  const store = useStoreApi();
+  // Read in the effect rather than subscribed to, so a pan or a zoom does not
+  // re-render every arc on the canvas.
+  const endpointsRef = useLatest(endpoints);
 
   useEffect(() => {
     // Only start a new animation when there's an actual firing (delta > 0)
     if (firingDelta === null || firingDelta <= 0 || pathRef.current === null) {
+      return;
+    }
+
+    const { sourceX, sourceY, targetX, targetY } = endpointsRef.current;
+    if (
+      !arcFiringIsVisible(store.getState(), sourceX, sourceY, targetX, targetY)
+    ) {
       return;
     }
 
@@ -110,7 +130,7 @@ function useFiringAnimation(
         animationStateRef.current = null;
       }
     };
-  }, [firingDelta, pathRef, weight]);
+  }, [firingDelta, pathRef, weight, endpointsRef, store]);
 
   // Cancel animation on unmount
   useEffect(() => {
@@ -297,7 +317,12 @@ export const Arc: React.FC<EdgeProps<ArcEdgeType>> = ({
   const arcPathRef = useRef<SVGPathElement | null>(null);
 
   // Animate stroke width when firing delta changes (scaled by arc weight)
-  useFiringAnimation(arcPathRef, firingDelta, data?.weight ?? 1);
+  useFiringAnimation(arcPathRef, firingDelta, data?.weight ?? 1, {
+    sourceX,
+    sourceY,
+    targetX,
+    targetY,
+  });
 
   // Compute path based on arc rendering setting.
   const [arcPath, labelX, labelY] =

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/arc.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/arc.tsx
@@ -61,9 +61,10 @@ function useFiringAnimation(
   },
 ): void {
   const animationStateRef = useRef<AnimationState | null>(null);
+  // The viewport is read when a firing lands rather than subscribed to, so a
+  // pan or a zoom does not re-render every arc on the canvas.
   const store = useStoreApi();
-  // Read in the effect rather than subscribed to, so a pan or a zoom does not
-  // re-render every arc on the canvas.
+  // Held in a ref so a node drag during a firing does not restart it.
   const endpointsRef = useLatest(endpoints);
 
   useEffect(() => {

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/classic-transition-node.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/classic-transition-node.tsx
@@ -1,13 +1,15 @@
-import { Handle, type NodeProps, Position } from "@xyflow/react";
+import { Handle, type NodeProps, Position, useStoreApi } from "@xyflow/react";
 import { useEffect, useRef } from "react";
 
 import { Icon } from "@hashintel/ds-components";
 import { css } from "@hashintel/ds-helpers/css";
 
+import { useLatest } from "../../../../../../react/hooks/use-latest";
 import { useTransitionFrame } from "../../../canvas-frame-store";
 import { useFiringDelta } from "../../../hooks/use-firing-delta";
 import { nodeFocusStyle } from "../../../styles/focus";
 import { handleStyling } from "../../../styles/styling";
+import { nodeFiringIsVisible } from "./firing-animation-visibility";
 
 import type { TransitionNodeType } from "./react-flow-types";
 
@@ -83,7 +85,13 @@ function useFiringAnimation(
   boxRef: React.RefObject<HTMLDivElement | null>,
   boltRef: React.RefObject<HTMLDivElement | null>,
   firingDelta: number | null,
+  position: { x: number; y: number },
 ): void {
+  const store = useStoreApi();
+  // Read in the effect rather than subscribed to, so panning and zooming do
+  // not re-render every transition on the canvas.
+  const positionRef = useLatest(position);
+
   useEffect(() => {
     // Only animate when there's an actual firing (delta > 0)
     if (firingDelta === null || firingDelta <= 0) {
@@ -94,6 +102,11 @@ function useFiringAnimation(
     const bolt = boltRef.current;
 
     if (!box || !bolt) {
+      return;
+    }
+
+    const { x, y } = positionRef.current;
+    if (!nodeFiringIsVisible(store.getState(), x, y)) {
       return;
     }
 
@@ -127,13 +140,15 @@ function useFiringAnimation(
         fill: "forwards",
       },
     );
-  }, [firingDelta, boxRef, boltRef]);
+  }, [firingDelta, boxRef, boltRef, positionRef, store]);
 }
 
 export const ClassicTransitionNode: React.FC<NodeProps<TransitionNodeType>> = ({
   id,
   data,
   isConnectable,
+  positionAbsoluteX,
+  positionAbsoluteY,
   selected,
 }: NodeProps<TransitionNodeType>) => {
   const { label } = data;
@@ -147,7 +162,10 @@ export const ClassicTransitionNode: React.FC<NodeProps<TransitionNodeType>> = ({
   const firingDelta = useFiringDelta(frame?.firingCount ?? null);
 
   // Animate when firing occurs
-  useFiringAnimation(boxRef, boltRef, firingDelta);
+  useFiringAnimation(boxRef, boltRef, firingDelta, {
+    x: positionAbsoluteX,
+    y: positionAbsoluteY,
+  });
 
   // React Flow marks a node selected as a drag-selection is drawn, before the
   // change reaches the editor's own selection.

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/classic-transition-node.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/classic-transition-node.tsx
@@ -1,19 +1,16 @@
-import { Handle, type NodeProps, Position, useStoreApi } from "@xyflow/react";
-import { useEffect, useRef } from "react";
+import { Handle, type NodeProps, Position } from "@xyflow/react";
+import { useRef } from "react";
 
 import { Icon } from "@hashintel/ds-components";
 import { css } from "@hashintel/ds-helpers/css";
 
-import { useLatest } from "../../../../../../react/hooks/use-latest";
 import { useTransitionFrame } from "../../../canvas-frame-store";
 import { useFiringDelta } from "../../../hooks/use-firing-delta";
 import { nodeFocusStyle } from "../../../styles/focus";
 import { handleStyling } from "../../../styles/styling";
-import { nodeFiringIsVisible } from "./firing-animation-visibility";
+import { useTransitionFiringAnimation } from "./use-transition-firing-animation";
 
 import type { TransitionNodeType } from "./react-flow-types";
-
-const FIRING_ANIMATION_DURATION_MS = 300;
 
 const containerStyle = css({
   position: "relative",
@@ -77,72 +74,6 @@ const firingIndicatorStyle = css({
   transform: "scale(0.5)",
 });
 
-/**
- * Hook to animate the transition box and lightning bolt when firing.
- * Uses Web Animations API for smooth, programmatic control.
- */
-function useFiringAnimation(
-  boxRef: React.RefObject<HTMLDivElement | null>,
-  boltRef: React.RefObject<HTMLDivElement | null>,
-  firingDelta: number | null,
-  position: { x: number; y: number },
-): void {
-  const store = useStoreApi();
-  // Read in the effect rather than subscribed to, so panning and zooming do
-  // not re-render every transition on the canvas.
-  const positionRef = useLatest(position);
-
-  useEffect(() => {
-    // Only animate when there's an actual firing (delta > 0)
-    if (firingDelta === null || firingDelta <= 0) {
-      return;
-    }
-
-    const box = boxRef.current;
-    const bolt = boltRef.current;
-
-    if (!box || !bolt) {
-      return;
-    }
-
-    const { x, y } = positionRef.current;
-    if (!nodeFiringIsVisible(store.getState(), x, y)) {
-      return;
-    }
-
-    // Flash the box yellow with a glow. Only the flash is a keyframe: the
-    // animation runs back to whatever the stylesheet says, so the focus ring's
-    // white band in `box-shadow` returns once it is over instead of staying
-    // replaced by the glow's transparent end.
-    box.animate(
-      [
-        {
-          background: "rgba(255, 224, 132, 0.7)",
-          boxShadow: "0 0 6px 1px rgba(255, 132, 0, 0.59)",
-          offset: 0,
-        },
-      ],
-      {
-        duration: FIRING_ANIMATION_DURATION_MS,
-        easing: "ease-out",
-      },
-    );
-
-    // Animate the lightning bolt: appear then fade out
-    bolt.animate(
-      [
-        { opacity: 1, transform: "scale(1)" },
-        { opacity: 0, transform: "scale(0.5)" },
-      ],
-      {
-        duration: FIRING_ANIMATION_DURATION_MS * 3,
-        easing: "cubic-bezier(0.4, 0, 0.2, 1)",
-        fill: "forwards",
-      },
-    );
-  }, [firingDelta, boxRef, boltRef, positionRef, store]);
-}
-
 export const ClassicTransitionNode: React.FC<NodeProps<TransitionNodeType>> = ({
   id,
   data,
@@ -162,7 +93,7 @@ export const ClassicTransitionNode: React.FC<NodeProps<TransitionNodeType>> = ({
   const firingDelta = useFiringDelta(frame?.firingCount ?? null);
 
   // Animate when firing occurs
-  useFiringAnimation(boxRef, boltRef, firingDelta, {
+  useTransitionFiringAnimation(boxRef, boltRef, firingDelta, {
     x: positionAbsoluteX,
     y: positionAbsoluteY,
   });

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/firing-animation-visibility.test.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/firing-animation-visibility.test.ts
@@ -36,7 +36,7 @@ describe("nodeFiringIsVisible", () => {
 
   it("skips everything once the net is drawn too small to read", () => {
     expect(nodeFiringIsVisible(viewport([0, 0, 0.1]), 500, 300)).toBe(false);
-    // The margin scales with the zoom, so a distant node stays out at any zoom.
+    // Just above the threshold the same node animates.
     expect(nodeFiringIsVisible(viewport([0, 0, 0.3]), 500, 300)).toBe(true);
   });
 });

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/firing-animation-visibility.test.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/firing-animation-visibility.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  arcFiringIsVisible,
+  nodeFiringIsVisible,
+  type ViewportState,
+} from "./firing-animation-visibility";
+
+/** A 1000x600 pane showing the net at 1:1, panned to the origin. */
+const viewport = (
+  transform: [number, number, number] = [0, 0, 1],
+): ViewportState => ({ transform, width: 1000, height: 600 });
+
+describe("nodeFiringIsVisible", () => {
+  it("animates a node in the pane", () => {
+    expect(nodeFiringIsVisible(viewport(), 500, 300)).toBe(true);
+  });
+
+  it("skips a node well off the side", () => {
+    expect(nodeFiringIsVisible(viewport(), 5000, 300)).toBe(false);
+    expect(nodeFiringIsVisible(viewport(), -5000, 300)).toBe(false);
+    expect(nodeFiringIsVisible(viewport(), 500, -5000)).toBe(false);
+  });
+
+  it("keeps a node just past the edge, whose body still shows", () => {
+    // A node's coordinates are its top-left corner, so one sitting just off
+    // the right edge is still partly in view.
+    expect(nodeFiringIsVisible(viewport(), 1050, 300)).toBe(true);
+  });
+
+  it("follows the pan", () => {
+    // Panned 2000px left, a node at x=2200 lands at x=200 on screen.
+    expect(nodeFiringIsVisible(viewport([-2000, 0, 1]), 2200, 300)).toBe(true);
+    expect(nodeFiringIsVisible(viewport([-2000, 0, 1]), 200, 300)).toBe(false);
+  });
+
+  it("skips everything once the net is drawn too small to read", () => {
+    expect(nodeFiringIsVisible(viewport([0, 0, 0.1]), 500, 300)).toBe(false);
+    // The margin scales with the zoom, so a distant node stays out at any zoom.
+    expect(nodeFiringIsVisible(viewport([0, 0, 0.3]), 500, 300)).toBe(true);
+  });
+});
+
+describe("arcFiringIsVisible", () => {
+  it("animates an arc crossing the pane, whichever way it runs", () => {
+    expect(arcFiringIsVisible(viewport(), -400, 300, 1400, 300)).toBe(true);
+    expect(arcFiringIsVisible(viewport(), 1400, 300, -400, 300)).toBe(true);
+  });
+
+  it("skips an arc whose whole span is off screen", () => {
+    expect(arcFiringIsVisible(viewport(), 3000, 300, 4000, 300)).toBe(false);
+  });
+
+  it("skips an arc when the net is drawn too small to read", () => {
+    expect(arcFiringIsVisible(viewport([0, 0, 0.1]), 0, 0, 500, 300)).toBe(
+      false,
+    );
+  });
+});

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/firing-animation-visibility.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/firing-animation-visibility.ts
@@ -25,17 +25,17 @@ export type ViewportState = {
 const MIN_ANIMATION_ZOOM = 0.25;
 
 /**
- * Flow units of slack around the pane. Node coordinates are the node's
- * top-left corner and an arc's are its endpoints, so the visible area is
- * widened by roughly a node to cover the rest of the shape.
+ * Flow units of slack around the pane. A node's coordinates are its top-left
+ * corner, so the visible area is widened by roughly a node to cover the rest
+ * of the shape.
  */
 const VISIBILITY_MARGIN = 200;
 
 /**
  * Whether the box spanning two points in flow coordinates overlaps the pane.
  *
- * Points may arrive in either order — an arc runs in any direction — so the
- * span is normalised here rather than at each call site.
+ * Points may arrive in either order, so the span is normalised here rather
+ * than at each call site.
  */
 const spanIsVisible = (
   viewport: ViewportState,
@@ -71,14 +71,14 @@ export const nodeFiringIsVisible = (
 ): boolean => spanIsVisible(viewport, x, y, x, y);
 
 /**
- * Whether an arc between these two flow positions should play its firing
- * animation. The arc is drawn as a curve, so the box between its endpoints
- * understates it; the margin covers the bulge.
+ * Whether an arc drawn within this box, in flow units, should play its firing
+ * animation. The box is the drawn path's own, so a curve that sweeps past its
+ * endpoints counts where it is drawn.
  */
 export const arcFiringIsVisible = (
   viewport: ViewportState,
-  sourceX: number,
-  sourceY: number,
-  targetX: number,
-  targetY: number,
-): boolean => spanIsVisible(viewport, sourceX, sourceY, targetX, targetY);
+  left: number,
+  top: number,
+  right: number,
+  bottom: number,
+): boolean => spanIsVisible(viewport, left, top, right, bottom);

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/firing-animation-visibility.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/firing-animation-visibility.ts
@@ -2,11 +2,8 @@
  * Whether a firing is close enough to see to be worth animating.
  *
  * Each transition that fires animates its box, its bolt and every arc it
- * touches, and each of those animations is resolved and painted on the main
- * thread for as long as it runs. On a large net that is hundreds of
- * animations in flight at once, which costs more per frame than everything
- * else the canvas does: on a 1000-node net, dropping them takes a scrub from
- * 13 to 48 frames per second.
+ * touches, and each animation is resolved and painted on the main thread for
+ * as long as it runs, so on a large net hundreds run at once.
  *
  * Most of that work is invisible. A node off the side of the pane cannot be
  * seen at all, and one drawn at a twentieth of its size is a smudge a few
@@ -22,8 +19,8 @@ export type ViewportState = {
 };
 
 /**
- * Zoom below which a firing is not animated. A transition's box is around
- * 40px wide, so this is the point where its flash covers ten pixels.
+ * Zoom below which a firing is not animated. Below it a compact transition
+ * is under 45px across, and its flash reads as a flicker rather than a firing.
  */
 const MIN_ANIMATION_ZOOM = 0.25;
 
@@ -33,12 +30,6 @@ const MIN_ANIMATION_ZOOM = 0.25;
  * widened by roughly a node to cover the rest of the shape.
  */
 const VISIBILITY_MARGIN = 200;
-
-const toScreenX = (x: number, { transform }: ViewportState): number =>
-  x * transform[2] + transform[0];
-
-const toScreenY = (y: number, { transform }: ViewportState): number =>
-  y * transform[2] + transform[1];
 
 /**
  * Whether the box spanning two points in flow coordinates overlaps the pane.
@@ -53,24 +44,15 @@ const spanIsVisible = (
   secondX: number,
   secondY: number,
 ): boolean => {
-  const margin = VISIBILITY_MARGIN * viewport.transform[2];
-  const left = Math.min(
-    toScreenX(firstX, viewport),
-    toScreenX(secondX, viewport),
-  );
-  const right = Math.max(
-    toScreenX(firstX, viewport),
-    toScreenX(secondX, viewport),
-  );
-  const top = Math.min(
-    toScreenY(firstY, viewport),
-    toScreenY(secondY, viewport),
-  );
-  const bottom = Math.max(
-    toScreenY(firstY, viewport),
-    toScreenY(secondY, viewport),
-  );
-
+  const [panX, panY, zoom] = viewport.transform;
+  if (zoom < MIN_ANIMATION_ZOOM) {
+    return false;
+  }
+  const margin = VISIBILITY_MARGIN * zoom;
+  const left = Math.min(firstX, secondX) * zoom + panX;
+  const right = Math.max(firstX, secondX) * zoom + panX;
+  const top = Math.min(firstY, secondY) * zoom + panY;
+  const bottom = Math.max(firstY, secondY) * zoom + panY;
   return (
     right >= -margin &&
     bottom >= -margin &&
@@ -86,9 +68,7 @@ export const nodeFiringIsVisible = (
   viewport: ViewportState,
   x: number,
   y: number,
-): boolean =>
-  viewport.transform[2] >= MIN_ANIMATION_ZOOM &&
-  spanIsVisible(viewport, x, y, x, y);
+): boolean => spanIsVisible(viewport, x, y, x, y);
 
 /**
  * Whether an arc between these two flow positions should play its firing
@@ -101,6 +81,4 @@ export const arcFiringIsVisible = (
   sourceY: number,
   targetX: number,
   targetY: number,
-): boolean =>
-  viewport.transform[2] >= MIN_ANIMATION_ZOOM &&
-  spanIsVisible(viewport, sourceX, sourceY, targetX, targetY);
+): boolean => spanIsVisible(viewport, sourceX, sourceY, targetX, targetY);

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/firing-animation-visibility.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/firing-animation-visibility.ts
@@ -1,0 +1,106 @@
+/**
+ * Whether a firing is close enough to see to be worth animating.
+ *
+ * Each transition that fires animates its box, its bolt and every arc it
+ * touches, and each of those animations is resolved and painted on the main
+ * thread for as long as it runs. On a large net that is hundreds of
+ * animations in flight at once, which costs more per frame than everything
+ * else the canvas does: on a 1000-node net, dropping them takes a scrub from
+ * 13 to 48 frames per second.
+ *
+ * Most of that work is invisible. A node off the side of the pane cannot be
+ * seen at all, and one drawn at a twentieth of its size is a smudge a few
+ * pixels across. Both are skipped, so the animations that survive are the
+ * ones somebody is looking at.
+ */
+
+/** React Flow's `[panX, panY, zoom]`, with the pane's size in pixels. */
+export type ViewportState = {
+  transform: [number, number, number];
+  width: number;
+  height: number;
+};
+
+/**
+ * Zoom below which a firing is not animated. A transition's box is around
+ * 40px wide, so this is the point where its flash covers ten pixels.
+ */
+const MIN_ANIMATION_ZOOM = 0.25;
+
+/**
+ * Flow units of slack around the pane. Node coordinates are the node's
+ * top-left corner and an arc's are its endpoints, so the visible area is
+ * widened by roughly a node to cover the rest of the shape.
+ */
+const VISIBILITY_MARGIN = 200;
+
+const toScreenX = (x: number, { transform }: ViewportState): number =>
+  x * transform[2] + transform[0];
+
+const toScreenY = (y: number, { transform }: ViewportState): number =>
+  y * transform[2] + transform[1];
+
+/**
+ * Whether the box spanning two points in flow coordinates overlaps the pane.
+ *
+ * Points may arrive in either order — an arc runs in any direction — so the
+ * span is normalised here rather than at each call site.
+ */
+const spanIsVisible = (
+  viewport: ViewportState,
+  firstX: number,
+  firstY: number,
+  secondX: number,
+  secondY: number,
+): boolean => {
+  const margin = VISIBILITY_MARGIN * viewport.transform[2];
+  const left = Math.min(
+    toScreenX(firstX, viewport),
+    toScreenX(secondX, viewport),
+  );
+  const right = Math.max(
+    toScreenX(firstX, viewport),
+    toScreenX(secondX, viewport),
+  );
+  const top = Math.min(
+    toScreenY(firstY, viewport),
+    toScreenY(secondY, viewport),
+  );
+  const bottom = Math.max(
+    toScreenY(firstY, viewport),
+    toScreenY(secondY, viewport),
+  );
+
+  return (
+    right >= -margin &&
+    bottom >= -margin &&
+    left <= viewport.width + margin &&
+    top <= viewport.height + margin
+  );
+};
+
+/**
+ * Whether a node at this flow position should play its firing animation.
+ */
+export const nodeFiringIsVisible = (
+  viewport: ViewportState,
+  x: number,
+  y: number,
+): boolean =>
+  viewport.transform[2] >= MIN_ANIMATION_ZOOM &&
+  spanIsVisible(viewport, x, y, x, y);
+
+/**
+ * Whether an arc between these two flow positions should play its firing
+ * animation. The arc is drawn as a curve, so the box between its endpoints
+ * understates it; the margin covers the bulge.
+ */
+export const arcFiringIsVisible = (
+  viewport: ViewportState,
+  sourceX: number,
+  sourceY: number,
+  targetX: number,
+  targetY: number,
+): boolean =>
+  viewport.transform[2] >= MIN_ANIMATION_ZOOM &&
+  spanIsVisible(viewport, sourceX, sourceY, targetX, targetY);

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/transition-node.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/transition-node.tsx
@@ -1,25 +1,21 @@
-import { useStoreApi } from "@xyflow/react";
-import { useEffect, useRef } from "react";
+import { useRef } from "react";
 
 import { Icon } from "@hashintel/ds-components";
 import { css } from "@hashintel/ds-helpers/css";
 
-import { useLatest } from "../../../../../../react/hooks/use-latest";
 import { useTransitionFrame } from "../../../canvas-frame-store";
 import { useFiringDelta } from "../../../hooks/use-firing-delta";
 import { nodeFocusStyle } from "../../../styles/focus";
-import { nodeFiringIsVisible } from "./firing-animation-visibility";
 import {
   iconBadgeStyle,
   iconContainerBaseStyle,
   NodeCard,
   nodeCardStyle,
 } from "./node-card";
+import { useTransitionFiringAnimation } from "./use-transition-firing-animation";
 
 import type { TransitionNodeType } from "./react-flow-types";
 import type { NodeProps } from "@xyflow/react";
-
-const FIRING_ANIMATION_DURATION_MS = 300;
 
 const transitionCardStyle = css({
   borderColor: "neutral.s70",
@@ -47,72 +43,6 @@ const firingIndicatorStyle = css({
   transform: "scale(0.5)",
 });
 
-/**
- * Hook to animate the transition box and lightning bolt when firing.
- * Uses Web Animations API for smooth, programmatic control.
- */
-function useFiringAnimation(
-  boxRef: React.RefObject<HTMLDivElement | null>,
-  boltRef: React.RefObject<HTMLDivElement | null>,
-  firingDelta: number | null,
-  position: { x: number; y: number },
-): void {
-  const store = useStoreApi();
-  // Read in the effect rather than subscribed to, so panning and zooming do
-  // not re-render every transition on the canvas.
-  const positionRef = useLatest(position);
-
-  useEffect(() => {
-    // Only animate when there's an actual firing (delta > 0)
-    if (firingDelta === null || firingDelta <= 0) {
-      return;
-    }
-
-    const box = boxRef.current;
-    const bolt = boltRef.current;
-
-    if (!box || !bolt) {
-      return;
-    }
-
-    const { x, y } = positionRef.current;
-    if (!nodeFiringIsVisible(store.getState(), x, y)) {
-      return;
-    }
-
-    // Flash the box yellow with a glow. Only the flash is a keyframe: the
-    // animation runs back to whatever the stylesheet says, so the focus ring's
-    // white band in `box-shadow` returns once it is over instead of staying
-    // replaced by the glow's transparent end.
-    box.animate(
-      [
-        {
-          background: "rgba(255, 224, 132, 0.7)",
-          boxShadow: "0 0 6px 1px rgba(255, 132, 0, 0.59)",
-          offset: 0,
-        },
-      ],
-      {
-        duration: FIRING_ANIMATION_DURATION_MS,
-        easing: "ease-out",
-      },
-    );
-
-    // Animate the lightning bolt: appear then fade out
-    bolt.animate(
-      [
-        { opacity: 1, transform: "scale(1)" },
-        { opacity: 0, transform: "scale(0.5)" },
-      ],
-      {
-        duration: FIRING_ANIMATION_DURATION_MS * 3,
-        easing: "cubic-bezier(0.4, 0, 0.2, 1)",
-        fill: "forwards",
-      },
-    );
-  }, [firingDelta, boxRef, boltRef, positionRef, store]);
-}
-
 export const TransitionNode: React.FC<NodeProps<TransitionNodeType>> = ({
   id,
   data,
@@ -132,7 +62,7 @@ export const TransitionNode: React.FC<NodeProps<TransitionNodeType>> = ({
   const firingDelta = useFiringDelta(frame?.firingCount ?? null);
 
   // Animate when firing occurs
-  useFiringAnimation(boxRef, boltRef, firingDelta, {
+  useTransitionFiringAnimation(boxRef, boltRef, firingDelta, {
     x: positionAbsoluteX,
     y: positionAbsoluteY,
   });

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/transition-node.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/transition-node.tsx
@@ -1,11 +1,14 @@
+import { useStoreApi } from "@xyflow/react";
 import { useEffect, useRef } from "react";
 
 import { Icon } from "@hashintel/ds-components";
 import { css } from "@hashintel/ds-helpers/css";
 
+import { useLatest } from "../../../../../../react/hooks/use-latest";
 import { useTransitionFrame } from "../../../canvas-frame-store";
 import { useFiringDelta } from "../../../hooks/use-firing-delta";
 import { nodeFocusStyle } from "../../../styles/focus";
+import { nodeFiringIsVisible } from "./firing-animation-visibility";
 import {
   iconBadgeStyle,
   iconContainerBaseStyle,
@@ -52,7 +55,13 @@ function useFiringAnimation(
   boxRef: React.RefObject<HTMLDivElement | null>,
   boltRef: React.RefObject<HTMLDivElement | null>,
   firingDelta: number | null,
+  position: { x: number; y: number },
 ): void {
+  const store = useStoreApi();
+  // Read in the effect rather than subscribed to, so panning and zooming do
+  // not re-render every transition on the canvas.
+  const positionRef = useLatest(position);
+
   useEffect(() => {
     // Only animate when there's an actual firing (delta > 0)
     if (firingDelta === null || firingDelta <= 0) {
@@ -63,6 +72,11 @@ function useFiringAnimation(
     const bolt = boltRef.current;
 
     if (!box || !bolt) {
+      return;
+    }
+
+    const { x, y } = positionRef.current;
+    if (!nodeFiringIsVisible(store.getState(), x, y)) {
       return;
     }
 
@@ -96,13 +110,15 @@ function useFiringAnimation(
         fill: "forwards",
       },
     );
-  }, [firingDelta, boxRef, boltRef]);
+  }, [firingDelta, boxRef, boltRef, positionRef, store]);
 }
 
 export const TransitionNode: React.FC<NodeProps<TransitionNodeType>> = ({
   id,
   data,
   isConnectable,
+  positionAbsoluteX,
+  positionAbsoluteY,
   selected,
 }: NodeProps<TransitionNodeType>) => {
   const { label } = data;
@@ -116,7 +132,10 @@ export const TransitionNode: React.FC<NodeProps<TransitionNodeType>> = ({
   const firingDelta = useFiringDelta(frame?.firingCount ?? null);
 
   // Animate when firing occurs
-  useFiringAnimation(boxRef, boltRef, firingDelta);
+  useFiringAnimation(boxRef, boltRef, firingDelta, {
+    x: positionAbsoluteX,
+    y: positionAbsoluteY,
+  });
 
   // React Flow marks a node selected as a drag-selection is drawn, before the
   // change reaches the editor's own selection.

--- a/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/use-transition-firing-animation.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/SDCPN/renderers/react-flow/react-flow-canvas/use-transition-firing-animation.ts
@@ -1,0 +1,75 @@
+import { useStoreApi } from "@xyflow/react";
+import { useEffect } from "react";
+
+import { useLatest } from "../../../../../../react/hooks/use-latest";
+import { nodeFiringIsVisible } from "./firing-animation-visibility";
+
+const FIRING_ANIMATION_DURATION_MS = 300;
+
+/**
+ * Flashes a transition's box and its lightning bolt when it fires, through
+ * the Web Animations API. Skipped for a transition that is off screen or
+ * drawn too small to see.
+ */
+export const useTransitionFiringAnimation = (
+  boxRef: React.RefObject<HTMLDivElement | null>,
+  boltRef: React.RefObject<HTMLDivElement | null>,
+  firingDelta: number | null,
+  position: { x: number; y: number },
+): void => {
+  // The viewport is read when a firing lands rather than subscribed to, so a
+  // pan or a zoom does not re-render every transition on the canvas.
+  const store = useStoreApi();
+  // Held in a ref so a node drag during a firing does not restart it.
+  const positionRef = useLatest(position);
+
+  useEffect(() => {
+    // Only animate when there's an actual firing (delta > 0)
+    if (firingDelta === null || firingDelta <= 0) {
+      return;
+    }
+
+    const box = boxRef.current;
+    const bolt = boltRef.current;
+
+    if (!box || !bolt) {
+      return;
+    }
+
+    const { x, y } = positionRef.current;
+    if (!nodeFiringIsVisible(store.getState(), x, y)) {
+      return;
+    }
+
+    // Flash the box yellow with a glow. Only the flash is a keyframe: the
+    // animation runs back to whatever the stylesheet says, so the focus ring's
+    // white band in `box-shadow` returns once it is over instead of staying
+    // replaced by the glow's transparent end.
+    box.animate(
+      [
+        {
+          background: "rgba(255, 224, 132, 0.7)",
+          boxShadow: "0 0 6px 1px rgba(255, 132, 0, 0.59)",
+          offset: 0,
+        },
+      ],
+      {
+        duration: FIRING_ANIMATION_DURATION_MS,
+        easing: "ease-out",
+      },
+    );
+
+    // Animate the lightning bolt: appear then fade out
+    bolt.animate(
+      [
+        { opacity: 1, transform: "scale(1)" },
+        { opacity: 0, transform: "scale(0.5)" },
+      ],
+      {
+        duration: FIRING_ANIMATION_DURATION_MS * 3,
+        easing: "cubic-bezier(0.4, 0, 0.2, 1)",
+        fill: "forwards",
+      },
+    );
+  }, [firingDelta, boxRef, boltRef, positionRef, store]);
+};


### PR DESCRIPTION
## Summary

Before this PR, playing or scrubbing a large net cost far more than the canvas draws. Every transition that fires animates its box, its bolt and each of its arcs, and the style engine resolves and paints each of those for as long as it runs. On a thousand-node net that is hundreds of animations in flight per frame, on nodes a few pixels across that nobody is looking at.

A firing now animates only where it can be seen: nodes and arcs off the side of the pane, and any net drawn small enough that a node covers a few pixels, skip the flash. The transitions in view still animate, and those animations are what the remaining frame time goes to when the canvas is zoomed in.

| Scenario                             | Before | After  |
| ------------------------------------ | ------ | ------ |
| Scrub, 1000 nodes                    | 13 fps | 44 fps |
| Playback, 1000 nodes                 | 16 fps | 39 fps |
| Playback, 1000-node ring, fitted view, this head | 9 fps, p95 250ms | 38 fps, p95 125ms |
| Playback, 1000-node ring, zoomed to an arc, this head | 10 fps, p95 283ms | 13 fps, p95 233ms |

Measured against the built website in headless Chromium, driving a ring net through a run, with frame intervals sampled from `requestAnimationFrame`; the last two rows against production builds of the base and this head with `smoke-ring.mjs`. Zoomed in, the transitions in view still animate, and those animations are what the remaining frame time goes to.

#### Before

https://github.com/user-attachments/assets/158778da-aa77-4ee6-882b-cf1c8371f1f0

#### After

https://github.com/user-attachments/assets/4c3387bb-2fc0-42a5-afc3-680102da60ab

## Links

- Ticket [FE-1671](https://linear.app/hash/issue/FE-1671)
- Docs [Simulation](https://github.com/hashintel/hash/blob/claude/canvas-firing-visibility/libs/%40hashintel/petrinaut/docs/simulation.md)

## Changes

- Firing animations run only on what is on screen
  > A node's position and an arc's endpoints are projected through React Flow's transform in the effect that starts the animation.
  > Reading the transform there rather than subscribing to it keeps a pan or a zoom from re-rendering every node.
- Both transition styles share one firing animation hook
  > `useTransitionFiringAnimation` holds the box and bolt animation once; the compact and classic nodes call it.
- Firing animations stop below a zoom of 0.25
  > Below it a compact transition is under 45px across, and its flash reads as a flicker rather than a firing.

#### Review fixes

- Arc firing judged by the box its drawn path occupies
  > `getBBox()` on the arc's path at firing time, so a curve sweeping past its endpoints animates where it is drawn.

## Test coverage

- `firing-animation-visibility.test.ts`:
  > Projection through pan and zoom, the zoom floor, and arcs that run in either direction.
- Existing `@hashintel/petrinaut` unit suite.

## How to test

- Open [Petrinaut preview](https://petrinaut-git-claude-canvas-firing-visibility.stage.hash.ai) on Vercel
- Menu > Load example > Supply Chain with Disruption
- Press Play
  > Expect transitions to flash and arcs to thicken as they fire
- Zoom out until nodes are a few pixels across
  > Expect no flashes, token counts and the timeline still moving
- Zoom back in
  > Expect flashes on the transitions in view


