### PR TITLE
FE-1691: Run the website's Vite dev server by path so the dev task survives Yarn hiding the bin

### DIFF
--- a/apps/petrinaut-website/scripts/dev.sh
+++ b/apps/petrinaut-website/scripts/dev.sh
@@ -9,4 +9,8 @@ cd "$(dirname "$0")/.."
 . ../../libs/@local/petrinaut-optimizer-client/scripts/optimizer-service.sh
 optimizer_service_parse "$@"
 yarn examples:generate
-run_dev_server yarn vite ${OPTIMIZER_FORWARDED[@]+"${OPTIMIZER_FORWARDED[@]}"}
+# Vite is run by path: Yarn hides a dependency's bin from `yarn run` when the
+# workspace also declares one of that dependency's peers (`@types/node` here),
+# so `yarn vite` fails with "Couldn't find a script named vite".
+vite_bin="$(node -p 'require("path").join(require("path").dirname(require.resolve("vite/package.json")), "bin", "vite.js")')"
+run_dev_server node "$vite_bin" ${OPTIMIZER_FORWARDED[@]+"${OPTIMIZER_FORWARDED[@]}"}


### PR DESCRIPTION
> [!IMPORTANT]
> Dev tooling only, nothing user-facing.

## Summary

Before this PR, `turbo run dev --filter @apps/petrinaut-website` and the `@apps/petrinaut-website` launch entry failed at startup with `Couldn't find a script named "vite"`. Yarn hides a dependency's binary from `yarn run` in a workspace that also declares one of that dependency's peers, and the website declares `@types/node`, a peer of Vite, since its Vercel functions were typed. Removing `@types/node` brings the binary back, which confirms the cause but is not an option.

This PR runs Vite by path. The dev script resolves `vite/package.json` from the workspace and starts `bin/vite.js` with Node, so the dev task no longer depends on Yarn exposing the binary. The optimizer-service flag and every forwarded Vite argument behave as before.

## Links

- Ticket [FE-1691](https://linear.app/hash/issue/FE-1691)
- Reference [Yarn `yarn run`](https://yarnpkg.com/cli/run)

## Changes

- Website dev script resolves the Vite binary itself
  > `scripts/dev.sh` computes the path through `require.resolve("vite/package.json")` and hands `node <path>` to `run_dev_server`, with a comment naming the Yarn behaviour.

## Test coverage

- Manual:
  > `yarn workspace @apps/petrinaut-website dev` starts Vite on a checkout where `yarn workspace @apps/petrinaut-website bin` lists no `vite`.

## How to test

- `yarn workspace @apps/petrinaut-website dev`
  > Expect the examples to generate and Vite to serve on port 5173

