### PR TITLE
SRE-1053: switch `minio/mc` from docker hub to quay

### DIFF
--- a/infra/compose/compose.yml
+++ b/infra/compose/compose.yml
@@ -369,7 +369,7 @@ services:
       - hash
     # Pinned by release timestamp — upstream ships no semver tags. Tag only, no
     # digest: a Docker Hub digest isn't valid for the quay copy of the same tag.
-    image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
+    image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e
     command: server /data --console-address ":9001"
     environment:
       MINIO_API_CORS_ALLOW_ORIGIN: ${FRONTEND_URL:-http://localhost:3000}
@@ -398,7 +398,7 @@ services:
       - hash
     # `mc` versions by release timestamp — upstream ships no semver tags — and
     # trails the server's series; pinned by digest too, as only that is immutable.
-    image: minio/mc:RELEASE.2025-08-13T08-35-41Z@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727
+    image: quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727
     depends_on:
       minio:
         condition: service_healthy

--- a/infra/compose/compose.yml
+++ b/infra/compose/compose.yml
@@ -367,8 +367,6 @@ services:
     profiles:
       - dev
       - hash
-    # Pinned by release timestamp — upstream ships no semver tags. Tag only, no
-    # digest: a Docker Hub digest isn't valid for the quay copy of the same tag.
     image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e
     command: server /data --console-address ":9001"
     environment:
@@ -396,8 +394,6 @@ services:
     profiles:
       - dev
       - hash
-    # `mc` versions by release timestamp — upstream ships no semver tags — and
-    # trails the server's series; pinned by digest too, as only that is immutable.
     image: quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727
     depends_on:
       minio:


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Pull both MinIO images from quay.io, pinned by digest. Docker Hub no longer hosts `minio/mc` or `minio/minio` (the rest of the `minio` namespace is still there), so bringing up the `dev` profile fails at the pull:

```
Error response from daemon: pull access denied for minio/mc, repository does not exist or may require 'docker login'
```

The server image already came from quay, and the bucket initialiser's `mc` image now does too. Both carry a digest, since release timestamps are the only tags upstream publishes and a tag is mutable. The digests are quay's own multi-arch manifest lists (`amd64`, `arm64`, `ppc64le`): `RELEASE.2025-09-07T16-13-09Z` resolves to `14cea493…` and `RELEASE.2025-08-13T08-35-41Z` to `a7fe349e…`. The `mc` digest is the one the file already pinned, so the client bytes we run do not change.

For review: the two digests are the whole change, and `docker manifest inspect` against each `quay.io` reference is the check.

## 🔍 What does this change?

- `infra/compose/compose.yml`: `minio` gains a digest on its existing quay tag, and `minio-ensure-bucket-exists` moves from `minio/mc` to `quay.io/minio/mc` at the same tag and digest.

## ❓ How to test this?

1. `yarn compose pull minio minio-ensure-bucket-exists`: both pull from `quay.io`.
2. `yarn compose up -d minio minio-ensure-bucket-exists`: the initialiser waits for the server's healthcheck, prints `Creating bucket dev-hash-bucket` and exits 0.
