### PR TITLE
FE-1672: Hold the simulation timeline still while it is off screen

### DIFF
--- a/.changeset/timeline-holds-still-off-screen.md
+++ b/.changeset/timeline-holds-still-off-screen.md
@@ -1,0 +1,5 @@
+---
+"@hashintel/petrinaut": patch
+---
+
+A closed simulation timeline stops reading frames and stops drawing until it is opened again, and the chart's columns are extended as frames arrive rather than rebuilt from the start of the run on every frame.

--- a/.changeset/timeline-holds-still-off-screen.md
+++ b/.changeset/timeline-holds-still-off-screen.md
@@ -2,4 +2,4 @@
 "@hashintel/petrinaut": patch
 ---
 
-A closed simulation timeline stops reading frames and stops drawing until it is opened again, and the chart's columns are extended as frames arrive rather than rebuilt from the start of the run on every frame.
+A closed simulation timeline stops reading frames and drawing until it is reopened.

--- a/libs/@hashintel/petrinaut/docs/simulation.md
+++ b/libs/@hashintel/petrinaut/docs/simulation.md
@@ -139,6 +139,7 @@ The **Timeline** tab appears in the bottom panel during and after simulation. It
 
 - **Chart type** -- toggle between **Run** (line chart) and **Stacked** (area chart) using the control in the tab header.
 - **Scrub** -- click or drag on the chart to jump to any frame. A playhead indicator shows the current position.
+- **Closing the panel** -- a closed timeline stops reading frames and stops drawing, so a run costs nothing on its account while it is out of sight. Reopen it and it catches up on everything it missed.
 - **Series selector** -- the strip below the chart lists the traces currently shown. Hover a trace and click the eye icon that replaces its colour swatch to hide it; the trace stays in place, struck through, until the pointer leaves the selector, so you can hide several traces in a row or click again to undo a change. Hidden traces are managed from the dropdown: click the **N/M shown** badge (or anywhere else in the selector) to open the full list for searching, which is also where traces that don't fit in the strip live. The badge shows how many traces are currently shown, and your selection is kept while you switch tabs. Use **Select All** or **Unselect All** for bulk changes, or choose **Only** on a trace row to focus the chart on that one series. Y axis is automatically scaled to the maximum value.
 
 ## Viewing state during simulation

--- a/libs/@hashintel/petrinaut/src/react/hooks/use-element-on-screen.ts
+++ b/libs/@hashintel/petrinaut/src/react/hooks/use-element-on-screen.ts
@@ -1,0 +1,74 @@
+import { useEffect, useRef, useState, type RefObject } from "react";
+
+/**
+ * Whether an element overlaps the viewport, kept in sync via
+ * IntersectionObserver.
+ *
+ * A panel that is closed but kept mounted is moved off the viewport rather
+ * than unmounted, so its contents keep running: this reports that, whatever
+ * the mechanism — a panel slid away, a page scrolled past, a container
+ * clipped — so work nobody can see can be skipped.
+ *
+ * Starts `true` and stays `true` where IntersectionObserver is unavailable,
+ * so a caller that gates work on it does that work rather than never doing
+ * it.
+ *
+ * @example
+ * ```tsx
+ * const ref = useRef<HTMLDivElement>(null);
+ * const onScreen = useElementOnScreen(ref);
+ *
+ * return <div ref={ref}>{onScreen ? <Chart /> : null}</div>;
+ * ```
+ */
+export function useElementOnScreen(ref: RefObject<Element | null>): boolean {
+  "use no memo"; // imperative observer management
+
+  const [onScreen, setOnScreen] = useState(true);
+  const observedRef = useRef<Element | null>(null);
+  const observerRef = useRef<IntersectionObserver | null>(null);
+
+  // Deliberately no dependency array, following `useElementSize`: a RefObject
+  // gives no signal when its `.current` changes, and the observed element can
+  // mount after the first commit — so re-check its identity after every
+  // render, and only re-subscribe when the element actually changed.
+  useEffect(() => {
+    const element = ref.current;
+    if (element === observedRef.current) {
+      return;
+    }
+
+    observerRef.current?.disconnect();
+    observerRef.current = null;
+    observedRef.current = element;
+
+    // With no element, or no observer to watch it with, the last answer
+    // stands — as in `useElementSize`, callers gate on the element's presence
+    // anyway and the next observation corrects any drift.
+    if (!element || typeof IntersectionObserver === "undefined") {
+      return;
+    }
+
+    const observer = new IntersectionObserver((entries) => {
+      const entry = entries[entries.length - 1];
+      if (entry) {
+        setOnScreen(entry.isIntersecting);
+      }
+    });
+
+    observer.observe(element);
+    observerRef.current = observer;
+  });
+
+  useEffect(
+    () => () => {
+      observerRef.current?.disconnect();
+      observerRef.current = null;
+      // A replayed setup (Strict Mode) must observe the element again.
+      observedRef.current = null;
+    },
+    [],
+  );
+
+  return onScreen;
+}

--- a/libs/@hashintel/petrinaut/src/react/hooks/use-element-on-screen.ts
+++ b/libs/@hashintel/petrinaut/src/react/hooks/use-element-on-screen.ts
@@ -43,8 +43,7 @@ export function useElementOnScreen(ref: RefObject<Element | null>): boolean {
     observedRef.current = element;
 
     // With no element, or no observer to watch it with, the last answer
-    // stands — as in `useElementSize`, callers gate on the element's presence
-    // anyway and the next observation corrects any drift.
+    // stands; the next observation corrects any drift.
     if (!element || typeof IntersectionObserver === "undefined") {
       return;
     }

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/BottomPanel/subviews/simulation-timeline/actual.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/BottomPanel/subviews/simulation-timeline/actual.tsx
@@ -1,6 +1,7 @@
-import { use, useEffect, useState } from "react";
+import { use, useEffect, useRef, useState } from "react";
 
 import { ExecutionFrameSourceContext } from "../../../../../../../react/execution-frame/context";
+import { useElementOnScreen } from "../../../../../../../react/hooks/use-element-on-screen";
 import { EditorContext } from "../../../../../../../react/state/editor-context";
 import { UPlotChart } from "./chart";
 import { TimelineLegend } from "./legend";
@@ -18,7 +19,15 @@ const ActualTimelineContent: React.FC = () => {
     timelineView,
   } = use(EditorContext);
   const source = use(ExecutionFrameSourceContext);
-  const { store, metricError } = useStreamingData(source);
+
+  // The timeline keeps reading frames and repainting while it is mounted, so
+  // a panel that has been slid off the viewport holds still instead.
+  const containerRef = useRef<HTMLDivElement>(null);
+  const onScreen = useElementOnScreen(containerRef);
+
+  const { store, metricError } = useStreamingData(source, {
+    paused: !onScreen,
+  });
 
   const [isFollowingLive, setIsFollowingLive] = useState(true);
   const { currentFrameIndex, scrubToFrame, totalFrames } = source;
@@ -41,41 +50,34 @@ const ActualTimelineContent: React.FC = () => {
     setIsFollowingLive(frameIndex >= lastFrameIndex);
   };
 
-  if (metricError) {
-    return (
-      <div className={containerStyle}>
+  return (
+    <div className={containerStyle} ref={containerRef}>
+      {metricError ? (
         <span style={{ fontSize: 12, color: "#b91c1c" }}>{metricError}</span>
-      </div>
-    );
-  }
-
-  if (store.length === 0 || totalFrames === 0) {
-    return (
-      <div className={containerStyle}>
+      ) : store.length === 0 || totalFrames === 0 ? (
         <span style={{ fontSize: 12, color: "#999" }}>
           No actual execution data available
         </span>
-      </div>
-    );
-  }
-
-  return (
-    <div className={containerStyle}>
-      <UPlotChart
-        className={chartAreaStyle}
-        store={store}
-        chartType={chartType}
-        hiddenSeries={hiddenSeries}
-        totalFrames={totalFrames}
-        currentFrameIndex={currentFrameIndex}
-        onScrub={handleScrub}
-      />
-      {store.series.length > 1 && (
-        <TimelineLegend
-          series={store.series}
-          hiddenSeries={hiddenSeries}
-          onHiddenSeriesChange={setHiddenSeries}
-        />
+      ) : (
+        <>
+          <UPlotChart
+            className={chartAreaStyle}
+            store={store}
+            chartType={chartType}
+            hiddenSeries={hiddenSeries}
+            totalFrames={totalFrames}
+            currentFrameIndex={currentFrameIndex}
+            onScrub={handleScrub}
+            paused={!onScreen}
+          />
+          {store.series.length > 1 && (
+            <TimelineLegend
+              series={store.series}
+              hiddenSeries={hiddenSeries}
+              onHiddenSeriesChange={setHiddenSeries}
+            />
+          )}
+        </>
       )}
     </div>
   );

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/BottomPanel/subviews/simulation-timeline/chart-data.test.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/BottomPanel/subviews/simulation-timeline/chart-data.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+
+import { createRunDataBuilder, createStackedDataBuilder } from "./chart-data";
+
+import type { StreamingStore, TimelineSeriesMeta } from "./types";
+
+const seriesMeta = (id: string): TimelineSeriesMeta => ({
+  seriesId: id,
+  seriesName: id,
+  color: "#000",
+});
+
+/**
+ * A store, and a way to append one frame to it: a time, then one value per
+ * series, as the streaming hook does.
+ */
+const makeStore = (seriesIds: string[]) => {
+  const store: StreamingStore = {
+    series: seriesIds.map(seriesMeta),
+    columns: [[], ...seriesIds.map(() => [])],
+    length: 0,
+    revision: 0,
+  };
+
+  const append = (time: number, values: number[]) => {
+    store.columns[0]!.push(time);
+    values.forEach((value, index) => store.columns[index + 1]!.push(value));
+    store.length = store.columns[0]!.length;
+  };
+
+  return { store, append };
+};
+
+describe("createRunDataBuilder", () => {
+  it("plots each visible series from the store's own column", () => {
+    const { store, append } = makeStore(["a", "b"]);
+    append(0, [1, 2]);
+    const build = createRunDataBuilder();
+
+    const data = build(store, new Set());
+
+    expect(data[0]).toBe(store.columns[0]);
+    expect(data[1]).toBe(store.columns[1]);
+    expect(data[2]).toBe(store.columns[2]);
+  });
+
+  it("plots a hidden series as gaps, one per frame", () => {
+    const { store, append } = makeStore(["a", "b"]);
+    append(0, [1, 2]);
+    append(1, [3, 4]);
+    const build = createRunDataBuilder();
+
+    const data = build(store, new Set(["a"]));
+
+    expect(data[1]).toStrictEqual([null, null]);
+    expect(data[2]).toBe(store.columns[2]);
+  });
+
+  it("extends the gaps as frames arrive", () => {
+    const { store, append } = makeStore(["a"]);
+    append(0, [1]);
+    const hidden = new Set(["a"]);
+    const build = createRunDataBuilder();
+
+    build(store, hidden);
+    append(1, [2]);
+    const data = build(store, hidden);
+
+    expect(data[1]).toStrictEqual([null, null]);
+  });
+
+  it("rebuilds when the hidden set changes", () => {
+    const { store, append } = makeStore(["a"]);
+    append(0, [1]);
+    const build = createRunDataBuilder();
+
+    build(store, new Set(["a"]));
+    const data = build(store, new Set());
+
+    expect(data[1]).toBe(store.columns[1]);
+  });
+});
+
+describe("createStackedDataBuilder", () => {
+  it("stacks each series on the ones below it, topmost band first", () => {
+    const { store, append } = makeStore(["a", "b", "c"]);
+    append(0, [1, 2, 3]);
+    const build = createStackedDataBuilder();
+
+    const data = build(store, new Set());
+
+    expect(data[0]).toBe(store.columns[0]);
+    // c on b on a: 6, 3, 1 — reversed, because uPlot fills from the top.
+    expect(data[1]).toStrictEqual([6]);
+    expect(data[2]).toStrictEqual([3]);
+    expect(data[3]).toStrictEqual([1]);
+  });
+
+  it("leaves a hidden series out of the sums", () => {
+    const { store, append } = makeStore(["a", "b"]);
+    append(0, [1, 2]);
+    const build = createStackedDataBuilder();
+
+    const data = build(store, new Set(["a"]));
+
+    expect(data).toHaveLength(2);
+    expect(data[1]).toStrictEqual([2]);
+  });
+
+  it("extends to the same sums a rebuild would produce", () => {
+    const { store, append } = makeStore(["a", "b"]);
+    const hidden = new Set<string>();
+    const incremental = createStackedDataBuilder();
+
+    for (const [time, values] of [
+      [0, [1, 2]],
+      [1, [3, 4]],
+      [2, [5, 6]],
+    ] as const) {
+      append(time, [...values]);
+      incremental(store, hidden);
+    }
+
+    const rebuilt = createStackedDataBuilder()(store, hidden);
+
+    expect(incremental(store, hidden)).toStrictEqual(rebuilt);
+    expect(rebuilt[1]).toStrictEqual([3, 7, 11]);
+  });
+
+  it("starts over when the run does", () => {
+    const { store, append } = makeStore(["a"]);
+    const hidden = new Set<string>();
+    const build = createStackedDataBuilder();
+
+    append(0, [5]);
+    build(store, hidden);
+
+    // A reset replaces the columns rather than emptying them.
+    store.columns = [[], []];
+    store.length = 0;
+    append(0, [1]);
+
+    expect(build(store, hidden)[1]).toStrictEqual([1]);
+  });
+
+  it("treats a missing value as zero", () => {
+    const { store } = makeStore(["a", "b"]);
+    store.columns[0]!.push(0);
+    store.columns[1]!.push(2);
+    // The second series has no value for this frame.
+    store.length = 1;
+    const build = createStackedDataBuilder();
+
+    expect(build(store, new Set())[2]).toStrictEqual([2]);
+  });
+});

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/BottomPanel/subviews/simulation-timeline/chart-data.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/BottomPanel/subviews/simulation-timeline/chart-data.ts
@@ -1,0 +1,119 @@
+/**
+ * The columns uPlot draws, extended as frames arrive rather than rebuilt.
+ *
+ * A run appends one row per frame, and the chart is asked for its data again
+ * on every one of them. Building that data from scratch each time costs a
+ * pass over the whole run: on a net with five hundred series, a thousand
+ * frames in, moving the chart on by one column meant half a million
+ * additions and five hundred fresh arrays. Rows are only ever appended, so
+ * both builders keep what they made and extend it, and start over only when
+ * the shape they were built from changes — a different series list, a
+ * different hidden set, or a new run.
+ *
+ * Each builder holds the state for one chart, so a chart makes its own.
+ */
+
+import type { StreamingStore, TimelineSeriesMeta } from "./types";
+import type uPlot from "uplot";
+
+type Source = {
+  time: number[];
+  series: TimelineSeriesMeta[];
+  hidden: Set<string>;
+};
+
+const sameSource = (
+  previous: Source | null,
+  store: StreamingStore,
+  hidden: Set<string>,
+): previous is Source =>
+  previous !== null &&
+  previous.time === store.columns[0] &&
+  previous.series === store.series &&
+  previous.hidden === hidden;
+
+/**
+ * Builds the plain (unstacked) data: the time column, then one column per
+ * series. A hidden series is plotted as gaps, and every hidden series shares
+ * one column of them.
+ */
+export const createRunDataBuilder = (): ((
+  store: StreamingStore,
+  hiddenSeries: Set<string>,
+  length?: number,
+) => uPlot.AlignedData) => {
+  let source: Source | null = null;
+  let gaps: null[] = [];
+  let data: uPlot.AlignedData = [[]];
+
+  return (store, hiddenSeries, length = store.length) => {
+    if (!sameSource(source, store, hiddenSeries)) {
+      source = {
+        time: store.columns[0]!,
+        series: store.series,
+        hidden: hiddenSeries,
+      };
+      gaps = [];
+      data = [
+        store.columns[0]!,
+        ...store.series.map((series, index) =>
+          hiddenSeries.has(series.seriesId) ? gaps : store.columns[index + 1]!,
+        ),
+      ] as uPlot.AlignedData;
+    }
+
+    while (gaps.length < length) {
+      gaps.push(null);
+    }
+
+    return data;
+  };
+};
+
+/**
+ * Builds the stacked data: each band is its series plus everything below it,
+ * ordered from the top down, which is the order uPlot fills bands in.
+ */
+export const createStackedDataBuilder = (): ((
+  store: StreamingStore,
+  hiddenSeries: Set<string>,
+  length?: number,
+) => uPlot.AlignedData) => {
+  let source: Source | null = null;
+  let built = 0;
+  let visibleColumns: number[] = [];
+  let bands: number[][] = [];
+  let data: uPlot.AlignedData = [[]];
+
+  return (store, hiddenSeries, length = store.length) => {
+    if (!sameSource(source, store, hiddenSeries) || length < built) {
+      source = {
+        time: store.columns[0]!,
+        series: store.series,
+        hidden: hiddenSeries,
+      };
+      built = 0;
+      visibleColumns = store.series
+        .map((series, index) => ({ series, column: index + 1 }))
+        .filter(({ series }) => !hiddenSeries.has(series.seriesId))
+        .map(({ column }) => column);
+      bands = visibleColumns.map(() => []);
+      data = [
+        store.columns[0]!,
+        ...[...bands].reverse(),
+      ] as unknown as uPlot.AlignedData;
+    }
+
+    for (let row = built; row < length; row++) {
+      let total = 0;
+      for (let band = 0; band < visibleColumns.length; band++) {
+        total += store.columns[visibleColumns[band]!]![row] ?? 0;
+        bands[band]![row] = total;
+      }
+    }
+
+    built = length;
+
+    return data;
+  };
+};

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/BottomPanel/subviews/simulation-timeline/chart-data.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/BottomPanel/subviews/simulation-timeline/chart-data.ts
@@ -2,13 +2,10 @@
  * The columns uPlot draws, extended as frames arrive rather than rebuilt.
  *
  * A run appends one row per frame, and the chart is asked for its data again
- * on every one of them. Building that data from scratch each time costs a
- * pass over the whole run: on a net with five hundred series, a thousand
- * frames in, moving the chart on by one column meant half a million
- * additions and five hundred fresh arrays. Rows are only ever appended, so
- * both builders keep what they made and extend it, and start over only when
- * the shape they were built from changes — a different series list, a
- * different hidden set, or a new run.
+ * on every one of them. Rows are only ever appended, so both builders keep
+ * what they made and extend it, and start over only when the shape they were
+ * built from changes — a different series list, a different hidden set, or a
+ * new run.
  *
  * Each builder holds the state for one chart, so a chart makes its own.
  */
@@ -22,11 +19,18 @@ type Source = {
   hidden: Set<string>;
 };
 
+/** The data for one chart, extended from what the builder last returned. */
+type ChartDataBuilder = (
+  store: StreamingStore,
+  hiddenSeries: Set<string>,
+  length?: number,
+) => uPlot.AlignedData;
+
 const sameSource = (
   previous: Source | null,
   store: StreamingStore,
   hidden: Set<string>,
-): previous is Source =>
+): boolean =>
   previous !== null &&
   previous.time === store.columns[0] &&
   previous.series === store.series &&
@@ -37,11 +41,7 @@ const sameSource = (
  * series. A hidden series is plotted as gaps, and every hidden series shares
  * one column of them.
  */
-export const createRunDataBuilder = (): ((
-  store: StreamingStore,
-  hiddenSeries: Set<string>,
-  length?: number,
-) => uPlot.AlignedData) => {
+export const createRunDataBuilder = (): ChartDataBuilder => {
   let source: Source | null = null;
   let gaps: null[] = [];
   let data: uPlot.AlignedData = [[]];
@@ -74,11 +74,7 @@ export const createRunDataBuilder = (): ((
  * Builds the stacked data: each band is its series plus everything below it,
  * ordered from the top down, which is the order uPlot fills bands in.
  */
-export const createStackedDataBuilder = (): ((
-  store: StreamingStore,
-  hiddenSeries: Set<string>,
-  length?: number,
-) => uPlot.AlignedData) => {
+export const createStackedDataBuilder = (): ChartDataBuilder => {
   let source: Source | null = null;
   let built = 0;
   let visibleColumns: number[] = [];

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/BottomPanel/subviews/simulation-timeline/chart.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/BottomPanel/subviews/simulation-timeline/chart.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import uPlot from "uplot";
 
 import { useElementSize } from "../../../../../../../react/hooks/use-element-size";
@@ -6,6 +6,7 @@ import "uplot/dist/uPlot.min.css";
 
 import { useLatest } from "../../../../../../../react/hooks/use-latest";
 import { useStableCallback } from "../../../../../../../react/hooks/use-stable-callback";
+import { createRunDataBuilder, createStackedDataBuilder } from "./chart-data";
 import {
   tooltipDotStyle,
   tooltipLabelStyle,
@@ -16,49 +17,6 @@ import {
 import type { TimelineChartType } from "../../../../../../../react/state/editor-context";
 import type { StreamingStore, TimelineSeriesMeta } from "./types";
 import type { FC, RefObject } from "react";
-
-function buildRunData(
-  store: StreamingStore,
-  hiddenSeries: Set<string>,
-  length = store.length,
-): uPlot.AlignedData {
-  const result: (number | null | undefined)[][] = [store.columns[0]!];
-  for (let i = 0; i < store.series.length; i++) {
-    if (hiddenSeries.has(store.series[i]!.seriesId)) {
-      result.push(new Array(length).fill(null));
-    } else {
-      result.push(store.columns[i + 1]!);
-    }
-  }
-  return result as uPlot.AlignedData;
-}
-
-function buildStackedData(
-  store: StreamingStore,
-  hiddenSeries: Set<string>,
-  length = store.length,
-): uPlot.AlignedData {
-  const visible = store.series
-    .map((p, i) => ({ ...p, colIdx: i + 1 }))
-    .filter((p) => !hiddenSeries.has(p.seriesId));
-
-  const cumulative = new Float64Array(length);
-  const series: number[][] = [];
-
-  for (const p of visible) {
-    const col = store.columns[p.colIdx]!;
-    const stacked = new Array<number>(length);
-    for (let i = 0; i < length; i++) {
-      cumulative[i]! += col[i] ?? 0;
-      stacked[i] = cumulative[i]!;
-    }
-    series.push(stacked);
-  }
-
-  series.reverse();
-
-  return [store.columns[0]!, ...series] as uPlot.AlignedData;
-}
 
 interface TooltipNodes {
   root: HTMLDivElement;
@@ -476,6 +434,11 @@ export const UPlotChart: FC<{
   currentFrameIndex: number;
   onScrub: (frameIndex: number) => void;
   className?: string;
+  /**
+   * Hold the chart as it stands. Data and playhead updates are skipped and
+   * applied together when it resumes, so an off-screen chart costs nothing.
+   */
+  paused?: boolean;
 }> = ({
   store,
   chartType,
@@ -484,6 +447,7 @@ export const UPlotChart: FC<{
   currentFrameIndex,
   onScrub,
   className,
+  paused = false,
 }) => {
   "use no memo";
 
@@ -491,6 +455,10 @@ export const UPlotChart: FC<{
   const chartRef = useRef<uPlot | null>(null);
   const playheadFrameRef = useRef(currentFrameIndex);
   const storeRef = useLatest(store);
+
+  // One builder per chart: each keeps the columns it has already made.
+  const [buildRunData] = useState(createRunDataBuilder);
+  const [buildStackedData] = useState(createStackedDataBuilder);
 
   const size = useElementSize(wrapperRef);
   const hasSize = size != null;
@@ -545,6 +513,8 @@ export const UPlotChart: FC<{
       chartRef.current = null;
     };
   }, [
+    buildRunData,
+    buildStackedData,
     chartType,
     hiddenSeries,
     store,
@@ -561,18 +531,32 @@ export const UPlotChart: FC<{
   }, [size]);
 
   useEffect(() => {
+    if (paused) {
+      return;
+    }
+
     const data =
       chartType === "stacked"
         ? buildStackedData(store, hiddenSeries, dataLength)
         : buildRunData(store, hiddenSeries, dataLength);
 
     chartRef.current?.setData(data);
-  }, [chartType, dataLength, hiddenSeries, store]);
+  }, [
+    buildRunData,
+    buildStackedData,
+    chartType,
+    dataLength,
+    hiddenSeries,
+    paused,
+    store,
+  ]);
 
   useEffect(() => {
     playheadFrameRef.current = currentFrameIndex;
-    chartRef.current?.redraw(false, false);
-  }, [currentFrameIndex]);
+    if (!paused) {
+      chartRef.current?.redraw(false, false);
+    }
+  }, [currentFrameIndex, paused]);
 
   return <div ref={wrapperRef} className={className} />;
 };

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/BottomPanel/subviews/simulation-timeline/content.tsx
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/BottomPanel/subviews/simulation-timeline/content.tsx
@@ -1,6 +1,7 @@
-import { use } from "react";
+import { use, useRef } from "react";
 
 import { ExecutionFrameSourceContext } from "../../../../../../../react/execution-frame/context";
+import { useElementOnScreen } from "../../../../../../../react/hooks/use-element-on-screen";
 import { EditorContext } from "../../../../../../../react/state/editor-context";
 import { UPlotChart } from "./chart";
 import { TimelineLegend } from "./legend";
@@ -16,43 +17,45 @@ export const SimulationTimeline: React.FC<{
     timelineChartType: chartType,
   } = use(EditorContext);
   const source = use(ExecutionFrameSourceContext);
-  const { store, metricError } = useStreamingData(source);
 
-  if (metricError) {
-    return (
-      <div className={containerStyle}>
+  // A closed bottom panel is moved off the viewport rather than unmounted, so
+  // without this the timeline would go on reading frames and repainting a
+  // chart nobody can see for as long as the run lasts.
+  const containerRef = useRef<HTMLDivElement>(null);
+  const onScreen = useElementOnScreen(containerRef);
+
+  const { store, metricError } = useStreamingData(source, {
+    paused: !onScreen,
+  });
+
+  return (
+    <div className={containerStyle} ref={containerRef}>
+      {metricError ? (
         <span style={{ fontSize: 12, color: "#b91c1c" }}>{metricError}</span>
-      </div>
-    );
-  }
-
-  if (store.length === 0 || source.totalFrames === 0) {
-    return (
-      <div className={containerStyle}>
+      ) : store.length === 0 || source.totalFrames === 0 ? (
         <span style={{ fontSize: 12, color: "#999" }}>
           No simulation data available
         </span>
-      </div>
-    );
-  }
-
-  return (
-    <div className={containerStyle}>
-      <UPlotChart
-        className={chartAreaStyle}
-        store={store}
-        chartType={chartType}
-        hiddenSeries={hiddenSeries}
-        totalFrames={source.totalFrames}
-        currentFrameIndex={source.currentFrameIndex}
-        onScrub={source.scrubToFrame}
-      />
-      {showLegend && store.series.length > 1 && (
-        <TimelineLegend
-          series={store.series}
-          hiddenSeries={hiddenSeries}
-          onHiddenSeriesChange={setHiddenSeries}
-        />
+      ) : (
+        <>
+          <UPlotChart
+            className={chartAreaStyle}
+            store={store}
+            chartType={chartType}
+            hiddenSeries={hiddenSeries}
+            totalFrames={source.totalFrames}
+            currentFrameIndex={source.currentFrameIndex}
+            onScrub={source.scrubToFrame}
+            paused={!onScreen}
+          />
+          {showLegend && store.series.length > 1 && (
+            <TimelineLegend
+              series={store.series}
+              hiddenSeries={hiddenSeries}
+              onHiddenSeriesChange={setHiddenSeries}
+            />
+          )}
+        </>
       )}
     </div>
   );

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/BottomPanel/subviews/simulation-timeline/use-streaming-data.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/BottomPanel/subviews/simulation-timeline/use-streaming-data.ts
@@ -322,27 +322,26 @@ export function useStreamingData(
 
   // Stream new frames into the store.
   useEffect(() => {
-    let cancelled = false;
-
-    const fetchData = async () => {
-      if (paused) {
-        return;
-      }
-
-      if (totalFrames === 0) {
-        if (storeController.getLength() > 0) {
-          storeController.resetCurrentSeries();
-          processedRef.current = 0;
-        }
-        return;
-      }
-
-      // Handle simulation restart
-      if (totalFrames < processedRef.current) {
+    // A reset is noticed while paused too, so resuming does not append a new
+    // run to the old one's rows.
+    if (totalFrames === 0) {
+      if (storeController.getLength() > 0) {
         storeController.resetCurrentSeries();
         processedRef.current = 0;
       }
+      return;
+    }
+    if (totalFrames < processedRef.current) {
+      storeController.resetCurrentSeries();
+      processedRef.current = 0;
+    }
+    if (paused) {
+      return;
+    }
 
+    let cancelled = false;
+
+    const fetchData = async () => {
       const startIndex = processedRef.current;
       if (startIndex >= totalFrames) {
         return;

--- a/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/BottomPanel/subviews/simulation-timeline/use-streaming-data.ts
+++ b/libs/@hashintel/petrinaut/src/ui/views/Editor/panels/BottomPanel/subviews/simulation-timeline/use-streaming-data.ts
@@ -254,10 +254,20 @@ function useTimelineMetric(metric: Metric | null): TimelineMetricState {
  *    places), values are the sum of token counts across places of that type.
  *  - `metric`: a single series computed by the compiled user metric.
  */
-export function useStreamingData(source: ExecutionFrameSource): {
+export function useStreamingData(
+  source: ExecutionFrameSource,
+  options?: {
+    /**
+     * Stop reading frames. The cursor is kept, so resuming appends everything
+     * that arrived meanwhile in one batch.
+     */
+    paused?: boolean;
+  },
+): {
   store: StreamingStore;
   metricError: string | null;
 } {
+  const paused = options?.paused ?? false;
   const {
     extensions,
     petriNetDefinition: { places, types, transitions, metrics },
@@ -315,6 +325,10 @@ export function useStreamingData(source: ExecutionFrameSource): {
     let cancelled = false;
 
     const fetchData = async () => {
+      if (paused) {
+        return;
+      }
+
       if (totalFrames === 0) {
         if (storeController.getLength() > 0) {
           storeController.resetCurrentSeries();
@@ -349,7 +363,14 @@ export function useStreamingData(source: ExecutionFrameSource): {
     };
     // sourceId is depended on so a source-identity change always restarts
     // frame reads after the reset effect above cleared the store.
-  }, [getFramesInRange, seriesConfig, sourceId, storeController, totalFrames]);
+  }, [
+    getFramesInRange,
+    paused,
+    seriesConfig,
+    sourceId,
+    storeController,
+    totalFrames,
+  ]);
 
   return {
     store,


### PR DESCRIPTION
## Summary

Before this PR, a closed bottom panel was moved off the viewport rather than unmounted, so the simulation timeline went on reading every frame and repainting a chart nobody could see. A stacked chart also re-summed the whole run on every frame to move on by one column.

A timeline that is off screen now stops reading frames and stops drawing until it comes back, and the chart's columns are extended as frames arrive rather than rebuilt from the start of the run.

| Scenario                             | Before | After  |
| ------------------------------------ | ------ | ------ |
| Playback, 200 nodes, panel closed    | 33 fps | 46 fps |
| Chart repaints, 4 s, panel closed    | 172    | 0      |

Measured against the built website in headless Chromium, driving a ring net through a run, with frame intervals sampled from `requestAnimationFrame` and repaints counted on the chart canvas.

#### Before

https://github.com/user-attachments/assets/5169b3d8-af79-48e6-8ba5-57ee8d287826

#### After

https://github.com/user-attachments/assets/cb7f6bfe-9f6b-432d-91c4-91b63cc05873

## Links

- Ticket [FE-1672](https://linear.app/hash/issue/FE-1672)
- Docs [Simulation](https://github.com/hashintel/hash/blob/claude/timeline-holds-still/libs/%40hashintel/petrinaut/docs/simulation.md)

## Changes

- Off-screen timeline stops reading frames and stops drawing
  > An IntersectionObserver on the chart's container drives it, so a panel slid away, a scrolled page and a clipped container are all covered.
  > The frame cursor is kept, so coming back appends everything that arrived meanwhile in one batch.
  > A run reset while the panel is shut is noticed all the same, so reopening does not append the new run to the old one's rows.
- Chart columns are extended as rows arrive
  > A stacked chart re-summed the whole run per frame: 500 series a thousand frames in is half a million additions to move the chart on by one column.
  > A run chart allocated a fresh array of gaps per hidden series per frame; every hidden series now shares one that only grows.
- `useElementOnScreen` reports whether an element overlaps the viewport
  > Starts true and stays true where IntersectionObserver is unavailable, so a caller that gates work on it does that work.

## Test coverage

- `chart-data.test.ts`:
  > Stacking order, hidden series, extension matching a rebuild, and starting over when a run resets.
- Existing `@hashintel/petrinaut` unit suite.

## How to test

- Open [Petrinaut preview](https://petrinaut-git-claude-timeline-holds-still.stage.hash.ai) on Vercel
- Menu > Load example > Supply Chain with Disruption
- Press Play
- Close the bottom panel
  > Expect playback to run visibly smoother
- Reopen the timeline
  > Expect the chart to show the whole run, including the frames computed while it was shut
- Timeline header > Stacked
  > Expect stacked bands to match the run chart's totals

